### PR TITLE
[SPARK-50492][SS][FOLLOWUP][3.5] Change `def references` to `lazy val references` in `DeduplicateWithinWatermark` to fix the compilation issue

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1945,7 +1945,8 @@ case class Deduplicate(
 
 case class DeduplicateWithinWatermark(keys: Seq[Attribute], child: LogicalPlan) extends UnaryNode {
   // Ensure that references include event time columns so they are not pruned away.
-  override def references: AttributeSet = AttributeSet(keys) ++
+  @transient
+  override lazy val references: AttributeSet = AttributeSet(keys) ++
     AttributeSet(child.output.filter(_.metadata.contains(EventTimeWatermark.delayKey)))
   override def maxRows: Option[Long] = child.maxRows
   override def output: Seq[Attribute] = child.output


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr change `def references` to `lazy val references` in `DeduplicateWithinWatermark` to fix the following compilation error：

- https://github.com/apache/spark/actions/runs/12191807324/job/34011354774

```
[error] /home/runner/work/spark/spark/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala:1948:16: overriding lazy value references in class QueryPlan of type org.apache.spark.sql.catalyst.expressions.AttributeSet;
[error]  method references needs to be a stable, immutable value
[error]   override def references: AttributeSet = AttributeSet(keys) ++
[error]                ^
[error] one error found
```

### Why are the changes needed?
Fix compile error.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No