### PR TITLE
[SPARK-33152][SQL] Implement new optimized logic for constraint propagation rule

### DIFF
--- a/sql/catalyst/src/main/scala-2.12/org/apache/spark/sql/catalyst/expressions/ConstraintSetImplicit.scala
+++ b/sql/catalyst/src/main/scala-2.12/org/apache/spark/sql/catalyst/expressions/ConstraintSetImplicit.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import scala.collection.mutable
+import scala.language.implicitConversions
+
+object ConstraintSetImplicit {
+
+  implicit def toImplicitWrapper[T](self: scala.collection.Iterable[T]): Wrapper[T] =
+    new Wrapper(self)
+
+  class Wrapper[T](val coll: scala.collection.Iterable[T]) {
+
+    def toMutableSet(mutableSet: mutable.Set.type): mutable.Set[T] = coll.to[mutable.Set]
+
+    def toMutableBuffer(mutableBuffer: mutable.Buffer.type): mutable.Buffer[T] =
+      coll.to[mutable.Buffer]
+  }
+}

--- a/sql/catalyst/src/main/scala-2.12/org/apache/spark/sql/catalyst/expressions/ExpressionMap.scala
+++ b/sql/catalyst/src/main/scala-2.12/org/apache/spark/sql/catalyst/expressions/ExpressionMap.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import scala.collection.mutable
+
+object ExpressionMap {
+
+  /** Constructs a new [[ExpressionMap]] by applying [[Canonicalize]] to `expressions`. */
+  def apply[T](map: Iterable[(Expression, T)]): ExpressionMap[T] = {
+    val newMap = new ExpressionMap[T]()
+    map.foreach(newMap.add)
+    newMap
+  }
+}
+
+/**
+ * A helper class created on the lines of [[AttributeMap]] and [[ExpressionSet]]
+ * The key added in the Map is always stored in canonicalized form.
+ *
+ * @param baseMap The underlying Map object which is either empty or pre-populated with all the
+ *                keys being canonicalized form of expressions
+ * @tparam T The value part of the Map
+ */
+class ExpressionMap[T](val baseMap: mutable.Map[Expression, T] = new mutable.HashMap[Expression, T])
+  extends mutable.Map[Expression, T] {
+
+  override def get(expr: Expression): Option[T] =
+    baseMap.get(expr.canonicalized)
+
+  protected def add(tup: (Expression, T)): Unit = {
+    this.baseMap += (tup._1.canonicalized -> tup._2)
+  }
+
+  override def contains(expr: Expression): Boolean = baseMap.contains(expr.canonicalized)
+
+  override def +=(kv: (Expression, T)): this.type = {
+    this.add(kv)
+    this
+  }
+
+  override def iterator: Iterator[(Expression, T)] = baseMap.iterator
+
+  override def -=(key: Expression): this.type = {
+    this.baseMap -= key.canonicalized
+    this
+  }
+}

--- a/sql/catalyst/src/main/scala-2.13/org/apache/spark/sql/catalyst/expressions/ConstraintSetImplicit.scala
+++ b/sql/catalyst/src/main/scala-2.13/org/apache/spark/sql/catalyst/expressions/ConstraintSetImplicit.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import scala.collection.mutable
+import scala.language.implicitConversions
+
+object ConstraintSetImplicit {
+  implicit def toImplicitWrapper[T](self: scala.collection.Iterable[T]): Wrapper[T] =
+    new Wrapper(self)
+
+  class Wrapper[T](val coll: scala.collection.Iterable[T]) {
+
+    def toMutableSet(mutableSet: mutable.Set.type): mutable.Set[T] =
+      coll.to(mutable.Set)
+
+    def toMutableBuffer(mutableBuffer: mutable.Buffer.type): mutable.Buffer[T] =
+      coll.to(mutable.Buffer)
+  }
+}
+

