### PR TITLE
[SPARK-50460][PYTHON][CONNECT] Generalize and simplify Connect exception handling

### DIFF
--- a/python/pyspark/errors/exceptions/connect.py
+++ b/python/pyspark/errors/exceptions/connect.py
@@ -54,10 +54,18 @@ def convert_exception(
     resp: Optional[pb2.FetchErrorDetailsResponse],
     display_server_stacktrace: bool = False,
 ) -> SparkConnectException:
-    classes = json.loads(info.metadata.get("classes", "[]"))
+    classes = info.metadata.get("classes")
+    if classes:
+        classes = json.loads(classes)
+    else:
+        classes = []
     sql_state = info.metadata.get("sqlState")
     error_class = info.metadata.get("errorClass")
-    message_parameters = json.loads(info.metadata.get("messageParameters", "{}"))
+    message_parameters = info.metadata.get("messageParameters")
+    if message_parameters:
+        message_parameters = json.loads(message_parameters)
+    else:
+        message_parameters = {}
     stacktrace: Optional[str] = None
 
     if resp is not None and resp.HasField("root_error_idx"):

--- a/python/pyspark/errors/exceptions/connect.py
+++ b/python/pyspark/errors/exceptions/connect.py
@@ -86,10 +86,6 @@ def convert_exception(
             "Please see the stack trace below.\n%s" % message
         )
 
-    # Add stacktrace to message if it exists
-    if stacktrace:
-        message += f"\n\nJVM stacktrace:\n{stacktrace}"
-
     # Return exception based on class mapping
     for error_class_name in classes:
         ExceptionClass = EXCEPTION_CLASS_MAPPING.get(error_class_name)

--- a/python/pyspark/errors/exceptions/connect.py
+++ b/python/pyspark/errors/exceptions/connect.py
@@ -54,18 +54,14 @@ def convert_exception(
     resp: Optional[pb2.FetchErrorDetailsResponse],
     display_server_stacktrace: bool = False,
 ) -> SparkConnectException:
-    classes = info.metadata.get("classes")
-    if classes:
-        classes = json.loads(classes)
-    else:
-        classes = []
+    raw_classes = info.metadata.get("classes")
+    classes: List[str] = json.loads(raw_classes) if raw_classes else []
     sql_state = info.metadata.get("sqlState")
     error_class = info.metadata.get("errorClass")
-    message_parameters = info.metadata.get("messageParameters")
-    if message_parameters:
-        message_parameters = json.loads(message_parameters)
-    else:
-        message_parameters = {}
+    raw_message_parameters = info.metadata.get("messageParameters")
+    message_parameters: Dict[str, str] = (
+        json.loads(raw_message_parameters) if raw_message_parameters else {}
+    )
     stacktrace: Optional[str] = None
 
     if resp is not None and resp.HasField("root_error_idx"):

--- a/python/pyspark/errors/exceptions/connect.py
+++ b/python/pyspark/errors/exceptions/connect.py
@@ -54,206 +54,67 @@ def convert_exception(
     resp: Optional[pb2.FetchErrorDetailsResponse],
     display_server_stacktrace: bool = False,
 ) -> SparkConnectException:
-    classes = []
-    sql_state = None
-    errorClass = None
-    messageParameters = None
-    contexts: Optional[List[BaseQueryContext]] = None
-
-    if "classes" in info.metadata:
-        classes = json.loads(info.metadata["classes"])
-
-    if "sqlState" in info.metadata:
-        sql_state = info.metadata["sqlState"]
-
-    if "errorClass" in info.metadata:
-        errorClass = info.metadata["errorClass"]
-
-    if "messageParameters" in info.metadata:
-        messageParameters = json.loads(info.metadata["messageParameters"])
-
+    classes = json.loads(info.metadata.get("classes", "[]"))
+    sql_state = info.metadata.get("sqlState")
+    error_class = info.metadata.get("errorClass")
+    message_parameters = json.loads(info.metadata.get("messageParameters", "{}"))
     stacktrace: Optional[str] = None
