### PR TITLE
[SPARK-50501][BUILD] Update cross-spawn to surpress a warning in lint

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "dev",
       "devDependencies": {
         "ansi-regex": "^5.0.1",
         "eslint": "^7.25.0",
@@ -316,10 +317,11 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1469,9 +1471,9 @@
       "dev": true
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR updates cross-spawn from 7.0.3 to 7.0.6.


### Why are the changes needed?
Recently, `./dev/lint-js` shows a warning like as follows.
```
1 high severity vulnerability

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
```

We can see the same message in CI.
https://github.com/apache/spark/actions/runs/12183892848/job/33986553884#step:24:20

To inspect more, I executed `npm audit` and the result is:
```
cross-spawn  7.0.0 - 7.0.4
Severity: high
Regular Expression Denial of Service (ReDoS) in cross-spawn - https://github.com/advisories/GHSA-3xgq-45jj-v275
fix available via `npm audit fix`
node_modules/cross-spawn

1 high severity vulnerability
```

`cross-spawn` is a dependency for the linter but the linter reports the issue as `high severity vulnerability` so let's fix it just in case.
This change is done by `npm audit fix` as the warning indicates.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
`./dev/lint-js` doesn't show the warning.


### Was this patch authored or co-authored using generative AI tooling?
No
