### PR TITLE
[SPARK-50489][SQL][PYTHON][FOLLOW-UP] Add applyInArrow in `DeduplicateRelations#collectConflictPlans`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeduplicateRelations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeduplicateRelations.scala
@@ -392,7 +392,19 @@ object DeduplicateRelations extends Rule[LogicalPlan] {
         newVersion.copyTagsFrom(oldVersion)
         Seq((oldVersion, newVersion))
 
+      case oldVersion @ FlatMapGroupsInArrow(_, _, output, _)
+        if oldVersion.outputSet.intersect(conflictingAttributes).nonEmpty =>
+        val newVersion = oldVersion.copy(output = output.map(_.newInstance()))
+        newVersion.copyTagsFrom(oldVersion)
+        Seq((oldVersion, newVersion))
+
       case oldVersion @ FlatMapCoGroupsInPandas(_, _, _, output, _, _)
+        if oldVersion.outputSet.intersect(conflictingAttributes).nonEmpty =>
+        val newVersion = oldVersion.copy(output = output.map(_.newInstance()))
+        newVersion.copyTagsFrom(oldVersion)
+        Seq((oldVersion, newVersion))
+
+      case oldVersion @ FlatMapCoGroupsInArrow(_, _, _, output, _, _)
         if oldVersion.outputSet.intersect(conflictingAttributes).nonEmpty =>
         val newVersion = oldVersion.copy(output = output.map(_.newInstance()))
         newVersion.copyTagsFrom(oldVersion)


### PR DESCRIPTION

### What changes were proposed in this pull request?
Add applyInArrow in `DeduplicateRelations#collectConflictPlans`


### Why are the changes needed?
In https://github.com/apache/spark/pull/49056, I forgot to add `applyInArrow` in `DeduplicateRelations#collectConflictPlans`


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
tests added in https://github.com/apache/spark/pull/49056


### Was this patch authored or co-authored using generative AI tooling?
no