+
     if resp is not None and resp.HasField("root_error_idx"):
         message = resp.errors[resp.root_error_idx].message
         stacktrace = _extract_jvm_stacktrace(resp)
     else:
         message = truncated_message
-        stacktrace = info.metadata["stackTrace"] if "stackTrace" in info.metadata else None
-        display_server_stacktrace = display_server_stacktrace if stacktrace is not None else False
+        stacktrace = info.metadata.get("stackTrace")
+        display_server_stacktrace = display_server_stacktrace if stacktrace else False
 
-    if (
-        resp is not None
-        and resp.errors
-        and hasattr(resp.errors[resp.root_error_idx], "spark_throwable")
-    ):
-        messageParameters = dict(
-            resp.errors[resp.root_error_idx].spark_throwable.message_parameters
-        )
-        contexts = []
-        for context in resp.errors[resp.root_error_idx].spark_throwable.query_contexts:
-            if context.context_type == pb2.FetchErrorDetailsResponse.QueryContext.SQL:
-                contexts.append(SQLQueryContext(context))
-            else:
-                contexts.append(DataFrameQueryContext(context))
+    contexts = None
+    if resp and resp.HasField("root_error_idx"):
+        root_error = resp.errors[resp.root_error_idx]
+        if hasattr(root_error, "spark_throwable"):
+            message_parameters = dict(root_error.spark_throwable.message_parameters)
+            contexts = [
+                SQLQueryContext(c)
+                if c.context_type == pb2.FetchErrorDetailsResponse.QueryContext.SQL
+                else DataFrameQueryContext(c)
+                for c in root_error.spark_throwable.query_contexts
+            ]
 
-    if "org.apache.spark.sql.catalyst.parser.ParseException" in classes:
-        return ParseException(
-            message,
-            errorClass=errorClass,
-            messageParameters=messageParameters,
-            sql_state=sql_state,
-            server_stacktrace=stacktrace,
-            display_server_stacktrace=display_server_stacktrace,
-            contexts=contexts,
-        )
-    # Order matters. ParseException inherits AnalysisException.
-    elif "org.apache.spark.sql.AnalysisException" in classes:
-        return AnalysisException(
-            message,
-            errorClass=errorClass,
-            messageParameters=messageParameters,
-            sql_state=sql_state,
-            server_stacktrace=stacktrace,
-            display_server_stacktrace=display_server_stacktrace,
-            contexts=contexts,
-        )
-    elif "org.apache.spark.sql.streaming.StreamingQueryException" in classes:
-        return StreamingQueryException(
-            message,
-            errorClass=errorClass,
-            messageParameters=messageParameters,
-            sql_state=sql_state,
-            server_stacktrace=stacktrace,
-            display_server_stacktrace=display_server_stacktrace,
-            contexts=contexts,
-        )
-    elif "org.apache.spark.sql.execution.QueryExecutionException" in classes:
-        return QueryExecutionException(
-            message,
-            errorClass=errorClass,
-            messageParameters=messageParameters,
-            sql_state=sql_state,
-            server_stacktrace=stacktrace,
-            display_server_stacktrace=display_server_stacktrace,
-            contexts=contexts,
-        )
-    # Order matters. NumberFormatException inherits IllegalArgumentException.
-    elif "java.lang.NumberFormatException" in classes:
-        return NumberFormatException(
-            message,
-            errorClass=errorClass,
-            messageParameters=messageParameters,
-            sql_state=sql_state,
-            server_stacktrace=stacktrace,
-            display_server_stacktrace=display_server_stacktrace,
-            contexts=contexts,
-        )
-    elif "java.lang.IllegalArgumentException" in classes:
-        return IllegalArgumentException(
-            message,
-            errorClass=errorClass,
-            messageParameters=messageParameters,
-            sql_state=sql_state,
-            server_stacktrace=stacktrace,
-            display_server_stacktrace=display_server_stacktrace,
-            contexts=contexts,
-        )
-    elif "java.lang.ArithmeticException" in classes:
-        return ArithmeticException(
-            message,
-            errorClass=errorClass,
-            messageParameters=messageParameters,
-            sql_state=sql_state,
-            server_stacktrace=stacktrace,
-            display_server_stacktrace=display_server_stacktrace,
-            contexts=contexts,
-        )
-    elif "java.lang.UnsupportedOperationException" in classes:
-        return UnsupportedOperationException(
-            message,
-            errorClass=errorClass,
-            messageParameters=messageParameters,
-            sql_state=sql_state,
-            server_stacktrace=stacktrace,
-            display_server_stacktrace=display_server_stacktrace,
-            contexts=contexts,
-        )
-    elif "java.lang.ArrayIndexOutOfBoundsException" in classes:
-        return ArrayIndexOutOfBoundsException(
-            message,
-            errorClass=errorClass,
-            messageParameters=messageParameters,
-            sql_state=sql_state,
-            server_stacktrace=stacktrace,
-            display_server_stacktrace=display_server_stacktrace,
-            contexts=contexts,
-        )
-    elif "java.time.DateTimeException" in classes:
-        return DateTimeException(
-            message,
-            errorClass=errorClass,
-            sql_state=sql_state,
-            server_stacktrace=stacktrace,
-            display_server_stacktrace=display_server_stacktrace,
-            contexts=contexts,
-        )
-    elif "org.apache.spark.SparkRuntimeException" in classes:
-        return SparkRuntimeException(
-            message,
-            errorClass=errorClass,
-            messageParameters=messageParameters,
-            sql_state=sql_state,
-            server_stacktrace=stacktrace,
-            display_server_stacktrace=display_server_stacktrace,
-            contexts=contexts,
-        )
-    elif "org.apache.spark.SparkUpgradeException" in classes:
-        return SparkUpgradeException(
-            message,
-            errorClass=errorClass,
-            messageParameters=messageParameters,
-            sql_state=sql_state,
-            server_stacktrace=stacktrace,
-            display_server_stacktrace=display_server_stacktrace,
-            contexts=contexts,
-        )
-    elif "org.apache.spark.api.python.PythonException" in classes:
+    if "org.apache.spark.api.python.PythonException" in classes:
         return PythonException(
             "\n  An exception was thrown from the Python worker. "
             "Please see the stack trace below.\n%s" % message
         )
