### PR TITLE
[SPARK-50604][SQL][TESTS] Extract MariaDBDatabaseOnDocker and upgrade `Mariadb` docker image version

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBDatabaseOnDocker.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBDatabaseOnDocker.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.jdbc
+
+import org.apache.spark.internal.Logging
+
+abstract class MariaDBDatabaseOnDocker extends DatabaseOnDocker with Logging {
+  override val imageName: String = sys.env.getOrElse("MARIADB_DOCKER_IMAGE_NAME", "mariadb:11.6.2")
+  override val env: Map[String, String] = Map(
+    "MYSQL_ROOT_PASSWORD" -> "rootpass"
+  )
+  override val usesIpc = false
+  override val jdbcPort = 3306
+
+  override def getEntryPoint: Option[String] =
+    Some("/docker-entrypoint/mariadb-docker-entrypoint.sh")
+}

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBDatabaseOnDocker.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBDatabaseOnDocker.scala
@@ -20,7 +20,8 @@ package org.apache.spark.sql.jdbc
 import org.apache.spark.internal.Logging
 
 abstract class MariaDBDatabaseOnDocker extends DatabaseOnDocker with Logging {
-  override val imageName: String = sys.env.getOrElse("MARIADB_DOCKER_IMAGE_NAME", "mariadb:11.6.2")
+  override val imageName: String =
+    sys.env.getOrElse("MARIADB_DOCKER_IMAGE_NAME", "mariadb:10.11.10")
   override val env: Map[String, String] = Map(
     "MYSQL_ROOT_PASSWORD" -> "rootpass"
   )

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBKrbIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBKrbIntegrationSuite.scala
@@ -37,19 +37,10 @@ class MariaDBKrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
   override protected val userName = s"mariadb/$dockerIp"
   override protected val keytabFileName = "mariadb.keytab"
 
-  override val db = new DatabaseOnDocker {
-    override val imageName = sys.env.getOrElse("MARIADB_DOCKER_IMAGE_NAME", "mariadb:10.6.19")
-    override val env = Map(
-      "MYSQL_ROOT_PASSWORD" -> "rootpass"
-    )
-    override val usesIpc = false
-    override val jdbcPort = 3306
+  override val db = new MariaDBDatabaseOnDocker() {
 
     override def getJdbcUrl(ip: String, port: Int): String =
       s"jdbc:mysql://$ip:$port/mysql?user=$principal"
-
-    override def getEntryPoint: Option[String] =
-      Some("/docker-entrypoint/mariadb-docker-entrypoint.sh")
 
     override def beforeContainerStart(
         hostConfigBuilder: HostConfig,


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to:
- extract MariaDBDatabaseOnDocker
- upgrade Mariadb docker image version from `10.6.19` to `10.11.10`.


### Why are the changes needed?
- Align testing logic with other databases, eg: `DB2DatabaseOnDocker`, `MsSQLServerDatabaseOnDocker`, `MySQLDatabaseOnDocker`, `OracleDatabaseOnDocker` and `PostgresDatabaseOnDocker`.
- Tests dependencies upgrading.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?

