### PR TITLE
[SPARK-50512][SQL][DOCS] Fix `CREATE TABLE` syntax in `sql-pipe-syntax.md`

### DIFF
--- a/docs/sql-pipe-syntax.md
+++ b/docs/sql-pipe-syntax.md
@@ -179,7 +179,7 @@ Returns all the output rows from the source table unmodified.
 For example:
 
 ```sql
-CREATE TABLE t AS VALUES (1, 2), (3, 4);
+CREATE TABLE t AS VALUES (1, 2), (3, 4) AS t(a, b);
 TABLE t;
 
 +---+---+
@@ -207,7 +207,7 @@ provided. You may provide the window specification in the `WINDOW` clause.
 For example:
 
 ```sql
-CREATE TABLE t AS VALUES (0), (1);
+CREATE TABLE t AS VALUES (0), (1) AS t(col);
 
 FROM t
 |> SELECT col * 2 AS result;

--- a/docs/sql-pipe-syntax.md
+++ b/docs/sql-pipe-syntax.md
@@ -179,7 +179,7 @@ Returns all the output rows from the source table unmodified.
 For example:
 
 ```sql
-CREATE TABLE t(a INT, b INT) AS VALUES (1, 2), (3, 4);
+CREATE TABLE t AS VALUES (1, 2), (3, 4);
 TABLE t;
 
 +---+---+
@@ -207,7 +207,7 @@ provided. You may provide the window specification in the `WINDOW` clause.
 For example:
 
 ```sql
-CREATE TABLE t(col INT) AS VALUES (0), (1);
+CREATE TABLE t AS VALUES (0), (1);
 
 FROM t
 |> SELECT col * 2 AS result;


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix invalid `CREATE TABLE` syntax in `sql-pipe-syntax.md`.

It seems that we missed during documentation. It causes `ParseException: Operation not allowed` .
- #48852

### Why are the changes needed?

The current documentation is here.

- https://apache.github.io/spark/sql-pipe-syntax.html#from-or-table

**BEFORE**
```
spark-sql (default)> CREATE TABLE t(col INT) AS VALUES (0), (1);

Operation not allowed: Schema may not be specified in a Create Table As Select (CTAS) statement.
== SQL (line 1, position 1) ==
CREATE TABLE t(col INT) AS VALUES (0), (1)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

**AFTER**
```
spark-sql (default)> CREATE TABLE t AS VALUES (0), (1);
Time taken: 0.142 seconds

spark-sql (default)> TABLE t;
1
0
Time taken: 0.287 seconds, Fetched 2 row(s)
```

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only change of the unreleased SQL Pipe syntax.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.