### PR TITLE
[SPARK-50546][SQL] Add subquery cast support to collation type coercion

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.catalyst.analysis.CollationStrength.{Default, Explicit, Implicit}
 import org.apache.spark.sql.catalyst.analysis.TypeCoercion.haveSameType
-import org.apache.spark.sql.catalyst.expressions.{SubqueryExpression, _}
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Project}
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.errors.QueryCompilationErrors

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.catalyst.analysis.CollationStrength.{Default, Explicit, Implicit}
 import org.apache.spark.sql.catalyst.analysis.TypeCoercion.haveSameType
-import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.{SubqueryExpression, _}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Project}
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StringType, StructType}
@@ -172,12 +173,45 @@ object CollationTypeCoercion {
         expr match {
           case lit: Literal => lit.copy(dataType = newDataType)
           case cast: Cast => cast.copy(dataType = newDataType)
+          case subquery: SubqueryExpression =>
+            changeTypeInSubquery(subquery, newType)
+
           case _ => Cast(expr, newDataType)
         }
 
       case _ =>
         expr
     }
+  }
+
+  /**
+   * Changes the data type of the expression in the subquery to the given `newType`.
+   * Currently only supports subqueries with [[Project]] and [[Aggregate]] plan.
+   */
+  private def changeTypeInSubquery(
+      subqueryExpression: SubqueryExpression,
+      newType: DataType): SubqueryExpression = {
+
+    def transformNamedExpressions(ex: NamedExpression): NamedExpression = {
+      changeType(ex, newType) match {
+        case named: NamedExpression => named
+        case other => Alias(other, ex.name)()
+      }
+    }
+
+    val newPlan = subqueryExpression.plan match {
+      case project: Project =>
+        val newProjectList = project.projectList.map(transformNamedExpressions)
+        project.copy(projectList = newProjectList)
+
+      case agg: Aggregate =>
+        val newAggregateExpressions = agg.aggregateExpressions.map(transformNamedExpressions)
+        agg.copy(aggregateExpressions = newAggregateExpressions)
+
+      case other => other
+    }
+
+    subqueryExpression.withNewPlan(newPlan)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationTypePrecedenceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationTypePrecedenceSuite.scala
@@ -175,6 +175,115 @@ class CollationTypePrecedenceSuite extends QueryTest with SharedSparkSession {
     )
   }
 
