### PR TITLE
[SPARK-50474][BUILD] Upgrade checkstyle to 10.20.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3225,7 +3225,7 @@
             -->
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.20.0</version>
+            <version>10.20.2</version>
           </dependency>
         </dependencies>
         <executions>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,10 +19,10 @@ addSbtPlugin("software.purpledragon" % "sbt-checkstyle-plugin" % "4.0.1")
 
 // If you are changing the dependency setting for checkstyle plugin,
 // please check pom.xml in the root of the source tree too.
-libraryDependencies += "com.puppycrawl.tools" % "checkstyle" % "10.20.0"
+libraryDependencies += "com.puppycrawl.tools" % "checkstyle" % "10.20.2"
 
-// checkstyle uses guava 33.1.0-jre.
-libraryDependencies += "com.google.guava" % "guava" % "33.1.0-jre"
+// checkstyle uses guava 33.3.1-jre.
+libraryDependencies += "com.google.guava" % "guava" % "33.3.1-jre"
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.0")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr upgrades `checkstyle` from version 10.20.0 to 10.20.2, and simultaneously updates the Guava library used by `checkstyle` in `project/plugins.sbt` to version `33.3.1-jre`. This is due to the fact

https://github.com/checkstyle/checkstyle/blob/checkstyle-10.20.2/pom.xml#L291-L301

![image](https://github.com/user-attachments/assets/903c02c1-fd07-4efe-8e13-8bdfd479be03)



### Why are the changes needed?
The new version will bring some bug fixes:

- https://checkstyle.org/releasenotes.html#Release_10.20.1
- https://checkstyle.org/releasenotes.html#Release_10.20.2


### Does this PR introduce _any_ user-facing change?
No, dev only


### How was this patch tested?
Manually by:

```
./dev/lint-java

```


### Was this patch authored or co-authored using generative AI tooling?
No
