### PR TITLE
[SPARK-50548][SQL] Extended DataSet API to support specifying JSON options in toJSON method

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1195,6 +1195,11 @@ class Dataset[T] private[sql] (
     select(to_json(struct(col("*")))).as(StringEncoder)
   }
 
+  /** @inheritdoc */
+  def toJSON(jsonOptions: Map[String, String]): Dataset[String] = {
+    select(to_json(struct(col("*")), jsonOptions)).as(StringEncoder)
+  }
+
   private[sql] def analyze: proto.AnalyzePlanResponse = {
     sparkSession.analyze(plan, proto.AnalyzePlanRequest.AnalyzeCase.SCHEMA)
   }

--- a/sql/api/src/main/scala/org/apache/spark/sql/api/Dataset.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/api/Dataset.scala
@@ -3170,6 +3170,14 @@ abstract class Dataset[T] extends Serializable {
   def toJSON: Dataset[String]
 
   /**
+   * Returns the content of the Dataset as a Dataset of JSON strings respecting specified
+   * `jsonOptions`.
+   *
+   * @since 4.0.0
+   */
+  def toJSON(jsonOptions: Map[String, String]): Dataset[String]
+
+  /**
    * Returns a best-effort snapshot of the files that compose this Dataset. This method simply
    * asks each constituent BaseRelation for its respective files and takes the union of all
    * results. Depending on the source relations, this may not find all input files. Duplicates are

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1672,13 +1672,18 @@ class Dataset[T] private[sql](
 
   /** @inheritdoc */
   override def toJSON: Dataset[String] = {
+    toJSON(Map.empty[String, String])
+  }
+
+  /** @inheritdoc */
+  override def toJSON(jsonOptions: Map[String, String]): Dataset[String] = {
     val rowSchema = exprEnc.schema
     val sessionLocalTimeZone = sparkSession.sessionState.conf.sessionLocalTimeZone
     mapPartitions { iter =>
       val writer = new CharArrayWriter()
       // create the Generator without separator inserted between 2 records
       val gen = new JacksonGenerator(rowSchema, writer,
-        new JSONOptions(Map.empty[String, String], sessionLocalTimeZone))
+        new JSONOptions(jsonOptions, sessionLocalTimeZone))
 
       new Iterator[String] {
         private val toRow = exprEnc.createSerializer()

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -2802,16 +2802,6 @@ class DatasetSuite extends QueryTest
       }
     }
   }
-
-  test("SPARK-50548: Dataset toJSON method works properly without arguments") {
-
-    val ds = Seq((
-      new Timestamp(0),
-      new Date(0),
-      new String("exampleString"))).toDS()
-
-    val dsJson = ds.toJSON
-  }
 }
 
 class DatasetLargeResultCollectingSuite extends QueryTest

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -2802,6 +2802,16 @@ class DatasetSuite extends QueryTest
       }
     }
   }
+
+  test("SPARK-50548: Dataset toJSON method works properly without arguments") {
+
+    val ds = Seq((
+      new Timestamp(0),
+      new Date(0),
+      new String("exampleString"))).toDS()
+
+    val dsJson = ds.toJSON
+  }
 }
 
 class DatasetLargeResultCollectingSuite extends QueryTest

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -4001,6 +4001,26 @@ abstract class JsonSuite
       "{\"key\":90000001,\"value\":\"Hey there\"}"
     )
   }
+
+  test("SPARK-50548: Dataset toJSON method works properly with options") {
+    val jsonOptions = Map[String, String](
+      "dateFormat" -> "dd.MM.yyyy",
+      "timestampFormat" -> "dd.MM.yyyy HH:mm:ss.SSSSSS")
+
+    // Use encoder for java.sql.Timestamp to ensure proper timestamp encoding.
+    val timestampDataSet =
+      spark.createDataset(timestampData)(Encoders.TIMESTAMP).toJSON(jsonOptions).collect()
+
+    // Use encoder for java.sql.Date to ensure proper date encoding.
+    val dateDataSet =
+      spark.createDataset(dateData)(Encoders.DATE).toJSON(jsonOptions).collect()
+
+    // Verify that the timestamp was correctly formatted respecting the jsonOptions.
+    assert(timestampDataSet.head === "{\"value\":\"01.02.2015 23:50:59.123456\"}")
+
+    // Verify that the date was correctly formatted respecting the jsonOptions.
+    assert(dateDataSet.head === "{\"value\":\"01.02.2015\"}")
+  }
 }
 
 class JsonV1Suite extends JsonSuite {

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.test
 
 import java.nio.charset.StandardCharsets
+import java.sql.{Date, Timestamp}
 import java.time.{Duration, Period}
 
 import org.apache.spark.rdd.RDD
@@ -159,6 +160,18 @@ private[sql] trait SQLTestData { self =>
       ArrayData(Seq(1, 2, 3), Seq(Seq(1, 2, 3))) ::
       ArrayData(Seq(2, 3, 4), Seq(Seq(2, 3, 4))) :: Nil)
     rdd.toDF().createOrReplaceTempView("arrayData")
+    rdd
+  }
+
+  protected lazy val timestampData: RDD[Timestamp] = {
+    val rdd = spark.sparkContext.parallelize(
+      Timestamp.valueOf("2015-02-01 23:50:59.123456") :: Nil)
+    rdd
+  }
+
+  protected lazy val dateData: RDD[Date] = {
+    val rdd = spark.sparkContext.parallelize(
+      Date.valueOf("2015-02-01") :: Nil)
     rdd
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In this PR, I propose extending the current `DataSet` API and adding another `toJSON` method which will take a jsonOptions map parameter.
The full list of `jsonOptions` is documented in the dataSources page: https://spark.apache.org/docs/3.5.1/sql-data-sources-json.html, so the new added method can be used with all of the options specified in the docs.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
These changes are needed because in some cases, users need to specify some options and more robustly control how the JSON strings will be formed from Dataset.
One example is when the output string has a timestamp:
Currently, the timestamp returned by `toJSON` method will have millisecond precision, but sometimes, users need better precision like micro. With appropriate option, users will be able to format the timestamp correctly.

In this case, user can call this new method with:
`dataSet.toJSON(Map("timestampFormat" -> "dd.MM.yyyy HH:mm:ss.SSSSSS"))` and get the desired precision.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. The change represents an extension for the `DataSet` API and allows users to call `toJSON` method with `options` argument, specifying the custom options for formatting the returned json.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
This patch was tested by adding a test in `JsonSuite`. There are a lot of tests that are testing `toJSON` method without arguments, but test was added for `toJSON` method with `options` argument, and they test that the date and timestamp accordingly to the format specified in the `jsonOptions` specified argument.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.