+  test("in subquery expression") {
+    val tableName = "subquery_tbl"
+    withTable(tableName) {
+      sql(
+        s"""
+           |CREATE TABLE $tableName (
+           | c1 STRING COLLATE UTF8_LCASE,
+           | c2 STRING COLLATE UNICODE
+           |) USING $dataSource
+           |""".stripMargin)
+
+      sql(s"INSERT INTO $tableName VALUES ('a', 'A')")
+
+      assertImplicitMismatch(
+        sql(
+          s"""
+             |SELECT * FROM $tableName
+             |WHERE c1 IN (SELECT c2 FROM $tableName)
+             |""".stripMargin))
+
+      // this fails since subquery expression collation is implicit by default
+      assertImplicitMismatch(
+        sql(
+          s"""
+             |SELECT * FROM $tableName
+             |WHERE c1 IN (SELECT c2 collate unicode FROM $tableName)
+             |""".stripMargin))
+
+      checkAnswer(
+        sql(
+          s"""
+             |SELECT COUNT(*) FROM $tableName
+             |WHERE c1 collate utf8_lcase IN (SELECT c2 collate unicode FROM $tableName)
+             |""".stripMargin),
+        Seq(Row(1)))
+
+      checkAnswer(
+        sql(
+          s"""
+             |SELECT COUNT(*) FROM $tableName
+             |WHERE c1 collate utf8_lcase IN (SELECT c2 FROM $tableName)
+             |""".stripMargin),
+        Seq(Row(1)))
+
+      checkAnswer(
+        sql(
+          s"""
+             |SELECT COUNT(*) FROM $tableName
+             |WHERE c1 collate unicode IN (SELECT c2 FROM $tableName)
+             |""".stripMargin),
+        Seq(Row(0)))
+
+      checkAnswer(
+        sql(
+          s"""
+             |SELECT COUNT(*) FROM $tableName
+             |WHERE c1 collate unicode IN (SELECT c2 FROM $tableName
+             |  WHERE c2 collate unicode IN (SELECT c1 FROM $tableName))
+             |""".stripMargin),
+        Seq(Row(0)))
+    }
+  }
+
+  test("scalar subquery") {
+    val tableName = "scalar_subquery_tbl"
+    withTable(tableName) {
+      sql(
+        s"""
+           |CREATE TABLE $tableName (
+           | c1 STRING COLLATE UTF8_LCASE,
+           | c2 STRING COLLATE UNICODE
+           |) USING $dataSource
+           |""".stripMargin)
+
+      sql(s"INSERT INTO $tableName VALUES ('a', 'A')")
+
+      assertImplicitMismatch(
+        sql(
+          s"""
+             |SELECT * FROM $tableName
+             |WHERE c1 = (SELECT MAX(c2) FROM $tableName)
+             |""".stripMargin))
+
+      checkAnswer(
+        sql(
+          s"""
+             |SELECT COUNT(*) FROM $tableName
+             |WHERE c1 collate utf8_lcase = (SELECT MAX(c2) collate unicode FROM $tableName)
+             |""".stripMargin),
+        Seq(Row(1)))
+
+      checkAnswer(
+        sql(
+          s"""
+             |SELECT COUNT(*) FROM $tableName
+             |WHERE c1 collate utf8_lcase = (SELECT MAX(c2) FROM $tableName)
+             |""".stripMargin),
+        Seq(Row(1)))
+
+      checkAnswer(
+        sql(
+          s"""
+             |SELECT COUNT(*) FROM $tableName
+             |WHERE c1 collate unicode = (SELECT MAX(c2) FROM $tableName)
+             |""".stripMargin),
+        Seq(Row(0)))
+    }
+  }
+
   test("struct test") {
     val tableName = "struct_tbl"
     val c1Collation = "UNICODE_CI"

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationTypePrecedenceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationTypePrecedenceSuite.scala
@@ -178,62 +178,55 @@ class CollationTypePrecedenceSuite extends QueryTest with SharedSparkSession {
   test("in subquery expression") {
     val tableName = "subquery_tbl"
     withTable(tableName) {
-      sql(
-        s"""
-           |CREATE TABLE $tableName (
-           | c1 STRING COLLATE UTF8_LCASE,
-           | c2 STRING COLLATE UNICODE
-           |) USING $dataSource
-           |""".stripMargin)
+      sql(s"""
+        |CREATE TABLE $tableName (
+        | c1 STRING COLLATE UTF8_LCASE,
+        | c2 STRING COLLATE UNICODE
+        |) USING $dataSource
+        |""".stripMargin)
 
       sql(s"INSERT INTO $tableName VALUES ('a', 'A')")
 
       assertImplicitMismatch(
-        sql(
-          s"""
-             |SELECT * FROM $tableName
-             |WHERE c1 IN (SELECT c2 FROM $tableName)
-             |""".stripMargin))
+        sql(s"""
+          |SELECT * FROM $tableName
+          |WHERE c1 IN (SELECT c2 FROM $tableName)
+          |""".stripMargin))
 
       // this fails since subquery expression collation is implicit by default
       assertImplicitMismatch(
-        sql(
-          s"""
-             |SELECT * FROM $tableName
-             |WHERE c1 IN (SELECT c2 collate unicode FROM $tableName)
-             |""".stripMargin))
+        sql(s"""
+          |SELECT * FROM $tableName
+          |WHERE c1 IN (SELECT c2 collate unicode FROM $tableName)
+          |""".stripMargin))
 
       checkAnswer(
-        sql(
-          s"""
-             |SELECT COUNT(*) FROM $tableName
-             |WHERE c1 collate utf8_lcase IN (SELECT c2 collate unicode FROM $tableName)
-             |""".stripMargin),
+        sql(s"""
+          |SELECT COUNT(*) FROM $tableName
+          |WHERE c1 collate utf8_lcase IN (SELECT c2 collate unicode FROM $tableName)
+          |""".stripMargin),
         Seq(Row(1)))
 
       checkAnswer(
-        sql(
-          s"""
-             |SELECT COUNT(*) FROM $tableName
-             |WHERE c1 collate utf8_lcase IN (SELECT c2 FROM $tableName)
-             |""".stripMargin),
+        sql(s"""
+          |SELECT COUNT(*) FROM $tableName
+          |WHERE c1 collate utf8_lcase IN (SELECT c2 FROM $tableName)
+          |""".stripMargin),
         Seq(Row(1)))
 
       checkAnswer(
-        sql(
-          s"""
-             |SELECT COUNT(*) FROM $tableName
-             |WHERE c1 collate unicode IN (SELECT c2 FROM $tableName)
-             |""".stripMargin),
+        sql(s"""
+          |SELECT COUNT(*) FROM $tableName
+          |WHERE c1 collate unicode IN (SELECT c2 FROM $tableName)
+          |""".stripMargin),
         Seq(Row(0)))
 
       checkAnswer(
-        sql(
-          s"""
-             |SELECT COUNT(*) FROM $tableName
-             |WHERE c1 collate unicode IN (SELECT c2 FROM $tableName
-             |  WHERE c2 collate unicode IN (SELECT c1 FROM $tableName))
-             |""".stripMargin),
+        sql(s"""
+          |SELECT COUNT(*) FROM $tableName
+          |WHERE c1 collate unicode IN (SELECT c2 FROM $tableName
+          |  WHERE c2 collate unicode IN (SELECT c1 FROM $tableName))
+          |""".stripMargin),
         Seq(Row(0)))
     }
   }
