### PR TITLE
[SPARK-50484][TESTS][CONNECT][PYTHON] Skip ClassificationTestsOnConnect tests properly if dependences are not found

### DIFF
--- a/python/pyspark/ml/tests/connect/test_connect_classification.py
+++ b/python/pyspark/ml/tests/connect/test_connect_classification.py
@@ -21,27 +21,32 @@ import os
 
 from pyspark.util import is_remote_only
 from pyspark.sql import SparkSession
-from pyspark.ml.tests.connect.test_legacy_mode_classification import ClassificationTestsMixin
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 from pyspark.testing.utils import have_torch, torch_requirement_message
 
+should_test = not should_test_connect or not have_torch or is_remote_only()
 
-@unittest.skipIf(
-    not should_test_connect or not have_torch or is_remote_only(),
-    connect_requirement_message
-    or torch_requirement_message
-    or "Requires PySpark core library in Spark Connect server",
-)
-class ClassificationTestsOnConnect(ClassificationTestsMixin, unittest.TestCase):
-    def setUp(self) -> None:
-        self.spark = (
-            SparkSession.builder.remote(os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[2]"))
-            .config("spark.sql.artifact.copyFromLocalToFs.allowDestLocal", "true")
-            .getOrCreate()
-        )
+if should_test:
+    from pyspark.ml.tests.connect.test_legacy_mode_classification import ClassificationTestsMixin
 
-    def tearDown(self) -> None:
-        self.spark.stop()
+    @unittest.skipIf(
+        should_test,
+        connect_requirement_message
+        or torch_requirement_message
+        or "Requires PySpark core library in Spark Connect server",
+    )
+    class ClassificationTestsOnConnect(ClassificationTestsMixin, unittest.TestCase):
+        def setUp(self) -> None:
+            self.spark = (
+                SparkSession.builder.remote(
+                    os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[2]")
+                )
+                .config("spark.sql.artifact.copyFromLocalToFs.allowDestLocal", "true")
+                .getOrCreate()
+            )
+
+        def tearDown(self) -> None:
+            self.spark.stop()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip `ClassificationTestsOnConnect` tests properly if dependences are not found

### Why are the changes needed?

So it does not require developers to install optional dependencies when running tests.

### Does this PR introduce _any_ user-facing change?

To fix up the build: https://github.com/apache/spark/actions/runs/12146458952/job/33870426859

### How was this patch tested?

Will monitor the tests

### Was this patch authored or co-authored using generative AI tooling?

No.