### PR TITLE
[SPARK-50553][CONNECT] Throw `InvalidPlanInput` for invalid plan message

### DIFF
--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
@@ -274,7 +274,7 @@ class SparkConnectPlannerSuite extends SparkFunSuite with SparkConnectPlanTest {
   test("Simple Join") {
     val incompleteJoin =
       proto.Relation.newBuilder.setJoin(proto.Join.newBuilder.setLeft(readRel)).build()
-    intercept[AssertionError](transform(incompleteJoin))
+    intercept[InvalidPlanInput](transform(incompleteJoin))
 
     // Join type JOIN_TYPE_UNSPECIFIED is not supported.
     intercept[InvalidPlanInput] {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Throw `InvalidPlanInput` for invalid plan message


### Why are the changes needed?
Should throw `InvalidPlanInput` for invalid plan message, instead of `AssertionError`


### Does this PR introduce _any_ user-facing change?
error message improvement: `AssertionError -> InvalidPlanInput`


### How was this patch tested?
updated tests


### Was this patch authored or co-authored using generative AI tooling?
no