### PR TITLE
[SPARK-50360][SS][FOLLOWUP][MINOR] Make readVersion lazy value

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreChangelog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreChangelog.scala
@@ -379,7 +379,7 @@ class StateStoreChangelogReaderFactory(
   def constructChangelogReader(): StateStoreChangelogReader = {
     var reader: StateStoreChangelogReader = null
     try {
-      reader = readVersion() match {
+      reader = readVersion match {
         case 1 => new StateStoreChangelogReaderV1(fm, fileToRead, compressionCodec)
         case 2 => new StateStoreChangelogReaderV2(fm, fileToRead, compressionCodec)
         case 3 => new StateStoreChangelogReaderV3(fm, fileToRead, compressionCodec)
@@ -389,7 +389,7 @@ class StateStoreChangelogReaderFactory(
     } finally {
       if (input != null) {
         input.close()
-        input = null
+        // input is not set to null because it is effectively lazy.
       }
     }
     reader

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreChangelog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreChangelog.scala
@@ -353,7 +353,7 @@ class StateStoreChangelogReaderFactory(
   }
   protected val input: DataInputStream = decompressStream(sourceStream)
 
-  private lazy val readVersion: Short = {
+  private lazy val changeLogVersion: Short = {
     try {
       val versionStr = input.readUTF()
       // Versions in the first line are prefixed with "v", e.g. "v2"
@@ -379,7 +379,7 @@ class StateStoreChangelogReaderFactory(
   def constructChangelogReader(): StateStoreChangelogReader = {
     var reader: StateStoreChangelogReader = null
     try {
-      reader = readVersion match {
+      reader = changeLogVersion match {
         case 1 => new StateStoreChangelogReaderV1(fm, fileToRead, compressionCodec)
         case 2 => new StateStoreChangelogReaderV2(fm, fileToRead, compressionCodec)
         case 3 => new StateStoreChangelogReaderV3(fm, fileToRead, compressionCodec)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is followup to https://github.com/apache/spark/pull/48880
`readVersion` is made a `lazy` value.
After `input` is closed, its value is not changed to `null` because `input` is only used by `readVersion`.

### Why are the changes needed?
`StateStoreChangelogReaderFactory` is able to produce more than one reader.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing test suite.

### Was this patch authored or co-authored using generative AI tooling?
No