### PR TITLE
[SPARK-50549][DOCS] Use `rouge` `4.5.x` by removing the upper bound `3.x`

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -24,9 +24,6 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3"
 gem "jekyll-redirect-from", "~> 0.16"
-# Rouge 4.0 drops support for Ruby < 2.7, which is EOL.
-# See: https://github.com/rouge-ruby/rouge/blob/61bdda18f204a661413daa93d9624bc65ad219a5/CHANGELOG.md#version-400-2022-09-04
-gem "rouge", "~> 3.26"
 # This resolves a build issue on Apple Silicon.
 # See: https://issues.apache.org/jira/browse/SPARK-38488
 gem "ffi", "~> 1.15"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.6)
-    rouge (3.30.0)
+    rouge (4.5.1)
     safe_yaml (1.0.5)
     sass-embedded (1.63.6)
       google-protobuf (~> 3.23)
@@ -71,7 +71,6 @@ DEPENDENCIES
   ffi (~> 1.15)
   jekyll (~> 4.3)
   jekyll-redirect-from (~> 0.16)
-  rouge (~> 3.26)
 
 BUNDLED WITH
    2.4.22


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use the latest `rouge` `4.5.x` by removing the upper-bound `3.x` (2022-07-29)

### Why are the changes needed?

We are using `Ruby 3.3` in Apache Spark 4 documentation. So, we don't need to be blocked in the old `rouge` versions.

https://github.com/apache/spark/blob/3bb9a72c8691786584eb2856ff6e3571f0118283/.github/workflows/pages.yml#L71

https://github.com/apache/spark/blob/b2c8b3069ef4f5288a5964af0da6f6b23a769e6b/docs/README.md?plain=1#L33

`Rouge` release notes:
- https://github.com/rouge-ruby/rouge/releases/tag/v4.5.1 (Latest)
- https://github.com/rouge-ruby/rouge/releases/tag/v4.5.0 (2024-11-10)
...
- https://github.com/rouge-ruby/rouge/releases/tag/v4.0.0 (2022-09-06)
- https://github.com/rouge-ruby/rouge/releases/tag/v3.30.0 (2022-07-29)

### Does this PR introduce _any_ user-facing change?

No behavior change. This only affects documentation.

### How was this patch tested?

Manual review. I checked the following.

```
$ cd docs
$ SKIP_API=1 bundle exec jekyll build
```

### Was this patch authored or co-authored using generative AI tooling?

No.