--- a/sql/catalyst/src/main/scala-2.13/org/apache/spark/sql/catalyst/expressions/ExpressionMap.scala
+++ b/sql/catalyst/src/main/scala-2.13/org/apache/spark/sql/catalyst/expressions/ExpressionMap.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.expressions
+
+import scala.collection.mutable
+
+object ExpressionMap {
+  /** Constructs a new [[ExpressionMap]] by applying [[Canonicalize]] to `expressions`. */
+  def apply[T](map: Iterable[(Expression, T)]): ExpressionMap[T] = {
+    val newMap = new ExpressionMap[T]()
+    map.foreach(newMap.addOne)
+    newMap
+  }
+}
+
+/**
+ * A helper class created on the lines of [[AttributeMap]] and [[ExpressionSet]]
+ * The key added in the Map is always stored in canonicalized form.
+ *
+ * @param baseMap The underlying Map object which is either empty or pre-populated with all the
+ *                keys being canonicalized form of expressions
+ * @tparam T The value part of the Map
+ */
+class ExpressionMap[T](val baseMap: mutable.Map[Expression, T] = new mutable.HashMap[Expression, T])
+  extends mutable.Map[Expression, T] {
+
+  override def get(expr: Expression): Option[T] = baseMap.get(expr.canonicalized)
+
+
+  override def addOne(tup: (Expression, T)): this.type = {
+    this.baseMap += (tup._1.canonicalized -> tup._2)
+    this
+  }
+
+  override def contains(expr: Expression): Boolean = baseMap.contains(expr.canonicalized)
+
+  override def iterator: Iterator[(Expression, T)] = baseMap.iterator
+
+  override def subtractOne(key: Expression): this.type = {
+    this.baseMap -= key.canonicalized
+    this
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ConstraintSet.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ConstraintSet.scala
@@ -1,0 +1,1525 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+import ConstraintSetImplicit._
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
+import org.apache.spark.sql.catalyst.plans.logical.{ConstraintHelper, LogicalPlan}
+import org.apache.spark.sql.types.DataType
+
+
+/**
+ * This class stores the constraints available at each node.
+ * The constraint expressions are stored in canonicalized form.
+ * The major way in which it differs from the [[ExpressionSet]] is that
+ * in case of Project Node, it stores information about the aliases
+ * and groups them on the basis of equivalence. In stock spark all the
+ * constraints are pre-created pessimistically for all possible combinations
+ * of equivalent aliases. While in this class only one constraint per filter
+ * is present.
+ * The core logic of new algorithm is as follows
+ * The base constraints present in this object will always be composed of
+ * as far as possible, of those attributes which were present in the incoming
+ * set & are also part of the output set for the node. If any attribute or expression
+ * is part of any outgoing alias, they will be added to either attribute equivalence list
+ * or expression equivalence list, depending upon whether the Alias's child is attribute
+ * or generic expression. The 0th element of each of the buffer in the attribute equivalence
+ * list & expression equivalence list are special in the sense, that any constraint,
+ * if it is referring to any attribute or expression in the two lists, is guaranteed to
+ * use the 0th element and not any other members. An attempt is made to ensure that the
+ * constraint survives when bubbling up. If an attribute or expression, which is part
+ * of incoming constraint, but is not present in output set, makes the survival of the
+ * constraint susceptible. In such case, the attribute equivalence list & expression
+ * equivalence list are consulted & if found that the buffer containing 0th element as
+ * the attribute which is getting removed, has another element, then that element ( the
+ * 1th member) is chosen to replace the attribute being removed  in the constraint.
+ * The constraint is updated to use the 1th element. This 1th element is then put in
+ * 0th place of the buffer.
+ * It is to be noted that attribute equivalence list will have buffers where each
+ * element will be of type attribute only. While expression equivalence list will
+ * have 0th element as of type generic expression, rest being attributes.
+ * It is also to be noted, that the 0th element of expression equivalence list being
+ * generic expression, itself is composed of attributes. And the expression equivalence
+ * list needs to be updated, if any of the attribute it refers to is being eliminated
+ * from the output set.
+ *
+ * For eg. consider an existing constraint a + b + c + d > 7
+ * let the input set comprise of attributes a, b, c, d
+ * Let the output set be  a, a as a1, a as a2, b + c as z, d as d1
+ * In the above d , b  & c are getting eliminated
+ * while a survives and also has a1 & a2.
+ * d is referred as d1.
+ * the initial attribute equivalence list will be
+ * a, a1, a2
+ * d, d1
+ * expression equivalence list will be
+ * b + c , z
+ * Now for the constraint a + b + c + d > 7 to survive
+ * b + c => can be replaced by z
+ * d can be replaced by d1
+ * so the constraint will be updated as
+ * a + z + d1 > 7
+ * the updated attribute equivalence list will be
+ * a, a1, a2
+ * since d1 will be left alone, it will no longer be part of the list
+ * same is the case with expression equivalence list.
+ * as b + c, will be removed, only z1 remains, so it will be removed
+ * from expression equivalence list & it will be empty.
+ *
+ * @param baseSet                        [[mutable.Set[Expression]] which contains Canonicalized
+ *                                       Constraint Expression
+ * @param originals                      [[mutable.Buffer[Expression]] buffer containing the
+ *                                       original constraint
+ *                                       expression
+ * @param attribRefBasedEquivalenceList  A List of List which contains grouping of equivalent
+ *                                       Aliases referring to same Attribute. The 0th attribute
+ *                                       has special significance
+ *                                       as the constraint expressions will be canonicalized in
+ *                                       terms of that.
+ * @param expressionBasedEquivalenceList A List of List which contains grouping of equivalent
+ *                                       Aliases referring to same Expression( which is not an
+ *                                       Attribute). The 0th expression is
+ *                                       necessarily NOT an attribute ( but a compound expression
+ *                                       containing 1 or more attributes).
+ *                                       All the other elements (except the 0th) will necessarily
+ *                                       be attributes. A constraint expression
+ *                                       if  given in terms of the attribute(s) of this list,
+ *                                       will be canonicalized to
+ *                                       contain the 0th expression.
+ *                                       For eg. if  this list has entries like  a + b, x, y, z
+ *                                       and if the constraint expression to be added to
+ *                                       constraintset looked like
+ *                                       x > 5, then it would be actually converted and stored as
+ *                                       a + b > 5
+ */
+
+class ConstraintSet private(
+    baseSet: mutable.Set[Expression],
+    originals: mutable.Buffer[Expression] = new mutable.ArrayBuffer(),
+    val attribRefBasedEquivalenceList: Seq[mutable.Buffer[Attribute]],
+    val expressionBasedEquivalenceList: Seq[mutable.Buffer[Expression]])
+  extends ExpressionSet(baseSet, originals) with Logging with ConstraintHelper {
+
+  import ConstraintSetImplicit._
+
+  def this(actuals: mutable.Buffer[Expression]) = this(
+    actuals.map(_.canonicalized).toMutableSet(mutable.Set),
+    actuals,
+    Seq.empty[mutable.Buffer[Attribute]],
+    Seq.empty[mutable.Buffer[Expression]])
+
+  def this(
+      actuals: mutable.Buffer[Expression],
+      attribRefBasedEquivalenceList: Seq[mutable.Buffer[Attribute]],
+      expressionBasedEquivalenceList: Seq[mutable.Buffer[Expression]]) =
+    this(
+      actuals.map(_.canonicalized).toMutableSet(mutable.Set),
+      actuals,
+      attribRefBasedEquivalenceList,
+      expressionBasedEquivalenceList)
+
+  def this(baseSet: mutable.Set[Expression], actuals: mutable.Buffer[Expression]) =
+    this(baseSet, actuals, Seq.empty[mutable.Buffer[Attribute]],
+      Seq.empty[mutable.Buffer[Expression]])
+
+  def this() = this(mutable.Buffer.empty[Expression])
+
+  override def clone(): ConstraintSet = new ConstraintSet(
+    baseSet.clone(),
+    originals.clone(),
+    this.attribRefBasedEquivalenceList.map(_.clone()),
+    this.expressionBasedEquivalenceList.map(_.clone()))
+
+  override def union(that: ExpressionSet): ExpressionSet = {
+    def commonEquivList[T <: Expression](
+        thisList: Seq[mutable.Buffer[T]],
+        thatList: Seq[mutable.Buffer[T]]): Seq[mutable.Buffer[T]] = {
+      val zerothElems = thisList.map(_.head)
+      val (common, other) = thatList.partition(buff => zerothElems.exists(
+        buff.head.canonicalized fastEquals _.canonicalized))
+      val copy = thisList.map(_.clone())
+      common.foreach(commonBuff => {
+        val copyBuff = copy.find(_.head.canonicalized fastEquals commonBuff.head.canonicalized).get
+        commonBuff.drop(1).foreach(expr => if (!copyBuff.exists(
+          _.canonicalized fastEquals expr.canonicalized)) {
+          copyBuff += expr
+        })
+      })
+      copy ++ other.map(_.clone())
+    }
+
+    def removeAnyResidualDuplicateAttribute(newAttribList: Seq[mutable.Buffer[Attribute]]):
+    (Seq[mutable.Buffer[Attribute]], Boolean) = {
+      val allAttribs = newAttribList.flatten
+      var foundEmptyBuff = false
+      var foundDuplicates = false
+      allAttribs.foreach(attrib => {
+        val buffs = newAttribList.filter(buff => buff.exists(_.canonicalized fastEquals
+                                                               attrib.canonicalized))
+        if (buffs.size > 1) {
+          foundDuplicates = true
+          val rests = buffs.drop(1)
+          rests.foreach(buff => {
+            ConstraintSetHelper.removeCanonicalizedExpressionFromBuffer(buff, attrib)
+            if (buff.isEmpty) {
+              foundEmptyBuff = true
+            }
+          })
+        }
+      })
+      (if (foundEmptyBuff) {
+        newAttribList.filterNot(_.isEmpty)
+      } else {
+        newAttribList
+      }) -> foundDuplicates
+    }
+
+    val (newAttribList, newExpEquivList) = that match {
+      case thatX: ConstraintSet =>
+        (commonEquivList(this.attribRefBasedEquivalenceList, thatX.attribRefBasedEquivalenceList),
+          commonEquivList(this.expressionBasedEquivalenceList,
+                          thatX.expressionBasedEquivalenceList))
+      case _ => (this.attribRefBasedEquivalenceList.map(_.clone()),
+        this.expressionBasedEquivalenceList.map(_.clone()))
+    }
+    // clean up new attribute list for any duplicate attribute refs if any
+    val (cleanedAttribList, foundDuplicates) = removeAnyResidualDuplicateAttribute(newAttribList)
+    if (foundDuplicates) {
+      val errorMessage = "Found same attribute ref present in more than 1 buffers." +
+        "This indicates either a faulty plan involving same dataframe reference self joined" +
+        "without alias or something murkier"
+      throwError(errorMessage)
+    }
+    val newSet = new ConstraintSet(this.baseSet.clone(), this.originals.clone(), cleanedAttribList,
+                                   newExpEquivList)
+    ConstraintSet.addFiltersToConstraintSet(that, newSet)
+    newSet
+  }
+
+  override def constructNew(
+      newBaseSet: mutable.Set[Expression] = new mutable.HashSet(),
+      newOriginals: mutable.Buffer[Expression] = new ArrayBuffer()): ExpressionSet =
+    new ConstraintSet(newBaseSet, newOriginals, this.attribRefBasedEquivalenceList.map(_.clone()),
+      this.expressionBasedEquivalenceList.map(_.clone()))
+
+  /**
+   * Converts the given expression to the canonicalized form, needed for ConstraintSet
+   * For eg lets assume expression equivalence list contains a buffer with following
+   * entries. Below a & b are attributes of the output & z is an alias of a + b
+   * a + b, z
+   * If the expression to be added to constraints is z > 10, then it should be
+   * entered in the constraintset  in terms of primary attributes (i.e a + b)
+   * so on canonicalization z > 10 will be converted to a + b > 10
+   *
+   * @param ele Expression to be canonicalized
+   * @return Expression which is canonicalized
+   */
+  override def convertToCanonicalizedIfRequired(ele: Expression): Expression =
+    if (this.baseSet.contains(ele.canonicalized)) {
+      ele
+    } else {
+      // Though it is guranteed that attrib equiv list will not be empty
+      // but for precaution using headOption as indicated in feedback
+      val suspectAttribs = ele.references --
+        AttributeSet(this.attribRefBasedEquivalenceList.map(_.headOption.map(Seq(_))).
+          flatMap(_.getOrElse(Seq.empty)))
+      if (suspectAttribs.isEmpty) {
+        ele
+      } else {
+        // the buff.size always has to be > 1, but this is just that curse of god does not
+        // hit in prodn
+        val mappings =
+          AttributeMap(suspectAttribs.map(attrib =>
+            (this.attribRefBasedEquivalenceList ++ this.expressionBasedEquivalenceList).find(buff =>
+             buff.size > 1 && buff.slice(1, buff.length).exists(
+             _.canonicalized fastEquals attrib.canonicalized)).map(
+              buff => attrib -> Option(buff.head)).getOrElse(attrib -> None)).filter {
+                case (_, Some(_)) => true
+                case _ => false
+              }.toSeq)
+        if (mappings.nonEmpty) {
+          ele.transformUp {
+            case attr: Attribute if mappings.contains(attr) => mappings(attr).getOrElse(attr)
+          }
+        } else {
+          ele
+        }
+      }
+    }
+
+  /**
+   * This function updates the existing non redundant, non trivial constraints stored
+   * as per the basis of incoming attributes and outgoing attributes of the node.
+   * If the attributes forming the constraints are not going to be part of the output set,
+   * then attempt is made ,as much as possible, to see if the constraint can survive
+   * by modifying it with 1st available alias for the attribute getting removed.
+   * It also tracks the aliases of the attribute which are then used
+   * for pruning in the contains function
+   *
+   * @param outputAttribs                The attributes which are part of the output set
+   * @param inputAttribs                 The attributes which make up the incoming attributes
+   * @param projectList                  The list of projections containing the NamedExpression
+   * @param oldAliasedConstraintsCreator A partial function used for generating all
+   *                                     combination of constraints as per old code.
+   *                                     Used only when the un optimized constraint propagation
+   *                                     is used. Used in ExpressionSet
+   * @return The new valid ConstraintSet
+   */
+  override def updateConstraints(
+      outputAttribs: Seq[Attribute],
+      inputAttribs: Seq[Attribute],
+      projectList: Seq[NamedExpression],
+      oldAliasedConstraintsCreator: Option[Seq[NamedExpression] => ExpressionSet]):
+    ConstraintSet = {
+    val (aliasBasedTemp, _) = projectList.partition {
+      case _: Alias => true
+      case _ => false
+    }
+
+    val groupHeadToGroupMap: ExpressionMap[mutable.Buffer[Expression]] =
+      new ExpressionMap[mutable.Buffer[Expression]]()
+
+    this.attribRefBasedEquivalenceList.foreach(
+      x => groupHeadToGroupMap += (x.head -> x.map(_.asInstanceOf[Expression]).toMutableBuffer(
+        mutable.Buffer))
+                                               )
+    this.expressionBasedEquivalenceList.foreach(x => groupHeadToGroupMap += (x.head -> x.clone()))
+
+    // the aliases containing expressions might have been written in terms
+    // of existing aliases. so we need to normalize them
+    // for eg if we had an alias a + b + t as K, and already expression
+    // based equivalence list contained c + d as t , we need to convert
+    // a + b + t to a + b + c +d. optimally it should be done in update
+    // of expression equiv list. But since c or d might be getting removed
+    // and that code handles that, it is better to replace here itself so
+    // that if c or d is getting removed, it will be tackled.
+
+    val aliasBased = aliasBasedTemp.map {
+      case al: Alias => val refs = al.child.references
+        val replacementMap = AttributeMap(refs.flatMap(
+          attrib => this.expressionBasedEquivalenceList.find(
+            buff => buff.exists(_.canonicalized == attrib.canonicalized)).map(
+            buff => Seq(attrib -> buff.head)).getOrElse(Seq.empty)).toSeq)
+        if (replacementMap.nonEmpty) {
+          al.copy(child = al.child transformUp {
+            case attr: Attribute if replacementMap.contains(attr) => replacementMap(attr)
+          })(al.exprId, al.qualifier, al.explicitMetadata, al.nonInheritableMetadataKeys)
+        } else {
+          al
+        }
+    }
+
+    // clone the keys so that the set obtained is static & detached from
+    // the groupHeadToGroupMap
+    val existingAttribGroupHead = groupHeadToGroupMap.keySet.toSet
+
+    // add the incoming attribs list
+    aliasBased.foreach(ne => ne match {
+      case al: Alias =>
+        // find the group to which this alias's child belongs to
+        // if the child is an attribute
+        val alChild = al.child
+        val key = this.attribRefBasedEquivalenceList.find(_.exists(
+          _.canonicalized fastEquals alChild.canonicalized)).map(_.head).getOrElse(
+          this.expressionBasedEquivalenceList.find(buff => buff.exists(
+            _.canonicalized fastEquals alChild.canonicalized)).map(_.head).getOrElse(alChild))
+
+        groupHeadToGroupMap.get(key) match {
+          case Some(seq) => seq += al.toAttribute
+          case None =>
+            // if key is a literal that indicates that the Alias may have
+            // an exprID which is somehow getting repeated across multiple nodes.
+            // However the code below checks for presence of the alias's exprID
+            // irrespective of the Alias's child is Literal or any general Expression.
+            // (At this point cannot completely rule out repetition of non Literals Alias)
+            // In such case even if the key is not in groupHead , the exprId might still be
+            // in attribute reference list. So before creating a new entry in the map
+            // check if the exprId of the alias is present in the attribute equivalence list.
+            // If it is present already, skip its entry
+            if (!this.attribRefBasedEquivalenceList.exists(
+              buff => buff.exists(_.canonicalized == al.toAttribute.canonicalized))) {
+              val temp: mutable.Buffer[Expression] = mutable.ArrayBuffer(al.child, al.toAttribute)
+              groupHeadToGroupMap += al.child -> temp
+            }
+        }
+      case _ => // not expected
+    })
+
+    // Find those incoming attributes which are not projecting out
+    val attribsRemoved = AttributeSet(inputAttribs.filterNot(
+      attr => outputAttribs.exists(_.canonicalized == attr.canonicalized)))
+    // for each of the attribute getting removed , find replacement if any
+    val replaceableAttributeMap: ExpressionMap[Attribute] = new ExpressionMap[Attribute]()
+    fillReplacementOrClearGroupHeadForRemovedAttributes(
+      attribsRemoved, replaceableAttributeMap, groupHeadToGroupMap)
+    val (attribBasedEquivalenceList, initialExprBasedEquivalenceList) = {
+      val (attribBased, expressionBased) = groupHeadToGroupMap.values.partition(
+        buff => buff.head match {
+          case _: Attribute => true
+          case _ => false
+        })
+      (attribBased.map(buff => buff.map(_.asInstanceOf[Attribute])).toMutableBuffer(mutable.Buffer),
+        expressionBased.toMutableBuffer(mutable.Buffer))
+    }
+
+    // now work on expression (other than attribute based)
+    val replaceableExpressionMap: ExpressionMap[Attribute] = new ExpressionMap[Attribute]()
+    val exprBasedEquivalenceList =
+      getUpdatedExpressionEquivalenceListWithSideEffects(attribsRemoved, replaceableAttributeMap,
+        replaceableExpressionMap, attribBasedEquivalenceList, initialExprBasedEquivalenceList)
+
+    // Now update or remove the filters depending upon which
+    // can survive based on replacement available
+    val updatedFilterExprs = getUpdatedConstraints(
+      attribsRemoved, replaceableAttributeMap, replaceableExpressionMap)
+
+    exprBasedEquivalenceList.foreach(buffer => {
+      val expr = buffer.head
+      if (!existingAttribGroupHead.contains(expr.canonicalized)) {
+        val newConstraintOpt = if (expr.references.isEmpty) {
+          buffer.remove(0)
+          expr match {
+            case NonNullLiteral(_, _) | _: NullIntolerant => Some(EqualTo(buffer.head, expr))
+            case _ => Some(EqualNullSafe(buffer.head, expr))
+          }
+        } else {
+          None
+        }
+
+        newConstraintOpt.foreach(newConstraint => if (!updatedFilterExprs.exists(
+          _.canonicalized fastEquals newConstraint.canonicalized)) {
+          updatedFilterExprs += newConstraint
+        })
+      }
+    })
+
+    // remove all mappings of constants as the expression
+    // also identify those elements which are plain attribute based only
+    // so that we transfer them to attribute ref list.Even if we do not transfer
+    // it would be fine. but better transfer so that bug  can be
+    // bug tested easily
+    val (attribsOnly, newExprBasedEquivalenceList) = exprBasedEquivalenceList.filter(
+      buff => buff.head.references.nonEmpty && buff.size > 1).
+      partition(_.head match {
+                  case _: Attribute => true
+                  case _ => false
+                })
+
+    // Now filter the attribBasedEquivalenceList which only has 1 element
+    // This is because if there is only 1 element in the buffer, it cannot
+    // be of any help in making a constraint survive, in case that attribute
+    // is not part of output set, so no point in keeping it in the attribute
+    // equivalence list.
+    val newAttribBasedEquivalenceList = (attribBasedEquivalenceList ++
+      attribsOnly.map(_.map(_.asInstanceOf[Attribute]))).filter(_.size > 1)
+    val canonicalized = updatedFilterExprs.map(_.canonicalized).toMutableSet(mutable.Set)
+
+    // Size not matching is an Error situation. This is Unexpected
+    // The code below is just to handle unanticipated situation
+    if (canonicalized.size != updatedFilterExprs.size) {
+      this.logWarning(s"Canonicalized filter expression set" +
+                        s" not matching with updated filter expressions, indicating duplicate " +
+                        s"filters.")
+      val duplicateFilters = mutable.ArrayBuffer[Seq[Expression]]()
+      canonicalized.foreach(canon => {
+        val tempExprs = updatedFilterExprs.filter(_.canonicalized fastEquals canon)
+        if (tempExprs.size > 1) {
+          duplicateFilters += tempExprs.toSeq
+        }
+      })
+      val errorMessage = s"Found following duplicate filters." +
+        s" Recording only first 4..." +
+        s" ${duplicateFilters.flatten.take(4).map(_.toString).mkString(",")}"
+      throwError(errorMessage)
+      duplicateFilters.foreach(duplicates => {
+        duplicates.drop(1).foreach(x => {
+          val indx = updatedFilterExprs.indexWhere(_ fastEquals x)
+          if (indx != -1) {
+            updatedFilterExprs.remove(indx)
+          }
+        })
+      })
+    }
+    new ConstraintSet(canonicalized, updatedFilterExprs, newAttribBasedEquivalenceList.toSeq,
+                      newExprBasedEquivalenceList.toSeq)
+  }
+
+  private def getUpdatedExpressionEquivalenceListWithSideEffects(
+      attribsRemoved: AttributeSet,
+      replaceableAttributeMap: ExpressionMap[Attribute],
+      replaceableExpressionMap: ExpressionMap[Attribute],
+      attribBasedEquivalenceList: mutable.Buffer[mutable.Buffer[Attribute]],
+      initialExprBasedEquivalenceList: mutable.Buffer[mutable.Buffer[Expression]]):
+    mutable.Buffer[mutable.Buffer[Expression]] = {
+    initialExprBasedEquivalenceList.map(buff => {
+      val zerothElem = buff.head
+      val refs = zerothElem.references
+      if (refs.nonEmpty) {
+        val removedAttribsReferedByExp = refs.intersect(attribsRemoved)
+        if (!removedAttribsReferedByExp.isEmpty) {
+          // if the replaceable attrib contains all the removed attrs referred, well & good
+          // else the 0th expression needs to be removed as its non-surviving
+          // attributes cannot be replaced by surviving attributes
+          val replacementsExistsForAll = removedAttribsReferedByExp.forall(
+            replaceableAttributeMap.contains(_))
+          if (replacementsExistsForAll) {
+            val newZeroth = zerothElem.transformUp {
+              case attr: Attribute if replaceableAttributeMap.contains(attr) =>
+                replaceableAttributeMap.get(attr).get
+            }
+            buff(0) = newZeroth
+            buff
+          } else {
+            val removedExpression = buff.remove(0)
+            if (buff.nonEmpty) {
+              replaceableExpressionMap += (removedExpression -> buff.head
+                .asInstanceOf[Attribute])
+            }
+            // If the buffer size after removal is > 1
+            // transfer the remaining attributes in the buffer to attrib equivalent list
+            // If the buffer size == 1, then it will be removed in the final filtration
+            // as the buffer size == 1 implies that the 0th position expression cannot
+            // survive up the chain, if any of the attribute it is referencing is lost,
+            // as there is no alias to support it
+            if (buff.size > 1) {
+              val checkTrue = buff.forall {
+                case _: Attribute => true
+                case _ => false
+              }
+              if (!checkTrue) {
+                val errorMessage = "Report Bug. ExpressionEquivalentList after removal of " +
+                  "0th element still contains expression which are not of type attribute." +
+                  s"the expressions are ${buff.map(_.toString).mkString(",")}"
+                throwError(errorMessage)
+                // remove expression other than attribute from the buffer
+                var keepGoing = true
+                while (keepGoing) {
+                  val index = buff.indexWhere(x => x match {
+                    case _: Attribute => false
+                    case _ => true
+                  })
+                  if (index == -1) {
+                    keepGoing = false
+                  } else {
+                    buff.remove(index)
+                  }
+                }
+              }
+              if (buff.nonEmpty) {
+                val preexistingExprs = buff.filter(expr => attribBasedEquivalenceList.exists(
+                  buffx => buffx.exists(_.canonicalized fastEquals expr.canonicalized)))
+                preexistingExprs.foreach(expr => {
+                  val index = buff.indexWhere(_.canonicalized fastEquals expr.canonicalized)
+                  buff.remove(index)
+                })
+                if (buff.nonEmpty) {
+                  attribBasedEquivalenceList += buff.map(_.asInstanceOf[Attribute])
+                }
+              }
+              mutable.Buffer.empty[Expression]
+            } else {
+              buff
+            }
+          }
+        } else {
+          buff
+        }
+      } else {
+        attribsRemoved.foreach(ConstraintSetHelper.removeCanonicalizedExpressionFromBuffer(buff, _))
+        buff
+      }
+    }).filter(_.size > 1)
+    // The above filtering ensures that if the buffer size after removal is 1,
+    // then purge the buffer
+  }
+
+  private def getUpdatedConstraints(
+      attribsRemoved: AttributeSet,
+      replaceableAttributeMap: ExpressionMap[Attribute],
+      replaceableExpressionMap: ExpressionMap[Attribute]): mutable.Buffer[Expression] = {
+    this.originals.flatMap(filterExpr => {
+      val attribRefs = filterExpr.references
+      if (attribRefs.isEmpty) {
+        Set.empty[Expression]
+      } else {
+        val attribsToHandle = attribRefs.intersect(attribsRemoved)
+        if (!attribsToHandle.isEmpty) {
+          var numReplacementExists = 0
+          attribsToHandle.foreach(x => if (replaceableAttributeMap.contains(x)) {
+            numReplacementExists += 1
+          })
+          if (numReplacementExists > 0) {
+            val newConstraintExpr = filterExpr.transformUp {
+              case attr: Attribute if replaceableAttributeMap.contains(attr) =>
+                replaceableAttributeMap.get(attr).get
+            }
+            if (numReplacementExists == attribsToHandle.size) {
+              Set(newConstraintExpr).filterNot(
+                x => this.originals.exists(_.canonicalized == x.canonicalized))
+            } else {
+              // if filter still contains attribs which will be removed,
+              // below code checks if filter can survive by replacement with a complex expression
+              val attributesSeen = mutable.Buffer[Attribute]()
+              val newerConstraintExpr = newConstraintExpr.transformDown {
+                case attr: Attribute => attributesSeen += attr
+                  attr
+                case expr: Expression =>
+                  replaceableExpressionMap.get(expr) match {
+                    case Some(x) => x
+                    case None => expr
+                  }
+              }
+              if (attribsRemoved.intersect(AttributeSet(attributesSeen)).nonEmpty) {
+                Set.empty[Expression]
+              } else {
+                Set(newerConstraintExpr).filterNot(
+                  x => this.originals.exists(_.canonicalized == x.canonicalized))
+              }
+            }
+          } else {
+            if (replaceableExpressionMap.isEmpty) {
+              Set.empty[Expression]
+            } else {
+              // if filter still contains attribs which will be removed,
+              // below code checks if filter can survive by replacement with a complex expression
+              val attributesSeen = mutable.Buffer[Attribute]()
+
+              val newConstraintExpr = filterExpr.transformDown {
+                case attr: Attribute => attributesSeen += attr
+                  attr
+                case expr: Expression =>
+                  replaceableExpressionMap.get(expr) match {
+                    case Some(x) => x
+                    case None => expr
+                  }
+              }
+              if (attribsRemoved.intersect(AttributeSet(attributesSeen)).nonEmpty) {
+                Set.empty[Expression]
+              } else {
+                Set(newConstraintExpr).filterNot(
+                  x => this.originals.exists(_.canonicalized == x.canonicalized))
+              }
+            }
+          }
+        } else {
+          Set(filterExpr)
+        }
+      }
+    })
+  }
+
+  private def fillReplacementOrClearGroupHeadForRemovedAttributes(
+      attribsRemoved: AttributeSet,
+      replaceableAttributeMap: ExpressionMap[Attribute],
+      groupHeadToGroupMap: ExpressionMap[mutable.Buffer[Expression]]): Unit = {
+    attribsRemoved.foreach(attrib => {
+      groupHeadToGroupMap.get(attrib) match {
+        case Some(buff) =>
+          if (attrib.canonicalized == buff.head.canonicalized) {
+            buff.remove(0)
+          } else {
+            val errorMessage = s"GroupHead =${attrib.toString} not" +
+              s" matching with the buffer head = ${buff.head.toString}." +
+              s"Not removing the head from the buffer"
+            throwError(errorMessage)
+          }
+
+          // remove any attributes which may be in non zero position in buffer
+          attribsRemoved.foreach(
+            x => ConstraintSetHelper.removeCanonicalizedExpressionFromBuffer(buff, x))
+          // if there is no replacement and the attribute being removed
+          // was the only one present, then the buffer is purged
+          // else replaced by updated key
+          groupHeadToGroupMap.remove(attrib)
+          if (buff.nonEmpty) {
+            replaceableAttributeMap += attrib -> buff.head.asInstanceOf[Attribute]
+            groupHeadToGroupMap.put(buff.head.asInstanceOf[Attribute], buff)
+          }
+        case None => // there may be attributes which are removed but lying in
+          // position other than 0th
+          // which may be such that zeroth attrib is not present in the list of attrib being
+          // removed & hence escaped in above op. so we need to again filter the map
+          // at this point it is guaranteed that once the filtering has happened , there will
+          // be no buffer which can be empty
+
+          val errorKeys = mutable.ArrayBuffer[Expression]()
+          groupHeadToGroupMap.foreach {
+            case (key, buffer) => val initialHead = buffer.head
+              // The operation below should not touch the head of any buffer
+              ConstraintSetHelper.removeCanonicalizedExpressionFromBuffer(buffer, attrib)
+              // Buffer being empty or head being changed is an Error situation.
+              // This is Unexpected.
+              // The code below is just to handle unanticipated situation
+              if (buffer.isEmpty || initialHead != buffer.head) {
+                errorKeys += key
+                this.logWarning(
+                  s"for non GroupHead key attribute" +
+                    s" ${attrib.toString}, It still modified the 0th position of " +
+                    s"buffer with group head key $key. The initial head of buffer was" +
+                    s" ${initialHead.toString}")
+              }
+          }
+          if (errorKeys.nonEmpty) {
+            val errorMessage = s"for non GroupHead key attribute" +
+              s" ${attrib.toString}, found following modified group head keys." +
+              s" ${errorKeys.map(_.toString).mkString(",")}"
+            throwError(errorMessage)
+            errorKeys.foreach(key => {
+              val oldValOpt = groupHeadToGroupMap.remove(key)
+              oldValOpt.foreach(buff => if (buff.nonEmpty) {
+                groupHeadToGroupMap.put(buff.head, buff)
+              })
+            })
+          }
+      }
+    })
+  }
+
+  /**
+   * This is used by Union to merge the constraints from the two legs.
+   * The expression based equivalence lists cannot be merged so it will be dropped
+   *
+   * @param filters               - Merged constraints from the two legs
+   * @param attribEquivalenceList - Merged attrib based equivalence list from two legs
+   */
+  override def withNewConstraints(filters: ExpressionSet,
+    attribEquivalenceList: Seq[mutable.Buffer[Attribute]]): ConstraintSet = {
+    val newConstraintSet = new ConstraintSet(
+      mutable.Buffer[Expression](), attribEquivalenceList, Seq.empty[mutable.Buffer[Expression]])
+    ConstraintSet.addFiltersToConstraintSet(filters, newConstraintSet)
+    newConstraintSet
+  }
+
+
+  override def attributesRewrite(mapping: AttributeMap[Attribute]): ConstraintSet = {
+    val transformer: PartialFunction[Expression, Expression] = {
+      case a: Attribute => mapping(a)
+    }
+    val newOriginals = this.originals.map(x => x.transformUp(transformer))
+    val newAttribBasedEquiList = this.attribRefBasedEquivalenceList.map(
+      buff => buff.map(mapping))
+    val newExpBasedEquiList = this.expressionBasedEquivalenceList.map(
+      buff => buff.map(_.transformUp(transformer)))
+    val newConstraintSet = new ConstraintSet(
+      mutable.Buffer[Expression](), newAttribBasedEquiList, newExpBasedEquiList)
+    ConstraintSet.addFiltersToConstraintSet(newOriginals, newConstraintSet)
+    newConstraintSet
+  }
+
+  /**
+   * This function is used during pruning and also when any new condition is being
+   * added to the constraintset. The idea is that existing conditions in the constraintset
+   * are the bare minimum essential (non redundant) constraints. So any filter to be checked
+   * if it can be pruned or not can be checked using this function, if that filter is
+   * derivable using the constraints available. If it is derivable it means the filter is
+   * redundant and can be pruned. Also if any new constraint is being added to the
+   * constraintset that also can be checked if it is redundant or not. If redundant,
+   * it will not get added. This method converts the incoming expression into its
+   * constituents attributes before being checked.
+   * For. eg if the incoming expression is say z + c > 10, where z is an alias of base
+   * attributes a + b. And say constraintset already contains a condition
+   * a + b + c > 10. Then z + c > 10, is converted into a + b + c > 10 making use
+   * of tacking data of aliases, and it will be found in the constraintset &
+   * contains will return as true
+   *
+   * @param elem Expression to be checked if it is redundant or not.
+   * @return boolean true if it already exists in constraintset( is redundant)
+   */
+  override def contains(elem: Expression): Boolean = {
+    if (super.contains(elem)) {
+      true
+    } else {
+      // check canonicalized
+      // find all attribs ref in all base expressions
+      val baseAttribs = elem.references
+      val checkList = this.attribRefBasedEquivalenceList.map(
+        buff => buff.head -> buff.slice(1, buff.length)) ++
+        this.expressionBasedEquivalenceList.map(buff => buff.head -> buff.slice(1, buff.length))
+      // collect all the list of canonicalized attributes for these base attribs
+      val substitutables = AttributeMap(
+        baseAttribs.map(x => {
+          val seqContainingAttrib = checkList.filter {
+            case (_, buff) => buff.exists(_.canonicalized == x.canonicalized) }
+          if (!(seqContainingAttrib.isEmpty || seqContainingAttrib.size == 1)) {
+            val errorMessage = s"Attribute ${x.toString} found in more than 1 buffers"
+            throwError(errorMessage)
+          }
+          if (seqContainingAttrib.nonEmpty) {
+            x -> seqContainingAttrib.head._1
+          } else {
+            x -> null
+          }
+        }).filter { case (_, replacement) => replacement ne null }.toSeq)
+      if (substitutables.nonEmpty) {
+        val canonicalizedExp = elem.transformUp {
+          case att: Attribute => substitutables.getOrElse(att, att)
+        }
+        super.contains(canonicalizedExp)
+      } else {
+        false
+      }
+    }
+  }
+
+  /**
+   * This gives all the constraints whose references are subset of canonicalized
+   * attributes of interests
+   *
+   * @param expressionsOfInterest A sequence of expression for which constraints are desired &
+   *                              constraints should be such that its references are subset of
+   *                              the canonicalized version of attributes in the passed sequence
+   * @return Sequence of constraint expressions of compound types.
+   */
+  override def getConstraintsSubsetOfAttributes(expressionsOfInterest: Iterable[Expression]):
+    Seq[Expression] = {
+    val canonicalAttribsMapping =
+      ExpressionMap(expressionsOfInterest.map(
+        expr =>
+          (this.attribRefBasedEquivalenceList ++ this.expressionBasedEquivalenceList).
+            find(buff => buff.exists(_.canonicalized fastEquals expr.canonicalized)).map(
+            buff => buff.head -> expr).getOrElse(expr -> expr)))
+    val refsOfInterest = canonicalAttribsMapping.keySet.map(_.references).reduce(_ ++ _)
+    this.originals.collect {
+      case expr => val refs = expr.references
+        if (refs.subsetOf(refsOfInterest) && refs.nonEmpty && expr.deterministic) {
+          expr -> true
+        } else expr -> false
+    }.filter(_._2).toSeq.map(_._1.transformUp {
+      case x => canonicalAttribsMapping.getOrElse(x, x)
+    })
+  }
+
+  /**
+   * Consider a new filter generated out of constraints of the form
+   * IsNotNull(case....a....b...c) where the case expressions are
+   * complex. Since new filters generated out of constraints are always canonicalized
+   * it is possible that they are not compact as they are written in terms of
+   * basic attributes. If an alias to this complex expression is present, then it
+   * makes sense to rewrite the newly generated filter as IsNotNull(alias.attribute)
+   * to avoid expensive calculation, especially that we have large case optimization.
+   * This function simply tries to compact the expression where possible by replacing
+   * the expression with an alias's attribute.
+   *
+   * @param expr Expression to compact ( decanonicalize)
+   * @return Expression which is compacted, if possible
+   */
+  override def rewriteUsingAlias(expr: Expression): Expression =
+    if (this.expressionBasedEquivalenceList.isEmpty) {
+      expr
+    } else {
+      val canonicalized = convertToCanonicalizedIfRequired(expr)
+      canonicalized.transformDown {
+        case x: Attribute => x
+        case x => getDecanonicalizedAttributeForExpression(x)
+      }
+    }
+
+
+  /**
+   * Decanonicalizes the NullIntolerant Expression.
+   * The need for this arises, because when spark is attempting to generate
+   * new NotNull constraints from the existing constraint, it may not return
+   * any NotNull constraints, if the underlying subexpression is not of type
+   * NullIntolerant.
+   * Consider following two cases:
+   * Lets say the base  canonicalized constraint is of the form a + b > 5.
+   * A GreaterThan expression is NullIntolerant, so spark delves deep
+   * and finds, it is composed of a & b attributes, & thus returns two
+   * new IsNotNull constraints, namely IsNotNull(a) and IsNotNull(b).
+   * But if the base canonicalized constraint is of the form
+   * case(a....., b...) > 5, in this situation because case expression
+   * does not implement NullIntolerant, spark does not go deep & hence
+   * returns 0 not null constraints.
+   * This function handles this situation, by replacing an underlying
+   * canonicalized complex expression with an alias's attribute so
+   * that NotNull constraint can be generated.
+   * Thus case (a.....b) > 5 will be temporarily converted into z > 5.
+   * Once an IsNotNull(z) is returned as a new constraint, we store
+   * IsNotNull(z) in the Constraint set, again as canonicalized constraint,
+   * that is IsNotNull(case...a...b), which will ensure that pruning logic
+   * works fine.
+   *
+   * The logic to get a Filter expression with most NullIntolerant expressions
+   * works this way
+   * Our aim here was to get maxmimum number of null intolerant attributes. for that we were
+   * traversing bottoms up , so that we get maximum attributes ( which otherwise would not be
+   * possible from top normally).
+   * But realized the following
+   * Consider an expression A -> B -> C -> D -> E -> F
+   * suppose
+   * A is NullIntolerant
+   * B is Null Intolerant
+   * C is Not Null Intolerant
+   * D, E , F are say Expressions which have attribute and can be NullIntolerant
+   * Now the thing is that if we traverse from bottom to top, we are able to replace D , E F as
+   * NullIntolerant attribute.
+   * But because C is not Null Intolerant , so if we are unable to find replacement of C , then D
+   * E F even if they have corresponding attributes for replacement, they are useless.
+   *
+   * So if I traverse from top to bottom, the moment I find C , I do not want to traverse further
+   * down from C, unless I can find a replacement for C.
+   * So the ExpressionHider wraps C & ExpressionHider masquerades as Leaf expression , which
+   * prevents traversal down.
+   * Then we see that if ExpressionHider is present, then just canonicalize from C , and then
+   * decanonicalize only from point C, and replace the ExpressionHider with the new
+   * decanonicalized C.
+   * else just replace it with C, if nothing can be done.
+   *
+   * @return Set of constraint expressions where underlying NullIntolerant
+   *         Expressions have been decanonicalized.
+   */
+  override def getConstraintsWithDecanonicalizedNullIntolerant: ExpressionSet = {
+    if (this.expressionBasedEquivalenceList.isEmpty) {
+      this
+    } else {
+      ExpressionSet(this.originals.map(expr => expr match {
+        case _: NullIntolerant =>
+          var hasHidden = false
+          val temp = expr.transformDown {
+            case x: NullIntolerant => x
+            case x =>
+              // check for constants/literals etc, they may be under cast
+              val hasAttribDependency = x.references.nonEmpty
+              if (hasAttribDependency) {
+                hasHidden = true
+                ExpressionHider(x)
+              } else {
+                x
+              }
+          }
+          if (hasHidden) {
+            val modified = temp.transformUp {
+              case ExpressionHider(hiddenChild) =>
+                // hiddenChild is already canonicalzed
+                val y = getDecanonicalizedAttributeForExpression(hiddenChild)
+                if (y ne hiddenChild) {
+                  y
+                } else {
+                  ExpressionHider(hiddenChild)
+                }
+              case x => // check if any of the child is still hidden
+                val hiddenChildIndexes = x.children.map(
+                  _ match {
+                    case _: ExpressionHider => true
+                    case _ => false
+                  })
+                // if any of the child are hidden then only
+                // look for decanonicalization of current
+                if (hiddenChildIndexes.exists(b => b)) {
+                  val newChildren = x.children.zipWithIndex.map {
+                    case (child, i) => if (hiddenChildIndexes(i)) {
+                      child.asInstanceOf[ExpressionHider].hiddenChild
+                    } else {
+                      convertToCanonicalizedIfRequired(child)
+                    }
+                  }
+                  val fullCanonicalized = x.withNewChildren(newChildren)
+                  getDecanonicalizedAttributeForExpression(fullCanonicalized)
+                } else {
+                  x
+                }
+            }
+            modified
+          } else {
+            expr
+          }
+        case _ => expr
+      }))
+    }
+  }
+
+  override def getAttribEquivalenceList: Seq[mutable.Buffer[Attribute]] =
+    this.attribRefBasedEquivalenceList
+
+  private def getDecanonicalizedAttributeForExpression(canonicalizedExpr: Expression):
+    Expression = {
+    val bufferIndex = this.expressionBasedEquivalenceList.indexWhere(
+      buff => buff.head.references.equals(canonicalizedExpr.references) &&
+        buff.head.fastEquals(canonicalizedExpr))
+    if (bufferIndex != -1) {
+      val buff = this.expressionBasedEquivalenceList(bufferIndex)
+      // buffer size will always be >= 2
+      // due to the decanonicalization being used in withUnion code
+      // to handle multi ref constraints , with equivalent expr list being lost,
+      // the attribute for decanonicalization has to be the first encountered attribute,
+      // as that attribute will be transferred to the attribute equivalence list
+      // the buff size is guaranteed to be >= 2
+      // but just so as not cause unexpected production issue
+      if (buff.size < 2) {
+        canonicalizedExpr
+      } else {
+        buff(1)
+      }
+    } else {
+      canonicalizedExpr
+    }
+  }
+
+  private def throwError(errorMessage: String): Unit = {
+    // scalastyle:off throwerror
+    throw new AssertionError(errorMessage)
+    // scalastyle:on throwerror
+  }
+}
+
+object ConstraintSet extends ConstraintHelper {
+  private def addFiltersToConstraintSet(filters: Iterable[Expression],
+    constraintSet: ConstraintSet): Unit = {
+    filters.foreach(expr => {
+      val conditionedElement = constraintSet.convertToCanonicalizedIfRequired(expr)
+      constraintSet.add(conditionedElement)
+    })
+  }
+
+  /**
+   * Aim 1) To find common expressions across two legs of union
+   * 2) To find all expressions which are exactly having 1 ref & are
+   * not common , for each Leg
+   * Union = {
+   * Leg1
+   * select a, a as a1,a as a2,a as a3,a as a4,a as a5,a as a6,
+   * b, b as b1, b as b2, b as b3 from tab
+   *
+   * Leg2
+   * select a, a as a1, a2 ,a2 as a3, a4, a4 as a5, a6,
+   * b , b as b1, b2, b2 as b3 from tab2
+   *
+   * }
+   *
+   * Leg1 =>
+   * a----a1----a2----a3---a4---a5---a6
+   * b----b1-----b2----b3
+   * filter a > 10
+   *
+   * Leg2
+   * a---a1
+   * a2---a3
+   * a4---a5
+   * a6
+   * b----b1
+   * b2---b3
+   * filter a2 > 10
+   *
+   * Common groups. :  obtained by crossing all the lists
+   * we also keep track of the respective heads of attrib equiv list
+   * which were used to obtain these mappings. As the actual expressions would
+   * be composed only of these variables. so basically we are finding what are
+   * the common elements for given two attrib equiv list. i.e
+   * If Leg1_0th_attribute is that attribute in terms of which constraint
+   * expressions are canonicalized on leg1.
+   * and Leg2_0th_attribute is that attribute in terms of which constraint
+   * expressions are canonicalized on leg2
+   * then
+   * (Leg1 0th attribute, Leg2 0th attr) -> union output equivalence list.
+   * (a, a)   -> a---a1
+   * (a, a2)  -> a2---a3
+   * (a, a4)  ->  a4---a5
+   * (a, a6) -> a6
+   * (b, b) -> b---b1
+   * (b, b2) -> b2---b3
+   *
+   * Output of union = select a , a as a1, a2, a2 as a3, a2 as a4, a5, a5 as a6, a5 as a7 ,
+   * b , b as b1 , b2, b2 as b3
+   *
+   * We want to partition each Leg's attribute equiv list into parts such that
+   * each part will/can be part of Union output node's attribute equiv list
+   * Processing of Union Leg1
+   * Get all the references across all the constraints in Leg1.
+   * They can only be composed of  a, b
+   * Processing of Union Leg2
+   * Get all the references across all the constraints in Leg1.
+   * They can only be composed of  a, a2, a4, a6, b, b2
+   * Partition each Leg's attribute eqiv list so that it is broken down
+   * in terms of common output attribute equiv list and rest.
+   * Now Group constraints of each Leg based on structural similarity
+   * for eg a + b > 5  & a2 + b2 > 5 are structurally similar.
+   * To identify common constraints across two legs, One required condition
+   * is their structural similarity
+   * This is done by replacing all the attributes across each leg , in terms of
+   * dummy attribute's which represent each of the data type of attribute
+   * occurring in tree.
+   * This will result in some thing like
+   * Leg1                Leg2
+   * condition1              condition1'
+   * condition2     key1     condition2'
+   * condition3
+   *
+   * Leg1                    Leg2
+   * condition4              condition4'
+   * condition5     key2     condition5'
+   * any common condition can be only within each group
+   * Then we pick each condition in Leg1, collect sequential attribute list(i.e attributes
+   * collected in a  deterministic order from the expressions)
+   * Similarly we check with each of the condition in Leg2, collect sequential attribute list
+   * For 1 : 1 attribute Seq, we check the common group mapping.
+   * If there is an entry available for each pair of refs, we have a solution , given
+   * by the 0th element of the common list
+   *
+   * @param headConstraint      The ConstraintSet of the first Leg say Leg1
+   * @param otherConstraintNode The Logical Plan for the second(other) Union Leg, say Leg2
+   * @param reference           The output attributes of Union which are represented in terms of
+   *                            Leg1
+   * @return ConstraintSet for the union
+   */
+  def unionWith(headConstraint: ConstraintSet, otherConstraintNode: LogicalPlan,
+      reference: Seq[Attribute]): ConstraintSet = {
+    val otherConstraint = otherConstraintNode.constraints.asInstanceOf[ConstraintSet]
+    val nodeOutput = otherConstraintNode.output
+    require(nodeOutput.size == reference.size)
+    val attributeRewrites = AttributeMap[Attribute](nodeOutput.zip(reference))
+
+    // convert leg2 constraints in terms of Leg1 attributes
+    val preparedConstraint2 = prepareConstraintForUnion(otherConstraint, Some(attributeRewrites))
+    val preparedConstraint1 = prepareConstraintForUnion(headConstraint, None)
+    val leg1RefsOfInterest = preparedConstraint1.originals.map(_.references).
+      foldLeft(AttributeSet.empty)(_ ++ _)
+    val leg2RefsOfInterest = preparedConstraint2.originals.map(_.references).
+      foldLeft(AttributeSet.empty)(_ ++ _)
+    // augment the equivalence list by adding stand alone refs too, which are part
+    // of constraints, so that common attribs for each ref which is not part of
+    // output union equivalence are also correctly identified
+    val allRefsOfInterest = leg1RefsOfInterest ++ leg2RefsOfInterest
+    /*
+    Standalone attributes are those attributes for which there is no presence in attrib equiv
+    list. Pls note that attrib equiv list may contain those refs, too, for which there are no
+    constraints defined( in either of the legs) but we need those to be part of output attrib
+    equiv list.
+    However those attributes in a leg, for which there may be constraints such that constraint
+    is function of only that attribute and there are no aliases for that attribute, then that
+    attribute is a standalone attribute.
+    AND the other attribs for which there are no constraints present, and also DO NOT have any
+      aliases are also STAND ALONE attributes.
+    Theoretically I can add all those attributes to generate mappings. But they will bloat the Map.
+    So instead I only add those to Mapping which are StandAlone and have presence in constraints
+    of either Leg1 ore Leg2. that helps in reducing the bloat.
+
+    It would not be wrong to add only those Standalone attribs in Leg1, for which there are
+    constraints only on Leg1.
+
+    But for the future possibility of enhancing the Union constraint, it would be better to add
+    any refs encountered in either Leg1 or Leg2 constraint, and has no aliases, as stand alone
+    attribute.
+   */
+    val standAloneRefsOfLeg1 = allRefsOfInterest.toSeq.diff(
+      preparedConstraint1.attribRefBasedEquivalenceList.
+        foldLeft(Seq.empty[Attribute])(_ ++ _)).map(Seq(_))
+    val standAloneRefsOfLeg2 = allRefsOfInterest.toSeq.diff(
+      preparedConstraint2.attribRefBasedEquivalenceList.
+        foldLeft(Seq.empty[Attribute])(_ ++ _)).map(Seq(_))
+    // identify the  attribute equivalence lists for the Union node
+    // this has the alias relationships which is same across both the legs
+    val commonAttribListMapping = mergeEquivalenceList(
+      preparedConstraint1.attribRefBasedEquivalenceList.map(_.toSeq) ++ standAloneRefsOfLeg1,
+      preparedConstraint2.attribRefBasedEquivalenceList.map(_.toSeq) ++ standAloneRefsOfLeg2)
+
+    // group structurally similar constraints on each side
+    // for this create a new exprID which replaces all attributes
+    val templateAttributeGenerator = new TemplateAttributeGenerator()
+
+    val templatizedConstraintsMapLeg1 = templatizedConstraints(templateAttributeGenerator,
+      preparedConstraint1.originals.toSeq)
+    val templatizedConstraintsMapLeg2 = templatizedConstraints(templateAttributeGenerator,
+      preparedConstraint2.originals.toSeq)
+
+    val netCommonSols = generateCommonSolutions(
+      templatizedConstraintsMapLeg1,
+      templatizedConstraintsMapLeg2,
+      commonAttribListMapping.map {
+        case (attrs, attribBuff) => attrs -> attribBuff.toSeq
+      })
+    val commonAttribList = commonAttribListMapping.values
+
+    val decomposedAttribEquivListsOfLeg1 = calculateDecomposedAttribEquivLists(
+      leg1RefsOfInterest, preparedConstraint1.attribRefBasedEquivalenceList, commonAttribList)
+
+    val decomposedAttribEquivListsOfLeg2 = calculateDecomposedAttribEquivLists(
+      leg2RefsOfInterest, preparedConstraint2.attribRefBasedEquivalenceList, commonAttribList)
+
+    // generator for single refs expression in terms of solution space
+    val singleRefExprGenerator: (ConstraintSet, AttributeMap[Set[Attribute]]) => ExpressionSet =
+      (constraintSet, solutionSpace) => {
+      val singleRefs = constraintSet.originals.filter(_.references.size == 1)
+      ExpressionSet(singleRefs.flatMap(expr => {
+        val attr = expr.references.head
+        solutionSpace.get(attr).map(atts => atts.map(att => expr transformDown {
+          case _: Attribute => att
+        })).getOrElse(Seq(expr))
+      }))
+    }
+
+    val singleRefExprsLeg1 = singleRefExprGenerator(
+      preparedConstraint1, decomposedAttribEquivListsOfLeg1)
+
+    val singleRefExprsLeg2 = singleRefExprGenerator(
+      preparedConstraint2, decomposedAttribEquivListsOfLeg2)
+    val other1 = singleRefExprsLeg1.diff(netCommonSols).groupBy(_.references.head)
+    val other2 = singleRefExprsLeg2.diff(netCommonSols).groupBy(_.references.head)
+    // loose the constraints by: A1 && B1 || A2 && B2  ->  (A1 || A2) && (B1 || B2)
+    val others = (other1.keySet intersect other2.keySet).map {
+      attr => Or(other1(attr).reduceLeft(And), other2(attr).reduceLeft(And))
+    }
+
+    headConstraint.withNewConstraints(
+      netCommonSols ++ others, commonAttribList.filterNot(_.size < 2).toSeq)
+  }
+
+  /**
+   * Prepares the Constraint for the union. This involves creating a new constraint
+   * object which satisfies the below requirements.
+   * If attributeRewriteOpt is defined, then it rewrites the constraintset in terms of
+   * mappings provided. It also decanonicalizes multi ref constraints into decanonicalized
+   * attribute so as to reduce the number of references used in the filter.
+   * Transfers the attributes contained in the expression equivalence list to attribute
+   * equivalence list.
+   *
+   * @param constraintSet       Existing ConstraintSet
+   * @param attributeRewriteOpt The re-write attributes mapping
+   * @return ConstraintSet
+   */
+  private def prepareConstraintForUnion(constraintSet: ConstraintSet,
+    attributeRewriteOpt: Option[AttributeMap[Attribute]]): ConstraintSet = {
+    val rewriter = (expr: Expression, attributeRewrites: AttributeMap[Attribute]) =>
+      expr transformDown {
+        case attr: Attribute => attributeRewrites(attr)
+      }
+
+    // first find all original filters which are multi ref and see which can be decanonicalized
+    val (multiRefs, singleRefs) = constraintSet.originals.partition(_.references.size > 1)
+    val finalConstraints = if (multiRefs.nonEmpty) {
+      // convert any multi ref constraints to decanonicalized form
+      val modifiedMultiRefs = multiRefs.map(constraintSet.rewriteUsingAlias)
+      val newConditions = ExpressionSet(modifiedMultiRefs).
+        diff(ExpressionSet(multiRefs))
+      val anyNewNotNulls = newConditions.flatMap(inferIsNotNullConstraints(_))
+      singleRefs ++ anyNewNotNulls ++ modifiedMultiRefs
+    } else {
+      constraintSet.originals
+    }
+    // transfer the attributes of expression equiv list to attribute equivlist
+    val newAttribEquivList = constraintSet.attribRefBasedEquivalenceList ++
+      constraintSet.expressionBasedEquivalenceList.filter(_.size > 2).
+        map(_.clone().drop(1).map(_.asInstanceOf[Attribute]))
+    // convert leg2 constraints in terms of attributes names used in leg1
+    val (attribEquivList, constraintsList) = attributeRewriteOpt.map(rewriteMap => {
+      newAttribEquivList.map(buff => buff.map(rewriteMap)) ->
+        finalConstraints.map(rewriter(_, rewriteMap))
+    }).getOrElse((newAttribEquivList, finalConstraints))
+    new ConstraintSet(constraintsList, attribEquivList, Seq.empty)
+  }
+
+  /**
+   * This is used by Union to merge the attribute based equivalence lists of its two legs.
+   * An attribute equivalency can only be added to the Union's equivalency list if it is true
+   * on both sides of the Union. Before going into this function, it is assumed that the
+   * equivalency lists have been rewritten to use the Union's output attributes.
+   * The algorithm to determine this is as follows.
+   * Cross multiply all the attribute equivalence list and identify all the intersection
+   * possible across all the combinations
+   * The key of the Map represents the canonicalized attribute ref of Leg1 & leg2
+   * equivalence lists , from which the common set was derived.
+   * for eg if a --- a1-----a2-----a3-----a4  is leg 1 equiv list
+   * and       a3----a4    is leg2 attrib equivalence list , then common output list a3---a4
+   * is obtained from the (a, a3) where a is the original attrib equiv 0th element
+   * of leg1 attrib equiv list and a3 is the 0th element of Leg2 attrib equiv list.
+   * this essentially means that if a filter expression on leg1 involved a
+   * and filter expression on leg2 involved a3, then for the union output perspective
+   * the common solution will be a3--a4
+   *
+   * @param leg1EquivList one of attrib equivalence list to merge
+   * @param leg2EquivList the other attrib equivalence list to merge
+   * @return A Map containing the mappings of the attributes forming the expression
+   *         and the attributes which are aliases to the attributes in the mapping
+   */
+  private def mergeEquivalenceList(leg1EquivList: Seq[Seq[Attribute]],
+    leg2EquivList: Seq[Seq[Attribute]]): Map[(Attribute, Attribute), mutable.Buffer[Attribute]] = {
+    var newAttribRefBasedEquivalenceList =
+      Seq.empty[((Attribute, Attribute), mutable.Buffer[Attribute])]
+
+    leg1EquivList.foreach { equivalenceList =>
+      leg2EquivList.foreach { otherEquivalenceList =>
+        val _0thKeyLeg1 = equivalenceList.head.canonicalized.asInstanceOf[Attribute]
+        val commonAttribs = equivalenceList.map(_.canonicalized).intersect(
+          otherEquivalenceList.map(_.canonicalized)).map(
+          canonicalizedAttrib => equivalenceList.find(
+            _.exprId == canonicalizedAttrib.asInstanceOf[Attribute].exprId).get).toBuffer
+        if (commonAttribs.nonEmpty) {
+          val _0thKeyLeg2 = otherEquivalenceList.head.canonicalized.asInstanceOf[Attribute]
+          newAttribRefBasedEquivalenceList = ((_0thKeyLeg1, _0thKeyLeg2) -> commonAttribs) +:
+            newAttribRefBasedEquivalenceList
+        }
+      }
+    }
+    newAttribRefBasedEquivalenceList.toMap
+  }
+
+  /**
+   * templatize the constraint so that structurally similar constraints are grouped under
+   * the same templatized constraint key. This will help in reducing the space of constraints
+   * between two legs, in which we have to find the identical common constraints.
+   * So if there are 2 constraints in a leg
+   * a + b + c > 10     &&  d + e + f > 10 where (a & d) are int , (b & e) are double
+   * and (c & f) are int,
+   * they will be transformed to same templatized expression like
+   * x1 + Y1 + x2 > 10  where X are of types Int, Y are of types double
+   *
+   * The return type is an ExpressionMap where key is the templatized expression and
+   * value is a 2D Array of Attributes.
+   * Each Row of 2D array represents the actual constraint when combined with the templatized
+   * constraint  expression key in the ExpressionMap.
+   * The elements contained in the 1D Array  of each row are the attribute
+   * references present in the actual constraint expression.
+   * for eg, in the above case ,the key = x1 + Y1 + x2 > 10 , will have a 2D array of Attribute refs
+   * where Row 1 will have refs of expression1 & Row2 of expression2
+   * i.e the value would be
+   * a, b, c
+   * d, e, f
+   * Note: This function is made public for testing purposes.
+   *
+   * @param templateAttributeGenerator The instance of {{TemplateAttributeGenerator}} which
+   *                                   maintains the state so as to ensure that Attributes for
+   *                                   templatization are returned correctly and in order
+   * @param expressions                The Sequence of Constraints which are to be templatized
+   * @return an instance of ExpressionMap which stores key as the templatized constraint expression
+   *         and value a 2D array of attributes representing attributes found in each constraint
+   */
+  def templatizedConstraints(templateAttributeGenerator: TemplateAttributeGenerator,
+    expressions: Seq[Expression]): Map[Expression, Array[Array[Attribute]]] = {
+    val templatizedExprsToSolutionSpace = expressions.map(origExpr => {
+      templateAttributeGenerator.reset()
+      // contains the refs comprising each of the constraint as collected
+      // when transforming the constraint to the templatized form
+      val valueList = mutable.ArrayBuffer[Attribute]()
+      val templatized = origExpr.transformDown {
+        case attr: AttributeReference => valueList += attr
+          templateAttributeGenerator.getNext(attr.dataType)
+      }
+      templatized -> valueList.toArray
+    })
+    val groupedData = templatizedExprsToSolutionSpace.groupBy(_._1.canonicalized).map {
+      case (_, keyVals) => keyVals.head._1 -> keyVals.map(_._2).toArray
+    }
+    Map(groupedData.toSeq: _*)
+  }
+
+  /**
+   * Consider the following example
+   * For a given leg let the constraint be a > 5.
+   * so the attrib of interest is 'a'
+   * let the attrib equiv list be
+   * a , a1, a2, a3, a4 , a5 , a6, a7
+   *
+   * let the common output attrib equiv lists based on the leg2 data is such that
+   * a1--a2
+   * a5 -- a6
+   *
+   * so this function will break the attrib equiv list of leg1 into
+   * a, a1, a3, a4, a5, a7
+   * and return a AttributeMap which will look like
+   * a -> Set (a, a1, a3, a4, a5, a7)
+   *
+   * @param refsOfInterest                Atributes which are present in the constraint expressions
+   * @param attribRefBasedEquivalenceList the input attribute equiv list which needs
+   *                                      to be decomposed
+   * @param commonAttribList              The output attribute equivalence list
+   * @return AttributeMap containing a Set of Attributes which are created
+   *         after breaking the incoming attribute equivalence list into
+   *         parts which are present in common AttribList and rest as
+   *         stand alone element
+   */
+  private def calculateDecomposedAttribEquivLists(
+    refsOfInterest: AttributeSet,
+    attribRefBasedEquivalenceList: Seq[mutable .Buffer[Attribute]],
+    commonAttribList: Iterable[mutable.Buffer[Attribute]]): AttributeMap[Set[Attribute]] = {
+    val totalRefsOfInterest = AttributeSet(
+      refsOfInterest.toSeq ++ attribRefBasedEquivalenceList.map(_.head))
+    AttributeMap(totalRefsOfInterest.map(attr => {
+      val equivListOpt = attribRefBasedEquivalenceList.find(
+        _.head.canonicalized == attr.canonicalized)
+      val sol = equivListOpt.map(completeList => {
+        var currentList = completeList
+        val subspaces = (for (common <- commonAttribList) yield {
+          if (currentList.exists(_.canonicalized == common.head.canonicalized)) {
+            currentList = currentList.diff(common)
+            Seq(common.head)
+          } else {
+            Seq.empty
+          }
+        }).flatten
+        (subspaces ++ currentList).toSet
+      }).getOrElse(Set[Attribute](attr))
+      attr -> sol
+    }).toSeq)
+  }
+
+  /**
+   * For each common templatized expression key in the two maps,
+   * do a cross of two Array(Array(Attribute)) of each side
+   * i.e if 2dArr1 = {
+   * {a, b, c}
+   * {d, e, f}
+   * }
+   * if 2dArr2 = {
+   * {x, y, z}
+   * {p, q, r}
+   * }
+   * so we take each row of either side
+   * and zip it  such that we get pairs of say
+   * (a,x), (b,y) , (c,f)
+   * each pair is looked into the Map commonAttribListMapping
+   * If there exists an entry in the Map for each of the pair
+   * we have a valid solution which is created by taking the 0th
+   * element of the common attrib list.
+   * The templatized expression is then regenerated using the solution
+   *
+   * @param templatizedConstraintsMapLeg1 Map containing templatized expression key
+   *                                      & 2d array containg the actual expression
+   *                                      bindings
+   * @param templatizedConstraintsMapLeg2 Map containg templatized expression key
+   *                                      & 2d array containg the actual expression
+   *                                      bindings
+   * @param commonAttribListMapping       The mapping of individual attrib equivalence list's 0th
+   *                                      element
+   *                                      of either leg to the common solution
+   * @return ExpressionSet containing common filters for the union output
+   */
+  private def generateCommonSolutions(
+      templatizedConstraintsMapLeg1: Map[Expression, Array[Array[Attribute]]],
+      templatizedConstraintsMapLeg2: Map[Expression, Array[Array[Attribute]]],
+      commonAttribListMapping: Map[(Attribute, Attribute), Seq[Attribute]]): ExpressionSet = {
+    val results = (for ((templatizedExpr1, bindings1) <- templatizedConstraintsMapLeg1) yield {
+      // For each templatized constraint on leg1 check if there exists an equivalent
+      // templatized constraint on leg2. If there is , then we need to find common
+      // solution by checking the bindings of each side.
+      // The way we do is that we take a cross of the 2d Array, comparing each 1d Row Array
+      // of leg1, with every other 1dRowArray of leg2.
+      // Between two 1d Array for comparison, we take pair of attribute from each
+      // side of the 1d Array, paired using the index position, and see the Mappings
+      // if the pair exists as key in the map. If each pair has a valid mapping, then
+      // we have a solution and we use the valid solution for each attribute as replacement
+      // value in templatized constraint, to get the valid constraint
+      templatizedConstraintsMapLeg2.get(templatizedExpr1).map(bindings2 => {
+        (for (refs1 <- bindings1; refs2 <- bindings2) yield {
+          assert(refs1.length == refs2.length)
+          val zippedRefs = refs1.zip(refs2)
+          val solution = (for (pair <- zippedRefs) yield {
+            val (canonicalRef1, canonicalRef2) = (pair._1.canonicalized.asInstanceOf[Attribute],
+              pair._2.canonicalized.asInstanceOf[Attribute])
+            // check from common attrib list mapping if we have a common
+            // solution from the output equiv list, if yes then take its
+            // 0th element
+            commonAttribListMapping.get(canonicalRef1 -> canonicalRef2).
+              map(_.head)
+          }).toBuffer
+          if (solution.forall(_.isDefined)) {
+            Seq(
+              templatizedExpr1.transformDown {
+                case _: Attribute => solution.remove(0).get
+              })
+          } else {
+            Seq.empty[Expression]
+          }
+        }).flatten
+      }).getOrElse(Array.empty[Expression])
+    }).flatten
+    ExpressionSet(results)
+  }
+
+  /**
+   * generates the AttributeRefs for templatization
+   * The first time this runs, it runs by generating the templates for leg1 constraints.
+   * It works by mapping Datatypes to a list of attributes (all with name "none") and the size of
+   * this list of attributes will be equal to the maximum number of times an attribute of this
+   * given type is used in the constraints.
+   * So if there is a constraint => f(int, int, int, double, double) and
+   * g(int, int, double, double, double), then the
+   * int attribute list size = 3 and double attribute list size = 3.
+   * Also the first int of any expression following corresponds to first element in the int list,
+   * second int corresponds to second element in int list etc.
+   * The purpose of copying on reset is to make sure this correspondence of first int in a
+   * constraint to first element in the int attribute list.
+   * Clone on reset is to keep the original mapping intact and to templatize, keep
+   * removing from the cloned data. when the cloned data is exhausted ,
+   * the new ids are generated and added to the original mapping.
+   */
+  class TemplateAttributeGenerator {
+    private val mappingKeys: mutable.Map[DataType, mutable.ListBuffer[Attribute]] = mutable.Map()
+    private var cloneOnReset: Map[DataType, mutable.ListBuffer[Attribute]] = _
+
+    def getNext(dataType: DataType): Attribute =
+      cloneOnReset.get(dataType).map(buff => if (buff.nonEmpty) {
+        buff.remove(0)
+      } else {
+        val templatizedAttrNew = AttributeReference("none", dataType)()
+        val originalBuffer = mappingKeys(dataType)
+        originalBuffer += templatizedAttrNew
+        templatizedAttrNew
+      }).getOrElse {
+        val templatizedAttrNew = AttributeReference("none", dataType)()
+        val originalBuffer = mappingKeys.getOrElse(dataType, {
+          val newBuff = mutable.ListBuffer[Attribute]()
+          mappingKeys += dataType -> newBuff
+          newBuff
+        })
+        originalBuffer += templatizedAttrNew
+        templatizedAttrNew
+      }
+
+    def reset(): Unit = this.cloneOnReset = this.mappingKeys.map(kv => kv._1 -> kv._2.clone()).toMap
+  }
+}
+
+object ConstraintSetHelper {
+  def removeCanonicalizedExpressionFromBuffer(buff: mutable.Buffer[_ <: Expression],
+    expr: Expression): Unit = {
+    var keepGoing = true
+    while (keepGoing) {
+      val indx = buff.indexWhere(_.canonicalized fastEquals expr.canonicalized)
+      if (indx == -1) {
+        keepGoing = false
+      } else {
+        buff.remove(indx)
+      }
+    }
+  }
+}
+
+/**
+ * A helper class which is used to hide the child node so
+ * as to prevent tree traversal below this node in case of
+ * transformDown method. It is used to stop the traversal down
+ * further
+ *
+ * @param hiddenChild the expression which we want to hide and prevent
+ *                    from being traversed down further
+ */
+case class ExpressionHider(hiddenChild: Expression) extends LeafExpression {
+  override def nullable: Boolean = false
+  override def eval(input: InternalRow): Any =
+    throw new UnsupportedOperationException(" not implemented")
+
+  override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode =
+    throw new UnsupportedOperationException(" not implemented")
+
+  override def dataType: DataType = hiddenChild.dataType
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSet.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSet.scala
@@ -21,6 +21,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 object ExpressionSet {
+
   /**
    * Constructs a new [[ExpressionSet]] by applying [[Expression#canonicalized]] to `expressions`.
    */
@@ -63,102 +64,95 @@ object ExpressionSet {
  * invariant that:
  * 1. Every expr `e` in `baseSet` satisfies `e.deterministic && e.canonicalized == e`
  * 2. Every deterministic expr `e` in `originals` satisfies that `e.canonicalized` is already
- *    accessed.
+ * accessed.
  */
 class ExpressionSet protected(
-    private val baseSet: mutable.Set[Expression] = new mutable.HashSet,
-    private var originals: mutable.Buffer[Expression] = new ArrayBuffer)
-  extends scala.collection.Set[Expression]
-    with scala.collection.SetOps[Expression, scala.collection.Set, ExpressionSet] {
+    protected val baseSet: mutable.Set[Expression] = new mutable.HashSet(),
+    protected val originals: mutable.Buffer[Expression] = new ArrayBuffer)
+  extends Iterable[Expression] {
 
-  override protected def fromSpecific(coll: IterableOnce[Expression]): ExpressionSet = {
-    val set = new ExpressionSet()
-    coll.iterator.foreach(set.add)
-    set
-  }
-
-  override protected def newSpecificBuilder: mutable.Builder[Expression, ExpressionSet] =
-    new mutable.Builder[Expression, ExpressionSet] {
-      var expr_set: ExpressionSet = new ExpressionSet()
-      def clear(): Unit = expr_set = new ExpressionSet()
-      def result(): ExpressionSet = expr_set
-      def addOne(expr: Expression): this.type = {
-        expr_set.add(expr)
-        this
-      }
-    }
-
-  override def empty: ExpressionSet = new ExpressionSet()
-
-  override def diff(that: scala.collection.Set[Expression]): ExpressionSet = this -- that
-
-  protected def add(e: Expression): Unit = {
-    if (!e.deterministic) {
+  protected def add(e: Expression): Unit = if (!e.deterministic) {
       originals += e
-    } else if (!baseSet.contains(e.canonicalized)) {
+    } else if (!this.contains(e)) {
       baseSet.add(e.canonicalized)
       originals += e
     }
-  }
 
-  protected def remove(e: Expression): Unit = {
-    if (e.deterministic) {
-      baseSet.remove(e.canonicalized)
-      originals = originals.filter(!_.semanticEquals(e))
+  protected def remove(e: Expression): Unit = if (e.deterministic) {
+      baseSet --= baseSet.filter(_ == e.canonicalized)
+      originals --= originals.filter(_.canonicalized == e.canonicalized)
     }
-  }
 
-  override def contains(elem: Expression): Boolean = baseSet.contains(elem.canonicalized)
+  def contains(elem: Expression): Boolean = baseSet.contains(elem.canonicalized)
 
   override def filter(p: Expression => Boolean): ExpressionSet = {
     val newBaseSet = baseSet.filter(e => p(e))
-    val newOriginals = originals.filter(e => p(e.canonicalized))
-    new ExpressionSet(newBaseSet, newOriginals)
+    val newOriginals = originals.filter(e => p(e))
+    this.constructNew(newBaseSet, newOriginals)
   }
 
   override def filterNot(p: Expression => Boolean): ExpressionSet = {
     val newBaseSet = baseSet.filterNot(e => p(e))
-    val newOriginals = originals.filterNot(e => p(e.canonicalized))
+    val newOriginals = originals.filterNot(e => p(e))
+    this.constructNew(newBaseSet, newOriginals)
+  }
+
+  def constructNew(
+      newBaseSet: mutable.Set[Expression] = new mutable.HashSet,
+      newOriginals: mutable.Buffer[Expression] = new ArrayBuffer): ExpressionSet =
     new ExpressionSet(newBaseSet, newOriginals)
-  }
 
-  override def +(elem: Expression): ExpressionSet = {
+  def +(elem: Expression): ExpressionSet = {
     val newSet = clone()
-    newSet.add(elem)
+    newSet.add(this.convertToCanonicalizedIfRequired(elem))
     newSet
   }
 
-  override def -(elem: Expression): ExpressionSet = {
+  def ++(elems: Iterable[Expression]): ExpressionSet = {
     val newSet = clone()
-    newSet.remove(elem)
+    elems.foreach(ele => newSet.add(this.convertToCanonicalizedIfRequired(ele)))
     newSet
   }
 
-  override def concat(that: IterableOnce[Expression]): ExpressionSet = {
+  def -(elem: Expression): ExpressionSet = {
+    val newSet = clone()
+    newSet.remove(this.convertToCanonicalizedIfRequired(elem))
+    newSet
+  }
+
+  def --(elems: Iterable[Expression]): ExpressionSet = {
+    val newSet = clone()
+    elems.foreach(ele => newSet.remove(this.convertToCanonicalizedIfRequired(ele)))
+    newSet
+  }
+
+  def map(f: Expression => Expression): ExpressionSet = {
+    val newSet = this.constructNew()
+    this.iterator.foreach(elem => newSet.add(this.convertToCanonicalizedIfRequired(f(elem))))
+    newSet
+  }
+
+  def flatMap(f: Expression => Iterable[Expression]): ExpressionSet = {
+    val newSet = this.constructNew()
+    this.iterator.foreach(f(_).foreach(e => newSet.add(this.convertToCanonicalizedIfRequired(e))))
+    newSet
+  }
+
+  def union(that: ExpressionSet): ExpressionSet = {
     val newSet = clone()
     that.iterator.foreach(newSet.add)
     newSet
   }
 
-  override def --(that: IterableOnce[Expression]): ExpressionSet = {
-    val newSet = clone()
-    that.iterator.foreach(newSet.remove)
-    newSet
-  }
+  def subsetOf(that: ExpressionSet): Boolean = this.iterator.forall(that.contains)
 
-  def map(f: Expression => Expression): ExpressionSet = {
-    val newSet = new ExpressionSet()
-    this.iterator.foreach(elem => newSet.add(f(elem)))
-    newSet
-  }
+  def intersect(that: ExpressionSet): ExpressionSet = this.filter(that.contains)
 
-  def flatMap(f: Expression => Iterable[Expression]): ExpressionSet = {
-    val newSet = new ExpressionSet()
-    this.iterator.foreach(f(_).foreach(newSet.add))
-    newSet
-  }
+  def diff(that: ExpressionSet): ExpressionSet = this -- that
 
   override def iterator: Iterator[Expression] = originals.iterator
+
+  def apply(elem: Expression): Boolean = this.contains(elem)
 
   override def equals(obj: Any): Boolean = obj match {
     case other: ExpressionSet => this.baseSet == other.baseSet
@@ -168,6 +162,36 @@ class ExpressionSet protected(
   override def hashCode(): Int = baseSet.hashCode()
 
   override def clone(): ExpressionSet = new ExpressionSet(baseSet.clone(), originals.clone())
+
+  def convertToCanonicalizedIfRequired(ele: Expression): Expression = ele
+
+  def getConstraintsSubsetOfAttributes(expressionsOfInterest: Iterable[Expression]):
+  Seq[Expression] = Seq.empty
+
+  def updateConstraints(
+      outputAttribs: Seq[Attribute],
+      inputAttribs: Seq[Attribute], projectList: Seq[NamedExpression],
+      oldAliasedConstraintsCreator: Option[Seq[NamedExpression] => ExpressionSet]): ExpressionSet =
+    oldAliasedConstraintsCreator.map(aliasCreator => this.union(aliasCreator(projectList)))
+      .getOrElse(this)
+
+  def attributesRewrite(mapping: AttributeMap[Attribute]): ExpressionSet =
+    ExpressionSet(this.map(_ transform {
+      case a: Attribute => mapping(a)
+    }))
+
+  def withNewConstraints(
+      filters: ExpressionSet,
+      attribEquiv: Seq[mutable.Buffer[Attribute]]): ExpressionSet = ExpressionSet(filters)
+
+  def rewriteUsingAlias(expr: Expression): Expression = expr
+
+  def getConstraintsWithDecanonicalizedNullIntolerant: ExpressionSet = this
+
+  def getAttribEquivalenceList: Seq[mutable.Buffer[Attribute]] =
+    Seq.empty[mutable.Buffer[Attribute]]
+
+  def getCanonicalizedFilters: Set[Expression] = this.baseSet.toSet
 
   /**
    * Returns a string containing both the post [[Expression#canonicalized]] expressions
@@ -179,4 +203,3 @@ class ExpressionSet protected(
        |originals: ${originals.mkString(", ")}
      """.stripMargin
 }
-

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -994,7 +994,8 @@ abstract class BinaryComparison extends BinaryOperator with Predicate {
 
   final override val nodePatterns: Seq[TreePattern] = Seq(BINARY_COMPARISON)
 
-  override lazy val canonicalized: Expression = {
+
+  override lazy val canonicalized: Expression =
     withNewChildren(children.map(_.canonicalized)) match {
       case EqualTo(l, r) if l.hashCode() > r.hashCode() => EqualTo(r, l)
       case EqualNullSafe(l, r) if l.hashCode() > r.hashCode() => EqualNullSafe(r, l)
@@ -1007,7 +1008,7 @@ abstract class BinaryComparison extends BinaryOperator with Predicate {
 
       case other => other
     }
-  }
+
 
   override def checkInputDataTypes(): TypeCheckResult = super.checkInputDataTypes() match {
     case TypeCheckResult.TypeCheckSuccess =>
@@ -1028,6 +1029,8 @@ abstract class BinaryComparison extends BinaryOperator with Predicate {
   }
 
   protected lazy val ordering: Ordering[Any] = TypeUtils.getInterpretedOrdering(left.dataType)
+
+  def reverseOperands(): BinaryComparison
 }
 
 
@@ -1088,6 +1091,8 @@ case class EqualTo(left: Expression, right: Expression)
 
   override protected def withNewChildrenInternal(
     newLeft: Expression, newRight: Expression): EqualTo = copy(left = newLeft, right = newRight)
+
+  def reverseOperands(): BinaryComparison = this
 }
 
 // TODO: although map type is not orderable, technically map type should be able to be used
@@ -1153,6 +1158,8 @@ case class EqualNullSafe(left: Expression, right: Expression) extends BinaryComp
   override protected def withNewChildrenInternal(
       newLeft: Expression, newRight: Expression): EqualNullSafe =
     copy(left = newLeft, right = newRight)
+
+  def reverseOperands(): BinaryComparison = this
 }
 
 @ExpressionDescription(
@@ -1226,6 +1233,8 @@ case class LessThan(left: Expression, right: Expression)
 
   override protected def withNewChildrenInternal(
     newLeft: Expression, newRight: Expression): Expression = copy(left = newLeft, right = newRight)
+
+  def reverseOperands(): BinaryComparison = GreaterThan(right, left)
 }
 
 @ExpressionDescription(
@@ -1261,6 +1270,8 @@ case class LessThanOrEqual(left: Expression, right: Expression)
 
   override protected def withNewChildrenInternal(
     newLeft: Expression, newRight: Expression): Expression = copy(left = newLeft, right = newRight)
+
+  def reverseOperands(): BinaryComparison = GreaterThanOrEqual(right, left)
 }
 
 @ExpressionDescription(
@@ -1297,6 +1308,8 @@ case class GreaterThan(left: Expression, right: Expression)
 
   override protected def withNewChildrenInternal(
     newLeft: Expression, newRight: Expression): Expression = copy(left = newLeft, right = newRight)
+
+  def reverseOperands(): BinaryComparison = LessThan(right, left)
 }
 
 @ExpressionDescription(
@@ -1334,6 +1347,8 @@ case class GreaterThanOrEqual(left: Expression, right: Expression)
   override protected def withNewChildrenInternal(
       newLeft: Expression, newRight: Expression): GreaterThanOrEqual =
     copy(left = newLeft, right = newRight)
+
+  def reverseOperands(): BinaryComparison = LessThanOrEqual(right, left)
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1425,7 +1425,7 @@ object TransposeWindow extends Rule[LogicalPlan] {
 object InferFiltersFromGenerate extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformUpWithPruning(
     _.containsPattern(GENERATE)) {
-    case generate @ Generate(g, _, false, _, _, _) if canInferFilters(g) =>
+    case generate @ Generate(g, _, false, _, _, child) if canInferFilters(g) =>
       assert(g.children.length == 1)
       val input = g.children.head
       // Generating extra predicates here has overheads/risks:
@@ -1439,10 +1439,12 @@ object InferFiltersFromGenerate extends Rule[LogicalPlan] {
       // idempotence will break.
       if (input.isInstanceOf[Attribute]) {
         // Exclude child's constraints to guarantee idempotency
-        val inferredFilters = ExpressionSet(
+        // create a new constraintset so that attrib ref list etc is copied
+        // else -- will not be able to canonicalize the expression
+        // causing idempotency to be broken
+        val possibleNewFilters = child.constraints.constructNew() ++
           Seq(GreaterThan(Size(input), Literal(0)), IsNotNull(input))
-        ) -- generate.child.constraints
-
+        val inferredFilters = possibleNewFilters -- child.constraints
         if (inferredFilters.nonEmpty) {
           generate.copy(child = Filter(inferredFilters.reduce(And), generate.child))
         } else {
@@ -1484,9 +1486,15 @@ object InferFiltersFromConstraints extends Rule[LogicalPlan]
     _.containsAnyPattern(FILTER, JOIN)) {
     case filter @ Filter(condition, child) =>
       val newFilters = filter.constraints --
-        (child.constraints ++ splitConjunctivePredicates(condition))
-      if (newFilters.nonEmpty) {
-        Filter(And(newFilters.reduce(And), condition), child)
+        (child.constraints ++ splitConjunctivePredicates(condition).map(
+          filter.constraints.convertToCanonicalizedIfRequired).toSet)
+      // do not directly use map on newFilters because the map function in ExpressionSet
+      // will reccanionicalize the expression
+      val decanonicalzedNewFilters = newFilters.iterator.map(
+        filter.constraints.rewriteUsingAlias(_))
+
+      if (decanonicalzedNewFilters.nonEmpty) {
+        Filter(And(decanonicalzedNewFilters.reduce(And), condition), child)
       } else {
         filter
       }
@@ -1494,43 +1502,30 @@ object InferFiltersFromConstraints extends Rule[LogicalPlan]
     case join @ Join(left, right, joinType, conditionOpt, _) =>
       joinType match {
         // For inner join, we can infer additional filters for both sides. LeftSemi is kind of an
-        // inner join, it just drops the right side in the final output.
+        // inner join, it just dr   ops the right side in the final output.
         case _: InnerLike | LeftSemi =>
-          val allConstraints = getAllConstraints(left, right, conditionOpt)
-          val newLeft = inferNewFilter(left, allConstraints)
-          val newRight = inferNewFilter(right, allConstraints)
+          val newLeft = inferAdditionalNewFilter(left, right.constraints, conditionOpt)
+          val newRight = inferAdditionalNewFilter(right, newLeft.constraints, conditionOpt)
+
           join.copy(left = newLeft, right = newRight)
 
         // For right outer join, we can only infer additional filters for left side.
         case RightOuter =>
-          val allConstraints = getAllConstraints(left, right, conditionOpt)
-          val newLeft = inferNewFilter(left, allConstraints)
+          val newLeft = inferAdditionalNewFilter(left, right.constraints, conditionOpt)
           join.copy(left = newLeft)
 
         // For left join, we can only infer additional filters for right side.
         case LeftOuter | LeftAnti =>
-          val allConstraints = getAllConstraints(left, right, conditionOpt)
-          val newRight = inferNewFilter(right, allConstraints)
+          val newRight = inferAdditionalNewFilter(right, left.constraints, conditionOpt)
           join.copy(right = newRight)
-
         case _ => join
       }
   }
 
-  private def getAllConstraints(
-      left: LogicalPlan,
-      right: LogicalPlan,
-      conditionOpt: Option[Expression]): ExpressionSet = {
-    val baseConstraints = left.constraints.union(right.constraints)
-      .union(ExpressionSet(conditionOpt.map(splitConjunctivePredicates).getOrElse(Nil)))
-    baseConstraints.union(inferAdditionalConstraints(baseConstraints))
-  }
-
   private def inferNewFilter(plan: LogicalPlan, constraints: ExpressionSet): LogicalPlan = {
-    val newPredicates = constraints
-      .union(constructIsNotNullConstraints(constraints, plan.output))
-      .filter { c =>
-        c.references.nonEmpty && c.references.subsetOf(plan.outputSet) && c.deterministic
+    val newPredicates = constraints.union(constructIsNotNullConstraints(constraints, plan.output))
+      .filter {
+        c => c.references.nonEmpty && c.references.subsetOf(plan.outputSet) && c.deterministic
       } -- plan.constraints
     if (newPredicates.isEmpty) {
       plan
@@ -1538,6 +1533,162 @@ object InferFiltersFromConstraints extends Rule[LogicalPlan]
       Filter(newPredicates.reduce(And), plan)
     }
   }
+
+  /**
+   * This function is similar to [[inferNewFilter()]] but it is used to create
+   * new filter of compound predicates for push down on the joining table.
+   * The issue is that when stock spark generates all the combination of
+   * constraints, (i.e with aliases as well as replacing the attribute of say
+   * LHS table with the joining RHS table's join condition), it replaces only one
+   * attribute in a constraint. As a result the constraints of the form of compound
+   * types ( i.e containing more than 1 attributes)are not created for push down.
+   * To elaborate:
+   * if LHS table is ( a, b, c) with projection (a1, a2, b, c) and RHS (x, y, z)
+   * with join condition a1 = x and b = y
+   * and say a constraint of the form a + b > 10 is present on LHS
+   * now stock spark will generate following constraints in expanded form
+   * a + b > 10, a1 +b > 10, a2 + b > 10
+   * since a1 = x , it will also generate
+   * x + b > 10
+   * and since b = y , it will generate
+   * a + y > 10, a1 + y > 10, a2 + y > 10
+   * so the problem is that since it is replacing one join variable at a time,
+   * a compound constraint never gets created. (i.e x + y > 10).
+   * The below code explicitly asks the [[ConstraintSet.getConstraintsSubsetOfAttributes]]
+   * to return the substituted compound constraints if available, for push down.
+   * For stock spark the function is sort of no-op
+   * This function now completely replaces the stock spark's inferNewFilter
+   * for Join cases.
+   * The source of new filters can be grouped in 3 categories
+   * 1) New filters inferred from the conditions present in the join clause
+   * 2) New Filters inferred from the constraints of the other side of
+   * the join node
+   * 3) Not Null filters formed from #1 and #2
+   * case 1 : consider a join condition of type
+   * a == x and b == y and c == z and d == a and d > 13
+   * In the above case d and a are attributes of the same table.
+   * since d == a and a == x and since d > 13, it means x > 13
+   * to get this new filer of type x > 13. the way it it is achieved is
+   * 1) First using the base equalTo constraints, generate extra equalTo
+   * constraints which means using a == x, b == y,  c == z and d == a,
+   * the [[inferAdditionalConstraints]], will yield a new equality
+   * constraint d == x
+   * 2) Using total equality constraints a == x, b == y,  c == z
+   * and d == a and d ==x [[inferAdditionalConstraints]] , will then be able
+   * to generate  x > 13
+   * 3) Then using total equality constraints, use the otherSide's
+   * constraint to get new filters of single & compound type
+   * (including isnotnull)
+   * 4) Remove the trivial constraints which may come out of above,
+   * that is of the form P == P, but these need to be used to generate
+   * isNotNull constraints.
+   * 5) Using all the constraints available from above #4,
+   * generate any IsNotNull constraints.
+   * 6) For NotNull constraints, if the expression is not of
+   * type attribute, decanonicalize if possible.
+   * 7) All these constraints are checked and pruned if they are
+   * already contained in the thisSide constraint.
+   *
+   * @param plan                Logical Plan on which pushdown filters are needed
+   * @param otherSideConstraint the constraints present on the other side of the join
+   * @param conditionOpt        the conditions in the join clause
+   * @return
+   */
+  private def inferAdditionalNewFilter(plan: LogicalPlan, otherSideConstraint: ExpressionSet,
+                                       conditionOpt: Option[Expression]): LogicalPlan = {
+    conditionOpt.map(condition => {
+      val predicates = splitConjunctivePredicates(condition)
+      val baseEqualityConstraints = predicates.filter(_.isInstanceOf[EqualTo])
+      val extraEqualityConstraints = inferAdditionalConstraints(
+        ExpressionSet(baseEqualityConstraints))
+      val totalEqualityConstraints = baseEqualityConstraints ++ extraEqualityConstraints
+      val extraOtherConstraints = inferAdditionalConstraints(
+        ExpressionSet(totalEqualityConstraints ++ predicates))
+
+      val allEqualityMappings = totalEqualityConstraints.map { case EqualTo(l, r) => (l, r) }
+      val planOutput = plan.outputSet
+      val validConstraintsFilter = (constraints: Iterable[Expression]) => constraints.filter(
+        x => x.references.nonEmpty &&  x.references.subsetOf(planOutput) &&
+               !plan.constraints.contains(x))
+      val isAttributeContainedInAttributeSet = (expr: Expression, superSet: AttributeSet) =>
+        expr.references.subsetOf(superSet)
+
+      val exprsOfOtherSide = allEqualityMappings.flatMap {
+        case (l, r) => if (!isAttributeContainedInAttributeSet(l, planOutput)) {
+          if (!isAttributeContainedInAttributeSet(r, planOutput)) {
+            Seq(l, r)
+          } else {
+            Seq(l)
+          }
+        } else if (!isAttributeContainedInAttributeSet(r, planOutput)) {
+          Seq(r)
+        } else {
+          Seq.empty[Expression]
+        }
+      }.toSet
+      val mappingsForThisSide = allEqualityMappings.filter {
+        case (lhsExpr, rhsExpr) => isAttributeContainedInAttributeSet(lhsExpr, planOutput) ||
+          isAttributeContainedInAttributeSet(rhsExpr, planOutput)
+      }
+      val totalNewFilters = if (exprsOfOtherSide.nonEmpty) {
+        val inferredFromOtherConstraint = inferNewConstraintsForThisSideFromOtherSideConstraints(
+          otherSideConstraint, exprsOfOtherSide, mappingsForThisSide)
+        // To generate non trivial constraints which are not of type isNotNull,
+        // the trivial constraints need to be removed. But for generating notnull
+        // constraints , even trivial constraints are needed. for eg
+        // if we have x = x as a condition, then the constraint is trivial,
+        // but it will still generate IsNotNull(x) constraint.
+        // this will be used to generate not null constraints
+        val (trivialConstraints, constraintsPart1) = inferredFromOtherConstraint.partition {
+           case EqualNullSafe(x, y) => x.canonicalized == y.canonicalized
+           case EqualTo(x, y) => x.canonicalized == y.canonicalized
+           case _ => false
+        }
+        val constraintsOfInterest = validConstraintsFilter(ExpressionSet(
+          extraOtherConstraints ++ predicates ++ constraintsPart1 ++ extraEqualityConstraints))
+          .flatMap{
+          case x @ IsNotNull(_: Attribute) => Seq(x)
+          case IsNotNull(exp: Expression) => validConstraintsFilter(inferIsNotNullConstraints(
+            plan.constraints.rewriteUsingAlias(exp)))
+          case x => Seq(x)
+        }
+        val newNotNulls = validConstraintsFilter(constructIsNotNullConstraints(
+          ExpressionSet( constraintsOfInterest ++ predicates ++ extraEqualityConstraints ++
+            extraOtherConstraints ++ trivialConstraints), plan.output))
+        constraintsOfInterest ++ newNotNulls
+      } else {
+        val constraintsOfInterest = validConstraintsFilter(
+          ExpressionSet(extraOtherConstraints ++ predicates ++ extraEqualityConstraints))
+        constraintsOfInterest ++ validConstraintsFilter(
+          constructIsNotNullConstraints(
+            ExpressionSet(constraintsOfInterest ++ predicates ++ extraEqualityConstraints ++
+                            extraOtherConstraints), plan.output))
+      }
+
+      if (totalNewFilters.isEmpty) {
+        plan
+      } else {
+        Filter(totalNewFilters.reduce(And), plan)
+      }
+    }).getOrElse(plan)
+  }
+
+  private def inferNewConstraintsForThisSideFromOtherSideConstraints(
+      otherSideConstraint: ExpressionSet,
+      exprsOfOtherSide: Set[Expression],
+      mappingsForThisSide: Seq[(Expression, Expression)]): Seq[Expression] =
+    otherSideConstraint.getConstraintsSubsetOfAttributes(exprsOfOtherSide).map(_.transformUp {
+      case _expr: Expression => mappingsForThisSide.find {
+        case (lhsExpr, rhsExpr) => lhsExpr.canonicalized == _expr.canonicalized ||
+          rhsExpr.canonicalized == _expr.canonicalized
+        }.map {
+          case (lhsExpr, rhsExpr) => if (lhsExpr.canonicalized == _expr.canonicalized) {
+            rhsExpr
+          } else {
+            lhsExpr
+          }
+        }.getOrElse(_expr)
+    })
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -180,7 +180,8 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
   }
 
   private def buildNewJoinType(filter: Filter, join: Join): JoinType = {
-    val conditions = splitConjunctivePredicates(filter.condition) ++ filter.constraints
+    val conditions = splitConjunctivePredicates(filter.condition).
+      map(filter.constraints.convertToCanonicalizedIfRequired) ++ filter.constraints
     val leftConditions = conditions.filter(_.references.subsetOf(join.left.outputSet))
     val rightConditions = conditions.filter(_.references.subsetOf(join.right.outputSet))
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/NormalizePlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/NormalizePlan.scala
@@ -74,7 +74,7 @@ object NormalizePlan extends PredicateHelper {
       case Filter(condition: Expression, child: LogicalPlan) =>
         Filter(
           splitConjunctivePredicates(condition)
-            .map(rewriteBinaryComparison)
+            .map(rewriteEqualAndComparisons)
             .sortBy(_.hashCode())
             .reduce(And),
           child
@@ -91,7 +91,7 @@ object NormalizePlan extends PredicateHelper {
 
         val newCondition =
           splitConjunctivePredicates(condition.get)
-            .map(rewriteBinaryComparison)
+            .map(rewriteEqualAndComparisons)
             .sortBy(_.hashCode())
             .reduce(And)
         Join(left, right, newJoinType, Some(newCondition), hint)
@@ -115,13 +115,14 @@ object NormalizePlan extends PredicateHelper {
    * 2. (a <=> b), (b <=> a).
    * 3. (a > b), (b < a)
    */
-  private def rewriteBinaryComparison(condition: Expression): Expression = condition match {
+  private def rewriteEqualAndComparisons(condition: Expression): Expression = condition match {
     case EqualTo(l, r) => Seq(l, r).sortBy(_.hashCode()).reduce(EqualTo)
     case EqualNullSafe(l, r) => Seq(l, r).sortBy(_.hashCode()).reduce(EqualNullSafe)
     case GreaterThan(l, r) if l.hashCode() > r.hashCode() => LessThan(r, l)
     case LessThan(l, r) if l.hashCode() > r.hashCode() => GreaterThan(r, l)
     case GreaterThanOrEqual(l, r) if l.hashCode() > r.hashCode() => LessThanOrEqual(r, l)
     case LessThanOrEqual(l, r) if l.hashCode() > r.hashCode() => GreaterThanOrEqual(r, l)
+    case br @ BinaryComparison(lhs: Literal, rhs: Expression) => br.reverseOperands()
     case _ => condition // Don't reorder.
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -283,7 +283,12 @@ trait UnaryNode extends LogicalPlan with UnaryLike[LogicalPlan] {
     allConstraints
   }
 
-  override protected lazy val validConstraints: ExpressionSet = child.constraints
+  override lazy val validConstraints: ExpressionSet = if (!this.inputSet.subsetOf(this.outputSet)) {
+    child.constraints.updateConstraints(
+      this.output, child.output, Seq.empty[NamedExpression], None)
+    } else {
+      child.constraints
+    }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -21,7 +21,6 @@ import scala.annotation.tailrec
 
 import org.apache.spark.sql.catalyst.expressions._
 
-
 trait QueryPlanConstraints extends ConstraintHelper { self: LogicalPlan =>
 
   /**
@@ -29,18 +28,16 @@ trait QueryPlanConstraints extends ConstraintHelper { self: LogicalPlan =>
    * example, if this set contains the expression `a = 2` then that expression is guaranteed to
    * evaluate to `true` for all rows produced.
    */
-  lazy val constraints: ExpressionSet = {
-    if (conf.constraintPropagationEnabled) {
-      validConstraints
-        .union(inferAdditionalConstraints(validConstraints))
-        .union(constructIsNotNullConstraints(validConstraints, output))
-        .filter { c =>
-          c.references.nonEmpty && c.references.subsetOf(outputSet) && c.deterministic
-        }
+  lazy val constraints: ExpressionSet = if (conf.constraintPropagationEnabled) {
+    val newConstraints = validConstraints.union(
+      inferAdditionalConstraints(validConstraints)).union(constructIsNotNullConstraints(
+        validConstraints.getConstraintsWithDecanonicalizedNullIntolerant, output))
+      // Removed the criteria  c.references.nonEmpty as it was causing a constraint of the
+      // of the form literal true or false being eliminated, causing idempotency check failure
+      newConstraints.filter(c => c.references.subsetOf(outputSet) && c.deterministic)
     } else {
-      ExpressionSet()
+      ExpressionSet(Set.empty)
     }
-  }
 
   /**
    * This method can be overridden by any child class of QueryPlan to specify a set of constraints
@@ -50,7 +47,12 @@ trait QueryPlanConstraints extends ConstraintHelper { self: LogicalPlan =>
    *
    * See [[Expression#canonicalized]] for more details.
    */
-  protected lazy val validConstraints: ExpressionSet = ExpressionSet()
+  protected lazy val validConstraints: ExpressionSet = if (conf.constraintPropagationEnabled) {
+    new ConstraintSet()
+  } else ExpressionSet(Set.empty[Expression])
+
+  // For testing purposes
+  def getValidConstraints: ExpressionSet = validConstraints
 }
 
 trait ConstraintHelper {
@@ -68,13 +70,16 @@ trait ConstraintHelper {
       case eq @ EqualTo(l: Attribute, r: Attribute) =>
         // Also remove EqualNullSafe with the same l and r to avoid Once strategy's idempotence
         // is broken. l = r and l <=> r can infer l <=> l and r <=> r which is useless.
-        val candidateConstraints = predicates - eq - EqualNullSafe(l, r)
+        val candidateConstraints = predicates - eq
         inferredConstraints ++= replaceConstraints(candidateConstraints, l, r)
         inferredConstraints ++= replaceConstraints(candidateConstraints, r, l)
+
       case eq @ EqualTo(l @ Cast(_: Attribute, _, _, _), r: Attribute) =>
-        inferredConstraints ++= replaceConstraints(predicates - eq - EqualNullSafe(l, r), r, l)
+        inferredConstraints ++= replaceConstraints(predicates - eq, r, l)
+
       case eq @ EqualTo(l: Attribute, r @ Cast(_: Attribute, _, _, _)) =>
-        inferredConstraints ++= replaceConstraints(predicates - eq - EqualNullSafe(l, r), l, r)
+        inferredConstraints ++= replaceConstraints(predicates - eq, l, r)
+
       case _ => // No inference
     }
     inferredConstraints -- constraints
@@ -110,7 +115,7 @@ trait ConstraintHelper {
    * Infer the Attribute-specific IsNotNull constraints from the null intolerant child expressions
    * of constraints.
    */
-  private def inferIsNotNullConstraints(constraint: Expression): Seq[Expression] =
+  def inferIsNotNullConstraints(constraint: Expression): Seq[Expression] =
     constraint match {
       // When the root is IsNotNull, we can push IsNotNull through the child null intolerant
       // expressions

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -89,8 +89,9 @@ case class Project(projectList: Seq[NamedExpression], child: LogicalPlan)
     expressions.forall(_.resolved) && childrenResolved && !hasSpecialExpressions
   }
 
-  override lazy val validConstraints: ExpressionSet =
-    getAllValidConstraints(projectList)
+
+  override lazy val validConstraints: ExpressionSet = child.constraints.updateConstraints(
+    this.output, child.output, this.projectList, Option(getAllValidConstraints))
 
   override def metadataOutput: Seq[Attribute] =
     getTagValue(Project.hiddenOutputTag).getOrElse(child.metadataOutput)
@@ -331,10 +332,21 @@ case class Filter(condition: Expression, child: LogicalPlan)
 
   final override val nodePatterns: Seq[TreePattern] = Seq(FILTER)
 
-  override protected lazy val validConstraints: ExpressionSet = {
+  override lazy val validConstraints: ExpressionSet = {
     val predicates = splitConjunctivePredicates(condition)
-      .filterNot(SubqueryExpression.hasCorrelatedSubquery)
-    child.constraints.union(ExpressionSet(predicates))
+          .filterNot(SubqueryExpression.hasCorrelatedSubquery)
+    // remove useless nullsafe filter if any for EqualTo predicates which are present
+    val nullSafePredsToRemove = predicates.flatMap[Expression] {
+        case EqualTo(l: Attribute, r: Attribute) => Seq(EqualNullSafe(l, r))
+
+        case EqualTo(l@Cast(_: Attribute, _, _, _), r: Attribute) => Seq(EqualNullSafe(l, r))
+
+        case EqualTo(l: Attribute, r@Cast(_: Attribute, _, _, _)) => Seq(EqualNullSafe(l, r))
+
+        case _ => Seq.empty
+      }.toSet
+    val netPreds = predicates.filterNot(nullSafePredsToRemove.contains)
+    child.constraints.union(ExpressionSet(netPreds))
   }
 
   override protected def withNewChildInternal(newChild: LogicalPlan): Filter =
@@ -350,9 +362,7 @@ abstract class SetOperation(left: LogicalPlan, right: LogicalPlan) extends Binar
   protected def rightConstraints: ExpressionSet = {
     require(left.output.size == right.output.size)
     val attributeRewrites = AttributeMap(right.output.zip(left.output))
-    right.constraints.map(_ transform {
-      case a: Attribute => attributeRewrites(a)
-    })
+    right.constraints.attributesRewrite(attributeRewrites)
   }
 
   override lazy val resolved: Boolean =
@@ -383,7 +393,7 @@ case class Intersect(
 
   override def metadataOutput: Seq[Attribute] = Nil
 
-  override protected lazy val validConstraints: ExpressionSet =
+  override lazy val validConstraints: ExpressionSet =
     leftConstraints.union(rightConstraints)
 
   override def maxRows: Option[Long] = {
@@ -410,7 +420,7 @@ case class Except(
 
   final override val nodePatterns : Seq[TreePattern] = Seq(EXCEPT)
 
-  override protected lazy val validConstraints: ExpressionSet = leftConstraints
+  override lazy val validConstraints: ExpressionSet = leftConstraints
 
   override def maxRows: Option[Long] = left.maxRows
 
@@ -515,14 +525,12 @@ case class Union(
    * mapping between the original and reference sequences are symmetric.
    */
   private def rewriteConstraints(
-      reference: Seq[Attribute],
-      original: Seq[Attribute],
-      constraints: ExpressionSet): ExpressionSet = {
+    reference: Seq[Attribute],
+    original: Seq[Attribute],
+    constraints: ExpressionSet): ExpressionSet = {
     require(reference.size == original.size)
     val attributeRewrites = AttributeMap(original.zip(reference))
-    constraints.map(_ transform {
-      case a: Attribute => attributeRewrites(a)
-    })
+    constraints.attributesRewrite(attributeRewrites)
   }
 
   private def merge(a: ExpressionSet, b: ExpressionSet): ExpressionSet = {
@@ -539,10 +547,17 @@ case class Union(
     common ++ others
   }
 
-  override protected lazy val validConstraints: ExpressionSet = {
-    children
-      .map(child => rewriteConstraints(children.head.output, child.output, child.constraints))
-      .reduce(merge(_, _))
+  override lazy val validConstraints: ExpressionSet = {
+    if (conf.constraintPropagationEnabled) {
+         val head = children.head
+        val headOutput = head.output
+        val remaining = children.slice(1, children.length)
+        remaining.foldLeft(head.constraints.asInstanceOf[ConstraintSet])((constraint, node) =>
+          ConstraintSet.unionWith(constraint, node, headOutput))
+    } else {
+      children.map(child => rewriteConstraints(children.head.output,
+        child.output, child.constraints)).reduce(merge(_, _))
+    }
   }
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[LogicalPlan]): Union =
@@ -612,7 +627,7 @@ case class Join(
     }
   }
 
-  override protected lazy val validConstraints: ExpressionSet = {
+  override lazy val validConstraints: ExpressionSet = {
     joinType match {
       case _: InnerLike if condition.isDefined =>
         left.constraints
@@ -631,8 +646,10 @@ case class Join(
         left.constraints
       case RightOuter =>
         right.constraints
-      case _ =>
-        ExpressionSet()
+
+      case _ => if (conf.constraintPropagationEnabled) {
+        new ConstraintSet()
+      } else ExpressionSet()
     }
   }
 
@@ -1226,7 +1243,8 @@ case class Aggregate(
 
   override lazy val validConstraints: ExpressionSet = {
     val nonAgg = aggregateExpressions.filter(!_.exists(_.isInstanceOf[AggregateExpression]))
-    getAllValidConstraints(nonAgg)
+    child.constraints.updateConstraints(this.output,
+     child.output, nonAgg, Option(getAllValidConstraints))
   }
 
   override protected def withNewChildInternal(newChild: LogicalPlan): Aggregate =
@@ -1427,7 +1445,10 @@ case class Expand(
 
   // This operator can reuse attributes (for example making them null when doing a roll up) so
   // the constraints of the child may no longer be valid.
-  override protected lazy val validConstraints: ExpressionSet = ExpressionSet()
+  override lazy val validConstraints: ExpressionSet =
+      if (conf.constraintPropagationEnabled) {
+        new ConstraintSet()
+      } else ExpressionSet(Set.empty)
 
   override protected def withNewChildInternal(newChild: LogicalPlan): Expand =
     copy(child = newChild)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
@@ -200,11 +200,17 @@ class InferFiltersFromConstraintsSuite extends PlanTest {
 
   test("constraints should be inferred from aliased literals") {
     val originalLeft = testRelation.subquery("left").as("left")
-    val optimizedLeft = testRelation.subquery("left")
-      .where(IsNotNull($"a") && $"a" <=> 2).as("left")
+    val optimizedLeft =
+      // The original commented code is slighly inefficient because if IsNotNull(a) is present
+      // then it should not form  'a <=> 2, but 'a === 2 ( i.e use EqualTo rather than
+      // EqualNullsafe
+      // val optimizedLeft = testRelation.subquery('left).where(IsNotNull('a) && 'a <=> 2).
+      // as("left")
+      testRelation.subquery("left").where(IsNotNull($"a") && $"a" === 2).as("left")
 
     val right = Project(Seq(Literal(2).as("two")),
       testRelation.subquery("right")).as("right")
+
     val condition = Some("left.a".attr === "right.two".attr)
 
     val original = originalLeft.join(right, Inner, condition)
@@ -382,7 +388,7 @@ class InferFiltersFromConstraintsSuite extends PlanTest {
       InferFiltersFromConstraints(x.select($"x.a", $"x.a".as("xa"))
         .where($"xa" <=> $"x.a" && $"xa" === $"x.a").analyze),
       x.select($"x.a", $"x.a".as("xa"))
-        .where($"xa".isNotNull && $"x.a".isNotNull && $"xa" <=> $"x.a" && $"xa" === $"x.a").analyze)
+        .where($"x.a".isNotNull && $"xa" <=> $"x.a" && $"xa" === $"x.a").analyze)
 
     // Once strategy's idempotence is not broken
     val originalQuery =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/CompareNewAndOldConstraintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/CompareNewAndOldConstraintsSuite.scala
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.analysis.{Analyzer, EliminateSubqueryAliases,
+  EmptyFunctionRegistry, FakeV2SessionCatalog}
+import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.{IsNotNull, _}
+import org.apache.spark.sql.catalyst.optimizer.{CombineFilters, CombineUnions,
+  InferFiltersFromConstraints, Optimizer, PruneFilters, PushDownPredicates,
+  PushPredicateThroughJoin, PushProjectionThroughUnion}
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.connector.catalog.CatalogManager
+import org.apache.spark.sql.internal.SQLConf
+
+class CompareNewAndOldConstraintsSuite extends SparkFunSuite with PlanTest with PredicateHelper {
+  test("new filter pushed down on Join Node with multiple join conditions") {
+    val tr1 = LocalRelation($"a".int, $"b".string, $"c".int)
+    val tr2 = LocalRelation($"x".int, $"y".string, $"z".int)
+    val query = tr1.where($"c" + $"a" > 10 && $"a" > -15).
+      select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c", $"c".as("c1")).
+      join(tr2, Inner, Some($"a2" === $"x" && $"c1" === $"z"))
+      .where($"a1" + $"c1" > 10)
+
+    withSQLConf() {
+      val optimized = executePlan(query, OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+      val correctAnswer = tr1.where($"c" + $"a" > 10 && $"a" > -15 &&
+        IsNotNull($"a") && IsNotNull($"c")).select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c",
+        $"c".as("c1")).join(tr2.where(IsNotNull($"x") && IsNotNull($"z") && $"x" > -15
+        && $"z" + $"x" > 10),
+        Inner, Some($"a2" === $"x" && $"c1" === $"z")).analyze
+
+      comparePlans(optimized, correctAnswer)
+    }
+  }
+
+  test("test pruning using constraints with filters after project - 2") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation($"a".int, $"b".string, $"c".int)
+      tr1.select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c", $"c".as("c1")).where($"c" + $"a" > 10 && $"a" > -15).
+        where($"c1" + $"a2" > 10 && $"a2" > -15)
+    }
+
+    withSQLConf() {
+      val optimizedPlan = executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+      val correctAnswer = LocalRelation($"a".int, $"b".string, $"c".int).
+        select($"a", $"a".as("a1"), $"a".as("a2"),
+          $"b".as("b1"), $"c", $"c".as("c1")).where($"c" + $"a" > 10 && $"a" > -15
+        && IsNotNull($"a") && IsNotNull($"c")).analyze
+      comparePlans(correctAnswer, optimizedPlan)
+    }
+  }
+
+  test("test pruning using constraints with filters after project - 3") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation($"a".int, $"b".string, $"c".int)
+      tr1.select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c", $"c".as("c1")).where($"c1" + $"a1" > 10 && $"a2" > -15).
+        where($"c" + $"a" > 10 && $"a" > -15)
+    }
+
+    withSQLConf() {
+      val optimizedPlan = executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+      val correctAnswer = LocalRelation($"a".int, $"b".string, $"c".int).
+        select($"a", $"a".as("a1"), $"a".as("a2"),
+          $"b".as("b1"), $"c", $"c".as("c1")).where($"c1" + $"a1" > 10 && $"a2" > -15
+        && IsNotNull($"a") && IsNotNull($"c")).analyze
+      comparePlans(correctAnswer, optimizedPlan)
+    }
+  }
+
+  test("test new filter inference with decanonicalization for expression not" +
+    " implementing NullIntolerant - 1") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation($"a".int, $"b".int, $"c".int)
+      tr1.select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c", $"c".as("c1"),
+        CaseWhen(Seq(($"a" + $"b" + $"c" > Literal(1),
+          Literal(1)), ($"a" + $"b" + $"c" > Literal(2), Literal(2))),
+          Option(Literal(null))).as("z")).where($"z" > 10 && $"a2" > -15).
+        where(CaseWhen(Seq(($"a" + $"b" + $"c" > Literal(1),
+          Literal(1)), ($"a" + $"b" + $"c" > Literal(2), Literal(2))),
+          Option(Literal(null))) > 10 && $"a" > -15).where($"z" > 10)
+    }
+
+    withSQLConf() {
+      val optimizedPlan = executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+      val correctAnswer = LocalRelation($"a".int, $"b".int, $"c".int).
+        select($"a", $"a".as("a1"), $"a".as("a2"),
+          $"b".as("b1"), $"c", $"c".as("c1"), CaseWhen(Seq(
+            ($"a" + $"b" + $"c" > Literal(1),
+              Literal(1)), ($"a" + $"b" + $"c" > Literal(2), Literal(2))),
+            Option(Literal(null))).as("z"), $"b").where($"z" > 10 && $"a2" > -15
+        && IsNotNull($"a") && IsNotNull($"z")).select($"a", $"a1", $"a2",
+        $"b1", $"c", $"c1", $"z").analyze
+      comparePlans(correctAnswer, optimizedPlan)
+    }
+  }
+
+  test("test new filter inference with decanonicalization for expression not" +
+    " implementing NullIntolerant - 2") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation($"a".int, $"b".int, $"c".int)
+      tr1.select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c", $"c".as("c1"),
+        ($"a" + CaseWhen(Seq(($"a" + $"b" + $"c" > Literal(1),
+          Literal(1)), ($"a" + $"b" + $"c" > Literal(2), Literal(2))),
+          Option(Literal(null)))).as("z")).where($"z" > 10 && $"a2" > -15).
+        where($"a" + CaseWhen(Seq(($"a" + $"b" + $"c" > Literal(1),
+          Literal(1)), ($"a" + $"b" + $"c" > Literal(2), Literal(2))),
+          Option(Literal(null))) > 10 && $"a" > -15).where($"z" > 10)
+    }
+
+    withSQLConf() {
+      val optimizedPlan = executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+      val correctAnswer = LocalRelation($"a".int, $"b".int, $"c".int).
+        select($"a", $"a".as("a1"), $"a".as("a2"),
+          $"b".as("b1"), $"c", $"c".as("c1"), ($"a" + CaseWhen(Seq(
+            ($"a" + $"b" + $"c" > Literal(1),
+              Literal(1)), ($"a" + $"b" + $"c" > Literal(2), Literal(2))),
+            Option(Literal(null)))).as("z"), $"b").where($"z" > 10 && $"a2" > -15
+        && IsNotNull($"a") && IsNotNull($"z")).select($"a", $"a1", $"a2",
+        $"b1", $"c", $"c1", $"z").analyze
+      comparePlans(correctAnswer, optimizedPlan)
+    }
+  }
+
+  test("test new filter inference with decanonicalization for expression" +
+    "implementing NullIntolerant") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation($"a".int, $"b".int, $"c".int)
+      tr1.select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c", $"c".as("c1"),
+        ($"a" + $"b" + $"c").as("z")).where($"z" > 10 && $"a2" > -15).
+        where($"a" + $"b1" + $"c" > 10 && $"a" > -15)
+    }
+
+    withSQLConf() {
+      val optimizedPlan = executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+      val correctAnswer = LocalRelation($"a".int, $"b".int, $"c".int).
+        select($"a", $"a".as("a1"), $"a".as("a2"),
+          $"b".as("b1"), $"c", $"c".as("c1"),
+          ($"a" + $"b" + $"c").as("z")).where($"z" > 10 && $"a2" > -15
+        && IsNotNull($"a") && IsNotNull($"b1") && IsNotNull($"c")).analyze
+      comparePlans(correctAnswer, optimizedPlan)
+    }
+  }
+
+  test("test pruning using constraints with filters after project with expression in" +
+    " alias.") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation($"a".int, $"b".int, $"c".int)
+      tr1.select($"a", $"a".as("a1"), $"a".as("a2"), $"b",
+        $"b".as("b1"), $"c", $"c".as("c1"), ($"a" + $"b").as("z")).
+        where($"c1" + $"z" > 10 &&
+          $"a2" > -15).
+        where($"c" + $"a" + $"b" > 10 &&
+          $"a" > -15)
+    }
+
+
+    withSQLConf() {
+      val optimizedPlan = executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+      val correctAnswer = LocalRelation($"a".int, $"b".int, $"c".int).
+        select($"a", $"a".as("a1"), $"a".as("a2"), $"b",
+          $"b".as("b1"), $"c", $"c".as("c1"), ($"a" + $"b").as("z")).
+        where($"c1" + $"z" > 10 &&
+          $"a2" > -15 && IsNotNull($"b")
+          && IsNotNull($"a") && IsNotNull($"c")).analyze
+      comparePlans(correctAnswer, optimizedPlan)
+    }
+  }
+
+  ignore("Disabled due to spark's canonicalization bug." +
+    " test pruning using constraints with filters after project with expression in alias.") {
+    val tr1 = LocalRelation($"a".int, $"b".string, $"c".int)
+    val query = tr1.select($"a", $"a".as("a1"), $"a".as("a2"), $"b",
+      $"b".as("b1"), $"c", $"c".as("c1"), ($"a" + $"b").as("z")).
+      where($"c1" + $"z" > 10 && $"a2" > -15).
+      where($"c" + $"a" + $"b" > 10 && $"a" > -15)
+
+    withSQLConf() {
+      val optimizedPlan = executePlan(query, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+      val correctAnswer = LocalRelation($"a".int, $"b".string, $"c".int).
+        select($"a", $"a".as("a1"), $"a".as("a2"), $"b",
+          $"b".as("b1"), $"c", $"c".as("c1"), ($"a" + $"b").as("z")).
+        where($"c1" + $"z" > 10 && $"a2" > -15
+          && IsNotNull($"a") && IsNotNull($"c") && IsNotNull($"b")).analyze
+      comparePlans(correctAnswer, optimizedPlan)
+    }
+  }
+
+  test("plan equivalence with case statements and performance comparison with benefit" +
+    "of more than 10x conservatively") {
+    val tr = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int, $"f".int, $"g".int,
+      $"h".int, $"i".int, $"j".int, $"k".int, $"l".int, $"m".int, $"n".int)
+    val query = tr.select($"a", $"b", $"c", $"d", $"e", $"f", $"g", $"h", $"i", $"j", $"k", $"l",
+      $"m", $"n",
+      CaseWhen(Seq(($"a" + $"b" + $"c" + $"d" + $"e" + $"f" + $"g"
+        + $"h" + $"i" + $"j" + $"k" + $"l" + $"m" + $"n" > Literal(1),
+        Literal(1)),
+        ($"a" + $"b" + $"c" + $"d" + $"e" + $"f" + $"g" + $"h" +
+          $"i" + $"j" + $"k" + $"l" + $"m" + $"n" > Literal(2), Literal(2))),
+        Option(Literal(0))).as("JoinKey1")
+    ).select($"a".as("a1"), $"b".as("b1"), $"c".as("c1"),
+      $"d".as("d1"), $"e".as("e1"), $"f".as("f1"),
+      $"g".as("g1"), $"h".as("h1"), $"i".as("i1"),
+      $"j".as("j1"), $"k".as("k1"), $"l".as("l1"),
+      $"m".as("m1"), $"n".as("n1"), $"JoinKey1".as("cf1"),
+      $"JoinKey1").select($"a1", $"b1", $"c1", $"d1", $"e1", $"f1", $"g1", $"h1", $"i1", $"j1",
+      $"k1", $"l1", $"m1", $"n1", $"cf1", $"JoinKey1").
+      join(tr, condition = Option($"a" <=> $"JoinKey1")).
+      analyze
+
+    withSQLConf() {
+      val optimizedPlan = executePlan(query,
+        OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+      comparePlans(query, optimizedPlan)
+    }
+  }
+
+  def executePlan(plan: LogicalPlan, optimizerType: OptimizerTypes.Value): LogicalPlan = {
+    object SimpleAnalyzer extends Analyzer(
+      new CatalogManager(FakeV2SessionCatalog,
+        new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry,
+          SQLConf.get)))
+
+    val optimizedPlan = GetOptimizer(optimizerType, Some(SQLConf.get)).
+      execute(SimpleAnalyzer.execute(plan))
+    optimizedPlan
+  }
+
+  private object OptimizerTypes extends Enumeration {
+    val WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING,
+    NO_PUSH_DOWN_ONLY_PRUNING, WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_UNIONS_PRUNING = Value
+  }
+
+  private object GetOptimizer {
+    def apply(optimizerType: OptimizerTypes.Value, useConf: Option[SQLConf] = None): Optimizer =
+      optimizerType match {
+        case OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING =>
+          new Optimizer(new CatalogManager(
+            FakeV2SessionCatalog,
+            new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry,
+              useConf.getOrElse(SQLConf.get)))) {
+            override def defaultBatches: Seq[Batch] =
+              Batch("Subqueries", Once,
+                EliminateSubqueryAliases) ::
+                Batch("Filter Pushdown and Pruning", FixedPoint(100),
+                  PushPredicateThroughJoin,
+                  PushDownPredicates,
+                  InferFiltersFromConstraints,
+                  CombineFilters,
+                  PruneFilters) :: Nil
+
+            override def nonExcludableRules: Seq[String] = Seq.empty[String]
+          }
+
+        case OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING =>
+          new Optimizer(new CatalogManager(
+            FakeV2SessionCatalog,
+            new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry,
+              useConf.getOrElse(SQLConf.get)))) {
+            override def defaultBatches: Seq[Batch] =
+              Batch("Subqueries", Once,
+                EliminateSubqueryAliases) ::
+                Batch("Filter Pruning", Once,
+                  InferFiltersFromConstraints,
+                  PruneFilters) :: Nil
+
+            override def nonExcludableRules: Seq[String] = Seq.empty[String]
+          }
+
+        case OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_UNIONS_PRUNING =>
+          new Optimizer(new CatalogManager(
+            FakeV2SessionCatalog,
+            new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry,
+              useConf.getOrElse(SQLConf.get)))) {
+            override def defaultBatches: Seq[Batch] =
+              Batch("Subqueries", Once,
+                EliminateSubqueryAliases) ::
+                Batch("Union Pushdown", FixedPoint(100),
+                  CombineUnions,
+                  PushProjectionThroughUnion,
+                  PushDownPredicates,
+                  InferFiltersFromConstraints,
+                  CombineFilters,
+                  PruneFilters) :: Nil
+
+            override def nonExcludableRules: Seq[String] = Seq.empty[String]
+          }
+      }
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
@@ -19,6 +19,10 @@ package org.apache.spark.sql.catalyst.plans
 
 import java.util.TimeZone
 
+import scala.collection.mutable
+
+import org.scalatest.Ignore
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.dsl.expressions._
@@ -28,15 +32,23 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, DoubleType, IntegerType, LongType, StringType}
 
+
+/**
+ * This class is extended by OptimizedConstraintSuite and when it runs,  all the tests
+ * of this class also be executed. The ignore is to prevent the tests from running twice
+ * unnecessarily
+ */
+
+@Ignore
 class ConstraintPropagationSuite extends SparkFunSuite with PlanTest {
 
-  private def resolveColumn(tr: LocalRelation, columnName: String): Expression =
+  def resolveColumn(tr: LocalRelation, columnName: String): Expression =
     resolveColumn(tr.analyze, columnName)
 
-  private def resolveColumn(plan: LogicalPlan, columnName: String): Expression =
+  def resolveColumn(plan: LogicalPlan, columnName: String): Expression =
     plan.resolveQuoted(columnName, caseInsensitiveResolution).get
 
-  private def verifyConstraints(found: ExpressionSet, expected: ExpressionSet): Unit = {
+  def verifyConstraints(found: ExpressionSet, expected: ExpressionSet): Unit = {
     val missing = expected -- found
     val extra = found -- expected
     if (missing.nonEmpty || extra.nonEmpty) {
@@ -134,13 +146,9 @@ class ConstraintPropagationSuite extends SparkFunSuite with PlanTest {
     val aliasedRelation = tr.where($"a".attr > 10).select($"a".as("x"), $"b",
       $"b".as("y"), $"a".as("z"))
 
-    verifyConstraints(aliasedRelation.analyze.constraints,
-      ExpressionSet(Seq(resolveColumn(aliasedRelation.analyze, "x") > 10,
-        IsNotNull(resolveColumn(aliasedRelation.analyze, "x")),
-        resolveColumn(aliasedRelation.analyze, "b") <=> resolveColumn(aliasedRelation.analyze, "y"),
-        resolveColumn(aliasedRelation.analyze, "z") <=> resolveColumn(aliasedRelation.analyze, "x"),
-        resolveColumn(aliasedRelation.analyze, "z") > 10,
-        IsNotNull(resolveColumn(aliasedRelation.analyze, "z")))))
+    verifyConstraints(ExpressionSet(aliasedRelation.analyze.constraints),
+        ExpressionSet(Seq(resolveColumn(aliasedRelation.analyze, "x") > 10,
+          IsNotNull(resolveColumn(aliasedRelation.analyze, "x")))))
 
     val multiAlias = tr.where($"a" === $"c" + 10).select($"a".as("x"), $"c".as("y"))
     verifyConstraints(multiAlias.analyze.constraints,
@@ -174,14 +182,21 @@ class ConstraintPropagationSuite extends SparkFunSuite with PlanTest {
       .where($"a".attr > 10)
       .union(tr2.where($"d".attr > 11))
       .analyze.constraints,
-      ExpressionSet(Seq(a > 10 || a > 11, IsNotNull(a))))
+      new ConstraintSet(mutable.Buffer((a > 10 || a > 11), IsNotNull(a))))
 
     val b = resolveColumn(tr1, "b")
+
+    val cond1 = a > 10 || a > 11
+    val cond2 = b < 10 || b < 11
+
+    cond1.canonicalized.deterministic
+    cond2.canonicalized.deterministic
     verifyConstraints(tr1
       .where($"a".attr > 10 && $"b".attr < 10)
       .union(tr2.where($"d".attr > 11 && $"e".attr < 11))
       .analyze.constraints,
-      ExpressionSet(Seq(a > 10 || a > 11, b < 10 || b < 11, IsNotNull(a), IsNotNull(b))))
+      new ConstraintSet(mutable.Buffer(cond1, cond2,
+        IsNotNull(a), IsNotNull(b))))
   }
 
   test("propagating constraints in intersect") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/OptimizedConstraintPropagationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/OptimizedConstraintPropagationSuite.scala
@@ -1,0 +1,1815 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans
+
+import org.apache.spark.sql.catalyst.analysis.{Analyzer, EliminateSubqueryAliases, EmptyFunctionRegistry,
+  FakeV2SessionCatalog}
+import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.{IsNotNull, _}
+import org.apache.spark.sql.catalyst.expressions.ConstraintSet.TemplateAttributeGenerator
+import org.apache.spark.sql.catalyst.optimizer.{CombineFilters, CombineUnions, InferFiltersFromConstraints, Optimizer,
+  PruneFilters, PushDownPredicates, PushPredicateThroughJoin, PushProjectionThroughUnion}
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.connector.catalog.CatalogManager
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{IntegerType, LongType}
+
+class OptimizedConstraintPropagationSuite extends ConstraintPropagationSuite
+  with PredicateHelper {
+
+  val trivialConstraintAbsenceChecker = (constraints: ExpressionSet) => assert(
+    !constraints.exists(x => x match {
+      case EqualNullSafe(a, b) if a.canonicalized == b.canonicalized => true
+      case EqualTo(a, b) if a.canonicalized == b.canonicalized => true
+      case _ => false
+    }))
+
+  /**
+   * Default spark optimizer is not used in the tests as some of the tests were false passing.
+   * Many assertions go through fine hiding the bugs because of other rules in the optimizer.
+   * For eg., a test dedicated to test filter pruning ( involving aliases) & hence relying
+   * on contains function of ConstraintSet ( & indirectly the attributeEquivalenceList etc )
+   * was false passing because of an optimizer rule, which replaces the alias with the actual
+   * expression in the plan. Combining Filter is commented just to be sure that ConstraintSet
+   * coming out of each node contains right the constraints & more importantly the
+   * attributeEquivalenceList & expressionEquivalenceList contains the right data.
+   * Otherwise it is possible that compound filter push down for left outer join
+   * those Lists are empty & tests false passing
+   */
+
+  test("checking number of base constraints in project node") {
+    val tr = LocalRelation($"a".int, $"b".string, $"c".int)
+    val y = tr.where($"c" > 10).select($"a".as("x"), $"b".as("y"), $"c",
+      $"c".as("c1")).analyze
+    assert(y.resolved)
+    val constraints = y.constraints
+    trivialConstraintAbsenceChecker(constraints)
+    assert(2 === constraints.size)
+    verifyConstraints(ExpressionSet(constraints),
+      ExpressionSet(Seq(resolveColumn(y.analyze, "c") > 10,
+        IsNotNull(resolveColumn(y.analyze, "c")))))
+  }
+
+  test("checking number of base constraints with " +
+    "filter dependent on multiple attributes") {
+    val tr = LocalRelation($"a".int, $"b".string, $"c".int)
+    val y = tr.where($"c" + $"a" > 10).select($"a", $"a".as("x"), $"b".as("y"),
+      $"c", $"c".as("c1")).analyze
+    assert(y.resolved)
+    val constraints = y.constraints
+    trivialConstraintAbsenceChecker(constraints)
+    assert(3 === constraints.size)
+    verifyConstraints(ExpressionSet(constraints),
+      ExpressionSet(Seq(
+        resolveColumn(y.analyze, "c") +
+          resolveColumn(y.analyze, "a") > 10,
+        IsNotNull(resolveColumn(y.analyze, "c")),
+        IsNotNull(resolveColumn(y.analyze, "a")))))
+  }
+
+  test("checking filter pruning") {
+    val tr = LocalRelation($"a".int, $"b".string, $"c".int)
+    val y = tr.where($"c" + $"a" > 10).select($"a", $"a".as("x"), $"b".as("y"),
+      $"c", $"c".as("c1")).where($"x" + $"c1" > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).execute(y)
+    val constraints = optimized.constraints
+    trivialConstraintAbsenceChecker(constraints)
+    assert(3 === constraints.size)
+
+    verifyConstraints(ExpressionSet(constraints),
+      ExpressionSet(Seq(
+        resolveColumn(y.analyze, "c") +
+          resolveColumn(y.analyze, "a") > 10,
+        IsNotNull(resolveColumn(y.analyze, "c")),
+        IsNotNull(resolveColumn(y.analyze, "a")))))
+
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    assert(1 === allFilters.size)
+    val conditionalExps = allFilters.head.expressions.flatMap(expr => expr.collect {
+      case x: GreaterThan => x
+      case y: LessThan => y
+    })
+    assert(1 === conditionalExps.size)
+    val correctAnswer = tr.where($"c" + $"a" > 10 && IsNotNull($"a") && IsNotNull($"c")).
+      select($"a", $"a".as("x"), $"b".as("y"), $"c", $"c".as("c1")).analyze
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("Alias in different projects have same exprID..!") {
+    val tr1 = LocalRelation($"a".int, $"b".string, $"c".int, $"d".int)
+    val y = tr1.where($"c" + $"a" > 10).select($"a", $"a".as("a1"),
+      $"a".as("a2"), $"b".as("b1"), $"c", $"c".as("c1"), Literal(1).as("one"),
+      Literal(1).as("one_")
+    ).where($"b1" > 10).select( Literal(1).as("one"),
+      Literal(1).as("one_"), $"b1").
+      where($"one" > 1).analyze
+    var exprId1: Option[ExprId] = None
+    var exprId2: Option[ExprId] = None
+    val bugify = y.transformUp {
+      case p@Project(pl, child) => if (exprId1.isEmpty) {
+        exprId1 = pl.find(_.name == "one").map(_.asInstanceOf[Alias].exprId)
+        exprId2 = pl.find(_.name == "one_").map(_.asInstanceOf[Alias].exprId)
+        p
+      } else {
+        val newPl = pl.map(ne => if (ne.name == "one") {
+          val al = ne.asInstanceOf[Alias]
+          Alias(al.child, al.name)(exprId1.get)
+        } else if (ne.name == "one_") {
+          val al = ne.asInstanceOf[Alias]
+          Alias(al.child, al.name)(exprId2.get)
+        } else ne )
+        Project(newPl, child)
+      }
+      case f: Filter if exprId1.isDefined => f.transformExpressionsUp {
+        case expr: Expression => expr.transformUp {
+          case at: AttributeReference if at.name == "one" => at.withExprId(exprId1.get)
+          case at: AttributeReference if at.name == "one_" => at.withExprId(exprId2.get)
+        }
+      }
+    }.analyze
+
+    assert(bugify.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(bugify)
+    val topConstraint = optimized.constraints
+    // there should not be any trivial constraint present
+    trivialConstraintAbsenceChecker(topConstraint)
+  }
+
+  test("trivial conditions should not be part of constraints") {
+    val tr1 = LocalRelation($"a".int, $"b".string, $"c".int)
+    val tr2 = LocalRelation($"x".int, $"y".string, $"z".int)
+    val y = tr1.where($"c" + $"a" > 10).select($"a", $"a".as("a1"), $"a".as("a2"),
+      $"b".as("b1"), $"c",
+      $"c".as("c1")).join(tr2.select($"x", $"x".as("x1"), $"y", $"z"), Inner,
+      Some("a" === "x")).where($"y" > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING).
+      execute(y)
+    val topConstraint = optimized.constraints
+    // there should not be any trivial constraint present
+    trivialConstraintAbsenceChecker(topConstraint)
+  }
+
+  test("filter pruning on Join Node") {
+    val tr1 = LocalRelation($"a".int, $"b".string, $"c".int)
+    val tr2 = LocalRelation($"x".int, $"y".string, $"z".int)
+    val y = tr1.where($"c" + $"a" > 10).select($"a", $"a".as("a1"), $"a".as("a2"),
+      $"b".as("b1"), $"c",
+      $"c".as("c1")).join(tr2, Inner, Some($"a2" === $"x"))
+      .where($"a1" + $"c1" > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING).
+      execute(y)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+
+    val conditionalExps = allFilters.flatMap(filter =>
+      filter.expressions.flatMap(expr => expr.collect {
+        case x: GreaterThan => x
+        case y: LessThan => y
+      }))
+    assert(1 === conditionalExps.size)
+    val correctAnswer = tr1.where($"c" + $"a" > 10 && IsNotNull($"a") && IsNotNull($"c")).
+      select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c",
+        $"c".as("c1")).join(tr2.where(IsNotNull($"x")), Inner,
+      Some($"a2" === $"x")).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("new filter pushed down on Join Node") {
+    val tr1 = LocalRelation($"a".int, $"b".string, $"c".int)
+    val tr2 = LocalRelation($"x".int, $"y".string, $"z".int)
+    val y = tr1.where($"c" + $"a" > 10 && $"a" > -15).select($"a", $"a".as("a1"),
+      $"a".as("a2"), $"b".as("b1"), $"c", $"c".as("c1")).join(tr2, Inner,
+      Some($"a2" === $"x")).where($"a1" + $"c1" > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING).
+      execute(y)
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    val conditionalExps = allFilters.flatMap(filter =>
+      filter.expressions.flatMap(expr => expr.collect {
+        case x: GreaterThan => x
+        case y: LessThan => y
+      }))
+    assert(3 === conditionalExps.size)
+    val correctAnswer = tr1.where($"c" + $"a" > 10 && $"a" > -15
+      && IsNotNull($"a") && IsNotNull($"c")).select($"a", $"a".as("a1"), $"a".as("a2"),
+      $"b".as("b1"), $"c",
+      $"c".as("c1")).join(tr2.where(IsNotNull($"x") && $"x" > -15),
+      Inner, Some($"a2" === $"x")).analyze
+
+    comparePlans(optimized, correctAnswer)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+  }
+
+  test("new filter pushed down on Join Node with multiple join conditions") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation($"a".int, $"b".string, $"c".int)
+      val tr2 = LocalRelation($"x".int, $"y".string, $"z".int)
+      tr1.where($"c" + $"a" > 10 && $"a" > -15).select($"a", $"a".as("a1"),
+        $"a".as("a2"), $"b".as("b1"), $"c", $"c".as("c1")).join(tr2, Inner,
+         Some($"a2" === $"x" && $"c1" === $"z")).where($"a1" + $"c1" > 10)
+    }
+    val (optimized, _) = withSQLConf[(LogicalPlan, ExpressionSet)]() {
+      executePlan(getTestPlan, OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+    }
+    trivialConstraintAbsenceChecker(optimized.constraints)
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    val conditionalExps = allFilters.flatMap(filter =>
+      filter.expressions.flatMap(expr => expr.collect {
+        case x: GreaterThan => x
+        case y: LessThan => y
+      }))
+    assert(4 === conditionalExps.size)
+
+    // there should be a + operator present on each side of the join node
+    val joinNode = optimized.collectFirst {
+      case j: Join => j
+    }.get
+    assert(joinNode.left.collect {
+      case f: Filter => f
+    }.exists(f => f.condition.collectFirst {
+      case a: Add => a
+    }.isDefined))
+    assert(joinNode.right.collect {
+      case f: Filter => f
+    }.exists(f => f.condition.collectFirst {
+      case a: Add => a
+    }.isDefined))
+    val tr1 = LocalRelation($"a".int, $"b".string, $"c".int)
+    val tr2 = LocalRelation($"x".int, $"y".string, $"z".int)
+    val correctAnswer = tr1.where($"c" + $"a" > 10 && $"a" > -15 &&
+      IsNotNull($"a") && IsNotNull($"c")).select($"a", $"a".as("a1"), $"a".as("a2"),
+      $"b".as("b1"), $"c",
+      $"c".as("c1")).join(tr2.where(IsNotNull($"x") && IsNotNull($"z") && $"x" > -15
+      && $"z" + $"x" > 10),
+      Inner, Some($"a2" === $"x" && $"c1" === $"z")).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("filter pruning when original attributes are lost") {
+    val tr = LocalRelation($"a".int, $"b".string, $"c".int)
+    val y = tr.where($"c" + $"a" > 10).select($"a", $"a".as("x"), $"b".as("y"),
+       $"c", $"c".as("c1")).select($"x".as("x1"), $"y".as("y1"),
+      $"c1".as("c2")).where($"x1" + $"c2" > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).execute(y)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    assert(1 === allFilters.size)
+    val conditionalExps = allFilters.head.expressions.flatMap(expr => expr.collect {
+      case x: GreaterThan => x
+      case y: LessThan => y
+    })
+    assert(1 === conditionalExps.size)
+    val correctAnswer = tr.where($"c" + $"a" > 10 && IsNotNull($"a") && IsNotNull($"c")).
+      select($"a", $"a".as("x"), $"b".as("y"), $"c",
+        $"c".as("c1")).select($"x".as("x1"), $"y".as("y1"),
+      $"c1".as("c2")).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("filter pruning when partial attributes are lost") {
+    val tr = LocalRelation($"a".int, $"b".string, $"c".int)
+    val y = tr.where($"c" + $"a" > 10).select($"a", $"a".as("x"), $"b".as("y"),
+       $"c", $"c".as("c1")).select($"c", $"x".as("x1"), $"y".as("y1"),
+      $"c1".as("c2")).where($"x1" + $"c" > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).execute(y)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    assert(1 === allFilters.size)
+    val conditionalExps = allFilters.head.expressions.flatMap(expr => expr.collect {
+      case x: GreaterThan => x
+      case y: LessThan => y
+    })
+    assert(1 === conditionalExps.size)
+    val correctAnswer = tr.where($"c" + $"a" > 10 && IsNotNull($"a") && IsNotNull($"c")).
+      select($"a", $"a".as("x"), $"b".as("y"), $"c",
+        $"c".as("c1")).select($"c", $"x".as("x1"), $"y".as("y1"),
+      $"c1".as("c2")).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("filter pruning with expressions in alias") {
+    val tr = LocalRelation($"a".int, $"b".string, $"c".int)
+    val y = tr.where($"c" + $"a" > 10).select($"a", ($"a" + $"c").as("x"),
+      $"b".as("y"), $"c",
+      $"c".as("c1")).select($"c", $"x".as("x1"), $"y".as("y1"),
+      $"c1".as("c2")).where($"x1" > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).execute(y)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    assert(1 === allFilters.size)
+    val conditionalExps = allFilters.head.expressions.flatMap(expr => expr.collect {
+      case x: GreaterThan => x
+      case y: LessThan => y
+    })
+    assert(1 === conditionalExps.size)
+    val correctAnswer = tr.where($"c" + $"a" > 10 && IsNotNull($"a") && IsNotNull($"c")).
+      select($"a", ($"a" + $"c").as("x"),
+        $"b".as("y"), $"c",
+        $"c".as("c1")).select($"c", $"x".as("x1"), $"y".as("y1"),
+      $"c1".as("c2")).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("filter pruning with subexpressions in alias") {
+    val tr = LocalRelation($"a".int, $"b".string, $"c".int)
+    val y = tr.where($"c" + $"a" + $"b" > 10).select(($"a" + $"c").as("x"),
+      $"b".as("y")).select($"x".as("x1"), $"y".as("y1")).
+      where($"x1" + $"y1" > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).execute(y)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    assert(1 === allFilters.size)
+    val conditionalExps = allFilters.head.expressions.flatMap(expr => expr.collect {
+      case x: GreaterThan => x
+      case y: LessThan => y
+    })
+    assert(1 === conditionalExps.size)
+    val correctAnswer = tr.where($"c" + $"a" + $"b" > 10 && IsNotNull($"a") && IsNotNull($"c")
+      && IsNotNull($"b")).
+      select(($"a" + $"c").as("x"),
+        $"b".as("y")).select($"x".as("x1"), $"y".as("y1")).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("filter pruning using expression equivalence list - #1") {
+    val tr = LocalRelation($"a".int, $"b".string, $"c".int)
+    val y = tr.where($"c" + $"a" + $"b" > 10).select($"a", $"c",
+      ($"a" + $"c").as("x"), $"b", $"b".as("y")).where($"x" + $"b" > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).execute(y)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    val conditionalExps = allFilters.flatMap(_.expressions).flatMap(expr => expr.collect {
+      case x: GreaterThan => x
+      case y: LessThan => y
+    })
+    assert(1 === conditionalExps.size)
+    val correctAnswer = tr.where($"c" + $"a" + $"b" > 10 && IsNotNull($"a") && IsNotNull($"c")
+      && IsNotNull($"b")).
+      select($"a", $"c", ($"a" + $"c").as("x"),
+        $"b", $"b".as("y")).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("filter pruning using expression equivalence list - #2") {
+    val tr = LocalRelation($"a".int, $"b".string, $"c".int)
+    val y = tr.where($"c" + $"a" + $"b" > 10).select($"c",
+      ($"a" + $"c").as("x"), ($"a" + $"c").as("z"), $"b",
+      $"b".as("y")).where($"x" + $"b" > 10).
+      select($"z", $"y").where($"z" + $"y" > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).execute(y)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    val conditionalExps = allFilters.flatMap(_.expressions).flatMap(expr => expr.collect {
+      case x: GreaterThan => x
+      case y: LessThan => y
+    })
+    assert(1 === conditionalExps.size)
+    val correctAnswer = tr.where($"c" + $"a" + $"b" > 10 && IsNotNull($"a") && IsNotNull($"c")
+      && IsNotNull($"b")).select($"c", ($"a" + $"c").as("x"),
+      ($"a" + $"c").as("z"), $"b", $"b".as("y")).select($"z", $"y").analyze
+
+    comparePlans(optimized, correctAnswer)
+    val z = tr.where($"c" + $"a" + $"b" > 10).
+      select($"c", ($"a" + $"c").as("x"),
+      ($"a" + $"c").as("z"), $"b", $"b".as("y")).
+      where($"x" + $"b" > 10).
+      select($"z", $"y").
+      where($"z" + $"y" > 10).select(($"z" + $"y").as("k")).
+      where($"k" > 10).analyze
+
+    val correctAnswer1 = tr.where($"c" + $"a" + $"b" > 10 && IsNotNull($"a") && IsNotNull($"c")
+      && IsNotNull($"b")).select($"c", ($"a" + $"c").as("x"),
+      ($"a" + $"c").as("z"), $"b", $"b".as("y")).select($"z", $"y").
+      select(($"z" + $"y").as("k")).analyze
+
+    comparePlans(GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).execute(z), correctAnswer1)
+  }
+
+  test("check redundant constraints are not added") {
+    val tr = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int)
+    val trAnalyzed = tr.analyze
+    val aliasedAnalyzed = trAnalyzed.where($"c" + $"a" + $"b" > 10 && $"d" > 8).
+      select($"a", $"d", $"d".as("z"), $"d".as("z1"),
+        ($"a" + $"c").as("x1"), ($"a" + $"c").as("x"),
+        $"b", $"b".as("y"), $"c").analyze
+    val y = aliasedAnalyzed.where($"x" + $"b" > 10 && $"z" > 8).analyze
+    assert(y.resolved)
+    /* total expected constraints
+    1) a + c + b > 10  2) isnotnull(a) 3) isnotnull(b) 4) isnotnull(c)  5) d > 8
+    6) isnotnull(d)
+    */
+    val expectedConstraints = ExpressionSet(Seq(
+      resolveColumn(trAnalyzed, "a") + resolveColumn(trAnalyzed, "b") +
+        resolveColumn(trAnalyzed, "c") > 10,
+      IsNotNull(resolveColumn(trAnalyzed, "a")),
+      IsNotNull(resolveColumn(trAnalyzed, "b")),
+      IsNotNull(resolveColumn(trAnalyzed, "c")),
+      IsNotNull(resolveColumn(trAnalyzed, "d")),
+      resolveColumn(trAnalyzed, "d") > 8
+    ))
+    val constraints = y.constraints
+    trivialConstraintAbsenceChecker(constraints)
+    assert(6 === constraints.size)
+    verifyConstraints(constraints, expectedConstraints)
+  }
+
+  test("new filter pushed down on Join Node with filter on each variable" +
+    " of join condition") {
+    val tr1 = LocalRelation($"a".int, $"b".string, $"c".int)
+    val tr1_ = tr1.where($"c" + $"a" > 10 && $"a" > -11)
+    val tr2 = LocalRelation($"x".int, $"y".string, $"z".int)
+    val tr2_ = tr2.where($"x" > -12)
+
+    val y = tr1_.select($"a", $"a".as("a1"), $"a".as("a2"),
+      $"b".as("b1"), $"c",
+      $"c".as("c1")).join(tr2_.select($"x".as("x1")), Inner,
+      Some($"a2" === $"x1")).where($"a1" + $"c1" > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING).
+      execute(y)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+    val joinNode = optimized.find({
+      case _: Join => true
+      case _ => false
+    }).get.asInstanceOf[Join]
+
+    def checkForGreaterThanFunctions(node: LogicalPlan): Unit = {
+      val filterExps = node.collect {
+        case x: Filter => x
+      }.flatMap(_.expressions)
+
+      assert(filterExps.exists(x => {
+        x.find {
+          case GreaterThan(_, Literal(-12, IntegerType)) => true
+          case _ => false
+        }.isDefined
+      }))
+
+      assert(filterExps.exists(x => {
+        x.find {
+          case GreaterThan(_, Literal(-11, IntegerType)) => true
+          case _ => false
+        }.isDefined
+      }))
+    }
+
+    checkForGreaterThanFunctions(joinNode.left)
+    checkForGreaterThanFunctions(joinNode.right)
+
+    val allFilterExpressions = optimized.collect {
+      case x: Filter => x
+    }.flatMap(_.expressions)
+    assert(5 === allFilterExpressions.flatMap(_.collect {
+      case _: GreaterThan => true
+    }).size)
+    val correctAnswer = tr1.where($"c" + $"a" > 10 && $"a" > -11
+      && $"a" > -12 && IsNotNull($"a") && IsNotNull($"c")).
+      select($"a", $"a".as("a1"), $"a".as("a2"), $"b".as("b1"),
+        $"c", $"c".as("c1")).join(tr2.where($"x" > -12 && IsNotNull($"x") && $"x" > -11).
+      select($"x".as("x1")), Inner,
+      Some($"a2" === $"x1")).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("compound filter push down for left outer join") {
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery("tr1")
+    val tr2 = LocalRelation($"x".int, $"y".int, $"z".int).subquery("tr2")
+    val y = tr1.where($"a" + $"b" > 10)
+      .join(tr2.where($"x" > 100), LeftOuter, Some($"a" === $"x" && $"b" === $"y")).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING).
+      execute(y)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+
+    val correctAnswer = tr1.where($"a" + $"b" > 10 && IsNotNull($"a") && IsNotNull($"b")).
+      join(tr2.where($"x" > 100 && IsNotNull($"x") && IsNotNull($"y") && $"x" + $"y" > 10),
+        LeftOuter, Some($"a" === $"x" && $"b" === $"y")).analyze
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("compound filter push down for left Anti join") {
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery("tr1")
+    val tr2 = LocalRelation($"x".int, $"y".int, $"z".int).subquery("tr2")
+    val y = tr1.where($"a" + $"b" > 10)
+      .join(tr2.where($"x" > 100), LeftAnti, Some($"a" === $"x" && $"b" === $"y")).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING).
+      execute(y)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+
+    val correctAnswer = tr1.where($"a" + $"b" > 10 && IsNotNull($"a") && IsNotNull($"b")).
+      join(tr2.where($"x" > 100 && IsNotNull($"x") && IsNotNull($"y") && $"x" + $"y" > 10),
+        LeftAnti, Some($"a" === $"x" && $"b" === $"y")).analyze
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("compound filter push down for left Semi join") {
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery("tr1")
+    val tr2 = LocalRelation($"x".int, $"y".int, $"z".int).subquery("tr2")
+    val y = tr1.where($"a" + $"b" > 10)
+      .join(tr2.where($"x" > 100), LeftSemi, Some($"a" === $"x" && $"b" === $"y")).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING).
+      execute(y)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+
+    val correctAnswer = tr1.where($"a" + $"b" > 10 && IsNotNull($"a") && IsNotNull($"b") &&
+      $"a" > 100).
+      join(tr2.where($"x" > 100 && IsNotNull($"x") && IsNotNull($"y") && $"x" + $"y" > 10),
+        LeftSemi, Some($"a" === $"x" && $"b" === $"y")).analyze
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("compound filter push down for right outer join") {
+   val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery("tr1")
+    val tr2 = LocalRelation($"x".int, $"y".int, $"z".int).subquery("tr2")
+    val y = tr1.join(tr2.where($"x" > 100 && $"x" + $"y" > 10), RightOuter,
+      Some($"a" === $"x" && $"b" === $"y")).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING).
+      execute(y)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+    val correctAnswer = tr1.where($"a" + $"b" > 10 && IsNotNull($"a") && IsNotNull($"b")
+      && $"a" > 100).join(tr2.where($"x" > 100 && IsNotNull($"x") && IsNotNull($"y") &&
+      $"x" + $"y" > 10), RightOuter, Some($"a" === $"x" && $"b" === $"y")).analyze
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("filter pruning due to new filter pushed down on Join Node ") {
+    val tr1 = LocalRelation($"a".int, $"b".string, $"c".int)
+    val tr1_ = tr1.where($"c" + $"a" > 10 && $"a" > -11)
+    val tr2 = LocalRelation($"x".int, $"y".string, $"z".int)
+    val tr2_ = tr2.where($"x" > -12)
+    val query = tr1_.select($"a", $"a".as("a1"), $"a".as("a2"),
+      $"b".as("b1"), $"c",
+      $"c".as("c1")).join(tr2_.select($"x".as("x1")), Inner,
+      Some($"a2" === $"x1")).where($"x1" + $"c1" > 10)
+
+    val expected = tr1.where($"c" + $"a" > 10 && $"a" > -11 && $"a" > -12
+      && IsNotNull($"a") && IsNotNull($"c")).
+      select($"a", $"a".as("a1"), $"a".as("a2"),
+      $"b".as("b1"), $"c", $"c".as("c1")).join(tr2.where(IsNotNull($"x") &&
+      $"x" > -12 && $"x" > -11).select($"x".as("x1")), Inner,
+      Some($"a2" === $"x1" && $"x1" + $"c1" > 10)).analyze
+
+    val (actual, constraints) = withSQLConf[(LogicalPlan, ExpressionSet)]() {
+      executePlan(query, OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+    }
+    trivialConstraintAbsenceChecker(constraints)
+
+    comparePlans(expected, actual)
+  }
+
+  test("top filter should not be pruned for union with lower filter only on one table") {
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int)
+    val tr2 = LocalRelation($"d".int, $"e".int, $"f".int)
+    val tr3 = LocalRelation($"g".int, $"h".int, $"i".int)
+    val y = tr1.where($"a" > 10).union(tr2).union(tr3.where($"g" > 10))
+    val y1 = y.where($"a" > 10).analyze
+    assert(y1.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_UNIONS_PRUNING).
+      execute(y1)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+    val allFilterExpressions = optimized.collect {
+      case x: Filter => x
+    }.flatMap(_.expressions)
+    assert(allFilterExpressions.flatMap(_.collect {
+      case _: GreaterThan => true
+    }).size == 3)
+    val union = optimized.find {
+      case _: Union => true
+      case _ => false
+    }.get.asInstanceOf[Union]
+
+    val numGTExpsBelowUnion = union.children.flatMap {
+      child =>
+        child.expressions.flatMap(_.collect {
+          case x: GreaterThan => x
+        })
+    }
+    assert(3 === numGTExpsBelowUnion.size)
+
+    assert(union.children.forall(p => {
+      p.expressions.flatMap(_.collect {
+        case x: GreaterThan => x
+      }).nonEmpty
+    }))
+    val correctAnswer = new Union(Seq(tr1.where($"a" > 10 && IsNotNull($"a")),
+      tr2.where($"d" > 10 && IsNotNull($"d")),
+      tr3.where($"g" > 10 && IsNotNull($"g")))).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("Union Node. missing attribute from equiv list behaviour - 1") {
+    val tr1 = LocalRelation($"a".int, $"a1".int, $"a2".int, $"a3".int, $"a4".int)
+    val tr2 = LocalRelation($"b".int, $"b1".int, $"b2".int, $"b3".int, $"b4".int)
+    val tr3 = LocalRelation($"c".int, $"c1".int, $"c2".int, $"c3".int, $"c4".int)
+    val u1 = tr1.where($"a" > 10).select($"a", $"a".as("a1_1"),
+      $"a".as("a1_2"), $"a".as("a1_3"))
+    val u2 = tr2.where($"b" > 10).select($"b", $"b1", $"b1".as("b1_2"),
+      $"b1".as("b1_3"))
+    val u3 = tr3.where($"c" > 10).select($"c", $"c1", $"c2", $"c2".as("c1_3"))
+    val union = u1.union(u2).union(u3)
+    // The condition $"a" > 10 is a redundant condition and should be removed
+    // by constraintset.
+    val y = union.where($"a" > 10).analyze
+    assert(y.resolved)
+    val optimized1 = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(y)
+    trivialConstraintAbsenceChecker(optimized1.constraints)
+
+    val correctAnswer1 = new Union(Seq(
+      tr1.where($"a" > 10 && IsNotNull($"a")).select($"a", $"a".as("a1_1"),
+        $"a".as("a1_2"), $"a".as("a1_3")).union(
+        tr2.where($"b" > 10 && IsNotNull($"b")).select($"b", $"b1", $"b1".as("b1_2"),
+          $"b1".as("b1_3"))),
+      tr3.where($"c" > 10 && IsNotNull($"c")).select($"c", $"c1", $"c2",
+        $"c2".as("c1_3")))).analyze
+
+    comparePlans(optimized1, correctAnswer1)
+    // on top of union put a projection which eats away 1st col
+    // in that case the filter after it should survive
+    // This is because the first column in each leg is respectively
+    // a, b, and c. For Leg2 & Leg3 the filters are respectively on
+    // b & c. So if a project on top of union only has constraint on
+    // 1st column that is a. Actually the filter should survive
+    // irrespective of whether a gets removed or not.
+    val y2 = union.select($"a1_1", $"a1_2", $"a1_3").where($"a1_1" > 10).analyze
+    assert(y2.resolved)
+    val optimized2 = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(y2)
+    trivialConstraintAbsenceChecker(optimized2.constraints)
+
+    val correctAnswer2 = tr1.where($"a" > 10 && IsNotNull($"a")).
+      select($"a", $"a".as("a1_1"),
+        $"a".as("a1_2"), $"a".as("a1_3")).union(
+      tr2.where($"b" > 10 && IsNotNull($"b")).select($"b", $"b1", $"b1".as("b1_2"),
+        $"b1".as("b1_3"))).union(
+      tr3.where($"c" > 10 && IsNotNull($"c")).select($"c", $"c1", $"c2",
+        $"c2".as("c1_3"))).select($"a1_1", $"a1_2", $"a1_3").
+      where($"a1_1" > 10 && IsNotNull($"a1_1")).analyze
+
+    comparePlans(optimized2, correctAnswer2)
+    // check that filter survives, even if no projection is applied on union
+    val y3 = union.where($"a1_1" > 10).analyze
+    assert(y3.resolved)
+    val optimized3 = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(y3)
+    trivialConstraintAbsenceChecker(optimized3.constraints)
+
+    val correctAnswer3 = tr1.where($"a" > 10 && IsNotNull($"a")).
+      select($"a", $"a".as("a1_1"),
+        $"a".as("a1_2"), $"a".as("a1_3")).union(
+      tr2.where($"b" > 10 && IsNotNull($"b")).select($"b", $"b1", $"b1".as("b1_2"),
+        $"b1".as("b1_3"))).union(
+      tr3.where($"c" > 10 && IsNotNull($"c")).select($"c", $"c1", $"c2",
+        $"c2".as("c1_3"))).where($"a1_1" > 10 && IsNotNull($"a1_1")).analyze
+
+    comparePlans(optimized3, correctAnswer3)
+
+  }
+  test("Union Node. missing attribute from equiv list behaviour - 1." +
+    " wth changed union legs order") {
+    val tr1 = LocalRelation($"a".int, $"a1".int, $"a2".int, $"a3".int, $"a4".int)
+    val tr2 = LocalRelation($"b".int, $"b1".int, $"b2".int, $"b3".int, $"b4".int)
+    val tr3 = LocalRelation($"c".int, $"c1".int, $"c2".int, $"c3".int, $"c4".int)
+    val u1 = tr1.where($"a" > 10).select($"a", $"a".as("a1_1"),
+      $"a".as("a1_2"), $"a".as("a1_3"))
+    val u2 = tr2.where($"b" > 10).select($"b", $"b1", $"b1".as("b1_2"),
+      $"b1".as("b1_3"))
+    val u3 = tr3.where($"c" > 10).select($"c", $"c1", $"c2", $"c2".as("c1_3"))
+    val union = u2.union(u3).union(u1)
+    // The condition $"b" > 10 is a redundant condition and should be removed
+    // by constraintset.
+    val y = union.where($"b" > 10).analyze
+    assert(y.resolved)
+    val optimized1 = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(y)
+    trivialConstraintAbsenceChecker(optimized1.constraints)
+
+    val correctAnswer1 = new Union(Seq(
+      tr2.where($"b" > 10 && IsNotNull($"b")).select($"b", $"b1", $"b1".as("b1_2"),
+        $"b1".as("b1_3"))
+        .union( tr3.where($"c" > 10 && IsNotNull($"c")).select($"c", $"c1", $"c2",
+          $"c2".as("c1_3"))
+        ),
+      tr1.where($"a" > 10 && IsNotNull($"a")).select($"a", $"a".as("a1_1"),
+        $"a".as("a1_2"), $"a".as("a1_3"))
+    )).analyze
+
+    comparePlans(optimized1, correctAnswer1)
+    // on top of union put a projection which eats away 1st col
+    // the filter after it should  survive
+    val y2 = union.select($"b1", $"b1_2", $"b1_3").where($"b1" > 10).analyze
+    assert(y2.resolved)
+    val optimized2 = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(y2)
+    trivialConstraintAbsenceChecker(optimized2.constraints)
+
+    val correctAnswer2 =
+      tr2.where($"b" > 10 && IsNotNull($"b")).select($"b", $"b1", $"b1".as("b1_2"),
+        $"b1".as("b1_3")).union(
+        tr3.where($"c" > 10 && IsNotNull($"c")).select($"c", $"c1", $"c2",
+          $"c2".as("c1_3"))).union(tr1.where($"a" > 10 && IsNotNull($"a")).
+        select($"a", $"a".as("a1_1"),
+          $"a".as("a1_2"), $"a".as("a1_3")))
+        .select($"b1", $"b1_2", $"b1_3").
+        where($"b1" > 10 && IsNotNull($"b1")).analyze
+
+    comparePlans(optimized2, correctAnswer2)
+  }
+
+  test("Union Node. missing attribute from equiv list behaviour - 2") {
+    val tr1 = LocalRelation($"a".int, $"a1".int, $"a2".int, $"a3".int, $"a4".int)
+    val tr2 = LocalRelation($"b".int, $"b1".int, $"b2".int, $"b3".int, $"b4".int)
+    val tr3 = LocalRelation($"c".int, $"c1".int, $"c2".int, $"c3".int, $"c4".int)
+    val u1 = tr1.select($"a", $"a".as("a1_1"),
+      $"a".as("a1_2"), $"a".as("a1_3"))
+    val u1_f1 = u1.where($"a1_2" > 10)
+    val u2 = tr2.select($"b", $"b1", $"b1".as("b1_2"),
+      $"b1".as("b1_3"))
+    val u2_f2 = u2.where($"b1_2" > 10)
+    val u3 = tr3.select($"c", $"c1", $"c2", $"c2".as("c1_3"))
+    val u3_f3 = u3.where($"c2" > 10)
+    val union = u1_f1.union(u2_f2).union(u3_f3)
+    // The condition $"a1_2" > 10 is a redundant condition and should be removed
+    // by constraintset.
+    val y = union.where($"a1_2" > 10).analyze
+    assert(y.resolved)
+    val optimized1 = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(y)
+    trivialConstraintAbsenceChecker(optimized1.constraints)
+
+    val correctAnswer1 = u1.where($"a1_2" > 10 && IsNotNull($"a")).
+      union(u2.where($"b1_2" > 10 && IsNotNull($"b1"))).union(
+      u3.where($"c2" > 10 && IsNotNull($"c2"))).analyze
+
+    comparePlans(optimized1, correctAnswer1)
+
+    // on top of union put a projection which eats away a1_2
+    // but still the top filter should be removed as constraint survives
+    val y2 = union.select($"a1_1", $"a1_3").where($"a1_3" > 10).analyze
+    assert(y2.resolved)
+    val correctAnswer2 = correctAnswer1.select($"a1_1", $"a1_3").analyze
+    val optimized2 = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(y2)
+    trivialConstraintAbsenceChecker(optimized2.constraints)
+    comparePlans(optimized2, correctAnswer2)
+  }
+  test("Union Node.  missing attribute from equiv list behaviour - 2." +
+    " reverse order of legs") {
+    val tr1 = LocalRelation($"a".int, $"a1".int, $"a2".int, $"a3".int, $"a4".int)
+    val tr2 = LocalRelation($"b".int, $"b1".int, $"b2".int, $"b3".int, $"b4".int)
+    val tr3 = LocalRelation($"c".int, $"c1".int, $"c2".int, $"c3".int, $"c4".int)
+    val u1 = tr1.select($"a", $"a".as("a1_1"),
+      $"a".as("a1_2"), $"a".as("a1_3"))
+    val u1_f1 = u1.where($"a1_2" > 10)
+    val u2 = tr2.select($"b", $"b1", $"b1".as("b1_2"),
+      $"b1".as("b1_3"))
+    val u2_f2 = u2.where($"b1_2" > 10)
+    val u3 = tr3.select($"c", $"c1", $"c2", $"c2".as("c1_3"))
+    val u3_f3 = u3.where($"c2" > 10)
+    val union = u3_f3.union(u1_f1).union(u2_f2)
+    // The condition $"c2" > 10 is a redundant condition and should be removed
+    // by constraintset.
+    // The reason $"c2" > 10 is redundant because each leg has already has the same
+    // constraint as a1_2, b1_2 and c2 so final union dataset column already
+    // has this constraint.
+    val y = union.where($"c2" > 10).analyze
+    assert(y.resolved)
+    val optimized1 = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(y)
+    trivialConstraintAbsenceChecker(optimized1.constraints)
+
+    val correctAnswer1 = u3.where($"c2" > 10 && IsNotNull($"c2")).
+      union(u1.where($"a1_2" > 10 && IsNotNull($"a"))).union(
+      u2.where($"b1_2" > 10 && IsNotNull($"b1"))).analyze
+
+    comparePlans(optimized1, correctAnswer1)
+
+    // on top of union put a projection which eats away a1_2
+    // but still the top filter should be removed as constraint survives
+    val y2 = union.select($"c1", $"c1_3").where($"c1_3" > 10).analyze
+    assert(y2.resolved)
+    val correctAnswer2 = correctAnswer1.select($"c1", $"c1_3").analyze
+    val optimized2 = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(y2)
+    trivialConstraintAbsenceChecker(optimized2.constraints)
+    comparePlans(optimized2, correctAnswer2)
+  }
+
+  test("Union Node. missing attribute from equiv list behaviour." +
+    "Common constraint dependent on more than 1 attributes") {
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int)
+    val tr2 = LocalRelation($"a1".int, $"b1".int, $"c1".int, $"d1".int, $"e1".int)
+    val tr3 = LocalRelation($"a2".int, $"b2".int, $"c2".int, $"d2".int, $"e2".int)
+    val u1 = tr1.select($"a", $"a".as("a_1"),
+      $"a".as("a_2"), $"a".as("a_3"), $"b", $"b".as("b_1"),
+      $"b".as("b_2"), $"c", $"c".as("c_1"), $"c".as("c_2"))
+    val u1_f1 = u1.where($"a" + $"b" + $"c" > 10).analyze
+    assert(u1_f1.resolved)
+
+    val u2 = tr2.select($"e1", $"d1", ($"e1" + $"d1").as("a_2"),
+      ($"e1" + $"a1").as("a_3"), ($"d1" + $"a1").as("b"), ($"e1" + $"a1" + $"d1").as("b_1"),
+      ($"e1" + $"a1" + $"d1").as("b_2"), ($"c1" + $"d1").as("c"),
+      $"c1".as("c_1"), ($"c1" + $"a1").as("c_2"))
+    val u2_f2 = u2.where($"a_3" + $"b_2" + $"c_2" > 10).analyze
+
+    assert(u2_f2.resolved)
+    val u3 = tr3.select(($"e2" + $"c2").as("a"), $"e2".as("a_1"),
+      ($"a2" + $"c2").as("a_2"),
+      ($"d2" * $"a2").as("a_3"), ($"c2" * $"d2").as("b"), $"b2".as("b_1"),
+      ($"e2" * $"a2" * $"d2").as("b_2"), ($"c2" + $"a2").as("c"),
+      $"e2".as("c_1"), ($"d2" + $"a2").as("c_2"))
+
+    val u3_f3 = u3.where($"a_3" + $"b_2" + $"c_2" > 10).analyze
+    assert(u3_f3.resolved)
+    val union = u1_f1.union(u2_f2).union(u3_f3)
+    // The condition $""$"a_3" + $"b_2" + $"c_2" > 10 is a redundant condition and should be removed
+    // by constraintset.
+    val y = union.where($"a_3" + $"b_2" + $"c_2" > 10).analyze
+    assert(y.resolved)
+    val optimized1 = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(y)
+    trivialConstraintAbsenceChecker(optimized1.constraints)
+
+    val correctAnswer1 = u1.
+      where($"a" + $"b" + $"c" > 10 && IsNotNull($"a") && IsNotNull($"b") && IsNotNull($"c")).
+      union(u2.where($"a_3" + $"b_2" + $"c_2" > 10 && IsNotNull($"a_3")
+        && IsNotNull($"b_1") && IsNotNull($"c_2"))).union(u3.where(
+      $"a_3" + $"b_2" + $"c_2" > 10 && IsNotNull($"a_3") && IsNotNull($"b_2")
+        && IsNotNull($"c_2"))).analyze
+
+    assert(correctAnswer1.resolved)
+
+    comparePlans(optimized1, correctAnswer1)
+  }
+
+  test("Union Node.  missing attribute from equiv list behaviour." +
+    "Common constraint dependent on more than 1 attributes. reverse union legs") {
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int)
+    val tr2 = LocalRelation($"a1".int, $"b1".int, $"c1".int, $"d1".int, $"e1".int)
+    val tr3 = LocalRelation($"a2".int, $"b2".int, $"c2".int, $"d2".int, $"e2".int)
+    val u1 = tr1.select($"a", $"a".as("a_1"),
+      $"a".as("a_2"), $"a".as("a_3"), $"b", $"b".as("b_1"),
+      $"b".as("b_2"), $"c", $"c".as("c_1"), $"c".as("c_2"))
+    val u1_f1 = u1.where($"a" + $"b" + $"c" > 10).analyze
+    assert(u1_f1.resolved)
+
+    val u2 = tr2.select($"e1", $"d1", ($"e1" + $"d1").as("a_2"),
+      ($"e1" + $"a1").as("a_3"), ($"d1" + $"a1").as("b"), ($"e1" + $"a1" + $"d1").as("b_1"),
+      ($"e1" + $"a1" + $"d1").as("b_2"), ($"c1" + $"d1").as("c"),
+      $"c1".as("c_1"), ($"c1" + $"a1").as("c_2"))
+    val u2_f2 = u2.where($"a_3" + $"b_2" + $"c_2" > 10).analyze
+
+    assert(u2_f2.resolved)
+    val u3 = tr3.select(($"e2" + $"c2").as("a"), $"e2".as("a_1"),
+      ($"a2" + $"c2").as("a_2"),
+      ($"d2" * $"a2").as("a_3"), ($"c2" * $"d2").as("b"), $"b2".as("b_1"),
+      ($"e2" * $"a2" * $"d2").as("b_2"), ($"c2" + $"a2").as("c"),
+      $"e2".as("c_1"), ($"d2" + $"a2").as("c_2"))
+
+    val u3_f3 = u3.where($"a_3" + $"b_2" + $"c_2" > 10).analyze
+    assert(u3_f3.resolved)
+    val union = u2_f2.union(u1_f1).union(u3_f3)
+    // The condition $"a1_2" > 10 is a redundant condition and should be removed
+    // by constraintset.
+    val y = union.where($"a_3" + $"b_2" + $"c_2" > 10).analyze
+    assert(y.resolved)
+    val optimized1 = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(y)
+    trivialConstraintAbsenceChecker(optimized1.constraints)
+
+    val correctAnswer1 = u2.where($"a_3" + $"b_2" + $"c_2" > 10 && IsNotNull($"a_3")
+      && IsNotNull($"b_1") && IsNotNull($"c_2")).
+      union(u1.
+        where($"a" + $"b" + $"c" > 10 && IsNotNull($"a") && IsNotNull($"b") && IsNotNull($"c"))).
+      union(u3.where(
+        $"a_3" + $"b_2" + $"c_2" > 10 && IsNotNull($"a_3") && IsNotNull($"b_2")
+          && IsNotNull($"c_2"))).analyze
+
+    assert(correctAnswer1.resolved)
+
+    comparePlans(optimized1, correctAnswer1)
+  }
+
+  test("Union Node identifying 'not common' constraints resulting in OR based constraints -1") {
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int)
+    val tr2 = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int)
+    val tr3 = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int)
+    val u1 = tr1.select($"a", $"a".as("a1"),
+      $"a".as("a2"), $"a".as("a3"), $"b", $"b".as("a5"), $"b".as("a6"),
+      $"b".as("a7"))
+    val u1_f1 = u1.where($"a" > 10 && $"b" > 11)
+
+    val u2 = tr2.select($"a", $"a".as("a1"),
+      $"a".as("a2"), $"a".as("a3"), $"a".as("X"), $"a".as("a5"),
+      $"a".as("a6"), $"a".as("a7"))
+    val u2_f2 = u2.where($"a" > 10 )
+    // This should result in following constraints
+    // a > 10  && (b > 11 ||b > 10)
+    // where a = {a, a1, a2 a3,}
+    // b = {b, a5, a6, a7}
+
+    val union1 = u1_f1.union(u2_f2)
+
+    val y1 = union1.analyze
+    assert(y1.resolved)
+    val optimized1 = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(y1)
+    trivialConstraintAbsenceChecker(optimized1.constraints)
+    val constraints = optimized1.getValidConstraints
+    val attribEquivList = constraints.asInstanceOf[ConstraintSet].
+      getAttribEquivalenceList
+    val output1 = optimized1.output
+    val expectedExprIdsInEquivList = Array[Seq[Attribute]](Seq(output1(0),
+      output1(1), output1(2), output1(3)), Seq(output1(4),
+      output1(5), output1(6), output1(7)))
+    assert(expectedExprIdsInEquivList.length === attribEquivList.length)
+    assert(expectedExprIdsInEquivList.forall(buff =>
+      attribEquivList.exists(eqiv => eqiv.map(_.canonicalized).toSet.
+        diff(buff.map(_.canonicalized).toSet).isEmpty && eqiv.size == buff.size)))
+    val expectedConstraint1 = output1.head > Literal(10)
+    val expectedConstraint2 = output1(4) > Literal(11) || output1(4) > Literal(10)
+    assert(constraints.contains(expectedConstraint1))
+    assert(constraints.contains(expectedConstraint2))
+    assert(4 === constraints.size)
+  }
+  test("Union Node. identifying 'not common' constraints resulting in OR based constraints -2") {
+
+    /*  The structure of union legs for the test
+            leg2 a---a1 ---a2                filter  a + b > 7
+                 a3---a4---a5                filter a3 + b > 10
+                 b---b1----b2----b3---b4
+
+            Leg1 a1----a2            a1 + b > 7
+                 a4---a5             a4 + b3 > 10
+                 b----b1
+                 b3---b4
+     */
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int)
+    val tr2 = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int)
+    val tr3 = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int)
+    val u1 = tr1.select($"a", $"b".as("a1"), $"b".as("a2"), ($"a" + $"b").as("a3"),
+      $"b".as("a4"), $"b".as("a5"), $"b", $"b".as("b1"), ($"b" + $"c").as("b2"),
+      ($"b" + $"e").as("b3"), ($"b" + $"e").as("b4"))
+    val u1_f1 = u1.where($"a1" + $"b" > 7 && $"a4" + $"b3" > 10)
+
+    val u2 = tr2.select($"a", $"a".as("a1"),
+      $"a".as("a2"), $"b".as("a3"), $"b".as("a4"), $"b".as("a5"),
+      $"e".as("b"), $"e".as("b1"), $"e".as("b2"), $"e".as("b3"),
+      $"e".as("b4"))
+    val u2_f2 = u2.where($"a" + $"b" > 7 && $"a3" + $"b" > 10 )
+    // This should result in following constraints
+    // a1 + b > 7  && a4 + b3 > 10
+    val union1 = u1_f1.union(u2_f2)
+
+    val y1 = union1.analyze
+    assert(y1.resolved)
+    val optimized1 = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(y1)
+    trivialConstraintAbsenceChecker(optimized1.constraints)
+    val constraints = optimized1.getValidConstraints
+    val attribEquivList = constraints.asInstanceOf[ConstraintSet].
+      getAttribEquivalenceList
+    val output1 = optimized1.output
+    val expectedExprIdsInEquivList = Array[Seq[Attribute]](Seq(output1(1),
+      output1(2)), Seq(output1(4), output1(5)), Seq(output1(9), output1(10)),
+      Seq(output1(6), output1(7)))
+    assert(expectedExprIdsInEquivList.length === attribEquivList.length)
+    assert(expectedExprIdsInEquivList.forall(buff =>
+      attribEquivList.exists(eqiv => eqiv.map(_.canonicalized).toSet.
+        diff(buff.map(_.canonicalized).toSet).isEmpty && eqiv.size == buff.size)))
+    val expectedConstraint1 = output1(1) + output1(6) > Literal(7)
+    val expectedConstraint2 = output1(4) + output1(9) > Literal(10)
+    assert(constraints.contains(expectedConstraint1))
+    assert(constraints.contains(expectedConstraint2))
+    // ensure no other wrong constraints are present
+    val totalFilters = constraints.getCanonicalizedFilters
+    val numNotNulls = totalFilters.count(_ match {
+      case _: IsNotNull => true
+      case _ => false
+    })
+
+    assert(constraints.size === numNotNulls + 2)
+  }
+  test("Union Node. identifying 'not common' constraints resulting in OR based constraints -3") {
+
+    /*   The structure of union legs for the test
+            leg1 a---a1--a2      a > 7
+                 a3---a4---a5   a3 > -13    a6 > 9
+            leg 2 a--a1--a2--a3--a4--a5--a6    a > 7
+     */
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int)
+    val tr2 = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int)
+    val tr3 = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int)
+    val u1 = tr1.select($"a", $"a".as("a1"), $"a".as("a2"),
+      ($"a" + $"b").as("a3"), ($"a" + $"b").as("a4"), ($"a" + $"b").as("a5"),
+      $"c".as("a6"))
+
+    val u1_f1 = u1.where($"a" > 7 && $"a6" > 9 && $"a3" > -13)
+
+    val u2 = tr2.select($"a", $"a".as("a1"),
+      $"a".as("a2"), $"a".as("a3"), $"a".as("a4"), $"a".as("a5"),
+      $"a".as("a6"))
+    val u2_f2 = u2.where($"a" > 7 )
+    // This should result in following constraints
+    // a > 7  &&  (a3 > -13 || a3 > 7)  && (a6 > 9 || a6 > 7)
+    val union1 = u1_f1.union(u2_f2)
+
+    val y1 = union1.analyze
+    assert(y1.resolved)
+    val optimized1 = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(y1)
+    trivialConstraintAbsenceChecker(optimized1.constraints)
+    val constraints = optimized1.getValidConstraints
+    val attribEquivList = constraints.asInstanceOf[ConstraintSet].
+      getAttribEquivalenceList
+    val output1 = optimized1.output
+    val expectedExprIdsInEquivList = Array[Seq[Attribute]](Seq(output1.head,
+      output1(1), output1(2)), Seq(output1(3), output1(4), output1(5)))
+    assert(expectedExprIdsInEquivList.length === attribEquivList.length)
+    assert(expectedExprIdsInEquivList.forall(buff =>
+      attribEquivList.exists(eqiv => eqiv.map(_.canonicalized).toSet.
+        diff(buff.map(_.canonicalized).toSet).isEmpty && eqiv.size == buff.size)))
+    val expectedConstraint1 = output1.head > Literal(7)
+    val expectedConstraint2 = output1(3) > Literal(7) || output1(3) > Literal(-13)
+    val expectedConstraint3 = output1(6) > Literal(7) || output1(6) > Literal(9)
+
+    assert(constraints.contains(expectedConstraint1))
+    assert(constraints.contains(expectedConstraint2))
+    assert(constraints.contains(expectedConstraint3))
+    // ensure no other wrong constraints are present
+    val totalFilters = constraints.getCanonicalizedFilters
+    val numNotNulls = totalFilters.count(_ match {
+      case _: IsNotNull => true
+      case _ => false
+    })
+
+    assert(constraints.size === numNotNulls + 3)
+  }
+  test("Union Node. identifying 'not common' constraints resulting in OR based constraints -4") {
+
+    /*   The structure of union legs for the test
+            leg1 a---a1--a2      a > 7
+                 a3   a3 > -13
+                 a4   a4 > 9
+                 a5   a5 > 11
+
+            leg 2 a--a1--a2--a3--a4     a > -17
+                  a6   a6 > 8
+     */
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int)
+    val tr2 = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int)
+    val tr3 = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int)
+    val u1 = tr1.select($"a", $"a".as("a1"), $"a".as("a2"),
+      ($"a" + $"b").as("a3"), ($"a" + $"c").as("a4"), ($"a" + $"d").as("a5"),
+      $"c".as("a6"))
+
+    val u1_f1 = u1.where($"a" > 7 && $"a3" > -13 && $"a4" > 9 && $"a5" > 11)
+
+    val u2 = tr2.select($"a", $"a".as("a1"),
+      $"a".as("a2"), $"a".as("a3"), $"a".as("a4"), ($"a" *$"e").as("a5"),
+      $"d".as("a6"))
+    val u2_f2 = u2.where($"a" > -17 && $"a6" > 8)
+    // This should result in following constraints
+    // (a > 7 || a > -17)  &&  (a3 > -13 || a3 > -17)  && (a4 > 9 || a4 > -17) &&
+    // ((a5 > 11 || a6 > 8)
+    val union1 = u1_f1.union(u2_f2)
+
+    val y1 = union1.analyze
+    assert(y1.resolved)
+    val optimized1 = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(y1)
+    trivialConstraintAbsenceChecker(optimized1.constraints)
+    val constraints = optimized1.getValidConstraints
+    val attribEquivList = constraints.asInstanceOf[ConstraintSet].
+      getAttribEquivalenceList
+    val output1 = optimized1.output
+    val expectedExprIdsInEquivList = Array[Seq[Attribute]](Seq(output1.head,
+      output1(1), output1(2)))
+    assert(expectedExprIdsInEquivList.length === attribEquivList.length)
+    assert(expectedExprIdsInEquivList.forall(buff =>
+      attribEquivList.exists(eqiv => eqiv.map(_.canonicalized).toSet.
+        diff(buff.map(_.canonicalized).toSet).isEmpty && eqiv.size == buff.size)))
+    val expectedConstraint1 = output1.head > Literal(7) || output1.head > Literal(-17)
+    val expectedConstraint2 = output1(3) > Literal(-13) || output1(3) > Literal(-17)
+    val expectedConstraint3 = output1(4) > Literal(9) || output1(4) > Literal(-17)
+
+    assert(constraints.contains(expectedConstraint1))
+    assert(constraints.contains(expectedConstraint2))
+    assert(constraints.contains(expectedConstraint3))
+    // ensure no other wrong constraints are present
+    val totalFilters = constraints.getCanonicalizedFilters
+    val numNotNulls = totalFilters.count(_ match {
+      case _: IsNotNull => true
+      case _ => false
+    })
+
+    assert(constraints.size === numNotNulls + 3)
+  }
+
+  test("Union Node. identifying 'not common' constraints resulting in OR based constraints -5") {
+
+    /*   The structure of union legs for the test
+            leg1 a---a1--a2--a3--a4
+                 b---b1--b2--b3--b4
+                 filter a + b > 5
+
+            leg 2 a--a1  a2   a3--a4
+                  b---b1  b2  b3--b4
+                   filter a + b > 5
+                          a3 + b3 > 5
+
+       expected union output constraints  a + b > 5
+                                          a3 + b3 > 5
+     */
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int)
+    val tr2 = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int)
+    val u1 = tr1.select($"a", $"a".as("a1"), $"a".as("a2"),
+      ($"a").as("a3"), ($"a").as("a4"), $"b", $"b".as("b1"),
+      $"b".as("b2"), $"b".as("b3"), $"b".as("b4"))
+
+    val u1_f1 = u1.where($"a" + $"b" > 5)
+
+    val u2 = tr2.select($"a", $"a".as("a1"),
+      $"c".as("a2"), ($"c" + $"d").as("a3"), ($"c" + $"d").as("a4"),
+      $"b", $"b".as("b1"), $"d".as("b2"), ($"d" * $"e").as("b3"),
+      ($"d" * $"e").as("b4"))
+    val u2_f2 = u2.where($"a" + $"b" > 5 && $"a3" + $"b3" > 5)
+    val union1 = u1_f1.union(u2_f2)
+
+    val y1 = union1.analyze
+    assert(y1.resolved)
+    val optimized1 = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(y1)
+    trivialConstraintAbsenceChecker(optimized1.constraints)
+    val constraints = optimized1.getValidConstraints
+    val attribEquivList = constraints.asInstanceOf[ConstraintSet].
+      getAttribEquivalenceList
+    val output1 = optimized1.output
+    val expectedExprIdsInEquivList = Array[Seq[Attribute]](Seq(output1.head,
+      output1(1)), Seq(output1(3), output1(4)), Seq(output1(5), output1(6)),
+      Seq(output1(8), output1(9)))
+    assert(expectedExprIdsInEquivList.length === attribEquivList.length)
+    assert(expectedExprIdsInEquivList.forall(buff =>
+      attribEquivList.exists(eqiv => eqiv.map(_.canonicalized).toSet.
+        diff(buff.map(_.canonicalized).toSet).isEmpty && eqiv.size == buff.size)))
+    val expectedConstraint1 = output1.head + output1(5) > Literal(5)
+    val expectedConstraint2 = output1(3) + output1(8) >  Literal(5)
+    assert(constraints.contains(expectedConstraint1))
+    assert(constraints.contains(expectedConstraint2))
+    // ensure no other wrong constraints are present
+    val totalFilters = constraints.getCanonicalizedFilters
+    val numNotNulls = totalFilters.count(_ match {
+      case _: IsNotNull => true
+      case _ => false
+    })
+
+    assert(constraints.size === numNotNulls + 2)
+  }
+
+  test("top filter should be pruned for union with lower filter on all tables") {
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int)
+    val tr2 = LocalRelation($"d".int, $"e".int, $"f".int)
+    val tr3 = LocalRelation($"g".int, $"h".int, $"i".int)
+
+    val y = tr1.where($"a" > 10).union(tr2.where($"d" > 10)).
+      union(tr3.where($"g" > 10))
+    val y1 = y.where($"a" > 10).analyze
+    assert(y1.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_UNIONS_PRUNING).
+      execute(y1)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+    val allFilterExpressions = optimized.collect {
+      case x: Filter => x
+    }.flatMap(_.expressions)
+    assert(allFilterExpressions.flatMap(_.collect {
+      case _: GreaterThan => true
+    }).size == 3)
+    val union = optimized.find {
+      case _: Union => true
+      case _ => false
+    }.get.asInstanceOf[Union]
+
+    assert(union.children.forall(p => {
+      p.expressions.flatMap(_.collect {
+        case x: GreaterThan => x
+      }).nonEmpty
+    }))
+
+    val correctAnswer = new Union(Seq(tr1.where($"a" > 10 && IsNotNull($"a")),
+      tr2.where($"d" > 10 && IsNotNull($"d")),
+      tr3.where($"g" > 10 && IsNotNull($"g")))).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("templatization of constraints") {
+    val tr1 = LocalRelation($"a".int, $"b".string, $"c".double, $"d".long, $"e".int, $"f".double,
+      $"g".long)
+    val tr2 = LocalRelation($"a1".int, $"b1".string, $"c1".double, $"d1".long, $"e1".int,
+      $"f1".double, $"g1".long)
+    val templateGenerator = new TemplateAttributeGenerator()
+    var filter1 = tr1.where($"a" + $"e" * ($"e" + $"a") > 7 ).
+      analyze.asInstanceOf[Filter]
+    val expr1 = filter1.condition
+    var templatized1 = ConstraintSet.templatizedConstraints(templateGenerator, Seq(expr1))
+    var filter2 = tr2.where($"a1" + $"e1" * ($"a1" + $"e1") > 7).
+      analyze.asInstanceOf[Filter]
+    val expr2 = filter2.condition
+    var templatized2 = ConstraintSet.templatizedConstraints(templateGenerator, Seq(expr2))
+    assert(templatized1.keySet.head == templatized2.keySet.head)
+
+    filter1 = tr1.where($"a" + $"b" * ($"e" + $"a" + $"c" * $"c" + $"b")  > 9).
+      analyze.asInstanceOf[Filter]
+    val expr3 = filter1.condition
+    templatized1 = ConstraintSet.templatizedConstraints(templateGenerator, Seq(expr3))
+    filter2 = tr2.where($"e1" + $"b1" * ($"a1" + $"a1" + $"f1" * $"c1" + $"b1" ) > 9 ).
+      analyze.asInstanceOf[Filter]
+    val expr4 = filter2.condition
+    templatized2 = ConstraintSet.templatizedConstraints(templateGenerator, Seq(expr4))
+    assert(templatized1.keySet.head == templatized2.keySet.head)
+
+    templatized1 = ConstraintSet.templatizedConstraints(templateGenerator, Seq(expr1, expr3))
+    templatized2 = ConstraintSet.templatizedConstraints(templateGenerator, Seq(expr2, expr4))
+    val pairs = templatized1.keySet.zip(templatized2.keySet)
+    pairs.foreach(tup => assert(tup._1 == tup._2))
+
+    // negative test
+    filter1 = tr1.where($"a" + $"b"  > 3).
+      analyze.asInstanceOf[Filter]
+    val expr5 = filter1.condition
+    templatized1 = ConstraintSet.templatizedConstraints(templateGenerator, Seq(expr5))
+    filter2 = tr2.where($"c1" + $"b1" > 3).
+      analyze.asInstanceOf[Filter]
+    val expr6 = filter2.condition
+    templatized2 = ConstraintSet.templatizedConstraints(templateGenerator, Seq(expr6))
+    assert(!(templatized1.keySet.head == templatized2.keySet.head))
+  }
+
+  test("top filter should be pruned for Intersection with lower filter on one" +
+    " or more tables") {
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int)
+    val tr2 = LocalRelation($"d".int, $"e".int, $"f".int)
+    val tr3 = LocalRelation($"g".int, $"h".int, $"i".int)
+
+    val y = tr1.where($"a" > 10).intersect(tr2.where($"e" > 5), isAll = true).
+      intersect(tr3.where($"i" > -5), isAll = true)
+
+    val y1 = y.select($"a".as("a1"), $"b".as("b1"), $"c".as("c1")).
+      analyze
+    assert(y1.resolved)
+
+    val y2 = y1.where($"a1" > 10 && $"b1" > 5 && $"c1" > -5).analyze
+    assert(y2.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_UNIONS_PRUNING).
+      execute(y2)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+    val allFilterExpressions = optimized.collect {
+      case x: Filter => x
+    }.flatMap(_.expressions)
+
+    assert(allFilterExpressions.flatMap(_.collect {
+      case _: GreaterThan => true
+    }).size == 3)
+    val correctAnswer = tr1.where(IsNotNull($"a") && $"a" > 10).
+      intersect(tr2.where(IsNotNull($"e") && $"e" > 5), isAll = true).
+      intersect(tr3.where(IsNotNull($"i") && $"i" > -5), isAll = true).
+      select($"a".as("a1"), $"b".as("b1"),
+        $"c".as("c1")).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("top filter should be pruned for aggregate with lower filter") {
+    val tr = LocalRelation($"a".int, $"b".string, $"c".int, $"d".int)
+    assert(tr.analyze.constraints.isEmpty)
+    val aliasedRelation = tr.where($"c" > 10 && $"a" < 5)
+      .groupBy($"a", $"c", $"b")($"a", $"c".as("c1"),
+        count($"a").as("a3")).
+      select($"c1", $"a", $"a3").analyze
+    val withTopFilter = aliasedRelation.where($"a" < 5 && $"c1" > 10 && $"a3" > 20).analyze
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING).
+      execute(withTopFilter)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+    val correctAnswer = tr.where($"c" > 10 && $"a" < 5 && IsNotNull($"a") && IsNotNull($"c")
+    ).groupBy($"a", $"c", $"b")($"a", $"c".as("c1"),
+      count($"a").as("a3")).where($"a3" > Literal(20).cast(LongType)).
+      select($"c1", $"a", $"a3").analyze
+    comparePlans(correctAnswer, optimized)
+  }
+
+  test("duplicate removed attributes with different metadata" +
+    "causes assert failure") {
+    val tr = LocalRelation($"a".int, $"b".string, $"c".int, $"d".int)
+    val aliasedRelation = tr.select($"a", $"a".as("a1"), $"a", $"a".as("a2"),
+      $"a".as("a3"), $"c", $"c".as("c1")).select($"c1", $"a3").where($"a3" > 5).
+      analyze
+    val bugify = aliasedRelation.transformUp {
+      case Project(projList, child) if projList.exists(_.name == "a") =>
+        Project(projList.zipWithIndex.map{ case(ne, i) =>
+          ne match {
+            case att: AttributeReference => att.withQualifier(Seq(i.toString))
+            case _ => ne
+          }
+        }, child)
+    }
+    GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).execute(bugify)
+  }
+
+  test("filter push down on join with aggregate") {
+    val tr1 = LocalRelation($"a".int, $"b".string, $"c".int)
+    val tr2 = LocalRelation($"x".int, $"y".string, $"z".int)
+    val query = tr1.where($"c" + $"a" > 10 && $"a" > -15).select($"a",
+      $"a".as("a1"), $"a".as("a2"), $"b".as("b1"), $"c", $"c".as("c1")).
+      groupBy($"b1", $"c1")($"b1", $"c1".as("c2"), count($"a").as("a3")).
+      select($"c2", $"a3").join(tr2.where($"x" > 9), Inner, Some($"c2" === $"x"))
+
+    val (actual, constraints) = withSQLConf[(LogicalPlan, ExpressionSet)]() {
+      executePlan(query, OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+    }
+
+    val expected = tr1.where(IsNotNull($"c") && IsNotNull($"a") && $"c" + $"a" > 10 &&
+      $"a" > -15 && $"c" > 9)
+      .select($"a",
+        $"a".as("a1"), $"a".as("a2"), $"b".as("b1"), $"c", $"c".as("c1")).
+      groupBy($"b1", $"c1")($"b1", $"c1".as("c2"), count($"a").as("a3")).
+      select($"c2", $"a3").join(tr2.where($"x" > 9 && IsNotNull($"x")),
+      Inner, Some($"c2" === $"x")).analyze
+
+
+    trivialConstraintAbsenceChecker(constraints)
+
+    comparePlans(expected, actual)
+
+    val conditionFinder: PartialFunction[LogicalPlan, Seq[Expression]] = {
+      case f: Filter => f.expressions.find(x => x.find {
+        case GreaterThan(att: Attribute, Literal(9, IntegerType)) if att.name == "c" => true
+        case LessThan(Literal(9, IntegerType), att: Attribute) if att.name == "c" => true
+        case _ => false
+      }.isDefined).map(Seq(_)).getOrElse(Seq.empty[Expression])
+    }
+
+    val result2 = actual.collect {
+      conditionFinder
+    }.flatten
+    assert(result2.nonEmpty)
+  }
+
+  /**
+   * Looks like in 3.1 some changes have gone into stock constraint optimization such
+   * that if the only rule present is PruneFilters in the optimizer, the stock
+   * spark$"s" constraint code is not behaving correctly. The problem lies in stock
+   * spark & not in the optimized constraints code, as in the stock spark the
+   * relevant constraints for the alias are not present.
+   * so modifying the test to allow it to pass for optimized constraint situation
+   */
+  test("test pruning using constraints with filters after project - 1") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation($"a".int, $"b".string, $"c".int)
+      tr1.select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c", $"c".as("c1")).where($"c" + $"a" > 10 && $"a" > -15).
+        where($"c1" + $"a2" > 10 && $"a2" > -15)
+    }
+
+
+    val (plan, constraints) = withSQLConf[(LogicalPlan, ExpressionSet)]() {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+    trivialConstraintAbsenceChecker(constraints)
+
+    val filters = plan.collect {
+      case f: Filter => f
+    }
+    assert(1 === filters.size)
+    val filterExprs = splitConjunctivePredicates(filters.head.condition)
+    assert(4 === filterExprs.size)
+    val exprsSet = ExpressionSet(filterExprs)
+    val proj = plan.collect {
+      case pr: Project => pr
+    }.head
+    val expectedFilters = Seq(IsNotNull(proj.output.find(_.name == "a").get),
+      IsNotNull(proj.output.find(_.name == "c").get),
+      proj.output.find(_.name == "a").get > -15,
+      proj.output.find(_.name == "a").get + proj.output.find(_.name == "c").get > 10
+    )
+    expectedFilters.foreach(f => assert(exprsSet.contains(f)))
+  }
+
+
+  test("test pruning using constraints with filters after project - 2") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation($"a".int, $"b".string, $"c".int)
+      tr1.select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c", $"c".as("c1")).where($"c" + $"a" > 10 && $"a" > -15).
+        where($"c1" + $"a2" > 10 && $"a2" > -15)
+    }
+
+    val (plan, constraints) = withSQLConf[(LogicalPlan, ExpressionSet)]() {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+    trivialConstraintAbsenceChecker(constraints)
+
+    val correctAnswer = LocalRelation($"a".int, $"b".string, $"c".int).
+      select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c", $"c".as("c1")).where($"c" + $"a" > 10 && $"a" > -15
+      && IsNotNull($"a") && IsNotNull($"c")).analyze
+    comparePlans(correctAnswer, plan)
+  }
+
+  // Not comparing with stock spark plan as stock spark plan is unoptimal
+  test("test pruning using constraints with filters after project - 3") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation($"a".int, $"b".string, $"c".int)
+      tr1.select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c", $"c".as("c1")).where($"c1" + $"a1" > 10 && $"a2" > -15).
+        where($"c" + $"a" > 10 && $"a"  > -15)
+    }
+
+    val (plan, constraints) = withSQLConf[(LogicalPlan, ExpressionSet)]() {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+    trivialConstraintAbsenceChecker(constraints)
+
+    val correctAnswer = LocalRelation($"a".int, $"b".string, $"c".int).
+      select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c", $"c".as("c1")).where($"c1" + $"a1" > 10 && $"a2" > -15
+      && IsNotNull($"a") && IsNotNull($"c")).analyze
+    comparePlans(correctAnswer, plan)
+  }
+
+  test("test new filter inference with decanonicalization for expression not" +
+    " implementing NullIntolerant - 1") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation($"a".int, $"b".int, $"c".int)
+      tr1.select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c", $"c".as("c1"),
+        CaseWhen(Seq(($"a" + $"b" + $"c" > Literal(1),
+          Literal(1)), ($"a" + $"b" + $"c" > Literal(2), Literal(2))),
+          Option(Literal(null))).as("z")).where($"z" > 10 && $"a2" > -15).
+        where(CaseWhen(Seq(($"a" + $"b" + $"c" > Literal(1),
+          Literal(1)), ($"a" + $"b" + $"c" > Literal(2), Literal(2))),
+          Option(Literal(null))) > 10 && $"a" > -15).where($"z" > 10)
+    }
+
+    val (plan, constraints) = withSQLConf[(LogicalPlan, ExpressionSet)]() {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+    trivialConstraintAbsenceChecker(constraints)
+
+    val correctAnswer = LocalRelation($"a".int, $"b".int, $"c".int).
+      select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c", $"c".as("c1"), CaseWhen(Seq(
+          ($"a" + $"b" + $"c" > Literal(1),
+            Literal(1)), ($"a" + $"b" + $"c" > Literal(2), Literal(2))),
+          Option(Literal(null))).as("z"), $"b").where($"z" > 10 && $"a2" > -15
+      && IsNotNull($"a") && IsNotNull($"z")).select($"a", $"a1", $"a2",
+      $"b1", $"c", $"c1", $"z").analyze
+    comparePlans(correctAnswer, plan)
+  }
+
+  test("test new filter inference with decanonicalization for expression not" +
+    " implementing NullIntolerant - 2") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation($"a".int, $"b".int, $"c".int)
+      tr1.select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c", $"c".as("c1"),
+        ($"a" + CaseWhen(Seq(($"a" + $"b" + $"c" > Literal(1),
+          Literal(1)), ($"a" + $"b" + $"c" > Literal(2), Literal(2))),
+          Option(Literal(null)))).as("z")).where($"z" > 10 && $"a2" > -15).
+        where($"a" + CaseWhen(Seq(($"a" + $"b" + $"c" > Literal(1),
+          Literal(1)), ($"a" + $"b" + $"c" > Literal(2), Literal(2))),
+          Option(Literal(null))) > 10 && $"a" > -15).where($"z" > 10)
+    }
+
+    val (plan, constraints) = withSQLConf[(LogicalPlan, ExpressionSet)]() {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+    trivialConstraintAbsenceChecker(constraints)
+
+    val correctAnswer = LocalRelation($"a".int, $"b".int, $"c".int).
+      select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c", $"c".as("c1"), ($"a" + CaseWhen(Seq(
+          ($"a" + $"b" + $"c" > Literal(1),
+            Literal(1)), ($"a" + $"b" + $"c" > Literal(2), Literal(2))),
+          Option(Literal(null)))).as("z"), $"b").where($"z" > 10 && $"a2" > -15
+      && IsNotNull($"a") && IsNotNull($"z")).select($"a", $"a1", $"a2",
+      $"b1", $"c", $"c1", $"z").analyze
+    comparePlans(correctAnswer, plan)
+  }
+
+  test("test new filter inference with decanonicalization for expression" +
+    "implementing NullIntolerant") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation($"a".int, $"b".int, $"c".int)
+      tr1.select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c", $"c".as("c1"),
+        ($"a" + $"b" + $"c" ).as("z")).where($"z" > 10 && $"a2" > -15).
+        where($"a" + $"b1" + $"c" > 10 && $"a" > -15)
+    }
+
+    val (plan2, constraints2) = withSQLConf[(LogicalPlan, ExpressionSet)]() {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+    trivialConstraintAbsenceChecker(constraints2)
+
+    val correctAnswer = LocalRelation($"a".int, $"b".int, $"c".int).
+      select($"a", $"a".as("a1"), $"a".as("a2"),
+        $"b".as("b1"), $"c", $"c".as("c1"),
+        ($"a" + $"b" + $"c" ).as("z")).where($"z" > 10 && $"a2" > -15
+      && IsNotNull($"a") && IsNotNull($"b1") && IsNotNull($"c")).analyze
+    comparePlans(correctAnswer, plan2)
+  }
+
+  test("test pruning using constraints with filters after project with expression in" +
+    " alias.") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation($"a".int, $"b".int, $"c".int)
+      tr1.select($"a", $"a".as("a1"), $"a".as("a2"), $"b",
+        $"b".as("b1"), $"c", $"c".as("c1"), ($"a" + $"b").as("z")).
+        where($"c1" + $"z" > 10 &&
+          $"a2" > -15).
+        where($"c" + $"a" + $"b" > 10 &&
+          $"a" > -15)
+    }
+
+    val (plan, constraints) = withSQLConf[(LogicalPlan, ExpressionSet)]() {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+    trivialConstraintAbsenceChecker(constraints)
+
+    val correctAnswer = LocalRelation($"a".int, $"b".int, $"c".int).
+      select($"a", $"a".as("a1"), $"a".as("a2"), $"b",
+        $"b".as("b1"), $"c", $"c".as("c1"), ($"a" + $"b").as("z")).
+      where($"c1" + $"z" > 10 &&
+        $"a2" > -15 && IsNotNull($"b")
+        && IsNotNull($"a") && IsNotNull($"c")).analyze
+    comparePlans(correctAnswer, plan)
+  }
+
+  test("aliased expression contains embedded alias in projection") {
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int)
+    val y = tr1.where($"c" + $"a" + $"b" * $"a" > 10).select($"a", $"b", $"c",
+      ($"a" + $"c").as("summ")).
+      select($"a", $"b", $"c", $"summ", ($"b" * $"a").as("mult")).
+      select($"a", $"b", $"c", ($"summ" + $"mult").as("z")).
+      where($"z" > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).
+      execute(y)
+    trivialConstraintAbsenceChecker(optimized.constraints)
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+
+    val correctAnswer = tr1.where($"c" + $"a" + $"b" * $"a" > 10 && IsNotNull($"a")
+      && IsNotNull($"c") && IsNotNull($"b")).select($"a", $"b", $"c",
+      ($"a" + $"c").as("summ")).
+      select($"a", $"b", $"c", $"summ", ($"b" * $"a").as("mult")).
+      select($"a", $"b", $"c", ($"summ" + $"mult").as("z")).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  ignore("Disabled due to spark's canonicalization bug." +
+    " test pruning using constraints with filters after project with expression in alias.") {
+
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation($"a".int, $"b".string, $"c".int)
+      tr1.select($"a", $"a".as("a1"), $"a".as("a2"), $"b",
+        $"b".as("b1"), $"c", $"c".as("c1"), ($"a" + $"b").as("z")).
+        where($"c1" + $"z" > 10 && $"a2" > -15).
+        where($"c" + $"a" + $"b" > 10 && $"a" > -15)
+    }
+
+
+    val (plan, constraints) = withSQLConf[(LogicalPlan, ExpressionSet)]() {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+
+
+    val correctAnswer = LocalRelation($"a".int, $"b".string, $"c".int).
+      select($"a", $"a".as("a1"), $"a".as("a2"), $"b",
+        $"b".as("b1"), $"c", $"c".as("c1"), ($"a" + $"b").as("z")).
+      where($"c1" + $"z" > 10 && $"a2" > -15
+        && IsNotNull($"a") && IsNotNull($"c") && IsNotNull($"b")).analyze
+    comparePlans(correctAnswer, plan)
+  }
+
+  test("Bug caused by swapping of operands due to" +
+    " canonicalization in ExpressionMap during templatization in union constraint eval") {
+    val tr = LocalRelation($"a".int, $"b".int, $"c".int)
+    val plan = tr.where($"b" < $"a" + 7 && $"a" + 2 < $"c").analyze
+    val optimized = GetOptimizer(
+      OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_UNIONS_PRUNING).
+      execute(plan)
+    val constraints = optimized.constraints
+    val templateAttributeGenerator = new TemplateAttributeGenerator()
+    val templatizedConstraintsMap = ConstraintSet.templatizedConstraints(templateAttributeGenerator,
+      constraints.toSeq)
+
+    assert(templatizedConstraintsMap.nonEmpty)
+
+    val reconstructedConstraints =
+      for ((templatizedExpr, bindings) <- templatizedConstraintsMap) yield {
+        for (binding <- bindings) yield {
+          val solution = binding.toBuffer
+          templatizedExpr.transformDown {
+            case _: Attribute => solution.remove(0)
+          }
+        }
+      }
+    val newExprSet = ExpressionSet(reconstructedConstraints.flatten)
+    assert(newExprSet.size === constraints.size)
+    assert((newExprSet -- constraints).isEmpty)
+  }
+
+  ignore("plan equivalence with case statements and performance comparison with benefit" +
+    "of more than 10x conservatively") {
+    val tr = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int, $"e".int, $"f".int, $"g".int,
+      $"h".int, $"i".int, $"j".int, $"k".int, $"l".int, $"m".int, $"n".int)
+    val query = tr.select($"a", $"b", $"c", $"d", $"e", $"f", $"g", $"h", $"i", $"j", $"k",
+      $"l", $"m", $"n",
+      CaseWhen(Seq(($"a" + $"b" + $"c" + $"d" + $"e" + $"f" + $"g"
+        + $"h" + $"i" + $"j" + $"k" + $"l" + $"m" + $"n" > Literal(1),
+        Literal(1)),
+        ($"a" + $"b" + $"c" + $"d" + $"e" + $"f" + $"g" + $"h" +
+          $"i" + $"j" + $"k" + $"l" + $"m" + $"n" > Literal(2), Literal(2))),
+        Option(Literal(0))).as("JoinKey1")
+    ).select($"a".as("a1"), $"b".as("b1"), $"c".as("c1"),
+      $"d".as("d1"), $"e".as("e1"), $"f".as("f1"),
+      $"g".as("g1"), $"h".as("h1"), $"i".as("i1"),
+      $"j".as("j1"), $"k".as("k1"), $"l".as("l1"),
+      $"m".as("m1"), $"n".as("n1"), $"JoinKey1".as("cf1"),
+      $"JoinKey1").select($"a1", $"b1", $"c1", $"d1", $"e1", $"f1", $"g1", $"h1", $"i1",
+      $"j1", $"k1", $"l1", $"m1", $"n1", $"cf1", $"JoinKey1").
+      join(tr, condition = Option($"a" <=> $"JoinKey1"))
+
+    val expected = tr.select($"a", $"b", $"c", $"d", $"e", $"f", $"g", $"h", $"i", $"j",
+      $"k", $"l", $"m", $"n",
+      CaseWhen(Seq(($"a" + $"b" + $"c" + $"d" + $"e" + $"f" + $"g"
+        + $"h" + $"i" + $"j" + $"k" + $"l" + $"m" + $"n" > Literal(1),
+        Literal(1)),
+        ($"a" + $"b" + $"c" + $"d" + $"e" + $"f" + $"g" + $"h" +
+          $"i" + $"j" + $"k" + $"l" + $"m" + $"n" > Literal(2), Literal(2))),
+        Option(Literal(0))).as("JoinKey1")
+    ).select($"a".as("a1"), $"b".as("b1"), $"c".as("c1"),
+      $"d".as("d1"), $"e".as("e1"), $"f".as("f1"),
+      $"g".as("g1"), $"h".as("h1"), $"i".as("i1"),
+      $"j".as("j1"), $"k".as("k1"), $"l".as("l1"),
+      $"m".as("m1"), $"n".as("n1"), $"JoinKey1".as("cf1"),
+      $"JoinKey1").select($"a1", $"b1", $"c1", $"d1", $"e1", $"f1", $"g1", $"h1", $"i1",
+      $"j1", $"k1",
+      $"l1", $"m1", $"n1", $"cf1", $"JoinKey1").join(tr, condition = Option($"a" <=> $"JoinKey1"))
+
+    val (plan, constraints) = withSQLConf[(LogicalPlan, ExpressionSet)]() {
+      executePlan(query, OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+    }
+    trivialConstraintAbsenceChecker(constraints)
+
+    // Due to proper tracking of aliases, it is possible that final number of constraints
+    // may be a liitle more than the number of constraints returned by old code
+    // but intermediate size of old code may be very large causing issue, which is
+    // eliminated in the new code. The reason why this happens is that in the
+    //  ConstraintSet code to allow proper pruning from canonicalization, it is
+    // possible that the incoming expression may be expanded into its constituents
+    // refer function ConstraintSet.convertToCanonicalizedIfRqeuired
+    // where we are expanding using expression list also.
+    // assert(constraints2.expand.size <= constraints1.expand.size)
+    comparePlans(expected, plan)
+
+
+  }
+
+  def executePlan(plan: LogicalPlan, optimizerType: OptimizerTypes.Value):
+  (LogicalPlan, ExpressionSet) = {
+    object SimpleAnalyzer extends Analyzer(
+      new CatalogManager(FakeV2SessionCatalog,
+        new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry,
+          SQLConf.get)))
+
+    val optimizedPlan = GetOptimizer(optimizerType, Some(SQLConf.get)).
+      execute(SimpleAnalyzer.execute(plan))
+    (optimizedPlan, optimizedPlan.constraints)
+  }
+
+  private object OptimizerTypes extends Enumeration {
+    val WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING,
+    NO_PUSH_DOWN_ONLY_PRUNING, WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_UNIONS_PRUNING = Value
+  }
+
+  private object GetOptimizer {
+    def apply(optimizerType: OptimizerTypes.Value, useConf: Option[SQLConf] = None): Optimizer =
+      optimizerType match {
+        case OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING =>
+          new Optimizer(new CatalogManager(
+            FakeV2SessionCatalog,
+            new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry,
+              useConf.getOrElse(SQLConf.get)))) {
+            override def defaultBatches: Seq[Batch] =
+              Batch("Subqueries", Once,
+                EliminateSubqueryAliases) ::
+                Batch("Filter Pushdown and Pruning", FixedPoint(100),
+                  PushPredicateThroughJoin,
+                  PushDownPredicates,
+                  InferFiltersFromConstraints,
+                  CombineFilters,
+                  PruneFilters) :: Nil
+
+            override def nonExcludableRules: Seq[String] = Seq.empty[String]
+          }
+
+        case OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING =>
+          new Optimizer(new CatalogManager(
+            FakeV2SessionCatalog,
+            new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry,
+              useConf.getOrElse(SQLConf.get)))) {
+            override def defaultBatches: Seq[Batch] =
+              Batch("Subqueries", Once,
+                EliminateSubqueryAliases) ::
+                Batch("Filter Pruning", Once,
+                  InferFiltersFromConstraints,
+                  PruneFilters) :: Nil
+
+            override def nonExcludableRules: Seq[String] = Seq.empty[String]
+          }
+
+        case OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_UNIONS_PRUNING =>
+          new Optimizer(new CatalogManager(
+            FakeV2SessionCatalog,
+            new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry,
+              useConf.getOrElse(SQLConf.get)))) {
+            override def defaultBatches: Seq[Batch] =
+              Batch("Subqueries", Once,
+                EliminateSubqueryAliases) ::
+                Batch("Union Pushdown", FixedPoint(100),
+                  CombineUnions,
+                  PushProjectionThroughUnion,
+                  PushDownPredicates,
+                  InferFiltersFromConstraints,
+                  CombineFilters,
+                  PruneFilters) :: Nil
+
+            override def nonExcludableRules: Seq[String] = Seq.empty[String]
+          }
+      }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
@@ -155,21 +155,18 @@ case class LogicalRDD(
     }
   }
 