@@ -241,45 +234,40 @@ class CollationTypePrecedenceSuite extends QueryTest with SharedSparkSession {
   test("scalar subquery") {
     val tableName = "scalar_subquery_tbl"
     withTable(tableName) {
-      sql(
-        s"""
-           |CREATE TABLE $tableName (
-           | c1 STRING COLLATE UTF8_LCASE,
-           | c2 STRING COLLATE UNICODE
-           |) USING $dataSource
-           |""".stripMargin)
+      sql(s"""
+        |CREATE TABLE $tableName (
+        | c1 STRING COLLATE UTF8_LCASE,
+        | c2 STRING COLLATE UNICODE
+        |) USING $dataSource
+        |""".stripMargin)
 
       sql(s"INSERT INTO $tableName VALUES ('a', 'A')")
 
       assertImplicitMismatch(
-        sql(
-          s"""
-             |SELECT * FROM $tableName
-             |WHERE c1 = (SELECT MAX(c2) FROM $tableName)
-             |""".stripMargin))
+        sql(s"""
+          |SELECT * FROM $tableName
+          |WHERE c1 = (SELECT MAX(c2) FROM $tableName)
+          |""".stripMargin))
 
       checkAnswer(
-        sql(
-          s"""
-             |SELECT COUNT(*) FROM $tableName
-             |WHERE c1 collate utf8_lcase = (SELECT MAX(c2) collate unicode FROM $tableName)
-             |""".stripMargin),
+        sql(s"""
+          |SELECT COUNT(*) FROM $tableName
+          |WHERE c1 collate utf8_lcase = (SELECT MAX(c2) collate unicode FROM $tableName)
+          |""".stripMargin),
         Seq(Row(1)))
 
       checkAnswer(
-        sql(
-          s"""
-             |SELECT COUNT(*) FROM $tableName
-             |WHERE c1 collate utf8_lcase = (SELECT MAX(c2) FROM $tableName)
-             |""".stripMargin),
+        sql(s"""
+          |SELECT COUNT(*) FROM $tableName
+          |WHERE c1 collate utf8_lcase = (SELECT MAX(c2) FROM $tableName)
+          |""".stripMargin),
         Seq(Row(1)))
 
       checkAnswer(
-        sql(
-          s"""
-             |SELECT COUNT(*) FROM $tableName
-             |WHERE c1 collate unicode = (SELECT MAX(c2) FROM $tableName)
-             |""".stripMargin),
+        sql(s"""
+          |SELECT COUNT(*) FROM $tableName
+          |WHERE c1 collate unicode = (SELECT MAX(c2) FROM $tableName)
+          |""".stripMargin),
         Seq(Row(0)))
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Adding proper support for implicit casting of subqueries in collation type coercion. Currently I only added support for `Project` and `Aggregate` plans in subquery expression, but we might need to add more later.


### Why are the changes needed?
Since `SubqueryExpression` is a special type of expression it is not possible to just cast it into a different type, and this was causing a runtime error. Instead we need to go inside of its plan and cast the plan outputs.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added new unit tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
