### PR TITLE
[SPARK-49349][SQL][FOLLOWUP] Rename isContainsUnsupportedLCA function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -192,7 +192,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
     )
   }
 
-  private def isContainsUnsupportedLCA(e: Expression, operator: LogicalPlan): Boolean = {
+  private def containsUnsupportedLCA(e: Expression, operator: LogicalPlan): Boolean = {
     e.containsPattern(LATERAL_COLUMN_ALIAS_REFERENCE) && operator.expressions.exists {
       case a: Alias
         if e.collect { case l: LateralColumnAliasReference => l.nameParts.head }.contains(a.name) =>
@@ -369,7 +369,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
           case GetMapValue(map, key: Attribute) if isMapWithStringKey(map) && !key.resolved =>
             failUnresolvedAttribute(operator, key, "UNRESOLVED_MAP_KEY")
 
-          case e: Expression if isContainsUnsupportedLCA(e, operator) =>
+          case e: Expression if containsUnsupportedLCA(e, operator) =>
             val lcaRefNames =
               e.collect { case lcaRef: LateralColumnAliasReference => lcaRef.name }.distinct
             failAnalysis(


### PR DESCRIPTION

### What changes were proposed in this pull request?
As follow-up to https://github.com/apache/spark/pull/48915, this PR renames `isContainsUnsupportedLCA` function

### Why are the changes needed?
The renamed function is easier to understand.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No change in functionality.
Existing tests suffice.

### Was this patch authored or co-authored using generative AI tooling?
No