### PR TITLE
[SPARK-50521][SQL] Align list table method of JDBCTableCatalog to TableCatalog API

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -66,7 +66,8 @@ class JDBCTableCatalog extends TableCatalog
   override def listTables(namespace: Array[String]): Array[Identifier] = {
     checkNamespace(namespace)
     JdbcUtils.withConnection(options) { conn =>
-      val schemaPattern = if (namespace.length == 1) namespace.head else null
+      val schemaName = if (namespace.length == 1) namespace.head else null
+      val schemaPattern = this.convertSchemaNameToPattern(schemaName)
       val rs = JdbcUtils.classifyException(
         errorClass = "FAILED_JDBC.GET_TABLES",
         messageParameters = Map(
@@ -417,5 +418,11 @@ class JDBCTableCatalog extends TableCatalog
 
   private def toSQLId(ident: Identifier): String = {
     toSQLId(ident.namespace.toSeq :+ ident.name)
+  }
+
+  protected def convertSchemaNameToPattern(schemaName: String): String = {
+    schemaName.replace("\\", "\\\\")
+        .replace("%", "\\%")
+        .replace("_", "\\_")
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -66,8 +66,7 @@ class JDBCTableCatalog extends TableCatalog
   override def listTables(namespace: Array[String]): Array[Identifier] = {
     checkNamespace(namespace)
     JdbcUtils.withConnection(options) { conn =>
-      val schemaNameExists = namespace.length == 1
-      val schemaPattern: Option[String] = if (schemaNameExists) {
+      val schemaPattern: Option[String] = if (namespace.length == 1) {
         val schemaName = namespace.head
         Some(this.convertSchemaNameToPattern(schemaName))
       } else {


### PR DESCRIPTION
TableCatalog listTables API accepts `namespace`, not the pattern of schema
But JDBC Table Catalog use provided `namespace` parameter as schema pattern instead of a name.

### What changes were proposed in this pull request?
- Treat received namespace as schema name instead of schema pattern in `JDBCTableCatalog`


### Why are the changes needed?
To align derived and base class API

### Does this PR introduce _any_ user-facing change?
Yes, users of DataSource V2 API for JDBC (probably not many users use it, since JDBC connectors still use RelationProvider for spark.read.format("jdbc")) needs to provide schema name now instead of schema pattern.

Example:
Imagine you have next MySQL tables
`my_schema.table1`
`myyschema.table2`

And you do next operation in Spark:
```
spark.conf.set("spark.sql.catalog.myCatalog", JDBCTableCatalog.getClass.getName)
spark.sql("SHOW TABLES IN myCatalog.my_schema")
```

Before (because provided name is not escaped, _ is any charcter):
`my_schema.table1`
`myyschema.table2`

After (because we escaped characters):
`my_schema.table1`



### How was this patch tested?
No suitable tests exists, since change is simple, I did not introduce new tests


### Was this patch authored or co-authored using generative AI tooling?
No