-    elif "org.apache.spark.SparkNoSuchElementException" in classes:
-        return SparkNoSuchElementException(
-            message,
-            errorClass=errorClass,
-            messageParameters=messageParameters,
-            sql_state=sql_state,
-            server_stacktrace=stacktrace,
-            display_server_stacktrace=display_server_stacktrace,
-            contexts=contexts,
-        )
-    # Make sure that the generic SparkException is handled last.
-    elif "org.apache.spark.SparkException" in classes:
-        return SparkException(
-            message,
-            errorClass=errorClass,
-            messageParameters=messageParameters,
-            sql_state=sql_state,
-            server_stacktrace=stacktrace,
-            display_server_stacktrace=display_server_stacktrace,
-            contexts=contexts,
-        )
-    else:
-        return SparkConnectGrpcException(
-            message,
-            reason=info.reason,
-            messageParameters=messageParameters,
-            errorClass=errorClass,
-            sql_state=sql_state,
-            server_stacktrace=stacktrace,
-            display_server_stacktrace=display_server_stacktrace,
-            contexts=contexts,
-        )
+
+    # Add stacktrace to message if it exists
+    if stacktrace:
+        message += f"\n\nJVM stacktrace:\n{stacktrace}"
+
+    # Return exception based on class mapping
+    for error_class_name in classes:
+        ExceptionClass = EXCEPTION_CLASS_MAPPING.get(error_class_name)
+        if ExceptionClass:
+            return ExceptionClass(
+                message,
+                errorClass=error_class,
+                messageParameters=message_parameters,
+                sql_state=sql_state,
+                server_stacktrace=stacktrace,
+                display_server_stacktrace=display_server_stacktrace,
+                contexts=contexts,
+            )
+
+    # Return SparkConnectGrpcException if there is no matched exception class
+    return SparkConnectGrpcException(
+        message,
+        reason=info.reason,
+        messageParameters=message_parameters,
+        errorClass=error_class,
+        sql_state=sql_state,
+        server_stacktrace=stacktrace,
+        display_server_stacktrace=display_server_stacktrace,
+        contexts=contexts,
+    )
 
 
 def _extract_jvm_stacktrace(resp: pb2.FetchErrorDetailsResponse) -> str:
