### PR TITLE
[SPARK-48426][DOCS][FOLLOWUP] Add `Operators` page to `sql-ref.md`

### DIFF
--- a/docs/sql-ref.md
+++ b/docs/sql-ref.md
@@ -26,6 +26,7 @@ Spark SQL is Apache Spark's module for working with structured data. This guide 
  * [Data Types](sql-ref-datatypes.html)
  * [Datetime Pattern](sql-ref-datetime-pattern.html)
  * [Number Pattern](sql-ref-number-pattern.html)
+ * [Operators](sql-ref-operators.html)
  * [Functions](sql-ref-functions.html)
    * [Built-in Functions](sql-ref-functions-builtin.html)
    * [Scalar User-Defined Functions (UDFs)](sql-ref-functions-udf-scalar.html)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of SPARK-48426 to add the newly added page to `SQL Reference` page, too.
- #46757

### Why are the changes needed?

**BEFORE**
![Screenshot 2024-12-06 at 11 42 07](https://github.com/user-attachments/assets/47cc4625-9897-4f73-9bac-535b638aa2a2)

**AFTER**
![Screenshot 2024-12-06 at 11 43 07](https://github.com/user-attachments/assets/dbc38d97-8c65-4983-a3cb-0ea3612c069c)

### Does this PR introduce _any_ user-facing change?

No, this is a new documentation page of Spark 4.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.