### PR TITLE
[SPARK-50514][DOCS] Add `IDENTIFIER clause` page to `menu-sql.yaml`

### DIFF
--- a/docs/_data/menu-sql.yaml
+++ b/docs/_data/menu-sql.yaml
@@ -93,6 +93,8 @@
       url: sql-ref-functions.html
     - text: Identifiers
       url: sql-ref-identifier.html
+    - text: IDENTIFIER clause
+      url: sql-ref-identifier-clause.html
     - text: Literals
       url: sql-ref-literals.html
     - text: Null Semantics


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `IDENTIFIER clause` page to `menu-sql.yaml` for Apache Spark 3.5.4.

### Why are the changes needed?

This was missed at SPARK-43205 (Apache Spark 3.5.0).
- #42506

### Does this PR introduce _any_ user-facing change?

**BEFORE**
![Screenshot 2024-12-06 at 11 35 52](https://github.com/user-attachments/assets/c3c8dc56-b8d4-4f8d-bb9e-31bccb1f5d42)

**AFTER**
![Screenshot 2024-12-06 at 11 36 14](https://github.com/user-attachments/assets/bd1606d2-eb3f-4640-92ef-b0079847c3a3)

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.