### PR TITLE
[SPARK-50343][SPARK-50344][SQL] Add SQL pipe syntax for the DROP and AS operators

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -1510,6 +1510,8 @@ operatorPipeRightSide
     : selectClause windowClause?
     | EXTEND extendList=namedExpressionSeq
     | SET operatorPipeSetAssignmentSeq
+    | DROP identifierSeq
+    | AS errorCapturingIdentifier
     // Note that the WINDOW clause is not allowed in the WHERE pipe operator, but we add it here in
     // the grammar simply for purposes of catching this invalid syntax and throwing a specific
     // dedicated error message.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -6018,11 +6018,7 @@ class AstBuilder extends DataTypeAstBuilder
           target = None, excepts = ids.map(s => Seq(s)), replacements = None))
       Project(projectList, left)
     }.getOrElse(Option(ctx.AS).map { _ =>
-      val child = left match {
-        case s: SubqueryAlias => s.child
-        case _ => left
-      }
-      SubqueryAlias(ctx.errorCapturingIdentifier().getText, child)
+      SubqueryAlias(ctx.errorCapturingIdentifier().getText, left)
     }.getOrElse(Option(ctx.whereClause).map { c =>
       if (ctx.windowClause() != null) {
         throw QueryParsingErrors.windowClauseInPipeOperatorWhereClauseNotAllowedError(ctx)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -6136,7 +6136,8 @@ class AstBuilder extends DataTypeAstBuilder
                 Seq("GROUPING", "GROUPING_ID").foreach { name =>
                   if (f.nameParts.head.equalsIgnoreCase(name)) error(name)
                 }
-              case _: WindowSpec => error("window functions")
+              case _: WindowSpec => error("window functions; please update the query to move " +
+                "the window functions to a subsequent |> SELECT operator instead")
               case _ =>
             }
             e.children.foreach(visit)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5106,7 +5106,7 @@ object SQLConf {
         "the sequence of steps that the query performs in a composable fashion.")
       .version("4.0.0")
       .booleanConf
-      .createWithDefault(Utils.isTesting)
+      .createWithDefault(true)
 
   val LEGACY_PERCENTILE_DISC_CALCULATION = buildConf("spark.sql.legacy.percentileDiscCalculation")
     .internal()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5106,7 +5106,7 @@ object SQLConf {
         "the sequence of steps that the query performs in a composable fashion.")
       .version("4.0.0")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(Utils.isTesting)
 
   val LEGACY_PERCENTILE_DISC_CALCULATION = buildConf("spark.sql.legacy.percentileDiscCalculation")
     .internal()

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -4512,6 +4512,73 @@ WithCTE
 
 
 -- !query
+select
+  dt.d_year,
+  item.i_brand_id brand_id,
+  item.i_brand brand,
+  sum(ss_ext_sales_price) sum_agg
+from date_dim dt, store_sales, item
+where dt.d_date_sk = store_sales.ss_sold_date_sk
+  and store_sales.ss_item_sk = item.i_item_sk
+  and item.i_manufact_id = 128
+  and dt.d_moy = 11
+group by dt.d_year, item.i_brand, item.i_brand_id
+order by dt.d_year, sum_agg desc, brand_id
+limit 100
+-- !query analysis
+GlobalLimit 100
++- LocalLimit 100
+   +- Sort [d_year#x ASC NULLS FIRST, sum_agg#x DESC NULLS LAST, brand_id#x ASC NULLS FIRST], true
+      +- Aggregate [d_year#x, i_brand#x, i_brand_id#x], [d_year#x, i_brand_id#x AS brand_id#x, i_brand#x AS brand#x, sum(ss_ext_sales_price#x) AS sum_agg#x]
+         +- Filter (((d_date_sk#x = ss_sold_date_sk#x) AND (ss_item_sk#x = i_item_sk#x)) AND ((i_manufact_id#x = 128) AND (d_moy#x = 11)))
+            +- Join Inner
+               :- Join Inner
+               :  :- SubqueryAlias dt
+               :  :  +- SubqueryAlias spark_catalog.default.date_dim
+               :  :     +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
+               :  :        +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
+               :  +- SubqueryAlias spark_catalog.default.store_sales
+               :     +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
+               +- SubqueryAlias spark_catalog.default.item
+                  +- Project [i_item_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_item_id#x, 16)) AS i_item_id#x, i_rec_start_date#x, i_rec_end_date#x, i_item_desc#x, i_current_price#x, i_wholesale_cost#x, i_brand_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_brand#x, 50)) AS i_brand#x, i_class_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_class#x, 50)) AS i_class#x, i_category_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_category#x, 50)) AS i_category#x, i_manufact_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_manufact#x, 50)) AS i_manufact#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_size#x, 20)) AS i_size#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_formulation#x, 20)) AS i_formulation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_color#x, 20)) AS i_color#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_units#x, 10)) AS i_units#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_container#x, 10)) AS i_container#x, i_manager_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_product_name#x, 50)) AS i_product_name#x]
+                     +- Relation spark_catalog.default.item[i_item_sk#x,i_item_id#x,i_rec_start_date#x,i_rec_end_date#x,i_item_desc#x,i_current_price#x,i_wholesale_cost#x,i_brand_id#x,i_brand#x,i_class_id#x,i_class#x,i_category_id#x,i_category#x,i_manufact_id#x,i_manufact#x,i_size#x,i_formulation#x,i_color#x,i_units#x,i_container#x,i_manager_id#x,i_product_name#x] parquet
+
+
+-- !query
+table date_dim
+|> as dt
+|> join store_sales
+|> join item
+|> where dt.d_date_sk = store_sales.ss_sold_date_sk
+     and store_sales.ss_item_sk = item.i_item_sk
+     and item.i_manufact_id = 128
+     and dt.d_moy = 11
+|> aggregate sum(ss_ext_sales_price) sum_agg
+     group by dt.d_year d_year, item.i_brand_id brand_id, item.i_brand brand
+|> order by d_year, sum_agg desc, brand_id
+|> limit 100
+-- !query analysis
+GlobalLimit 100
++- LocalLimit 100
+   +- SubqueryAlias __auto_generated_subquery_name
+      +- Sort [d_year#x ASC NULLS FIRST, sum_agg#x DESC NULLS LAST, brand_id#x ASC NULLS FIRST], true
+         +- SubqueryAlias __auto_generated_subquery_name
+            +- Aggregate [d_year#x, i_brand_id#x, i_brand#x], [d_year#x AS d_year#x, i_brand_id#x AS brand_id#x, i_brand#x AS brand#x, pipeexpression(sum(ss_ext_sales_price#x), true, AGGREGATE) AS sum_agg#x]
+               +- Filter (((d_date_sk#x = ss_sold_date_sk#x) AND (ss_item_sk#x = i_item_sk#x)) AND ((i_manufact_id#x = 128) AND (d_moy#x = 11)))
+                  +- Join Inner
+                     :- Join Inner
+                     :  :- SubqueryAlias dt
+                     :  :  +- SubqueryAlias spark_catalog.default.date_dim
+                     :  :     +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
+                     :  :        +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
+                     :  +- SubqueryAlias spark_catalog.default.store_sales
+                     :     +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
+                     +- SubqueryAlias spark_catalog.default.item
+                        +- Project [i_item_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_item_id#x, 16)) AS i_item_id#x, i_rec_start_date#x, i_rec_end_date#x, i_item_desc#x, i_current_price#x, i_wholesale_cost#x, i_brand_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_brand#x, 50)) AS i_brand#x, i_class_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_class#x, 50)) AS i_class#x, i_category_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_category#x, 50)) AS i_category#x, i_manufact_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_manufact#x, 50)) AS i_manufact#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_size#x, 20)) AS i_size#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_formulation#x, 20)) AS i_formulation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_color#x, 20)) AS i_color#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_units#x, 10)) AS i_units#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_container#x, 10)) AS i_container#x, i_manager_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_product_name#x, 50)) AS i_product_name#x]
+                           +- Relation spark_catalog.default.item[i_item_sk#x,i_item_id#x,i_rec_start_date#x,i_rec_end_date#x,i_item_desc#x,i_current_price#x,i_wholesale_cost#x,i_brand_id#x,i_brand#x,i_class_id#x,i_class#x,i_category_id#x,i_category#x,i_manufact_id#x,i_manufact#x,i_size#x,i_formulation#x,i_color#x,i_units#x,i_container#x,i_manager_id#x,i_product_name#x] parquet
+
+
+-- !query
 drop table t
 -- !query analysis
 DropTable false, false

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -3870,7 +3870,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "errorClass" : "UNSUPPORTED_FEATURE.PIPE_OPERATOR_AGGREGATE_UNSUPPORTED_CASE",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "case" : "window functions"
+    "case" : "window functions; please update the query to move the window functions to a subsequent |> SELECT operator instead"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -4663,6 +4663,218 @@ GlobalLimit 100
                                     +- SubqueryAlias spark_catalog.default.date_dim
                                        +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
                                           +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
+
+
+-- !query
+select
+  asceding.rnk,
+  i1.i_product_name best_performing,
+  i2.i_product_name worst_performing
+from (select *
+from (select
+  item_sk,
+  rank()
+  over (
+    order by rank_col asc) rnk
+from (select
+  ss_item_sk item_sk,
+  avg(ss_net_profit) rank_col
+from store_sales ss1
+where ss_store_sk = 4
+group by ss_item_sk
+having avg(ss_net_profit) > 0.9 * (select avg(ss_net_profit) rank_col
+from store_sales
+where ss_store_sk = 4
+  and ss_addr_sk is null
+group by ss_store_sk)) v1) v11
+where rnk < 11) asceding,
+  (select *
+  from (select
+    item_sk,
+    rank()
+    over (
+      order by rank_col desc) rnk
+  from (select
+    ss_item_sk item_sk,
+    avg(ss_net_profit) rank_col
+  from store_sales ss1
+  where ss_store_sk = 4
+  group by ss_item_sk
+  having avg(ss_net_profit) > 0.9 * (select avg(ss_net_profit) rank_col
+  from store_sales
+  where ss_store_sk = 4
+    and ss_addr_sk is null
+  group by ss_store_sk)) v2) v21
+  where rnk < 11) descending,
+  item i1, item i2
+where asceding.rnk = descending.rnk
+  and i1.i_item_sk = asceding.item_sk
+  and i2.i_item_sk = descending.item_sk
+order by asceding.rnk
+limit 100
+-- !query analysis
+GlobalLimit 100
++- LocalLimit 100
+   +- Sort [rnk#x ASC NULLS FIRST], true
+      +- Project [rnk#x, i_product_name#x AS best_performing#x, i_product_name#x AS worst_performing#x]
+         +- Filter (((rnk#x = rnk#x) AND (i_item_sk#x = item_sk#x)) AND (i_item_sk#x = item_sk#x))
+            +- Join Inner
+               :- Join Inner
+               :  :- Join Inner
+               :  :  :- SubqueryAlias asceding
+               :  :  :  +- Project [item_sk#x, rnk#x]
+               :  :  :     +- Filter (rnk#x < 11)
+               :  :  :        +- SubqueryAlias v11
+               :  :  :           +- Project [item_sk#x, rnk#x]
+               :  :  :              +- Project [item_sk#x, rank_col#x, rnk#x, rnk#x]
+               :  :  :                 +- Window [rank(rank_col#x) windowspecdefinition(rank_col#x ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#x], [rank_col#x ASC NULLS FIRST]
+               :  :  :                    +- Project [item_sk#x, rank_col#x]
+               :  :  :                       +- SubqueryAlias v1
+               :  :  :                          +- Filter (cast(rank_col#x as decimal(13,7)) > (0.9 * scalar-subquery#x []))
+               :  :  :                             :  +- Aggregate [ss_store_sk#x], [avg(ss_net_profit#x) AS rank_col#x]
+               :  :  :                             :     +- Filter ((ss_store_sk#x = 4) AND isnull(ss_addr_sk#x))
+               :  :  :                             :        +- SubqueryAlias spark_catalog.default.store_sales
+               :  :  :                             :           +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
+               :  :  :                             +- Aggregate [ss_item_sk#x], [ss_item_sk#x AS item_sk#x, avg(ss_net_profit#x) AS rank_col#x]
+               :  :  :                                +- Filter (ss_store_sk#x = 4)
+               :  :  :                                   +- SubqueryAlias ss1
+               :  :  :                                      +- SubqueryAlias spark_catalog.default.store_sales
+               :  :  :                                         +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
+               :  :  +- SubqueryAlias descending
+               :  :     +- Project [item_sk#x, rnk#x]
+               :  :        +- Filter (rnk#x < 11)
+               :  :           +- SubqueryAlias v21
+               :  :              +- Project [item_sk#x, rnk#x]
+               :  :                 +- Project [item_sk#x, rank_col#x, rnk#x, rnk#x]
+               :  :                    +- Window [rank(rank_col#x) windowspecdefinition(rank_col#x DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#x], [rank_col#x DESC NULLS LAST]
+               :  :                       +- Project [item_sk#x, rank_col#x]
+               :  :                          +- SubqueryAlias v2
+               :  :                             +- Filter (cast(rank_col#x as decimal(13,7)) > (0.9 * scalar-subquery#x []))
+               :  :                                :  +- Aggregate [ss_store_sk#x], [avg(ss_net_profit#x) AS rank_col#x]
+               :  :                                :     +- Filter ((ss_store_sk#x = 4) AND isnull(ss_addr_sk#x))
+               :  :                                :        +- SubqueryAlias spark_catalog.default.store_sales
+               :  :                                :           +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
+               :  :                                +- Aggregate [ss_item_sk#x], [ss_item_sk#x AS item_sk#x, avg(ss_net_profit#x) AS rank_col#x]
+               :  :                                   +- Filter (ss_store_sk#x = 4)
+               :  :                                      +- SubqueryAlias ss1
+               :  :                                         +- SubqueryAlias spark_catalog.default.store_sales
+               :  :                                            +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
+               :  +- SubqueryAlias i1
+               :     +- SubqueryAlias spark_catalog.default.item
+               :        +- Project [i_item_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_item_id#x, 16)) AS i_item_id#x, i_rec_start_date#x, i_rec_end_date#x, i_item_desc#x, i_current_price#x, i_wholesale_cost#x, i_brand_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_brand#x, 50)) AS i_brand#x, i_class_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_class#x, 50)) AS i_class#x, i_category_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_category#x, 50)) AS i_category#x, i_manufact_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_manufact#x, 50)) AS i_manufact#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_size#x, 20)) AS i_size#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_formulation#x, 20)) AS i_formulation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_color#x, 20)) AS i_color#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_units#x, 10)) AS i_units#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_container#x, 10)) AS i_container#x, i_manager_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_product_name#x, 50)) AS i_product_name#x]
+               :           +- Relation spark_catalog.default.item[i_item_sk#x,i_item_id#x,i_rec_start_date#x,i_rec_end_date#x,i_item_desc#x,i_current_price#x,i_wholesale_cost#x,i_brand_id#x,i_brand#x,i_class_id#x,i_class#x,i_category_id#x,i_category#x,i_manufact_id#x,i_manufact#x,i_size#x,i_formulation#x,i_color#x,i_units#x,i_container#x,i_manager_id#x,i_product_name#x] parquet
+               +- SubqueryAlias i2
+                  +- SubqueryAlias spark_catalog.default.item
+                     +- Project [i_item_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_item_id#x, 16)) AS i_item_id#x, i_rec_start_date#x, i_rec_end_date#x, i_item_desc#x, i_current_price#x, i_wholesale_cost#x, i_brand_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_brand#x, 50)) AS i_brand#x, i_class_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_class#x, 50)) AS i_class#x, i_category_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_category#x, 50)) AS i_category#x, i_manufact_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_manufact#x, 50)) AS i_manufact#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_size#x, 20)) AS i_size#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_formulation#x, 20)) AS i_formulation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_color#x, 20)) AS i_color#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_units#x, 10)) AS i_units#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_container#x, 10)) AS i_container#x, i_manager_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_product_name#x, 50)) AS i_product_name#x]
+                        +- Relation spark_catalog.default.item[i_item_sk#x,i_item_id#x,i_rec_start_date#x,i_rec_end_date#x,i_item_desc#x,i_current_price#x,i_wholesale_cost#x,i_brand_id#x,i_brand#x,i_class_id#x,i_class#x,i_category_id#x,i_category#x,i_manufact_id#x,i_manufact#x,i_size#x,i_formulation#x,i_color#x,i_units#x,i_container#x,i_manager_id#x,i_product_name#x] parquet
+
+
+-- !query
+table store_sales
+|> as ss1
+|> where ss_store_sk = 4
+|> aggregate avg(ss_net_profit) rank_col
+     group by ss_item_sk as item_sk
+|> where rank_col > 0.9 * (
+     table store_sales
+     |> where ss_store_sk = 4
+          and ss_addr_sk is null
+     |> aggregate avg(ss_net_profit) rank_col
+          group by ss_store_sk
+     |> select rank_col)
+|> as v1
+|> select
+     item_sk,
+     rank() over (
+       order by rank_col asc) rnk
+|> as v11
+|> where rnk < 11
+|> as asceding
+|> join (
+     table store_sales
+     |> as ss1
+     |> where ss_store_sk = 4
+     |> aggregate avg(ss_net_profit) rank_col
+          group by ss_item_sk as item_sk
+     |> where rank_col > 0.9 * (
+          table store_sales
+          |> where ss_store_sk = 4
+               and ss_addr_sk is null
+          |> aggregate avg(ss_net_profit) rank_col
+               group by ss_store_sk
+          |> select rank_col)
+     |> as v2
+     |> select
+          item_sk,
+          rank() over (
+            order by rank_col asc) rnk
+     |> as v21
+     |> where rnk < 11) descending
+|> join item i1
+|> join item i2
+|> where asceding.rnk = descending.rnk
+     and i1.i_item_sk = asceding.item_sk
+     and i2.i_item_sk = descending.item_sk
+|> order by asceding.rnk
+|> select
+     asceding.rnk,
+     i1.i_product_name best_performing,
+     i2.i_product_name worst_performing
+-- !query analysis
+Project [rnk#x, pipeexpression(i_product_name#x, false, SELECT) AS best_performing#x, pipeexpression(i_product_name#x, false, SELECT) AS worst_performing#x]
++- Sort [rnk#x ASC NULLS FIRST], true
+   +- Filter (((rnk#x = rnk#x) AND (i_item_sk#x = item_sk#x)) AND (i_item_sk#x = item_sk#x))
+      +- Join Inner
+         :- Join Inner
+         :  :- Join Inner
+         :  :  :- SubqueryAlias asceding
+         :  :  :  +- Filter (rnk#x < 11)
+         :  :  :     +- SubqueryAlias v11
+         :  :  :        +- Project [item_sk#x, rnk#x]
+         :  :  :           +- Project [item_sk#x, rank_col#x, _we0#x, pipeexpression(_we0#x, false, SELECT) AS rnk#x]
+         :  :  :              +- Window [rank(rank_col#x) windowspecdefinition(rank_col#x ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS _we0#x], [rank_col#x ASC NULLS FIRST]
+         :  :  :                 +- Project [item_sk#x, rank_col#x]
+         :  :  :                    +- SubqueryAlias v1
+         :  :  :                       +- Filter (cast(rank_col#x as decimal(13,7)) > (0.9 * scalar-subquery#x []))
+         :  :  :                          :  +- Project [rank_col#x]
+         :  :  :                          :     +- Aggregate [ss_store_sk#x], [ss_store_sk#x, pipeexpression(avg(ss_net_profit#x), true, AGGREGATE) AS rank_col#x]
+         :  :  :                          :        +- Filter ((ss_store_sk#x = 4) AND isnull(ss_addr_sk#x))
+         :  :  :                          :           +- SubqueryAlias spark_catalog.default.store_sales
+         :  :  :                          :              +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
+         :  :  :                          +- SubqueryAlias __auto_generated_subquery_name
+         :  :  :                             +- Aggregate [ss_item_sk#x], [ss_item_sk#x AS item_sk#x, pipeexpression(avg(ss_net_profit#x), true, AGGREGATE) AS rank_col#x]
+         :  :  :                                +- Filter (ss_store_sk#x = 4)
+         :  :  :                                   +- SubqueryAlias ss1
+         :  :  :                                      +- SubqueryAlias spark_catalog.default.store_sales
+         :  :  :                                         +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
+         :  :  +- SubqueryAlias descending
+         :  :     +- Filter (rnk#x < 11)
+         :  :        +- SubqueryAlias v21
+         :  :           +- Project [item_sk#x, rnk#x]
+         :  :              +- Project [item_sk#x, rank_col#x, _we0#x, pipeexpression(_we0#x, false, SELECT) AS rnk#x]
+         :  :                 +- Window [rank(rank_col#x) windowspecdefinition(rank_col#x ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS _we0#x], [rank_col#x ASC NULLS FIRST]
+         :  :                    +- Project [item_sk#x, rank_col#x]
+         :  :                       +- SubqueryAlias v2
+         :  :                          +- Filter (cast(rank_col#x as decimal(13,7)) > (0.9 * scalar-subquery#x []))
+         :  :                             :  +- Project [rank_col#x]
+         :  :                             :     +- Aggregate [ss_store_sk#x], [ss_store_sk#x, pipeexpression(avg(ss_net_profit#x), true, AGGREGATE) AS rank_col#x]
+         :  :                             :        +- Filter ((ss_store_sk#x = 4) AND isnull(ss_addr_sk#x))
+         :  :                             :           +- SubqueryAlias spark_catalog.default.store_sales
+         :  :                             :              +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
+         :  :                             +- SubqueryAlias __auto_generated_subquery_name
+         :  :                                +- Aggregate [ss_item_sk#x], [ss_item_sk#x AS item_sk#x, pipeexpression(avg(ss_net_profit#x), true, AGGREGATE) AS rank_col#x]
+         :  :                                   +- Filter (ss_store_sk#x = 4)
+         :  :                                      +- SubqueryAlias ss1
+         :  :                                         +- SubqueryAlias spark_catalog.default.store_sales
+         :  :                                            +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
+         :  +- SubqueryAlias i1
+         :     +- SubqueryAlias spark_catalog.default.item
+         :        +- Project [i_item_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_item_id#x, 16)) AS i_item_id#x, i_rec_start_date#x, i_rec_end_date#x, i_item_desc#x, i_current_price#x, i_wholesale_cost#x, i_brand_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_brand#x, 50)) AS i_brand#x, i_class_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_class#x, 50)) AS i_class#x, i_category_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_category#x, 50)) AS i_category#x, i_manufact_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_manufact#x, 50)) AS i_manufact#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_size#x, 20)) AS i_size#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_formulation#x, 20)) AS i_formulation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_color#x, 20)) AS i_color#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_units#x, 10)) AS i_units#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_container#x, 10)) AS i_container#x, i_manager_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_product_name#x, 50)) AS i_product_name#x]
+         :           +- Relation spark_catalog.default.item[i_item_sk#x,i_item_id#x,i_rec_start_date#x,i_rec_end_date#x,i_item_desc#x,i_current_price#x,i_wholesale_cost#x,i_brand_id#x,i_brand#x,i_class_id#x,i_class#x,i_category_id#x,i_category#x,i_manufact_id#x,i_manufact#x,i_size#x,i_formulation#x,i_color#x,i_units#x,i_container#x,i_manager_id#x,i_product_name#x] parquet
+         +- SubqueryAlias i2
+            +- SubqueryAlias spark_catalog.default.item
+               +- Project [i_item_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_item_id#x, 16)) AS i_item_id#x, i_rec_start_date#x, i_rec_end_date#x, i_item_desc#x, i_current_price#x, i_wholesale_cost#x, i_brand_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_brand#x, 50)) AS i_brand#x, i_class_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_class#x, 50)) AS i_class#x, i_category_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_category#x, 50)) AS i_category#x, i_manufact_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_manufact#x, 50)) AS i_manufact#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_size#x, 20)) AS i_size#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_formulation#x, 20)) AS i_formulation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_color#x, 20)) AS i_color#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_units#x, 10)) AS i_units#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_container#x, 10)) AS i_container#x, i_manager_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_product_name#x, 50)) AS i_product_name#x]
+                  +- Relation spark_catalog.default.item[i_item_sk#x,i_item_id#x,i_rec_start_date#x,i_rec_end_date#x,i_item_desc#x,i_current_price#x,i_wholesale_cost#x,i_brand_id#x,i_brand#x,i_class_id#x,i_class#x,i_category_id#x,i_category#x,i_manufact_id#x,i_manufact#x,i_size#x,i_formulation#x,i_color#x,i_units#x,i_container#x,i_manager_id#x,i_product_name#x] parquet
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -266,6 +266,575 @@ CreateViewCommand `windowTestData`, select * from values
 
 
 -- !query
+create table store_sales(
+  `ss_sold_date_sk` int,
+  `ss_sold_time_sk` int,
+  `ss_item_sk` int,
+  `ss_customer_sk` int,
+  `ss_cdemo_sk` int,
+  `ss_hdemo_sk` int,
+  `ss_addr_sk` int,
+  `ss_store_sk` int,
+  `ss_promo_sk` int,
+  `ss_ticket_number` int,
+  `ss_quantity` int,
+  `ss_wholesale_cost` decimal(7,2),
+  `ss_list_price` decimal(7,2),
+  `ss_sales_price` decimal(7,2),
+  `ss_ext_discount_amt` decimal(7,2),
+  `ss_ext_sales_price` decimal(7,2),
+  `ss_ext_wholesale_cost` decimal(7,2),
+  `ss_ext_list_price` decimal(7,2),
+  `ss_ext_tax` decimal(7,2),
+  `ss_coupon_amt` decimal(7,2),
+  `ss_net_paid` decimal(7,2),
+  `ss_net_paid_inc_tax` decimal(7,2),
+  `ss_net_profit` decimal(7,2))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`store_sales`, false
+
+
+-- !query
+create table store_returns(
+  `sr_returned_date_sk` int,
+  `sr_return_time_sk` int,
+  `sr_item_sk` int,
+  `sr_customer_sk` int,
+  `sr_cdemo_sk` int,
+  `sr_hdemo_sk` int,
+  `sr_addr_sk` int,
+  `sr_store_sk` int,
+  `sr_reason_sk` int,
+  `sr_ticket_number` int,
+  `sr_return_quantity` int,
+  `sr_return_amt` decimal(7,2),
+  `sr_return_tax` decimal(7,2),
+  `sr_return_amt_inc_tax` decimal(7,2),
+  `sr_fee` decimal(7,2),
+  `sr_return_ship_cost` decimal(7,2),
+  `sr_refunded_cash` decimal(7,2),
+  `sr_reversed_charge` decimal(7,2),
+  `sr_store_credit` decimal(7,2),
+  `sr_net_loss` decimal(7,2))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`store_returns`, false
+
+
+-- !query
+create table catalog_sales(
+  `cs_sold_date_sk` int,
+  `cs_sold_time_sk` int,
+  `cs_ship_date_sk` int,
+  `cs_bill_customer_sk` int,
+  `cs_bill_cdemo_sk` int,
+  `cs_bill_hdemo_sk` int,
+  `cs_bill_addr_sk` int,
+  `cs_ship_customer_sk` int,
+  `cs_ship_cdemo_sk` int,
+  `cs_ship_hdemo_sk` int,
+  `cs_ship_addr_sk` int,
+  `cs_call_center_sk` int,
+  `cs_catalog_page_sk` int,
+  `cs_ship_mode_sk` int,
+  `cs_warehouse_sk` int,
+  `cs_item_sk` int,
+  `cs_promo_sk` int,
+  `cs_order_number` int,
+  `cs_quantity` int,
+  `cs_wholesale_cost` decimal(7,2),
+  `cs_list_price` decimal(7,2),
+  `cs_sales_price` decimal(7,2),
+  `cs_ext_discount_amt` decimal(7,2),
+  `cs_ext_sales_price` decimal(7,2),
+  `cs_ext_wholesale_cost` decimal(7,2),
+  `cs_ext_list_price` decimal(7,2),
+  `cs_ext_tax` decimal(7,2),
+  `cs_coupon_amt` decimal(7,2),
+  `cs_ext_ship_cost` decimal(7,2),
+  `cs_net_paid` decimal(7,2),
+  `cs_net_paid_inc_tax` decimal(7,2),
+  `cs_net_paid_inc_ship` decimal(7,2),
+  `cs_net_paid_inc_ship_tax` decimal(7,2),
+  `cs_net_profit` decimal(7,2))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`catalog_sales`, false
+
+
+-- !query
+create table catalog_returns(
+  `cr_returned_date_sk` int,
+  `cr_returned_time_sk` int,
+  `cr_item_sk` int,
+  `cr_refunded_customer_sk` int,
+  `cr_refunded_cdemo_sk` int,
+  `cr_refunded_hdemo_sk` int,
+  `cr_refunded_addr_sk` int,
+  `cr_returning_customer_sk` int,
+  `cr_returning_cdemo_sk` int,
+  `cr_returning_hdemo_sk` int,
+  `cr_returning_addr_sk` int,
+  `cr_call_center_sk` int,
+  `cr_catalog_page_sk` int,
+  `cr_ship_mode_sk` int,
+  `cr_warehouse_sk` int,
+  `cr_reason_sk` int,
+  `cr_order_number` int,
+  `cr_return_quantity` int,
+  `cr_return_amount` decimal(7,2),
+  `cr_return_tax` decimal(7,2),
+  `cr_return_amt_inc_tax` decimal(7,2),
+  `cr_fee` decimal(7,2),
+  `cr_return_ship_cost` decimal(7,2),
+  `cr_refunded_cash` decimal(7,2),
+  `cr_reversed_charge` decimal(7,2),
+  `cr_store_credit` decimal(7,2),
+  `cr_net_loss` decimal(7,2))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`catalog_returns`, false
+
+
+-- !query
+create table web_sales(
+  `ws_sold_date_sk` int,
+  `ws_sold_time_sk` int,
+  `ws_ship_date_sk` int,
+  `ws_item_sk` int,
+  `ws_bill_customer_sk` int,
+  `ws_bill_cdemo_sk` int,
+  `ws_bill_hdemo_sk` int,
+  `ws_bill_addr_sk` int,
+  `ws_ship_customer_sk` int,
+  `ws_ship_cdemo_sk` int,
+  `ws_ship_hdemo_sk` int,
+  `ws_ship_addr_sk` int,
+  `ws_web_page_sk` int,
+  `ws_web_site_sk` int,
+  `ws_ship_mode_sk` int,
+  `ws_warehouse_sk` int,
+  `ws_promo_sk` int,
+  `ws_order_number` int,
+  `ws_quantity` int,
+  `ws_wholesale_cost` decimal(7,2),
+  `ws_list_price` decimal(7,2),
+  `ws_sales_price` decimal(7,2),
+  `ws_ext_discount_amt` decimal(7,2),
+  `ws_ext_sales_price` decimal(7,2),
+  `ws_ext_wholesale_cost` decimal(7,2),
+  `ws_ext_list_price` decimal(7,2),
+  `ws_ext_tax` decimal(7,2),
+  `ws_coupon_amt` decimal(7,2),
+  `ws_ext_ship_cost` decimal(7,2),
+  `ws_net_paid` decimal(7,2),
+  `ws_net_paid_inc_tax` decimal(7,2),
+  `ws_net_paid_inc_ship` decimal(7,2),
+  `ws_net_paid_inc_ship_tax` decimal(7,2),
+  `ws_net_profit` decimal(7,2))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`web_sales`, false
+
+
+-- !query
+create table web_returns(
+  `wr_returned_date_sk` int,
+  `wr_returned_time_sk` int,
+  `wr_item_sk` int,
+  `wr_refunded_customer_sk` int,
+  `wr_refunded_cdemo_sk` int,
+  `wr_refunded_hdemo_sk` int,
+  `wr_refunded_addr_sk` int,
+  `wr_returning_customer_sk` int,
+  `wr_returning_cdemo_sk` int,
+  `wr_returning_hdemo_sk` int,
+  `wr_returning_addr_sk` int,
+  `wr_web_page_sk` int,
+  `wr_reason_sk` int,
+  `wr_order_number` int,
+  `wr_return_quantity` int,
+  `wr_return_amt` decimal(7,2),
+  `wr_return_tax` decimal(7,2),
+  `wr_return_amt_inc_tax` decimal(7,2),
+  `wr_fee` decimal(7,2),
+  `wr_return_ship_cost` decimal(7,2),
+  `wr_refunded_cash` decimal(7,2),
+  `wr_reversed_charge` decimal(7,2),
+  `wr_account_credit` decimal(7,2),
+  `wr_net_loss` decimal(7,2))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`web_returns`, false
+
+
+-- !query
+create table inventory(
+  `inv_date_sk` int,
+  `inv_item_sk` int,
+  `inv_warehouse_sk` int,
+  `inv_quantity_on_hand` int)
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`inventory`, false
+
+
+-- !query
+create table store(
+  `s_store_sk` int,
+  `s_store_id` char(16),
+  `s_rec_start_date` date,
+  `s_rec_end_date` date,
+  `s_closed_date_sk` int,
+  `s_store_name` varchar(50),
+  `s_number_employees` int,
+  `s_floor_space` int,
+  `s_hours` char(20),
+  `s_manager` varchar(40),
+  `s_market_id` int,
+  `s_geography_class` varchar(100),
+  `s_market_desc` varchar(100),
+  `s_market_manager` varchar(40),
+  `s_division_id` int,
+  `s_division_name` varchar(50),
+  `s_company_id` int,
+  `s_company_name` varchar(50),
+  `s_street_number` varchar(10),
+  `s_street_name` varchar(60),
+  `s_street_type` char(15),
+  `s_suite_number` char(10),
+  `s_city` varchar(60),
+  `s_county` varchar(30),
+  `s_state` char(2),
+  `s_zip` char(10),
+  `s_country` varchar(20),
+  `s_gmt_offset` decimal(5,2),
+  `s_tax_percentage` decimal(5,2))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`store`, false
+
+
+-- !query
+create table call_center(
+  `cc_call_center_sk` int,
+  `cc_call_center_id` char(16),
+  `cc_rec_start_date` date,
+  `cc_rec_end_date` date,
+  `cc_closed_date_sk` int,
+  `cc_open_date_sk` int,
+  `cc_name` varchar(50),
+  `cc_class` varchar(50),
+  `cc_employees` int,
+  `cc_sq_ft` int,
+  `cc_hours` char(20),
+  `cc_manager` varchar(40),
+  `cc_mkt_id` int,
+  `cc_mkt_class` char(50),
+  `cc_mkt_desc` varchar(100),
+  `cc_market_manager` varchar(40),
+  `cc_division` int,
+  `cc_division_name` varchar(50),
+  `cc_company` int,
+  `cc_company_name` char(50),
+  `cc_street_number` char(10),
+  `cc_street_name` varchar(60),
+  `cc_street_type` char(15),
+  `cc_suite_number` char(10),
+  `cc_city` varchar(60),
+  `cc_county` varchar(30),
+  `cc_state` char(2),
+  `cc_zip` char(10),
+  `cc_country` varchar(20),
+  `cc_gmt_offset` decimal(5,2),
+  `cc_tax_percentage` decimal(5,2))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`call_center`, false
+
+
+-- !query
+create table catalog_page(
+  `cp_catalog_page_sk` int,
+  `cp_catalog_page_id` char(16),
+  `cp_start_date_sk` int,
+  `cp_end_date_sk` int,
+  `cp_department` varchar(50),
+  `cp_catalog_number` int,
+  `cp_catalog_page_number` int,
+  `cp_description` varchar(100),
+  `cp_type` varchar(100))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`catalog_page`, false
+
+
+-- !query
+create table web_site(
+  `web_site_sk` int,
+  `web_site_id` char(16),
+  `web_rec_start_date` date,
+  `web_rec_end_date` date,
+  `web_name` varchar(50),
+  `web_open_date_sk` int,
+  `web_close_date_sk` int,
+  `web_class` varchar(50),
+  `web_manager` varchar(40),
+  `web_mkt_id` int,
+  `web_mkt_class` varchar(50),
+  `web_mkt_desc` varchar(100),
+  `web_market_manager` varchar(40),
+  `web_company_id` int,
+  `web_company_name` char(50),
+  `web_street_number` char(10),
+  `web_street_name` varchar(60),
+  `web_street_type` char(15),
+  `web_suite_number` char(10),
+  `web_city` varchar(60),
+  `web_county` varchar(30),
+  `web_state` char(2),
+  `web_zip` char(10),
+  `web_country` varchar(20),
+  `web_gmt_offset` decimal(5,2),
+  `web_tax_percentage` decimal(5,2))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`web_site`, false
+
+
+-- !query
+create table web_page(
+  `wp_web_page_sk` int,
+  `wp_web_page_id` char(16),
+  `wp_rec_start_date` date,
+  `wp_rec_end_date` date,
+  `wp_creation_date_sk` int,
+  `wp_access_date_sk` int,
+  `wp_autogen_flag` char(1),
+  `wp_customer_sk` int,
+  `wp_url` varchar(100),
+  `wp_type` char(50),
+  `wp_char_count` int,
+  `wp_link_count` int,
+  `wp_image_count` int,
+  `wp_max_ad_count` int)
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`web_page`, false
+
+
+-- !query
+create table warehouse(
+  `w_warehouse_sk` int,
+  `w_warehouse_id` char(16),
+  `w_warehouse_name` varchar(20),
+  `w_warehouse_sq_ft` int,
+  `w_street_number` char(10),
+  `w_street_name` varchar(20),
+  `w_street_type` char(15),
+  `w_suite_number` char(10),
+  `w_city` varchar(60),
+  `w_county` varchar(30),
+  `w_state` char(2),
+  `w_zip` char(10),
+  `w_country` varchar(20),
+  `w_gmt_offset` decimal(5,2))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`warehouse`, false
+
+
+-- !query
+create table customer(
+  `c_customer_sk` int,
+  `c_customer_id` char(16),
+  `c_current_cdemo_sk` int,
+  `c_current_hdemo_sk` int,
+  `c_current_addr_sk` int,
+  `c_first_shipto_date_sk` int,
+  `c_first_sales_date_sk` int,
+  `c_salutation` char(10),
+  `c_first_name` char(20),
+  `c_last_name` char(30),
+  `c_preferred_cust_flag` char(1),
+  `c_birth_day` int,
+  `c_birth_month` int,
+  `c_birth_year` int,
+  `c_birth_country` varchar(20),
+  `c_login` char(13),
+  `c_email_address` char(50),
+  `c_last_review_date` int)
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`customer`, false
+
+
+-- !query
+create table customer_address(
+  `ca_address_sk` int,
+  `ca_address_id` char(16),
+  `ca_street_number` char(10),
+  `ca_street_name` varchar(60),
+  `ca_street_type` char(15),
+  `ca_suite_number` char(10),
+  `ca_city` varchar(60),
+  `ca_county` varchar(30),
+  `ca_state` char(2),
+  `ca_zip` char(10),
+  `ca_country` varchar(20),
+  `ca_gmt_offset` decimal(5,2),
+  `ca_location_type` char(20))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`customer_address`, false
+
+
+-- !query
+create table customer_demographics(
+  `cd_demo_sk` int,
+  `cd_gender` char(1),
+  `cd_marital_status` char(1),
+  `cd_education_status` char(20),
+  `cd_purchase_estimate` int,
+  `cd_credit_rating` char(10),
+  `cd_dep_count` int,
+  `cd_dep_employed_count` int,
+  `cd_dep_college_count` int)
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`customer_demographics`, false
+
+
+-- !query
+create table date_dim(
+  `d_date_sk` int,
+  `d_date_id` char(16),
+  `d_date` date,
+  `d_month_seq` int,
+  `d_week_seq` int,
+  `d_quarter_seq` int,
+  `d_year` int,
+  `d_dow` int,
+  `d_moy` int,
+  `d_dom` int,
+  `d_qoy` int,
+  `d_fy_year` int,
+  `d_fy_quarter_seq` int,
+  `d_fy_week_seq` int,
+  `d_day_name` char(9),
+  `d_quarter_name` char(6),
+  `d_holiday` char(1),
+  `d_weekend` char(1),
+  `d_following_holiday` char(1),
+  `d_first_dom` int,
+  `d_last_dom` int,
+  `d_same_day_ly` int,
+  `d_same_day_lq` int,
+  `d_current_day` char(1),
+  `d_current_week` char(1),
+  `d_current_month` char(1),
+  `d_current_quarter` char(1),
+  `d_current_year` char(1))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`date_dim`, false
+
+
+-- !query
+create table household_demographics(
+  `hd_demo_sk` int,
+  `hd_income_band_sk` int,
+  `hd_buy_potential` char(15),
+  `hd_dep_count` int,
+  `hd_vehicle_count` int)
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`household_demographics`, false
+
+
+-- !query
+create table item(
+  `i_item_sk` int,
+  `i_item_id` char(16),
+  `i_rec_start_date` date,
+  `i_rec_end_date` date,
+  `i_item_desc` varchar(200),
+  `i_current_price` decimal(7,2),
+  `i_wholesale_cost` decimal(7,2),
+  `i_brand_id` int,
+  `i_brand` char(50),
+  `i_class_id` int,
+  `i_class` char(50),
+  `i_category_id` int,
+  `i_category` char(50),
+  `i_manufact_id` int,
+  `i_manufact` char(50),
+  `i_size` char(20),
+  `i_formulation` char(20),
+  `i_color` char(20),
+  `i_units` char(10),
+  `i_container` char(10),
+  `i_manager_id` int,
+  `i_product_name` char(50))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`item`, false
+
+
+-- !query
+create table income_band(
+  `ib_income_band_sk` int,
+  `ib_lower_bound` int,
+  `ib_upper_bound` int)
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`income_band`, false
+
+
+-- !query
+create table promotion(
+  `p_promo_sk` int,
+  `p_promo_id` char(16),
+  `p_start_date_sk` int,
+  `p_end_date_sk` int,
+  `p_item_sk` int,
+  `p_cost` decimal(15,2),
+  `p_response_target` int,
+  `p_promo_name` char(50),
+  `p_channel_dmail` char(1),
+  `p_channel_email` char(1),
+  `p_channel_catalog` char(1),
+  `p_channel_tv` char(1),
+  `p_channel_radio` char(1),
+  `p_channel_press` char(1),
+  `p_channel_event` char(1),
+  `p_channel_demo` char(1),
+  `p_channel_details` varchar(100),
+  `p_purpose` char(15),
+  `p_discount_active` char(1))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`promotion`, false
+
+
+-- !query
+create table reason(
+  `r_reason_sk` int,
+  `r_reason_id` char(16),
+  `r_reason_desc` char(100))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`reason`, false
+
+
+-- !query
+create table ship_mode(
+  `sm_ship_mode_sk` int,
+  `sm_ship_mode_id` char(16),
+  `sm_type` char(30),
+  `sm_code` char(10),
+  `sm_carrier` char(20),
+  `sm_contract` char(20))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`ship_mode`, false
+
+
+-- !query
+create table time_dim(
+  `t_time_sk` int,
+  `t_time_id` char(16),
+  `t_time` int,
+  `t_hour` int,
+  `t_minute` int,
+  `t_second` int,
+  `t_am_pm` char(2),
+  `t_shift` char(20),
+  `t_sub_shift` char(20),
+  `t_meal_time` char(20))
+-- !query analysis
+CreateDataSourceTableCommand `spark_catalog`.`default`.`time_dim`, false
+
+
+-- !query
 table t
 |> select 1 as x
 -- !query analysis
@@ -936,6 +1505,211 @@ org.apache.spark.sql.catalyst.parser.ParseException
 
 -- !query
 table t
+|> drop y
+-- !query analysis
+Project [x#x]
++- SubqueryAlias spark_catalog.default.t
+   +- Relation spark_catalog.default.t[x#x,y#x] csv
+
+
+-- !query
+select 1 as x, 2 as y, 3 as z
+|> drop z, y
+-- !query analysis
+Project [x#x]
++- Project [1 AS x#x, 2 AS y#x, 3 AS z#x]
+   +- OneRowRelation
+
+
+-- !query
+select 1 as x, 2 as y, 3 as z
+|> drop z
+|> drop y
+-- !query analysis
+Project [x#x]
++- Project [x#x, y#x]
+   +- Project [1 AS x#x, 2 AS y#x, 3 AS z#x]
+      +- OneRowRelation
+
+
+-- !query
+select x from t
+|> drop x
+-- !query analysis
+Project
++- Project [x#x]
+   +- SubqueryAlias spark_catalog.default.t
+      +- Relation spark_catalog.default.t[x#x,y#x] csv
+
+
+-- !query
+table t
+|> extend 1 as `x.y.z`
+|> drop `x.y.z`
+-- !query analysis
+Project [x#x, y#x]
++- Project [x#x, y#x, pipeexpression(1, false, EXTEND) AS x.y.z#x]
+   +- SubqueryAlias spark_catalog.default.t
+      +- Relation spark_catalog.default.t[x#x,y#x] csv
+
+
+-- !query
+table t
+|> drop z
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNRESOLVED_COLUMN.WITH_SUGGESTION",
+  "sqlState" : "42703",
+  "messageParameters" : {
+    "objectName" : "`z`",
+    "proposal" : "`x`, `y`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 17,
+    "fragment" : "table t\n|> drop z"
+  } ]
+}
+
+
+-- !query
+table st
+|> drop col.i1
+-- !query analysis
+org.apache.spark.sql.catalyst.parser.ParseException
+{
+  "errorClass" : "PARSE_SYNTAX_ERROR",
+  "sqlState" : "42601",
+  "messageParameters" : {
+    "error" : "'.'",
+    "hint" : ""
+  }
+}
+
+
+-- !query
+table st
+|> drop `col.i1`
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNRESOLVED_COLUMN.WITH_SUGGESTION",
+  "sqlState" : "42703",
+  "messageParameters" : {
+    "objectName" : "`col.i1`",
+    "proposal" : "`col`, `x`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 25,
+    "fragment" : "table st\n|> drop `col.i1`"
+  } ]
+}
+
+
+-- !query
+select 1 as x, 2 as y, 3 as z
+|> drop z, y, z
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "EXCEPT_OVERLAPPING_COLUMNS",
+  "sqlState" : "42702",
+  "messageParameters" : {
+    "columns" : "z, y, z"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 45,
+    "fragment" : "select 1 as x, 2 as y, 3 as z\n|> drop z, y, z"
+  } ]
+}
+
+
+-- !query
+table t
+|> as u
+|> select u.x, u.y
+-- !query analysis
+Project [x#x, y#x]
++- SubqueryAlias u
+   +- SubqueryAlias spark_catalog.default.t
+      +- Relation spark_catalog.default.t[x#x,y#x] csv
+
+
+-- !query
+select 1 as x, 2 as y
+|> as u
+|> select u.x, u.y
+-- !query analysis
+Project [x#x, y#x]
++- SubqueryAlias u
+   +- Project [1 AS x#x, 2 AS y#x]
+      +- OneRowRelation
+
+
+-- !query
+table t
+|> as u
+|> as v
+|> select v.x, v.y
+-- !query analysis
+Project [x#x, y#x]
++- SubqueryAlias v
+   +- SubqueryAlias spark_catalog.default.t
+      +- Relation spark_catalog.default.t[x#x,y#x] csv
+
+
+-- !query
+table t
+|> as u
+|> where u.x = 1
+-- !query analysis
+Filter (x#x = 1)
++- SubqueryAlias u
+   +- SubqueryAlias spark_catalog.default.t
+      +- Relation spark_catalog.default.t[x#x,y#x] csv
+
+
+-- !query
+table t
+|> as u, v
+-- !query analysis
+org.apache.spark.sql.catalyst.parser.ParseException
+{
+  "errorClass" : "PARSE_SYNTAX_ERROR",
+  "sqlState" : "42601",
+  "messageParameters" : {
+    "error" : "','",
+    "hint" : ""
+  }
+}
+
+
+-- !query
+table t
+|> as 1 + 2
+-- !query analysis
+org.apache.spark.sql.catalyst.parser.ParseException
+{
+  "errorClass" : "PARSE_SYNTAX_ERROR",
+  "sqlState" : "42601",
+  "messageParameters" : {
+    "error" : "'1'",
+    "hint" : ""
+  }
+}
+
+
+-- !query
+table t
 |> where true
 -- !query analysis
 Filter true
@@ -958,10 +1732,9 @@ table t
 |> where x + length(y) < 3
 -- !query analysis
 Filter ((x#x + length(y#x)) < 3)
-+- SubqueryAlias __auto_generated_subquery_name
-   +- Filter ((x#x + length(y#x)) < 4)
-      +- SubqueryAlias spark_catalog.default.t
-         +- Relation spark_catalog.default.t[x#x,y#x] csv
++- Filter ((x#x + length(y#x)) < 4)
+   +- SubqueryAlias spark_catalog.default.t
+      +- Relation spark_catalog.default.t[x#x,y#x] csv
 
 
 -- !query
@@ -2126,21 +2899,20 @@ table natural_join_test_t1
 |> where k = "one"
 -- !query analysis
 Filter (k#x = one)
-+- SubqueryAlias __auto_generated_subquery_name
-   +- Project [k#x, v1#x, v2#x]
-      +- Join Inner, (k#x = k#x)
-         :- SubqueryAlias natural_join_test_t1
-         :  +- View (`natural_join_test_t1`, [k#x, v1#x])
-         :     +- Project [cast(k#x as string) AS k#x, cast(v1#x as int) AS v1#x]
-         :        +- Project [k#x, v1#x]
-         :           +- SubqueryAlias natural_join_test_t1
-         :              +- LocalRelation [k#x, v1#x]
-         +- SubqueryAlias natural_join_test_t2
-            +- View (`natural_join_test_t2`, [k#x, v2#x])
-               +- Project [cast(k#x as string) AS k#x, cast(v2#x as int) AS v2#x]
-                  +- Project [k#x, v2#x]
-                     +- SubqueryAlias natural_join_test_t2
-                        +- LocalRelation [k#x, v2#x]
++- Project [k#x, v1#x, v2#x]
+   +- Join Inner, (k#x = k#x)
+      :- SubqueryAlias natural_join_test_t1
+      :  +- View (`natural_join_test_t1`, [k#x, v1#x])
+      :     +- Project [cast(k#x as string) AS k#x, cast(v1#x as int) AS v1#x]
+      :        +- Project [k#x, v1#x]
+      :           +- SubqueryAlias natural_join_test_t1
+      :              +- LocalRelation [k#x, v1#x]
+      +- SubqueryAlias natural_join_test_t2
+         +- View (`natural_join_test_t2`, [k#x, v2#x])
+            +- Project [cast(k#x as string) AS k#x, cast(v2#x as int) AS v2#x]
+               +- Project [k#x, v2#x]
+                  +- SubqueryAlias natural_join_test_t2
+                     +- LocalRelation [k#x, v2#x]
 
 
 -- !query
@@ -3363,6 +4135,383 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 
 
 -- !query
+with customer_total_return as
+(select
+    sr_customer_sk as ctr_customer_sk,
+    sr_store_sk as ctr_store_sk,
+    sum(sr_return_amt) as ctr_total_return
+  from store_returns, date_dim
+  where sr_returned_date_sk = d_date_sk and d_year = 2000
+  group by sr_customer_sk, sr_store_sk)
+select c_customer_id
+from customer_total_return ctr1, store, customer
+where ctr1.ctr_total_return >
+  (select avg(ctr_total_return) * 1.2
+  from customer_total_return ctr2
+  where ctr1.ctr_store_sk = ctr2.ctr_store_sk)
+  and s_store_sk = ctr1.ctr_store_sk
+  and s_state = 'tn'
+  and ctr1.ctr_customer_sk = c_customer_sk
+order by c_customer_id
+limit 100
+-- !query analysis
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias customer_total_return
+:     +- Aggregate [sr_customer_sk#x, sr_store_sk#x], [sr_customer_sk#x AS ctr_customer_sk#x, sr_store_sk#x AS ctr_store_sk#x, sum(sr_return_amt#x) AS ctr_total_return#x]
+:        +- Filter ((sr_returned_date_sk#x = d_date_sk#x) AND (d_year#x = 2000))
+:           +- Join Inner
+:              :- SubqueryAlias spark_catalog.default.store_returns
+:              :  +- Relation spark_catalog.default.store_returns[sr_returned_date_sk#x,sr_return_time_sk#x,sr_item_sk#x,sr_customer_sk#x,sr_cdemo_sk#x,sr_hdemo_sk#x,sr_addr_sk#x,sr_store_sk#x,sr_reason_sk#x,sr_ticket_number#x,sr_return_quantity#x,sr_return_amt#x,sr_return_tax#x,sr_return_amt_inc_tax#x,sr_fee#x,sr_return_ship_cost#x,sr_refunded_cash#x,sr_reversed_charge#x,sr_store_credit#x,sr_net_loss#x] parquet
+:              +- SubqueryAlias spark_catalog.default.date_dim
+:                 +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
+:                    +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
++- GlobalLimit 100
+   +- LocalLimit 100
+      +- Sort [c_customer_id#x ASC NULLS FIRST], true
+         +- Project [c_customer_id#x]
+            +- Filter (((cast(ctr_total_return#x as decimal(24,7)) > scalar-subquery#x [ctr_store_sk#x]) AND (s_store_sk#x = ctr_store_sk#x)) AND ((s_state#x = tn) AND (ctr_customer_sk#x = c_customer_sk#x)))
+               :  +- Aggregate [(avg(ctr_total_return#x) * 1.2) AS (avg(ctr_total_return) * 1.2)#x]
+               :     +- Filter (outer(ctr_store_sk#x) = ctr_store_sk#x)
+               :        +- SubqueryAlias ctr2
+               :           +- SubqueryAlias customer_total_return
+               :              +- CTERelationRef xxxx, true, [ctr_customer_sk#x, ctr_store_sk#x, ctr_total_return#x], false
+               +- Join Inner
+                  :- Join Inner
+                  :  :- SubqueryAlias ctr1
+                  :  :  +- SubqueryAlias customer_total_return
+                  :  :     +- CTERelationRef xxxx, true, [ctr_customer_sk#x, ctr_store_sk#x, ctr_total_return#x], false
+                  :  +- SubqueryAlias spark_catalog.default.store
+                  :     +- Project [s_store_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(s_store_id#x, 16)) AS s_store_id#x, s_rec_start_date#x, s_rec_end_date#x, s_closed_date_sk#x, s_store_name#x, s_number_employees#x, s_floor_space#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(s_hours#x, 20)) AS s_hours#x, s_manager#x, s_market_id#x, s_geography_class#x, s_market_desc#x, s_market_manager#x, s_division_id#x, s_division_name#x, s_company_id#x, s_company_name#x, s_street_number#x, s_street_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(s_street_type#x, 15)) AS s_street_type#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(s_suite_number#x, 10)) AS s_suite_number#x, s_city#x, s_county#x, ... 5 more fields]
+                  :        +- Relation spark_catalog.default.store[s_store_sk#x,s_store_id#x,s_rec_start_date#x,s_rec_end_date#x,s_closed_date_sk#x,s_store_name#x,s_number_employees#x,s_floor_space#x,s_hours#x,s_manager#x,s_market_id#x,s_geography_class#x,s_market_desc#x,s_market_manager#x,s_division_id#x,s_division_name#x,s_company_id#x,s_company_name#x,s_street_number#x,s_street_name#x,s_street_type#x,s_suite_number#x,s_city#x,s_county#x,... 5 more fields] parquet
+                  +- SubqueryAlias spark_catalog.default.customer
+                     +- Project [c_customer_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_customer_id#x, 16)) AS c_customer_id#x, c_current_cdemo_sk#x, c_current_hdemo_sk#x, c_current_addr_sk#x, c_first_shipto_date_sk#x, c_first_sales_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_salutation#x, 10)) AS c_salutation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_first_name#x, 20)) AS c_first_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_last_name#x, 30)) AS c_last_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_preferred_cust_flag#x, 1)) AS c_preferred_cust_flag#x, c_birth_day#x, c_birth_month#x, c_birth_year#x, c_birth_country#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_login#x, 13)) AS c_login#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_email_address#x, 50)) AS c_email_address#x, c_last_review_date#x]
+                        +- Relation spark_catalog.default.customer[c_customer_sk#x,c_customer_id#x,c_current_cdemo_sk#x,c_current_hdemo_sk#x,c_current_addr_sk#x,c_first_shipto_date_sk#x,c_first_sales_date_sk#x,c_salutation#x,c_first_name#x,c_last_name#x,c_preferred_cust_flag#x,c_birth_day#x,c_birth_month#x,c_birth_year#x,c_birth_country#x,c_login#x,c_email_address#x,c_last_review_date#x] parquet
+
+
+-- !query
+with customer_total_return as
+  (table store_returns
+  |> join date_dim
+  |> where sr_returned_date_sk = d_date_sk and d_year = 2000
+  |> aggregate sum(sr_return_amt) as ctr_total_return
+       group by sr_customer_sk as ctr_customer_sk, sr_store_sk as ctr_store_sk)
+table customer_total_return
+|> as ctr1
+|> join store
+|> join customer
+|> where ctr1.ctr_total_return >
+     (table customer_total_return
+      |> as ctr2
+      |> where ctr1.ctr_store_sk = ctr2.ctr_store_sk
+      |> aggregate avg(ctr_total_return) * 1.2)
+     and s_store_sk = ctr1.ctr_store_sk
+     and s_state = 'tn'
+     and ctr1.ctr_customer_sk = c_customer_sk
+|> order by c_customer_id
+|> limit 100
+|> select c_customer_id
+-- !query analysis
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias customer_total_return
+:     +- Aggregate [sr_customer_sk#x, sr_store_sk#x], [sr_customer_sk#x AS ctr_customer_sk#x, sr_store_sk#x AS ctr_store_sk#x, pipeexpression(sum(sr_return_amt#x), true, AGGREGATE) AS ctr_total_return#x]
+:        +- Filter ((sr_returned_date_sk#x = d_date_sk#x) AND (d_year#x = 2000))
+:           +- Join Inner
+:              :- SubqueryAlias spark_catalog.default.store_returns
+:              :  +- Relation spark_catalog.default.store_returns[sr_returned_date_sk#x,sr_return_time_sk#x,sr_item_sk#x,sr_customer_sk#x,sr_cdemo_sk#x,sr_hdemo_sk#x,sr_addr_sk#x,sr_store_sk#x,sr_reason_sk#x,sr_ticket_number#x,sr_return_quantity#x,sr_return_amt#x,sr_return_tax#x,sr_return_amt_inc_tax#x,sr_fee#x,sr_return_ship_cost#x,sr_refunded_cash#x,sr_reversed_charge#x,sr_store_credit#x,sr_net_loss#x] parquet
+:              +- SubqueryAlias spark_catalog.default.date_dim
+:                 +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
+:                    +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
++- Project [c_customer_id#x]
+   +- GlobalLimit 100
+      +- LocalLimit 100
+         +- SubqueryAlias __auto_generated_subquery_name
+            +- Sort [c_customer_id#x ASC NULLS FIRST], true
+               +- Filter (((cast(ctr_total_return#x as decimal(24,7)) > scalar-subquery#x [ctr_store_sk#x]) AND (s_store_sk#x = ctr_store_sk#x)) AND ((s_state#x = tn) AND (ctr_customer_sk#x = c_customer_sk#x)))
+                  :  +- Aggregate [pipeexpression((avg(ctr_total_return#x) * 1.2), true, AGGREGATE) AS pipeexpression((avg(ctr_total_return) * 1.2))#x]
+                  :     +- Filter (outer(ctr_store_sk#x) = ctr_store_sk#x)
+                  :        +- SubqueryAlias ctr2
+                  :           +- SubqueryAlias customer_total_return
+                  :              +- CTERelationRef xxxx, true, [ctr_customer_sk#x, ctr_store_sk#x, ctr_total_return#x], false
+                  +- Join Inner
+                     :- Join Inner
+                     :  :- SubqueryAlias ctr1
+                     :  :  +- SubqueryAlias customer_total_return
+                     :  :     +- CTERelationRef xxxx, true, [ctr_customer_sk#x, ctr_store_sk#x, ctr_total_return#x], false
+                     :  +- SubqueryAlias spark_catalog.default.store
+                     :     +- Project [s_store_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(s_store_id#x, 16)) AS s_store_id#x, s_rec_start_date#x, s_rec_end_date#x, s_closed_date_sk#x, s_store_name#x, s_number_employees#x, s_floor_space#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(s_hours#x, 20)) AS s_hours#x, s_manager#x, s_market_id#x, s_geography_class#x, s_market_desc#x, s_market_manager#x, s_division_id#x, s_division_name#x, s_company_id#x, s_company_name#x, s_street_number#x, s_street_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(s_street_type#x, 15)) AS s_street_type#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(s_suite_number#x, 10)) AS s_suite_number#x, s_city#x, s_county#x, ... 5 more fields]
+                     :        +- Relation spark_catalog.default.store[s_store_sk#x,s_store_id#x,s_rec_start_date#x,s_rec_end_date#x,s_closed_date_sk#x,s_store_name#x,s_number_employees#x,s_floor_space#x,s_hours#x,s_manager#x,s_market_id#x,s_geography_class#x,s_market_desc#x,s_market_manager#x,s_division_id#x,s_division_name#x,s_company_id#x,s_company_name#x,s_street_number#x,s_street_name#x,s_street_type#x,s_suite_number#x,s_city#x,s_county#x,... 5 more fields] parquet
+                     +- SubqueryAlias spark_catalog.default.customer
+                        +- Project [c_customer_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_customer_id#x, 16)) AS c_customer_id#x, c_current_cdemo_sk#x, c_current_hdemo_sk#x, c_current_addr_sk#x, c_first_shipto_date_sk#x, c_first_sales_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_salutation#x, 10)) AS c_salutation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_first_name#x, 20)) AS c_first_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_last_name#x, 30)) AS c_last_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_preferred_cust_flag#x, 1)) AS c_preferred_cust_flag#x, c_birth_day#x, c_birth_month#x, c_birth_year#x, c_birth_country#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_login#x, 13)) AS c_login#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_email_address#x, 50)) AS c_email_address#x, c_last_review_date#x]
+                           +- Relation spark_catalog.default.customer[c_customer_sk#x,c_customer_id#x,c_current_cdemo_sk#x,c_current_hdemo_sk#x,c_current_addr_sk#x,c_first_shipto_date_sk#x,c_first_sales_date_sk#x,c_salutation#x,c_first_name#x,c_last_name#x,c_preferred_cust_flag#x,c_birth_day#x,c_birth_month#x,c_birth_year#x,c_birth_country#x,c_login#x,c_email_address#x,c_last_review_date#x] parquet
+
+
+-- !query
+with wscs as
+( select
+    sold_date_sk,
+    sales_price
+  from (select
+    ws_sold_date_sk sold_date_sk,
+    ws_ext_sales_price sales_price
+  from web_sales) x
+  union all
+  (select
+    cs_sold_date_sk sold_date_sk,
+    cs_ext_sales_price sales_price
+  from catalog_sales)),
+    wswscs as
+  ( select
+    d_week_seq,
+    sum(case when (d_day_name = 'sunday')
+      then sales_price
+        else null end)
+    sun_sales,
+    sum(case when (d_day_name = 'monday')
+      then sales_price
+        else null end)
+    mon_sales,
+    sum(case when (d_day_name = 'tuesday')
+      then sales_price
+        else null end)
+    tue_sales,
+    sum(case when (d_day_name = 'wednesday')
+      then sales_price
+        else null end)
+    wed_sales,
+    sum(case when (d_day_name = 'thursday')
+      then sales_price
+        else null end)
+    thu_sales,
+    sum(case when (d_day_name = 'friday')
+      then sales_price
+        else null end)
+    fri_sales,
+    sum(case when (d_day_name = 'saturday')
+      then sales_price
+        else null end)
+    sat_sales
+  from wscs, date_dim
+  where d_date_sk = sold_date_sk
+  group by d_week_seq)
+select
+  d_week_seq1,
+  round(sun_sales1 / sun_sales2, 2),
+  round(mon_sales1 / mon_sales2, 2),
+  round(tue_sales1 / tue_sales2, 2),
+  round(wed_sales1 / wed_sales2, 2),
+  round(thu_sales1 / thu_sales2, 2),
+  round(fri_sales1 / fri_sales2, 2),
+  round(sat_sales1 / sat_sales2, 2)
+from
+  (select
+    wswscs.d_week_seq d_week_seq1,
+    sun_sales sun_sales1,
+    mon_sales mon_sales1,
+    tue_sales tue_sales1,
+    wed_sales wed_sales1,
+    thu_sales thu_sales1,
+    fri_sales fri_sales1,
+    sat_sales sat_sales1
+  from wswscs, date_dim
+  where date_dim.d_week_seq = wswscs.d_week_seq and d_year = 2001) y,
+  (select
+    wswscs.d_week_seq d_week_seq2,
+    sun_sales sun_sales2,
+    mon_sales mon_sales2,
+    tue_sales tue_sales2,
+    wed_sales wed_sales2,
+    thu_sales thu_sales2,
+    fri_sales fri_sales2,
+    sat_sales sat_sales2
+  from wswscs, date_dim
+  where date_dim.d_week_seq = wswscs.d_week_seq and d_year = 2001 + 1) z
+where d_week_seq1 = d_week_seq2 - 53
+order by d_week_seq1
+-- !query analysis
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias wscs
+:     +- Union false, false
+:        :- Project [sold_date_sk#x, sales_price#x]
+:        :  +- SubqueryAlias x
+:        :     +- Project [ws_sold_date_sk#x AS sold_date_sk#x, ws_ext_sales_price#x AS sales_price#x]
+:        :        +- SubqueryAlias spark_catalog.default.web_sales
+:        :           +- Relation spark_catalog.default.web_sales[ws_sold_date_sk#x,ws_sold_time_sk#x,ws_ship_date_sk#x,ws_item_sk#x,ws_bill_customer_sk#x,ws_bill_cdemo_sk#x,ws_bill_hdemo_sk#x,ws_bill_addr_sk#x,ws_ship_customer_sk#x,ws_ship_cdemo_sk#x,ws_ship_hdemo_sk#x,ws_ship_addr_sk#x,ws_web_page_sk#x,ws_web_site_sk#x,ws_ship_mode_sk#x,ws_warehouse_sk#x,ws_promo_sk#x,ws_order_number#x,ws_quantity#x,ws_wholesale_cost#x,ws_list_price#x,ws_sales_price#x,ws_ext_discount_amt#x,ws_ext_sales_price#x,... 10 more fields] parquet
+:        +- Project [cs_sold_date_sk#x AS sold_date_sk#x, cs_ext_sales_price#x AS sales_price#x]
+:           +- SubqueryAlias spark_catalog.default.catalog_sales
+:              +- Relation spark_catalog.default.catalog_sales[cs_sold_date_sk#x,cs_sold_time_sk#x,cs_ship_date_sk#x,cs_bill_customer_sk#x,cs_bill_cdemo_sk#x,cs_bill_hdemo_sk#x,cs_bill_addr_sk#x,cs_ship_customer_sk#x,cs_ship_cdemo_sk#x,cs_ship_hdemo_sk#x,cs_ship_addr_sk#x,cs_call_center_sk#x,cs_catalog_page_sk#x,cs_ship_mode_sk#x,cs_warehouse_sk#x,cs_item_sk#x,cs_promo_sk#x,cs_order_number#x,cs_quantity#x,cs_wholesale_cost#x,cs_list_price#x,cs_sales_price#x,cs_ext_discount_amt#x,cs_ext_sales_price#x,... 10 more fields] parquet
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias wswscs
+:     +- Aggregate [d_week_seq#x], [d_week_seq#x, sum(CASE WHEN (d_day_name#x = rpad(sunday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END) AS sun_sales#x, sum(CASE WHEN (d_day_name#x = rpad(monday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END) AS mon_sales#x, sum(CASE WHEN (d_day_name#x = rpad(tuesday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END) AS tue_sales#x, sum(CASE WHEN (d_day_name#x = wednesday) THEN sales_price#x ELSE cast(null as decimal(7,2)) END) AS wed_sales#x, sum(CASE WHEN (d_day_name#x = rpad(thursday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END) AS thu_sales#x, sum(CASE WHEN (d_day_name#x = rpad(friday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END) AS fri_sales#x, sum(CASE WHEN (d_day_name#x = rpad(saturday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END) AS sat_sales#x]
+:        +- Filter (d_date_sk#x = sold_date_sk#x)
+:           +- Join Inner
+:              :- SubqueryAlias wscs
+:              :  +- CTERelationRef xxxx, true, [sold_date_sk#x, sales_price#x], false
+:              +- SubqueryAlias spark_catalog.default.date_dim
+:                 +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
+:                    +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
++- Sort [d_week_seq1#x ASC NULLS FIRST], true
+   +- Project [d_week_seq1#x, round((sun_sales1#x / sun_sales2#x), 2) AS round((sun_sales1 / sun_sales2), 2)#x, round((mon_sales1#x / mon_sales2#x), 2) AS round((mon_sales1 / mon_sales2), 2)#x, round((tue_sales1#x / tue_sales2#x), 2) AS round((tue_sales1 / tue_sales2), 2)#x, round((wed_sales1#x / wed_sales2#x), 2) AS round((wed_sales1 / wed_sales2), 2)#x, round((thu_sales1#x / thu_sales2#x), 2) AS round((thu_sales1 / thu_sales2), 2)#x, round((fri_sales1#x / fri_sales2#x), 2) AS round((fri_sales1 / fri_sales2), 2)#x, round((sat_sales1#x / sat_sales2#x), 2) AS round((sat_sales1 / sat_sales2), 2)#x]
+      +- Filter (d_week_seq1#x = (d_week_seq2#x - 53))
+         +- Join Inner
+            :- SubqueryAlias y
+            :  +- Project [d_week_seq#x AS d_week_seq1#x, sun_sales#x AS sun_sales1#x, mon_sales#x AS mon_sales1#x, tue_sales#x AS tue_sales1#x, wed_sales#x AS wed_sales1#x, thu_sales#x AS thu_sales1#x, fri_sales#x AS fri_sales1#x, sat_sales#x AS sat_sales1#x]
+            :     +- Filter ((d_week_seq#x = d_week_seq#x) AND (d_year#x = 2001))
+            :        +- Join Inner
+            :           :- SubqueryAlias wswscs
+            :           :  +- CTERelationRef xxxx, true, [d_week_seq#x, sun_sales#x, mon_sales#x, tue_sales#x, wed_sales#x, thu_sales#x, fri_sales#x, sat_sales#x], false
+            :           +- SubqueryAlias spark_catalog.default.date_dim
+            :              +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
+            :                 +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
+            +- SubqueryAlias z
+               +- Project [d_week_seq#x AS d_week_seq2#x, sun_sales#x AS sun_sales2#x, mon_sales#x AS mon_sales2#x, tue_sales#x AS tue_sales2#x, wed_sales#x AS wed_sales2#x, thu_sales#x AS thu_sales2#x, fri_sales#x AS fri_sales2#x, sat_sales#x AS sat_sales2#x]
+                  +- Filter ((d_week_seq#x = d_week_seq#x) AND (d_year#x = (2001 + 1)))
+                     +- Join Inner
+                        :- SubqueryAlias wswscs
+                        :  +- CTERelationRef xxxx, true, [d_week_seq#x, sun_sales#x, mon_sales#x, tue_sales#x, wed_sales#x, thu_sales#x, fri_sales#x, sat_sales#x], false
+                        +- SubqueryAlias spark_catalog.default.date_dim
+                           +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
+                              +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
+
+
+-- !query
+with wscs as
+  (table web_sales
+  |> select
+       ws_sold_date_sk sold_date_sk,
+       ws_ext_sales_price sales_price
+  |> as x
+  |> union all (
+       table catalog_sales
+       |> select
+            cs_sold_date_sk sold_date_sk,
+            cs_ext_sales_price sales_price)
+  |> select
+       sold_date_sk,
+       sales_price),
+wswscs as
+  (table wscs
+  |> join date_dim
+  |> where d_date_sk = sold_date_sk
+  |> aggregate
+      sum(case when (d_day_name = 'sunday')
+        then sales_price
+          else null end)
+      sun_sales,
+      sum(case when (d_day_name = 'monday')
+        then sales_price
+          else null end)
+      mon_sales,
+      sum(case when (d_day_name = 'tuesday')
+        then sales_price
+          else null end)
+      tue_sales,
+      sum(case when (d_day_name = 'wednesday')
+        then sales_price
+          else null end)
+      wed_sales,
+      sum(case when (d_day_name = 'thursday')
+        then sales_price
+          else null end)
+      thu_sales,
+      sum(case when (d_day_name = 'friday')
+        then sales_price
+          else null end)
+      fri_sales,
+      sum(case when (d_day_name = 'saturday')
+        then sales_price
+          else null end)
+      sat_sales
+      group by d_week_seq)
+table wswscs
+|> join date_dim
+|> where date_dim.d_week_seq = wswscs.d_week_seq AND d_year = 2001
+|> select
+     wswscs.d_week_seq d_week_seq1,
+     sun_sales sun_sales1,
+     mon_sales mon_sales1,
+     tue_sales tue_sales1,
+     wed_sales wed_sales1,
+     thu_sales thu_sales1,
+     fri_sales fri_sales1,
+     sat_sales sat_sales1
+|> as y
+|> join (
+     table wswscs
+     |> join date_dim
+     |> where date_dim.d_week_seq = wswscs.d_week_seq AND d_year = 2001 + 1
+     |> select
+          wswscs.d_week_seq d_week_seq2,
+          sun_sales sun_sales2,
+          mon_sales mon_sales2,
+          tue_sales tue_sales2,
+          wed_sales wed_sales2,
+          thu_sales thu_sales2,
+          fri_sales fri_sales2,
+          sat_sales sat_sales2
+     |> as z)
+|> where d_week_seq1 = d_week_seq2 - 53
+|> order by d_week_seq1
+|> select
+     d_week_seq1,
+     round(sun_sales1 / sun_sales2, 2),
+     round(mon_sales1 / mon_sales2, 2),
+     round(tue_sales1 / tue_sales2, 2),
+     round(wed_sales1 / wed_sales2, 2),
+     round(thu_sales1 / thu_sales2, 2),
+     round(fri_sales1 / fri_sales2, 2),
+     round(sat_sales1 / sat_sales2, 2)
+-- !query analysis
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias wscs
+:     +- Union false, false
+:        :- SubqueryAlias x
+:        :  +- Project [pipeexpression(ws_sold_date_sk#x, false, SELECT) AS sold_date_sk#x, pipeexpression(ws_ext_sales_price#x, false, SELECT) AS sales_price#x]
+:        :     +- SubqueryAlias spark_catalog.default.web_sales
+:        :        +- Relation spark_catalog.default.web_sales[ws_sold_date_sk#x,ws_sold_time_sk#x,ws_ship_date_sk#x,ws_item_sk#x,ws_bill_customer_sk#x,ws_bill_cdemo_sk#x,ws_bill_hdemo_sk#x,ws_bill_addr_sk#x,ws_ship_customer_sk#x,ws_ship_cdemo_sk#x,ws_ship_hdemo_sk#x,ws_ship_addr_sk#x,ws_web_page_sk#x,ws_web_site_sk#x,ws_ship_mode_sk#x,ws_warehouse_sk#x,ws_promo_sk#x,ws_order_number#x,ws_quantity#x,ws_wholesale_cost#x,ws_list_price#x,ws_sales_price#x,ws_ext_discount_amt#x,ws_ext_sales_price#x,... 10 more fields] parquet
+:        +- Project [sold_date_sk#x, sales_price#x]
+:           +- Project [pipeexpression(cs_sold_date_sk#x, false, SELECT) AS sold_date_sk#x, pipeexpression(cs_ext_sales_price#x, false, SELECT) AS sales_price#x]
+:              +- SubqueryAlias spark_catalog.default.catalog_sales
+:                 +- Relation spark_catalog.default.catalog_sales[cs_sold_date_sk#x,cs_sold_time_sk#x,cs_ship_date_sk#x,cs_bill_customer_sk#x,cs_bill_cdemo_sk#x,cs_bill_hdemo_sk#x,cs_bill_addr_sk#x,cs_ship_customer_sk#x,cs_ship_cdemo_sk#x,cs_ship_hdemo_sk#x,cs_ship_addr_sk#x,cs_call_center_sk#x,cs_catalog_page_sk#x,cs_ship_mode_sk#x,cs_warehouse_sk#x,cs_item_sk#x,cs_promo_sk#x,cs_order_number#x,cs_quantity#x,cs_wholesale_cost#x,cs_list_price#x,cs_sales_price#x,cs_ext_discount_amt#x,cs_ext_sales_price#x,... 10 more fields] parquet
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias wswscs
+:     +- Aggregate [d_week_seq#x], [d_week_seq#x, pipeexpression(sum(CASE WHEN (d_day_name#x = rpad(sunday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END), true, AGGREGATE) AS sun_sales#x, pipeexpression(sum(CASE WHEN (d_day_name#x = rpad(monday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END), true, AGGREGATE) AS mon_sales#x, pipeexpression(sum(CASE WHEN (d_day_name#x = rpad(tuesday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END), true, AGGREGATE) AS tue_sales#x, pipeexpression(sum(CASE WHEN (d_day_name#x = wednesday) THEN sales_price#x ELSE cast(null as decimal(7,2)) END), true, AGGREGATE) AS wed_sales#x, pipeexpression(sum(CASE WHEN (d_day_name#x = rpad(thursday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END), true, AGGREGATE) AS thu_sales#x, pipeexpression(sum(CASE WHEN (d_day_name#x = rpad(friday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END), true, AGGREGATE) AS fri_sales#x, pipeexpression(sum(CASE WHEN (d_day_name#x = rpad(saturday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END), true, AGGREGATE) AS sat_sales#x]
+:        +- Filter (d_date_sk#x = sold_date_sk#x)
+:           +- Join Inner
+:              :- SubqueryAlias wscs
+:              :  +- CTERelationRef xxxx, true, [sold_date_sk#x, sales_price#x], false
+:              +- SubqueryAlias spark_catalog.default.date_dim
+:                 +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
+:                    +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
++- Project [d_week_seq1#x, round((sun_sales1#x / sun_sales2#x), 2) AS round((sun_sales1 / sun_sales2), 2)#x, round((mon_sales1#x / mon_sales2#x), 2) AS round((mon_sales1 / mon_sales2), 2)#x, round((tue_sales1#x / tue_sales2#x), 2) AS round((tue_sales1 / tue_sales2), 2)#x, round((wed_sales1#x / wed_sales2#x), 2) AS round((wed_sales1 / wed_sales2), 2)#x, round((thu_sales1#x / thu_sales2#x), 2) AS round((thu_sales1 / thu_sales2), 2)#x, round((fri_sales1#x / fri_sales2#x), 2) AS round((fri_sales1 / fri_sales2), 2)#x, round((sat_sales1#x / sat_sales2#x), 2) AS round((sat_sales1 / sat_sales2), 2)#x]
+   +- Sort [d_week_seq1#x ASC NULLS FIRST], true
+      +- Filter (d_week_seq1#x = (d_week_seq2#x - 53))
+         +- Join Inner
+            :- SubqueryAlias y
+            :  +- Project [pipeexpression(d_week_seq#x, false, SELECT) AS d_week_seq1#x, pipeexpression(sun_sales#x, false, SELECT) AS sun_sales1#x, pipeexpression(mon_sales#x, false, SELECT) AS mon_sales1#x, pipeexpression(tue_sales#x, false, SELECT) AS tue_sales1#x, pipeexpression(wed_sales#x, false, SELECT) AS wed_sales1#x, pipeexpression(thu_sales#x, false, SELECT) AS thu_sales1#x, pipeexpression(fri_sales#x, false, SELECT) AS fri_sales1#x, pipeexpression(sat_sales#x, false, SELECT) AS sat_sales1#x]
+            :     +- Filter ((d_week_seq#x = d_week_seq#x) AND (d_year#x = 2001))
+            :        +- Join Inner
+            :           :- SubqueryAlias wswscs
+            :           :  +- CTERelationRef xxxx, true, [d_week_seq#x, sun_sales#x, mon_sales#x, tue_sales#x, wed_sales#x, thu_sales#x, fri_sales#x, sat_sales#x], false
+            :           +- SubqueryAlias spark_catalog.default.date_dim
+            :              +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
+            :                 +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
+            +- SubqueryAlias __auto_generated_subquery_name
+               +- SubqueryAlias z
+                  +- Project [pipeexpression(d_week_seq#x, false, SELECT) AS d_week_seq2#x, pipeexpression(sun_sales#x, false, SELECT) AS sun_sales2#x, pipeexpression(mon_sales#x, false, SELECT) AS mon_sales2#x, pipeexpression(tue_sales#x, false, SELECT) AS tue_sales2#x, pipeexpression(wed_sales#x, false, SELECT) AS wed_sales2#x, pipeexpression(thu_sales#x, false, SELECT) AS thu_sales2#x, pipeexpression(fri_sales#x, false, SELECT) AS fri_sales2#x, pipeexpression(sat_sales#x, false, SELECT) AS sat_sales2#x]
+                     +- Filter ((d_week_seq#x = d_week_seq#x) AND (d_year#x = (2001 + 1)))
+                        +- Join Inner
+                           :- SubqueryAlias wswscs
+                           :  +- CTERelationRef xxxx, true, [d_week_seq#x, sun_sales#x, mon_sales#x, tue_sales#x, wed_sales#x, thu_sales#x, fri_sales#x, sat_sales#x], false
+                           +- SubqueryAlias spark_catalog.default.date_dim
+                              +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
+                                 +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
+
+
+-- !query
 drop table t
 -- !query analysis
 DropTable false, false
@@ -3381,3 +4530,171 @@ drop table st
 -- !query analysis
 DropTable false, false
 +- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.st
+
+
+-- !query
+drop table call_center
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.call_center
+
+
+-- !query
+drop table catalog_page
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.catalog_page
+
+
+-- !query
+drop table catalog_returns
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.catalog_returns
+
+
+-- !query
+drop table catalog_sales
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.catalog_sales
+
+
+-- !query
+drop table customer
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.customer
+
+
+-- !query
+drop table customer_address
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.customer_address
+
+
+-- !query
+drop table customer_demographics
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.customer_demographics
+
+
+-- !query
+drop table date_dim
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.date_dim
+
+
+-- !query
+drop table household_demographics
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.household_demographics
+
+
+-- !query
+drop table income_band
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.income_band
+
+
+-- !query
+drop table inventory
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.inventory
+
+
+-- !query
+drop table item
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.item
+
+
+-- !query
+drop table promotion
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.promotion
+
+
+-- !query
+drop table reason
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.reason
+
+
+-- !query
+drop table ship_mode
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.ship_mode
+
+
+-- !query
+drop table store
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.store
+
+
+-- !query
+drop table store_returns
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.store_returns
+
+
+-- !query
+drop table store_sales
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.store_sales
+
+
+-- !query
+drop table time_dim
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.time_dim
+
+
+-- !query
+drop table warehouse
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.warehouse
+
+
+-- !query
+drop table web_page
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.web_page
+
+
+-- !query
+drop table web_returns
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.web_returns
+
+
+-- !query
+drop table web_sales
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.web_sales
+
+
+-- !query
+drop table web_site
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.web_site

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -4634,7 +4634,7 @@ table web_sales
      and (cast('1999-02-22' as date) + interval 30 days)
 |> aggregate sum(ws_ext_sales_price) AS itemrevenue
      group by i_item_id, i_item_desc, i_category, i_class, i_current_price
-|> select *,
+|> extend
      itemrevenue * 100 / sum(itemrevenue)
        over (partition by i_class) as revenueratio
 |> order by i_category, i_class, i_item_id, i_item_desc, revenueratio
@@ -4648,7 +4648,7 @@ GlobalLimit 100
          +- Sort [i_category#x ASC NULLS FIRST, i_class#x ASC NULLS FIRST, i_item_id#x ASC NULLS FIRST, i_item_desc#x ASC NULLS FIRST, revenueratio#x ASC NULLS FIRST], true
             +- SubqueryAlias __auto_generated_subquery_name
                +- Project [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x, revenueratio#x]
-                  +- Project [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x, _we0#x, pipeexpression(((itemrevenue#x * cast(100 as decimal(3,0))) / _we0#x), false, SELECT) AS revenueratio#x]
+                  +- Project [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x, _we0#x, pipeexpression(((itemrevenue#x * cast(100 as decimal(3,0))) / _we0#x), false, EXTEND) AS revenueratio#x]
                      +- Window [sum(itemrevenue#x) windowspecdefinition(i_class#x, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#x], [i_class#x]
                         +- Project [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x]
                            +- Aggregate [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x], [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x, pipeexpression(sum(ws_ext_sales_price#x), true, AGGREGATE) AS itemrevenue#x]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -266,575 +266,6 @@ CreateViewCommand `windowTestData`, select * from values
 
 
 -- !query
-create table store_sales(
-  `ss_sold_date_sk` int,
-  `ss_sold_time_sk` int,
-  `ss_item_sk` int,
-  `ss_customer_sk` int,
-  `ss_cdemo_sk` int,
-  `ss_hdemo_sk` int,
-  `ss_addr_sk` int,
-  `ss_store_sk` int,
-  `ss_promo_sk` int,
-  `ss_ticket_number` int,
-  `ss_quantity` int,
-  `ss_wholesale_cost` decimal(7,2),
-  `ss_list_price` decimal(7,2),
-  `ss_sales_price` decimal(7,2),
-  `ss_ext_discount_amt` decimal(7,2),
-  `ss_ext_sales_price` decimal(7,2),
-  `ss_ext_wholesale_cost` decimal(7,2),
-  `ss_ext_list_price` decimal(7,2),
-  `ss_ext_tax` decimal(7,2),
-  `ss_coupon_amt` decimal(7,2),
-  `ss_net_paid` decimal(7,2),
-  `ss_net_paid_inc_tax` decimal(7,2),
-  `ss_net_profit` decimal(7,2))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`store_sales`, false
-
-
--- !query
-create table store_returns(
-  `sr_returned_date_sk` int,
-  `sr_return_time_sk` int,
-  `sr_item_sk` int,
-  `sr_customer_sk` int,
-  `sr_cdemo_sk` int,
-  `sr_hdemo_sk` int,
-  `sr_addr_sk` int,
-  `sr_store_sk` int,
-  `sr_reason_sk` int,
-  `sr_ticket_number` int,
-  `sr_return_quantity` int,
-  `sr_return_amt` decimal(7,2),
-  `sr_return_tax` decimal(7,2),
-  `sr_return_amt_inc_tax` decimal(7,2),
-  `sr_fee` decimal(7,2),
-  `sr_return_ship_cost` decimal(7,2),
-  `sr_refunded_cash` decimal(7,2),
-  `sr_reversed_charge` decimal(7,2),
-  `sr_store_credit` decimal(7,2),
-  `sr_net_loss` decimal(7,2))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`store_returns`, false
-
-
--- !query
-create table catalog_sales(
-  `cs_sold_date_sk` int,
-  `cs_sold_time_sk` int,
-  `cs_ship_date_sk` int,
-  `cs_bill_customer_sk` int,
-  `cs_bill_cdemo_sk` int,
-  `cs_bill_hdemo_sk` int,
-  `cs_bill_addr_sk` int,
-  `cs_ship_customer_sk` int,
-  `cs_ship_cdemo_sk` int,
-  `cs_ship_hdemo_sk` int,
-  `cs_ship_addr_sk` int,
-  `cs_call_center_sk` int,
-  `cs_catalog_page_sk` int,
-  `cs_ship_mode_sk` int,
-  `cs_warehouse_sk` int,
-  `cs_item_sk` int,
-  `cs_promo_sk` int,
-  `cs_order_number` int,
-  `cs_quantity` int,
-  `cs_wholesale_cost` decimal(7,2),
-  `cs_list_price` decimal(7,2),
-  `cs_sales_price` decimal(7,2),
-  `cs_ext_discount_amt` decimal(7,2),
-  `cs_ext_sales_price` decimal(7,2),
-  `cs_ext_wholesale_cost` decimal(7,2),
-  `cs_ext_list_price` decimal(7,2),
-  `cs_ext_tax` decimal(7,2),
-  `cs_coupon_amt` decimal(7,2),
-  `cs_ext_ship_cost` decimal(7,2),
-  `cs_net_paid` decimal(7,2),
-  `cs_net_paid_inc_tax` decimal(7,2),
-  `cs_net_paid_inc_ship` decimal(7,2),
-  `cs_net_paid_inc_ship_tax` decimal(7,2),
-  `cs_net_profit` decimal(7,2))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`catalog_sales`, false
-
-
--- !query
-create table catalog_returns(
-  `cr_returned_date_sk` int,
-  `cr_returned_time_sk` int,
-  `cr_item_sk` int,
-  `cr_refunded_customer_sk` int,
-  `cr_refunded_cdemo_sk` int,
-  `cr_refunded_hdemo_sk` int,
-  `cr_refunded_addr_sk` int,
-  `cr_returning_customer_sk` int,
-  `cr_returning_cdemo_sk` int,
-  `cr_returning_hdemo_sk` int,
-  `cr_returning_addr_sk` int,
-  `cr_call_center_sk` int,
-  `cr_catalog_page_sk` int,
-  `cr_ship_mode_sk` int,
-  `cr_warehouse_sk` int,
-  `cr_reason_sk` int,
-  `cr_order_number` int,
-  `cr_return_quantity` int,
-  `cr_return_amount` decimal(7,2),
-  `cr_return_tax` decimal(7,2),
-  `cr_return_amt_inc_tax` decimal(7,2),
-  `cr_fee` decimal(7,2),
-  `cr_return_ship_cost` decimal(7,2),
-  `cr_refunded_cash` decimal(7,2),
-  `cr_reversed_charge` decimal(7,2),
-  `cr_store_credit` decimal(7,2),
-  `cr_net_loss` decimal(7,2))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`catalog_returns`, false
-
-
--- !query
-create table web_sales(
-  `ws_sold_date_sk` int,
-  `ws_sold_time_sk` int,
-  `ws_ship_date_sk` int,
-  `ws_item_sk` int,
-  `ws_bill_customer_sk` int,
-  `ws_bill_cdemo_sk` int,
-  `ws_bill_hdemo_sk` int,
-  `ws_bill_addr_sk` int,
-  `ws_ship_customer_sk` int,
-  `ws_ship_cdemo_sk` int,
-  `ws_ship_hdemo_sk` int,
-  `ws_ship_addr_sk` int,
-  `ws_web_page_sk` int,
-  `ws_web_site_sk` int,
-  `ws_ship_mode_sk` int,
-  `ws_warehouse_sk` int,
-  `ws_promo_sk` int,
-  `ws_order_number` int,
-  `ws_quantity` int,
-  `ws_wholesale_cost` decimal(7,2),
-  `ws_list_price` decimal(7,2),
-  `ws_sales_price` decimal(7,2),
-  `ws_ext_discount_amt` decimal(7,2),
-  `ws_ext_sales_price` decimal(7,2),
-  `ws_ext_wholesale_cost` decimal(7,2),
-  `ws_ext_list_price` decimal(7,2),
-  `ws_ext_tax` decimal(7,2),
-  `ws_coupon_amt` decimal(7,2),
-  `ws_ext_ship_cost` decimal(7,2),
-  `ws_net_paid` decimal(7,2),
-  `ws_net_paid_inc_tax` decimal(7,2),
-  `ws_net_paid_inc_ship` decimal(7,2),
-  `ws_net_paid_inc_ship_tax` decimal(7,2),
-  `ws_net_profit` decimal(7,2))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`web_sales`, false
-
-
--- !query
-create table web_returns(
-  `wr_returned_date_sk` int,
-  `wr_returned_time_sk` int,
-  `wr_item_sk` int,
-  `wr_refunded_customer_sk` int,
-  `wr_refunded_cdemo_sk` int,
-  `wr_refunded_hdemo_sk` int,
-  `wr_refunded_addr_sk` int,
-  `wr_returning_customer_sk` int,
-  `wr_returning_cdemo_sk` int,
-  `wr_returning_hdemo_sk` int,
-  `wr_returning_addr_sk` int,
-  `wr_web_page_sk` int,
-  `wr_reason_sk` int,
-  `wr_order_number` int,
-  `wr_return_quantity` int,
-  `wr_return_amt` decimal(7,2),
-  `wr_return_tax` decimal(7,2),
-  `wr_return_amt_inc_tax` decimal(7,2),
-  `wr_fee` decimal(7,2),
-  `wr_return_ship_cost` decimal(7,2),
-  `wr_refunded_cash` decimal(7,2),
-  `wr_reversed_charge` decimal(7,2),
-  `wr_account_credit` decimal(7,2),
-  `wr_net_loss` decimal(7,2))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`web_returns`, false
-
-
--- !query
-create table inventory(
-  `inv_date_sk` int,
-  `inv_item_sk` int,
-  `inv_warehouse_sk` int,
-  `inv_quantity_on_hand` int)
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`inventory`, false
-
-
--- !query
-create table store(
-  `s_store_sk` int,
-  `s_store_id` char(16),
-  `s_rec_start_date` date,
-  `s_rec_end_date` date,
-  `s_closed_date_sk` int,
-  `s_store_name` varchar(50),
-  `s_number_employees` int,
-  `s_floor_space` int,
-  `s_hours` char(20),
-  `s_manager` varchar(40),
-  `s_market_id` int,
-  `s_geography_class` varchar(100),
-  `s_market_desc` varchar(100),
-  `s_market_manager` varchar(40),
-  `s_division_id` int,
-  `s_division_name` varchar(50),
-  `s_company_id` int,
-  `s_company_name` varchar(50),
-  `s_street_number` varchar(10),
-  `s_street_name` varchar(60),
-  `s_street_type` char(15),
-  `s_suite_number` char(10),
-  `s_city` varchar(60),
-  `s_county` varchar(30),
-  `s_state` char(2),
-  `s_zip` char(10),
-  `s_country` varchar(20),
-  `s_gmt_offset` decimal(5,2),
-  `s_tax_percentage` decimal(5,2))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`store`, false
-
-
--- !query
-create table call_center(
-  `cc_call_center_sk` int,
-  `cc_call_center_id` char(16),
-  `cc_rec_start_date` date,
-  `cc_rec_end_date` date,
-  `cc_closed_date_sk` int,
-  `cc_open_date_sk` int,
-  `cc_name` varchar(50),
-  `cc_class` varchar(50),
-  `cc_employees` int,
-  `cc_sq_ft` int,
-  `cc_hours` char(20),
-  `cc_manager` varchar(40),
-  `cc_mkt_id` int,
-  `cc_mkt_class` char(50),
-  `cc_mkt_desc` varchar(100),
-  `cc_market_manager` varchar(40),
-  `cc_division` int,
-  `cc_division_name` varchar(50),
-  `cc_company` int,
-  `cc_company_name` char(50),
-  `cc_street_number` char(10),
-  `cc_street_name` varchar(60),
-  `cc_street_type` char(15),
-  `cc_suite_number` char(10),
-  `cc_city` varchar(60),
-  `cc_county` varchar(30),
-  `cc_state` char(2),
-  `cc_zip` char(10),
-  `cc_country` varchar(20),
-  `cc_gmt_offset` decimal(5,2),
-  `cc_tax_percentage` decimal(5,2))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`call_center`, false
-
-
--- !query
-create table catalog_page(
-  `cp_catalog_page_sk` int,
-  `cp_catalog_page_id` char(16),
-  `cp_start_date_sk` int,
-  `cp_end_date_sk` int,
-  `cp_department` varchar(50),
-  `cp_catalog_number` int,
-  `cp_catalog_page_number` int,
-  `cp_description` varchar(100),
-  `cp_type` varchar(100))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`catalog_page`, false
-
-
--- !query
-create table web_site(
-  `web_site_sk` int,
-  `web_site_id` char(16),
-  `web_rec_start_date` date,
-  `web_rec_end_date` date,
-  `web_name` varchar(50),
-  `web_open_date_sk` int,
-  `web_close_date_sk` int,
-  `web_class` varchar(50),
-  `web_manager` varchar(40),
-  `web_mkt_id` int,
-  `web_mkt_class` varchar(50),
-  `web_mkt_desc` varchar(100),
-  `web_market_manager` varchar(40),
-  `web_company_id` int,
-  `web_company_name` char(50),
-  `web_street_number` char(10),
-  `web_street_name` varchar(60),
-  `web_street_type` char(15),
-  `web_suite_number` char(10),
-  `web_city` varchar(60),
-  `web_county` varchar(30),
-  `web_state` char(2),
-  `web_zip` char(10),
-  `web_country` varchar(20),
-  `web_gmt_offset` decimal(5,2),
-  `web_tax_percentage` decimal(5,2))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`web_site`, false
-
-
--- !query
-create table web_page(
-  `wp_web_page_sk` int,
-  `wp_web_page_id` char(16),
-  `wp_rec_start_date` date,
-  `wp_rec_end_date` date,
-  `wp_creation_date_sk` int,
-  `wp_access_date_sk` int,
-  `wp_autogen_flag` char(1),
-  `wp_customer_sk` int,
-  `wp_url` varchar(100),
-  `wp_type` char(50),
-  `wp_char_count` int,
-  `wp_link_count` int,
-  `wp_image_count` int,
-  `wp_max_ad_count` int)
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`web_page`, false
-
-
--- !query
-create table warehouse(
-  `w_warehouse_sk` int,
-  `w_warehouse_id` char(16),
-  `w_warehouse_name` varchar(20),
-  `w_warehouse_sq_ft` int,
-  `w_street_number` char(10),
-  `w_street_name` varchar(20),
-  `w_street_type` char(15),
-  `w_suite_number` char(10),
-  `w_city` varchar(60),
-  `w_county` varchar(30),
-  `w_state` char(2),
-  `w_zip` char(10),
-  `w_country` varchar(20),
-  `w_gmt_offset` decimal(5,2))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`warehouse`, false
-
-
--- !query
-create table customer(
-  `c_customer_sk` int,
-  `c_customer_id` char(16),
-  `c_current_cdemo_sk` int,
-  `c_current_hdemo_sk` int,
-  `c_current_addr_sk` int,
-  `c_first_shipto_date_sk` int,
-  `c_first_sales_date_sk` int,
-  `c_salutation` char(10),
-  `c_first_name` char(20),
-  `c_last_name` char(30),
-  `c_preferred_cust_flag` char(1),
-  `c_birth_day` int,
-  `c_birth_month` int,
-  `c_birth_year` int,
-  `c_birth_country` varchar(20),
-  `c_login` char(13),
-  `c_email_address` char(50),
-  `c_last_review_date` int)
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`customer`, false
-
-
--- !query
-create table customer_address(
-  `ca_address_sk` int,
-  `ca_address_id` char(16),
-  `ca_street_number` char(10),
-  `ca_street_name` varchar(60),
-  `ca_street_type` char(15),
-  `ca_suite_number` char(10),
-  `ca_city` varchar(60),
-  `ca_county` varchar(30),
-  `ca_state` char(2),
-  `ca_zip` char(10),
-  `ca_country` varchar(20),
-  `ca_gmt_offset` decimal(5,2),
-  `ca_location_type` char(20))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`customer_address`, false
-
-
--- !query
-create table customer_demographics(
-  `cd_demo_sk` int,
-  `cd_gender` char(1),
-  `cd_marital_status` char(1),
-  `cd_education_status` char(20),
-  `cd_purchase_estimate` int,
-  `cd_credit_rating` char(10),
-  `cd_dep_count` int,
-  `cd_dep_employed_count` int,
-  `cd_dep_college_count` int)
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`customer_demographics`, false
-
-
--- !query
-create table date_dim(
-  `d_date_sk` int,
-  `d_date_id` char(16),
-  `d_date` date,
-  `d_month_seq` int,
-  `d_week_seq` int,
-  `d_quarter_seq` int,
-  `d_year` int,
-  `d_dow` int,
-  `d_moy` int,
-  `d_dom` int,
-  `d_qoy` int,
-  `d_fy_year` int,
-  `d_fy_quarter_seq` int,
-  `d_fy_week_seq` int,
-  `d_day_name` char(9),
-  `d_quarter_name` char(6),
-  `d_holiday` char(1),
-  `d_weekend` char(1),
-  `d_following_holiday` char(1),
-  `d_first_dom` int,
-  `d_last_dom` int,
-  `d_same_day_ly` int,
-  `d_same_day_lq` int,
-  `d_current_day` char(1),
-  `d_current_week` char(1),
-  `d_current_month` char(1),
-  `d_current_quarter` char(1),
-  `d_current_year` char(1))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`date_dim`, false
-
-
--- !query
-create table household_demographics(
-  `hd_demo_sk` int,
-  `hd_income_band_sk` int,
-  `hd_buy_potential` char(15),
-  `hd_dep_count` int,
-  `hd_vehicle_count` int)
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`household_demographics`, false
-
-
--- !query
-create table item(
-  `i_item_sk` int,
-  `i_item_id` char(16),
-  `i_rec_start_date` date,
-  `i_rec_end_date` date,
-  `i_item_desc` varchar(200),
-  `i_current_price` decimal(7,2),
-  `i_wholesale_cost` decimal(7,2),
-  `i_brand_id` int,
-  `i_brand` char(50),
-  `i_class_id` int,
-  `i_class` char(50),
-  `i_category_id` int,
-  `i_category` char(50),
-  `i_manufact_id` int,
-  `i_manufact` char(50),
-  `i_size` char(20),
-  `i_formulation` char(20),
-  `i_color` char(20),
-  `i_units` char(10),
-  `i_container` char(10),
-  `i_manager_id` int,
-  `i_product_name` char(50))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`item`, false
-
-
--- !query
-create table income_band(
-  `ib_income_band_sk` int,
-  `ib_lower_bound` int,
-  `ib_upper_bound` int)
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`income_band`, false
-
-
--- !query
-create table promotion(
-  `p_promo_sk` int,
-  `p_promo_id` char(16),
-  `p_start_date_sk` int,
-  `p_end_date_sk` int,
-  `p_item_sk` int,
-  `p_cost` decimal(15,2),
-  `p_response_target` int,
-  `p_promo_name` char(50),
-  `p_channel_dmail` char(1),
-  `p_channel_email` char(1),
-  `p_channel_catalog` char(1),
-  `p_channel_tv` char(1),
-  `p_channel_radio` char(1),
-  `p_channel_press` char(1),
-  `p_channel_event` char(1),
-  `p_channel_demo` char(1),
-  `p_channel_details` varchar(100),
-  `p_purpose` char(15),
-  `p_discount_active` char(1))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`promotion`, false
-
-
--- !query
-create table reason(
-  `r_reason_sk` int,
-  `r_reason_id` char(16),
-  `r_reason_desc` char(100))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`reason`, false
-
-
--- !query
-create table ship_mode(
-  `sm_ship_mode_sk` int,
-  `sm_ship_mode_id` char(16),
-  `sm_type` char(30),
-  `sm_code` char(10),
-  `sm_carrier` char(20),
-  `sm_contract` char(20))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`ship_mode`, false
-
-
--- !query
-create table time_dim(
-  `t_time_sk` int,
-  `t_time_id` char(16),
-  `t_time` int,
-  `t_hour` int,
-  `t_minute` int,
-  `t_second` int,
-  `t_am_pm` char(2),
-  `t_shift` char(20),
-  `t_sub_shift` char(20),
-  `t_meal_time` char(20))
--- !query analysis
-CreateDataSourceTableCommand `spark_catalog`.`default`.`time_dim`, false
-
-
--- !query
 table t
 |> select 1 as x
 -- !query analysis
@@ -1657,14 +1088,26 @@ Project [x#x, y#x]
 
 -- !query
 table t
+|> as `u.v`
+|> select `u.v`.x, `u.v`.y
+-- !query analysis
+Project [x#x, y#x]
++- SubqueryAlias `u.v`
+   +- SubqueryAlias spark_catalog.default.t
+      +- Relation spark_catalog.default.t[x#x,y#x] csv
+
+
+-- !query
+table t
 |> as u
 |> as v
 |> select v.x, v.y
 -- !query analysis
 Project [x#x, y#x]
 +- SubqueryAlias v
-   +- SubqueryAlias spark_catalog.default.t
-      +- Relation spark_catalog.default.t[x#x,y#x] csv
+   +- SubqueryAlias u
+      +- SubqueryAlias spark_catalog.default.t
+         +- Relation spark_catalog.default.t[x#x,y#x] csv
 
 
 -- !query
@@ -1703,6 +1146,50 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "sqlState" : "42601",
   "messageParameters" : {
     "error" : "'1'",
+    "hint" : ""
+  }
+}
+
+
+-- !query
+table t
+|> as u-v
+-- !query analysis
+org.apache.spark.sql.catalyst.parser.ParseException
+{
+  "errorClass" : "INVALID_IDENTIFIER",
+  "sqlState" : "42602",
+  "messageParameters" : {
+    "ident" : "u-v"
+  }
+}
+
+
+-- !query
+table t
+|> as u@v
+-- !query analysis
+org.apache.spark.sql.catalyst.parser.ParseException
+{
+  "errorClass" : "PARSE_SYNTAX_ERROR",
+  "sqlState" : "42601",
+  "messageParameters" : {
+    "error" : "'@'",
+    "hint" : ""
+  }
+}
+
+
+-- !query
+table t
+|> as u#######v
+-- !query analysis
+org.apache.spark.sql.catalyst.parser.ParseException
+{
+  "errorClass" : "PARSE_SYNTAX_ERROR",
+  "sqlState" : "42601",
+  "messageParameters" : {
+    "error" : "'#'",
     "hint" : ""
   }
 }
@@ -4155,38 +3642,21 @@ where ctr1.ctr_total_return >
 order by c_customer_id
 limit 100
 -- !query analysis
-WithCTE
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias customer_total_return
-:     +- Aggregate [sr_customer_sk#x, sr_store_sk#x], [sr_customer_sk#x AS ctr_customer_sk#x, sr_store_sk#x AS ctr_store_sk#x, sum(sr_return_amt#x) AS ctr_total_return#x]
-:        +- Filter ((sr_returned_date_sk#x = d_date_sk#x) AND (d_year#x = 2000))
-:           +- Join Inner
-:              :- SubqueryAlias spark_catalog.default.store_returns
-:              :  +- Relation spark_catalog.default.store_returns[sr_returned_date_sk#x,sr_return_time_sk#x,sr_item_sk#x,sr_customer_sk#x,sr_cdemo_sk#x,sr_hdemo_sk#x,sr_addr_sk#x,sr_store_sk#x,sr_reason_sk#x,sr_ticket_number#x,sr_return_quantity#x,sr_return_amt#x,sr_return_tax#x,sr_return_amt_inc_tax#x,sr_fee#x,sr_return_ship_cost#x,sr_refunded_cash#x,sr_reversed_charge#x,sr_store_credit#x,sr_net_loss#x] parquet
-:              +- SubqueryAlias spark_catalog.default.date_dim
-:                 +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
-:                    +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
-+- GlobalLimit 100
-   +- LocalLimit 100
-      +- Sort [c_customer_id#x ASC NULLS FIRST], true
-         +- Project [c_customer_id#x]
-            +- Filter (((cast(ctr_total_return#x as decimal(24,7)) > scalar-subquery#x [ctr_store_sk#x]) AND (s_store_sk#x = ctr_store_sk#x)) AND ((s_state#x = tn) AND (ctr_customer_sk#x = c_customer_sk#x)))
-               :  +- Aggregate [(avg(ctr_total_return#x) * 1.2) AS (avg(ctr_total_return) * 1.2)#x]
-               :     +- Filter (outer(ctr_store_sk#x) = ctr_store_sk#x)
-               :        +- SubqueryAlias ctr2
-               :           +- SubqueryAlias customer_total_return
-               :              +- CTERelationRef xxxx, true, [ctr_customer_sk#x, ctr_store_sk#x, ctr_total_return#x], false
-               +- Join Inner
-                  :- Join Inner
-                  :  :- SubqueryAlias ctr1
-                  :  :  +- SubqueryAlias customer_total_return
-                  :  :     +- CTERelationRef xxxx, true, [ctr_customer_sk#x, ctr_store_sk#x, ctr_total_return#x], false
-                  :  +- SubqueryAlias spark_catalog.default.store
-                  :     +- Project [s_store_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(s_store_id#x, 16)) AS s_store_id#x, s_rec_start_date#x, s_rec_end_date#x, s_closed_date_sk#x, s_store_name#x, s_number_employees#x, s_floor_space#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(s_hours#x, 20)) AS s_hours#x, s_manager#x, s_market_id#x, s_geography_class#x, s_market_desc#x, s_market_manager#x, s_division_id#x, s_division_name#x, s_company_id#x, s_company_name#x, s_street_number#x, s_street_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(s_street_type#x, 15)) AS s_street_type#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(s_suite_number#x, 10)) AS s_suite_number#x, s_city#x, s_county#x, ... 5 more fields]
-                  :        +- Relation spark_catalog.default.store[s_store_sk#x,s_store_id#x,s_rec_start_date#x,s_rec_end_date#x,s_closed_date_sk#x,s_store_name#x,s_number_employees#x,s_floor_space#x,s_hours#x,s_manager#x,s_market_id#x,s_geography_class#x,s_market_desc#x,s_market_manager#x,s_division_id#x,s_division_name#x,s_company_id#x,s_company_name#x,s_street_number#x,s_street_name#x,s_street_type#x,s_suite_number#x,s_city#x,s_county#x,... 5 more fields] parquet
-                  +- SubqueryAlias spark_catalog.default.customer
-                     +- Project [c_customer_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_customer_id#x, 16)) AS c_customer_id#x, c_current_cdemo_sk#x, c_current_hdemo_sk#x, c_current_addr_sk#x, c_first_shipto_date_sk#x, c_first_sales_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_salutation#x, 10)) AS c_salutation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_first_name#x, 20)) AS c_first_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_last_name#x, 30)) AS c_last_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_preferred_cust_flag#x, 1)) AS c_preferred_cust_flag#x, c_birth_day#x, c_birth_month#x, c_birth_year#x, c_birth_country#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_login#x, 13)) AS c_login#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_email_address#x, 50)) AS c_email_address#x, c_last_review_date#x]
-                        +- Relation spark_catalog.default.customer[c_customer_sk#x,c_customer_id#x,c_current_cdemo_sk#x,c_current_hdemo_sk#x,c_current_addr_sk#x,c_first_shipto_date_sk#x,c_first_sales_date_sk#x,c_salutation#x,c_first_name#x,c_last_name#x,c_preferred_cust_flag#x,c_birth_day#x,c_birth_month#x,c_birth_year#x,c_birth_country#x,c_login#x,c_email_address#x,c_last_review_date#x] parquet
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "TABLE_OR_VIEW_NOT_FOUND",
+  "sqlState" : "42P01",
+  "messageParameters" : {
+    "relationName" : "`store_returns`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 161,
+    "stopIndex" : 173,
+    "fragment" : "store_returns"
+  } ]
+}
 
 
 -- !query
@@ -4212,39 +3682,21 @@ table customer_total_return
 |> limit 100
 |> select c_customer_id
 -- !query analysis
-WithCTE
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias customer_total_return
-:     +- Aggregate [sr_customer_sk#x, sr_store_sk#x], [sr_customer_sk#x AS ctr_customer_sk#x, sr_store_sk#x AS ctr_store_sk#x, pipeexpression(sum(sr_return_amt#x), true, AGGREGATE) AS ctr_total_return#x]
-:        +- Filter ((sr_returned_date_sk#x = d_date_sk#x) AND (d_year#x = 2000))
-:           +- Join Inner
-:              :- SubqueryAlias spark_catalog.default.store_returns
-:              :  +- Relation spark_catalog.default.store_returns[sr_returned_date_sk#x,sr_return_time_sk#x,sr_item_sk#x,sr_customer_sk#x,sr_cdemo_sk#x,sr_hdemo_sk#x,sr_addr_sk#x,sr_store_sk#x,sr_reason_sk#x,sr_ticket_number#x,sr_return_quantity#x,sr_return_amt#x,sr_return_tax#x,sr_return_amt_inc_tax#x,sr_fee#x,sr_return_ship_cost#x,sr_refunded_cash#x,sr_reversed_charge#x,sr_store_credit#x,sr_net_loss#x] parquet
-:              +- SubqueryAlias spark_catalog.default.date_dim
-:                 +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
-:                    +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
-+- Project [c_customer_id#x]
-   +- GlobalLimit 100
-      +- LocalLimit 100
-         +- SubqueryAlias __auto_generated_subquery_name
-            +- Sort [c_customer_id#x ASC NULLS FIRST], true
-               +- Filter (((cast(ctr_total_return#x as decimal(24,7)) > scalar-subquery#x [ctr_store_sk#x]) AND (s_store_sk#x = ctr_store_sk#x)) AND ((s_state#x = tn) AND (ctr_customer_sk#x = c_customer_sk#x)))
-                  :  +- Aggregate [pipeexpression((avg(ctr_total_return#x) * 1.2), true, AGGREGATE) AS pipeexpression((avg(ctr_total_return) * 1.2))#x]
-                  :     +- Filter (outer(ctr_store_sk#x) = ctr_store_sk#x)
-                  :        +- SubqueryAlias ctr2
-                  :           +- SubqueryAlias customer_total_return
-                  :              +- CTERelationRef xxxx, true, [ctr_customer_sk#x, ctr_store_sk#x, ctr_total_return#x], false
-                  +- Join Inner
-                     :- Join Inner
-                     :  :- SubqueryAlias ctr1
-                     :  :  +- SubqueryAlias customer_total_return
-                     :  :     +- CTERelationRef xxxx, true, [ctr_customer_sk#x, ctr_store_sk#x, ctr_total_return#x], false
-                     :  +- SubqueryAlias spark_catalog.default.store
-                     :     +- Project [s_store_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(s_store_id#x, 16)) AS s_store_id#x, s_rec_start_date#x, s_rec_end_date#x, s_closed_date_sk#x, s_store_name#x, s_number_employees#x, s_floor_space#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(s_hours#x, 20)) AS s_hours#x, s_manager#x, s_market_id#x, s_geography_class#x, s_market_desc#x, s_market_manager#x, s_division_id#x, s_division_name#x, s_company_id#x, s_company_name#x, s_street_number#x, s_street_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(s_street_type#x, 15)) AS s_street_type#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(s_suite_number#x, 10)) AS s_suite_number#x, s_city#x, s_county#x, ... 5 more fields]
-                     :        +- Relation spark_catalog.default.store[s_store_sk#x,s_store_id#x,s_rec_start_date#x,s_rec_end_date#x,s_closed_date_sk#x,s_store_name#x,s_number_employees#x,s_floor_space#x,s_hours#x,s_manager#x,s_market_id#x,s_geography_class#x,s_market_desc#x,s_market_manager#x,s_division_id#x,s_division_name#x,s_company_id#x,s_company_name#x,s_street_number#x,s_street_name#x,s_street_type#x,s_suite_number#x,s_city#x,s_county#x,... 5 more fields] parquet
-                     +- SubqueryAlias spark_catalog.default.customer
-                        +- Project [c_customer_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_customer_id#x, 16)) AS c_customer_id#x, c_current_cdemo_sk#x, c_current_hdemo_sk#x, c_current_addr_sk#x, c_first_shipto_date_sk#x, c_first_sales_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_salutation#x, 10)) AS c_salutation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_first_name#x, 20)) AS c_first_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_last_name#x, 30)) AS c_last_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_preferred_cust_flag#x, 1)) AS c_preferred_cust_flag#x, c_birth_day#x, c_birth_month#x, c_birth_year#x, c_birth_country#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_login#x, 13)) AS c_login#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(c_email_address#x, 50)) AS c_email_address#x, c_last_review_date#x]
-                           +- Relation spark_catalog.default.customer[c_customer_sk#x,c_customer_id#x,c_current_cdemo_sk#x,c_current_hdemo_sk#x,c_current_addr_sk#x,c_first_shipto_date_sk#x,c_first_sales_date_sk#x,c_salutation#x,c_first_name#x,c_last_name#x,c_preferred_cust_flag#x,c_birth_day#x,c_birth_month#x,c_birth_year#x,c_birth_country#x,c_login#x,c_email_address#x,c_last_review_date#x] parquet
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "TABLE_OR_VIEW_NOT_FOUND",
+  "sqlState" : "42P01",
+  "messageParameters" : {
+    "relationName" : "`store_returns`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 40,
+    "stopIndex" : 52,
+    "fragment" : "store_returns"
+  } ]
+}
 
 
 -- !query
@@ -4330,50 +3782,21 @@ from
 where d_week_seq1 = d_week_seq2 - 53
 order by d_week_seq1
 -- !query analysis
-WithCTE
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias wscs
-:     +- Union false, false
-:        :- Project [sold_date_sk#x, sales_price#x]
-:        :  +- SubqueryAlias x
-:        :     +- Project [ws_sold_date_sk#x AS sold_date_sk#x, ws_ext_sales_price#x AS sales_price#x]
-:        :        +- SubqueryAlias spark_catalog.default.web_sales
-:        :           +- Relation spark_catalog.default.web_sales[ws_sold_date_sk#x,ws_sold_time_sk#x,ws_ship_date_sk#x,ws_item_sk#x,ws_bill_customer_sk#x,ws_bill_cdemo_sk#x,ws_bill_hdemo_sk#x,ws_bill_addr_sk#x,ws_ship_customer_sk#x,ws_ship_cdemo_sk#x,ws_ship_hdemo_sk#x,ws_ship_addr_sk#x,ws_web_page_sk#x,ws_web_site_sk#x,ws_ship_mode_sk#x,ws_warehouse_sk#x,ws_promo_sk#x,ws_order_number#x,ws_quantity#x,ws_wholesale_cost#x,ws_list_price#x,ws_sales_price#x,ws_ext_discount_amt#x,ws_ext_sales_price#x,... 10 more fields] parquet
-:        +- Project [cs_sold_date_sk#x AS sold_date_sk#x, cs_ext_sales_price#x AS sales_price#x]
-:           +- SubqueryAlias spark_catalog.default.catalog_sales
-:              +- Relation spark_catalog.default.catalog_sales[cs_sold_date_sk#x,cs_sold_time_sk#x,cs_ship_date_sk#x,cs_bill_customer_sk#x,cs_bill_cdemo_sk#x,cs_bill_hdemo_sk#x,cs_bill_addr_sk#x,cs_ship_customer_sk#x,cs_ship_cdemo_sk#x,cs_ship_hdemo_sk#x,cs_ship_addr_sk#x,cs_call_center_sk#x,cs_catalog_page_sk#x,cs_ship_mode_sk#x,cs_warehouse_sk#x,cs_item_sk#x,cs_promo_sk#x,cs_order_number#x,cs_quantity#x,cs_wholesale_cost#x,cs_list_price#x,cs_sales_price#x,cs_ext_discount_amt#x,cs_ext_sales_price#x,... 10 more fields] parquet
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias wswscs
-:     +- Aggregate [d_week_seq#x], [d_week_seq#x, sum(CASE WHEN (d_day_name#x = rpad(sunday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END) AS sun_sales#x, sum(CASE WHEN (d_day_name#x = rpad(monday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END) AS mon_sales#x, sum(CASE WHEN (d_day_name#x = rpad(tuesday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END) AS tue_sales#x, sum(CASE WHEN (d_day_name#x = wednesday) THEN sales_price#x ELSE cast(null as decimal(7,2)) END) AS wed_sales#x, sum(CASE WHEN (d_day_name#x = rpad(thursday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END) AS thu_sales#x, sum(CASE WHEN (d_day_name#x = rpad(friday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END) AS fri_sales#x, sum(CASE WHEN (d_day_name#x = rpad(saturday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END) AS sat_sales#x]
-:        +- Filter (d_date_sk#x = sold_date_sk#x)
-:           +- Join Inner
-:              :- SubqueryAlias wscs
-:              :  +- CTERelationRef xxxx, true, [sold_date_sk#x, sales_price#x], false
-:              +- SubqueryAlias spark_catalog.default.date_dim
-:                 +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
-:                    +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
-+- Sort [d_week_seq1#x ASC NULLS FIRST], true
-   +- Project [d_week_seq1#x, round((sun_sales1#x / sun_sales2#x), 2) AS round((sun_sales1 / sun_sales2), 2)#x, round((mon_sales1#x / mon_sales2#x), 2) AS round((mon_sales1 / mon_sales2), 2)#x, round((tue_sales1#x / tue_sales2#x), 2) AS round((tue_sales1 / tue_sales2), 2)#x, round((wed_sales1#x / wed_sales2#x), 2) AS round((wed_sales1 / wed_sales2), 2)#x, round((thu_sales1#x / thu_sales2#x), 2) AS round((thu_sales1 / thu_sales2), 2)#x, round((fri_sales1#x / fri_sales2#x), 2) AS round((fri_sales1 / fri_sales2), 2)#x, round((sat_sales1#x / sat_sales2#x), 2) AS round((sat_sales1 / sat_sales2), 2)#x]
-      +- Filter (d_week_seq1#x = (d_week_seq2#x - 53))
-         +- Join Inner
-            :- SubqueryAlias y
-            :  +- Project [d_week_seq#x AS d_week_seq1#x, sun_sales#x AS sun_sales1#x, mon_sales#x AS mon_sales1#x, tue_sales#x AS tue_sales1#x, wed_sales#x AS wed_sales1#x, thu_sales#x AS thu_sales1#x, fri_sales#x AS fri_sales1#x, sat_sales#x AS sat_sales1#x]
-            :     +- Filter ((d_week_seq#x = d_week_seq#x) AND (d_year#x = 2001))
-            :        +- Join Inner
-            :           :- SubqueryAlias wswscs
-            :           :  +- CTERelationRef xxxx, true, [d_week_seq#x, sun_sales#x, mon_sales#x, tue_sales#x, wed_sales#x, thu_sales#x, fri_sales#x, sat_sales#x], false
-            :           +- SubqueryAlias spark_catalog.default.date_dim
-            :              +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
-            :                 +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
-            +- SubqueryAlias z
-               +- Project [d_week_seq#x AS d_week_seq2#x, sun_sales#x AS sun_sales2#x, mon_sales#x AS mon_sales2#x, tue_sales#x AS tue_sales2#x, wed_sales#x AS wed_sales2#x, thu_sales#x AS thu_sales2#x, fri_sales#x AS fri_sales2#x, sat_sales#x AS sat_sales2#x]
-                  +- Filter ((d_week_seq#x = d_week_seq#x) AND (d_year#x = (2001 + 1)))
-                     +- Join Inner
-                        :- SubqueryAlias wswscs
-                        :  +- CTERelationRef xxxx, true, [d_week_seq#x, sun_sales#x, mon_sales#x, tue_sales#x, wed_sales#x, thu_sales#x, fri_sales#x, sat_sales#x], false
-                        +- SubqueryAlias spark_catalog.default.date_dim
-                           +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
-                              +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "TABLE_OR_VIEW_NOT_FOUND",
+  "sqlState" : "42P01",
+  "messageParameters" : {
+    "relationName" : "`web_sales`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 148,
+    "stopIndex" : 156,
+    "fragment" : "web_sales"
+  } ]
+}
 
 
 -- !query
@@ -4464,51 +3887,21 @@ table wswscs
      round(fri_sales1 / fri_sales2, 2),
      round(sat_sales1 / sat_sales2, 2)
 -- !query analysis
-WithCTE
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias wscs
-:     +- Union false, false
-:        :- SubqueryAlias x
-:        :  +- Project [pipeexpression(ws_sold_date_sk#x, false, SELECT) AS sold_date_sk#x, pipeexpression(ws_ext_sales_price#x, false, SELECT) AS sales_price#x]
-:        :     +- SubqueryAlias spark_catalog.default.web_sales
-:        :        +- Relation spark_catalog.default.web_sales[ws_sold_date_sk#x,ws_sold_time_sk#x,ws_ship_date_sk#x,ws_item_sk#x,ws_bill_customer_sk#x,ws_bill_cdemo_sk#x,ws_bill_hdemo_sk#x,ws_bill_addr_sk#x,ws_ship_customer_sk#x,ws_ship_cdemo_sk#x,ws_ship_hdemo_sk#x,ws_ship_addr_sk#x,ws_web_page_sk#x,ws_web_site_sk#x,ws_ship_mode_sk#x,ws_warehouse_sk#x,ws_promo_sk#x,ws_order_number#x,ws_quantity#x,ws_wholesale_cost#x,ws_list_price#x,ws_sales_price#x,ws_ext_discount_amt#x,ws_ext_sales_price#x,... 10 more fields] parquet
-:        +- Project [sold_date_sk#x, sales_price#x]
-:           +- Project [pipeexpression(cs_sold_date_sk#x, false, SELECT) AS sold_date_sk#x, pipeexpression(cs_ext_sales_price#x, false, SELECT) AS sales_price#x]
-:              +- SubqueryAlias spark_catalog.default.catalog_sales
-:                 +- Relation spark_catalog.default.catalog_sales[cs_sold_date_sk#x,cs_sold_time_sk#x,cs_ship_date_sk#x,cs_bill_customer_sk#x,cs_bill_cdemo_sk#x,cs_bill_hdemo_sk#x,cs_bill_addr_sk#x,cs_ship_customer_sk#x,cs_ship_cdemo_sk#x,cs_ship_hdemo_sk#x,cs_ship_addr_sk#x,cs_call_center_sk#x,cs_catalog_page_sk#x,cs_ship_mode_sk#x,cs_warehouse_sk#x,cs_item_sk#x,cs_promo_sk#x,cs_order_number#x,cs_quantity#x,cs_wholesale_cost#x,cs_list_price#x,cs_sales_price#x,cs_ext_discount_amt#x,cs_ext_sales_price#x,... 10 more fields] parquet
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias wswscs
-:     +- Aggregate [d_week_seq#x], [d_week_seq#x, pipeexpression(sum(CASE WHEN (d_day_name#x = rpad(sunday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END), true, AGGREGATE) AS sun_sales#x, pipeexpression(sum(CASE WHEN (d_day_name#x = rpad(monday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END), true, AGGREGATE) AS mon_sales#x, pipeexpression(sum(CASE WHEN (d_day_name#x = rpad(tuesday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END), true, AGGREGATE) AS tue_sales#x, pipeexpression(sum(CASE WHEN (d_day_name#x = wednesday) THEN sales_price#x ELSE cast(null as decimal(7,2)) END), true, AGGREGATE) AS wed_sales#x, pipeexpression(sum(CASE WHEN (d_day_name#x = rpad(thursday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END), true, AGGREGATE) AS thu_sales#x, pipeexpression(sum(CASE WHEN (d_day_name#x = rpad(friday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END), true, AGGREGATE) AS fri_sales#x, pipeexpression(sum(CASE WHEN (d_day_name#x = rpad(saturday, 9,  )) THEN sales_price#x ELSE cast(null as decimal(7,2)) END), true, AGGREGATE) AS sat_sales#x]
-:        +- Filter (d_date_sk#x = sold_date_sk#x)
-:           +- Join Inner
-:              :- SubqueryAlias wscs
-:              :  +- CTERelationRef xxxx, true, [sold_date_sk#x, sales_price#x], false
-:              +- SubqueryAlias spark_catalog.default.date_dim
-:                 +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
-:                    +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
-+- Project [d_week_seq1#x, round((sun_sales1#x / sun_sales2#x), 2) AS round((sun_sales1 / sun_sales2), 2)#x, round((mon_sales1#x / mon_sales2#x), 2) AS round((mon_sales1 / mon_sales2), 2)#x, round((tue_sales1#x / tue_sales2#x), 2) AS round((tue_sales1 / tue_sales2), 2)#x, round((wed_sales1#x / wed_sales2#x), 2) AS round((wed_sales1 / wed_sales2), 2)#x, round((thu_sales1#x / thu_sales2#x), 2) AS round((thu_sales1 / thu_sales2), 2)#x, round((fri_sales1#x / fri_sales2#x), 2) AS round((fri_sales1 / fri_sales2), 2)#x, round((sat_sales1#x / sat_sales2#x), 2) AS round((sat_sales1 / sat_sales2), 2)#x]
-   +- Sort [d_week_seq1#x ASC NULLS FIRST], true
-      +- Filter (d_week_seq1#x = (d_week_seq2#x - 53))
-         +- Join Inner
-            :- SubqueryAlias y
-            :  +- Project [pipeexpression(d_week_seq#x, false, SELECT) AS d_week_seq1#x, pipeexpression(sun_sales#x, false, SELECT) AS sun_sales1#x, pipeexpression(mon_sales#x, false, SELECT) AS mon_sales1#x, pipeexpression(tue_sales#x, false, SELECT) AS tue_sales1#x, pipeexpression(wed_sales#x, false, SELECT) AS wed_sales1#x, pipeexpression(thu_sales#x, false, SELECT) AS thu_sales1#x, pipeexpression(fri_sales#x, false, SELECT) AS fri_sales1#x, pipeexpression(sat_sales#x, false, SELECT) AS sat_sales1#x]
-            :     +- Filter ((d_week_seq#x = d_week_seq#x) AND (d_year#x = 2001))
-            :        +- Join Inner
-            :           :- SubqueryAlias wswscs
-            :           :  +- CTERelationRef xxxx, true, [d_week_seq#x, sun_sales#x, mon_sales#x, tue_sales#x, wed_sales#x, thu_sales#x, fri_sales#x, sat_sales#x], false
-            :           +- SubqueryAlias spark_catalog.default.date_dim
-            :              +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
-            :                 +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
-            +- SubqueryAlias __auto_generated_subquery_name
-               +- SubqueryAlias z
-                  +- Project [pipeexpression(d_week_seq#x, false, SELECT) AS d_week_seq2#x, pipeexpression(sun_sales#x, false, SELECT) AS sun_sales2#x, pipeexpression(mon_sales#x, false, SELECT) AS mon_sales2#x, pipeexpression(tue_sales#x, false, SELECT) AS tue_sales2#x, pipeexpression(wed_sales#x, false, SELECT) AS wed_sales2#x, pipeexpression(thu_sales#x, false, SELECT) AS thu_sales2#x, pipeexpression(fri_sales#x, false, SELECT) AS fri_sales2#x, pipeexpression(sat_sales#x, false, SELECT) AS sat_sales2#x]
-                     +- Filter ((d_week_seq#x = d_week_seq#x) AND (d_year#x = (2001 + 1)))
-                        +- Join Inner
-                           :- SubqueryAlias wswscs
-                           :  +- CTERelationRef xxxx, true, [d_week_seq#x, sun_sales#x, mon_sales#x, tue_sales#x, wed_sales#x, thu_sales#x, fri_sales#x, sat_sales#x], false
-                           +- SubqueryAlias spark_catalog.default.date_dim
-                              +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
-                                 +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "TABLE_OR_VIEW_NOT_FOUND",
+  "sqlState" : "42P01",
+  "messageParameters" : {
+    "relationName" : "`web_sales`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 23,
+    "stopIndex" : 31,
+    "fragment" : "web_sales"
+  } ]
+}
 
 
 -- !query
@@ -4526,22 +3919,21 @@ group by dt.d_year, item.i_brand, item.i_brand_id
 order by dt.d_year, sum_agg desc, brand_id
 limit 100
 -- !query analysis
-GlobalLimit 100
-+- LocalLimit 100
-   +- Sort [d_year#x ASC NULLS FIRST, sum_agg#x DESC NULLS LAST, brand_id#x ASC NULLS FIRST], true
-      +- Aggregate [d_year#x, i_brand#x, i_brand_id#x], [d_year#x, i_brand_id#x AS brand_id#x, i_brand#x AS brand#x, sum(ss_ext_sales_price#x) AS sum_agg#x]
-         +- Filter (((d_date_sk#x = ss_sold_date_sk#x) AND (ss_item_sk#x = i_item_sk#x)) AND ((i_manufact_id#x = 128) AND (d_moy#x = 11)))
-            +- Join Inner
-               :- Join Inner
-               :  :- SubqueryAlias dt
-               :  :  +- SubqueryAlias spark_catalog.default.date_dim
-               :  :     +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
-               :  :        +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
-               :  +- SubqueryAlias spark_catalog.default.store_sales
-               :     +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
-               +- SubqueryAlias spark_catalog.default.item
-                  +- Project [i_item_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_item_id#x, 16)) AS i_item_id#x, i_rec_start_date#x, i_rec_end_date#x, i_item_desc#x, i_current_price#x, i_wholesale_cost#x, i_brand_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_brand#x, 50)) AS i_brand#x, i_class_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_class#x, 50)) AS i_class#x, i_category_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_category#x, 50)) AS i_category#x, i_manufact_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_manufact#x, 50)) AS i_manufact#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_size#x, 20)) AS i_size#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_formulation#x, 20)) AS i_formulation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_color#x, 20)) AS i_color#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_units#x, 10)) AS i_units#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_container#x, 10)) AS i_container#x, i_manager_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_product_name#x, 50)) AS i_product_name#x]
-                     +- Relation spark_catalog.default.item[i_item_sk#x,i_item_id#x,i_rec_start_date#x,i_rec_end_date#x,i_item_desc#x,i_current_price#x,i_wholesale_cost#x,i_brand_id#x,i_brand#x,i_class_id#x,i_class#x,i_category_id#x,i_category#x,i_manufact_id#x,i_manufact#x,i_size#x,i_formulation#x,i_color#x,i_units#x,i_container#x,i_manager_id#x,i_product_name#x] parquet
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "TABLE_OR_VIEW_NOT_FOUND",
+  "sqlState" : "42P01",
+  "messageParameters" : {
+    "relationName" : "`date_dim`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 110,
+    "stopIndex" : 117,
+    "fragment" : "date_dim"
+  } ]
+}
 
 
 -- !query
@@ -4558,24 +3950,21 @@ table date_dim
 |> order by d_year, sum_agg desc, brand_id
 |> limit 100
 -- !query analysis
-GlobalLimit 100
-+- LocalLimit 100
-   +- SubqueryAlias __auto_generated_subquery_name
-      +- Sort [d_year#x ASC NULLS FIRST, sum_agg#x DESC NULLS LAST, brand_id#x ASC NULLS FIRST], true
-         +- SubqueryAlias __auto_generated_subquery_name
-            +- Aggregate [d_year#x, i_brand_id#x, i_brand#x], [d_year#x AS d_year#x, i_brand_id#x AS brand_id#x, i_brand#x AS brand#x, pipeexpression(sum(ss_ext_sales_price#x), true, AGGREGATE) AS sum_agg#x]
-               +- Filter (((d_date_sk#x = ss_sold_date_sk#x) AND (ss_item_sk#x = i_item_sk#x)) AND ((i_manufact_id#x = 128) AND (d_moy#x = 11)))
-                  +- Join Inner
-                     :- Join Inner
-                     :  :- SubqueryAlias dt
-                     :  :  +- SubqueryAlias spark_catalog.default.date_dim
-                     :  :     +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
-                     :  :        +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
-                     :  +- SubqueryAlias spark_catalog.default.store_sales
-                     :     +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
-                     +- SubqueryAlias spark_catalog.default.item
-                        +- Project [i_item_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_item_id#x, 16)) AS i_item_id#x, i_rec_start_date#x, i_rec_end_date#x, i_item_desc#x, i_current_price#x, i_wholesale_cost#x, i_brand_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_brand#x, 50)) AS i_brand#x, i_class_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_class#x, 50)) AS i_class#x, i_category_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_category#x, 50)) AS i_category#x, i_manufact_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_manufact#x, 50)) AS i_manufact#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_size#x, 20)) AS i_size#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_formulation#x, 20)) AS i_formulation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_color#x, 20)) AS i_color#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_units#x, 10)) AS i_units#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_container#x, 10)) AS i_container#x, i_manager_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_product_name#x, 50)) AS i_product_name#x]
-                           +- Relation spark_catalog.default.item[i_item_sk#x,i_item_id#x,i_rec_start_date#x,i_rec_end_date#x,i_item_desc#x,i_current_price#x,i_wholesale_cost#x,i_brand_id#x,i_brand#x,i_class_id#x,i_class#x,i_category_id#x,i_category#x,i_manufact_id#x,i_manufact#x,i_size#x,i_formulation#x,i_color#x,i_units#x,i_container#x,i_manager_id#x,i_product_name#x] parquet
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "TABLE_OR_VIEW_NOT_FOUND",
+  "sqlState" : "42P01",
+  "messageParameters" : {
+    "relationName" : "`date_dim`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 7,
+    "stopIndex" : 14,
+    "fragment" : "date_dim"
+  } ]
+}
 
 
 -- !query
@@ -4602,25 +3991,21 @@ order by
   i_category, i_class, i_item_id, i_item_desc, revenueratio
 limit 100
 -- !query analysis
-GlobalLimit 100
-+- LocalLimit 100
-   +- Project [i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x, revenueratio#x]
-      +- Sort [i_category#x ASC NULLS FIRST, i_class#x ASC NULLS FIRST, i_item_id#x ASC NULLS FIRST, i_item_desc#x ASC NULLS FIRST, revenueratio#x ASC NULLS FIRST], true
-         +- Project [i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x, revenueratio#x, i_item_id#x]
-            +- Project [i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x, _w0#x, _we0#x, ((_w0#x * cast(100 as decimal(3,0))) / _we0#x) AS revenueratio#x, i_item_id#x]
-               +- Window [sum(_w0#x) windowspecdefinition(i_class#x, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#x], [i_class#x]
-                  +- Aggregate [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x], [i_item_desc#x, i_category#x, i_class#x, i_current_price#x, sum(ws_ext_sales_price#x) AS itemrevenue#x, sum(ws_ext_sales_price#x) AS _w0#x, i_item_id#x]
-                     +- Filter (((ws_item_sk#x = i_item_sk#x) AND i_category#x IN (rpad(sports, 50,  ),rpad(books, 50,  ),rpad(home, 50,  ))) AND ((ws_sold_date_sk#x = d_date_sk#x) AND between(d_date#x, cast(1999-02-22 as date), date_add(cast(1999-02-22 as date), extractansiintervaldays(INTERVAL '30' DAY)))))
-                        +- Join Inner
-                           :- Join Inner
-                           :  :- SubqueryAlias spark_catalog.default.web_sales
-                           :  :  +- Relation spark_catalog.default.web_sales[ws_sold_date_sk#x,ws_sold_time_sk#x,ws_ship_date_sk#x,ws_item_sk#x,ws_bill_customer_sk#x,ws_bill_cdemo_sk#x,ws_bill_hdemo_sk#x,ws_bill_addr_sk#x,ws_ship_customer_sk#x,ws_ship_cdemo_sk#x,ws_ship_hdemo_sk#x,ws_ship_addr_sk#x,ws_web_page_sk#x,ws_web_site_sk#x,ws_ship_mode_sk#x,ws_warehouse_sk#x,ws_promo_sk#x,ws_order_number#x,ws_quantity#x,ws_wholesale_cost#x,ws_list_price#x,ws_sales_price#x,ws_ext_discount_amt#x,ws_ext_sales_price#x,... 10 more fields] parquet
-                           :  +- SubqueryAlias spark_catalog.default.item
-                           :     +- Project [i_item_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_item_id#x, 16)) AS i_item_id#x, i_rec_start_date#x, i_rec_end_date#x, i_item_desc#x, i_current_price#x, i_wholesale_cost#x, i_brand_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_brand#x, 50)) AS i_brand#x, i_class_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_class#x, 50)) AS i_class#x, i_category_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_category#x, 50)) AS i_category#x, i_manufact_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_manufact#x, 50)) AS i_manufact#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_size#x, 20)) AS i_size#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_formulation#x, 20)) AS i_formulation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_color#x, 20)) AS i_color#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_units#x, 10)) AS i_units#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_container#x, 10)) AS i_container#x, i_manager_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_product_name#x, 50)) AS i_product_name#x]
-                           :        +- Relation spark_catalog.default.item[i_item_sk#x,i_item_id#x,i_rec_start_date#x,i_rec_end_date#x,i_item_desc#x,i_current_price#x,i_wholesale_cost#x,i_brand_id#x,i_brand#x,i_class_id#x,i_class#x,i_category_id#x,i_category#x,i_manufact_id#x,i_manufact#x,i_size#x,i_formulation#x,i_color#x,i_units#x,i_container#x,i_manager_id#x,i_product_name#x] parquet
-                           +- SubqueryAlias spark_catalog.default.date_dim
-                              +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
-                                 +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "TABLE_OR_VIEW_NOT_FOUND",
+  "sqlState" : "42P01",
+  "messageParameters" : {
+    "relationName" : "`web_sales`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 227,
+    "stopIndex" : 235,
+    "fragment" : "web_sales"
+  } ]
+}
 
 
 -- !query
@@ -4641,28 +4026,21 @@ table web_sales
 |> select i_item_desc, i_category, i_class, i_current_price, itemrevenue, revenueratio
 |> limit 100
 -- !query analysis
-GlobalLimit 100
-+- LocalLimit 100
-   +- SubqueryAlias __auto_generated_subquery_name
-      +- Project [i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x, revenueratio#x]
-         +- Sort [i_category#x ASC NULLS FIRST, i_class#x ASC NULLS FIRST, i_item_id#x ASC NULLS FIRST, i_item_desc#x ASC NULLS FIRST, revenueratio#x ASC NULLS FIRST], true
-            +- SubqueryAlias __auto_generated_subquery_name
-               +- Project [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x, revenueratio#x]
-                  +- Project [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x, _we0#x, pipeexpression(((itemrevenue#x * cast(100 as decimal(3,0))) / _we0#x), false, EXTEND) AS revenueratio#x]
-                     +- Window [sum(itemrevenue#x) windowspecdefinition(i_class#x, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#x], [i_class#x]
-                        +- Project [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x]
-                           +- Aggregate [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x], [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x, pipeexpression(sum(ws_ext_sales_price#x), true, AGGREGATE) AS itemrevenue#x]
-                              +- Filter (((ws_item_sk#x = i_item_sk#x) AND i_category#x IN (rpad(sports, 50,  ),rpad(books, 50,  ),rpad(home, 50,  ))) AND ((ws_sold_date_sk#x = d_date_sk#x) AND between(d_date#x, cast(1999-02-22 as date), date_add(cast(1999-02-22 as date), extractansiintervaldays(INTERVAL '30' DAY)))))
-                                 +- Join Inner
-                                    :- Join Inner
-                                    :  :- SubqueryAlias spark_catalog.default.web_sales
-                                    :  :  +- Relation spark_catalog.default.web_sales[ws_sold_date_sk#x,ws_sold_time_sk#x,ws_ship_date_sk#x,ws_item_sk#x,ws_bill_customer_sk#x,ws_bill_cdemo_sk#x,ws_bill_hdemo_sk#x,ws_bill_addr_sk#x,ws_ship_customer_sk#x,ws_ship_cdemo_sk#x,ws_ship_hdemo_sk#x,ws_ship_addr_sk#x,ws_web_page_sk#x,ws_web_site_sk#x,ws_ship_mode_sk#x,ws_warehouse_sk#x,ws_promo_sk#x,ws_order_number#x,ws_quantity#x,ws_wholesale_cost#x,ws_list_price#x,ws_sales_price#x,ws_ext_discount_amt#x,ws_ext_sales_price#x,... 10 more fields] parquet
-                                    :  +- SubqueryAlias spark_catalog.default.item
-                                    :     +- Project [i_item_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_item_id#x, 16)) AS i_item_id#x, i_rec_start_date#x, i_rec_end_date#x, i_item_desc#x, i_current_price#x, i_wholesale_cost#x, i_brand_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_brand#x, 50)) AS i_brand#x, i_class_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_class#x, 50)) AS i_class#x, i_category_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_category#x, 50)) AS i_category#x, i_manufact_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_manufact#x, 50)) AS i_manufact#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_size#x, 20)) AS i_size#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_formulation#x, 20)) AS i_formulation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_color#x, 20)) AS i_color#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_units#x, 10)) AS i_units#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_container#x, 10)) AS i_container#x, i_manager_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_product_name#x, 50)) AS i_product_name#x]
-                                    :        +- Relation spark_catalog.default.item[i_item_sk#x,i_item_id#x,i_rec_start_date#x,i_rec_end_date#x,i_item_desc#x,i_current_price#x,i_wholesale_cost#x,i_brand_id#x,i_brand#x,i_class_id#x,i_class#x,i_category_id#x,i_category#x,i_manufact_id#x,i_manufact#x,i_size#x,i_formulation#x,i_color#x,i_units#x,i_container#x,i_manager_id#x,i_product_name#x] parquet
-                                    +- SubqueryAlias spark_catalog.default.date_dim
-                                       +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
-                                          +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "TABLE_OR_VIEW_NOT_FOUND",
+  "sqlState" : "42P01",
+  "messageParameters" : {
+    "relationName" : "`web_sales`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 7,
+    "stopIndex" : 15,
+    "fragment" : "web_sales"
+  } ]
+}
 
 
 -- !query
@@ -4713,60 +4091,21 @@ where asceding.rnk = descending.rnk
 order by asceding.rnk
 limit 100
 -- !query analysis
-GlobalLimit 100
-+- LocalLimit 100
-   +- Sort [rnk#x ASC NULLS FIRST], true
-      +- Project [rnk#x, i_product_name#x AS best_performing#x, i_product_name#x AS worst_performing#x]
-         +- Filter (((rnk#x = rnk#x) AND (i_item_sk#x = item_sk#x)) AND (i_item_sk#x = item_sk#x))
-            +- Join Inner
-               :- Join Inner
-               :  :- Join Inner
-               :  :  :- SubqueryAlias asceding
-               :  :  :  +- Project [item_sk#x, rnk#x]
-               :  :  :     +- Filter (rnk#x < 11)
-               :  :  :        +- SubqueryAlias v11
-               :  :  :           +- Project [item_sk#x, rnk#x]
-               :  :  :              +- Project [item_sk#x, rank_col#x, rnk#x, rnk#x]
-               :  :  :                 +- Window [rank(rank_col#x) windowspecdefinition(rank_col#x ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#x], [rank_col#x ASC NULLS FIRST]
-               :  :  :                    +- Project [item_sk#x, rank_col#x]
-               :  :  :                       +- SubqueryAlias v1
-               :  :  :                          +- Filter (cast(rank_col#x as decimal(13,7)) > (0.9 * scalar-subquery#x []))
-               :  :  :                             :  +- Aggregate [ss_store_sk#x], [avg(ss_net_profit#x) AS rank_col#x]
-               :  :  :                             :     +- Filter ((ss_store_sk#x = 4) AND isnull(ss_addr_sk#x))
-               :  :  :                             :        +- SubqueryAlias spark_catalog.default.store_sales
-               :  :  :                             :           +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
-               :  :  :                             +- Aggregate [ss_item_sk#x], [ss_item_sk#x AS item_sk#x, avg(ss_net_profit#x) AS rank_col#x]
-               :  :  :                                +- Filter (ss_store_sk#x = 4)
-               :  :  :                                   +- SubqueryAlias ss1
-               :  :  :                                      +- SubqueryAlias spark_catalog.default.store_sales
-               :  :  :                                         +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
-               :  :  +- SubqueryAlias descending
-               :  :     +- Project [item_sk#x, rnk#x]
-               :  :        +- Filter (rnk#x < 11)
-               :  :           +- SubqueryAlias v21
-               :  :              +- Project [item_sk#x, rnk#x]
-               :  :                 +- Project [item_sk#x, rank_col#x, rnk#x, rnk#x]
-               :  :                    +- Window [rank(rank_col#x) windowspecdefinition(rank_col#x DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#x], [rank_col#x DESC NULLS LAST]
-               :  :                       +- Project [item_sk#x, rank_col#x]
-               :  :                          +- SubqueryAlias v2
-               :  :                             +- Filter (cast(rank_col#x as decimal(13,7)) > (0.9 * scalar-subquery#x []))
-               :  :                                :  +- Aggregate [ss_store_sk#x], [avg(ss_net_profit#x) AS rank_col#x]
-               :  :                                :     +- Filter ((ss_store_sk#x = 4) AND isnull(ss_addr_sk#x))
-               :  :                                :        +- SubqueryAlias spark_catalog.default.store_sales
-               :  :                                :           +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
-               :  :                                +- Aggregate [ss_item_sk#x], [ss_item_sk#x AS item_sk#x, avg(ss_net_profit#x) AS rank_col#x]
-               :  :                                   +- Filter (ss_store_sk#x = 4)
-               :  :                                      +- SubqueryAlias ss1
-               :  :                                         +- SubqueryAlias spark_catalog.default.store_sales
-               :  :                                            +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
-               :  +- SubqueryAlias i1
-               :     +- SubqueryAlias spark_catalog.default.item
-               :        +- Project [i_item_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_item_id#x, 16)) AS i_item_id#x, i_rec_start_date#x, i_rec_end_date#x, i_item_desc#x, i_current_price#x, i_wholesale_cost#x, i_brand_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_brand#x, 50)) AS i_brand#x, i_class_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_class#x, 50)) AS i_class#x, i_category_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_category#x, 50)) AS i_category#x, i_manufact_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_manufact#x, 50)) AS i_manufact#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_size#x, 20)) AS i_size#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_formulation#x, 20)) AS i_formulation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_color#x, 20)) AS i_color#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_units#x, 10)) AS i_units#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_container#x, 10)) AS i_container#x, i_manager_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_product_name#x, 50)) AS i_product_name#x]
-               :           +- Relation spark_catalog.default.item[i_item_sk#x,i_item_id#x,i_rec_start_date#x,i_rec_end_date#x,i_item_desc#x,i_current_price#x,i_wholesale_cost#x,i_brand_id#x,i_brand#x,i_class_id#x,i_class#x,i_category_id#x,i_category#x,i_manufact_id#x,i_manufact#x,i_size#x,i_formulation#x,i_color#x,i_units#x,i_container#x,i_manager_id#x,i_product_name#x] parquet
-               +- SubqueryAlias i2
-                  +- SubqueryAlias spark_catalog.default.item
-                     +- Project [i_item_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_item_id#x, 16)) AS i_item_id#x, i_rec_start_date#x, i_rec_end_date#x, i_item_desc#x, i_current_price#x, i_wholesale_cost#x, i_brand_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_brand#x, 50)) AS i_brand#x, i_class_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_class#x, 50)) AS i_class#x, i_category_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_category#x, 50)) AS i_category#x, i_manufact_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_manufact#x, 50)) AS i_manufact#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_size#x, 20)) AS i_size#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_formulation#x, 20)) AS i_formulation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_color#x, 20)) AS i_color#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_units#x, 10)) AS i_units#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_container#x, 10)) AS i_container#x, i_manager_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_product_name#x, 50)) AS i_product_name#x]
-                        +- Relation spark_catalog.default.item[i_item_sk#x,i_item_id#x,i_rec_start_date#x,i_rec_end_date#x,i_item_desc#x,i_current_price#x,i_wholesale_cost#x,i_brand_id#x,i_brand#x,i_class_id#x,i_class#x,i_category_id#x,i_category#x,i_manufact_id#x,i_manufact#x,i_size#x,i_formulation#x,i_color#x,i_units#x,i_container#x,i_manager_id#x,i_product_name#x] parquet
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "TABLE_OR_VIEW_NOT_FOUND",
+  "sqlState" : "42P01",
+  "messageParameters" : {
+    "relationName" : "`store_sales`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 256,
+    "stopIndex" : 266,
+    "fragment" : "store_sales"
+  } ]
+}
 
 
 -- !query
@@ -4821,60 +4160,171 @@ table store_sales
      i1.i_product_name best_performing,
      i2.i_product_name worst_performing
 -- !query analysis
-Project [rnk#x, pipeexpression(i_product_name#x, false, SELECT) AS best_performing#x, pipeexpression(i_product_name#x, false, SELECT) AS worst_performing#x]
-+- Sort [rnk#x ASC NULLS FIRST], true
-   +- Filter (((rnk#x = rnk#x) AND (i_item_sk#x = item_sk#x)) AND (i_item_sk#x = item_sk#x))
-      +- Join Inner
-         :- Join Inner
-         :  :- Join Inner
-         :  :  :- SubqueryAlias asceding
-         :  :  :  +- Filter (rnk#x < 11)
-         :  :  :     +- SubqueryAlias v11
-         :  :  :        +- Project [item_sk#x, rnk#x]
-         :  :  :           +- Project [item_sk#x, rank_col#x, _we0#x, pipeexpression(_we0#x, false, SELECT) AS rnk#x]
-         :  :  :              +- Window [rank(rank_col#x) windowspecdefinition(rank_col#x ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS _we0#x], [rank_col#x ASC NULLS FIRST]
-         :  :  :                 +- Project [item_sk#x, rank_col#x]
-         :  :  :                    +- SubqueryAlias v1
-         :  :  :                       +- Filter (cast(rank_col#x as decimal(13,7)) > (0.9 * scalar-subquery#x []))
-         :  :  :                          :  +- Project [rank_col#x]
-         :  :  :                          :     +- Aggregate [ss_store_sk#x], [ss_store_sk#x, pipeexpression(avg(ss_net_profit#x), true, AGGREGATE) AS rank_col#x]
-         :  :  :                          :        +- Filter ((ss_store_sk#x = 4) AND isnull(ss_addr_sk#x))
-         :  :  :                          :           +- SubqueryAlias spark_catalog.default.store_sales
-         :  :  :                          :              +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
-         :  :  :                          +- SubqueryAlias __auto_generated_subquery_name
-         :  :  :                             +- Aggregate [ss_item_sk#x], [ss_item_sk#x AS item_sk#x, pipeexpression(avg(ss_net_profit#x), true, AGGREGATE) AS rank_col#x]
-         :  :  :                                +- Filter (ss_store_sk#x = 4)
-         :  :  :                                   +- SubqueryAlias ss1
-         :  :  :                                      +- SubqueryAlias spark_catalog.default.store_sales
-         :  :  :                                         +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
-         :  :  +- SubqueryAlias descending
-         :  :     +- Filter (rnk#x < 11)
-         :  :        +- SubqueryAlias v21
-         :  :           +- Project [item_sk#x, rnk#x]
-         :  :              +- Project [item_sk#x, rank_col#x, _we0#x, pipeexpression(_we0#x, false, SELECT) AS rnk#x]
-         :  :                 +- Window [rank(rank_col#x) windowspecdefinition(rank_col#x ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS _we0#x], [rank_col#x ASC NULLS FIRST]
-         :  :                    +- Project [item_sk#x, rank_col#x]
-         :  :                       +- SubqueryAlias v2
-         :  :                          +- Filter (cast(rank_col#x as decimal(13,7)) > (0.9 * scalar-subquery#x []))
-         :  :                             :  +- Project [rank_col#x]
-         :  :                             :     +- Aggregate [ss_store_sk#x], [ss_store_sk#x, pipeexpression(avg(ss_net_profit#x), true, AGGREGATE) AS rank_col#x]
-         :  :                             :        +- Filter ((ss_store_sk#x = 4) AND isnull(ss_addr_sk#x))
-         :  :                             :           +- SubqueryAlias spark_catalog.default.store_sales
-         :  :                             :              +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
-         :  :                             +- SubqueryAlias __auto_generated_subquery_name
-         :  :                                +- Aggregate [ss_item_sk#x], [ss_item_sk#x AS item_sk#x, pipeexpression(avg(ss_net_profit#x), true, AGGREGATE) AS rank_col#x]
-         :  :                                   +- Filter (ss_store_sk#x = 4)
-         :  :                                      +- SubqueryAlias ss1
-         :  :                                         +- SubqueryAlias spark_catalog.default.store_sales
-         :  :                                            +- Relation spark_catalog.default.store_sales[ss_sold_date_sk#x,ss_sold_time_sk#x,ss_item_sk#x,ss_customer_sk#x,ss_cdemo_sk#x,ss_hdemo_sk#x,ss_addr_sk#x,ss_store_sk#x,ss_promo_sk#x,ss_ticket_number#x,ss_quantity#x,ss_wholesale_cost#x,ss_list_price#x,ss_sales_price#x,ss_ext_discount_amt#x,ss_ext_sales_price#x,ss_ext_wholesale_cost#x,ss_ext_list_price#x,ss_ext_tax#x,ss_coupon_amt#x,ss_net_paid#x,ss_net_paid_inc_tax#x,ss_net_profit#x] parquet
-         :  +- SubqueryAlias i1
-         :     +- SubqueryAlias spark_catalog.default.item
-         :        +- Project [i_item_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_item_id#x, 16)) AS i_item_id#x, i_rec_start_date#x, i_rec_end_date#x, i_item_desc#x, i_current_price#x, i_wholesale_cost#x, i_brand_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_brand#x, 50)) AS i_brand#x, i_class_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_class#x, 50)) AS i_class#x, i_category_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_category#x, 50)) AS i_category#x, i_manufact_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_manufact#x, 50)) AS i_manufact#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_size#x, 20)) AS i_size#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_formulation#x, 20)) AS i_formulation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_color#x, 20)) AS i_color#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_units#x, 10)) AS i_units#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_container#x, 10)) AS i_container#x, i_manager_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_product_name#x, 50)) AS i_product_name#x]
-         :           +- Relation spark_catalog.default.item[i_item_sk#x,i_item_id#x,i_rec_start_date#x,i_rec_end_date#x,i_item_desc#x,i_current_price#x,i_wholesale_cost#x,i_brand_id#x,i_brand#x,i_class_id#x,i_class#x,i_category_id#x,i_category#x,i_manufact_id#x,i_manufact#x,i_size#x,i_formulation#x,i_color#x,i_units#x,i_container#x,i_manager_id#x,i_product_name#x] parquet
-         +- SubqueryAlias i2
-            +- SubqueryAlias spark_catalog.default.item
-               +- Project [i_item_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_item_id#x, 16)) AS i_item_id#x, i_rec_start_date#x, i_rec_end_date#x, i_item_desc#x, i_current_price#x, i_wholesale_cost#x, i_brand_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_brand#x, 50)) AS i_brand#x, i_class_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_class#x, 50)) AS i_class#x, i_category_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_category#x, 50)) AS i_category#x, i_manufact_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_manufact#x, 50)) AS i_manufact#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_size#x, 20)) AS i_size#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_formulation#x, 20)) AS i_formulation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_color#x, 20)) AS i_color#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_units#x, 10)) AS i_units#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_container#x, 10)) AS i_container#x, i_manager_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_product_name#x, 50)) AS i_product_name#x]
-                  +- Relation spark_catalog.default.item[i_item_sk#x,i_item_id#x,i_rec_start_date#x,i_rec_end_date#x,i_item_desc#x,i_current_price#x,i_wholesale_cost#x,i_brand_id#x,i_brand#x,i_class_id#x,i_class#x,i_category_id#x,i_category#x,i_manufact_id#x,i_manufact#x,i_size#x,i_formulation#x,i_color#x,i_units#x,i_container#x,i_manager_id#x,i_product_name#x] parquet
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "TABLE_OR_VIEW_NOT_FOUND",
+  "sqlState" : "42P01",
+  "messageParameters" : {
+    "relationName" : "`store_sales`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 7,
+    "stopIndex" : 17,
+    "fragment" : "store_sales"
+  } ]
+}
+
+
+-- !query
+with web_v1 as (
+  select
+    ws_item_sk item_sk,
+    d_date,
+    sum(sum(ws_sales_price))
+    over (partition by ws_item_sk
+      order by d_date
+      rows between unbounded preceding and current row) cume_sales
+  from web_sales, date_dim
+  where ws_sold_date_sk = d_date_sk
+    and d_month_seq between 1200 and 1200 + 11
+    and ws_item_sk is not null
+  group by ws_item_sk, d_date),
+    store_v1 as (
+    select
+      ss_item_sk item_sk,
+      d_date,
+      sum(sum(ss_sales_price))
+      over (partition by ss_item_sk
+        order by d_date
+        rows between unbounded preceding and current row) cume_sales
+    from store_sales, date_dim
+    where ss_sold_date_sk = d_date_sk
+      and d_month_seq between 1200 and 1200 + 11
+      and ss_item_sk is not null
+    group by ss_item_sk, d_date)
+select *
+from (select
+  item_sk,
+  d_date,
+  web_sales,
+  store_sales,
+  max(web_sales)
+  over (partition by item_sk
+    order by d_date
+    rows between unbounded preceding and current row) web_cumulative,
+  max(store_sales)
+  over (partition by item_sk
+    order by d_date
+    rows between unbounded preceding and current row) store_cumulative
+from (select
+  case when web.item_sk is not null
+    then web.item_sk
+  else store.item_sk end item_sk,
+  case when web.d_date is not null
+    then web.d_date
+  else store.d_date end d_date,
+  web.cume_sales web_sales,
+  store.cume_sales store_sales
+from web_v1 web full outer join store_v1 store on (web.item_sk = store.item_sk
+  and web.d_date = store.d_date)
+     ) x) y
+where web_cumulative > store_cumulative
+order by item_sk, d_date
+limit 100
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "TABLE_OR_VIEW_NOT_FOUND",
+  "sqlState" : "42P01",
+  "messageParameters" : {
+    "relationName" : "`web_sales`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 222,
+    "stopIndex" : 230,
+    "fragment" : "web_sales"
+  } ]
+}
+
+
+-- !query
+with web_v1 as (
+  table web_sales
+  |> join date_dim
+  |> where ws_sold_date_sk = d_date_sk
+       and d_month_seq between 1200 and 1200 + 11
+       and ws_item_sk is not null
+  |> aggregate sum(ws_sales_price) as sum_ws_sales_price
+       group by ws_item_sk as item_sk, d_date
+  |> extend sum(sum_ws_sales_price)
+       over (partition by item_sk
+         order by d_date
+         rows between unbounded preceding and current row)
+       as cume_sales),
+store_v1 as (
+  table store_sales
+  |> join date_dim
+  |> where ss_sold_date_sk = d_date_sk
+       and d_month_seq between 1200 and 1200 + 11
+       and ss_item_sk is not null
+  |> aggregate sum(ss_sales_price) as sum_ss_sales_price
+       group by ss_item_sk as item_sk, d_date
+  |> extend sum(sum_ss_sales_price)
+       over (partition by item_sk
+           order by d_date
+           rows between unbounded preceding and current row)
+       as cume_sales)
+table web_v1
+|> as web
+|> full outer join store_v1 store
+     on (web.item_sk = store.item_sk and web.d_date = store.d_date)
+|> select
+     case when web.item_sk is not null
+       then web.item_sk
+       else store.item_sk end item_sk,
+     case when web.d_date is not null
+       then web.d_date
+       else store.d_date end d_date,
+     web.cume_sales web_sales,
+     store.cume_sales store_sales
+|> as x
+|> select
+     item_sk,
+     d_date,
+     web_sales,
+     store_sales,
+     max(web_sales)
+       over (partition by item_sk
+         order by d_date
+         rows between unbounded preceding and current row) web_cumulative,
+     max(store_sales)
+       over (partition by item_sk
+         order by d_date
+         rows between unbounded preceding and current row) store_cumulative
+|> as y
+|> where web_cumulative > store_cumulative
+|> order by item_sk, d_date
+|> limit 100
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "TABLE_OR_VIEW_NOT_FOUND",
+  "sqlState" : "42P01",
+  "messageParameters" : {
+    "relationName" : "`web_sales`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 26,
+    "stopIndex" : 34,
+    "fragment" : "web_sales"
+  } ]
+}
 
 
 -- !query
@@ -4896,171 +4346,3 @@ drop table st
 -- !query analysis
 DropTable false, false
 +- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.st
-
-
--- !query
-drop table call_center
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.call_center
-
-
--- !query
-drop table catalog_page
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.catalog_page
-
-
--- !query
-drop table catalog_returns
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.catalog_returns
-
-
--- !query
-drop table catalog_sales
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.catalog_sales
-
-
--- !query
-drop table customer
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.customer
-
-
--- !query
-drop table customer_address
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.customer_address
-
-
--- !query
-drop table customer_demographics
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.customer_demographics
-
-
--- !query
-drop table date_dim
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.date_dim
-
-
--- !query
-drop table household_demographics
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.household_demographics
-
-
--- !query
-drop table income_band
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.income_band
-
-
--- !query
-drop table inventory
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.inventory
-
-
--- !query
-drop table item
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.item
-
-
--- !query
-drop table promotion
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.promotion
-
-
--- !query
-drop table reason
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.reason
-
-
--- !query
-drop table ship_mode
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.ship_mode
-
-
--- !query
-drop table store
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.store
-
-
--- !query
-drop table store_returns
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.store_returns
-
-
--- !query
-drop table store_sales
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.store_sales
-
-
--- !query
-drop table time_dim
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.time_dim
-
-
--- !query
-drop table warehouse
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.warehouse
-
-
--- !query
-drop table web_page
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.web_page
-
-
--- !query
-drop table web_returns
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.web_returns
-
-
--- !query
-drop table web_sales
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.web_sales
-
-
--- !query
-drop table web_site
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.web_site

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -4579,6 +4579,93 @@ GlobalLimit 100
 
 
 -- !query
+select
+  i_item_desc,
+  i_category,
+  i_class,
+  i_current_price,
+  sum(ws_ext_sales_price) as itemrevenue,
+  sum(ws_ext_sales_price) * 100 / sum(sum(ws_ext_sales_price))
+  over
+  (partition by i_class) as revenueratio
+from
+  web_sales, item, date_dim
+where
+  ws_item_sk = i_item_sk
+    and i_category in ('sports', 'books', 'home')
+    and ws_sold_date_sk = d_date_sk
+    and d_date between cast('1999-02-22' as date)
+  and (cast('1999-02-22' as date) + interval 30 days)
+group by
+  i_item_id, i_item_desc, i_category, i_class, i_current_price
+order by
+  i_category, i_class, i_item_id, i_item_desc, revenueratio
+limit 100
+-- !query analysis
+GlobalLimit 100
++- LocalLimit 100
+   +- Project [i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x, revenueratio#x]
+      +- Sort [i_category#x ASC NULLS FIRST, i_class#x ASC NULLS FIRST, i_item_id#x ASC NULLS FIRST, i_item_desc#x ASC NULLS FIRST, revenueratio#x ASC NULLS FIRST], true
+         +- Project [i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x, revenueratio#x, i_item_id#x]
+            +- Project [i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x, _w0#x, _we0#x, ((_w0#x * cast(100 as decimal(3,0))) / _we0#x) AS revenueratio#x, i_item_id#x]
+               +- Window [sum(_w0#x) windowspecdefinition(i_class#x, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#x], [i_class#x]
+                  +- Aggregate [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x], [i_item_desc#x, i_category#x, i_class#x, i_current_price#x, sum(ws_ext_sales_price#x) AS itemrevenue#x, sum(ws_ext_sales_price#x) AS _w0#x, i_item_id#x]
+                     +- Filter (((ws_item_sk#x = i_item_sk#x) AND i_category#x IN (rpad(sports, 50,  ),rpad(books, 50,  ),rpad(home, 50,  ))) AND ((ws_sold_date_sk#x = d_date_sk#x) AND between(d_date#x, cast(1999-02-22 as date), date_add(cast(1999-02-22 as date), extractansiintervaldays(INTERVAL '30' DAY)))))
+                        +- Join Inner
+                           :- Join Inner
+                           :  :- SubqueryAlias spark_catalog.default.web_sales
+                           :  :  +- Relation spark_catalog.default.web_sales[ws_sold_date_sk#x,ws_sold_time_sk#x,ws_ship_date_sk#x,ws_item_sk#x,ws_bill_customer_sk#x,ws_bill_cdemo_sk#x,ws_bill_hdemo_sk#x,ws_bill_addr_sk#x,ws_ship_customer_sk#x,ws_ship_cdemo_sk#x,ws_ship_hdemo_sk#x,ws_ship_addr_sk#x,ws_web_page_sk#x,ws_web_site_sk#x,ws_ship_mode_sk#x,ws_warehouse_sk#x,ws_promo_sk#x,ws_order_number#x,ws_quantity#x,ws_wholesale_cost#x,ws_list_price#x,ws_sales_price#x,ws_ext_discount_amt#x,ws_ext_sales_price#x,... 10 more fields] parquet
+                           :  +- SubqueryAlias spark_catalog.default.item
+                           :     +- Project [i_item_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_item_id#x, 16)) AS i_item_id#x, i_rec_start_date#x, i_rec_end_date#x, i_item_desc#x, i_current_price#x, i_wholesale_cost#x, i_brand_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_brand#x, 50)) AS i_brand#x, i_class_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_class#x, 50)) AS i_class#x, i_category_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_category#x, 50)) AS i_category#x, i_manufact_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_manufact#x, 50)) AS i_manufact#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_size#x, 20)) AS i_size#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_formulation#x, 20)) AS i_formulation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_color#x, 20)) AS i_color#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_units#x, 10)) AS i_units#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_container#x, 10)) AS i_container#x, i_manager_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_product_name#x, 50)) AS i_product_name#x]
+                           :        +- Relation spark_catalog.default.item[i_item_sk#x,i_item_id#x,i_rec_start_date#x,i_rec_end_date#x,i_item_desc#x,i_current_price#x,i_wholesale_cost#x,i_brand_id#x,i_brand#x,i_class_id#x,i_class#x,i_category_id#x,i_category#x,i_manufact_id#x,i_manufact#x,i_size#x,i_formulation#x,i_color#x,i_units#x,i_container#x,i_manager_id#x,i_product_name#x] parquet
+                           +- SubqueryAlias spark_catalog.default.date_dim
+                              +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
+                                 +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
+
+
+-- !query
+table web_sales
+|> join item
+|> join date_dim
+|> where ws_item_sk = i_item_sk
+     and i_category in ('sports', 'books', 'home')
+     and ws_sold_date_sk = d_date_sk
+     and d_date between cast('1999-02-22' as date)
+     and (cast('1999-02-22' as date) + interval 30 days)
+|> aggregate sum(ws_ext_sales_price) AS itemrevenue
+     group by i_item_id, i_item_desc, i_category, i_class, i_current_price
+|> select *,
+     itemrevenue * 100 / sum(itemrevenue)
+       over (partition by i_class) as revenueratio
+|> order by i_category, i_class, i_item_id, i_item_desc, revenueratio
+|> select i_item_desc, i_category, i_class, i_current_price, itemrevenue, revenueratio
+|> limit 100
+-- !query analysis
+GlobalLimit 100
++- LocalLimit 100
+   +- SubqueryAlias __auto_generated_subquery_name
+      +- Project [i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x, revenueratio#x]
+         +- Sort [i_category#x ASC NULLS FIRST, i_class#x ASC NULLS FIRST, i_item_id#x ASC NULLS FIRST, i_item_desc#x ASC NULLS FIRST, revenueratio#x ASC NULLS FIRST], true
+            +- SubqueryAlias __auto_generated_subquery_name
+               +- Project [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x, revenueratio#x]
+                  +- Project [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x, _we0#x, pipeexpression(((itemrevenue#x * cast(100 as decimal(3,0))) / _we0#x), false, SELECT) AS revenueratio#x]
+                     +- Window [sum(itemrevenue#x) windowspecdefinition(i_class#x, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#x], [i_class#x]
+                        +- Project [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x, itemrevenue#x]
+                           +- Aggregate [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x], [i_item_id#x, i_item_desc#x, i_category#x, i_class#x, i_current_price#x, pipeexpression(sum(ws_ext_sales_price#x), true, AGGREGATE) AS itemrevenue#x]
+                              +- Filter (((ws_item_sk#x = i_item_sk#x) AND i_category#x IN (rpad(sports, 50,  ),rpad(books, 50,  ),rpad(home, 50,  ))) AND ((ws_sold_date_sk#x = d_date_sk#x) AND between(d_date#x, cast(1999-02-22 as date), date_add(cast(1999-02-22 as date), extractansiintervaldays(INTERVAL '30' DAY)))))
+                                 +- Join Inner
+                                    :- Join Inner
+                                    :  :- SubqueryAlias spark_catalog.default.web_sales
+                                    :  :  +- Relation spark_catalog.default.web_sales[ws_sold_date_sk#x,ws_sold_time_sk#x,ws_ship_date_sk#x,ws_item_sk#x,ws_bill_customer_sk#x,ws_bill_cdemo_sk#x,ws_bill_hdemo_sk#x,ws_bill_addr_sk#x,ws_ship_customer_sk#x,ws_ship_cdemo_sk#x,ws_ship_hdemo_sk#x,ws_ship_addr_sk#x,ws_web_page_sk#x,ws_web_site_sk#x,ws_ship_mode_sk#x,ws_warehouse_sk#x,ws_promo_sk#x,ws_order_number#x,ws_quantity#x,ws_wholesale_cost#x,ws_list_price#x,ws_sales_price#x,ws_ext_discount_amt#x,ws_ext_sales_price#x,... 10 more fields] parquet
+                                    :  +- SubqueryAlias spark_catalog.default.item
+                                    :     +- Project [i_item_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_item_id#x, 16)) AS i_item_id#x, i_rec_start_date#x, i_rec_end_date#x, i_item_desc#x, i_current_price#x, i_wholesale_cost#x, i_brand_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_brand#x, 50)) AS i_brand#x, i_class_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_class#x, 50)) AS i_class#x, i_category_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_category#x, 50)) AS i_category#x, i_manufact_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_manufact#x, 50)) AS i_manufact#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_size#x, 20)) AS i_size#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_formulation#x, 20)) AS i_formulation#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_color#x, 20)) AS i_color#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_units#x, 10)) AS i_units#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_container#x, 10)) AS i_container#x, i_manager_id#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(i_product_name#x, 50)) AS i_product_name#x]
+                                    :        +- Relation spark_catalog.default.item[i_item_sk#x,i_item_id#x,i_rec_start_date#x,i_rec_end_date#x,i_item_desc#x,i_current_price#x,i_wholesale_cost#x,i_brand_id#x,i_brand#x,i_class_id#x,i_class#x,i_category_id#x,i_category#x,i_manufact_id#x,i_manufact#x,i_size#x,i_formulation#x,i_color#x,i_units#x,i_container#x,i_manager_id#x,i_product_name#x] parquet
+                                    +- SubqueryAlias spark_catalog.default.date_dim
+                                       +- Project [d_date_sk#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_date_id#x, 16)) AS d_date_id#x, d_date#x, d_month_seq#x, d_week_seq#x, d_quarter_seq#x, d_year#x, d_dow#x, d_moy#x, d_dom#x, d_qoy#x, d_fy_year#x, d_fy_quarter_seq#x, d_fy_week_seq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_day_name#x, 9)) AS d_day_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_quarter_name#x, 6)) AS d_quarter_name#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_holiday#x, 1)) AS d_holiday#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_weekend#x, 1)) AS d_weekend#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_following_holiday#x, 1)) AS d_following_holiday#x, d_first_dom#x, d_last_dom#x, d_same_day_ly#x, d_same_day_lq#x, static_invoke(CharVarcharCodegenUtils.readSidePadding(d_current_day#x, 1)) AS d_current_day#x, ... 4 more fields]
+                                          +- Relation spark_catalog.default.date_dim[d_date_sk#x,d_date_id#x,d_date#x,d_month_seq#x,d_week_seq#x,d_quarter_seq#x,d_year#x,d_dow#x,d_moy#x,d_dom#x,d_qoy#x,d_fy_year#x,d_fy_quarter_seq#x,d_fy_week_seq#x,d_day_name#x,d_quarter_name#x,d_holiday#x,d_weekend#x,d_following_holiday#x,d_first_dom#x,d_last_dom#x,d_same_day_ly#x,d_same_day_lq#x,d_current_day#x,... 4 more fields] parquet
+
+
+-- !query
 drop table t
 -- !query analysis
 DropTable false, false

--- a/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
@@ -1784,6 +1784,34 @@ table wswscs
      round(fri_sales1 / fri_sales2, 2),
      round(sat_sales1 / sat_sales2, 2);
 
+-- Q3
+select
+  dt.d_year,
+  item.i_brand_id brand_id,
+  item.i_brand brand,
+  sum(ss_ext_sales_price) sum_agg
+from date_dim dt, store_sales, item
+where dt.d_date_sk = store_sales.ss_sold_date_sk
+  and store_sales.ss_item_sk = item.i_item_sk
+  and item.i_manufact_id = 128
+  and dt.d_moy = 11
+group by dt.d_year, item.i_brand, item.i_brand_id
+order by dt.d_year, sum_agg desc, brand_id
+limit 100;
+
+table date_dim
+|> as dt
+|> join store_sales
+|> join item
+|> where dt.d_date_sk = store_sales.ss_sold_date_sk
+     and store_sales.ss_item_sk = item.i_item_sk
+     and item.i_manufact_id = 128
+     and dt.d_moy = 11
+|> aggregate sum(ss_ext_sales_price) sum_agg
+     group by dt.d_year d_year, item.i_brand_id brand_id, item.i_brand brand
+|> order by d_year, sum_agg desc, brand_id
+|> limit 100;
+
 -- Cleanup.
 -----------
 drop table t;

--- a/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
@@ -1846,7 +1846,7 @@ table web_sales
      and (cast('1999-02-22' as date) + interval 30 days)
 |> aggregate sum(ws_ext_sales_price) AS itemrevenue
      group by i_item_id, i_item_desc, i_category, i_class, i_current_price
-|> select *,
+|> extend
      itemrevenue * 100 / sum(itemrevenue)
        over (partition by i_class) as revenueratio
 |> order by i_category, i_class, i_item_id, i_item_desc, revenueratio

--- a/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
@@ -1812,6 +1812,47 @@ table date_dim
 |> order by d_year, sum_agg desc, brand_id
 |> limit 100;
 
+-- Q12
+select
+  i_item_desc,
+  i_category,
+  i_class,
+  i_current_price,
+  sum(ws_ext_sales_price) as itemrevenue,
+  sum(ws_ext_sales_price) * 100 / sum(sum(ws_ext_sales_price))
+  over
+  (partition by i_class) as revenueratio
+from
+  web_sales, item, date_dim
+where
+  ws_item_sk = i_item_sk
+    and i_category in ('sports', 'books', 'home')
+    and ws_sold_date_sk = d_date_sk
+    and d_date between cast('1999-02-22' as date)
+  and (cast('1999-02-22' as date) + interval 30 days)
+group by
+  i_item_id, i_item_desc, i_category, i_class, i_current_price
+order by
+  i_category, i_class, i_item_id, i_item_desc, revenueratio
+limit 100;
+
+table web_sales
+|> join item
+|> join date_dim
+|> where ws_item_sk = i_item_sk
+     and i_category in ('sports', 'books', 'home')
+     and ws_sold_date_sk = d_date_sk
+     and d_date between cast('1999-02-22' as date)
+     and (cast('1999-02-22' as date) + interval 30 days)
+|> aggregate sum(ws_ext_sales_price) AS itemrevenue
+     group by i_item_id, i_item_desc, i_category, i_class, i_current_price
+|> select *,
+     itemrevenue * 100 / sum(itemrevenue)
+       over (partition by i_class) as revenueratio
+|> order by i_category, i_class, i_item_id, i_item_desc, revenueratio
+|> select i_item_desc, i_category, i_class, i_current_price, itemrevenue, revenueratio
+|> limit 100;
+
 -- Cleanup.
 -----------
 drop table t;

--- a/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
@@ -71,456 +71,6 @@ create temporary view windowTestData as select * from values
   (3, 1L, 1.0D, date("2017-08-01"), timestamp_seconds(1501545600), null)
   AS testData(val, val_long, val_double, val_date, val_timestamp, cate);
 
-create table store_sales(
-  `ss_sold_date_sk` int,
-  `ss_sold_time_sk` int,
-  `ss_item_sk` int,
-  `ss_customer_sk` int,
-  `ss_cdemo_sk` int,
-  `ss_hdemo_sk` int,
-  `ss_addr_sk` int,
-  `ss_store_sk` int,
-  `ss_promo_sk` int,
-  `ss_ticket_number` int,
-  `ss_quantity` int,
-  `ss_wholesale_cost` decimal(7,2),
-  `ss_list_price` decimal(7,2),
-  `ss_sales_price` decimal(7,2),
-  `ss_ext_discount_amt` decimal(7,2),
-  `ss_ext_sales_price` decimal(7,2),
-  `ss_ext_wholesale_cost` decimal(7,2),
-  `ss_ext_list_price` decimal(7,2),
-  `ss_ext_tax` decimal(7,2),
-  `ss_coupon_amt` decimal(7,2),
-  `ss_net_paid` decimal(7,2),
-  `ss_net_paid_inc_tax` decimal(7,2),
-  `ss_net_profit` decimal(7,2));
-create table store_returns(
-  `sr_returned_date_sk` int,
-  `sr_return_time_sk` int,
-  `sr_item_sk` int,
-  `sr_customer_sk` int,
-  `sr_cdemo_sk` int,
-  `sr_hdemo_sk` int,
-  `sr_addr_sk` int,
-  `sr_store_sk` int,
-  `sr_reason_sk` int,
-  `sr_ticket_number` int,
-  `sr_return_quantity` int,
-  `sr_return_amt` decimal(7,2),
-  `sr_return_tax` decimal(7,2),
-  `sr_return_amt_inc_tax` decimal(7,2),
-  `sr_fee` decimal(7,2),
-  `sr_return_ship_cost` decimal(7,2),
-  `sr_refunded_cash` decimal(7,2),
-  `sr_reversed_charge` decimal(7,2),
-  `sr_store_credit` decimal(7,2),
-  `sr_net_loss` decimal(7,2));
-create table catalog_sales(
-  `cs_sold_date_sk` int,
-  `cs_sold_time_sk` int,
-  `cs_ship_date_sk` int,
-  `cs_bill_customer_sk` int,
-  `cs_bill_cdemo_sk` int,
-  `cs_bill_hdemo_sk` int,
-  `cs_bill_addr_sk` int,
-  `cs_ship_customer_sk` int,
-  `cs_ship_cdemo_sk` int,
-  `cs_ship_hdemo_sk` int,
-  `cs_ship_addr_sk` int,
-  `cs_call_center_sk` int,
-  `cs_catalog_page_sk` int,
-  `cs_ship_mode_sk` int,
-  `cs_warehouse_sk` int,
-  `cs_item_sk` int,
-  `cs_promo_sk` int,
-  `cs_order_number` int,
-  `cs_quantity` int,
-  `cs_wholesale_cost` decimal(7,2),
-  `cs_list_price` decimal(7,2),
-  `cs_sales_price` decimal(7,2),
-  `cs_ext_discount_amt` decimal(7,2),
-  `cs_ext_sales_price` decimal(7,2),
-  `cs_ext_wholesale_cost` decimal(7,2),
-  `cs_ext_list_price` decimal(7,2),
-  `cs_ext_tax` decimal(7,2),
-  `cs_coupon_amt` decimal(7,2),
-  `cs_ext_ship_cost` decimal(7,2),
-  `cs_net_paid` decimal(7,2),
-  `cs_net_paid_inc_tax` decimal(7,2),
-  `cs_net_paid_inc_ship` decimal(7,2),
-  `cs_net_paid_inc_ship_tax` decimal(7,2),
-  `cs_net_profit` decimal(7,2));
-create table catalog_returns(
-  `cr_returned_date_sk` int,
-  `cr_returned_time_sk` int,
-  `cr_item_sk` int,
-  `cr_refunded_customer_sk` int,
-  `cr_refunded_cdemo_sk` int,
-  `cr_refunded_hdemo_sk` int,
-  `cr_refunded_addr_sk` int,
-  `cr_returning_customer_sk` int,
-  `cr_returning_cdemo_sk` int,
-  `cr_returning_hdemo_sk` int,
-  `cr_returning_addr_sk` int,
-  `cr_call_center_sk` int,
-  `cr_catalog_page_sk` int,
-  `cr_ship_mode_sk` int,
-  `cr_warehouse_sk` int,
-  `cr_reason_sk` int,
-  `cr_order_number` int,
-  `cr_return_quantity` int,
-  `cr_return_amount` decimal(7,2),
-  `cr_return_tax` decimal(7,2),
-  `cr_return_amt_inc_tax` decimal(7,2),
-  `cr_fee` decimal(7,2),
-  `cr_return_ship_cost` decimal(7,2),
-  `cr_refunded_cash` decimal(7,2),
-  `cr_reversed_charge` decimal(7,2),
-  `cr_store_credit` decimal(7,2),
-  `cr_net_loss` decimal(7,2));
-create table web_sales(
-  `ws_sold_date_sk` int,
-  `ws_sold_time_sk` int,
-  `ws_ship_date_sk` int,
-  `ws_item_sk` int,
-  `ws_bill_customer_sk` int,
-  `ws_bill_cdemo_sk` int,
-  `ws_bill_hdemo_sk` int,
-  `ws_bill_addr_sk` int,
-  `ws_ship_customer_sk` int,
-  `ws_ship_cdemo_sk` int,
-  `ws_ship_hdemo_sk` int,
-  `ws_ship_addr_sk` int,
-  `ws_web_page_sk` int,
-  `ws_web_site_sk` int,
-  `ws_ship_mode_sk` int,
-  `ws_warehouse_sk` int,
-  `ws_promo_sk` int,
-  `ws_order_number` int,
-  `ws_quantity` int,
-  `ws_wholesale_cost` decimal(7,2),
-  `ws_list_price` decimal(7,2),
-  `ws_sales_price` decimal(7,2),
-  `ws_ext_discount_amt` decimal(7,2),
-  `ws_ext_sales_price` decimal(7,2),
-  `ws_ext_wholesale_cost` decimal(7,2),
-  `ws_ext_list_price` decimal(7,2),
-  `ws_ext_tax` decimal(7,2),
-  `ws_coupon_amt` decimal(7,2),
-  `ws_ext_ship_cost` decimal(7,2),
-  `ws_net_paid` decimal(7,2),
-  `ws_net_paid_inc_tax` decimal(7,2),
-  `ws_net_paid_inc_ship` decimal(7,2),
-  `ws_net_paid_inc_ship_tax` decimal(7,2),
-  `ws_net_profit` decimal(7,2));
-create table web_returns(
-  `wr_returned_date_sk` int,
-  `wr_returned_time_sk` int,
-  `wr_item_sk` int,
-  `wr_refunded_customer_sk` int,
-  `wr_refunded_cdemo_sk` int,
-  `wr_refunded_hdemo_sk` int,
-  `wr_refunded_addr_sk` int,
-  `wr_returning_customer_sk` int,
-  `wr_returning_cdemo_sk` int,
-  `wr_returning_hdemo_sk` int,
-  `wr_returning_addr_sk` int,
-  `wr_web_page_sk` int,
-  `wr_reason_sk` int,
-  `wr_order_number` int,
-  `wr_return_quantity` int,
-  `wr_return_amt` decimal(7,2),
-  `wr_return_tax` decimal(7,2),
-  `wr_return_amt_inc_tax` decimal(7,2),
-  `wr_fee` decimal(7,2),
-  `wr_return_ship_cost` decimal(7,2),
-  `wr_refunded_cash` decimal(7,2),
-  `wr_reversed_charge` decimal(7,2),
-  `wr_account_credit` decimal(7,2),
-  `wr_net_loss` decimal(7,2));
-create table inventory(
-  `inv_date_sk` int,
-  `inv_item_sk` int,
-  `inv_warehouse_sk` int,
-  `inv_quantity_on_hand` int);
-create table store(
-  `s_store_sk` int,
-  `s_store_id` char(16),
-  `s_rec_start_date` date,
-  `s_rec_end_date` date,
-  `s_closed_date_sk` int,
-  `s_store_name` varchar(50),
-  `s_number_employees` int,
-  `s_floor_space` int,
-  `s_hours` char(20),
-  `s_manager` varchar(40),
-  `s_market_id` int,
-  `s_geography_class` varchar(100),
-  `s_market_desc` varchar(100),
-  `s_market_manager` varchar(40),
-  `s_division_id` int,
-  `s_division_name` varchar(50),
-  `s_company_id` int,
-  `s_company_name` varchar(50),
-  `s_street_number` varchar(10),
-  `s_street_name` varchar(60),
-  `s_street_type` char(15),
-  `s_suite_number` char(10),
-  `s_city` varchar(60),
-  `s_county` varchar(30),
-  `s_state` char(2),
-  `s_zip` char(10),
-  `s_country` varchar(20),
-  `s_gmt_offset` decimal(5,2),
-  `s_tax_percentage` decimal(5,2));
-create table call_center(
-  `cc_call_center_sk` int,
-  `cc_call_center_id` char(16),
-  `cc_rec_start_date` date,
-  `cc_rec_end_date` date,
-  `cc_closed_date_sk` int,
-  `cc_open_date_sk` int,
-  `cc_name` varchar(50),
-  `cc_class` varchar(50),
-  `cc_employees` int,
-  `cc_sq_ft` int,
-  `cc_hours` char(20),
-  `cc_manager` varchar(40),
-  `cc_mkt_id` int,
-  `cc_mkt_class` char(50),
-  `cc_mkt_desc` varchar(100),
-  `cc_market_manager` varchar(40),
-  `cc_division` int,
-  `cc_division_name` varchar(50),
-  `cc_company` int,
-  `cc_company_name` char(50),
-  `cc_street_number` char(10),
-  `cc_street_name` varchar(60),
-  `cc_street_type` char(15),
-  `cc_suite_number` char(10),
-  `cc_city` varchar(60),
-  `cc_county` varchar(30),
-  `cc_state` char(2),
-  `cc_zip` char(10),
-  `cc_country` varchar(20),
-  `cc_gmt_offset` decimal(5,2),
-  `cc_tax_percentage` decimal(5,2));
-create table catalog_page(
-  `cp_catalog_page_sk` int,
-  `cp_catalog_page_id` char(16),
-  `cp_start_date_sk` int,
-  `cp_end_date_sk` int,
-  `cp_department` varchar(50),
-  `cp_catalog_number` int,
-  `cp_catalog_page_number` int,
-  `cp_description` varchar(100),
-  `cp_type` varchar(100));
-create table web_site(
-  `web_site_sk` int,
-  `web_site_id` char(16),
-  `web_rec_start_date` date,
-  `web_rec_end_date` date,
-  `web_name` varchar(50),
-  `web_open_date_sk` int,
-  `web_close_date_sk` int,
-  `web_class` varchar(50),
-  `web_manager` varchar(40),
-  `web_mkt_id` int,
-  `web_mkt_class` varchar(50),
-  `web_mkt_desc` varchar(100),
-  `web_market_manager` varchar(40),
-  `web_company_id` int,
-  `web_company_name` char(50),
-  `web_street_number` char(10),
-  `web_street_name` varchar(60),
-  `web_street_type` char(15),
-  `web_suite_number` char(10),
-  `web_city` varchar(60),
-  `web_county` varchar(30),
-  `web_state` char(2),
-  `web_zip` char(10),
-  `web_country` varchar(20),
-  `web_gmt_offset` decimal(5,2),
-  `web_tax_percentage` decimal(5,2));
-create table web_page(
-  `wp_web_page_sk` int,
-  `wp_web_page_id` char(16),
-  `wp_rec_start_date` date,
-  `wp_rec_end_date` date,
-  `wp_creation_date_sk` int,
-  `wp_access_date_sk` int,
-  `wp_autogen_flag` char(1),
-  `wp_customer_sk` int,
-  `wp_url` varchar(100),
-  `wp_type` char(50),
-  `wp_char_count` int,
-  `wp_link_count` int,
-  `wp_image_count` int,
-  `wp_max_ad_count` int);
-create table warehouse(
-  `w_warehouse_sk` int,
-  `w_warehouse_id` char(16),
-  `w_warehouse_name` varchar(20),
-  `w_warehouse_sq_ft` int,
-  `w_street_number` char(10),
-  `w_street_name` varchar(20),
-  `w_street_type` char(15),
-  `w_suite_number` char(10),
-  `w_city` varchar(60),
-  `w_county` varchar(30),
-  `w_state` char(2),
-  `w_zip` char(10),
-  `w_country` varchar(20),
-  `w_gmt_offset` decimal(5,2));
-create table customer(
-  `c_customer_sk` int,
-  `c_customer_id` char(16),
-  `c_current_cdemo_sk` int,
-  `c_current_hdemo_sk` int,
-  `c_current_addr_sk` int,
-  `c_first_shipto_date_sk` int,
-  `c_first_sales_date_sk` int,
-  `c_salutation` char(10),
-  `c_first_name` char(20),
-  `c_last_name` char(30),
-  `c_preferred_cust_flag` char(1),
-  `c_birth_day` int,
-  `c_birth_month` int,
-  `c_birth_year` int,
-  `c_birth_country` varchar(20),
-  `c_login` char(13),
-  `c_email_address` char(50),
-  `c_last_review_date` int);
-create table customer_address(
-  `ca_address_sk` int,
-  `ca_address_id` char(16),
-  `ca_street_number` char(10),
-  `ca_street_name` varchar(60),
-  `ca_street_type` char(15),
-  `ca_suite_number` char(10),
-  `ca_city` varchar(60),
-  `ca_county` varchar(30),
-  `ca_state` char(2),
-  `ca_zip` char(10),
-  `ca_country` varchar(20),
-  `ca_gmt_offset` decimal(5,2),
-  `ca_location_type` char(20));
-create table customer_demographics(
-  `cd_demo_sk` int,
-  `cd_gender` char(1),
-  `cd_marital_status` char(1),
-  `cd_education_status` char(20),
-  `cd_purchase_estimate` int,
-  `cd_credit_rating` char(10),
-  `cd_dep_count` int,
-  `cd_dep_employed_count` int,
-  `cd_dep_college_count` int);
-create table date_dim(
-  `d_date_sk` int,
-  `d_date_id` char(16),
-  `d_date` date,
-  `d_month_seq` int,
-  `d_week_seq` int,
-  `d_quarter_seq` int,
-  `d_year` int,
-  `d_dow` int,
-  `d_moy` int,
-  `d_dom` int,
-  `d_qoy` int,
-  `d_fy_year` int,
-  `d_fy_quarter_seq` int,
-  `d_fy_week_seq` int,
-  `d_day_name` char(9),
-  `d_quarter_name` char(6),
-  `d_holiday` char(1),
-  `d_weekend` char(1),
-  `d_following_holiday` char(1),
-  `d_first_dom` int,
-  `d_last_dom` int,
-  `d_same_day_ly` int,
-  `d_same_day_lq` int,
-  `d_current_day` char(1),
-  `d_current_week` char(1),
-  `d_current_month` char(1),
-  `d_current_quarter` char(1),
-  `d_current_year` char(1));
-create table household_demographics(
-  `hd_demo_sk` int,
-  `hd_income_band_sk` int,
-  `hd_buy_potential` char(15),
-  `hd_dep_count` int,
-  `hd_vehicle_count` int);
-create table item(
-  `i_item_sk` int,
-  `i_item_id` char(16),
-  `i_rec_start_date` date,
-  `i_rec_end_date` date,
-  `i_item_desc` varchar(200),
-  `i_current_price` decimal(7,2),
-  `i_wholesale_cost` decimal(7,2),
-  `i_brand_id` int,
-  `i_brand` char(50),
-  `i_class_id` int,
-  `i_class` char(50),
-  `i_category_id` int,
-  `i_category` char(50),
-  `i_manufact_id` int,
-  `i_manufact` char(50),
-  `i_size` char(20),
-  `i_formulation` char(20),
-  `i_color` char(20),
-  `i_units` char(10),
-  `i_container` char(10),
-  `i_manager_id` int,
-  `i_product_name` char(50));
-create table income_band(
-  `ib_income_band_sk` int,
-  `ib_lower_bound` int,
-  `ib_upper_bound` int);
-create table promotion(
-  `p_promo_sk` int,
-  `p_promo_id` char(16),
-  `p_start_date_sk` int,
-  `p_end_date_sk` int,
-  `p_item_sk` int,
-  `p_cost` decimal(15,2),
-  `p_response_target` int,
-  `p_promo_name` char(50),
-  `p_channel_dmail` char(1),
-  `p_channel_email` char(1),
-  `p_channel_catalog` char(1),
-  `p_channel_tv` char(1),
-  `p_channel_radio` char(1),
-  `p_channel_press` char(1),
-  `p_channel_event` char(1),
-  `p_channel_demo` char(1),
-  `p_channel_details` varchar(100),
-  `p_purpose` char(15),
-  `p_discount_active` char(1));
-create table reason(
-  `r_reason_sk` int,
-  `r_reason_id` char(16),
-  `r_reason_desc` char(100));
-create table ship_mode(
-  `sm_ship_mode_sk` int,
-  `sm_ship_mode_id` char(16),
-  `sm_type` char(30),
-  `sm_code` char(10),
-  `sm_carrier` char(20),
-  `sm_contract` char(20));
-create table time_dim(
-  `t_time_sk` int,
-  `t_time_id` char(16),
-  `t_time` int,
-  `t_hour` int,
-  `t_minute` int,
-  `t_second` int,
-  `t_am_pm` char(2),
-  `t_shift` char(20),
-  `t_sub_shift` char(20),
-  `t_meal_time` char(20));
-
 -- SELECT operators: positive tests.
 ---------------------------------------
 
@@ -826,6 +376,11 @@ select 1 as x, 2 as y
 |> as u
 |> select u.x, u.y;
 
+-- Renaming as a backquoted name including a period.
+table t
+|> as `u.v`
+|> select `u.v`.x, `u.v`.y;
+
 -- Renaming two times.
 table t
 |> as u
@@ -847,6 +402,16 @@ table t
 -- Expressions are not supported.
 table t
 |> as 1 + 2;
+
+-- Renaming as an invalid name.
+table t
+|> as u-v;
+
+table t
+|> as u@v;
+
+table t
+|> as u#######v;
 
 -- WHERE operators: positive tests.
 -----------------------------------
@@ -1952,32 +1517,123 @@ table store_sales
      i1.i_product_name best_performing,
      i2.i_product_name worst_performing;
 
+-- Q51
+with web_v1 as (
+  select
+    ws_item_sk item_sk,
+    d_date,
+    sum(sum(ws_sales_price))
+    over (partition by ws_item_sk
+      order by d_date
+      rows between unbounded preceding and current row) cume_sales
+  from web_sales, date_dim
+  where ws_sold_date_sk = d_date_sk
+    and d_month_seq between 1200 and 1200 + 11
+    and ws_item_sk is not null
+  group by ws_item_sk, d_date),
+    store_v1 as (
+    select
+      ss_item_sk item_sk,
+      d_date,
+      sum(sum(ss_sales_price))
+      over (partition by ss_item_sk
+        order by d_date
+        rows between unbounded preceding and current row) cume_sales
+    from store_sales, date_dim
+    where ss_sold_date_sk = d_date_sk
+      and d_month_seq between 1200 and 1200 + 11
+      and ss_item_sk is not null
+    group by ss_item_sk, d_date)
+select *
+from (select
+  item_sk,
+  d_date,
+  web_sales,
+  store_sales,
+  max(web_sales)
+  over (partition by item_sk
+    order by d_date
+    rows between unbounded preceding and current row) web_cumulative,
+  max(store_sales)
+  over (partition by item_sk
+    order by d_date
+    rows between unbounded preceding and current row) store_cumulative
+from (select
+  case when web.item_sk is not null
+    then web.item_sk
+  else store.item_sk end item_sk,
+  case when web.d_date is not null
+    then web.d_date
+  else store.d_date end d_date,
+  web.cume_sales web_sales,
+  store.cume_sales store_sales
+from web_v1 web full outer join store_v1 store on (web.item_sk = store.item_sk
+  and web.d_date = store.d_date)
+     ) x) y
+where web_cumulative > store_cumulative
+order by item_sk, d_date
+limit 100;
+
+with web_v1 as (
+  table web_sales
+  |> join date_dim
+  |> where ws_sold_date_sk = d_date_sk
+       and d_month_seq between 1200 and 1200 + 11
+       and ws_item_sk is not null
+  |> aggregate sum(ws_sales_price) as sum_ws_sales_price
+       group by ws_item_sk as item_sk, d_date
+  |> extend sum(sum_ws_sales_price)
+       over (partition by item_sk
+         order by d_date
+         rows between unbounded preceding and current row)
+       as cume_sales),
+store_v1 as (
+  table store_sales
+  |> join date_dim
+  |> where ss_sold_date_sk = d_date_sk
+       and d_month_seq between 1200 and 1200 + 11
+       and ss_item_sk is not null
+  |> aggregate sum(ss_sales_price) as sum_ss_sales_price
+       group by ss_item_sk as item_sk, d_date
+  |> extend sum(sum_ss_sales_price)
+       over (partition by item_sk
+           order by d_date
+           rows between unbounded preceding and current row)
+       as cume_sales)
+table web_v1
+|> as web
+|> full outer join store_v1 store
+     on (web.item_sk = store.item_sk and web.d_date = store.d_date)
+|> select
+     case when web.item_sk is not null
+       then web.item_sk
+       else store.item_sk end item_sk,
+     case when web.d_date is not null
+       then web.d_date
+       else store.d_date end d_date,
+     web.cume_sales web_sales,
+     store.cume_sales store_sales
+|> as x
+|> select
+     item_sk,
+     d_date,
+     web_sales,
+     store_sales,
+     max(web_sales)
+       over (partition by item_sk
+         order by d_date
+         rows between unbounded preceding and current row) web_cumulative,
+     max(store_sales)
+       over (partition by item_sk
+         order by d_date
+         rows between unbounded preceding and current row) store_cumulative
+|> as y
+|> where web_cumulative > store_cumulative
+|> order by item_sk, d_date
+|> limit 100;
+
 -- Cleanup.
 -----------
 drop table t;
 drop table other;
 drop table st;
-drop table call_center;
-drop table catalog_page;
-drop table catalog_returns;
-drop table catalog_sales;
-drop table customer;
-drop table customer_address;
-drop table customer_demographics;
-drop table date_dim;
-drop table household_demographics;
-drop table income_band;
-drop table inventory;
-drop table item;
-drop table promotion;
-drop table reason;
-drop table ship_mode;
-drop table store;
-drop table store_returns;
-drop table store_sales;
-drop table time_dim;
-drop table warehouse;
-drop table web_page;
-drop table web_returns;
-drop table web_sales;
-drop table web_site;

--- a/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
@@ -71,6 +71,456 @@ create temporary view windowTestData as select * from values
   (3, 1L, 1.0D, date("2017-08-01"), timestamp_seconds(1501545600), null)
   AS testData(val, val_long, val_double, val_date, val_timestamp, cate);
 
+create table store_sales(
+  `ss_sold_date_sk` int,
+  `ss_sold_time_sk` int,
+  `ss_item_sk` int,
+  `ss_customer_sk` int,
+  `ss_cdemo_sk` int,
+  `ss_hdemo_sk` int,
+  `ss_addr_sk` int,
+  `ss_store_sk` int,
+  `ss_promo_sk` int,
+  `ss_ticket_number` int,
+  `ss_quantity` int,
+  `ss_wholesale_cost` decimal(7,2),
+  `ss_list_price` decimal(7,2),
+  `ss_sales_price` decimal(7,2),
+  `ss_ext_discount_amt` decimal(7,2),
+  `ss_ext_sales_price` decimal(7,2),
+  `ss_ext_wholesale_cost` decimal(7,2),
+  `ss_ext_list_price` decimal(7,2),
+  `ss_ext_tax` decimal(7,2),
+  `ss_coupon_amt` decimal(7,2),
+  `ss_net_paid` decimal(7,2),
+  `ss_net_paid_inc_tax` decimal(7,2),
+  `ss_net_profit` decimal(7,2));
+create table store_returns(
+  `sr_returned_date_sk` int,
+  `sr_return_time_sk` int,
+  `sr_item_sk` int,
+  `sr_customer_sk` int,
+  `sr_cdemo_sk` int,
+  `sr_hdemo_sk` int,
+  `sr_addr_sk` int,
+  `sr_store_sk` int,
+  `sr_reason_sk` int,
+  `sr_ticket_number` int,
+  `sr_return_quantity` int,
+  `sr_return_amt` decimal(7,2),
+  `sr_return_tax` decimal(7,2),
+  `sr_return_amt_inc_tax` decimal(7,2),
+  `sr_fee` decimal(7,2),
+  `sr_return_ship_cost` decimal(7,2),
+  `sr_refunded_cash` decimal(7,2),
+  `sr_reversed_charge` decimal(7,2),
+  `sr_store_credit` decimal(7,2),
+  `sr_net_loss` decimal(7,2));
+create table catalog_sales(
+  `cs_sold_date_sk` int,
+  `cs_sold_time_sk` int,
+  `cs_ship_date_sk` int,
+  `cs_bill_customer_sk` int,
+  `cs_bill_cdemo_sk` int,
+  `cs_bill_hdemo_sk` int,
+  `cs_bill_addr_sk` int,
+  `cs_ship_customer_sk` int,
+  `cs_ship_cdemo_sk` int,
+  `cs_ship_hdemo_sk` int,
+  `cs_ship_addr_sk` int,
+  `cs_call_center_sk` int,
+  `cs_catalog_page_sk` int,
+  `cs_ship_mode_sk` int,
+  `cs_warehouse_sk` int,
+  `cs_item_sk` int,
+  `cs_promo_sk` int,
+  `cs_order_number` int,
+  `cs_quantity` int,
+  `cs_wholesale_cost` decimal(7,2),
+  `cs_list_price` decimal(7,2),
+  `cs_sales_price` decimal(7,2),
+  `cs_ext_discount_amt` decimal(7,2),
+  `cs_ext_sales_price` decimal(7,2),
+  `cs_ext_wholesale_cost` decimal(7,2),
+  `cs_ext_list_price` decimal(7,2),
+  `cs_ext_tax` decimal(7,2),
+  `cs_coupon_amt` decimal(7,2),
+  `cs_ext_ship_cost` decimal(7,2),
+  `cs_net_paid` decimal(7,2),
+  `cs_net_paid_inc_tax` decimal(7,2),
+  `cs_net_paid_inc_ship` decimal(7,2),
+  `cs_net_paid_inc_ship_tax` decimal(7,2),
+  `cs_net_profit` decimal(7,2));
+create table catalog_returns(
+  `cr_returned_date_sk` int,
+  `cr_returned_time_sk` int,
+  `cr_item_sk` int,
+  `cr_refunded_customer_sk` int,
+  `cr_refunded_cdemo_sk` int,
+  `cr_refunded_hdemo_sk` int,
+  `cr_refunded_addr_sk` int,
+  `cr_returning_customer_sk` int,
+  `cr_returning_cdemo_sk` int,
+  `cr_returning_hdemo_sk` int,
+  `cr_returning_addr_sk` int,
+  `cr_call_center_sk` int,
+  `cr_catalog_page_sk` int,
+  `cr_ship_mode_sk` int,
+  `cr_warehouse_sk` int,
+  `cr_reason_sk` int,
+  `cr_order_number` int,
+  `cr_return_quantity` int,
+  `cr_return_amount` decimal(7,2),
+  `cr_return_tax` decimal(7,2),
+  `cr_return_amt_inc_tax` decimal(7,2),
+  `cr_fee` decimal(7,2),
+  `cr_return_ship_cost` decimal(7,2),
+  `cr_refunded_cash` decimal(7,2),
+  `cr_reversed_charge` decimal(7,2),
+  `cr_store_credit` decimal(7,2),
+  `cr_net_loss` decimal(7,2));
+create table web_sales(
+  `ws_sold_date_sk` int,
+  `ws_sold_time_sk` int,
+  `ws_ship_date_sk` int,
+  `ws_item_sk` int,
+  `ws_bill_customer_sk` int,
+  `ws_bill_cdemo_sk` int,
+  `ws_bill_hdemo_sk` int,
+  `ws_bill_addr_sk` int,
+  `ws_ship_customer_sk` int,
+  `ws_ship_cdemo_sk` int,
+  `ws_ship_hdemo_sk` int,
+  `ws_ship_addr_sk` int,
+  `ws_web_page_sk` int,
+  `ws_web_site_sk` int,
+  `ws_ship_mode_sk` int,
+  `ws_warehouse_sk` int,
+  `ws_promo_sk` int,
+  `ws_order_number` int,
+  `ws_quantity` int,
+  `ws_wholesale_cost` decimal(7,2),
+  `ws_list_price` decimal(7,2),
+  `ws_sales_price` decimal(7,2),
+  `ws_ext_discount_amt` decimal(7,2),
+  `ws_ext_sales_price` decimal(7,2),
+  `ws_ext_wholesale_cost` decimal(7,2),
+  `ws_ext_list_price` decimal(7,2),
+  `ws_ext_tax` decimal(7,2),
+  `ws_coupon_amt` decimal(7,2),
+  `ws_ext_ship_cost` decimal(7,2),
+  `ws_net_paid` decimal(7,2),
+  `ws_net_paid_inc_tax` decimal(7,2),
+  `ws_net_paid_inc_ship` decimal(7,2),
+  `ws_net_paid_inc_ship_tax` decimal(7,2),
+  `ws_net_profit` decimal(7,2));
+create table web_returns(
+  `wr_returned_date_sk` int,
+  `wr_returned_time_sk` int,
+  `wr_item_sk` int,
+  `wr_refunded_customer_sk` int,
+  `wr_refunded_cdemo_sk` int,
+  `wr_refunded_hdemo_sk` int,
+  `wr_refunded_addr_sk` int,
+  `wr_returning_customer_sk` int,
+  `wr_returning_cdemo_sk` int,
+  `wr_returning_hdemo_sk` int,
+  `wr_returning_addr_sk` int,
+  `wr_web_page_sk` int,
+  `wr_reason_sk` int,
+  `wr_order_number` int,
+  `wr_return_quantity` int,
+  `wr_return_amt` decimal(7,2),
+  `wr_return_tax` decimal(7,2),
+  `wr_return_amt_inc_tax` decimal(7,2),
+  `wr_fee` decimal(7,2),
+  `wr_return_ship_cost` decimal(7,2),
+  `wr_refunded_cash` decimal(7,2),
+  `wr_reversed_charge` decimal(7,2),
+  `wr_account_credit` decimal(7,2),
+  `wr_net_loss` decimal(7,2));
+create table inventory(
+  `inv_date_sk` int,
+  `inv_item_sk` int,
+  `inv_warehouse_sk` int,
+  `inv_quantity_on_hand` int);
+create table store(
+  `s_store_sk` int,
+  `s_store_id` char(16),
+  `s_rec_start_date` date,
+  `s_rec_end_date` date,
+  `s_closed_date_sk` int,
+  `s_store_name` varchar(50),
+  `s_number_employees` int,
+  `s_floor_space` int,
+  `s_hours` char(20),
+  `s_manager` varchar(40),
+  `s_market_id` int,
+  `s_geography_class` varchar(100),
+  `s_market_desc` varchar(100),
+  `s_market_manager` varchar(40),
+  `s_division_id` int,
+  `s_division_name` varchar(50),
+  `s_company_id` int,
+  `s_company_name` varchar(50),
+  `s_street_number` varchar(10),
+  `s_street_name` varchar(60),
+  `s_street_type` char(15),
+  `s_suite_number` char(10),
+  `s_city` varchar(60),
+  `s_county` varchar(30),
+  `s_state` char(2),
+  `s_zip` char(10),
+  `s_country` varchar(20),
+  `s_gmt_offset` decimal(5,2),
+  `s_tax_percentage` decimal(5,2));
+create table call_center(
+  `cc_call_center_sk` int,
+  `cc_call_center_id` char(16),
+  `cc_rec_start_date` date,
+  `cc_rec_end_date` date,
+  `cc_closed_date_sk` int,
+  `cc_open_date_sk` int,
+  `cc_name` varchar(50),
+  `cc_class` varchar(50),
+  `cc_employees` int,
+  `cc_sq_ft` int,
+  `cc_hours` char(20),
+  `cc_manager` varchar(40),
+  `cc_mkt_id` int,
+  `cc_mkt_class` char(50),
+  `cc_mkt_desc` varchar(100),
+  `cc_market_manager` varchar(40),
+  `cc_division` int,
+  `cc_division_name` varchar(50),
+  `cc_company` int,
+  `cc_company_name` char(50),
+  `cc_street_number` char(10),
+  `cc_street_name` varchar(60),
+  `cc_street_type` char(15),
+  `cc_suite_number` char(10),
+  `cc_city` varchar(60),
+  `cc_county` varchar(30),
+  `cc_state` char(2),
+  `cc_zip` char(10),
+  `cc_country` varchar(20),
+  `cc_gmt_offset` decimal(5,2),
+  `cc_tax_percentage` decimal(5,2));
+create table catalog_page(
+  `cp_catalog_page_sk` int,
+  `cp_catalog_page_id` char(16),
+  `cp_start_date_sk` int,
+  `cp_end_date_sk` int,
+  `cp_department` varchar(50),
+  `cp_catalog_number` int,
+  `cp_catalog_page_number` int,
+  `cp_description` varchar(100),
+  `cp_type` varchar(100));
+create table web_site(
+  `web_site_sk` int,
+  `web_site_id` char(16),
+  `web_rec_start_date` date,
+  `web_rec_end_date` date,
+  `web_name` varchar(50),
+  `web_open_date_sk` int,
+  `web_close_date_sk` int,
+  `web_class` varchar(50),
+  `web_manager` varchar(40),
+  `web_mkt_id` int,
+  `web_mkt_class` varchar(50),
+  `web_mkt_desc` varchar(100),
+  `web_market_manager` varchar(40),
+  `web_company_id` int,
+  `web_company_name` char(50),
+  `web_street_number` char(10),
+  `web_street_name` varchar(60),
+  `web_street_type` char(15),
+  `web_suite_number` char(10),
+  `web_city` varchar(60),
+  `web_county` varchar(30),
+  `web_state` char(2),
+  `web_zip` char(10),
+  `web_country` varchar(20),
+  `web_gmt_offset` decimal(5,2),
+  `web_tax_percentage` decimal(5,2));
+create table web_page(
+  `wp_web_page_sk` int,
+  `wp_web_page_id` char(16),
+  `wp_rec_start_date` date,
+  `wp_rec_end_date` date,
+  `wp_creation_date_sk` int,
+  `wp_access_date_sk` int,
+  `wp_autogen_flag` char(1),
+  `wp_customer_sk` int,
+  `wp_url` varchar(100),
+  `wp_type` char(50),
+  `wp_char_count` int,
+  `wp_link_count` int,
+  `wp_image_count` int,
+  `wp_max_ad_count` int);
+create table warehouse(
+  `w_warehouse_sk` int,
+  `w_warehouse_id` char(16),
+  `w_warehouse_name` varchar(20),
+  `w_warehouse_sq_ft` int,
+  `w_street_number` char(10),
+  `w_street_name` varchar(20),
+  `w_street_type` char(15),
+  `w_suite_number` char(10),
+  `w_city` varchar(60),
+  `w_county` varchar(30),
+  `w_state` char(2),
+  `w_zip` char(10),
+  `w_country` varchar(20),
+  `w_gmt_offset` decimal(5,2));
+create table customer(
+  `c_customer_sk` int,
+  `c_customer_id` char(16),
+  `c_current_cdemo_sk` int,
+  `c_current_hdemo_sk` int,
+  `c_current_addr_sk` int,
+  `c_first_shipto_date_sk` int,
+  `c_first_sales_date_sk` int,
+  `c_salutation` char(10),
+  `c_first_name` char(20),
+  `c_last_name` char(30),
+  `c_preferred_cust_flag` char(1),
+  `c_birth_day` int,
+  `c_birth_month` int,
+  `c_birth_year` int,
+  `c_birth_country` varchar(20),
+  `c_login` char(13),
+  `c_email_address` char(50),
+  `c_last_review_date` int);
+create table customer_address(
+  `ca_address_sk` int,
+  `ca_address_id` char(16),
+  `ca_street_number` char(10),
+  `ca_street_name` varchar(60),
+  `ca_street_type` char(15),
+  `ca_suite_number` char(10),
+  `ca_city` varchar(60),
+  `ca_county` varchar(30),
+  `ca_state` char(2),
+  `ca_zip` char(10),
+  `ca_country` varchar(20),
+  `ca_gmt_offset` decimal(5,2),
+  `ca_location_type` char(20));
+create table customer_demographics(
+  `cd_demo_sk` int,
+  `cd_gender` char(1),
+  `cd_marital_status` char(1),
+  `cd_education_status` char(20),
+  `cd_purchase_estimate` int,
+  `cd_credit_rating` char(10),
+  `cd_dep_count` int,
+  `cd_dep_employed_count` int,
+  `cd_dep_college_count` int);
+create table date_dim(
+  `d_date_sk` int,
+  `d_date_id` char(16),
+  `d_date` date,
+  `d_month_seq` int,
+  `d_week_seq` int,
+  `d_quarter_seq` int,
+  `d_year` int,
+  `d_dow` int,
+  `d_moy` int,
+  `d_dom` int,
+  `d_qoy` int,
+  `d_fy_year` int,
+  `d_fy_quarter_seq` int,
+  `d_fy_week_seq` int,
+  `d_day_name` char(9),
+  `d_quarter_name` char(6),
+  `d_holiday` char(1),
+  `d_weekend` char(1),
+  `d_following_holiday` char(1),
+  `d_first_dom` int,
+  `d_last_dom` int,
+  `d_same_day_ly` int,
+  `d_same_day_lq` int,
+  `d_current_day` char(1),
+  `d_current_week` char(1),
+  `d_current_month` char(1),
+  `d_current_quarter` char(1),
+  `d_current_year` char(1));
+create table household_demographics(
+  `hd_demo_sk` int,
+  `hd_income_band_sk` int,
+  `hd_buy_potential` char(15),
+  `hd_dep_count` int,
+  `hd_vehicle_count` int);
+create table item(
+  `i_item_sk` int,
+  `i_item_id` char(16),
+  `i_rec_start_date` date,
+  `i_rec_end_date` date,
+  `i_item_desc` varchar(200),
+  `i_current_price` decimal(7,2),
+  `i_wholesale_cost` decimal(7,2),
+  `i_brand_id` int,
+  `i_brand` char(50),
+  `i_class_id` int,
+  `i_class` char(50),
+  `i_category_id` int,
+  `i_category` char(50),
+  `i_manufact_id` int,
+  `i_manufact` char(50),
+  `i_size` char(20),
+  `i_formulation` char(20),
+  `i_color` char(20),
+  `i_units` char(10),
+  `i_container` char(10),
+  `i_manager_id` int,
+  `i_product_name` char(50));
+create table income_band(
+  `ib_income_band_sk` int,
+  `ib_lower_bound` int,
+  `ib_upper_bound` int);
+create table promotion(
+  `p_promo_sk` int,
+  `p_promo_id` char(16),
+  `p_start_date_sk` int,
+  `p_end_date_sk` int,
+  `p_item_sk` int,
+  `p_cost` decimal(15,2),
+  `p_response_target` int,
+  `p_promo_name` char(50),
+  `p_channel_dmail` char(1),
+  `p_channel_email` char(1),
+  `p_channel_catalog` char(1),
+  `p_channel_tv` char(1),
+  `p_channel_radio` char(1),
+  `p_channel_press` char(1),
+  `p_channel_event` char(1),
+  `p_channel_demo` char(1),
+  `p_channel_details` varchar(100),
+  `p_purpose` char(15),
+  `p_discount_active` char(1));
+create table reason(
+  `r_reason_sk` int,
+  `r_reason_id` char(16),
+  `r_reason_desc` char(100));
+create table ship_mode(
+  `sm_ship_mode_sk` int,
+  `sm_ship_mode_id` char(16),
+  `sm_type` char(30),
+  `sm_code` char(10),
+  `sm_carrier` char(20),
+  `sm_contract` char(20));
+create table time_dim(
+  `t_time_sk` int,
+  `t_time_id` char(16),
+  `t_time` int,
+  `t_hour` int,
+  `t_minute` int,
+  `t_second` int,
+  `t_am_pm` char(2),
+  `t_shift` char(20),
+  `t_sub_shift` char(20),
+  `t_meal_time` char(20));
+
 -- SELECT operators: positive tests.
 ---------------------------------------
 
@@ -319,6 +769,84 @@ table t
 -- Setting nested fields in structs is not supported.
 select col from st
 |> set col.i1 = 42;
+
+-- DROP operators: positive tests.
+------------------------------------
+
+-- Dropping a column.
+table t
+|> drop y;
+
+-- Dropping two times.
+select 1 as x, 2 as y, 3 as z
+|> drop z, y;
+
+-- Dropping two times in sequence.
+select 1 as x, 2 as y, 3 as z
+|> drop z
+|> drop y;
+
+-- Dropping all columns in the input relation.
+select x from t
+|> drop x;
+
+-- Dropping a backquoted column name with a dot inside.
+table t
+|> extend 1 as `x.y.z`
+|> drop `x.y.z`;
+
+-- DROP operators: negative tests.
+----------------------------------
+
+-- Dropping a column that is not present in the input relation.
+table t
+|> drop z;
+
+-- Attempting to drop a struct field.
+table st
+|> drop col.i1;
+
+table st
+|> drop `col.i1`;
+
+-- Duplicate fields in the drop list.
+select 1 as x, 2 as y, 3 as z
+|> drop z, y, z;
+
+-- AS operators: positive tests.
+--------------------------------
+
+-- Renaming a table.
+table t
+|> as u
+|> select u.x, u.y;
+
+-- Renaming an input relation that is not a table.
+select 1 as x, 2 as y
+|> as u
+|> select u.x, u.y;
+
+-- Renaming two times.
+table t
+|> as u
+|> as v
+|> select v.x, v.y;
+
+-- Filtering by referring to the table or table subquery alias.
+table t
+|> as u
+|> where u.x = 1;
+
+-- AS operators: negative tests.
+--------------------------------
+
+-- Multiple aliases are not supported.
+table t
+|> as u, v;
+
+-- Expressions are not supported.
+table t
+|> as 1 + 2;
 
 -- WHERE operators: positive tests.
 -----------------------------------
@@ -1040,8 +1568,248 @@ table windowTestData
 |> select cate, val, sum(val) over w as sum_val
    window w as (order by val);
 
+-- Exercise SQL compilation using a subset of TPC-DS table schemas.
+-------------------------------------------------------------------
+
+-- Q1
+with customer_total_return as
+(select
+    sr_customer_sk as ctr_customer_sk,
+    sr_store_sk as ctr_store_sk,
+    sum(sr_return_amt) as ctr_total_return
+  from store_returns, date_dim
+  where sr_returned_date_sk = d_date_sk and d_year = 2000
+  group by sr_customer_sk, sr_store_sk)
+select c_customer_id
+from customer_total_return ctr1, store, customer
+where ctr1.ctr_total_return >
+  (select avg(ctr_total_return) * 1.2
+  from customer_total_return ctr2
+  where ctr1.ctr_store_sk = ctr2.ctr_store_sk)
+  and s_store_sk = ctr1.ctr_store_sk
+  and s_state = 'tn'
+  and ctr1.ctr_customer_sk = c_customer_sk
+order by c_customer_id
+limit 100;
+
+with customer_total_return as
+  (table store_returns
+  |> join date_dim
+  |> where sr_returned_date_sk = d_date_sk and d_year = 2000
+  |> aggregate sum(sr_return_amt) as ctr_total_return
+       group by sr_customer_sk as ctr_customer_sk, sr_store_sk as ctr_store_sk)
+table customer_total_return
+|> as ctr1
+|> join store
+|> join customer
+|> where ctr1.ctr_total_return >
+     (table customer_total_return
+      |> as ctr2
+      |> where ctr1.ctr_store_sk = ctr2.ctr_store_sk
+      |> aggregate avg(ctr_total_return) * 1.2)
+     and s_store_sk = ctr1.ctr_store_sk
+     and s_state = 'tn'
+     and ctr1.ctr_customer_sk = c_customer_sk
+|> order by c_customer_id
+|> limit 100
+|> select c_customer_id;
+
+-- Q2
+with wscs as
+( select
+    sold_date_sk,
+    sales_price
+  from (select
+    ws_sold_date_sk sold_date_sk,
+    ws_ext_sales_price sales_price
+  from web_sales) x
+  union all
+  (select
+    cs_sold_date_sk sold_date_sk,
+    cs_ext_sales_price sales_price
+  from catalog_sales)),
+    wswscs as
+  ( select
+    d_week_seq,
+    sum(case when (d_day_name = 'sunday')
+      then sales_price
+        else null end)
+    sun_sales,
+    sum(case when (d_day_name = 'monday')
+      then sales_price
+        else null end)
+    mon_sales,
+    sum(case when (d_day_name = 'tuesday')
+      then sales_price
+        else null end)
+    tue_sales,
+    sum(case when (d_day_name = 'wednesday')
+      then sales_price
+        else null end)
+    wed_sales,
+    sum(case when (d_day_name = 'thursday')
+      then sales_price
+        else null end)
+    thu_sales,
+    sum(case when (d_day_name = 'friday')
+      then sales_price
+        else null end)
+    fri_sales,
+    sum(case when (d_day_name = 'saturday')
+      then sales_price
+        else null end)
+    sat_sales
+  from wscs, date_dim
+  where d_date_sk = sold_date_sk
+  group by d_week_seq)
+select
+  d_week_seq1,
+  round(sun_sales1 / sun_sales2, 2),
+  round(mon_sales1 / mon_sales2, 2),
+  round(tue_sales1 / tue_sales2, 2),
+  round(wed_sales1 / wed_sales2, 2),
+  round(thu_sales1 / thu_sales2, 2),
+  round(fri_sales1 / fri_sales2, 2),
+  round(sat_sales1 / sat_sales2, 2)
+from
+  (select
+    wswscs.d_week_seq d_week_seq1,
+    sun_sales sun_sales1,
+    mon_sales mon_sales1,
+    tue_sales tue_sales1,
+    wed_sales wed_sales1,
+    thu_sales thu_sales1,
+    fri_sales fri_sales1,
+    sat_sales sat_sales1
+  from wswscs, date_dim
+  where date_dim.d_week_seq = wswscs.d_week_seq and d_year = 2001) y,
+  (select
+    wswscs.d_week_seq d_week_seq2,
+    sun_sales sun_sales2,
+    mon_sales mon_sales2,
+    tue_sales tue_sales2,
+    wed_sales wed_sales2,
+    thu_sales thu_sales2,
+    fri_sales fri_sales2,
+    sat_sales sat_sales2
+  from wswscs, date_dim
+  where date_dim.d_week_seq = wswscs.d_week_seq and d_year = 2001 + 1) z
+where d_week_seq1 = d_week_seq2 - 53
+order by d_week_seq1;
+
+with wscs as
+  (table web_sales
+  |> select
+       ws_sold_date_sk sold_date_sk,
+       ws_ext_sales_price sales_price
+  |> as x
+  |> union all (
+       table catalog_sales
+       |> select
+            cs_sold_date_sk sold_date_sk,
+            cs_ext_sales_price sales_price)
+  |> select
+       sold_date_sk,
+       sales_price),
+wswscs as
+  (table wscs
+  |> join date_dim
+  |> where d_date_sk = sold_date_sk
+  |> aggregate
+      sum(case when (d_day_name = 'sunday')
+        then sales_price
+          else null end)
+      sun_sales,
+      sum(case when (d_day_name = 'monday')
+        then sales_price
+          else null end)
+      mon_sales,
+      sum(case when (d_day_name = 'tuesday')
+        then sales_price
+          else null end)
+      tue_sales,
+      sum(case when (d_day_name = 'wednesday')
+        then sales_price
+          else null end)
+      wed_sales,
+      sum(case when (d_day_name = 'thursday')
+        then sales_price
+          else null end)
+      thu_sales,
+      sum(case when (d_day_name = 'friday')
+        then sales_price
+          else null end)
+      fri_sales,
+      sum(case when (d_day_name = 'saturday')
+        then sales_price
+          else null end)
+      sat_sales
+      group by d_week_seq)
+table wswscs
+|> join date_dim
+|> where date_dim.d_week_seq = wswscs.d_week_seq AND d_year = 2001
+|> select
+     wswscs.d_week_seq d_week_seq1,
+     sun_sales sun_sales1,
+     mon_sales mon_sales1,
+     tue_sales tue_sales1,
+     wed_sales wed_sales1,
+     thu_sales thu_sales1,
+     fri_sales fri_sales1,
+     sat_sales sat_sales1
+|> as y
+|> join (
+     table wswscs
+     |> join date_dim
+     |> where date_dim.d_week_seq = wswscs.d_week_seq AND d_year = 2001 + 1
+     |> select
+          wswscs.d_week_seq d_week_seq2,
+          sun_sales sun_sales2,
+          mon_sales mon_sales2,
+          tue_sales tue_sales2,
+          wed_sales wed_sales2,
+          thu_sales thu_sales2,
+          fri_sales fri_sales2,
+          sat_sales sat_sales2
+     |> as z)
+|> where d_week_seq1 = d_week_seq2 - 53
+|> order by d_week_seq1
+|> select
+     d_week_seq1,
+     round(sun_sales1 / sun_sales2, 2),
+     round(mon_sales1 / mon_sales2, 2),
+     round(tue_sales1 / tue_sales2, 2),
+     round(wed_sales1 / wed_sales2, 2),
+     round(thu_sales1 / thu_sales2, 2),
+     round(fri_sales1 / fri_sales2, 2),
+     round(sat_sales1 / sat_sales2, 2);
+
 -- Cleanup.
 -----------
 drop table t;
 drop table other;
 drop table st;
+drop table call_center;
+drop table catalog_page;
+drop table catalog_returns;
+drop table catalog_sales;
+drop table customer;
+drop table customer_address;
+drop table customer_demographics;
+drop table date_dim;
+drop table household_demographics;
+drop table income_band;
+drop table inventory;
+drop table item;
+drop table promotion;
+drop table reason;
+drop table ship_mode;
+drop table store;
+drop table store_returns;
+drop table store_sales;
+drop table time_dim;
+drop table warehouse;
+drop table web_page;
+drop table web_returns;
+drop table web_sales;
+drop table web_site;

--- a/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
@@ -3602,7 +3602,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "errorClass" : "UNSUPPORTED_FEATURE.PIPE_OPERATOR_AGGREGATE_UNSUPPORTED_CASE",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "case" : "window functions"
+    "case" : "window functions; please update the query to move the window functions to a subsequent |> SELECT operator instead"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -4194,6 +4194,116 @@ table web_sales
 |> limit 100
 -- !query schema
 struct<i_item_desc:string,i_category:string,i_class:string,i_current_price:decimal(7,2),itemrevenue:decimal(17,2),revenueratio:decimal(38,17)>
+-- !query output
+
+
+
+-- !query
+select
+  asceding.rnk,
+  i1.i_product_name best_performing,
+  i2.i_product_name worst_performing
+from (select *
+from (select
+  item_sk,
+  rank()
+  over (
+    order by rank_col asc) rnk
+from (select
+  ss_item_sk item_sk,
+  avg(ss_net_profit) rank_col
+from store_sales ss1
+where ss_store_sk = 4
+group by ss_item_sk
+having avg(ss_net_profit) > 0.9 * (select avg(ss_net_profit) rank_col
+from store_sales
+where ss_store_sk = 4
+  and ss_addr_sk is null
+group by ss_store_sk)) v1) v11
+where rnk < 11) asceding,
+  (select *
+  from (select
+    item_sk,
+    rank()
+    over (
+      order by rank_col desc) rnk
+  from (select
+    ss_item_sk item_sk,
+    avg(ss_net_profit) rank_col
+  from store_sales ss1
+  where ss_store_sk = 4
+  group by ss_item_sk
+  having avg(ss_net_profit) > 0.9 * (select avg(ss_net_profit) rank_col
+  from store_sales
+  where ss_store_sk = 4
+    and ss_addr_sk is null
+  group by ss_store_sk)) v2) v21
+  where rnk < 11) descending,
+  item i1, item i2
+where asceding.rnk = descending.rnk
+  and i1.i_item_sk = asceding.item_sk
+  and i2.i_item_sk = descending.item_sk
+order by asceding.rnk
+limit 100
+-- !query schema
+struct<rnk:int,best_performing:string,worst_performing:string>
+-- !query output
+
+
+
+-- !query
+table store_sales
+|> as ss1
+|> where ss_store_sk = 4
+|> aggregate avg(ss_net_profit) rank_col
+     group by ss_item_sk as item_sk
+|> where rank_col > 0.9 * (
+     table store_sales
+     |> where ss_store_sk = 4
+          and ss_addr_sk is null
+     |> aggregate avg(ss_net_profit) rank_col
+          group by ss_store_sk
+     |> select rank_col)
+|> as v1
+|> select
+     item_sk,
+     rank() over (
+       order by rank_col asc) rnk
+|> as v11
+|> where rnk < 11
+|> as asceding
+|> join (
+     table store_sales
+     |> as ss1
+     |> where ss_store_sk = 4
+     |> aggregate avg(ss_net_profit) rank_col
+          group by ss_item_sk as item_sk
+     |> where rank_col > 0.9 * (
+          table store_sales
+          |> where ss_store_sk = 4
+               and ss_addr_sk is null
+          |> aggregate avg(ss_net_profit) rank_col
+               group by ss_store_sk
+          |> select rank_col)
+     |> as v2
+     |> select
+          item_sk,
+          rank() over (
+            order by rank_col asc) rnk
+     |> as v21
+     |> where rnk < 11) descending
+|> join item i1
+|> join item i2
+|> where asceding.rnk = descending.rnk
+     and i1.i_item_sk = asceding.item_sk
+     and i2.i_item_sk = descending.item_sk
+|> order by asceding.rnk
+|> select
+     asceding.rnk,
+     i1.i_product_name best_performing,
+     i2.i_product_name worst_performing
+-- !query schema
+struct<rnk:int,best_performing:string,worst_performing:string>
 -- !query output
 
 

--- a/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
@@ -4186,7 +4186,7 @@ table web_sales
      and (cast('1999-02-22' as date) + interval 30 days)
 |> aggregate sum(ws_ext_sales_price) AS itemrevenue
      group by i_item_id, i_item_desc, i_category, i_class, i_current_price
-|> select *,
+|> extend
      itemrevenue * 100 / sum(itemrevenue)
        over (partition by i_class) as revenueratio
 |> order by i_category, i_class, i_item_id, i_item_desc, revenueratio

--- a/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
@@ -233,6 +233,623 @@ struct<>
 
 
 -- !query
+create table store_sales(
+  `ss_sold_date_sk` int,
+  `ss_sold_time_sk` int,
+  `ss_item_sk` int,
+  `ss_customer_sk` int,
+  `ss_cdemo_sk` int,
+  `ss_hdemo_sk` int,
+  `ss_addr_sk` int,
+  `ss_store_sk` int,
+  `ss_promo_sk` int,
+  `ss_ticket_number` int,
+  `ss_quantity` int,
+  `ss_wholesale_cost` decimal(7,2),
+  `ss_list_price` decimal(7,2),
+  `ss_sales_price` decimal(7,2),
+  `ss_ext_discount_amt` decimal(7,2),
+  `ss_ext_sales_price` decimal(7,2),
+  `ss_ext_wholesale_cost` decimal(7,2),
+  `ss_ext_list_price` decimal(7,2),
+  `ss_ext_tax` decimal(7,2),
+  `ss_coupon_amt` decimal(7,2),
+  `ss_net_paid` decimal(7,2),
+  `ss_net_paid_inc_tax` decimal(7,2),
+  `ss_net_profit` decimal(7,2))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table store_returns(
+  `sr_returned_date_sk` int,
+  `sr_return_time_sk` int,
+  `sr_item_sk` int,
+  `sr_customer_sk` int,
+  `sr_cdemo_sk` int,
+  `sr_hdemo_sk` int,
+  `sr_addr_sk` int,
+  `sr_store_sk` int,
+  `sr_reason_sk` int,
+  `sr_ticket_number` int,
+  `sr_return_quantity` int,
+  `sr_return_amt` decimal(7,2),
+  `sr_return_tax` decimal(7,2),
+  `sr_return_amt_inc_tax` decimal(7,2),
+  `sr_fee` decimal(7,2),
+  `sr_return_ship_cost` decimal(7,2),
+  `sr_refunded_cash` decimal(7,2),
+  `sr_reversed_charge` decimal(7,2),
+  `sr_store_credit` decimal(7,2),
+  `sr_net_loss` decimal(7,2))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table catalog_sales(
+  `cs_sold_date_sk` int,
+  `cs_sold_time_sk` int,
+  `cs_ship_date_sk` int,
+  `cs_bill_customer_sk` int,
+  `cs_bill_cdemo_sk` int,
+  `cs_bill_hdemo_sk` int,
+  `cs_bill_addr_sk` int,
+  `cs_ship_customer_sk` int,
+  `cs_ship_cdemo_sk` int,
+  `cs_ship_hdemo_sk` int,
+  `cs_ship_addr_sk` int,
+  `cs_call_center_sk` int,
+  `cs_catalog_page_sk` int,
+  `cs_ship_mode_sk` int,
+  `cs_warehouse_sk` int,
+  `cs_item_sk` int,
+  `cs_promo_sk` int,
+  `cs_order_number` int,
+  `cs_quantity` int,
+  `cs_wholesale_cost` decimal(7,2),
+  `cs_list_price` decimal(7,2),
+  `cs_sales_price` decimal(7,2),
+  `cs_ext_discount_amt` decimal(7,2),
+  `cs_ext_sales_price` decimal(7,2),
+  `cs_ext_wholesale_cost` decimal(7,2),
+  `cs_ext_list_price` decimal(7,2),
+  `cs_ext_tax` decimal(7,2),
+  `cs_coupon_amt` decimal(7,2),
+  `cs_ext_ship_cost` decimal(7,2),
+  `cs_net_paid` decimal(7,2),
+  `cs_net_paid_inc_tax` decimal(7,2),
+  `cs_net_paid_inc_ship` decimal(7,2),
+  `cs_net_paid_inc_ship_tax` decimal(7,2),
+  `cs_net_profit` decimal(7,2))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table catalog_returns(
+  `cr_returned_date_sk` int,
+  `cr_returned_time_sk` int,
+  `cr_item_sk` int,
+  `cr_refunded_customer_sk` int,
+  `cr_refunded_cdemo_sk` int,
+  `cr_refunded_hdemo_sk` int,
+  `cr_refunded_addr_sk` int,
+  `cr_returning_customer_sk` int,
+  `cr_returning_cdemo_sk` int,
+  `cr_returning_hdemo_sk` int,
+  `cr_returning_addr_sk` int,
+  `cr_call_center_sk` int,
+  `cr_catalog_page_sk` int,
+  `cr_ship_mode_sk` int,
+  `cr_warehouse_sk` int,
+  `cr_reason_sk` int,
+  `cr_order_number` int,
+  `cr_return_quantity` int,
+  `cr_return_amount` decimal(7,2),
+  `cr_return_tax` decimal(7,2),
+  `cr_return_amt_inc_tax` decimal(7,2),
+  `cr_fee` decimal(7,2),
+  `cr_return_ship_cost` decimal(7,2),
+  `cr_refunded_cash` decimal(7,2),
+  `cr_reversed_charge` decimal(7,2),
+  `cr_store_credit` decimal(7,2),
+  `cr_net_loss` decimal(7,2))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table web_sales(
+  `ws_sold_date_sk` int,
+  `ws_sold_time_sk` int,
+  `ws_ship_date_sk` int,
+  `ws_item_sk` int,
+  `ws_bill_customer_sk` int,
+  `ws_bill_cdemo_sk` int,
+  `ws_bill_hdemo_sk` int,
+  `ws_bill_addr_sk` int,
+  `ws_ship_customer_sk` int,
+  `ws_ship_cdemo_sk` int,
+  `ws_ship_hdemo_sk` int,
+  `ws_ship_addr_sk` int,
+  `ws_web_page_sk` int,
+  `ws_web_site_sk` int,
+  `ws_ship_mode_sk` int,
+  `ws_warehouse_sk` int,
+  `ws_promo_sk` int,
+  `ws_order_number` int,
+  `ws_quantity` int,
+  `ws_wholesale_cost` decimal(7,2),
+  `ws_list_price` decimal(7,2),
+  `ws_sales_price` decimal(7,2),
+  `ws_ext_discount_amt` decimal(7,2),
+  `ws_ext_sales_price` decimal(7,2),
+  `ws_ext_wholesale_cost` decimal(7,2),
+  `ws_ext_list_price` decimal(7,2),
+  `ws_ext_tax` decimal(7,2),
+  `ws_coupon_amt` decimal(7,2),
+  `ws_ext_ship_cost` decimal(7,2),
+  `ws_net_paid` decimal(7,2),
+  `ws_net_paid_inc_tax` decimal(7,2),
+  `ws_net_paid_inc_ship` decimal(7,2),
+  `ws_net_paid_inc_ship_tax` decimal(7,2),
+  `ws_net_profit` decimal(7,2))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table web_returns(
+  `wr_returned_date_sk` int,
+  `wr_returned_time_sk` int,
+  `wr_item_sk` int,
+  `wr_refunded_customer_sk` int,
+  `wr_refunded_cdemo_sk` int,
+  `wr_refunded_hdemo_sk` int,
+  `wr_refunded_addr_sk` int,
+  `wr_returning_customer_sk` int,
+  `wr_returning_cdemo_sk` int,
+  `wr_returning_hdemo_sk` int,
+  `wr_returning_addr_sk` int,
+  `wr_web_page_sk` int,
+  `wr_reason_sk` int,
+  `wr_order_number` int,
+  `wr_return_quantity` int,
+  `wr_return_amt` decimal(7,2),
+  `wr_return_tax` decimal(7,2),
+  `wr_return_amt_inc_tax` decimal(7,2),
+  `wr_fee` decimal(7,2),
+  `wr_return_ship_cost` decimal(7,2),
+  `wr_refunded_cash` decimal(7,2),
+  `wr_reversed_charge` decimal(7,2),
+  `wr_account_credit` decimal(7,2),
+  `wr_net_loss` decimal(7,2))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table inventory(
+  `inv_date_sk` int,
+  `inv_item_sk` int,
+  `inv_warehouse_sk` int,
+  `inv_quantity_on_hand` int)
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table store(
+  `s_store_sk` int,
+  `s_store_id` char(16),
+  `s_rec_start_date` date,
+  `s_rec_end_date` date,
+  `s_closed_date_sk` int,
+  `s_store_name` varchar(50),
+  `s_number_employees` int,
+  `s_floor_space` int,
+  `s_hours` char(20),
+  `s_manager` varchar(40),
+  `s_market_id` int,
+  `s_geography_class` varchar(100),
+  `s_market_desc` varchar(100),
+  `s_market_manager` varchar(40),
+  `s_division_id` int,
+  `s_division_name` varchar(50),
+  `s_company_id` int,
+  `s_company_name` varchar(50),
+  `s_street_number` varchar(10),
+  `s_street_name` varchar(60),
+  `s_street_type` char(15),
+  `s_suite_number` char(10),
+  `s_city` varchar(60),
+  `s_county` varchar(30),
+  `s_state` char(2),
+  `s_zip` char(10),
+  `s_country` varchar(20),
+  `s_gmt_offset` decimal(5,2),
+  `s_tax_percentage` decimal(5,2))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table call_center(
+  `cc_call_center_sk` int,
+  `cc_call_center_id` char(16),
+  `cc_rec_start_date` date,
+  `cc_rec_end_date` date,
+  `cc_closed_date_sk` int,
+  `cc_open_date_sk` int,
+  `cc_name` varchar(50),
+  `cc_class` varchar(50),
+  `cc_employees` int,
+  `cc_sq_ft` int,
+  `cc_hours` char(20),
+  `cc_manager` varchar(40),
+  `cc_mkt_id` int,
+  `cc_mkt_class` char(50),
+  `cc_mkt_desc` varchar(100),
+  `cc_market_manager` varchar(40),
+  `cc_division` int,
+  `cc_division_name` varchar(50),
+  `cc_company` int,
+  `cc_company_name` char(50),
+  `cc_street_number` char(10),
+  `cc_street_name` varchar(60),
+  `cc_street_type` char(15),
+  `cc_suite_number` char(10),
+  `cc_city` varchar(60),
+  `cc_county` varchar(30),
+  `cc_state` char(2),
+  `cc_zip` char(10),
+  `cc_country` varchar(20),
+  `cc_gmt_offset` decimal(5,2),
+  `cc_tax_percentage` decimal(5,2))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table catalog_page(
+  `cp_catalog_page_sk` int,
+  `cp_catalog_page_id` char(16),
+  `cp_start_date_sk` int,
+  `cp_end_date_sk` int,
+  `cp_department` varchar(50),
+  `cp_catalog_number` int,
+  `cp_catalog_page_number` int,
+  `cp_description` varchar(100),
+  `cp_type` varchar(100))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table web_site(
+  `web_site_sk` int,
+  `web_site_id` char(16),
+  `web_rec_start_date` date,
+  `web_rec_end_date` date,
+  `web_name` varchar(50),
+  `web_open_date_sk` int,
+  `web_close_date_sk` int,
+  `web_class` varchar(50),
+  `web_manager` varchar(40),
+  `web_mkt_id` int,
+  `web_mkt_class` varchar(50),
+  `web_mkt_desc` varchar(100),
+  `web_market_manager` varchar(40),
+  `web_company_id` int,
+  `web_company_name` char(50),
+  `web_street_number` char(10),
+  `web_street_name` varchar(60),
+  `web_street_type` char(15),
+  `web_suite_number` char(10),
+  `web_city` varchar(60),
+  `web_county` varchar(30),
+  `web_state` char(2),
+  `web_zip` char(10),
+  `web_country` varchar(20),
+  `web_gmt_offset` decimal(5,2),
+  `web_tax_percentage` decimal(5,2))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table web_page(
+  `wp_web_page_sk` int,
+  `wp_web_page_id` char(16),
+  `wp_rec_start_date` date,
+  `wp_rec_end_date` date,
+  `wp_creation_date_sk` int,
+  `wp_access_date_sk` int,
+  `wp_autogen_flag` char(1),
+  `wp_customer_sk` int,
+  `wp_url` varchar(100),
+  `wp_type` char(50),
+  `wp_char_count` int,
+  `wp_link_count` int,
+  `wp_image_count` int,
+  `wp_max_ad_count` int)
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table warehouse(
+  `w_warehouse_sk` int,
+  `w_warehouse_id` char(16),
+  `w_warehouse_name` varchar(20),
+  `w_warehouse_sq_ft` int,
+  `w_street_number` char(10),
+  `w_street_name` varchar(20),
+  `w_street_type` char(15),
+  `w_suite_number` char(10),
+  `w_city` varchar(60),
+  `w_county` varchar(30),
+  `w_state` char(2),
+  `w_zip` char(10),
+  `w_country` varchar(20),
+  `w_gmt_offset` decimal(5,2))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table customer(
+  `c_customer_sk` int,
+  `c_customer_id` char(16),
+  `c_current_cdemo_sk` int,
+  `c_current_hdemo_sk` int,
+  `c_current_addr_sk` int,
+  `c_first_shipto_date_sk` int,
+  `c_first_sales_date_sk` int,
+  `c_salutation` char(10),
+  `c_first_name` char(20),
+  `c_last_name` char(30),
+  `c_preferred_cust_flag` char(1),
+  `c_birth_day` int,
+  `c_birth_month` int,
+  `c_birth_year` int,
+  `c_birth_country` varchar(20),
+  `c_login` char(13),
+  `c_email_address` char(50),
+  `c_last_review_date` int)
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table customer_address(
+  `ca_address_sk` int,
+  `ca_address_id` char(16),
+  `ca_street_number` char(10),
+  `ca_street_name` varchar(60),
+  `ca_street_type` char(15),
+  `ca_suite_number` char(10),
+  `ca_city` varchar(60),
+  `ca_county` varchar(30),
+  `ca_state` char(2),
+  `ca_zip` char(10),
+  `ca_country` varchar(20),
+  `ca_gmt_offset` decimal(5,2),
+  `ca_location_type` char(20))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table customer_demographics(
+  `cd_demo_sk` int,
+  `cd_gender` char(1),
+  `cd_marital_status` char(1),
+  `cd_education_status` char(20),
+  `cd_purchase_estimate` int,
+  `cd_credit_rating` char(10),
+  `cd_dep_count` int,
+  `cd_dep_employed_count` int,
+  `cd_dep_college_count` int)
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table date_dim(
+  `d_date_sk` int,
+  `d_date_id` char(16),
+  `d_date` date,
+  `d_month_seq` int,
+  `d_week_seq` int,
+  `d_quarter_seq` int,
+  `d_year` int,
+  `d_dow` int,
+  `d_moy` int,
+  `d_dom` int,
+  `d_qoy` int,
+  `d_fy_year` int,
+  `d_fy_quarter_seq` int,
+  `d_fy_week_seq` int,
+  `d_day_name` char(9),
+  `d_quarter_name` char(6),
+  `d_holiday` char(1),
+  `d_weekend` char(1),
+  `d_following_holiday` char(1),
+  `d_first_dom` int,
+  `d_last_dom` int,
+  `d_same_day_ly` int,
+  `d_same_day_lq` int,
+  `d_current_day` char(1),
+  `d_current_week` char(1),
+  `d_current_month` char(1),
+  `d_current_quarter` char(1),
+  `d_current_year` char(1))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table household_demographics(
+  `hd_demo_sk` int,
+  `hd_income_band_sk` int,
+  `hd_buy_potential` char(15),
+  `hd_dep_count` int,
+  `hd_vehicle_count` int)
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table item(
+  `i_item_sk` int,
+  `i_item_id` char(16),
+  `i_rec_start_date` date,
+  `i_rec_end_date` date,
+  `i_item_desc` varchar(200),
+  `i_current_price` decimal(7,2),
+  `i_wholesale_cost` decimal(7,2),
+  `i_brand_id` int,
+  `i_brand` char(50),
+  `i_class_id` int,
+  `i_class` char(50),
+  `i_category_id` int,
+  `i_category` char(50),
+  `i_manufact_id` int,
+  `i_manufact` char(50),
+  `i_size` char(20),
+  `i_formulation` char(20),
+  `i_color` char(20),
+  `i_units` char(10),
+  `i_container` char(10),
+  `i_manager_id` int,
+  `i_product_name` char(50))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table income_band(
+  `ib_income_band_sk` int,
+  `ib_lower_bound` int,
+  `ib_upper_bound` int)
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table promotion(
+  `p_promo_sk` int,
+  `p_promo_id` char(16),
+  `p_start_date_sk` int,
+  `p_end_date_sk` int,
+  `p_item_sk` int,
+  `p_cost` decimal(15,2),
+  `p_response_target` int,
+  `p_promo_name` char(50),
+  `p_channel_dmail` char(1),
+  `p_channel_email` char(1),
+  `p_channel_catalog` char(1),
+  `p_channel_tv` char(1),
+  `p_channel_radio` char(1),
+  `p_channel_press` char(1),
+  `p_channel_event` char(1),
+  `p_channel_demo` char(1),
+  `p_channel_details` varchar(100),
+  `p_purpose` char(15),
+  `p_discount_active` char(1))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table reason(
+  `r_reason_sk` int,
+  `r_reason_id` char(16),
+  `r_reason_desc` char(100))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table ship_mode(
+  `sm_ship_mode_sk` int,
+  `sm_ship_mode_id` char(16),
+  `sm_type` char(30),
+  `sm_code` char(10),
+  `sm_carrier` char(20),
+  `sm_contract` char(20))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+create table time_dim(
+  `t_time_sk` int,
+  `t_time_id` char(16),
+  `t_time` int,
+  `t_hour` int,
+  `t_minute` int,
+  `t_second` int,
+  `t_am_pm` char(2),
+  `t_shift` char(20),
+  `t_sub_shift` char(20),
+  `t_meal_time` char(20))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
 table t
 |> select 1 as x
 -- !query schema
@@ -870,6 +1487,220 @@ org.apache.spark.sql.catalyst.parser.ParseException
     "stopIndex" : 37,
     "fragment" : "col.i1 = 42"
   } ]
+}
+
+
+-- !query
+table t
+|> drop y
+-- !query schema
+struct<x:int>
+-- !query output
+0
+1
+
+
+-- !query
+select 1 as x, 2 as y, 3 as z
+|> drop z, y
+-- !query schema
+struct<x:int>
+-- !query output
+1
+
+
+-- !query
+select 1 as x, 2 as y, 3 as z
+|> drop z
+|> drop y
+-- !query schema
+struct<x:int>
+-- !query output
+1
+
+
+-- !query
+select x from t
+|> drop x
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+table t
+|> extend 1 as `x.y.z`
+|> drop `x.y.z`
+-- !query schema
+struct<x:int,y:string>
+-- !query output
+0	abc
+1	def
+
+
+-- !query
+table t
+|> drop z
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNRESOLVED_COLUMN.WITH_SUGGESTION",
+  "sqlState" : "42703",
+  "messageParameters" : {
+    "objectName" : "`z`",
+    "proposal" : "`x`, `y`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 17,
+    "fragment" : "table t\n|> drop z"
+  } ]
+}
+
+
+-- !query
+table st
+|> drop col.i1
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.parser.ParseException
+{
+  "errorClass" : "PARSE_SYNTAX_ERROR",
+  "sqlState" : "42601",
+  "messageParameters" : {
+    "error" : "'.'",
+    "hint" : ""
+  }
+}
+
+
+-- !query
+table st
+|> drop `col.i1`
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNRESOLVED_COLUMN.WITH_SUGGESTION",
+  "sqlState" : "42703",
+  "messageParameters" : {
+    "objectName" : "`col.i1`",
+    "proposal" : "`col`, `x`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 25,
+    "fragment" : "table st\n|> drop `col.i1`"
+  } ]
+}
+
+
+-- !query
+select 1 as x, 2 as y, 3 as z
+|> drop z, y, z
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "EXCEPT_OVERLAPPING_COLUMNS",
+  "sqlState" : "42702",
+  "messageParameters" : {
+    "columns" : "z, y, z"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 45,
+    "fragment" : "select 1 as x, 2 as y, 3 as z\n|> drop z, y, z"
+  } ]
+}
+
+
+-- !query
+table t
+|> as u
+|> select u.x, u.y
+-- !query schema
+struct<x:int,y:string>
+-- !query output
+0	abc
+1	def
+
+
+-- !query
+select 1 as x, 2 as y
+|> as u
+|> select u.x, u.y
+-- !query schema
+struct<x:int,y:int>
+-- !query output
+1	2
+
+
+-- !query
+table t
+|> as u
+|> as v
+|> select v.x, v.y
+-- !query schema
+struct<x:int,y:string>
+-- !query output
+0	abc
+1	def
+
+
+-- !query
+table t
+|> as u
+|> where u.x = 1
+-- !query schema
+struct<x:int,y:string>
+-- !query output
+1	def
+
+
+-- !query
+table t
+|> as u, v
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.parser.ParseException
+{
+  "errorClass" : "PARSE_SYNTAX_ERROR",
+  "sqlState" : "42601",
+  "messageParameters" : {
+    "error" : "','",
+    "hint" : ""
+  }
+}
+
+
+-- !query
+table t
+|> as 1 + 2
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.parser.ParseException
+{
+  "errorClass" : "PARSE_SYNTAX_ERROR",
+  "sqlState" : "42601",
+  "messageParameters" : {
+    "error" : "'1'",
+    "hint" : ""
+  }
 }
 
 
@@ -3042,6 +3873,241 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 
 
 -- !query
+with customer_total_return as
+(select
+    sr_customer_sk as ctr_customer_sk,
+    sr_store_sk as ctr_store_sk,
+    sum(sr_return_amt) as ctr_total_return
+  from store_returns, date_dim
+  where sr_returned_date_sk = d_date_sk and d_year = 2000
+  group by sr_customer_sk, sr_store_sk)
+select c_customer_id
+from customer_total_return ctr1, store, customer
+where ctr1.ctr_total_return >
+  (select avg(ctr_total_return) * 1.2
+  from customer_total_return ctr2
+  where ctr1.ctr_store_sk = ctr2.ctr_store_sk)
+  and s_store_sk = ctr1.ctr_store_sk
+  and s_state = 'tn'
+  and ctr1.ctr_customer_sk = c_customer_sk
+order by c_customer_id
+limit 100
+-- !query schema
+struct<c_customer_id:string>
+-- !query output
+
+
+
+-- !query
+with customer_total_return as
+  (table store_returns
+  |> join date_dim
+  |> where sr_returned_date_sk = d_date_sk and d_year = 2000
+  |> aggregate sum(sr_return_amt) as ctr_total_return
+       group by sr_customer_sk as ctr_customer_sk, sr_store_sk as ctr_store_sk)
+table customer_total_return
+|> as ctr1
+|> join store
+|> join customer
+|> where ctr1.ctr_total_return >
+     (table customer_total_return
+      |> as ctr2
+      |> where ctr1.ctr_store_sk = ctr2.ctr_store_sk
+      |> aggregate avg(ctr_total_return) * 1.2)
+     and s_store_sk = ctr1.ctr_store_sk
+     and s_state = 'tn'
+     and ctr1.ctr_customer_sk = c_customer_sk
+|> order by c_customer_id
+|> limit 100
+|> select c_customer_id
+-- !query schema
+struct<c_customer_id:string>
+-- !query output
+
+
+
+-- !query
+with wscs as
+( select
+    sold_date_sk,
+    sales_price
+  from (select
+    ws_sold_date_sk sold_date_sk,
+    ws_ext_sales_price sales_price
+  from web_sales) x
+  union all
+  (select
+    cs_sold_date_sk sold_date_sk,
+    cs_ext_sales_price sales_price
+  from catalog_sales)),
+    wswscs as
+  ( select
+    d_week_seq,
+    sum(case when (d_day_name = 'sunday')
+      then sales_price
+        else null end)
+    sun_sales,
+    sum(case when (d_day_name = 'monday')
+      then sales_price
+        else null end)
+    mon_sales,
+    sum(case when (d_day_name = 'tuesday')
+      then sales_price
+        else null end)
+    tue_sales,
+    sum(case when (d_day_name = 'wednesday')
+      then sales_price
+        else null end)
+    wed_sales,
+    sum(case when (d_day_name = 'thursday')
+      then sales_price
+        else null end)
+    thu_sales,
+    sum(case when (d_day_name = 'friday')
+      then sales_price
+        else null end)
+    fri_sales,
+    sum(case when (d_day_name = 'saturday')
+      then sales_price
+        else null end)
+    sat_sales
+  from wscs, date_dim
+  where d_date_sk = sold_date_sk
+  group by d_week_seq)
+select
+  d_week_seq1,
+  round(sun_sales1 / sun_sales2, 2),
+  round(mon_sales1 / mon_sales2, 2),
+  round(tue_sales1 / tue_sales2, 2),
+  round(wed_sales1 / wed_sales2, 2),
+  round(thu_sales1 / thu_sales2, 2),
+  round(fri_sales1 / fri_sales2, 2),
+  round(sat_sales1 / sat_sales2, 2)
+from
+  (select
+    wswscs.d_week_seq d_week_seq1,
+    sun_sales sun_sales1,
+    mon_sales mon_sales1,
+    tue_sales tue_sales1,
+    wed_sales wed_sales1,
+    thu_sales thu_sales1,
+    fri_sales fri_sales1,
+    sat_sales sat_sales1
+  from wswscs, date_dim
+  where date_dim.d_week_seq = wswscs.d_week_seq and d_year = 2001) y,
+  (select
+    wswscs.d_week_seq d_week_seq2,
+    sun_sales sun_sales2,
+    mon_sales mon_sales2,
+    tue_sales tue_sales2,
+    wed_sales wed_sales2,
+    thu_sales thu_sales2,
+    fri_sales fri_sales2,
+    sat_sales sat_sales2
+  from wswscs, date_dim
+  where date_dim.d_week_seq = wswscs.d_week_seq and d_year = 2001 + 1) z
+where d_week_seq1 = d_week_seq2 - 53
+order by d_week_seq1
+-- !query schema
+struct<d_week_seq1:int,round((sun_sales1 / sun_sales2), 2):decimal(20,2),round((mon_sales1 / mon_sales2), 2):decimal(20,2),round((tue_sales1 / tue_sales2), 2):decimal(20,2),round((wed_sales1 / wed_sales2), 2):decimal(20,2),round((thu_sales1 / thu_sales2), 2):decimal(20,2),round((fri_sales1 / fri_sales2), 2):decimal(20,2),round((sat_sales1 / sat_sales2), 2):decimal(20,2)>
+-- !query output
+
+
+
+-- !query
+with wscs as
+  (table web_sales
+  |> select
+       ws_sold_date_sk sold_date_sk,
+       ws_ext_sales_price sales_price
+  |> as x
+  |> union all (
+       table catalog_sales
+       |> select
+            cs_sold_date_sk sold_date_sk,
+            cs_ext_sales_price sales_price)
+  |> select
+       sold_date_sk,
+       sales_price),
+wswscs as
+  (table wscs
+  |> join date_dim
+  |> where d_date_sk = sold_date_sk
+  |> aggregate
+      sum(case when (d_day_name = 'sunday')
+        then sales_price
+          else null end)
+      sun_sales,
+      sum(case when (d_day_name = 'monday')
+        then sales_price
+          else null end)
+      mon_sales,
+      sum(case when (d_day_name = 'tuesday')
+        then sales_price
+          else null end)
+      tue_sales,
+      sum(case when (d_day_name = 'wednesday')
+        then sales_price
+          else null end)
+      wed_sales,
+      sum(case when (d_day_name = 'thursday')
+        then sales_price
+          else null end)
+      thu_sales,
+      sum(case when (d_day_name = 'friday')
+        then sales_price
+          else null end)
+      fri_sales,
+      sum(case when (d_day_name = 'saturday')
+        then sales_price
+          else null end)
+      sat_sales
+      group by d_week_seq)
+table wswscs
+|> join date_dim
+|> where date_dim.d_week_seq = wswscs.d_week_seq AND d_year = 2001
+|> select
+     wswscs.d_week_seq d_week_seq1,
+     sun_sales sun_sales1,
+     mon_sales mon_sales1,
+     tue_sales tue_sales1,
+     wed_sales wed_sales1,
+     thu_sales thu_sales1,
+     fri_sales fri_sales1,
+     sat_sales sat_sales1
+|> as y
+|> join (
+     table wswscs
+     |> join date_dim
+     |> where date_dim.d_week_seq = wswscs.d_week_seq AND d_year = 2001 + 1
+     |> select
+          wswscs.d_week_seq d_week_seq2,
+          sun_sales sun_sales2,
+          mon_sales mon_sales2,
+          tue_sales tue_sales2,
+          wed_sales wed_sales2,
+          thu_sales thu_sales2,
+          fri_sales fri_sales2,
+          sat_sales sat_sales2
+     |> as z)
+|> where d_week_seq1 = d_week_seq2 - 53
+|> order by d_week_seq1
+|> select
+     d_week_seq1,
+     round(sun_sales1 / sun_sales2, 2),
+     round(mon_sales1 / mon_sales2, 2),
+     round(tue_sales1 / tue_sales2, 2),
+     round(wed_sales1 / wed_sales2, 2),
+     round(thu_sales1 / thu_sales2, 2),
+     round(fri_sales1 / fri_sales2, 2),
+     round(sat_sales1 / sat_sales2, 2)
+-- !query schema
+struct<d_week_seq1:int,round((sun_sales1 / sun_sales2), 2):decimal(20,2),round((mon_sales1 / mon_sales2), 2):decimal(20,2),round((tue_sales1 / tue_sales2), 2):decimal(20,2),round((wed_sales1 / wed_sales2), 2):decimal(20,2),round((thu_sales1 / thu_sales2), 2):decimal(20,2),round((fri_sales1 / fri_sales2), 2):decimal(20,2),round((sat_sales1 / sat_sales2), 2):decimal(20,2)>
+-- !query output
+
+
+
+-- !query
 drop table t
 -- !query schema
 struct<>
@@ -3059,6 +4125,198 @@ struct<>
 
 -- !query
 drop table st
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table call_center
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table catalog_page
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table catalog_returns
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table catalog_sales
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table customer
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table customer_address
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table customer_demographics
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table date_dim
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table household_demographics
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table income_band
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table inventory
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table item
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table promotion
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table reason
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table ship_mode
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table store
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table store_returns
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table store_sales
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table time_dim
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table warehouse
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table web_page
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table web_returns
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table web_sales
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+drop table web_site
 -- !query schema
 struct<>
 -- !query output

--- a/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
@@ -4108,6 +4108,45 @@ struct<d_week_seq1:int,round((sun_sales1 / sun_sales2), 2):decimal(20,2),round((
 
 
 -- !query
+select
+  dt.d_year,
+  item.i_brand_id brand_id,
+  item.i_brand brand,
+  sum(ss_ext_sales_price) sum_agg
+from date_dim dt, store_sales, item
+where dt.d_date_sk = store_sales.ss_sold_date_sk
+  and store_sales.ss_item_sk = item.i_item_sk
+  and item.i_manufact_id = 128
+  and dt.d_moy = 11
+group by dt.d_year, item.i_brand, item.i_brand_id
+order by dt.d_year, sum_agg desc, brand_id
+limit 100
+-- !query schema
+struct<d_year:int,brand_id:int,brand:string,sum_agg:decimal(17,2)>
+-- !query output
+
+
+
+-- !query
+table date_dim
+|> as dt
+|> join store_sales
+|> join item
+|> where dt.d_date_sk = store_sales.ss_sold_date_sk
+     and store_sales.ss_item_sk = item.i_item_sk
+     and item.i_manufact_id = 128
+     and dt.d_moy = 11
+|> aggregate sum(ss_ext_sales_price) sum_agg
+     group by dt.d_year d_year, item.i_brand_id brand_id, item.i_brand brand
+|> order by d_year, sum_agg desc, brand_id
+|> limit 100
+-- !query schema
+struct<d_year:int,brand_id:int,brand:string,sum_agg:decimal(17,2)>
+-- !query output
+
+
+
+-- !query
 drop table t
 -- !query schema
 struct<>

--- a/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
@@ -4147,6 +4147,58 @@ struct<d_year:int,brand_id:int,brand:string,sum_agg:decimal(17,2)>
 
 
 -- !query
+select
+  i_item_desc,
+  i_category,
+  i_class,
+  i_current_price,
+  sum(ws_ext_sales_price) as itemrevenue,
+  sum(ws_ext_sales_price) * 100 / sum(sum(ws_ext_sales_price))
+  over
+  (partition by i_class) as revenueratio
+from
+  web_sales, item, date_dim
+where
+  ws_item_sk = i_item_sk
+    and i_category in ('sports', 'books', 'home')
+    and ws_sold_date_sk = d_date_sk
+    and d_date between cast('1999-02-22' as date)
+  and (cast('1999-02-22' as date) + interval 30 days)
+group by
+  i_item_id, i_item_desc, i_category, i_class, i_current_price
+order by
+  i_category, i_class, i_item_id, i_item_desc, revenueratio
+limit 100
+-- !query schema
+struct<i_item_desc:string,i_category:string,i_class:string,i_current_price:decimal(7,2),itemrevenue:decimal(17,2),revenueratio:decimal(38,17)>
+-- !query output
+
+
+
+-- !query
+table web_sales
+|> join item
+|> join date_dim
+|> where ws_item_sk = i_item_sk
+     and i_category in ('sports', 'books', 'home')
+     and ws_sold_date_sk = d_date_sk
+     and d_date between cast('1999-02-22' as date)
+     and (cast('1999-02-22' as date) + interval 30 days)
+|> aggregate sum(ws_ext_sales_price) AS itemrevenue
+     group by i_item_id, i_item_desc, i_category, i_class, i_current_price
+|> select *,
+     itemrevenue * 100 / sum(itemrevenue)
+       over (partition by i_class) as revenueratio
+|> order by i_category, i_class, i_item_id, i_item_desc, revenueratio
+|> select i_item_desc, i_category, i_class, i_current_price, itemrevenue, revenueratio
+|> limit 100
+-- !query schema
+struct<i_item_desc:string,i_category:string,i_class:string,i_current_price:decimal(7,2),itemrevenue:decimal(17,2),revenueratio:decimal(38,17)>
+-- !query output
+
+
+
+-- !query
 drop table t
 -- !query schema
 struct<>

--- a/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
@@ -233,623 +233,6 @@ struct<>
 
 
 -- !query
-create table store_sales(
-  `ss_sold_date_sk` int,
-  `ss_sold_time_sk` int,
-  `ss_item_sk` int,
-  `ss_customer_sk` int,
-  `ss_cdemo_sk` int,
-  `ss_hdemo_sk` int,
-  `ss_addr_sk` int,
-  `ss_store_sk` int,
-  `ss_promo_sk` int,
-  `ss_ticket_number` int,
-  `ss_quantity` int,
-  `ss_wholesale_cost` decimal(7,2),
-  `ss_list_price` decimal(7,2),
-  `ss_sales_price` decimal(7,2),
-  `ss_ext_discount_amt` decimal(7,2),
-  `ss_ext_sales_price` decimal(7,2),
-  `ss_ext_wholesale_cost` decimal(7,2),
-  `ss_ext_list_price` decimal(7,2),
-  `ss_ext_tax` decimal(7,2),
-  `ss_coupon_amt` decimal(7,2),
-  `ss_net_paid` decimal(7,2),
-  `ss_net_paid_inc_tax` decimal(7,2),
-  `ss_net_profit` decimal(7,2))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table store_returns(
-  `sr_returned_date_sk` int,
-  `sr_return_time_sk` int,
-  `sr_item_sk` int,
-  `sr_customer_sk` int,
-  `sr_cdemo_sk` int,
-  `sr_hdemo_sk` int,
-  `sr_addr_sk` int,
-  `sr_store_sk` int,
-  `sr_reason_sk` int,
-  `sr_ticket_number` int,
-  `sr_return_quantity` int,
-  `sr_return_amt` decimal(7,2),
-  `sr_return_tax` decimal(7,2),
-  `sr_return_amt_inc_tax` decimal(7,2),
-  `sr_fee` decimal(7,2),
-  `sr_return_ship_cost` decimal(7,2),
-  `sr_refunded_cash` decimal(7,2),
-  `sr_reversed_charge` decimal(7,2),
-  `sr_store_credit` decimal(7,2),
-  `sr_net_loss` decimal(7,2))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table catalog_sales(
-  `cs_sold_date_sk` int,
-  `cs_sold_time_sk` int,
-  `cs_ship_date_sk` int,
-  `cs_bill_customer_sk` int,
-  `cs_bill_cdemo_sk` int,
-  `cs_bill_hdemo_sk` int,
-  `cs_bill_addr_sk` int,
-  `cs_ship_customer_sk` int,
-  `cs_ship_cdemo_sk` int,
-  `cs_ship_hdemo_sk` int,
-  `cs_ship_addr_sk` int,
-  `cs_call_center_sk` int,
-  `cs_catalog_page_sk` int,
-  `cs_ship_mode_sk` int,
-  `cs_warehouse_sk` int,
-  `cs_item_sk` int,
-  `cs_promo_sk` int,
-  `cs_order_number` int,
-  `cs_quantity` int,
-  `cs_wholesale_cost` decimal(7,2),
-  `cs_list_price` decimal(7,2),
-  `cs_sales_price` decimal(7,2),
-  `cs_ext_discount_amt` decimal(7,2),
-  `cs_ext_sales_price` decimal(7,2),
-  `cs_ext_wholesale_cost` decimal(7,2),
-  `cs_ext_list_price` decimal(7,2),
-  `cs_ext_tax` decimal(7,2),
-  `cs_coupon_amt` decimal(7,2),
-  `cs_ext_ship_cost` decimal(7,2),
-  `cs_net_paid` decimal(7,2),
-  `cs_net_paid_inc_tax` decimal(7,2),
-  `cs_net_paid_inc_ship` decimal(7,2),
-  `cs_net_paid_inc_ship_tax` decimal(7,2),
-  `cs_net_profit` decimal(7,2))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table catalog_returns(
-  `cr_returned_date_sk` int,
-  `cr_returned_time_sk` int,
-  `cr_item_sk` int,
-  `cr_refunded_customer_sk` int,
-  `cr_refunded_cdemo_sk` int,
-  `cr_refunded_hdemo_sk` int,
-  `cr_refunded_addr_sk` int,
-  `cr_returning_customer_sk` int,
-  `cr_returning_cdemo_sk` int,
-  `cr_returning_hdemo_sk` int,
-  `cr_returning_addr_sk` int,
-  `cr_call_center_sk` int,
-  `cr_catalog_page_sk` int,
-  `cr_ship_mode_sk` int,
-  `cr_warehouse_sk` int,
-  `cr_reason_sk` int,
-  `cr_order_number` int,
-  `cr_return_quantity` int,
-  `cr_return_amount` decimal(7,2),
-  `cr_return_tax` decimal(7,2),
-  `cr_return_amt_inc_tax` decimal(7,2),
-  `cr_fee` decimal(7,2),
-  `cr_return_ship_cost` decimal(7,2),
-  `cr_refunded_cash` decimal(7,2),
-  `cr_reversed_charge` decimal(7,2),
-  `cr_store_credit` decimal(7,2),
-  `cr_net_loss` decimal(7,2))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table web_sales(
-  `ws_sold_date_sk` int,
-  `ws_sold_time_sk` int,
-  `ws_ship_date_sk` int,
-  `ws_item_sk` int,
-  `ws_bill_customer_sk` int,
-  `ws_bill_cdemo_sk` int,
-  `ws_bill_hdemo_sk` int,
-  `ws_bill_addr_sk` int,
-  `ws_ship_customer_sk` int,
-  `ws_ship_cdemo_sk` int,
-  `ws_ship_hdemo_sk` int,
-  `ws_ship_addr_sk` int,
-  `ws_web_page_sk` int,
-  `ws_web_site_sk` int,
-  `ws_ship_mode_sk` int,
-  `ws_warehouse_sk` int,
-  `ws_promo_sk` int,
-  `ws_order_number` int,
-  `ws_quantity` int,
-  `ws_wholesale_cost` decimal(7,2),
-  `ws_list_price` decimal(7,2),
-  `ws_sales_price` decimal(7,2),
-  `ws_ext_discount_amt` decimal(7,2),
-  `ws_ext_sales_price` decimal(7,2),
-  `ws_ext_wholesale_cost` decimal(7,2),
-  `ws_ext_list_price` decimal(7,2),
-  `ws_ext_tax` decimal(7,2),
-  `ws_coupon_amt` decimal(7,2),
-  `ws_ext_ship_cost` decimal(7,2),
-  `ws_net_paid` decimal(7,2),
-  `ws_net_paid_inc_tax` decimal(7,2),
-  `ws_net_paid_inc_ship` decimal(7,2),
-  `ws_net_paid_inc_ship_tax` decimal(7,2),
-  `ws_net_profit` decimal(7,2))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table web_returns(
-  `wr_returned_date_sk` int,
-  `wr_returned_time_sk` int,
-  `wr_item_sk` int,
-  `wr_refunded_customer_sk` int,
-  `wr_refunded_cdemo_sk` int,
-  `wr_refunded_hdemo_sk` int,
-  `wr_refunded_addr_sk` int,
-  `wr_returning_customer_sk` int,
-  `wr_returning_cdemo_sk` int,
-  `wr_returning_hdemo_sk` int,
-  `wr_returning_addr_sk` int,
-  `wr_web_page_sk` int,
-  `wr_reason_sk` int,
-  `wr_order_number` int,
-  `wr_return_quantity` int,
-  `wr_return_amt` decimal(7,2),
-  `wr_return_tax` decimal(7,2),
-  `wr_return_amt_inc_tax` decimal(7,2),
-  `wr_fee` decimal(7,2),
-  `wr_return_ship_cost` decimal(7,2),
-  `wr_refunded_cash` decimal(7,2),
-  `wr_reversed_charge` decimal(7,2),
-  `wr_account_credit` decimal(7,2),
-  `wr_net_loss` decimal(7,2))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table inventory(
-  `inv_date_sk` int,
-  `inv_item_sk` int,
-  `inv_warehouse_sk` int,
-  `inv_quantity_on_hand` int)
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table store(
-  `s_store_sk` int,
-  `s_store_id` char(16),
-  `s_rec_start_date` date,
-  `s_rec_end_date` date,
-  `s_closed_date_sk` int,
-  `s_store_name` varchar(50),
-  `s_number_employees` int,
-  `s_floor_space` int,
-  `s_hours` char(20),
-  `s_manager` varchar(40),
-  `s_market_id` int,
-  `s_geography_class` varchar(100),
-  `s_market_desc` varchar(100),
-  `s_market_manager` varchar(40),
-  `s_division_id` int,
-  `s_division_name` varchar(50),
-  `s_company_id` int,
-  `s_company_name` varchar(50),
-  `s_street_number` varchar(10),
-  `s_street_name` varchar(60),
-  `s_street_type` char(15),
-  `s_suite_number` char(10),
-  `s_city` varchar(60),
-  `s_county` varchar(30),
-  `s_state` char(2),
-  `s_zip` char(10),
-  `s_country` varchar(20),
-  `s_gmt_offset` decimal(5,2),
-  `s_tax_percentage` decimal(5,2))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table call_center(
-  `cc_call_center_sk` int,
-  `cc_call_center_id` char(16),
-  `cc_rec_start_date` date,
-  `cc_rec_end_date` date,
-  `cc_closed_date_sk` int,
-  `cc_open_date_sk` int,
-  `cc_name` varchar(50),
-  `cc_class` varchar(50),
-  `cc_employees` int,
-  `cc_sq_ft` int,
-  `cc_hours` char(20),
-  `cc_manager` varchar(40),
-  `cc_mkt_id` int,
-  `cc_mkt_class` char(50),
-  `cc_mkt_desc` varchar(100),
-  `cc_market_manager` varchar(40),
-  `cc_division` int,
-  `cc_division_name` varchar(50),
-  `cc_company` int,
-  `cc_company_name` char(50),
-  `cc_street_number` char(10),
-  `cc_street_name` varchar(60),
-  `cc_street_type` char(15),
-  `cc_suite_number` char(10),
-  `cc_city` varchar(60),
-  `cc_county` varchar(30),
-  `cc_state` char(2),
-  `cc_zip` char(10),
-  `cc_country` varchar(20),
-  `cc_gmt_offset` decimal(5,2),
-  `cc_tax_percentage` decimal(5,2))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table catalog_page(
-  `cp_catalog_page_sk` int,
-  `cp_catalog_page_id` char(16),
-  `cp_start_date_sk` int,
-  `cp_end_date_sk` int,
-  `cp_department` varchar(50),
-  `cp_catalog_number` int,
-  `cp_catalog_page_number` int,
-  `cp_description` varchar(100),
-  `cp_type` varchar(100))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table web_site(
-  `web_site_sk` int,
-  `web_site_id` char(16),
-  `web_rec_start_date` date,
-  `web_rec_end_date` date,
-  `web_name` varchar(50),
-  `web_open_date_sk` int,
-  `web_close_date_sk` int,
-  `web_class` varchar(50),
-  `web_manager` varchar(40),
-  `web_mkt_id` int,
-  `web_mkt_class` varchar(50),
-  `web_mkt_desc` varchar(100),
-  `web_market_manager` varchar(40),
-  `web_company_id` int,
-  `web_company_name` char(50),
-  `web_street_number` char(10),
-  `web_street_name` varchar(60),
-  `web_street_type` char(15),
-  `web_suite_number` char(10),
-  `web_city` varchar(60),
-  `web_county` varchar(30),
-  `web_state` char(2),
-  `web_zip` char(10),
-  `web_country` varchar(20),
-  `web_gmt_offset` decimal(5,2),
-  `web_tax_percentage` decimal(5,2))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table web_page(
-  `wp_web_page_sk` int,
-  `wp_web_page_id` char(16),
-  `wp_rec_start_date` date,
-  `wp_rec_end_date` date,
-  `wp_creation_date_sk` int,
-  `wp_access_date_sk` int,
-  `wp_autogen_flag` char(1),
-  `wp_customer_sk` int,
-  `wp_url` varchar(100),
-  `wp_type` char(50),
-  `wp_char_count` int,
-  `wp_link_count` int,
-  `wp_image_count` int,
-  `wp_max_ad_count` int)
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table warehouse(
-  `w_warehouse_sk` int,
-  `w_warehouse_id` char(16),
-  `w_warehouse_name` varchar(20),
-  `w_warehouse_sq_ft` int,
-  `w_street_number` char(10),
-  `w_street_name` varchar(20),
-  `w_street_type` char(15),
-  `w_suite_number` char(10),
-  `w_city` varchar(60),
-  `w_county` varchar(30),
-  `w_state` char(2),
-  `w_zip` char(10),
-  `w_country` varchar(20),
-  `w_gmt_offset` decimal(5,2))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table customer(
-  `c_customer_sk` int,
-  `c_customer_id` char(16),
-  `c_current_cdemo_sk` int,
-  `c_current_hdemo_sk` int,
-  `c_current_addr_sk` int,
-  `c_first_shipto_date_sk` int,
-  `c_first_sales_date_sk` int,
-  `c_salutation` char(10),
-  `c_first_name` char(20),
-  `c_last_name` char(30),
-  `c_preferred_cust_flag` char(1),
-  `c_birth_day` int,
-  `c_birth_month` int,
-  `c_birth_year` int,
-  `c_birth_country` varchar(20),
-  `c_login` char(13),
-  `c_email_address` char(50),
-  `c_last_review_date` int)
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table customer_address(
-  `ca_address_sk` int,
-  `ca_address_id` char(16),
-  `ca_street_number` char(10),
-  `ca_street_name` varchar(60),
-  `ca_street_type` char(15),
-  `ca_suite_number` char(10),
-  `ca_city` varchar(60),
-  `ca_county` varchar(30),
-  `ca_state` char(2),
-  `ca_zip` char(10),
-  `ca_country` varchar(20),
-  `ca_gmt_offset` decimal(5,2),
-  `ca_location_type` char(20))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table customer_demographics(
-  `cd_demo_sk` int,
-  `cd_gender` char(1),
-  `cd_marital_status` char(1),
-  `cd_education_status` char(20),
-  `cd_purchase_estimate` int,
-  `cd_credit_rating` char(10),
-  `cd_dep_count` int,
-  `cd_dep_employed_count` int,
-  `cd_dep_college_count` int)
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table date_dim(
-  `d_date_sk` int,
-  `d_date_id` char(16),
-  `d_date` date,
-  `d_month_seq` int,
-  `d_week_seq` int,
-  `d_quarter_seq` int,
-  `d_year` int,
-  `d_dow` int,
-  `d_moy` int,
-  `d_dom` int,
-  `d_qoy` int,
-  `d_fy_year` int,
-  `d_fy_quarter_seq` int,
-  `d_fy_week_seq` int,
-  `d_day_name` char(9),
-  `d_quarter_name` char(6),
-  `d_holiday` char(1),
-  `d_weekend` char(1),
-  `d_following_holiday` char(1),
-  `d_first_dom` int,
-  `d_last_dom` int,
-  `d_same_day_ly` int,
-  `d_same_day_lq` int,
-  `d_current_day` char(1),
-  `d_current_week` char(1),
-  `d_current_month` char(1),
-  `d_current_quarter` char(1),
-  `d_current_year` char(1))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table household_demographics(
-  `hd_demo_sk` int,
-  `hd_income_band_sk` int,
-  `hd_buy_potential` char(15),
-  `hd_dep_count` int,
-  `hd_vehicle_count` int)
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table item(
-  `i_item_sk` int,
-  `i_item_id` char(16),
-  `i_rec_start_date` date,
-  `i_rec_end_date` date,
-  `i_item_desc` varchar(200),
-  `i_current_price` decimal(7,2),
-  `i_wholesale_cost` decimal(7,2),
-  `i_brand_id` int,
-  `i_brand` char(50),
-  `i_class_id` int,
-  `i_class` char(50),
-  `i_category_id` int,
-  `i_category` char(50),
-  `i_manufact_id` int,
-  `i_manufact` char(50),
-  `i_size` char(20),
-  `i_formulation` char(20),
-  `i_color` char(20),
-  `i_units` char(10),
-  `i_container` char(10),
-  `i_manager_id` int,
-  `i_product_name` char(50))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table income_band(
-  `ib_income_band_sk` int,
-  `ib_lower_bound` int,
-  `ib_upper_bound` int)
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table promotion(
-  `p_promo_sk` int,
-  `p_promo_id` char(16),
-  `p_start_date_sk` int,
-  `p_end_date_sk` int,
-  `p_item_sk` int,
-  `p_cost` decimal(15,2),
-  `p_response_target` int,
-  `p_promo_name` char(50),
-  `p_channel_dmail` char(1),
-  `p_channel_email` char(1),
-  `p_channel_catalog` char(1),
-  `p_channel_tv` char(1),
-  `p_channel_radio` char(1),
-  `p_channel_press` char(1),
-  `p_channel_event` char(1),
-  `p_channel_demo` char(1),
-  `p_channel_details` varchar(100),
-  `p_purpose` char(15),
-  `p_discount_active` char(1))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table reason(
-  `r_reason_sk` int,
-  `r_reason_id` char(16),
-  `r_reason_desc` char(100))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table ship_mode(
-  `sm_ship_mode_sk` int,
-  `sm_ship_mode_id` char(16),
-  `sm_type` char(30),
-  `sm_code` char(10),
-  `sm_carrier` char(20),
-  `sm_contract` char(20))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-create table time_dim(
-  `t_time_sk` int,
-  `t_time_id` char(16),
-  `t_time` int,
-  `t_hour` int,
-  `t_minute` int,
-  `t_second` int,
-  `t_am_pm` char(2),
-  `t_shift` char(20),
-  `t_sub_shift` char(20),
-  `t_meal_time` char(20))
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
 table t
 |> select 1 as x
 -- !query schema
@@ -1650,6 +1033,17 @@ struct<x:int,y:int>
 
 -- !query
 table t
+|> as `u.v`
+|> select `u.v`.x, `u.v`.y
+-- !query schema
+struct<x:int,y:string>
+-- !query output
+0	abc
+1	def
+
+
+-- !query
+table t
 |> as u
 |> as v
 |> select v.x, v.y
@@ -1699,6 +1093,56 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "sqlState" : "42601",
   "messageParameters" : {
     "error" : "'1'",
+    "hint" : ""
+  }
+}
+
+
+-- !query
+table t
+|> as u-v
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.parser.ParseException
+{
+  "errorClass" : "INVALID_IDENTIFIER",
+  "sqlState" : "42602",
+  "messageParameters" : {
+    "ident" : "u-v"
+  }
+}
+
+
+-- !query
+table t
+|> as u@v
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.parser.ParseException
+{
+  "errorClass" : "PARSE_SYNTAX_ERROR",
+  "sqlState" : "42601",
+  "messageParameters" : {
+    "error" : "'@'",
+    "hint" : ""
+  }
+}
+
+
+-- !query
+table t
+|> as u#######v
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.parser.ParseException
+{
+  "errorClass" : "PARSE_SYNTAX_ERROR",
+  "sqlState" : "42601",
+  "messageParameters" : {
+    "error" : "'#'",
     "hint" : ""
   }
 }
@@ -4309,6 +3753,132 @@ struct<rnk:int,best_performing:string,worst_performing:string>
 
 
 -- !query
+with web_v1 as (
+  select
+    ws_item_sk item_sk,
+    d_date,
+    sum(sum(ws_sales_price))
+    over (partition by ws_item_sk
+      order by d_date
+      rows between unbounded preceding and current row) cume_sales
+  from web_sales, date_dim
+  where ws_sold_date_sk = d_date_sk
+    and d_month_seq between 1200 and 1200 + 11
+    and ws_item_sk is not null
+  group by ws_item_sk, d_date),
+    store_v1 as (
+    select
+      ss_item_sk item_sk,
+      d_date,
+      sum(sum(ss_sales_price))
+      over (partition by ss_item_sk
+        order by d_date
+        rows between unbounded preceding and current row) cume_sales
+    from store_sales, date_dim
+    where ss_sold_date_sk = d_date_sk
+      and d_month_seq between 1200 and 1200 + 11
+      and ss_item_sk is not null
+    group by ss_item_sk, d_date)
+select *
+from (select
+  item_sk,
+  d_date,
+  web_sales,
+  store_sales,
+  max(web_sales)
+  over (partition by item_sk
+    order by d_date
+    rows between unbounded preceding and current row) web_cumulative,
+  max(store_sales)
+  over (partition by item_sk
+    order by d_date
+    rows between unbounded preceding and current row) store_cumulative
+from (select
+  case when web.item_sk is not null
+    then web.item_sk
+  else store.item_sk end item_sk,
+  case when web.d_date is not null
+    then web.d_date
+  else store.d_date end d_date,
+  web.cume_sales web_sales,
+  store.cume_sales store_sales
+from web_v1 web full outer join store_v1 store on (web.item_sk = store.item_sk
+  and web.d_date = store.d_date)
+     ) x) y
+where web_cumulative > store_cumulative
+order by item_sk, d_date
+limit 100
+-- !query schema
+struct<item_sk:int,d_date:date,web_sales:decimal(27,2),store_sales:decimal(27,2),web_cumulative:decimal(27,2),store_cumulative:decimal(27,2)>
+-- !query output
+
+
+
+-- !query
+with web_v1 as (
+  table web_sales
+  |> join date_dim
+  |> where ws_sold_date_sk = d_date_sk
+       and d_month_seq between 1200 and 1200 + 11
+       and ws_item_sk is not null
+  |> aggregate sum(ws_sales_price) as sum_ws_sales_price
+       group by ws_item_sk as item_sk, d_date
+  |> extend sum(sum_ws_sales_price)
+       over (partition by item_sk
+         order by d_date
+         rows between unbounded preceding and current row)
+       as cume_sales),
+store_v1 as (
+  table store_sales
+  |> join date_dim
+  |> where ss_sold_date_sk = d_date_sk
+       and d_month_seq between 1200 and 1200 + 11
+       and ss_item_sk is not null
+  |> aggregate sum(ss_sales_price) as sum_ss_sales_price
+       group by ss_item_sk as item_sk, d_date
+  |> extend sum(sum_ss_sales_price)
+       over (partition by item_sk
+           order by d_date
+           rows between unbounded preceding and current row)
+       as cume_sales)
+table web_v1
+|> as web
+|> full outer join store_v1 store
+     on (web.item_sk = store.item_sk and web.d_date = store.d_date)
+|> select
+     case when web.item_sk is not null
+       then web.item_sk
+       else store.item_sk end item_sk,
+     case when web.d_date is not null
+       then web.d_date
+       else store.d_date end d_date,
+     web.cume_sales web_sales,
+     store.cume_sales store_sales
+|> as x
+|> select
+     item_sk,
+     d_date,
+     web_sales,
+     store_sales,
+     max(web_sales)
+       over (partition by item_sk
+         order by d_date
+         rows between unbounded preceding and current row) web_cumulative,
+     max(store_sales)
+       over (partition by item_sk
+         order by d_date
+         rows between unbounded preceding and current row) store_cumulative
+|> as y
+|> where web_cumulative > store_cumulative
+|> order by item_sk, d_date
+|> limit 100
+-- !query schema
+struct<item_sk:int,d_date:date,web_sales:decimal(27,2),store_sales:decimal(27,2),web_cumulative:decimal(27,2),store_cumulative:decimal(27,2)>
+-- !query output
+
+
+
+-- !query
 drop table t
 -- !query schema
 struct<>
@@ -4326,198 +3896,6 @@ struct<>
 
 -- !query
 drop table st
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table call_center
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table catalog_page
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table catalog_returns
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table catalog_sales
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table customer
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table customer_address
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table customer_demographics
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table date_dim
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table household_demographics
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table income_band
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table inventory
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table item
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table promotion
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table reason
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table ship_mode
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table store
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table store_returns
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table store_sales
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table time_dim
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table warehouse
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table web_page
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table web_returns
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table web_sales
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-drop table web_site
 -- !query schema
 struct<>
 -- !query output


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds SQL pipe syntax support for DROP and AS operators.

The DROP operator removes one or more existing column from the input table.
The AS operator assigns a new table alias to the preceding relation.

These are equivalent to `SELECT * EXCEPT(<columnNames>)` and `SELECT ... FROM (...) <tableAlias>`, respectively.

For example:

```
values (0, 'pqr', 2), (3, 'tuv', 5) as tab(a, b, c)
|> as v
|> drop v.b
|> drop v.c

0
3
```

This PR also fixes a small bug and adds more testing.

### Why are the changes needed?

The SQL pipe operator syntax will let users compose queries in a more flexible fashion.

### Does this PR introduce _any_ user-facing change?

Yes, see above.

### How was this patch tested?

This PR adds a few unit test cases, but mostly relies on golden file test coverage. I did this to make sure the answers are correct as this feature is implemented and also so we can look at the analyzer output plans to ensure they look right as well.

### Was this patch authored or co-authored using generative AI tooling?

No