### PR TITLE
[SPARK-50536][CORE] Log downloaded archive file sizes in `SparkContext` and `Executor`

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1878,6 +1878,7 @@ class SparkContext(config: SparkConf) extends Logging {
         if (uri.getFragment != null) uri.getFragment else source.getName)
       logInfo(
         log"Unpacking an archive ${MDC(LogKeys.PATH, path)}" +
+          log" (${MDC(LogKeys.BYTE_SIZE, source.length)} bytes)" +
           log" from ${MDC(LogKeys.SOURCE_PATH, source.getAbsolutePath)}" +
           log" to ${MDC(LogKeys.DESTINATION_PATH, dest.getAbsolutePath)}")
       Utils.deleteRecursively(dest)

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -1210,6 +1210,7 @@ private[spark] class Executor(
           if (sourceURI.getFragment != null) sourceURI.getFragment else source.getName)
         logInfo(
           log"Unpacking an archive ${LogMDC(ARCHIVE_NAME, name)}" +
+            log" (${LogMDC(BYTE_SIZE, source.length)} bytes)" +
             log" from ${LogMDC(SOURCE_PATH, source.getAbsolutePath)}" +
             log" to ${LogMDC(DESTINATION_PATH, dest.getAbsolutePath)}")
         Utils.deleteRecursively(dest)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to log downloaded archive file sizes in `SparkContext` and `Executor`.

### Why are the changes needed?

To improve the UX by showing the file size intuitively in order to help check file health.

### Does this PR introduce _any_ user-facing change?

No, this is a log message.

### How was this patch tested?

Manual check with the Apache Spark test jar file.
- https://github.com/apache/spark/raw/refs/heads/master/data/artifact-tests/smallJar.jar

```
$ ls -al data/artifact-tests/smallJar.jar
-rwxr-xr-x  1 dongjoon  staff  787 Dec  3 09:06 data/artifact-tests/smallJar.jar
```

Run the spark-shell and grep `(787 bytes)` from the log message like the following.
```
$ bin/spark-shell --archives https://github.com/apache/spark/raw/refs/heads/master/data/artifact-tests/smallJar.jar -c spark.log.level=DEBUG 2>&1 | grep '787 bytes'
24/12/10 10:05:09 INFO SparkContext: Unpacking an archive https://github.com/apache/spark/raw/refs/heads/master/data/artifact-tests/smallJar.jar (787 bytes) from /private/var/folders/c8/9r5k3d7n19g2m72c86qm08580000gn/T/spark-28ceb587-8376-403e-b364-e675529aeef0/smallJar.jar to /private/var/folders/c8/9r5k3d7n19g2m72c86qm08580000gn/T/spark-d97fc8fc-358e-4044-a904-dfc6823d742d/userFiles-89ff1008-a0d7-4c83-bd9f-9c4e2e830645/smallJar.jar
24/12/10 10:05:09 INFO Executor: Unpacking an archive https://github.com/apache/spark/raw/refs/heads/master/data/artifact-tests/smallJar.jar (787 bytes) from /private/var/folders/c8/9r5k3d7n19g2m72c86qm08580000gn/T/spark-b9020649-cb2b-476b-89f5-5d502f1e0ba8/smallJar.jar to /private/var/folders/c8/9r5k3d7n19g2m72c86qm08580000gn/T/spark-d97fc8fc-358e-4044-a904-dfc6823d742d/userFiles-89ff1008-a0d7-4c83-bd9f-9c4e2e830645/smallJar.jar
```

### Was this patch authored or co-authored using generative AI tooling?

No.