@@ -432,6 +293,26 @@ class SparkNoSuchElementException(SparkConnectGrpcException, BaseNoSuchElementEx
     """
     No such element exception.
     """
+
+
+# Update EXCEPTION_CLASS_MAPPING here when adding a new exception
+EXCEPTION_CLASS_MAPPING = {
+    "org.apache.spark.sql.catalyst.parser.ParseException": ParseException,
+    "org.apache.spark.sql.AnalysisException": AnalysisException,
+    "org.apache.spark.sql.streaming.StreamingQueryException": StreamingQueryException,
+    "org.apache.spark.sql.execution.QueryExecutionException": QueryExecutionException,
+    "java.lang.NumberFormatException": NumberFormatException,
+    "java.lang.IllegalArgumentException": IllegalArgumentException,
+    "java.lang.ArithmeticException": ArithmeticException,
+    "java.lang.UnsupportedOperationException": UnsupportedOperationException,
+    "java.lang.ArrayIndexOutOfBoundsException": ArrayIndexOutOfBoundsException,
+    "java.time.DateTimeException": DateTimeException,
+    "org.apache.spark.SparkRuntimeException": SparkRuntimeException,
+    "org.apache.spark.SparkUpgradeException": SparkUpgradeException,
+    "org.apache.spark.api.python.PythonException": PythonException,
+    "org.apache.spark.SparkNoSuchElementException": SparkNoSuchElementException,
+    "org.apache.spark.SparkException": SparkException,
+}
 
 
 class SQLQueryContext(BaseQueryContext):

--- a/python/pyspark/errors/tests/test_connect_errors_conversion.py
+++ b/python/pyspark/errors/tests/test_connect_errors_conversion.py
@@ -1,0 +1,169 @@
+# -*- encoding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+from pyspark.errors.exceptions.connect import (
+    convert_exception,
+    EXCEPTION_CLASS_MAPPING,
+    SparkConnectGrpcException,
+    PythonException,
+    AnalysisException,
+)
+from pyspark.sql.connect.proto import FetchErrorDetailsResponse as pb2
+from google.rpc.error_details_pb2 import ErrorInfo
+
+
+class ConnectErrorsTest(unittest.TestCase):
+    def test_convert_exception_known_class(self):
+        # Mock ErrorInfo with a known error class
+        info = {
+            "reason": "org.apache.spark.sql.AnalysisException",
+            "metadata": {
+                "classes": '["org.apache.spark.sql.AnalysisException"]',
+                "sqlState": "42000",
+                "errorClass": "ANALYSIS.ERROR",
+                "messageParameters": '{"param1": "value1"}',
+            },
+        }
+        truncated_message = "Analysis error occurred"
+        exception = convert_exception(
+            info=ErrorInfo(**info), truncated_message=truncated_message, resp=None
+        )
+
+        self.assertIsInstance(exception, AnalysisException)
+        self.assertEqual(exception.getSqlState(), "42000")
+        self.assertEqual(exception._errorClass, "ANALYSIS.ERROR")
+        self.assertEqual(exception._messageParameters, {"param1": "value1"})
+
+    def test_convert_exception_python_exception(self):
+        # Mock ErrorInfo for PythonException
+        info = {
+            "reason": "org.apache.spark.api.python.PythonException",
+            "metadata": {
+                "classes": '["org.apache.spark.api.python.PythonException"]',
+            },
+        }
+        truncated_message = "Python worker error occurred"
+        exception = convert_exception(
+            info=ErrorInfo(**info), truncated_message=truncated_message, resp=None
+        )
+
+        self.assertIsInstance(exception, PythonException)
+        self.assertIn("An exception was thrown from the Python worker", exception.getMessage())
+
+    def test_convert_exception_unknown_class(self):
+        # Mock ErrorInfo with an unknown error class
+        info = {
+            "reason": "org.apache.spark.UnknownException",
+            "metadata": {"classes": '["org.apache.spark.UnknownException"]'},
+        }
+        truncated_message = "Unknown error occurred"
+        exception = convert_exception(
+            info=ErrorInfo(**info), truncated_message=truncated_message, resp=None
+        )
+
+        self.assertIsInstance(exception, SparkConnectGrpcException)
+        self.assertEqual(
+            exception.getMessage(), "(org.apache.spark.UnknownException) Unknown error occurred"
+        )
+
+    def test_exception_class_mapping(self):
+        # Ensure that all keys in EXCEPTION_CLASS_MAPPING are valid
+        for error_class_name, exception_class in EXCEPTION_CLASS_MAPPING.items():
+            self.assertTrue(
+                hasattr(exception_class, "__name__"),
+                f"{exception_class} in EXCEPTION_CLASS_MAPPING is not a valid class",
+            )
+
+    def test_convert_exception_with_stacktrace(self):
+        # Mock FetchErrorDetailsResponse with stacktrace
+        resp = pb2(
+            root_error_idx=0,
+            errors=[
+                pb2.Error(
+                    message="Root error message",
+                    error_type_hierarchy=["org.apache.spark.SparkException"],
+                    stack_trace=[
+                        pb2.StackTraceElement(
+                            declaring_class="org.apache.spark.Main",
+                            method_name="main",
+                            file_name="Main.scala",
+                            line_number=42,
+                        ),
+                    ],
+                    cause_idx=1,
+                ),
+                pb2.Error(
+                    message="Cause error message",
+                    error_type_hierarchy=["java.lang.RuntimeException"],
+                    stack_trace=[
+                        pb2.StackTraceElement(
+                            declaring_class="org.apache.utils.Helper",
+                            method_name="help",
+                            file_name="Helper.java",
+                            line_number=10,
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        info = {
+            "reason": "org.apache.spark.SparkException",
+            "metadata": {
+                "classes": '["org.apache.spark.SparkException"]',
+                "sqlState": "42000",
+            },
+        }
+        truncated_message = "Root error message"
+        exception = convert_exception(
+            info=ErrorInfo(**info), truncated_message=truncated_message, resp=resp
+        )
+
+        self.assertIsInstance(exception, SparkConnectGrpcException)
+        self.assertIn("Root error message", exception.getMessage())
+        self.assertIn("Caused by", exception.getMessage())
+
+    def test_convert_exception_fallback(self):
+        # Mock ErrorInfo with missing class information
+        info = {
+            "reason": "org.apache.spark.UnknownReason",
+            "metadata": {},
+        }
+        truncated_message = "Fallback error occurred"
+        exception = convert_exception(
+            info=ErrorInfo(**info), truncated_message=truncated_message, resp=None
+        )
+
+        self.assertIsInstance(exception, SparkConnectGrpcException)
+        self.assertEqual(
+            exception.getMessage(), "(org.apache.spark.UnknownReason) Fallback error occurred"
+        )
+
+
+if __name__ == "__main__":
+    import unittest
+    from pyspark.errors.tests.test_errors import *  # noqa: F401
+
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)


### PR DESCRIPTION


### What changes were proposed in this pull request?

This PR introduces a generalized and streamlined approach to handling exceptions in the Spark Connect Python client.

This PR includes:

1. Replaces the large if-else block for exception type matching with a more extensible class mapping (`EXCEPTION_CLASS_MAPPING`).
2. Maintains compatibility for existing exception types while making it easier to add new ones in the future.
3. Keeps the unique handling logic for specific exceptions like `PythonException` intact.

### Why are the changes needed?

The previous exception handling logic relied on a large `if-else` block, which was not scalable or maintainable as more exception types were added.

Generalizing the exception handling mechanism reduces the complexity of the code, making it easier to extend when adding new exception types now requires minimal changes to the `EXCEPTION_CLASS_MAPPING`, avoiding duplication of logic.

### Does this PR introduce _any_ user-facing change?

No API changes, but it enhances the internal implementation of exception handling.

### How was this patch tested?

Added new UTs to verify that all existing exception handling scenarios are still supported.

### Was this patch authored or co-authored using generative AI tooling?

No.
