### PR TITLE
[SPARK-50523][SQL] Fix casts on complex types in collation coercion

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
@@ -149,15 +149,17 @@ object CollationTypeCoercion {
    * should be that of the childType.
    */
   private def shouldRemoveCast(cast: Cast): Boolean = {
-    val isUserDefined = cast.getTagValue(Cast.USER_SPECIFIED_CAST).isDefined
     val isChildTypeCollatedString = cast.child.dataType match {
       case st: StringType => !st.isUTF8BinaryCollation
       case _ => false
     }
     val targetType = cast.dataType
 
-    isUserDefined && isChildTypeCollatedString && targetType == StringType
+    isUserDefined(cast) && isChildTypeCollatedString && targetType == StringType
   }
+
+  private def isUserDefined(cast: Cast): Boolean =
+    cast.getTagValue(Cast.USER_SPECIFIED_CAST).isDefined
 
   /**
    * Changes the data type of the expression to the given `newType`.
@@ -167,18 +169,11 @@ object CollationTypeCoercion {
       case Some(newDataType) if newDataType != expr.dataType =>
         assert(!newDataType.existsRecursively(_.isInstanceOf[StringTypeWithContext]))
 
-        val exprWithNewType = expr match {
+        expr match {
           case lit: Literal => lit.copy(dataType = newDataType)
           case cast: Cast => cast.copy(dataType = newDataType)
           case _ => Cast(expr, newDataType)
         }
-
-        // also copy the collation context tag
-        if (hasCollationContextTag(expr)) {
-          exprWithNewType.setTagValue(
-            COLLATION_CONTEXT_TAG, expr.getTagValue(COLLATION_CONTEXT_TAG).get)
-        }
-        exprWithNewType
 
       case _ =>
         expr
@@ -362,6 +357,15 @@ object CollationTypeCoercion {
     case collate: Collate =>
       Some(addContextToStringType(collate.dataType, Explicit))
 
+    case cast: Cast =>
+      if (isUserDefined(cast) && isComplexType(cast.dataType)) {
+        // since we can't use collate clause with complex types
+        // user defined casts should be treated as explicit
+        Some(addContextToStringType(cast.dataType, Explicit))
+      } else {
+        Some(addContextToStringType(cast.dataType, Default))
+      }
+
     case expr @ (_: Alias | _: SubqueryExpression | _: AttributeReference | _: VariableReference) =>
       Some(addContextToStringType(expr.dataType, Implicit))
 
@@ -433,6 +437,13 @@ object CollationTypeCoercion {
       case (leftPriority, rightPriority) =>
         if (leftPriority < rightPriority) left
         else right
+    }
+  }
+
+  private def isComplexType(dataType: DataType): Boolean = {
+    dataType match {
+      case _: ArrayType | _: MapType | _: StructType => true
+      case _ => false
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
@@ -360,8 +360,8 @@ object CollationTypeCoercion {
     case cast: Cast =>
       if (isUserDefined(cast) && isComplexType(cast.dataType)) {
         // since we can't use collate clause with complex types
-        // user defined casts should be treated as explicit
-        Some(addContextToStringType(cast.dataType, Explicit))
+        // user defined casts should be treated as implicit
+        Some(addContextToStringType(cast.dataType, Implicit))
       } else {
         Some(addContextToStringType(cast.dataType, Default))
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationTypePrecedenceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationTypePrecedenceSuite.scala
@@ -438,6 +438,32 @@ class CollationTypePrecedenceSuite extends QueryTest with SharedSparkSession {
       sql(s"SELECT map('key1', 'val1' collate utf8_lcase, 'key2', 'val2' collate unicode)"))
   }
 
+  test("user defined cast on maps") {
+    checkAnswer(
+      sql(s"""
+             |SELECT map_contains_key(
+             |  map('a' collate utf8_lcase, 'b'),
+             |  'A' collate utf8_lcase)
+             |""".stripMargin),
+      Seq(Row(true)))
+
+    checkAnswer(
+      sql(s"""
+             |SELECT map_contains_key(
+             |  CAST(map('a' collate utf8_lcase, 'b') AS MAP<STRING, STRING>),
+             |  'A')
+             |""".stripMargin),
+      Seq(Row(false)))
+
+    checkAnswer(
+      sql(s"""
+             |SELECT map_contains_key(
+             |  CAST(map('a' collate utf8_lcase, 'b') AS MAP<STRING COLLATE UNICODE, STRING>),
+             |  'A' COLLATE UNICODE)
+             |""".stripMargin),
+      Seq(Row(false)))
+  }
+
   test("maps of structs") {
     assertQuerySchema(
       sql(s"SELECT map('key1', struct(1, 'a' collate unicode), 'key2', struct(2, 'b'))"),
@@ -480,6 +506,49 @@ class CollationTypePrecedenceSuite extends QueryTest with SharedSparkSession {
 
     assertExplicitMismatch(
       sql(s"SELECT array('a', 'b' collate unicode) = array('A' collate utf8_lcase, 'B')"))
+  }
+
+  test("user defined cast on arrays") {
+    checkAnswer(
+      sql(s"""
+             |SELECT array_contains(
+             |  array('a', 'b' collate utf8_lcase),
+             |  'A')
+             |""".stripMargin),
+      Seq(Row(true)))
+
+    // should be false because ARRAY<STRING> should take precedence
+    // over UTF8_LCASE in array creation
+    checkAnswer(
+      sql(s"""
+             |SELECT array_contains(
+             |  CAST(array('a', 'b' collate utf8_lcase) AS ARRAY<STRING>),
+             |  'A')
+             |""".stripMargin),
+      Seq(Row(false)))
+
+    checkAnswer(
+      sql(s"""
+             |SELECT array_contains(
+             |  CAST(array('a', 'b' collate utf8_lcase) AS ARRAY<STRING COLLATE UNICODE>),
+             |  'A')
+             |""".stripMargin),
+      Seq(Row(false)))
+
+    checkAnswer(
+      sql(s"""
+             |SELECT array_contains(
+             |  CAST(array('a', 'b' collate utf8_lcase) AS ARRAY<STRING COLLATE UNICODE>),
+             |  'A' collate unicode)
+             |""".stripMargin),
+      Seq(Row(false)))
+
+    assertExplicitMismatch(
+      sql(s"""
+             |SELECT array_contains(
+             |  CAST(array('a', 'b' collate utf8_lcase) AS ARRAY<STRING>),
+             |  'A' collate utf8_lcase)
+             |""".stripMargin))
   }
 
   test("array of structs") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationTypePrecedenceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationTypePrecedenceSuite.scala
@@ -542,13 +542,6 @@ class CollationTypePrecedenceSuite extends QueryTest with SharedSparkSession {
              |  'A' collate unicode)
              |""".stripMargin),
       Seq(Row(false)))
-
-    assertExplicitMismatch(
-      sql(s"""
-             |SELECT array_contains(
-             |  CAST(array('a', 'b' collate utf8_lcase) AS ARRAY<STRING>),
-             |  'A' collate utf8_lcase)
-             |""".stripMargin))
   }
 
   test("array of structs") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationTypePrecedenceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationTypePrecedenceSuite.scala
@@ -441,26 +441,26 @@ class CollationTypePrecedenceSuite extends QueryTest with SharedSparkSession {
   test("user defined cast on maps") {
     checkAnswer(
       sql(s"""
-             |SELECT map_contains_key(
-             |  map('a' collate utf8_lcase, 'b'),
-             |  'A' collate utf8_lcase)
-             |""".stripMargin),
+        |SELECT map_contains_key(
+        |  map('a' collate utf8_lcase, 'b'),
+        |  'A' collate utf8_lcase)
+        |""".stripMargin),
       Seq(Row(true)))
 
     checkAnswer(
       sql(s"""
-             |SELECT map_contains_key(
-             |  CAST(map('a' collate utf8_lcase, 'b') AS MAP<STRING, STRING>),
-             |  'A')
-             |""".stripMargin),
+        |SELECT map_contains_key(
+        |  CAST(map('a' collate utf8_lcase, 'b') AS MAP<STRING, STRING>),
+        |  'A')
+        |""".stripMargin),
       Seq(Row(false)))
 
     checkAnswer(
       sql(s"""
-             |SELECT map_contains_key(
-             |  CAST(map('a' collate utf8_lcase, 'b') AS MAP<STRING COLLATE UNICODE, STRING>),
-             |  'A' COLLATE UNICODE)
-             |""".stripMargin),
+        |SELECT map_contains_key(
+        |  CAST(map('a' collate utf8_lcase, 'b') AS MAP<STRING COLLATE UNICODE, STRING>),
+        |  'A' COLLATE UNICODE)
+        |""".stripMargin),
       Seq(Row(false)))
   }
 
@@ -511,36 +511,36 @@ class CollationTypePrecedenceSuite extends QueryTest with SharedSparkSession {
   test("user defined cast on arrays") {
     checkAnswer(
       sql(s"""
-             |SELECT array_contains(
-             |  array('a', 'b' collate utf8_lcase),
-             |  'A')
-             |""".stripMargin),
+        |SELECT array_contains(
+        |  array('a', 'b' collate utf8_lcase),
+        |  'A')
+        |""".stripMargin),
       Seq(Row(true)))
 
     // should be false because ARRAY<STRING> should take precedence
     // over UTF8_LCASE in array creation
     checkAnswer(
       sql(s"""
-             |SELECT array_contains(
-             |  CAST(array('a', 'b' collate utf8_lcase) AS ARRAY<STRING>),
-             |  'A')
-             |""".stripMargin),
+        |SELECT array_contains(
+        |  CAST(array('a', 'b' collate utf8_lcase) AS ARRAY<STRING>),
+        |  'A')
+        |""".stripMargin),
       Seq(Row(false)))
 
     checkAnswer(
       sql(s"""
-             |SELECT array_contains(
-             |  CAST(array('a', 'b' collate utf8_lcase) AS ARRAY<STRING COLLATE UNICODE>),
-             |  'A')
-             |""".stripMargin),
+        |SELECT array_contains(
+        |  CAST(array('a', 'b' collate utf8_lcase) AS ARRAY<STRING COLLATE UNICODE>),
+        |  'A')
+        |""".stripMargin),
       Seq(Row(false)))
 
     checkAnswer(
       sql(s"""
-             |SELECT array_contains(
-             |  CAST(array('a', 'b' collate utf8_lcase) AS ARRAY<STRING COLLATE UNICODE>),
-             |  'A' collate unicode)
-             |""".stripMargin),
+        |SELECT array_contains(
+        |  CAST(array('a', 'b' collate utf8_lcase) AS ARRAY<STRING COLLATE UNICODE>),
+        |  'A' collate unicode)
+        |""".stripMargin),
       Seq(Row(false)))
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add proper support and tests for finding the collation context of cast expressions, especially on complex types.


### Why are the changes needed?
#48936 introduced a way for handling collation type coercion in complex types, however I didn't think about casting, which should be special cased when searching for the collation context of an expression. This means that currently collation context could return the type which is not the target type of the cast, and that is just incorrect.

Also we should be able to use casts to change collation of complex types (arrays, maps, structs), and since we can't just use `collate` clause on complex types we should assign IMPLICIT strength to user defined casts on complex types. 

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New unit tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
