### PR TITLE
[SPARK-50505][DOCS] Fix `spark.storage.replication.proactive` default value documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2116,7 +2116,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.storage.replication.proactive</code></td>
-  <td>false</td>
+  <td>true</td>
   <td>
     Enables proactive block replication for RDD blocks. Cached RDD block replicas lost due to
     executor failures are replenished if there are any existing available replicas. This tries


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `spark.storage.replication.proactive` default value documentation.

### Why are the changes needed?

`spark.storage.replication.proactive` has been enabled by default since Apache Spark 3.2.0.

https://github.com/apache/spark/blob/6add9c89855f9311d5e185774ddddcbf4323beee/docs/core-migration-guide.md?plain=1#L85

https://github.com/apache/spark/blob/6add9c89855f9311d5e185774ddddcbf4323beee/core/src/main/scala/org/apache/spark/internal/config/package.scala#L494-L502

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.