### PR TITLE
Adding typing for creating a pyspark dataframe from a list of dicts

### DIFF
--- a/examples/src/main/python/sql/arrow.py
+++ b/examples/src/main/python/sql/arrow.py
@@ -33,6 +33,14 @@ require_minimum_pandas_version()
 require_minimum_pyarrow_version()
 
 
+def dataframe_from_list_of_dicts_example(spark: SparkSession) -> None:
+    """Test creating a DataFrame from a list of dictionaries."""
+
+    data_iter = [{'name': 'Alice', 'age': 1}]
+    result_table = spark.createDataFrame(data_iter)
+
+    print(result_table.schema)
+
 def dataframe_to_from_arrow_table_example(spark: SparkSession) -> None:
     import pyarrow as pa
     import numpy as np
@@ -321,6 +329,8 @@ if __name__ == "__main__":
         .appName("Python Arrow-in-Spark example") \
         .getOrCreate()
 
+    print("Running DataFrame from list of dictionaries example")
+    dataframe_from_list_of_dicts_example(spark)
     print("Running Arrow conversion example: DataFrame to Table")
     dataframe_to_from_arrow_table_example(spark)
     print("Running Pandas to/from conversion example")

--- a/python/pyspark/sql/_typing.pyi
+++ b/python/pyspark/sql/_typing.pyi
@@ -57,7 +57,7 @@ AtomicValue = TypeVar(
     float,
 )
 
-RowLike = TypeVar("RowLike", List[Any], Tuple[Any, ...], pyspark.sql.types.Row)
+RowLike = TypeVar("RowLike", List[Any], Tuple[Any, ...], Dict[str, Any], pyspark.sql.types.Row)
 
 SQLBatchedUDFType = Literal[100]
 SQLArrowBatchedUDFType = Literal[101]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add so that a python dict can be typed as RowLike 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In the examples for creating a pyspark dataframe using spark.createDataFrame there is an example code snippet for passing a list of dicts:

https://github.com/apache/spark/blob/3d063a01d7c2a6d9613e11dec882739daa7eeb71/python/pyspark/sql/session.py#L1404-L1412

Though in the typing of this method it accepts an iterable of "RowLike" objects

https://github.com/apache/spark/blob/3d063a01d7c2a6d9613e11dec882739daa7eeb71/python/pyspark/sql/session.py#L1245-L1251

Where a dict is not a RowLike object

https://github.com/apache/spark/blob/3d063a01d7c2a6d9613e11dec882739daa7eeb71/python/pyspark/sql/_typing.pyi#L60

Creating a dataframe from a list of dicts works fine, but the typing of it doesn't (using mypy)

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, users would correctly test for typings when passing a list of dicts in the createDataFrame method. 

At the moment, users would get

`error: Value of type variable "RowLike" of "createDataFrame" of "SparkSession" cannot be "dict[str, Any]"  [type-var]`

when using mypy for static type checking the following code snippet

```
from pyspark.sql import SparkSession

spark = SparkSession.builder.appName("SimpleApp").getOrCreate()

d = [{"name": "Alice", "age": 1}]
spark.createDataFrame(d).show()
```

while the expected result would be 

`Success: no issues found in 1 source file`

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Haven't setup a local environment for testing the repo. Can do this if I get a heads up that I am on the right track.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No