### PR TITLE
[SPARK-50524][SQL] Lower `RowBasedKeyValueBatch.spill` warning message to debug level

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatch.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatch.java
@@ -174,7 +174,7 @@ public abstract class RowBasedKeyValueBatch extends MemoryConsumer implements Cl
    */
   @Override
   public final long spill(long size, MemoryConsumer trigger) throws IOException {
-    logger.warn("Calling spill() on RowBasedKeyValueBatch. Will not spill but return 0.");
+    logger.debug("Calling spill() on RowBasedKeyValueBatch. Will not spill but return 0.");
     return 0;
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to lower `RowBasedKeyValueBatch.spill` warning message to debug level.

```java
   public final long spill(long size, MemoryConsumer trigger) throws IOException {
-    logger.warn("Calling spill() on RowBasedKeyValueBatch. Will not spill but return 0.");
+    logger.debug("Calling spill() on RowBasedKeyValueBatch. Will not spill but return 0.");
     return 0;
   }
```

### Why are the changes needed?

Although Apache Spark has been showing a warning message since 2.1.0, there is nothing for a user to be able to do further. This is more like a dev-side debug message. So, we had better lower the level to `DEBUG` from `WARN`.
- #14349

### Does this PR introduce _any_ user-facing change?

No behavior change. This is a log message.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.