### PR TITLE
[SPARK-47609][SQL] Making CacheLookup more optimal to minimize cache miss 

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1564,7 +1564,8 @@ class Dataset[T] private[sql](
   /** @inheritdoc */
   def storageLevel: StorageLevel = {
     sparkSession.sharedState.cacheManager.lookupCachedData(this).map { cachedData =>
-      cachedData.cachedRepresentation.cacheBuilder.storageLevel
+      cachedData.cachedRepresentation.fold(CacheManager.inMemoryRelationExtractor, identity).
+        cacheBuilder.storageLevel
     }.getOrElse(StorageLevel.NONE)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -17,15 +17,17 @@
 
 package org.apache.spark.sql.execution
 
+import scala.collection.mutable
+
 import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.internal.{LogEntry, Logging, MDC}
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.sql.{Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
-import org.apache.spark.sql.catalyst.expressions.{Attribute, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, AttributeReference, AttributeSet, Expression, NamedExpression, SubqueryExpression}
 import org.apache.spark.sql.catalyst.optimizer.EliminateResolvedHint
-import org.apache.spark.sql.catalyst.plans.logical.{IgnoreCachedData, LogicalPlan, ResolvedHint, View}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, IgnoreCachedData, LeafNode, LogicalPlan, Project, ResolvedHint, View}
 import org.apache.spark.sql.catalyst.trees.TreePattern.PLAN_EXPRESSION
 import org.apache.spark.sql.catalyst.util.sideBySide
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
@@ -37,18 +39,21 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.storage.StorageLevel.MEMORY_AND_DISK
 
+
 /** Holds a cached logical plan and its data */
+
 case class CachedData(
-    // A normalized resolved plan (See QueryExecution#normalized).
     plan: LogicalPlan,
-    cachedRepresentation: InMemoryRelation) {
+    cachedRepresentation: Either[LogicalPlan, InMemoryRelation]) {
+
   override def toString: String =
     s"""
        |CachedData(
        |logicalPlan=$plan
-       |InMemoryRelation=$cachedRepresentation)
+       |InMemoryRelation=${cachedRepresentation.merge})
        |""".stripMargin
 }
+
 
 /**
  * Provides support in a SQLContext for caching query results and automatically using these cached
@@ -72,7 +77,8 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
 
   /** Clears all cached tables. */
   def clearCache(): Unit = this.synchronized {
-    cachedData.foreach(_.cachedRepresentation.cacheBuilder.clearCache())
+    cachedData.foreach(_.cachedRepresentation.fold(CacheManager.inMemoryRelationExtractor, identity)
+      .cacheBuilder.clearCache())
     cachedData = IndexedSeq[CachedData]()
     CacheManager.logCacheOperation(log"Cleared all Dataframe cache entries")
   }
@@ -125,7 +131,7 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
       storageLevel: StorageLevel): Unit = {
     if (storageLevel == StorageLevel.NONE) {
       // Do nothing for StorageLevel.NONE since it will not actually cache any data.
-    } else if (lookupCachedDataInternal(normalizedPlan).nonEmpty) {
+    } else if (lookupCachedDataInternal(normalizedPlan).exists(_.cachedRepresentation.isRight)) {
       logWarning("Asked to cache already cached data.")
     } else {
       val sessionWithConfigsOff = getOrCloneSessionWithConfigsOff(spark)
@@ -139,11 +145,11 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
       }
 
       this.synchronized {
-        if (lookupCachedDataInternal(normalizedPlan).nonEmpty) {
+        if (lookupCachedDataInternal(normalizedPlan).exists(_.cachedRepresentation.isRight)) {
           logWarning("Data has already been cached.")
         } else {
           // the cache key is the normalized plan
-          val cd = CachedData(normalizedPlan, inMemoryRelation)
+          val cd = CachedData(normalizedPlan, Right(inMemoryRelation))
           cachedData = cd +: cachedData
           CacheManager.logCacheOperation(log"Added Dataframe cache entry:" +
             log"${MDC(DATAFRAME_CACHE_ENTRY, cd)}")
@@ -200,21 +206,46 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
     uncacheQuery(spark, plan, cascade, blocking = false)
   }
 
-  // The `plan` should have been normalized.
-  private def uncacheQueryInternal(
+  /**
+   * Un-cache the given plan or all the cache entries that refer to the given plan.
+   *
+   * @param spark    The Spark session.
+   * @param plan     The plan to be un-cached.
+   * @param cascade  If true, un-cache all the cache entries that refer to the given
+   *                 plan; otherwise un-cache the given plan only.
+   * @param blocking Whether to block until all blocks are deleted.
+   */
+  def uncacheQueryInternal(
       spark: SparkSession,
       plan: LogicalPlan,
       cascade: Boolean,
-      blocking: Boolean): Unit = {
-    uncacheByCondition(spark, _.sameResult(plan), cascade, blocking)
+      blocking: Boolean = false): Unit = {
+    val dummyCd = CachedData(plan, Left(plan))
+    uncacheByCondition(spark,
+      (planToCheck: LogicalPlan, partialMatchOk: Boolean) => {
+      dummyCd.plan.sameResult(planToCheck) || (partialMatchOk &&
+        (planToCheck match {
+        case p: Project => lookUpPartiallyMatchedCachedPlan(p, IndexedSeq(dummyCd)).isDefined
+        case _ => false
+      }))
+    }, cascade, blocking)
   }
+
 
   def uncacheTableOrView(spark: SparkSession, name: Seq[String], cascade: Boolean): Unit = {
     uncacheByCondition(
-      spark, isMatchedTableOrView(_, name, spark.sessionState.conf), cascade, blocking = false)
+      spark,
+      isMatchedTableOrView(_, _, name, spark.sessionState.conf),
+      cascade,
+      blocking = false)
   }
 
-  private def isMatchedTableOrView(plan: LogicalPlan, name: Seq[String], conf: SQLConf): Boolean = {
+
+  private def isMatchedTableOrView(
+      plan: LogicalPlan,
+      partialMatch: Boolean,
+      name: Seq[String],
+      conf: SQLConf): Boolean = {
     def isSameName(nameInCache: Seq[String]): Boolean = {
       nameInCache.length == name.length && nameInCache.zip(name).forall(conf.resolver.tupled)
     }
@@ -239,20 +270,22 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
 
   private def uncacheByCondition(
       spark: SparkSession,
-      isMatchedPlan: LogicalPlan => Boolean,
+      isMatchedPlan: (LogicalPlan, Boolean) => Boolean,
       cascade: Boolean,
       blocking: Boolean): Unit = {
-    val shouldRemove: LogicalPlan => Boolean =
-      if (cascade) {
-        _.exists(isMatchedPlan)
+
+    val shouldRemove: LogicalPlan => Boolean = if (cascade) {
+        _.exists(isMatchedPlan(_, false))
       } else {
-        isMatchedPlan
+        isMatchedPlan(_, false)
       }
     val plansToUncache = cachedData.filter(cd => shouldRemove(cd.plan))
     this.synchronized {
       cachedData = cachedData.filterNot(cd => plansToUncache.exists(_ eq cd))
     }
-    plansToUncache.foreach { _.cachedRepresentation.cacheBuilder.clearCache(blocking) }
+    plansToUncache.foreach { _.cachedRepresentation.
+      fold(CacheManager.inMemoryRelationExtractor, identity).cacheBuilder.clearCache(blocking) }
+
     CacheManager.logCacheOperation(log"Removed ${MDC(SIZE, plansToUncache.size)} Dataframe " +
       log"cache entries, with logical plans being " +
       log"\n[${MDC(QUERY_PLAN, plansToUncache.map(_.plan).mkString(",\n"))}]")
@@ -272,8 +305,10 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
         // 2) The buffer has been cleared, but `isCachedColumnBuffersLoaded` returns true, then we
         //    will keep it as it is. It means the physical plan has been re-compiled already in the
         //    other thread.
-        val cacheAlreadyLoaded = cd.cachedRepresentation.cacheBuilder.isCachedColumnBuffersLoaded
-        cd.plan.exists(isMatchedPlan) && !cacheAlreadyLoaded
+        val cacheAlreadyLoaded = cd.cachedRepresentation.
+          fold(CacheManager.inMemoryRelationExtractor, identity).cacheBuilder.
+          isCachedColumnBuffersLoaded
+        !cacheAlreadyLoaded && cd.plan.exists(isMatchedPlan(_, true))
       })
     }
   }
@@ -285,8 +320,9 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
       column: Seq[Attribute]): Unit = {
     val relation = cachedData.cachedRepresentation
     val (rowCount, newColStats) =
-      CommandUtils.computeColumnStats(sparkSession, relation, column)
-    relation.updateStats(rowCount, newColStats)
+      CommandUtils.computeColumnStats(sparkSession, relation.merge, column)
+    relation.fold(CacheManager.inMemoryRelationExtractor, identity).
+      updateStats(rowCount, newColStats)
   }
 
   /**
@@ -310,15 +346,17 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
       cachedData = cachedData.filterNot(cd => needToRecache.exists(_ eq cd))
     }
     needToRecache.foreach { cd =>
-      cd.cachedRepresentation.cacheBuilder.clearCache()
+      cd.cachedRepresentation.fold(CacheManager.inMemoryRelationExtractor, identity).
+        cacheBuilder.clearCache()
       val sessionWithConfigsOff = getOrCloneSessionWithConfigsOff(spark)
       val newCache = sessionWithConfigsOff.withActive {
         val qe = sessionWithConfigsOff.sessionState.executePlan(cd.plan)
-        InMemoryRelation(cd.cachedRepresentation.cacheBuilder, qe)
+        InMemoryRelation(cd.cachedRepresentation.
+          fold(CacheManager.inMemoryRelationExtractor, identity).cacheBuilder, qe)
       }
-      val recomputedPlan = cd.copy(cachedRepresentation = newCache)
+      val recomputedPlan = cd.copy(cachedRepresentation = Right(newCache))
       this.synchronized {
-        if (lookupCachedDataInternal(recomputedPlan.plan).nonEmpty) {
+        if (lookupCachedDataInternal(recomputedPlan.plan).exists(_.cachedRepresentation.isRight)) {
           logWarning("While recaching, data was already added to cache.")
         } else {
           cachedData = recomputedPlan +: cachedData
@@ -336,6 +374,34 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
     lookupCachedDataInternal(query.queryExecution.normalized)
   }
 
+    /*
+        Partial match cases:
+        InComingPlan (case of add cols)         cached plan      InComing Plan ( case of rename)
+       Project P2                              Project P1         Project P2
+         attr1                                  attr1               attr1
+         attr2                                  attr2               Alias2'(x, attr2)
+         Alias3                                 Alias3              Alias3'(y, Alias3-childExpr)
+         Alias4                                 Alias4              Alias4'(z, Alias4-childExpr)
+         Alias5 (k, f(attr1, attr2, al3, al4)
+         Alias6 (p, f(attr1, attr2, al3, al4)
+     */
+
+    /** Optionally returns cached data for the given [[LogicalPlan]]. */
+    def lookupCachedDataInternal(plan: LogicalPlan): Option[CachedData] = {
+      val fullMatch = cachedData.find(cd => plan.sameResult(cd.plan))
+      val result = fullMatch.map(Option(_)).getOrElse(
+        plan match {
+          case p: Project => lookUpPartiallyMatchedCachedPlan(p, cachedData)
+          case _ => None
+        })
+      if (result.isDefined) {
+        CacheManager.logCacheOperation(log"Dataframe cache hit for input plan:" +
+          log"\n${MDC(QUERY_PLAN, plan)} matched with cache entry:" +
+          log"${MDC(DATAFRAME_CACHE_ENTRY, result.get)}")
+      }
+      result
+    }
+
   /**
    * Optionally returns cached data for the given [[LogicalPlan]]. The given plan will be normalized
    * before being used further.
@@ -345,29 +411,248 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
     lookupCachedDataInternal(normalized)
   }
 
-  private def lookupCachedDataInternal(plan: LogicalPlan): Option[CachedData] = {
-    val result = cachedData.find(cd => plan.sameResult(cd.plan))
-    if (result.isDefined) {
-      CacheManager.logCacheOperation(log"Dataframe cache hit for input plan:" +
-        log"\n${MDC(QUERY_PLAN, plan)} matched with cache entry:" +
-        log"${MDC(DATAFRAME_CACHE_ENTRY, result.get)}")
+  private def lookUpPartiallyMatchedCachedPlan(
+        incomingProject: Project,
+        cachedPlansToUse: IndexedSeq[CachedData]): Option[CachedData] = {
+    var foundMatch = false
+    var partialMatch: Option[CachedData] = None
+    val (incmngchild, incomingFilterChain) =
+      CompatibilityChecker.extractChildIgnoringFiltersFromIncomingProject(incomingProject)
+    for (cd <- cachedPlansToUse if !foundMatch) {
+      (incmngchild, incomingFilterChain, cd.plan) match {
+        case CompatibilityChecker(residualIncomingFilterChain, cdPlanProject) =>
+          // since the child of both incoming and cached plan are same
+          // that is why we are here. for mapping and comparison purposes lets
+          // canonicalize the cachedPlan's project list in terms of the incoming plan's child
+          // so that we can map correctly.
+          val cdPlanToIncomngPlanChildOutputMapping =
+            cdPlanProject.child.output.zip(incmngchild.output).toMap
+
+          val canonicalizedCdProjList = cdPlanProject.projectList.map(_.transformUp {
+            case attr: Attribute => cdPlanToIncomngPlanChildOutputMapping(attr)
+          }.asInstanceOf[NamedExpression])
+
+          // matchIndexInCdPlanProj remains  -1 in the end, it indicates it is
+          // new cols created out of existing output attribs
+          val (directlyMappedincomingToCachedPlanIndx, inComingProjNoDirectMapping) =
+          getDirectAndIndirectMappingOfIncomingToCachedProjectAttribs(
+            incomingProject, canonicalizedCdProjList)
+
+          // Now there is a possible case where a literal is present in IMR as attribute
+          // and the incoming project also has that literal somewhere in the alias. Though
+          // we do not need to read it but looks like the deserializer fails if we skip that
+          // literal in the projection enforced on IMR. so in effect even if we do not
+          // require an attribute it still needs to be present in the projection forced
+          // also its possible that some attribute from IMR can be used in subexpression
+          // of the incoming projection. so we have to handle that
+          val unusedAttribsOfCDPlanToGenIncomingAttr =
+          cdPlanProject.projectList.indices.filterNot(i =>
+            directlyMappedincomingToCachedPlanIndx.exists(_._2 == i)).map(i => {
+            val cdAttrib = cdPlanProject.projectList(i)
+            i -> AttributeReference(cdAttrib.name, cdAttrib.dataType,
+              cdAttrib.nullable, cdAttrib.metadata)(qualifier = cdAttrib.qualifier)
+          })
+
+          // Because in case of rename multiple incmong named exprs ( attribute or aliases)
+          // will point to a common cdplan attrib, we need to ensure they do not create
+          // separate attribute in the the modifiedProject for incoming plan..
+          // that is a single attribute ref is present in all mixes of rename and  pass thru
+          // attributes.
+          // so we will use the first attribute ref in the incoming directly mapped project
+          // or if no attrib exists ( only case of rename) we will pick the child expr which
+          // is bound to be an attribute as the common ref.
+          val cdAttribToCommonAttribForIncmngNe = directlyMappedincomingToCachedPlanIndx.map {
+            case (inAttribIndex, cdAttribIndex) =>
+              cdPlanProject.projectList(cdAttribIndex).toAttribute ->
+                incomingProject.projectList(inAttribIndex)
+          }.groupBy(_._1).map {
+            case (cdAttr, incomngSeq) =>
+              val incmngCommonAttrib = incomngSeq.map(_._2).flatMap {
+                case attr: Attribute => Seq(attr)
+                case Alias(attr: Attribute, _) => Seq(attr)
+                case _ => Seq.empty
+              }.headOption.getOrElse(
+                AttributeReference(cdAttr.name, cdAttr.dataType, cdAttr.nullable)())
+              cdAttr -> incmngCommonAttrib
+          }
+
+          // If expressions of inComingProjNoDirectMapping can be expressed in terms of the
+          // incoming attribute refs or incoming alias exprs,  which can be mapped directly
+          // to the CachedPlan's output, we are good. so lets transform such indirectly
+          // mappable named expressions in terms of mappable attributes of the incoming plan
+          val transformedIndirectlyMappableExpr =
+          transformIndirectlyMappedExpressionsToUseCachedPlanAttributes(
+            inComingProjNoDirectMapping, incomingProject, cdPlanProject,
+            directlyMappedincomingToCachedPlanIndx, cdAttribToCommonAttribForIncmngNe,
+            unusedAttribsOfCDPlanToGenIncomingAttr, canonicalizedCdProjList)
+
+          val projectionToForceOnCdPlan = cdPlanProject.output.zipWithIndex.map {
+            case (cdAttr, i) =>
+              cdAttribToCommonAttribForIncmngNe.getOrElse(cdAttr,
+                unusedAttribsOfCDPlanToGenIncomingAttr.find(_._1 == i).map(_._2).get)
+          }
+          val forcedAttribset = AttributeSet(projectionToForceOnCdPlan)
+          if (transformedIndirectlyMappableExpr.forall(
+            _._2.references.subsetOf(forcedAttribset))) {
+            val transformedIntermediateFilters = transformFilters(residualIncomingFilterChain,
+              projectionToForceOnCdPlan, canonicalizedCdProjList)
+            if (transformedIntermediateFilters.forall(_.references.subsetOf(forcedAttribset))) {
+              val modifiedInProj = replacementProjectListForIncomingProject(incomingProject,
+                directlyMappedincomingToCachedPlanIndx, cdPlanProject,
+                cdAttribToCommonAttribForIncmngNe, transformedIndirectlyMappableExpr)
+              // If InMemoryRelation (right is defined) it is the case of lookup or cache query
+              // Else it is a case of dummy CachedData partial lookup for finding out if the
+              // plan being checked uses the uncached plan
+              val newPartialPlan = if (cd.cachedRepresentation.isRight) {
+                val root = cd.cachedRepresentation.toOption.get.withOutput(
+                  projectionToForceOnCdPlan)
+                if (transformedIntermediateFilters.isEmpty) {
+                  Project(modifiedInProj, root)
+                } else {
+                  val chainedFilter = CompatibilityChecker.combineFilterChainUsingRoot(
+                    transformedIntermediateFilters, root)
+                  Project(modifiedInProj, chainedFilter)
+                }
+              } else {
+                cd.cachedRepresentation.left.toOption.get
+              }
+              partialMatch = Option(cd.copy(cachedRepresentation = Left(newPartialPlan)))
+              foundMatch = true
+            }
+          }
+        case _ =>
+      }
     }
-    result
+    partialMatch
   }
 
-  /**
-   * Replaces segments of the given logical plan with cached versions where possible. The input
-   * plan must be normalized.
-   */
-  private[sql] def useCachedData(plan: LogicalPlan): LogicalPlan = {
+  private def transformFilters(skippedFilters: Seq[Filter],
+      projectionToForceOnCdPlan: Seq[Attribute],
+      canonicalizedCdProjList: Seq[NamedExpression]): Seq[Filter] = {
+    val canonicalizedCdProjAsExpr = canonicalizedCdProjList.map {
+      case Alias(child, _) => child
+      case x => x
+    }
+    skippedFilters.map(f => {
+      val transformedCondn = f.condition.transformDown {
+        case expr => val matchedIndex = canonicalizedCdProjAsExpr.indexWhere(_ == expr)
+          if (matchedIndex != -1) {
+            projectionToForceOnCdPlan(matchedIndex)
+          } else {
+            expr
+          }
+      }
+      f.copy(condition = transformedCondn)
+    })
+  }
+
+  private def replacementProjectListForIncomingProject(
+      incomingProject: Project,
+      directlyMappedincomingToCachedPlanIndx: Seq[(Int, Int)],
+      cdPlanProject: Project,
+      cdAttribToCommonAttribForIncmngNe: Map[Attribute, Attribute],
+      transformedIndirectlyMappableExpr: Map[Int, NamedExpression]): Seq[NamedExpression] =
+  {
+    incomingProject.projectList.zipWithIndex.map {
+      case (ne, indx) =>
+        directlyMappedincomingToCachedPlanIndx.find(_._1 == indx).map {
+          case (_, cdIndex) =>
+            ne match {
+              case attr: Attribute => attr
+              case al: Alias =>
+                val cdAttr = cdPlanProject.projectList(cdIndex).toAttribute
+                al.copy(child = cdAttribToCommonAttribForIncmngNe(cdAttr))(
+                  exprId = al.exprId, qualifier = al.qualifier,
+                  explicitMetadata = al.explicitMetadata,
+                  nonInheritableMetadataKeys = al.nonInheritableMetadataKeys
+                )
+            }
+        }.getOrElse({
+          transformedIndirectlyMappableExpr(indx)
+        })
+    }
+  }
+
+  private def transformIndirectlyMappedExpressionsToUseCachedPlanAttributes(
+      inComingProjNoDirectMapping: Seq[(Int, Int)],
+      incomingProject: Project,
+      cdPlanProject: Project,
+      directlyMappedincomingToCachedPlanIndx: Seq[(Int, Int)],
+      cdAttribToCommonAttribForIncmngNe: Map[Attribute, Attribute],
+      unusedAttribsOfCDPlanToGenIncomingAttr: Seq[(Int, AttributeReference)],
+      canonicalizedCdProjList: Seq[NamedExpression]): Map[Int, NamedExpression] =
+  {
+    inComingProjNoDirectMapping.map {
+      case (incomngIndex, _) =>
+        val indirectIncmnNe = incomingProject.projectList(incomngIndex)
+        val modifiedNe = indirectIncmnNe.transformDown {
+          case expr => directlyMappedincomingToCachedPlanIndx.find {
+            case (incomingIndex, _) =>
+              val directMappedNe = incomingProject.projectList(incomingIndex)
+              directMappedNe.toAttribute == expr ||
+                directMappedNe.children.headOption.contains(expr)
+          }.map {
+            case (_, cdIndex) =>
+              val cdAttrib = cdPlanProject.projectList(cdIndex).toAttribute
+              cdAttribToCommonAttribForIncmngNe(cdAttrib)
+          }.orElse(
+            unusedAttribsOfCDPlanToGenIncomingAttr.find {
+              case (i, _) => val cdNe = canonicalizedCdProjList(i)
+                cdNe.children.headOption.contains(expr)
+            }.map(_._2)).
+            map(ne => ne.toAttribute).getOrElse(expr)
+        }.asInstanceOf[NamedExpression]
+
+        incomngIndex -> modifiedNe
+    }.toMap
+  }
+
+  private def getDirectAndIndirectMappingOfIncomingToCachedProjectAttribs(
+      incomingProject: Project,
+      canonicalizedCdProjList: Seq[NamedExpression]): (Seq[(Int, Int)], Seq[(Int, Int)]) =
+  {
+    incomingProject.projectList.zipWithIndex.map {
+      case (inComingNE, index) =>
+        // first check for equivalent named expressions..if index is != -1, that means
+        // it is pass thru Alias or pass thru - Attribute
+        var matchIndexInCdPlanProj = canonicalizedCdProjList.indexWhere(_ == inComingNE)
+        if (matchIndexInCdPlanProj == -1) {
+          // if match index is -1, that means it could be two possibilities:
+          // 1) it is a case of rename which means the incoming expr is an alias and
+          // its child is an attrib ref, which may have a direct attribref in the
+          // cdPlanProj, or it may actually have an alias whose ref matches the ref
+          // of incoming attribRef
+          // 2) the positions in the incoming project alias and the cdPlanProject are
+          // different. as a result the canonicalized alias of each would have
+          // relatively different exprIDs ( as their relative positions differ), but
+          // even in such cases as their child logical plans are same, so the child
+          // expression of each alias will have same canonicalized data
+          val incomingExprToCheck = inComingNE match {
+            case x: AttributeReference => x
+            case Alias(expr, _) => expr
+          }
+          matchIndexInCdPlanProj = canonicalizedCdProjList.indexWhere {
+            case Alias(expr, _) => expr == incomingExprToCheck
+            case x => x == incomingExprToCheck
+          }
+        }
+        index -> matchIndexInCdPlanProj
+    }.partition(_._2 != -1)
+  }
+
+  /** Replaces segments of the given logical plan with cached versions where possible. */
+  def useCachedData(plan: LogicalPlan): LogicalPlan = {
     val newPlan = plan transformDown {
       case command: IgnoreCachedData => command
 
-      case currentFragment =>
+      case currentFragment if !currentFragment.isInstanceOf[InMemoryRelation] =>
         lookupCachedDataInternal(currentFragment).map { cached =>
+
           // After cache lookup, we should still keep the hints from the input plan.
           val hints = EliminateResolvedHint.extractHintsFromPlan(currentFragment)._2
-          val cachedPlan = cached.cachedRepresentation.withOutput(currentFragment.output)
+          val cachedPlan = cached.cachedRepresentation.map(_.withOutput(currentFragment.output)).
+            merge
+
           // The returned hint list is in top-down order, we should create the hint nodes from
           // right to left.
           hints.foldRight[LogicalPlan](cachedPlan) { case (hint, p) =>
@@ -485,6 +770,19 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
 }
 
 object CacheManager extends Logging {
+
+  val expressionRemapper: (Expression, AttributeMap[(NamedExpression, Expression)]) => Expression =
+    (expr, mappings) => {
+      expr transformUp {
+        case attr: AttributeReference => mappings.get(attr).map {
+          case (_, expr) => expr
+        }.getOrElse(attr)
+      }
+    }
+
+  val inMemoryRelationExtractor: LogicalPlan => InMemoryRelation =
+    plan => plan.collectLeaves().head.asInstanceOf[InMemoryRelation]
+
   def logCacheOperation(f: => LogEntry): Unit = {
     SQLConf.get.dataframeCacheLogLevel match {
       case "TRACE" => logTrace(f)
@@ -494,5 +792,89 @@ object CacheManager extends Logging {
       case "ERROR" => logError(f)
       case _ => logTrace(f)
     }
+  }
+}
+
+object CompatibilityChecker {
+  def unapply(data: (LogicalPlan, Seq[Filter], LogicalPlan)): Option[(Seq[Filter], Project)] = {
+    val(incomingChild, incomingFilterChain, cachedPlan) = data
+    cachedPlan match {
+      case p: Project if incomingChild.sameResult(p.child) => Option(incomingFilterChain -> p)
+
+      case f: Filter =>
+        val collectedFilters = mutable.ListBuffer[Filter](f)
+        var projectFound: Option[Project] = None
+        var child: LogicalPlan = f.child
+        var keepChecking = true
+        while (keepChecking) {
+          child match {
+            case x: Filter => child = x.child
+              collectedFilters += x
+            case p: Project => projectFound = Option(p)
+              keepChecking = false
+            case _ => keepChecking = false
+          }
+        }
+        if (collectedFilters.size <= incomingFilterChain.size &&
+          projectFound.exists(_.child.sameResult(incomingChild))) {
+          val (residualIncomingFilterChain, otherFilterChain) = incomingFilterChain.splitAt(
+            incomingFilterChain.size - collectedFilters.size)
+          val isCompatible = if (otherFilterChain.isEmpty) {
+            true
+          } else {
+            // the other filter chain must be equal to the collected filter chain
+            // But we need to transform the collected Filter chain such that it is below
+            // the project of the cached plan, we have found, as the incoming filters are also below
+            // the incoming project.
+            val mappingFilterExpr = AttributeMap(projectFound.get.projectList.flatMap {
+              case _: Attribute => Seq.empty[(Attribute, (NamedExpression, Expression))]
+              case al: Alias => Seq(al.toAttribute -> (al, al.child))
+            })
+
+            val modifiedCdFilters = collectedFilters.map(f =>
+              f.copy(condition = CacheManager.expressionRemapper(
+                f.condition, mappingFilterExpr))).toSeq
+            val chainedFilter1 = combineFilterChainUsingRoot(otherFilterChain,
+              EmptyRelation(incomingChild.output))
+            val chainedFilter2 = combineFilterChainUsingRoot(modifiedCdFilters,
+              EmptyRelation(projectFound.map(_.child).get.output))
+            chainedFilter1.sameResult(chainedFilter2)
+          }
+          if (isCompatible) {
+            Option(residualIncomingFilterChain -> projectFound.get)
+          } else {
+            None
+          }
+        } else {
+          None
+        }
+
+      case _ => None
+    }
+  }
+
+  def combineFilterChainUsingRoot(filters: Seq[Filter], root: LogicalPlan): Filter = {
+    val lastFilterNode = filters.last
+    val lastFilterMod = lastFilterNode.copy(child = root)
+    filters.dropRight(1).foldRight(lastFilterMod)((f, c) => f.copy(child = c))
+  }
+
+  def extractChildIgnoringFiltersFromIncomingProject(incomingProject: Project):
+      (LogicalPlan, Seq[Filter]) = {
+    val collectedFilters = mutable.ListBuffer[Filter]()
+    var child: LogicalPlan = incomingProject.child
+    var keepChecking = true
+    while (keepChecking) {
+      child match {
+        case f: Filter => child = f.child
+          collectedFilters += f
+        case _ => keepChecking = false
+      }
+    }
+    (child, collectedFilters.toSeq)
+  }
+
+  case class EmptyRelation(output: Seq[Attribute]) extends LeafNode {
+    override def maxRows: Option[Long] = Some(0)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -241,7 +241,7 @@ object CommandUtils extends Logging {
       // Analyzes a catalog view if the view is cached
       val table = sparkSession.table(tableIdent.quotedString)
       val cacheManager = sparkSession.sharedState.cacheManager
-      if (cacheManager.lookupCachedData(table).isDefined) {
+      if (cacheManager.lookupCachedData(table).exists(_.cachedRepresentation.isRight)) {
         if (!noScan) {
           // To collect table stats, materializes an underlying columnar RDD
           table.count()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.connector.read.LocalScan
 import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, MicroBatchStream}
 import org.apache.spark.sql.connector.write.V1Write
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
-import org.apache.spark.sql.execution.{FilterExec, InSubqueryExec, LeafExecNode, LocalTableScanExec, ProjectExec, RowDataSourceScanExec, SparkPlan}
+import org.apache.spark.sql.execution.{CacheManager, FilterExec, InSubqueryExec, LeafExecNode, LocalTableScanExec, ProjectExec, RowDataSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.command.CommandUtils
 import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, LogicalRelationWithTable, PushableColumnAndNestedColumn}
 import org.apache.spark.sql.execution.streaming.continuous.{WriteToContinuousDataSource, WriteToContinuousDataSourceExec}
@@ -74,8 +74,9 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
     val v2Relation = DataSourceV2Relation.create(r.table, Some(r.catalog), Some(r.identifier))
     val cache = session.sharedState.cacheManager.lookupCachedData(session, v2Relation)
     session.sharedState.cacheManager.uncacheQuery(session, v2Relation, cascade = true)
-    if (cache.isDefined) {
-      val cacheLevel = cache.get.cachedRepresentation.cacheBuilder.storageLevel
+    if (cache.exists(_.cachedRepresentation.isRight)) {
+      val cacheLevel = cache.get.cachedRepresentation.
+        fold(CacheManager.inMemoryRelationExtractor, identity).cacheBuilder.storageLevel
       Some(cacheLevel)
     } else {
       None

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.command
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.execution.CacheManager
 import org.apache.spark.storage.StorageLevel
 
 /**
@@ -73,7 +74,8 @@ trait AlterTableRenameSuiteBase extends QueryTest with DDLCommandTestUtils {
       def getStorageLevel(tableName: String): StorageLevel = {
         val table = spark.table(tableName)
         val cachedData = spark.sharedState.cacheManager.lookupCachedData(table).get
-        cachedData.cachedRepresentation.cacheBuilder.storageLevel
+        cachedData.cachedRepresentation.fold(CacheManager.inMemoryRelationExtractor, identity).
+          cacheBuilder.storageLevel
       }
       sql(s"CREATE TABLE $src (c0 INT) $defaultUsing")
       sql(s"INSERT INTO $src SELECT 0")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently the  CacheLookup relies on the fragment ( sub plan of incoming query)  matching exactly the analyzed Logical Plan in CacheManager for which InMemoryRelation exists.
This limits efficiency of the lookup.. for eg  
consider a simple case
we have an InMemoryRelation available for a plan as

 Project(a, b, c, d)                                                ->  Cached IMR
      |
Project( x as a, b,  b+a as c, b - c as d) 

and the incoming plan is say
  Project( a, b, c)
  |
Project( x as a, b,  b+a as c, b - c as d) 

Currently the incoming look up will not be able to use Cached IMR, as top level Projects do not match.
But it is possible to use the IMR by putting a projection of   (a, b c)
i.e Project( a, b, c)
         |
    Cached IMR

Below describes how more complex plans can use cache IMR , with filters present in between Projects.
**The main idea is : for each incoming fragment of incoming subplan, check if there is an exact match plan in the cache data. ( this is the current code).  If matches use that, else  look for a partial match ** 

** A partial match, among other requirements, also mandates that incoming_plan.child  is canonically same as cachePlan.child **

It can be argued that why only 1  level depth equality is needed, as it is possible that the cache plan is usable even if the child do not match, but grand child match.

 i.e incoming_plan.child.child == cachePlan.child .child
and in that sense the argument can be extended to the leaf..

So we limit to 1 child level check for partial match for following reasons:
1) Reduce the complexity 
2) Keep lookup time in reasonable limit
3) Hopefully the next PR in line [PR-SPARK-45959](https://github.com/apache/spark/pull/49124), which aggresively collapses two adjacents Projects or 2 Projects interspersed with Filters, into a single project in analyzer phase, if possible, means that in most cases, the child match would be good enough for partial match requirement..



Case 1: using InMemoryRelation in a plan having 2 consecutive Projects.

We start with a DataFrame df1 with plan = Project2 -> X
and then we cache this df1. So that the CachedRepresentation has ( IMR and the logical Plan as Project2 -> X)

Now we create a new data frame Df2 =  Some Project -> X 
Clearly Project may no longer be same as Project2, so a direct check with CacheManager will not result in matching IMR.
But clearly X are same .
So the criteria is : an IMR can be used IFF following conditions are met

X for both is same ( i.e incoming Project's child and CachedPlan's Project's child are same)
All the NamedExpressions of Incoming Project are expressable in terms of output of Project2 ( which is what IMR's output is )
To do the check for above point 2, we consider following logic
Now given that X for both are same, which means their outputs are equivalent, so we remap the cached plan's Project2 in terms of output attribute ( Expr IDs) of X of incoming Project Plan
This will help us find out following
Those NamedExpressions of incoming Project which are directly same as NamedExpressions of Project 2
Those NamedExpressions of incoming Project which are some functions of output of Project 2
Those NamedExpressions of incoming Project which are sort of Literal Constants and independent of output of Project2
Those NamedExpressions of incoming Project which are functions of some attributes but those attributes are unavailable in the output of Project2
So so long as above # 4 types of NamedExpressions are empty, it means that InMemoryRelation of the CachedPlan is usable.
and this above logic is coded in CacheManager. The logic involves modifying the NamedExpressions in incoming Project, in terms of the Seq[Attributes] which will be forced on the IMR.

Case 2: using InMemoryRelation in a plan resulting from collapse of Projects interspersed with Filters.

We start with a DataFrame df1 with plan = Filter3 -> Filter4 -> Project2 -> X
and then we cache this df1. So that the CachedRepresentation has ( IMR and the logical Plan as
Filter3 -> Filter4 -> Project2 -> X )

Now we create a new data frame Df2 = Project -> Filter1 -> Filter2 -> Filter3 -> Filter4  -> X 

Clearly here the cached plan chain
Filter3 -> Filter4 -> Project2 -> X
is no longer directly similar to
Project -> Filter1 -> Filter2 -> Filter3 - Filter4 - > X
But it is still possible to use IMR as actually the cached plan's LogicalPlan can be used as a subtree of the incoming Plan.

The logic for such check is partly the same as above for 2 consecutive Projects, with some handling for filters.
The algo for this is as follows

Identify the "child" X from the incoming plan and the Cached Plan 's Logical Plan. for similarity check.
For incoming Plan, we reach X, and store all the consecutive Filter Chain.
For the Cached Plan, we identify the first encountered Project , which is Project 2, and its child which is X.

so we have X from both incoming and cached plan, and we identify the incoming project "Project" and the CachedPlan's "Project2".
Now we can apply the Rule of case 1 of two consecutive Projects, and correctly modify the NamedExpressions of incoming Project , in terms of Seq[Attributes] which will be enforced upon the IMR.

But we also need to ensure that the filter chain present in Cached Plan i.e Filter3 -> Filter4 is a subset of filter chain in the incoming Plan , which is Filter1 -> Filter2 -> Filter3 - Filter4.
Now thing to note is that
for incoming plan it is
Project -> Filter1 -> Filter2 -> Filter3 - Filter4 - > X
In the above chain, the filters are expressed in terms of output of X
But for cached plan the filters are expressed in terms of output of Project2.
Filter3 -> Filter4 -> Project2 -> X

So for comparison we need to express the filter chain of Cached Plan in terms of X, by pulling up the P2 above filters such that
it is now
Project2 -> Filter3' -> Filter4' -> -> X

Now we can see that if we compare
Project -> Filter1 -> Filter2 -> Filter3 - Filter4 - > X

and find that Filter3' -> Filter4' is a subset of Filter1 -> Filter2 -> Filter3 - Filter4
and as the Project and Project2 are already compatible ( by case point 1)
we can use cached IMR , with a modified Project with partial filter chain.

i.e we should be able to get a plan like

Project -> Filter1 -> Filter2 -> IMR.


### Why are the changes needed?
This PR attempts to make cache look up more robust to make use of existing IMR as much as possible.
And this change is a neccessary requirement for another opened PR which collapses projects aggresively [PR_SPARK-45959](https://github.com/apache/spark/pull/43854)

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added new tests and relying on existing tests.


### Was this patch authored or co-authored using generative AI tooling?
No

