### PR TITLE
[WIP] Fix problem in NestedColumnAliasing.scala , replaceWithAliases in connection with Generate plan node

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
@@ -188,7 +188,6 @@ object NestedColumnAliasing {
     // withNewChildren is dangerous for Generate; one has to adjust unrequiredChildIndex accordingly in this case
     val withNewChildren= plan match {
       case g: Generate => {
-        // child.output.zipWithIndex.filterNot(t => unrequiredSet.contains(t._2)).map(_._1)
         val unrequiredSet = g.unrequiredChildIndex.toSet
         val flagRes= g.child.output.zipWithIndex.flatMap( t =>
           attrToAliases.getOrElse(t._1, Seq(t._1)).map( e => ( e, unrequiredSet.contains(t._2) ) )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
@@ -185,16 +185,16 @@ object NestedColumnAliasing {
       plan: LogicalPlan,
       nestedFieldToAlias: Map[Expression, Alias],
       attrToAliases: AttributeMap[Seq[Alias]]): LogicalPlan = {
-    // withNewChildren is dangerous for Generate; one has to adjust unrequiredChildIndex accordingly in this case
-    val withNewChildren= plan match {
-      case g: Generate => {
+    // withNewChildren is dangerous for Generate;
+    // one has to adjust unrequiredChildIndex accordingly in this case
+    val withNewChildren = plan match {
+      case g: Generate =>
         val unrequiredSet = g.unrequiredChildIndex.toSet
-        val flagRes= g.child.output.zipWithIndex.flatMap( t =>
+        val flagRes = g.child.output.zipWithIndex.flatMap( t =>
           attrToAliases.getOrElse(t._1, Seq(t._1)).map( e => ( e, unrequiredSet.contains(t._2) ) )
         )
-        val unrequiredChildIndex= flagRes.map(_._2).zipWithIndex.filter(t => t._1).map(_._2)
-        g.copy(child=Project(flagRes.map(_._1), g.child), unrequiredChildIndex=unrequiredChildIndex)
-      }
+        val unrequiredChildIndex = flagRes.map(_._2).zipWithIndex.filter(t => t._1).map(_._2)
+        g.copy(child = Project(flagRes.map(_._1), g.child), unrequiredChildIndex = unrequiredChildIndex)
       case _ => plan.withNewChildren(plan.children.map { plan =>
         Project(plan.output.flatMap(a => attrToAliases.getOrElse(a, Seq(a))), plan)})
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
@@ -185,9 +185,21 @@ object NestedColumnAliasing {
       plan: LogicalPlan,
       nestedFieldToAlias: Map[Expression, Alias],
       attrToAliases: AttributeMap[Seq[Alias]]): LogicalPlan = {
-    plan.withNewChildren(plan.children.map { plan =>
-      Project(plan.output.flatMap(a => attrToAliases.getOrElse(a, Seq(a))), plan)
-    }).transformExpressions {
+    // withNewChildren is dangerous for Generate; one has to adjust unrequiredChildIndex accordingly in this case
+    val withNewChildren= plan match {
+      case g: Generate => {
+        // child.output.zipWithIndex.filterNot(t => unrequiredSet.contains(t._2)).map(_._1)
+        val unrequiredSet = g.unrequiredChildIndex.toSet
+        val flagRes= g.child.output.zipWithIndex.flatMap( t =>
+          attrToAliases.getOrElse(t._1, Seq(t._1)).map( e => ( e, unrequiredSet.contains(t._2) ) )
+        )
+        val unrequiredChildIndex= flagRes.map(_._2).zipWithIndex.filter(t => t._1).map(_._2)
+        g.copy(child=Project(flagRes.map(_._1), g.child), unrequiredChildIndex=unrequiredChildIndex)
+      }
+      case _ => plan.withNewChildren(plan.children.map { plan =>
+        Project(plan.output.flatMap(a => attrToAliases.getOrElse(a, Seq(a))), plan)})
+    }
+    withNewChildren.transformExpressions {
       case f: ExtractValue if nestedFieldToAlias.contains(f.canonicalized) =>
         nestedFieldToAlias(f.canonicalized).toAttribute
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
@@ -194,7 +194,10 @@ object NestedColumnAliasing {
           attrToAliases.getOrElse(t._1, Seq(t._1)).map( e => ( e, unrequiredSet.contains(t._2) ) )
         )
         val unrequiredChildIndex = flagRes.map(_._2).zipWithIndex.filter(t => t._1).map(_._2)
-        g.copy(child = Project(flagRes.map(_._1), g.child), unrequiredChildIndex = unrequiredChildIndex)
+        g.copy(
+          child = Project(flagRes.map(_._1), g.child),
+          unrequiredChildIndex = unrequiredChildIndex
+        )
       case _ => plan.withNewChildren(plan.children.map { plan =>
         Project(plan.output.flatMap(a => attrToAliases.getOrElse(a, Seq(a))), plan)})
     }


### PR DESCRIPTION
When one uses replaceWithChildren, one has to be careful with Generate plan nodes. Generate contains a list unrequiredChildIndex of unneeded child outputs in the Generate output. This data has to be adjusted accordingly. Otherwise an incorrect plan may be generated during optimisation. Here is an example (tested with Spark 3.5.3):

```
from pyspark.sql import SparkSession

session= SparkSession.builder.master("local").getOrCreate()

session.sql("""
select
    named_struct(
          'b', '',
          'c', '',
          'd', array(named_struct('f', '', 'g', '')),
          'e', ''
    ) as a
""").write.mode("overwrite").parquet("tmp")

df= session.read.parquet("tmp")
df.createOrReplaceTempView("tmp")

sql="""
SELECT
a.b f1, a.c f2, x.f,
STACK(1, y) as (z)
FROM tmp
LATERAL VIEW POSEXPLODE_OUTER(a.d) as y, x
"""

session.sql(sql).explain()

#== Physical Plan ==                                                             
#*(1) !Project [_extract_b#21 AS f1#5, _extract_c#19 AS f2#6, _extract_f#20 AS f#12, z#13]
#+- *(1) Generate stack(1, y#8), [_extract_b#21, _extract_f#20], false, [z#13]
#   +- *(1) Project [_extract_b#21, y#8, x#9 AS _extract_f#20]
#      +- *(1) Generate posexplode(_extract_f#26), [_extract_b#21], true, [y#8, x#9]
#         +- *(1) Project [a#3.b AS _extract_b#21, a#3.d.f AS _extract_f#26]
#            +- *(1) ColumnarToRow
#               +- FileScan parquet [a#3] Batched: true, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex(1 paths)[file:/home/pa/test/spark-bug/tmp], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<a:struct<b:string,d:array<struct<f:string>>>>

session.sql(sql).show()

# java.lang.IllegalStateException: Couldn't find _extract_c#54 in [_extract_b#56,_extract_f#55,z#36]
```


One can see, that the generated plan is invalid (_extract_c_#19 is missing in the in previous Project) and yields an error during execution. With this fix, the problem does not occur.