-  override lazy val constraints: ExpressionSet = originConstraints.getOrElse(ExpressionSet())
-    // Subqueries can have non-deterministic results even when they only contain deterministic
-    // expressions (e.g. consider a LIMIT 1 subquery without an ORDER BY). Propagating predicates
-    // containing a subquery causes the subquery to be executed twice (as the result of the subquery
-    // in the checkpoint computation cannot be reused), which could result in incorrect results.
-    // Therefore we assume that all subqueries are non-deterministic, and we do not expose any
-    // constraints that contain a subquery.
-    .filterNot(SubqueryExpression.hasSubquery)
+  override lazy val constraints: ExpressionSet = originConstraints.getOrElse(
+    if (conf.constraintPropagationEnabled) {
+      new ConstraintSet()
+    } else {
+      ExpressionSet()
+    }).filterNot(SubqueryExpression.hasSubquery)
 
   override def withStream(stream: SparkDataStream): LogicalRDD = {
     copy(stream = Some(stream))(session, originStats, originConstraints)
   }
 
   override def getStream: Option[SparkDataStream] = stream
-
 }
 
 object LogicalRDD extends Logging {

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/explain.txt
@@ -119,7 +119,7 @@ Input [6]: [ss_item_sk#4, ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7,
 Output [2]: [s_store_sk#12, s_zip#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_zip), IsNotNull(s_store_sk)]
+PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_zip:string>
 
 (18) ColumnarToRow [codegen id : 3]
@@ -127,7 +127,7 @@ Input [2]: [s_store_sk#12, s_zip#13]
 
 (19) Filter [codegen id : 3]
 Input [2]: [s_store_sk#12, s_zip#13]
-Condition : (isnotnull(s_zip#13) AND isnotnull(s_store_sk#12))
+Condition : (isnotnull(s_store_sk#12) AND isnotnull(s_zip#13))
 
 (20) BroadcastExchange
 Input [2]: [s_store_sk#12, s_zip#13]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/simplified.txt
@@ -42,7 +42,7 @@ TakeOrderedAndProject [ext_price,brand,brand_id,i_manufact_id,i_manufact]
                                 InputAdapter
                                   BroadcastExchange #5
                                     WholeStageCodegen (3)
-                                      Filter [s_zip,s_store_sk]
+                                      Filter [s_store_sk,s_zip]
                                         ColumnarToRow
                                           InputAdapter
                                             Scan parquet spark_catalog.default.store [s_store_sk,s_zip]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19/explain.txt
@@ -179,7 +179,7 @@ Input [9]: [ss_store_sk#6, ss_ext_sales_price#7, i_brand_id#10, i_brand#11, i_ma
 Output [2]: [s_store_sk#19, s_zip#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_zip), IsNotNull(s_store_sk)]
+PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_zip:string>
 
 (31) ColumnarToRow [codegen id : 5]
@@ -187,7 +187,7 @@ Input [2]: [s_store_sk#19, s_zip#20]
 
 (32) Filter [codegen id : 5]
 Input [2]: [s_store_sk#19, s_zip#20]
-Condition : (isnotnull(s_zip#20) AND isnotnull(s_store_sk#19))
+Condition : (isnotnull(s_store_sk#19) AND isnotnull(s_zip#20))
 
 (33) BroadcastExchange
 Input [2]: [s_store_sk#19, s_zip#20]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19/simplified.txt
@@ -52,7 +52,7 @@ TakeOrderedAndProject [ext_price,brand,brand_id,i_manufact_id,i_manufact]
                   InputAdapter
                     BroadcastExchange #6
                       WholeStageCodegen (5)
-                        Filter [s_zip,s_store_sk]
+                        Filter [s_store_sk,s_zip]
                           ColumnarToRow
                             InputAdapter
                               Scan parquet spark_catalog.default.store [s_store_sk,s_zip]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19.sf100/explain.txt
@@ -106,7 +106,7 @@ Input [9]: [ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_
 Output [2]: [s_store_sk#14, s_zip#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_zip), IsNotNull(s_store_sk)]
+PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_zip:string>
 
 (15) ColumnarToRow [codegen id : 3]
@@ -114,7 +114,7 @@ Input [2]: [s_store_sk#14, s_zip#15]
 
 (16) Filter [codegen id : 3]
 Input [2]: [s_store_sk#14, s_zip#15]
-Condition : (isnotnull(s_zip#15) AND isnotnull(s_store_sk#14))
+Condition : (isnotnull(s_store_sk#14) AND isnotnull(s_zip#15))
 
 (17) BroadcastExchange
 Input [2]: [s_store_sk#14, s_zip#15]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19.sf100/simplified.txt
@@ -44,7 +44,7 @@ TakeOrderedAndProject [ext_price,brand,brand_id,i_manufact_id,i_manufact]
                                   InputAdapter
                                     BroadcastExchange #5
                                       WholeStageCodegen (3)
-                                        Filter [s_zip,s_store_sk]
+                                        Filter [s_store_sk,s_zip]
                                           ColumnarToRow
                                             InputAdapter
                                               Scan parquet spark_catalog.default.store [s_store_sk,s_zip]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19/explain.txt
@@ -179,7 +179,7 @@ Input [9]: [ss_store_sk#6, ss_ext_sales_price#7, i_brand_id#10, i_brand#11, i_ma
 Output [2]: [s_store_sk#19, s_zip#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_zip), IsNotNull(s_store_sk)]
+PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_zip:string>
 
 (31) ColumnarToRow [codegen id : 5]
@@ -187,7 +187,7 @@ Input [2]: [s_store_sk#19, s_zip#20]
 
 (32) Filter [codegen id : 5]
 Input [2]: [s_store_sk#19, s_zip#20]
-Condition : (isnotnull(s_zip#20) AND isnotnull(s_store_sk#19))
+Condition : (isnotnull(s_store_sk#19) AND isnotnull(s_zip#20))
 
 (33) BroadcastExchange
 Input [2]: [s_store_sk#19, s_zip#20]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19/simplified.txt
@@ -52,7 +52,7 @@ TakeOrderedAndProject [ext_price,brand,brand_id,i_manufact_id,i_manufact]
                   InputAdapter
                     BroadcastExchange #6
                       WholeStageCodegen (5)
-                        Filter [s_zip,s_store_sk]
+                        Filter [s_store_sk,s_zip]
                           ColumnarToRow
                             InputAdapter
                               Scan parquet spark_catalog.default.store [s_store_sk,s_zip]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/explain.txt
@@ -154,7 +154,7 @@ Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, 
 Output [2]: [d_date_sk#14, d_date#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_date), IsNotNull(d_date_sk)]
+PushedFilters: [IsNotNull(d_date_sk), IsNotNull(d_date)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (19) ColumnarToRow [codegen id : 3]
@@ -162,7 +162,7 @@ Input [2]: [d_date_sk#14, d_date#15]
 
 (20) Filter [codegen id : 3]
 Input [2]: [d_date_sk#14, d_date#15]
-Condition : (isnotnull(d_date#15) AND isnotnull(d_date_sk#14))
+Condition : (isnotnull(d_date_sk#14) AND isnotnull(d_date#15))
 
 (21) BroadcastExchange
 Input [2]: [d_date_sk#14, d_date#15]
@@ -244,7 +244,7 @@ Output [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_d
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(inv_date_sk#25), dynamicpruningexpression(true)]
-PushedFilters: [IsNotNull(inv_quantity_on_hand), IsNotNull(inv_item_sk), IsNotNull(inv_warehouse_sk)]
+PushedFilters: [IsNotNull(inv_item_sk), IsNotNull(inv_quantity_on_hand), IsNotNull(inv_warehouse_sk)]
 ReadSchema: struct<inv_item_sk:int,inv_warehouse_sk:int,inv_quantity_on_hand:int>
 
 (39) ColumnarToRow [codegen id : 13]
@@ -252,7 +252,7 @@ Input [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_da
 
 (40) Filter [codegen id : 13]
 Input [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25]
-Condition : ((isnotnull(inv_quantity_on_hand#24) AND isnotnull(inv_item_sk#22)) AND isnotnull(inv_warehouse_sk#23))
+Condition : ((isnotnull(inv_item_sk#22) AND isnotnull(inv_quantity_on_hand#24)) AND isnotnull(inv_warehouse_sk#23))
 
 (41) Scan parquet spark_catalog.default.warehouse
 Output [2]: [w_warehouse_sk#26, w_warehouse_name#27]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/simplified.txt
@@ -79,7 +79,7 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                                           InputAdapter
                                                                             BroadcastExchange #9
                                                                               WholeStageCodegen (3)
-                                                                                Filter [d_date,d_date_sk]
+                                                                                Filter [d_date_sk,d_date]
                                                                                   ColumnarToRow
                                                                                     InputAdapter
                                                                                       Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
@@ -103,7 +103,7 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                 WholeStageCodegen (13)
                                                   Project [inv_item_sk,inv_quantity_on_hand,inv_date_sk,w_warehouse_name]
                                                     BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
-                                                      Filter [inv_quantity_on_hand,inv_item_sk,inv_warehouse_sk]
+                                                      Filter [inv_item_sk,inv_quantity_on_hand,inv_warehouse_sk]
                                                         ColumnarToRow
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72/explain.txt
@@ -91,7 +91,7 @@ Output [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_d
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(inv_date_sk#13)]
-PushedFilters: [IsNotNull(inv_quantity_on_hand), IsNotNull(inv_item_sk), IsNotNull(inv_warehouse_sk)]
+PushedFilters: [IsNotNull(inv_item_sk), IsNotNull(inv_quantity_on_hand), IsNotNull(inv_warehouse_sk)]
 ReadSchema: struct<inv_item_sk:int,inv_warehouse_sk:int,inv_quantity_on_hand:int>
 
 (5) ColumnarToRow [codegen id : 1]
@@ -99,7 +99,7 @@ Input [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_da
 
 (6) Filter [codegen id : 1]
 Input [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_date_sk#13]
-Condition : ((isnotnull(inv_quantity_on_hand#12) AND isnotnull(inv_item_sk#10)) AND isnotnull(inv_warehouse_sk#11))
+Condition : ((isnotnull(inv_item_sk#10) AND isnotnull(inv_quantity_on_hand#12)) AND isnotnull(inv_warehouse_sk#11))
 
 (7) BroadcastExchange
 Input [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_date_sk#13]
@@ -280,7 +280,7 @@ Input [11]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, 
 Output [2]: [d_date_sk#27, d_date#28]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_date), IsNotNull(d_date_sk)]
+PushedFilters: [IsNotNull(d_date_sk), IsNotNull(d_date)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (46) ColumnarToRow [codegen id : 8]
@@ -288,7 +288,7 @@ Input [2]: [d_date_sk#27, d_date#28]
 
 (47) Filter [codegen id : 8]
 Input [2]: [d_date_sk#27, d_date#28]
-Condition : (isnotnull(d_date#28) AND isnotnull(d_date_sk#27))
+Condition : (isnotnull(d_date_sk#27) AND isnotnull(d_date#28))
 
 (48) BroadcastExchange
 Input [2]: [d_date_sk#27, d_date#28]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72/simplified.txt
@@ -46,7 +46,7 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                                   InputAdapter
                                                                     BroadcastExchange #4
                                                                       WholeStageCodegen (1)
-                                                                        Filter [inv_quantity_on_hand,inv_item_sk,inv_warehouse_sk]
+                                                                        Filter [inv_item_sk,inv_quantity_on_hand,inv_warehouse_sk]
                                                                           ColumnarToRow
                                                                             InputAdapter
                                                                               Scan parquet spark_catalog.default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]
@@ -92,7 +92,7 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                       InputAdapter
                                         BroadcastExchange #10
                                           WholeStageCodegen (8)
-                                            Filter [d_date,d_date_sk]
+                                            Filter [d_date_sk,d_date]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/explain.txt
@@ -154,7 +154,7 @@ Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, 
 Output [2]: [d_date_sk#14, d_date#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_date), IsNotNull(d_date_sk)]
+PushedFilters: [IsNotNull(d_date_sk), IsNotNull(d_date)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (19) ColumnarToRow [codegen id : 3]
@@ -162,7 +162,7 @@ Input [2]: [d_date_sk#14, d_date#15]
 
 (20) Filter [codegen id : 3]
 Input [2]: [d_date_sk#14, d_date#15]
-Condition : (isnotnull(d_date#15) AND isnotnull(d_date_sk#14))
+Condition : (isnotnull(d_date_sk#14) AND isnotnull(d_date#15))
 
 (21) BroadcastExchange
 Input [2]: [d_date_sk#14, d_date#15]
@@ -244,7 +244,7 @@ Output [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_d
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(inv_date_sk#25), dynamicpruningexpression(true)]
-PushedFilters: [IsNotNull(inv_quantity_on_hand), IsNotNull(inv_item_sk), IsNotNull(inv_warehouse_sk)]
+PushedFilters: [IsNotNull(inv_item_sk), IsNotNull(inv_quantity_on_hand), IsNotNull(inv_warehouse_sk)]
 ReadSchema: struct<inv_item_sk:int,inv_warehouse_sk:int,inv_quantity_on_hand:int>
 
 (39) ColumnarToRow [codegen id : 13]
@@ -252,7 +252,7 @@ Input [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_da
 
 (40) Filter [codegen id : 13]
 Input [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25]
-Condition : ((isnotnull(inv_quantity_on_hand#24) AND isnotnull(inv_item_sk#22)) AND isnotnull(inv_warehouse_sk#23))
+Condition : ((isnotnull(inv_item_sk#22) AND isnotnull(inv_quantity_on_hand#24)) AND isnotnull(inv_warehouse_sk#23))
 
 (41) Scan parquet spark_catalog.default.warehouse
 Output [2]: [w_warehouse_sk#26, w_warehouse_name#27]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/simplified.txt
@@ -79,7 +79,7 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                                           InputAdapter
                                                                             BroadcastExchange #9
                                                                               WholeStageCodegen (3)
-                                                                                Filter [d_date,d_date_sk]
+                                                                                Filter [d_date_sk,d_date]
                                                                                   ColumnarToRow
                                                                                     InputAdapter
                                                                                       Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
@@ -103,7 +103,7 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                 WholeStageCodegen (13)
                                                   Project [inv_item_sk,inv_quantity_on_hand,inv_date_sk,w_warehouse_name]
                                                     BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
-                                                      Filter [inv_quantity_on_hand,inv_item_sk,inv_warehouse_sk]
+                                                      Filter [inv_item_sk,inv_quantity_on_hand,inv_warehouse_sk]
                                                         ColumnarToRow
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72/explain.txt
@@ -91,7 +91,7 @@ Output [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_d
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(inv_date_sk#13)]
-PushedFilters: [IsNotNull(inv_quantity_on_hand), IsNotNull(inv_item_sk), IsNotNull(inv_warehouse_sk)]
+PushedFilters: [IsNotNull(inv_item_sk), IsNotNull(inv_quantity_on_hand), IsNotNull(inv_warehouse_sk)]
 ReadSchema: struct<inv_item_sk:int,inv_warehouse_sk:int,inv_quantity_on_hand:int>
 
 (5) ColumnarToRow [codegen id : 1]
@@ -99,7 +99,7 @@ Input [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_da
 
 (6) Filter [codegen id : 1]
 Input [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_date_sk#13]
-Condition : ((isnotnull(inv_quantity_on_hand#12) AND isnotnull(inv_item_sk#10)) AND isnotnull(inv_warehouse_sk#11))
+Condition : ((isnotnull(inv_item_sk#10) AND isnotnull(inv_quantity_on_hand#12)) AND isnotnull(inv_warehouse_sk#11))
 
 (7) BroadcastExchange
 Input [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_date_sk#13]
@@ -280,7 +280,7 @@ Input [11]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, 
 Output [2]: [d_date_sk#27, d_date#28]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_date), IsNotNull(d_date_sk)]
+PushedFilters: [IsNotNull(d_date_sk), IsNotNull(d_date)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (46) ColumnarToRow [codegen id : 8]
@@ -288,7 +288,7 @@ Input [2]: [d_date_sk#27, d_date#28]
 
 (47) Filter [codegen id : 8]
 Input [2]: [d_date_sk#27, d_date#28]
-Condition : (isnotnull(d_date#28) AND isnotnull(d_date_sk#27))
+Condition : (isnotnull(d_date_sk#27) AND isnotnull(d_date#28))
 
 (48) BroadcastExchange
 Input [2]: [d_date_sk#27, d_date#28]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72/simplified.txt
@@ -46,7 +46,7 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                                   InputAdapter
                                                                     BroadcastExchange #4
                                                                       WholeStageCodegen (1)
-                                                                        Filter [inv_quantity_on_hand,inv_item_sk,inv_warehouse_sk]
+                                                                        Filter [inv_item_sk,inv_quantity_on_hand,inv_warehouse_sk]
                                                                           ColumnarToRow
                                                                             InputAdapter
                                                                               Scan parquet spark_catalog.default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]
@@ -92,7 +92,7 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                       InputAdapter
                                         BroadcastExchange #10
                                           WholeStageCodegen (8)
-                                            Filter [d_date,d_date_sk]
+                                            Filter [d_date_sk,d_date]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/explain.txt
@@ -202,7 +202,7 @@ Arguments: [cs_order_number#2 ASC NULLS FIRST, cs_item_sk#1 ASC NULLS FIRST], fa
 Output [5]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18, cr_returned_date_sk#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
-PushedFilters: [IsNotNull(cr_order_number), IsNotNull(cr_item_sk)]
+PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_return_quantity:int,cr_return_amount:decimal(7,2)>
 
 (17) ColumnarToRow [codegen id : 5]
@@ -210,7 +210,7 @@ Input [5]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_
 
 (18) Filter [codegen id : 5]
 Input [5]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18, cr_returned_date_sk#19]
-Condition : (isnotnull(cr_order_number#16) AND isnotnull(cr_item_sk#15))
+Condition : (isnotnull(cr_item_sk#15) AND isnotnull(cr_order_number#16))
 
 (19) Project [codegen id : 5]
 Output [4]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18]
@@ -287,7 +287,7 @@ Arguments: [ss_ticket_number#23 ASC NULLS FIRST, ss_item_sk#22 ASC NULLS FIRST],
 Output [5]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37, sr_returned_date_sk#38]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
-PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
+PushedFilters: [IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int,sr_return_quantity:int,sr_return_amt:decimal(7,2)>
 
 (36) ColumnarToRow [codegen id : 12]
@@ -295,7 +295,7 @@ Input [5]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return
 
 (37) Filter [codegen id : 12]
 Input [5]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37, sr_returned_date_sk#38]
-Condition : (isnotnull(sr_ticket_number#35) AND isnotnull(sr_item_sk#34))
+Condition : (isnotnull(sr_item_sk#34) AND isnotnull(sr_ticket_number#35))
 
 (38) Project [codegen id : 12]
 Output [4]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37]
@@ -372,7 +372,7 @@ Arguments: [ws_order_number#42 ASC NULLS FIRST, ws_item_sk#41 ASC NULLS FIRST], 
 Output [5]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56, wr_returned_date_sk#57]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_returns]
-PushedFilters: [IsNotNull(wr_order_number), IsNotNull(wr_item_sk)]
+PushedFilters: [IsNotNull(wr_item_sk), IsNotNull(wr_order_number)]
 ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_quantity:int,wr_return_amt:decimal(7,2)>
 
 (55) ColumnarToRow [codegen id : 19]
@@ -380,7 +380,7 @@ Input [5]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_
 
 (56) Filter [codegen id : 19]
 Input [5]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56, wr_returned_date_sk#57]
-Condition : (isnotnull(wr_order_number#54) AND isnotnull(wr_item_sk#53))
+Condition : (isnotnull(wr_item_sk#53) AND isnotnull(wr_order_number#54))
 
 (57) Project [codegen id : 19]
 Output [4]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/simplified.txt
@@ -62,7 +62,7 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                             Exchange [cr_order_number,cr_item_sk] #7
                                                               WholeStageCodegen (5)
                                                                 Project [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount]
-                                                                  Filter [cr_order_number,cr_item_sk]
+                                                                  Filter [cr_item_sk,cr_order_number]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.catalog_returns [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount,cr_returned_date_sk]
@@ -95,7 +95,7 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                             Exchange [sr_ticket_number,sr_item_sk] #9
                                                               WholeStageCodegen (12)
                                                                 Project [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt]
-                                                                  Filter [sr_ticket_number,sr_item_sk]
+                                                                  Filter [sr_item_sk,sr_ticket_number]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt,sr_returned_date_sk]
@@ -128,7 +128,7 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                             Exchange [wr_order_number,wr_item_sk] #11
                                                               WholeStageCodegen (19)
                                                                 Project [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt]
-                                                                  Filter [wr_order_number,wr_item_sk]
+                                                                  Filter [wr_item_sk,wr_order_number]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt,wr_returned_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75/explain.txt
@@ -202,7 +202,7 @@ Arguments: [cs_order_number#2 ASC NULLS FIRST, cs_item_sk#1 ASC NULLS FIRST], fa
 Output [5]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18, cr_returned_date_sk#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
-PushedFilters: [IsNotNull(cr_order_number), IsNotNull(cr_item_sk)]
+PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_return_quantity:int,cr_return_amount:decimal(7,2)>
 
 (17) ColumnarToRow [codegen id : 5]
@@ -210,7 +210,7 @@ Input [5]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_
 
 (18) Filter [codegen id : 5]
 Input [5]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18, cr_returned_date_sk#19]
-Condition : (isnotnull(cr_order_number#16) AND isnotnull(cr_item_sk#15))
+Condition : (isnotnull(cr_item_sk#15) AND isnotnull(cr_order_number#16))
 
 (19) Project [codegen id : 5]
 Output [4]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18]
@@ -287,7 +287,7 @@ Arguments: [ss_ticket_number#23 ASC NULLS FIRST, ss_item_sk#22 ASC NULLS FIRST],
 Output [5]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37, sr_returned_date_sk#38]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
-PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
+PushedFilters: [IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int,sr_return_quantity:int,sr_return_amt:decimal(7,2)>
 
 (36) ColumnarToRow [codegen id : 12]
@@ -295,7 +295,7 @@ Input [5]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return
 
 (37) Filter [codegen id : 12]
 Input [5]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37, sr_returned_date_sk#38]
-Condition : (isnotnull(sr_ticket_number#35) AND isnotnull(sr_item_sk#34))
+Condition : (isnotnull(sr_item_sk#34) AND isnotnull(sr_ticket_number#35))
 
 (38) Project [codegen id : 12]
 Output [4]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37]
@@ -372,7 +372,7 @@ Arguments: [ws_order_number#42 ASC NULLS FIRST, ws_item_sk#41 ASC NULLS FIRST], 
 Output [5]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56, wr_returned_date_sk#57]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_returns]
-PushedFilters: [IsNotNull(wr_order_number), IsNotNull(wr_item_sk)]
+PushedFilters: [IsNotNull(wr_item_sk), IsNotNull(wr_order_number)]
 ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_quantity:int,wr_return_amt:decimal(7,2)>
 
 (55) ColumnarToRow [codegen id : 19]
@@ -380,7 +380,7 @@ Input [5]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_
 
 (56) Filter [codegen id : 19]
 Input [5]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56, wr_returned_date_sk#57]
-Condition : (isnotnull(wr_order_number#54) AND isnotnull(wr_item_sk#53))
+Condition : (isnotnull(wr_item_sk#53) AND isnotnull(wr_order_number#54))
 
 (57) Project [codegen id : 19]
 Output [4]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75/simplified.txt
@@ -62,7 +62,7 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                             Exchange [cr_order_number,cr_item_sk] #7
                                                               WholeStageCodegen (5)
                                                                 Project [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount]
-                                                                  Filter [cr_order_number,cr_item_sk]
+                                                                  Filter [cr_item_sk,cr_order_number]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.catalog_returns [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount,cr_returned_date_sk]
@@ -95,7 +95,7 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                             Exchange [sr_ticket_number,sr_item_sk] #9
                                                               WholeStageCodegen (12)
                                                                 Project [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt]
-                                                                  Filter [sr_ticket_number,sr_item_sk]
+                                                                  Filter [sr_item_sk,sr_ticket_number]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt,sr_returned_date_sk]
@@ -128,7 +128,7 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                             Exchange [wr_order_number,wr_item_sk] #11
                                                               WholeStageCodegen (19)
                                                                 Project [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt]
-                                                                  Filter [wr_order_number,wr_item_sk]
+                                                                  Filter [wr_item_sk,wr_order_number]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt,wr_returned_date_sk]

--- a/sql/core/src/test/resources/tpch-plan-stability/q9/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q9/explain.txt
@@ -118,7 +118,7 @@ Input [8]: [l_orderkey#3, l_partkey#4, l_suppkey#5, l_quantity#6, l_extendedpric
 Output [3]: [ps_partkey#11, ps_suppkey#12, ps_supplycost#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/partsupp]
-PushedFilters: [IsNotNull(ps_suppkey), IsNotNull(ps_partkey)]
+PushedFilters: [IsNotNull(ps_partkey), IsNotNull(ps_suppkey)]
 ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint,ps_supplycost:decimal(10,0)>
 
 (18) ColumnarToRow [codegen id : 3]
@@ -126,7 +126,7 @@ Input [3]: [ps_partkey#11, ps_suppkey#12, ps_supplycost#13]
 
 (19) Filter [codegen id : 3]
 Input [3]: [ps_partkey#11, ps_suppkey#12, ps_supplycost#13]
-Condition : (isnotnull(ps_suppkey#12) AND isnotnull(ps_partkey#11))
+Condition : (isnotnull(ps_partkey#11) AND isnotnull(ps_suppkey#12))
 
 (20) BroadcastExchange
 Input [3]: [ps_partkey#11, ps_suppkey#12, ps_supplycost#13]

--- a/sql/core/src/test/resources/tpch-plan-stability/q9/simplified.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q9/simplified.txt
@@ -40,7 +40,7 @@ WholeStageCodegen (8)
                                 InputAdapter
                                   BroadcastExchange #5
                                     WholeStageCodegen (3)
-                                      Filter [ps_suppkey,ps_partkey]
+                                      Filter [ps_partkey,ps_suppkey]
                                         ColumnarToRow
                                           InputAdapter
                                             Scan parquet spark_catalog.default.partsupp [ps_partkey,ps_suppkey,ps_supplycost]


### PR DESCRIPTION
… rule
### What changes were proposed in this pull request?
This PR proposes new algorithm to create & store the constraints.
It tracks aliases in projection which eliminates the need of pessimistically generating all the permutations of a given constraint. It is also more effective in correctly identifying the filters which can be pruned , apart from minimizing the memory used as compared to the current code. This also has changes to push compound filters if the join condition is on multiple attributes and the constraint comprises of more than 1 attributes of the join conditions.

Presently I have kept the code which retains the old logic of constraint management along with the new logic. It is controlled by the sql conf property spark.sql.optimizer.optimizedConstraintPropagation.enabled which is by default true. Once the PR is approved it would make sense to remove the old code & merge the code of ConstraintSet into ExpressionSet and removing some if else blocks in the Optimizer & the function Optimizer.getAllConstraints and LogicalPlan.getAllValidConstraints.

The new logic is as follows:
In the class ConstraintSet which extends ExpressionSet, we track the aliases , along with the base constraint.
Any constraint which is added to the ConstraintSet is stored in the most canonicalized form (i.e consisting of only those attributes which are part of the output set and NOT the Alias's attribute).

for eg consider a hypothetical plan
>            Filter( z > 10 && a1 + b2 > 10)
                                 |
>         Projection1 ( a, a as a1, a as a2, b , b as b1, b as b2, c, a +b as z)
                                 |
 >                 Filter ( a + b > 10)
                                 |
 >              base relation (a, b, c, d)

At the node Filter the constraint set will just have constraint a + b > 10
At the Node Projection1 , the constraint set will have
constraint a + b > 10
and maintain following buffers
buff1 -> a , a1.attribute, a2. attribute
buff2 -> b, b1.attribute, b2.attribute
buff3 -> a + b, z.attribute

constraint a + b > 10 is already canonicalized in terms of output attributes.

Now there are two filters on top of projection1
Filter( z > 10) and Filter ( a1 + b2 > 10)

To prune the above two filters, we canonicalize z as a + b ( from the data maintained in the ConstraintSet) & check if the underlying set contains a +b > 10 & so can be pruned.
For Filter a1 + b2 > 10, we identify the buffer to which a1 & b2 belong to and replace it with 0th elements of the buffer, which will yield a +b > 10, and so filter can be pruned.

Now suppose there is another Project2 ( a1, a2, b1, b2, z, c)
i.e say attributes a & b are no longer part of OutputSet.

such that the plan looks like:
>         Projection2 ( a1,  a2,  b1,  b2, c,  z)
                                |
>            Filter( z > 10 && a1 + b2 > 10)
                                 |
>         Projection1 ( a, a as a1, a as a2, b , b as b1, b as b2, c, a +b as z)
                                 |
 >                 Filter ( a + b > 10)
                                 |
 >              base relation (a, b, c, d)

**The idea is that "as much as possible try to make a constraint survive.**

So in Project2 , the atttributes a & b are being eliminated.
we have a constraint a + b > 10 which is dependent on it.
so in the ConstraintSet of the ProjectP2, we update it such that
constraint a + b > 10 becomes ----> a1 + b1 > 10
**buff1   ->  a , a1, a2   will become --> a1, a2
buff2  ->  b , b1, b2.  will become  --> b1, b2
buff3   ->  a +b , z  will become  -->. a1 + b1 , z**

This way by tracking aliases & just storing the canonicalized base constraints we can eliminate the need of pessimistically generating all combination of constraints.

**This PR also eliminates the need of EqualNullSafe constraints for the alias.
It also is able to handle the literal boolean constraints.**

_**For inferring new Filter from constraints**_
we use following logic
New Filter = Filter.constraints -- ( Filter.child.constraints ++ Filter.constraints.convertToCanonicalizedIfRequired(Filter.conditions) )
So the idea is that new filter conditions without redundancy can be obtained by difference of current node's constraints & the child node's constraints & the condition itself properly canonicalized in terms of base attributes which will be part of the output set of filter node.

_**For inferring new filters for Join push down,**_
 we identify all the equality conditions & then the attributes are segregated on the lines of LHS & RHS of joins. So to identify filters for push down on RHS side, we get all equality atttributes of LHS side & ask the ConstraintSet to return all the constraints which are subset of the passed LHS attributes. The LHS attributes are appropriately canonicalized & the ConstraintSet identified.
Once the constraints are know, we can replace the attributes with the corresponding RHS attributes. This helps in identifying the compound filters for push down & not just single attribute filters.

_**Below is a description of the changes proposed.**_

ConstraintSet: This is the class which does the tracking of the aliases , stores the constraints in the canonicalized form, updates the constraints using available aliases if any of the attribute comprising constraint is getting eliminated. The contains method of this class is used for filter pruning. It also identifies those constraints which can generated new filters for push down in join nodes.
Rest all the changes are just to integrate the new logic as well as retain the old constraints logic.
Pls notice that related to tpcds plan stability , I had to add new golden files for q75. The change as such is trivial.
previously pushed filter was generated as
PushedFilters: [IsNotNull(cr_order_number), IsNotNull(cr_item_sk)]
and with the change it is
PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]

### Why are the changes needed?

1. This issue if not fixed can cause OutOfMemory issue or unacceptable query compilation times.
Added a test **"plan equivalence with case statements and performance comparison with benefit of more than 10x conservatively"  in  org.apache.spark.sql.catalyst.plans.OptimizedConstraintPropagationSuite**. With this PR the compilation _**time is 247 ms vs 13958 ms without the change**_
2. It is more effective in filter pruning as is evident in some of the tests in org.apache.spark.sql.catalyst.plans.OptimizedConstraintPropagationSuite where current code is not able to identify the redundant filter in some cases.
3. It is able to generate a better optimized plan for join queries as it can push compound predicates.
4. The current logic can miss a lot of possible cases of removing redundant predicates, as it fails to take into account if same attribute or its aliases are repeated multiple times in a complex expression.
5. There are cases where some of the optimizer rules involving removal of redundant predicates fail to remove on the basis of constraint data. In some cases the rule works, just by the virtue of previous rules helping it out to cover the inaccuracy. That the ConstraintPropagation rule & its function of removal of redundant filters & addition of new inferred filters is dependent on the working of some of the other unrelated previous optimizer rules is behaving, is indicative of issues.
6. It does away with all the EqualNullSafe constraints as this logic does not need those constraints to be created.
7.  There is atleast one test in existing **ConstraintPropagationSuite** which is missing a IsNotNull constraints because the code incorrectly generated a EqualsNullSafeConstraint instead of EqualTo constraint, when using the existing Constraints code.  With these changes, the test correctly creates an EqualTo constraint, resulting in an inferred IsNotNull constraint
8. It does away with the current combinatorial  logic of evaluation all the constraints can cause compilation to run into hours or cause OOM. The number of constraints stored is exactly the same as the number of filters encountered


Added a test suite **CompareNewAndOldConstraintsSuite** which when run on current master, will fail highlighting the issues with current master ( in terms of functionality) and also show the perf problem.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Many new tests are added. All existing tests are passing cleanly.
Code is functional in workday env. for 1.5 years  without any issue
