### PR TITLE
[SPARK-50498][PYTHON] Avoid unnecessary py4j call in `listFunctions`

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -479,7 +479,6 @@ class Catalog:
         """
         if dbName is None:
             dbName = self.currentDatabase()
-        iter = self._jcatalog.listFunctions(dbName).toLocalIterator()
         if pattern is None:
             iter = self._jcatalog.listFunctions(dbName).toLocalIterator()
         else:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Avoid unnecessary py4j call in `listFunctions`


### Why are the changes needed?
```
        iter = self._jcatalog.listFunctions(dbName).toLocalIterator()
        if pattern is None:
            iter = self._jcatalog.listFunctions(dbName).toLocalIterator()
        else:
            iter = self._jcatalog.listFunctions(dbName, pattern).toLocalIterator()
```

the first `self._jcatalog.listFunctions` is unnecessary


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no