### PR TITLE
[SPARK-50485][SQL] Unwrap SparkThrowable in (Unchecked)ExecutionException thrown by tableRelationCache

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -219,7 +219,6 @@ class SessionCatalog(
     }
   }
 
-
   /** This method provides a way to get a cached plan if the key exists. */
   def getCachedTable(key: QualifiedTableName): LogicalPlan = {
     tableRelationCache.getIfPresent(key)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -19,18 +19,18 @@ package org.apache.spark.sql.catalyst.catalog
 
 import java.net.URI
 import java.util.Locale
-import java.util.concurrent.Callable
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{Callable, TimeUnit}
 import javax.annotation.concurrent.GuardedBy
 
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 
 import com.google.common.cache.{Cache, CacheBuilder}
+import com.google.common.util.concurrent.UncheckedExecutionException
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkException, SparkThrowable}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst._
 import org.apache.spark.sql.catalyst.analysis._
@@ -210,12 +210,25 @@ class SessionCatalog(
 
   /** This method provides a way to get a cached plan. */
   def getCachedPlan(t: QualifiedTableName, c: Callable[LogicalPlan]): LogicalPlan = {
-    tableRelationCache.get(t, c)
+    try {
+      tableRelationCache.get(t, c)
+    } catch {
+      case e: UncheckedExecutionException
+          if e.getCause != null && e.getCause.isInstanceOf[SparkThrowable] =>
+        throw e.getCause
+    }
   }
+
 
   /** This method provides a way to get a cached plan if the key exists. */
   def getCachedTable(key: QualifiedTableName): LogicalPlan = {
-    tableRelationCache.getIfPresent(key)
+    try {
+      tableRelationCache.getIfPresent(key)
+    } catch {
+      case e: UncheckedExecutionException
+          if e.getCause != null && e.getCause.isInstanceOf[SparkThrowable] =>
+        throw e.getCause
+    }
   }
 
   /** This method provides a way to cache a plan. */

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -1258,6 +1258,22 @@ class QueryExecutionErrorsSuite
       )
     )
   }
+
+  test("SPARK-50485: Unwrap SparkThrowable in UEE thrown by tableRelationCache") {
+    withTable("t") {
+      sql(s"CREATE TABLE t (a INT)")
+      checkError(
+        exception = intercept[SparkUnsupportedOperationException] {
+          sql(s"ALTER TABLE t SET LOCATION 'https://mister/spark'")
+        },
+        condition = "FAILED_READ_FILE.UNSUPPORTED_FILE_SYSTEM",
+        parameters = Map(
+          "path" -> "https://mister/spark",
+          "fileSystemClass" -> "org.apache.hadoop.fs.http.HttpsFileSystem",
+          "method" -> "listStatus"))
+      sql(s"ALTER TABLE t SET LOCATION '/mister/spark'")
+    }
+  }
 }
 
 class FakeFileSystemSetPermission extends LocalFileSystem {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -1271,7 +1271,7 @@ class QueryExecutionErrorsSuite
           "path" -> "https://mister/spark",
           "fileSystemClass" -> "org.apache.hadoop.fs.http.HttpsFileSystem",
           "method" -> "listStatus"))
-      sql(s"ALTER TABLE t SET LOCATION '/mister/spark'")
+      sql("ALTER TABLE t SET LOCATION '/mister/spark'")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -1264,7 +1264,7 @@ class QueryExecutionErrorsSuite
       sql("CREATE TABLE t (a INT)")
       checkError(
         exception = intercept[SparkUnsupportedOperationException] {
-          sql(s"ALTER TABLE t SET LOCATION 'https://mister/spark'")
+          sql("ALTER TABLE t SET LOCATION 'https://mister/spark'")
         },
         condition = "FAILED_READ_FILE.UNSUPPORTED_FILE_SYSTEM",
         parameters = Map(

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -1261,7 +1261,7 @@ class QueryExecutionErrorsSuite
 
   test("SPARK-50485: Unwrap SparkThrowable in UEE thrown by tableRelationCache") {
     withTable("t") {
-      sql(s"CREATE TABLE t (a INT)")
+      sql("CREATE TABLE t (a INT)")
       checkError(
         exception = intercept[SparkUnsupportedOperationException] {
           sql(s"ALTER TABLE t SET LOCATION 'https://mister/spark'")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableSetLocationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableSetLocationSuite.scala
@@ -142,7 +142,7 @@ trait AlterTableSetLocationSuiteBase extends command.AlterTableSetLocationSuiteB
       sql(s"CREATE TABLE $t (a INT)")
       checkError(
         exception = intercept[SparkUnsupportedOperationException] {
-          sql(s"ALTER TABLE t SET LOCATION 'https://mister/spark'")
+          sql(s"ALTER TABLE $t SET LOCATION 'https://mister/spark'")
         },
         condition = "FAILED_READ_FILE.UNSUPPORTED_FILE_SYSTEM",
         parameters = Map(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableSetLocationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableSetLocationSuite.scala
@@ -21,7 +21,6 @@ import java.net.URI
 
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
@@ -133,23 +132,6 @@ trait AlterTableSetLocationSuiteBase extends command.AlterTableSetLocationSuiteB
           "specKeys" -> "b",
           "partitionColumnNames" -> "a, b",
           "tableName" -> "`spark_catalog`.`ns`.`tbl`"))
-    }
-  }
-
-  test("SPARK-50485: Unwrap SparkThrowable in UEE thrown by tableRelationCache") {
-    withNamespaceAndTable("ns", "tbl") { t =>
-      sql(buildCreateTableSQL(t))
-      sql(s"CREATE TABLE $t (a INT)")
-      checkError(
-        exception = intercept[SparkUnsupportedOperationException] {
-          sql(s"ALTER TABLE $t SET LOCATION 'https://mister/spark'")
-        },
-        condition = "FAILED_READ_FILE.UNSUPPORTED_FILE_SYSTEM",
-        parameters = Map(
-          "path" -> "https://mister/spark",
-          "fileSystemClass" -> "org.apache.hadoop.fs.http.HttpsFileSystem",
-          "method" -> "listStatus"))
-
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableSetLocationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableSetLocationSuite.scala
@@ -139,7 +139,7 @@ trait AlterTableSetLocationSuiteBase extends command.AlterTableSetLocationSuiteB
   test("SPARK-50485: Unwrap SparkThrowable in UEE thrown by tableRelationCache") {
     withNamespaceAndTable("ns", "tbl") { t =>
       sql(buildCreateTableSQL(t))
-      sql(s"CREATE TABLE t (a INT)")
+      sql(s"CREATE TABLE $t (a INT)")
       checkError(
         exception = intercept[SparkUnsupportedOperationException] {
           sql(s"ALTER TABLE t SET LOCATION 'https://mister/spark'")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR unwraps SparkThrowable in (Unchecked)ExecutionException thrown by tableRelationCache
### Why are the changes needed?

The guava cache library wraps exceptions thrown by `c: Callable[LogicalPlan]` as `(Unchecked)ExecutionException`s. This makes our code paths of special handling for SparkThrowable inoperative. For example, this kind of error in spark-sql cli is very lengthy.



### Does this PR introduce _any_ user-facing change?

Yes, when you visit an invalid plan in the table cache layer, you will get the original spark error instead of getting them under `(Unchecked)ExecutionException`s

### How was this patch tested?
new tests


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no