### PR TITLE
[SPARK-50605][CONNECT] Support SQL API mode for easier migration to Spark Connect

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -358,7 +358,7 @@ jobs:
         python-version: '3.11'
         architecture: x64
     - name: Install Python packages (Python 3.11)
-      if: (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-')) || contains(matrix.modules, 'connect')
+      if: (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-')) || contains(matrix.modules, 'connect') || contains(matrix.modules, 'yarn')
       run: |
         python3.11 -m pip install 'numpy>=1.20.0' pyarrow pandas scipy unittest-xml-reporting 'lxml==4.9.4' 'grpcio==1.67.0' 'grpcio-status==1.67.0' 'protobuf==5.29.1'
         python3.11 -m pip list

--- a/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
@@ -20,6 +20,7 @@ package org.apache.spark.deploy
 import java.io.File
 import java.net.URI
 import java.nio.file.Files
+import java.util.Locale
 
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
@@ -52,7 +53,7 @@ object PythonRunner {
     // Format python file paths before adding them to the PYTHONPATH
     val formattedPythonFile = formatPath(pythonFile)
     val formattedPyFiles = resolvePyFiles(formatPaths(pyFiles))
-    lazy val apiMode = sparkConf.get(SPARK_API_MODE)
+    lazy val apiMode = sparkConf.get(SPARK_API_MODE).toLowerCase(Locale.ROOT)
     lazy val isAPIModeClassic = apiMode == "classic"
     lazy val isAPIModeConnect = apiMode == "connect"
 

--- a/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
@@ -53,9 +53,9 @@ object PythonRunner {
     // Format python file paths before adding them to the PYTHONPATH
     val formattedPythonFile = formatPath(pythonFile)
     val formattedPyFiles = resolvePyFiles(formatPaths(pyFiles))
-    lazy val apiMode = sparkConf.get(SPARK_API_MODE).toLowerCase(Locale.ROOT)
-    lazy val isAPIModeClassic = apiMode == "classic"
-    lazy val isAPIModeConnect = apiMode == "connect"
+    val apiMode = sparkConf.get(SPARK_API_MODE).toLowerCase(Locale.ROOT)
+    val isAPIModeClassic = apiMode == "classic"
+    val isAPIModeConnect = apiMode == "connect"
 
     var gatewayServer: Option[Py4JServer] = None
     if (sparkConf.getOption("spark.remote").isEmpty || isAPIModeClassic) {

--- a/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
@@ -20,6 +20,7 @@ package org.apache.spark.deploy
 import java.io.File
 import java.net.URI
 import java.nio.file.Files
+import java.util.Locale
 
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
@@ -52,9 +53,13 @@ object PythonRunner {
     // Format python file paths before adding them to the PYTHONPATH
     val formattedPythonFile = formatPath(pythonFile)
     val formattedPyFiles = resolvePyFiles(formatPaths(pyFiles))
+    lazy val apiMode = sparkConf.get(
+      "spark.api.mode", "classic").toLowerCase(Locale.ROOT)
+    lazy val isAPIModeClassic = apiMode == "classic"
+    lazy val isAPIModeConnect = apiMode == "connect"
 
     var gatewayServer: Option[Py4JServer] = None
-    if (sparkConf.getOption("spark.remote").isEmpty) {
+    if (sparkConf.getOption("spark.remote").isEmpty || isAPIModeClassic) {
       gatewayServer = Some(new Py4JServer(sparkConf))
 
       val thread = new Thread(() => Utils.logUncaughtExceptions { gatewayServer.get.start() })
@@ -80,7 +85,7 @@ object PythonRunner {
     // Launch Python process
     val builder = new ProcessBuilder((Seq(pythonExec, formattedPythonFile) ++ otherArgs).asJava)
     val env = builder.environment()
-    if (sparkConf.getOption("spark.remote").nonEmpty) {
+    if (sparkConf.getOption("spark.remote").nonEmpty || isAPIModeConnect) {
       // For non-local remote, pass configurations to environment variables so
       // Spark Connect client sets them. For local remotes, they will be set
       // via Py4J.
@@ -90,7 +95,11 @@ object PythonRunner {
         env.put(s"PYSPARK_REMOTE_INIT_CONF_$idx", compact(render(group)))
       }
     }
-    sparkConf.getOption("spark.remote").foreach(url => env.put("SPARK_REMOTE", url))
+    if (isAPIModeClassic) {
+      sparkConf.getOption("spark.master").foreach(url => env.put("MASTER", url))
+    } else {
+      sparkConf.getOption("spark.remote").foreach(url => env.put("SPARK_REMOTE", url))
+    }
     env.put("PYTHONPATH", pythonPath)
     // This is equivalent to setting the -u flag; we use it because ipython doesn't support -u:
     env.put("PYTHONUNBUFFERED", "YES") // value is needed to be set to a non-empty string

--- a/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
@@ -20,7 +20,6 @@ package org.apache.spark.deploy
 import java.io.File
 import java.net.URI
 import java.nio.file.Files
-import java.util.Locale
 
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
@@ -53,8 +52,7 @@ object PythonRunner {
     // Format python file paths before adding them to the PYTHONPATH
     val formattedPythonFile = formatPath(pythonFile)
     val formattedPyFiles = resolvePyFiles(formatPaths(pyFiles))
-    lazy val apiMode = sparkConf.get(
-      "spark.api.mode", "classic").toLowerCase(Locale.ROOT)
+    lazy val apiMode = sparkConf.get(SPARK_API_MODE)
     lazy val isAPIModeClassic = apiMode == "classic"
     lazy val isAPIModeConnect = apiMode == "connect"
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2824,11 +2824,12 @@ package object config {
 
   private[spark] val SPARK_API_MODE =
     ConfigBuilder("spark.api.mode")
-      .doc("For Spark Classic applications, specify whether to automatically use Spark Connect by" +
-        "running a local Spark Connect server. The value can be `classic` or `connect`.")
+      .doc("For Spark Classic applications, specify whether to automatically use Spark Connect " +
+        "by running a local Spark Connect server dedicated to the application. The server is " +
+        "terminated when the application is terminated. The value can be `classic` or `connect`.")
       .version("4.0.0")
       .stringConf
-      .transform(_.toUpperCase(Locale.ROOT))
+      .transform(_.toLowerCase(Locale.ROOT))
       .checkValues(Set("connect", "classic"))
       .createWithDefault("classic")
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2821,4 +2821,14 @@ package object config {
       .version("4.0.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createOptional
+
+  private[spark] val SPARK_API_MODE =
+    ConfigBuilder("spark.api.mode")
+      .doc("For Spark Classic applications, specify whether to automatically use Spark Connect by" +
+        "running a local Spark Connect server. The value can be `classic` or `connect`.")
+      .version("4.0.0")
+      .stringConf
+      .transform(_.toUpperCase(Locale.ROOT))
+      .checkValues(Set("connect", "classic"))
+      .createWithDefault("classic")
 }

--- a/docs/app-dev-spark-connect.md
+++ b/docs/app-dev-spark-connect.md
@@ -60,8 +60,8 @@ with the custom logic/library.
 
 ## Spark API Mode: Spark Client and Spark Classic
 
-Spark provides API mode (`spark.api.mode`) configuration that can seamlessly start Spark Classic
-applications to use Spark Connect. Based on `spark.api.mode` configuration, the application either
+Spark provides API mode (`spark.api.mode`) configuration that can seamlessly let Spark
+applications use Spark Connect. Based on `spark.api.mode` configuration, the application either
 be executed in Spark Classic or Spark Connect mode. See the examples below:
 
 {% highlight python %}

--- a/docs/app-dev-spark-connect.md
+++ b/docs/app-dev-spark-connect.md
@@ -60,31 +60,6 @@ with the custom logic/library.
 
 ## Spark API Mode: Spark Client and Spark Classic
 
-Spark provides API mode (`spark.api.mode`) configuration that can seamlessly let Spark
-applications use Spark Connect. Based on `spark.api.mode` configuration, the application either
-be executed in Spark Classic or Spark Connect mode. See the examples below:
-
-{% highlight python %}
-from pyspark.sql import SparkSession
-
-SparkSession.builder.config("spark.api.mode", "connect").master("...").getOrCreate()
-{% endhighlight %}
-
-
-This configuration can be also effectively set for both Scala Spark application and PySpark
-applications via Spark submission:
-
-{% highlight bash %}
-spark-submit --master "..." --conf spark.api.mode=connect
-{% endhighlight %}
-
-In addition, Spark Connect provides convient special cases for you to locally test. `spark.remote`
-can be set as `local[...]` and `local-cluster[...]`. In this case, it creates a locally running
-Spark Connect server, and provide users the Spark Connect session. This is similar when
-`--conf spark.api.mode=connect` and `--master ...` are set together. However `spark.remote`
-and `--remote` only supports `local*` whereas `--conf spark.api.mode=connect` and `--master ...`
-allow other Spark cluster URLs such as `spark://` for better compatibility.
-
 Spark provides the API mode, `spark.api.mode` configuration, enabling Spark Classic applications
 to seamlessly switch to Spark Connect. Depending on the value of `spark.api.mode`, the application
 can run in either Spark Classic or Spark Connect mode. Here is an example:
@@ -109,7 +84,6 @@ This is similar to using `--conf spark.api.mode=connect` with `--master ...`. Ho
 `spark.remote` and `--remote` are limited to `local*` values, while `--conf spark.api.mode=connect`
 with `--master ...` supports additional cluster URLs, such as spark://, for broader compatibility with
 Spark Classic.
-
 
 ## Spark Client Applications
 

--- a/docs/app-dev-spark-connect.md
+++ b/docs/app-dev-spark-connect.md
@@ -58,6 +58,59 @@ to the client via the blue box as part of the Spark Connect API. The client uses
 alongside PySpark or the Spark Scala client, making it easy for Spark client applications to work
 with the custom logic/library. 
 
+## Spark API Mode: Spark Client and Spark Classic
+
+Spark provides API mode (`spark.api.mode`) configuration that can seamlessly start Spark Classic
+applications to use Spark Connect. Based on `spark.api.mode` configuration, the application either
+be executed in Spark Classic or Spark Connect mode. See the examples below:
+
+{% highlight python %}
+from pyspark.sql import SparkSession
+
+SparkSession.builder.config("spark.api.mode", "connect").master("...").getOrCreate()
+{% endhighlight %}
+
+
+This configuration can be also effectively set for both Scala Spark application and PySpark
+applications via Spark submission:
+
+{% highlight bash %}
+spark-submit --master "..." --conf spark.api.mode=connect
+{% endhighlight %}
+
+In addition, Spark Connect provides convient special cases for you to locally test. `spark.remote`
+can be set as `local[...]` and `local-cluster[...]`. In this case, it creates a locally running
+Spark Connect server, and provide users the Spark Connect session. This is similar when
+`--conf spark.api.mode=connect` and `--master ...` are set together. However `spark.remote`
+and `--remote` only supports `local*` whereas `--conf spark.api.mode=connect` and `--master ...`
+allow other Spark cluster URLs such as `spark://` for better compatibility.
+
+Spark provides the API mode, `spark.api.mode` configuration, enabling Spark Classic applications
+to seamlessly switch to Spark Connect. Depending on the value of `spark.api.mode`, the application
+can run in either Spark Classic or Spark Connect mode. Here is an example:
+
+{% highlight python %}
+from pyspark.sql import SparkSession
+
+SparkSession.builder.config("spark.api.mode", "connect").master("...").getOrCreate()
+{% endhighlight %}
+
+You can also apply this configuration to both Scala and PySpark applications when submitting yours:
+
+{% highlight bash %}
+spark-submit --master "..." --conf spark.api.mode=connect
+{% endhighlight %}
+
+Additionally, Spark Connect offers convenient options for local testing. By setting `spark.remote`
+to `local[...]` or `local-cluster[...]`, you can start a local Spark Connect server and access a Spark
+Connect session.
+
+This is similar to using `--conf spark.api.mode=connect` with `--master ...`. However, note that
+`spark.remote` and `--remote` are limited to `local*` values, while `--conf spark.api.mode=connect`
+with `--master ...` supports additional cluster URLs, such as spark://, for broader compatibility with
+Spark Classic.
+
+
 ## Spark Client Applications
 
 Spark Client Applications are the _regular Spark applications_ that Spark users develop today, e.g.,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3391,6 +3391,14 @@ They are typically set via the config file and command-line options with `--conf
 <table class="spark-config">
 <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>
 <tr>
+  <td><code>spark.api.mode</code></td>
+  <td>
+    classic
+  </td>
+  <td>For Spark Classic applications, specify whether to automatically use Spark Connect by running a local Spark Connect server. The value can be <code>classic</code> or <code>connect</code>.</td>
+  <td>4.0.0</td>
+</tr>
+<tr>
   <td><code>spark.connect.grpc.binding.port</code></td>
   <td>
     15002

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
@@ -49,6 +49,9 @@ public class SparkLauncher extends AbstractLauncher<SparkLauncher> {
   public static final String SPARK_REMOTE = "spark.remote";
   public static final String SPARK_LOCAL_REMOTE = "spark.local.connect";
 
+  /** The Spark API mode. */
+  public static final String SPARK_API_MODE = "spark.api.mode";
+
   /** The Spark deploy mode. */
   public static final String DEPLOY_MODE = "spark.submit.deployMode";
 

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -529,7 +529,7 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
           String[] setConf = value.split("=", 2);
           checkArgument(setConf.length == 2, "Invalid argument to %s: %s", CONF, value);
           if (setConf[0].equals("spark.remote") ||
-              (setConf[0].equals("spark.api.mode") &&
+              (setConf[0].equals(SparkLauncher.SPARK_API_MODE) &&
                 setConf[1].toLowerCase(Locale.ROOT).equals("connect"))) {
             isRemote = true;
           }

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -384,6 +384,11 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
     if (remoteStr != null) {
       env.put("SPARK_REMOTE", remoteStr);
       env.put("SPARK_CONNECT_MODE_ENABLED", "1");
+    } else if (conf.getOrDefault(
+        SparkLauncher.SPARK_API_MODE, "classic").toLowerCase(Locale.ROOT).equals("connect") &&
+        masterStr != null) {
+      env.put("SPARK_REMOTE", masterStr);
+      env.put("SPARK_CONNECT_MODE_ENABLED", "1");
     }
 
     if (!isEmpty(pyOpts)) {
@@ -523,7 +528,9 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
           checkArgument(value != null, "Missing argument to %s", CONF);
           String[] setConf = value.split("=", 2);
           checkArgument(setConf.length == 2, "Invalid argument to %s: %s", CONF, value);
-          if (setConf[0].equals("spark.remote")) {
+          if (setConf[0].equals("spark.remote") ||
+              (setConf[0].equals("spark.api.mode") &&
+                setConf[1].toLowerCase(Locale.ROOT).equals("connect"))) {
             isRemote = true;
           }
           conf.put(setConf[0], setConf[1]);

--- a/python/pyspark/sql/tests/connect/test_connect_session.py
+++ b/python/pyspark/sql/tests/connect/test_connect_session.py
@@ -281,6 +281,15 @@ class SparkConnectSessionTests(ReusedConnectTestCase):
         # Should not throw any error
         session.stop()
 
+    def test_api_mode(self):
+        session = (
+            PySparkSession.builder.config("spark.api.mode", "connect")
+            .master("sc://localhost")
+            .getOrCreate()
+        )
+        self.assertEqual(session.range(1).first()[0], 0)
+        self.assertIsInstance(session, RemoteSparkSession)
+
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
 class SparkConnectSessionWithOptionsTest(unittest.TestCase):

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PythonTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PythonTestsSuite.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.deploy.k8s.integrationtest
 
+import org.apache.spark.internal.config.SPARK_API_MODE
+
 private[spark] trait PythonTestsSuite { k8sSuite: KubernetesSuite =>
 
   import PythonTestsSuite._
@@ -71,7 +73,7 @@ private[spark] trait PythonTestsSuite { k8sSuite: KubernetesSuite =>
   // Needs to install Spark Connect dependencies in Python Dockerfile, ignored for now.
   ignore("Run PySpark with Spark Connect", k8sTestTag) {
     sparkAppConf.set("spark.kubernetes.container.image", pyImage)
-    sparkAppConf.set("spark.api.mode", "connect")
+    sparkAppConf.set(SPARK_API_MODE.key, "connect")
     runSparkApplicationAndVerifyCompletion(
       appResource = PYSPARK_CONNECT_FILES,
       mainClass = "",

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PythonTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PythonTestsSuite.scala
@@ -67,6 +67,21 @@ private[spark] trait PythonTestsSuite { k8sSuite: KubernetesSuite =>
       isJVM = false,
       pyFiles = Some(PYSPARK_CONTAINER_TESTS))
   }
+
+  // Needs to install Spark Connect dependencies in Python Dockerfile, ignored for now.
+  ignore("Run PySpark with Spark Connect", k8sTestTag) {
+    sparkAppConf.set("spark.kubernetes.container.image", pyImage)
+    sparkAppConf.set("spark.api.mode", "connect")
+    runSparkApplicationAndVerifyCompletion(
+      appResource = PYSPARK_CONNECT_FILES,
+      mainClass = "",
+      expectedDriverLogOnCompletion = Seq("Python runtime version check for executor is: True"),
+      appArgs = Array(sparkAppConf.get("spark.master")),
+      driverPodChecker = doBasicDriverPyPodCheck,
+      executorPodChecker = doBasicExecutorPyPodCheck,
+      isJVM = false,
+      pyFiles = Some(PYSPARK_CONTAINER_TESTS))
+  }
 }
 
 private[spark] object PythonTestsSuite {
@@ -74,6 +89,7 @@ private[spark] object PythonTestsSuite {
   val PYSPARK_PI: String = CONTAINER_LOCAL_PYSPARK + "pi.py"
   val TEST_LOCAL_PYSPARK: String = "local:///opt/spark/tests/"
   val PYSPARK_FILES: String = TEST_LOCAL_PYSPARK + "pyfiles.py"
+  val PYSPARK_CONNECT_FILES: String = TEST_LOCAL_PYSPARK + "pyfiles_connect.py"
   val PYSPARK_CONTAINER_TESTS: String = TEST_LOCAL_PYSPARK + "py_container_checks.py"
   val PYSPARK_MEMORY_CHECK: String = TEST_LOCAL_PYSPARK + "worker_memory_check.py"
 }

--- a/resource-managers/kubernetes/integration-tests/tests/pyfiles_connect.py
+++ b/resource-managers/kubernetes/integration-tests/tests/pyfiles_connect.py
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import sys
+
+from pyspark.sql import SparkSession
+from pyspark.sql.types import StringType
+
+
+if __name__ == "__main__":
+    """
+        Usage: pyfiles
+    """
+    spark = SparkSession \
+        .builder \
+        .appName("PyFilesTest") \
+        .config("spark.api.mode", "connect") \
+        .master(sys.argv[1]) \
+        .getOrCreate()
+
+    assert "connect" in str(spark)
+
+    # Check python executable at executors
+    spark.udf.register("get_sys_ver",
+                       lambda: "%d.%d" % sys.version_info[:2], StringType())
+    [row] = spark.sql("SELECT get_sys_ver()").collect()
+    driver_version = "%d.%d" % sys.version_info[:2]
+    print("Python runtime version check for executor is: " + str(row[0] == driver_version))
+
+    spark.stop()

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
@@ -190,8 +190,8 @@ abstract class BaseYarnClusterSuite extends SparkFunSuite with Matchers {
       .setPropertiesFile(propsFile)
       .addAppArgs(appArgs.toArray: _*)
 
-    extraConf.get("spark.api.mode").foreach { v =>
-      launcher.setConf("spark.api.mode", v)
+    extraConf.get(SPARK_API_MODE.key).foreach { v =>
+      launcher.setConf(SPARK_API_MODE.key, v)
     }
 
     sparkArgs.foreach { case (name, value) =>

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
@@ -190,6 +190,10 @@ abstract class BaseYarnClusterSuite extends SparkFunSuite with Matchers {
       .setPropertiesFile(propsFile)
       .addAppArgs(appArgs.toArray: _*)
 
+    extraConf.get("spark.api.mode").foreach { v =>
+      launcher.setConf("spark.api.mode", v)
+    }
+
     sparkArgs.foreach { case (name, value) =>
       if (value != null) {
         launcher.addSparkArg(name, value)

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -86,7 +86,7 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     |    sc.stop()
     """.stripMargin
 
-  private val TEST_CONNECT_PYFILE = """
+  private val TEST_CONNECT_PYFILE = s"""
     |import mod1, mod2
     |import sys
     |from operator import add
@@ -98,7 +98,7 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     |        print >> sys.stderr, "Usage: test.py [result file]"
     |        exit(-1)
     |    spark = SparkSession.builder.config(
-    |        "spark.api.mode", "connect").master("yarn").getOrCreate()
+    |        "${SPARK_API_MODE.key}", "connect").master("yarn").getOrCreate()
     |    assert "connect" in str(spark)
     |    status = open(sys.argv[1],'w')
     |    result = "failure"
@@ -266,11 +266,13 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
   }
 
   test("run Python application with Spark Connect in yarn-client mode") {
-    testPySpark(true, extraConf = Map("spark.api.mode" -> "connect"), script = TEST_CONNECT_PYFILE)
+    testPySpark(
+      true, extraConf = Map(SPARK_API_MODE.key -> "connect"), script = TEST_CONNECT_PYFILE)
   }
 
   test("run Python application with Spark Connect in yarn-cluster mode") {
-    testPySpark(false, extraConf = Map("spark.api.mode" -> "connect"), script = TEST_CONNECT_PYFILE)
+    testPySpark(
+      false, extraConf = Map(SPARK_API_MODE.key -> "connect"), script = TEST_CONNECT_PYFILE)
   }
 
   test("run Python application in yarn-cluster mode using " +
@@ -757,7 +759,7 @@ private object YarnConnectTest extends Logging {
     val obj = moduleField.get(null)
     var builder = clz.getMethod("builder").invoke(obj)
     builder = builder.getClass().getMethod(
-      "config", classOf[String], classOf[String]).invoke(builder, "spark.api.mode", "connect")
+      "config", classOf[String], classOf[String]).invoke(builder, SPARK_API_MODE.key, "connect")
     builder = builder.getClass().getMethod("master", classOf[String]).invoke(builder, "yarn")
     val session = builder.getClass().getMethod("getOrCreate").invoke(builder)
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -86,6 +86,34 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     |    sc.stop()
     """.stripMargin
 
+  private val TEST_CONNECT_PYFILE = """
+    |import mod1, mod2
+    |import sys
+    |from operator import add
+    |
+    |from pyspark.sql import SparkSession
+    |from pyspark.sql.functions import udf
+    |if __name__ == "__main__":
+    |    if len(sys.argv) != 2:
+    |        print >> sys.stderr, "Usage: test.py [result file]"
+    |        exit(-1)
+    |    spark = SparkSession.builder.config(
+    |        "spark.api.mode", "connect").master("yarn").getOrCreate()
+    |    assert "connect" in str(spark)
+    |    status = open(sys.argv[1],'w')
+    |    result = "failure"
+    |    @udf
+    |    def test():
+    |        return mod1.func() * mod2.func()
+    |    df = spark.range(10).select(test())
+    |    cnt = df.count()
+    |    if cnt == 10:
+    |        result = "success"
+    |    status.write(result)
+    |    status.close()
+    |    spark.stop()
+    """.stripMargin
+
   private val TEST_PYMODULE = """
     |def func():
     |    return 42
@@ -237,6 +265,14 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     testPySpark(false)
   }
 
+  test("run Python application with Spark Connect in yarn-client mode") {
+    testPySpark(true, extraConf = Map("spark.api.mode" -> "connect"), script = TEST_CONNECT_PYFILE)
+  }
+
+  test("run Python application with Spark Connect in yarn-cluster mode") {
+    testPySpark(false, extraConf = Map("spark.api.mode" -> "connect"), script = TEST_CONNECT_PYFILE)
+  }
+
   test("run Python application in yarn-cluster mode using " +
     "spark.yarn.appMasterEnv to override local envvar") {
     testPySpark(
@@ -370,10 +406,11 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
   private def testPySpark(
       clientMode: Boolean,
       extraConf: Map[String, String] = Map(),
-      extraEnv: Map[String, String] = Map()): Unit = {
+      extraEnv: Map[String, String] = Map(),
+      script: String = TEST_PYFILE): Unit = {
     assume(isPythonAvailable)
     val primaryPyFile = new File(tempDir, "test.py")
-    Files.asCharSink(primaryPyFile, StandardCharsets.UTF_8).write(TEST_PYFILE)
+    Files.asCharSink(primaryPyFile, StandardCharsets.UTF_8).write(script)
 
     // When running tests, let's not assume the user has built the assembly module, which also
     // creates the pyspark archive. Instead, let's use PYSPARK_ARCHIVES_PATH to point at the
@@ -710,6 +747,34 @@ private object YarnClasspathTest extends Logging {
     }
   }
 
+}
+
+private object YarnConnectTest extends Logging {
+  def main(args: Array[String]): Unit = {
+    val output = new java.io.PrintStream(new File(args(0)))
+    val clz = Utils.classForName("org.apache.spark.sql.SparkSession$")
+    val moduleField = clz.getDeclaredField("MODULE$")
+    val obj = moduleField.get(null)
+    var builder = clz.getMethod("builder").invoke(obj)
+    builder = builder.getClass().getMethod(
+      "config", classOf[String], classOf[String]).invoke(builder, "spark.api.mode", "connect")
+    builder = builder.getClass().getMethod("master", classOf[String]).invoke(builder, "yarn")
+    val session = builder.getClass().getMethod("getOrCreate").invoke(builder)
+
+    try {
+      // Check if the current session is a Spark Connect session.
+      session.getClass().getDeclaredField("client")
+      val df = session.getClass().getMethod("range", classOf[Long]).invoke(session, 10)
+      assert(df.getClass().getMethod("count").invoke(df) == 10)
+    } catch {
+      case e: Throwable =>
+        e.printStackTrace(new java.io.PrintStream(output))
+        throw e
+    } finally {
+      session.getClass().getMethod("stop").invoke(session)
+      output.close()
+    }
+  }
 }
 
 private object YarnAddJarTest extends Logging {

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SparkSession.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SparkSession.scala
@@ -689,9 +689,10 @@ object SparkSession extends SparkSessionCompanion with Logging {
    */
   private[sql] def withLocalConnectServer[T](f: => T): T = {
     synchronized {
-      lazy val isAPIModeConnect = Option(System.getProperty("spark.api.mode"))
-        .getOrElse("classic")
-        .toLowerCase(Locale.ROOT) == "connect"
+      lazy val isAPIModeConnect =
+        Option(System.getProperty(org.apache.spark.sql.SparkSessionBuilder.API_MODE_KEY))
+          .getOrElse("classic")
+          .toLowerCase(Locale.ROOT) == "connect"
       val remoteString = sparkOptions
         .get("spark.remote")
         .orElse(Option(System.getProperty("spark.remote"))) // Set from Spark Submit

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SparkSession.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SparkSession.scala
@@ -708,9 +708,9 @@ object SparkSession extends SparkSessionCompanion with Logging {
         Option(System.getenv("SPARK_HOME")).map(Paths.get(_, "sbin", "start-connect-server.sh"))
 
       if (server.isEmpty &&
-          (remoteString.exists(_.startsWith("local")) ||
-            (remoteString.isDefined && isAPIModeConnect)) &&
-          maybeConnectScript.exists(Files.exists(_))) {
+        (remoteString.exists(_.startsWith("local")) ||
+          (remoteString.isDefined && isAPIModeConnect)) &&
+        maybeConnectScript.exists(Files.exists(_))) {
         server = Some {
           val args =
             Seq(maybeConnectScript.get.toString, "--master", remoteString.get) ++ sparkOptions

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SparkSession.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SparkSession.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.connect
 
 import java.net.URI
 import java.nio.file.{Files, Paths}
+import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
@@ -688,17 +689,28 @@ object SparkSession extends SparkSessionCompanion with Logging {
    */
   private[sql] def withLocalConnectServer[T](f: => T): T = {
     synchronized {
+      lazy val isAPIModeConnect = Option(System.getProperty("spark.api.mode"))
+        .getOrElse("classic")
+        .toLowerCase(Locale.ROOT) == "connect"
       val remoteString = sparkOptions
         .get("spark.remote")
         .orElse(Option(System.getProperty("spark.remote"))) // Set from Spark Submit
         .orElse(sys.env.get(SparkConnectClient.SPARK_REMOTE))
+        .orElse {
+          if (isAPIModeConnect) {
+            sparkOptions.get("spark.master").orElse(sys.env.get("MASTER"))
+          } else {
+            None
+          }
+        }
 
       val maybeConnectScript =
         Option(System.getenv("SPARK_HOME")).map(Paths.get(_, "sbin", "start-connect-server.sh"))
 
       if (server.isEmpty &&
-        remoteString.exists(_.startsWith("local")) &&
-        maybeConnectScript.exists(Files.exists(_))) {
+          (remoteString.exists(_.startsWith("local")) ||
+            (remoteString.isDefined && isAPIModeConnect)) &&
+          maybeConnectScript.exists(Files.exists(_))) {
         server = Some {
           val args =
             Seq(maybeConnectScript.get.toString, "--master", remoteString.get) ++ sparkOptions
@@ -748,8 +760,15 @@ object SparkSession extends SparkSessionCompanion with Logging {
     // Initialize the connection string of the Spark Connect client builder from SPARK_REMOTE
     // by default, if it exists. The connection string can be overridden using
     // the remote() function, as it takes precedence over the SPARK_REMOTE environment variable.
-    private val builder = SparkConnectClient.builder().loadFromEnvironment()
+    private var connectionString: Option[String] = None
+    private var interceptor: Option[ClientInterceptor] = None
     private var client: SparkConnectClient = _
+    private lazy val builder = {
+      val b = SparkConnectClient.builder().loadFromEnvironment()
+      connectionString.foreach(b.connectionString)
+      interceptor.foreach(b.interceptor)
+      b
+    }
 
     /** @inheritdoc */
     @deprecated("sparkContext does not work in Spark Connect")
@@ -765,7 +784,7 @@ object SparkSession extends SparkSessionCompanion with Logging {
      * @since 3.5.0
      */
     def interceptor(interceptor: ClientInterceptor): this.type = {
-      builder.interceptor(interceptor)
+      this.interceptor = Some(interceptor)
       this
     }
 
@@ -813,7 +832,7 @@ object SparkSession extends SparkSessionCompanion with Logging {
 
     override protected def handleBuilderConfig(key: String, value: String): Boolean = key match {
       case CONNECT_REMOTE_KEY =>
-        builder.connectionString(value)
+        connectionString = Some(value)
         true
       case APP_NAME_KEY | MASTER_KEY | CATALOG_IMPL_KEY | API_MODE_KEY =>
         logWarning(log"${MDC(CONFIG, key)} configuration is not supported in Connect mode.")

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -620,9 +620,10 @@ object SparkConnectClient {
      * Configure the builder using the env SPARK_REMOTE environment variable.
      */
     def loadFromEnvironment(): Builder = {
-      lazy val isAPIModeConnect = Option(System.getProperty("spark.api.mode"))
-        .getOrElse("classic")
-        .toLowerCase(Locale.ROOT) == "connect"
+      lazy val isAPIModeConnect =
+        Option(System.getProperty(org.apache.spark.sql.SparkSessionBuilder.API_MODE_KEY))
+          .getOrElse("classic")
+          .toLowerCase(Locale.ROOT) == "connect"
       Option(System.getProperty("spark.remote")) // Set from Spark Submit
         .orElse(sys.env.get(SparkConnectClient.SPARK_REMOTE))
         .orElse {

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -620,8 +620,18 @@ object SparkConnectClient {
      * Configure the builder using the env SPARK_REMOTE environment variable.
      */
     def loadFromEnvironment(): Builder = {
+      lazy val isAPIModeConnect = Option(System.getProperty("spark.api.mode"))
+        .getOrElse("classic")
+        .toLowerCase(Locale.ROOT) == "connect"
       Option(System.getProperty("spark.remote")) // Set from Spark Submit
         .orElse(sys.env.get(SparkConnectClient.SPARK_REMOTE))
+        .orElse {
+          if (isAPIModeConnect) {
+            Option(System.getProperty("spark.master")).orElse(sys.env.get("MASTER"))
+          } else {
+            None
+          }
+        }
         .foreach(connectionString)
       this
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add a new configuration called `spark.api.mode` (default `classic`) that allows existing Spark Classic applications to easily use Spark Connect.

### Why are the changes needed?

In order users to easily try Spark Connect with their existing Spark Classic applications.

### Does this PR introduce _any_ user-facing change?

It adds a new configuration `spark.api.mode` without changing the default behaviour.

### How was this patch tested?

For PySpark applications, added unittests for Spark Submissions in Yarn and Kubernates, and manual tests.
For Scala applications, it is difficult to add a test because SBT picks up the complied jars into the classpathes automatically (whereas we can easily control it for production environment).

For this case, I manually tested as below:

```bash
git clone https://github.com/HyukjinKwon/spark-connect-example
cd spark-connect-example
build/sbt package
cd ..
git clone https://github.com/apache/spark.git
cd spark
build/sbt package
# sbin/start-connect-server.sh
bin/spark-submit --name "testApp" --master "local[*]" --conf spark.api.mode=connect --class com.hyukjinkwon.SparkConnectExample ../spark-connect-example/target/scala-2.13/spark-connect-example_2.13-0.0.1.jar
```

### Was this patch authored or co-authored using generative AI tooling?

No.