### PR TITLE
[SPARK-49872][CORE] allow unlimited json size again

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/EventFilter.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventFilter.scala
@@ -72,6 +72,7 @@ private[spark] object EventFilter extends Logging {
       fs: FileSystem,
       filters: Seq[EventFilter],
       path: Path,
+      jsonProtocol: JsonProtocol,
       onAccepted: (String, SparkListenerEvent) => Unit,
       onRejected: (String, SparkListenerEvent) => Unit,
       onUnidentified: String => Unit): Unit = {
@@ -81,7 +82,7 @@ private[spark] object EventFilter extends Logging {
       lines.zipWithIndex.foreach { case (line, lineNum) =>
         try {
           val event = try {
-            Some(JsonProtocol.sparkEventFromJson(line))
+            Some(jsonProtocol.sparkEventFromJson(line))
           } catch {
             // ignore any exception occurred from unidentified json
             case NonFatal(_) =>

--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileCompactor.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileCompactor.scala
@@ -31,7 +31,7 @@ import org.apache.spark.deploy.history.EventFilter.FilterStatistics
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys
 import org.apache.spark.scheduler.ReplayListenerBus
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{JsonProtocol, Utils}
 
 /**
  * This class compacts the old event log files into one compact file, via two phases reading:
@@ -54,6 +54,8 @@ class EventLogFileCompactor(
     compactionThresholdScore: Double) extends Logging {
 
   require(maxFilesToRetain > 0, "Max event log files to retain should be higher than 0.")
+
+  private val jsonProtocol = new JsonProtocol(sparkConf)
 
   /**
    * Compacts the old event log files into one compact file, and clean old event log files being
@@ -113,7 +115,7 @@ class EventLogFileCompactor(
    * them via replaying events in given files.
    */
   private def initializeBuilders(fs: FileSystem, files: Seq[Path]): Seq[EventFilterBuilder] = {
-    val bus = new ReplayListenerBus()
+    val bus = new ReplayListenerBus(jsonProtocol)
 
     val builders = ServiceLoader.load(classOf[EventFilterBuilder],
       Utils.getContextOrSparkClassLoader).asScala.toSeq
@@ -153,7 +155,7 @@ class EventLogFileCompactor(
     val startTime = System.currentTimeMillis()
     logWriter.start()
     eventLogFiles.foreach { file =>
-      EventFilter.applyFilterToFile(fs, filters, file.getPath,
+      EventFilter.applyFilterToFile(fs, filters, file.getPath, jsonProtocol,
         onAccepted = (line, _) => logWriter.writeEvent(line, flushLogger = true),
         onRejected = (_, _) => {},
         onUnidentified = line => logWriter.writeEvent(line, flushLogger = true)

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -52,7 +52,7 @@ import org.apache.spark.status._
 import org.apache.spark.status.KVUtils._
 import org.apache.spark.status.api.v1.{ApplicationAttemptInfo, ApplicationInfo}
 import org.apache.spark.ui.SparkUI
-import org.apache.spark.util.{CallerContext, Clock, SystemClock, ThreadUtils, Utils}
+import org.apache.spark.util.{CallerContext, Clock, JsonProtocol, SystemClock, ThreadUtils, Utils}
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.kvstore._
 
@@ -802,7 +802,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     val shouldHalt = enableOptimizations &&
       ((!appCompleted && fastInProgressParsing) || reparseChunkSize > 0)
 
-    val bus = new ReplayListenerBus()
+    val bus = new ReplayListenerBus(new JsonProtocol(conf))
     val listener = new AppListingListener(reader, clock, shouldHalt)
     bus.addListener(listener)
 
@@ -1119,7 +1119,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     // to parse the event logs in the SHS.
     val replayConf = conf.clone().set(ASYNC_TRACKING_ENABLED, false)
     val trackingStore = new ElementTrackingStore(store, replayConf)
-    val replayBus = new ReplayListenerBus()
+    val replayBus = new ReplayListenerBus(new JsonProtocol(conf))
     val listener = new AppStatusListener(trackingStore, replayConf, false,
       lastUpdateTime = Some(lastUpdated))
     replayBus.addListener(listener)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -283,6 +283,14 @@ package object config {
       .booleanConf
       .createWithDefault(true)
 
+  private[spark] val EVENT_LOG_READER_MAX_STRING_LENGTH =
+    ConfigBuilder("spark.eventLog.readerMaxStringLength")
+      .doc("Limit the maximum string size an eventlog item can have when deserializing it.")
+      .version("4.1.0")
+      .intConf
+      .checkValue(_ > 0, "Maximum string size of an eventLog item should be positive.")
+      .createWithDefault(Int.MaxValue)
+
   private[spark] val EVENT_LOG_OVERWRITE =
     ConfigBuilder("spark.eventLog.overwrite")
       .version("1.0.0")

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -31,7 +31,7 @@ import org.apache.spark.deploy.history.EventLogFileWriter
 import org.apache.spark.executor.ExecutorMetrics
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
-import org.apache.spark.util.{JsonProtocol, JsonProtocolOptions, Utils}
+import org.apache.spark.util.{JsonProtocol, Utils}
 
 /**
  * A SparkListener that logs events to persistent storage.
@@ -74,7 +74,7 @@ private[spark] class EventLoggingListener(
   private val liveStageExecutorMetrics =
     mutable.HashMap.empty[(Int, Int), mutable.HashMap[String, ExecutorMetrics]]
 
-  private[this] val jsonProtocolOptions = new JsonProtocolOptions(sparkConf)
+  private[this] val jsonProtocol = new JsonProtocol(sparkConf)
 
   /**
    * Creates the log file in the configured log directory.
@@ -86,7 +86,7 @@ private[spark] class EventLoggingListener(
 
   private def initEventLog(): Unit = {
     val metadata = SparkListenerLogStart(SPARK_VERSION)
-    val eventJson = JsonProtocol.sparkEventToJsonString(metadata, jsonProtocolOptions)
+    val eventJson = jsonProtocol.sparkEventToJsonString(metadata)
     logWriter.writeEvent(eventJson, flushLogger = true)
     if (testing && loggedEvents != null) {
       loggedEvents += eventJson
@@ -95,7 +95,7 @@ private[spark] class EventLoggingListener(
 
   /** Log the event as JSON. */
   private def logEvent(event: SparkListenerEvent, flushLogger: Boolean = false): Unit = {
-    val eventJson = JsonProtocol.sparkEventToJsonString(event, jsonProtocolOptions)
+    val eventJson = jsonProtocol.sparkEventToJsonString(event)
     logWriter.writeEvent(eventJson, flushLogger)
     if (testing) {
       loggedEvents += eventJson

--- a/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
@@ -32,7 +32,8 @@ import org.apache.spark.util.JsonProtocol
 /**
  * A SparkListenerBus that can be used to replay events from serialized event data.
  */
-private[spark] class ReplayListenerBus extends SparkListenerBus with Logging {
+private[spark] class ReplayListenerBus(
+    jsonProtocol: JsonProtocol) extends SparkListenerBus with Logging {
 
   /**
    * Replay each event in the order maintained in the given stream. The stream is expected to
@@ -86,7 +87,7 @@ private[spark] class ReplayListenerBus extends SparkListenerBus with Logging {
           currentLine = entry._1
           lineNumber = entry._2 + 1
 
-          postToAll(JsonProtocol.sparkEventFromJson(currentLine))
+          postToAll(jsonProtocol.sparkEventFromJson(currentLine))
         } catch {
           case e: ClassNotFoundException =>
             // Ignore unknown events, parse through the event log file.

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -22,7 +22,7 @@ import java.util.{Properties, UUID}
 import scala.collection.Map
 import scala.jdk.CollectionConverters._
 
-import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.{JsonGenerator, StreamReadConstraints}
 import com.fasterxml.jackson.databind.JsonNode
 import org.json4s.jackson.JsonMethods.compact
 
@@ -39,16 +39,6 @@ import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils.weakIntern
 
 /**
- * Helper class for passing configuration options to JsonProtocol.
- * We use this instead of passing SparkConf directly because it lets us avoid
- * repeated re-parsing of configuration values on each read.
- */
-private[spark] class JsonProtocolOptions(conf: SparkConf) {
-  val includeTaskMetricsAccumulators: Boolean =
-    conf.get(EVENT_LOG_INCLUDE_TASK_METRICS_ACCUMULATORS)
-}
-
-/**
  * Serializes SparkListener events to/from JSON.  This protocol provides strong backwards-
  * and forwards-compatibility guarantees: any version of Spark should be able to read JSON output
  * written by any other version, including newer versions.
@@ -63,44 +53,45 @@ private[spark] class JsonProtocolOptions(conf: SparkConf) {
  *  - Any new JSON fields should be optional; use `jsonOption` when reading these fields
  *    in `*FromJson` methods.
  */
-private[spark] object JsonProtocol extends JsonUtils {
+private[spark] class JsonProtocol(sparkConf: SparkConf) extends JsonUtils {
   // TODO: Remove this file and put JSON serialization into each individual class.
 
-  private[util]
-  val defaultOptions: JsonProtocolOptions = new JsonProtocolOptions(new SparkConf(false))
+  // SPARK-49872 remove limit on string lengths
+  mapper.getFactory.setStreamReadConstraints(
+    StreamReadConstraints.builder().maxStringLength(
+      sparkConf.get(EVENT_LOG_READER_MAX_STRING_LENGTH)
+    ).build()
+  )
+
+  val includeTaskMetricsAccumulators: Boolean =
+    sparkConf.get(EVENT_LOG_INCLUDE_TASK_METRICS_ACCUMULATORS)
 
   /** ------------------------------------------------- *
    * JSON serialization methods for SparkListenerEvents |
    * -------------------------------------------------- */
 
-  // Only for use in tests. Production code should use the two-argument overload defined below.
   def sparkEventToJsonString(event: SparkListenerEvent): String = {
-    sparkEventToJsonString(event, defaultOptions)
-  }
-
-  def sparkEventToJsonString(event: SparkListenerEvent, options: JsonProtocolOptions): String = {
     toJsonString { generator =>
-      writeSparkEventToJson(event, generator, options)
+      writeSparkEventToJson(event, generator)
     }
   }
 
   def writeSparkEventToJson(
       event: SparkListenerEvent,
-      g: JsonGenerator,
-      options: JsonProtocolOptions): Unit = {
+      g: JsonGenerator): Unit = {
     event match {
       case stageSubmitted: SparkListenerStageSubmitted =>
-        stageSubmittedToJson(stageSubmitted, g, options)
+        stageSubmittedToJson(stageSubmitted, g)
       case stageCompleted: SparkListenerStageCompleted =>
-        stageCompletedToJson(stageCompleted, g, options)
+        stageCompletedToJson(stageCompleted, g)
       case taskStart: SparkListenerTaskStart =>
-        taskStartToJson(taskStart, g, options)
+        taskStartToJson(taskStart, g)
       case taskGettingResult: SparkListenerTaskGettingResult =>
-        taskGettingResultToJson(taskGettingResult, g, options)
+        taskGettingResultToJson(taskGettingResult, g)
       case taskEnd: SparkListenerTaskEnd =>
-        taskEndToJson(taskEnd, g, options)
+        taskEndToJson(taskEnd, g)
       case jobStart: SparkListenerJobStart =>
-        jobStartToJson(jobStart, g, options)
+        jobStartToJson(jobStart, g)
       case jobEnd: SparkListenerJobEnd =>
         jobEndToJson(jobEnd, g)
       case environmentUpdate: SparkListenerEnvironmentUpdate =>
@@ -134,15 +125,16 @@ private[spark] object JsonProtocol extends JsonUtils {
     }
   }
 
+  import JsonProtocol.SPARK_LISTENER_EVENT_FORMATTED_CLASS_NAMES
+
   def stageSubmittedToJson(
       stageSubmitted: SparkListenerStageSubmitted,
-      g: JsonGenerator,
-      options: JsonProtocolOptions): Unit = {
+      g: JsonGenerator): Unit = {
     g.writeStartObject()
     g.writeStringField("Event", SPARK_LISTENER_EVENT_FORMATTED_CLASS_NAMES.stageSubmitted)
     g.writeFieldName("Stage Info")
     // SPARK-42205: don't log accumulables in start events:
-    stageInfoToJson(stageSubmitted.stageInfo, g, options, includeAccumulables = false)
+    stageInfoToJson(stageSubmitted.stageInfo, g, includeAccumulables = false)
     Option(stageSubmitted.properties).foreach { properties =>
       g.writeFieldName("Properties")
       propertiesToJson(properties, g)
@@ -152,46 +144,42 @@ private[spark] object JsonProtocol extends JsonUtils {
 
   def stageCompletedToJson(
       stageCompleted: SparkListenerStageCompleted,
-      g: JsonGenerator,
-      options: JsonProtocolOptions): Unit = {
+      g: JsonGenerator): Unit = {
     g.writeStartObject()
     g.writeStringField("Event", SPARK_LISTENER_EVENT_FORMATTED_CLASS_NAMES.stageCompleted)
     g.writeFieldName("Stage Info")
-    stageInfoToJson(stageCompleted.stageInfo, g, options, includeAccumulables = true)
+    stageInfoToJson(stageCompleted.stageInfo, g, includeAccumulables = true)
     g.writeEndObject()
   }
 
   def taskStartToJson(
       taskStart: SparkListenerTaskStart,
-      g: JsonGenerator,
-      options: JsonProtocolOptions): Unit = {
+      g: JsonGenerator): Unit = {
     g.writeStartObject()
     g.writeStringField("Event", SPARK_LISTENER_EVENT_FORMATTED_CLASS_NAMES.taskStart)
     g.writeNumberField("Stage ID", taskStart.stageId)
     g.writeNumberField("Stage Attempt ID", taskStart.stageAttemptId)
     g.writeFieldName("Task Info")
     // SPARK-42205: don't log accumulables in start events:
-    taskInfoToJson(taskStart.taskInfo, g, options, includeAccumulables = false)
+    taskInfoToJson(taskStart.taskInfo, g, includeAccumulables = false)
     g.writeEndObject()
   }
 
   def taskGettingResultToJson(
       taskGettingResult: SparkListenerTaskGettingResult,
-      g: JsonGenerator,
-      options: JsonProtocolOptions): Unit = {
+      g: JsonGenerator): Unit = {
     val taskInfo = taskGettingResult.taskInfo
     g.writeStartObject()
     g.writeStringField("Event", SPARK_LISTENER_EVENT_FORMATTED_CLASS_NAMES.taskGettingResult)
     g.writeFieldName("Task Info")
     // SPARK-42205: don't log accumulables in "task getting result" events:
-    taskInfoToJson(taskInfo, g, options, includeAccumulables = false)
+    taskInfoToJson(taskInfo, g, includeAccumulables = false)
     g.writeEndObject()
   }
 
   def taskEndToJson(
       taskEnd: SparkListenerTaskEnd,
-      g: JsonGenerator,
-      options: JsonProtocolOptions): Unit = {
+      g: JsonGenerator): Unit = {
     g.writeStartObject()
     g.writeStringField("Event", SPARK_LISTENER_EVENT_FORMATTED_CLASS_NAMES.taskEnd)
     g.writeNumberField("Stage ID", taskEnd.stageId)
@@ -200,7 +188,7 @@ private[spark] object JsonProtocol extends JsonUtils {
     g.writeFieldName("Task End Reason")
     taskEndReasonToJson(taskEnd.reason, g)
     g.writeFieldName("Task Info")
-    taskInfoToJson(taskEnd.taskInfo, g, options, includeAccumulables = true)
+    taskInfoToJson(taskEnd.taskInfo, g, includeAccumulables = true)
     g.writeFieldName("Task Executor Metrics")
     executorMetricsToJson(taskEnd.taskExecutorMetrics, g)
     Option(taskEnd.taskMetrics).foreach { m =>
@@ -212,8 +200,7 @@ private[spark] object JsonProtocol extends JsonUtils {
 
   def jobStartToJson(
       jobStart: SparkListenerJobStart,
-      g: JsonGenerator,
-      options: JsonProtocolOptions): Unit = {
+      g: JsonGenerator): Unit = {
     g.writeStartObject()
     g.writeStringField("Event", SPARK_LISTENER_EVENT_FORMATTED_CLASS_NAMES.jobStart)
     g.writeNumberField("Job ID", jobStart.jobId)
@@ -224,7 +211,7 @@ private[spark] object JsonProtocol extends JsonUtils {
     // the job was submitted: it is technically possible for a stage to belong to multiple
     // concurrent jobs, so this situation can arise even without races occurring between
     // event logging and stage completion.
-    jobStart.stageInfos.foreach(stageInfoToJson(_, g, options, includeAccumulables = true))
+    jobStart.stageInfos.foreach(stageInfoToJson(_, g, includeAccumulables = true))
     g.writeEndArray()
     g.writeArrayFieldStart("Stage IDs")
     jobStart.stageIds.foreach(g.writeNumber)
@@ -423,7 +410,6 @@ private[spark] object JsonProtocol extends JsonUtils {
   def stageInfoToJson(
       stageInfo: StageInfo,
       g: JsonGenerator,
-      options: JsonProtocolOptions,
       includeAccumulables: Boolean): Unit = {
     g.writeStartObject()
     g.writeNumberField("Stage ID", stageInfo.stageId)
@@ -445,7 +431,7 @@ private[spark] object JsonProtocol extends JsonUtils {
       accumulablesToJson(
         stageInfo.accumulables.values,
         g,
-        includeTaskMetricsAccumulators = options.includeTaskMetricsAccumulators)
+        includeTaskMetricsAccumulators = includeTaskMetricsAccumulators)
     } else {
       g.writeStartArray()
       g.writeEndArray()
@@ -459,7 +445,6 @@ private[spark] object JsonProtocol extends JsonUtils {
   def taskInfoToJson(
       taskInfo: TaskInfo,
       g: JsonGenerator,
-      options: JsonProtocolOptions,
       includeAccumulables: Boolean): Unit = {
     g.writeStartObject()
     g.writeNumberField("Task ID", taskInfo.taskId)
@@ -480,7 +465,7 @@ private[spark] object JsonProtocol extends JsonUtils {
       accumulablesToJson(
         taskInfo.accumulables,
         g,
-        includeTaskMetricsAccumulators = options.includeTaskMetricsAccumulators)
+        includeTaskMetricsAccumulators = includeTaskMetricsAccumulators)
     } else {
       g.writeStartArray()
       g.writeEndArray()
@@ -905,29 +890,6 @@ private[spark] object JsonProtocol extends JsonUtils {
   /** --------------------------------------------------- *
    * JSON deserialization methods for SparkListenerEvents |
    * ---------------------------------------------------- */
-
-  private object SPARK_LISTENER_EVENT_FORMATTED_CLASS_NAMES {
-    val stageSubmitted = Utils.getFormattedClassName(SparkListenerStageSubmitted)
-    val stageCompleted = Utils.getFormattedClassName(SparkListenerStageCompleted)
-    val taskStart = Utils.getFormattedClassName(SparkListenerTaskStart)
-    val taskGettingResult = Utils.getFormattedClassName(SparkListenerTaskGettingResult)
-    val taskEnd = Utils.getFormattedClassName(SparkListenerTaskEnd)
-    val jobStart = Utils.getFormattedClassName(SparkListenerJobStart)
-    val jobEnd = Utils.getFormattedClassName(SparkListenerJobEnd)
-    val environmentUpdate = Utils.getFormattedClassName(SparkListenerEnvironmentUpdate)
-    val blockManagerAdded = Utils.getFormattedClassName(SparkListenerBlockManagerAdded)
-    val blockManagerRemoved = Utils.getFormattedClassName(SparkListenerBlockManagerRemoved)
-    val unpersistRDD = Utils.getFormattedClassName(SparkListenerUnpersistRDD)
-    val applicationStart = Utils.getFormattedClassName(SparkListenerApplicationStart)
-    val applicationEnd = Utils.getFormattedClassName(SparkListenerApplicationEnd)
-    val executorAdded = Utils.getFormattedClassName(SparkListenerExecutorAdded)
-    val executorRemoved = Utils.getFormattedClassName(SparkListenerExecutorRemoved)
-    val logStart = Utils.getFormattedClassName(SparkListenerLogStart)
-    val metricsUpdate = Utils.getFormattedClassName(SparkListenerExecutorMetricsUpdate)
-    val stageExecutorMetrics = Utils.getFormattedClassName(SparkListenerStageExecutorMetrics)
-    val blockUpdate = Utils.getFormattedClassName(SparkListenerBlockUpdated)
-    val resourceProfileAdded = Utils.getFormattedClassName(SparkListenerResourceProfileAdded)
-  }
 
   def sparkEventFromJson(json: String): SparkListenerEvent = {
     sparkEventFromJson(mapper.readTree(json))
@@ -1398,20 +1360,8 @@ private[spark] object JsonProtocol extends JsonUtils {
     metrics
   }
 
-  private object TASK_END_REASON_FORMATTED_CLASS_NAMES {
-    val success = Utils.getFormattedClassName(Success)
-    val resubmitted = Utils.getFormattedClassName(Resubmitted)
-    val fetchFailed = Utils.getFormattedClassName(FetchFailed)
-    val exceptionFailure = Utils.getFormattedClassName(ExceptionFailure)
-    val taskResultLost = Utils.getFormattedClassName(TaskResultLost)
-    val taskKilled = Utils.getFormattedClassName(TaskKilled)
-    val taskCommitDenied = Utils.getFormattedClassName(TaskCommitDenied)
-    val executorLostFailure = Utils.getFormattedClassName(ExecutorLostFailure)
-    val unknownReason = Utils.getFormattedClassName(UnknownReason)
-  }
-
   def taskEndReasonFromJson(json: JsonNode): TaskEndReason = {
-    import TASK_END_REASON_FORMATTED_CLASS_NAMES._
+    import JsonProtocol.TASK_END_REASON_FORMATTED_CLASS_NAMES._
 
     json.get("Reason").extractString match {
       case `success` => Success
@@ -1484,13 +1434,8 @@ private[spark] object JsonProtocol extends JsonUtils {
     BlockManagerId(executorId, host, port)
   }
 
-  private object JOB_RESULT_FORMATTED_CLASS_NAMES {
-    val jobSucceeded = Utils.getFormattedClassName(JobSucceeded)
-    val jobFailed = Utils.getFormattedClassName(JobFailed)
-  }
-
   def jobResultFromJson(json: JsonNode): JobResult = {
-    import JOB_RESULT_FORMATTED_CLASS_NAMES._
+    import JsonProtocol.JOB_RESULT_FORMATTED_CLASS_NAMES._
 
     json.get("Result").extractString match {
       case `jobSucceeded` => JobSucceeded
@@ -1690,5 +1635,47 @@ private[spark] object JsonProtocol extends JsonUtils {
       require(json.isTextual || json.isNull, s"Expected string or NULL, got ${json.getNodeType}")
       json.textValue
     }
+  }
+}
+
+private[spark] object JsonProtocol {
+  private object JOB_RESULT_FORMATTED_CLASS_NAMES {
+    val jobSucceeded = Utils.getFormattedClassName(JobSucceeded)
+    val jobFailed = Utils.getFormattedClassName(JobFailed)
+  }
+
+  private object SPARK_LISTENER_EVENT_FORMATTED_CLASS_NAMES {
+    val stageSubmitted = Utils.getFormattedClassName(SparkListenerStageSubmitted)
+    val stageCompleted = Utils.getFormattedClassName(SparkListenerStageCompleted)
+    val taskStart = Utils.getFormattedClassName(SparkListenerTaskStart)
+    val taskGettingResult = Utils.getFormattedClassName(SparkListenerTaskGettingResult)
+    val taskEnd = Utils.getFormattedClassName(SparkListenerTaskEnd)
+    val jobStart = Utils.getFormattedClassName(SparkListenerJobStart)
+    val jobEnd = Utils.getFormattedClassName(SparkListenerJobEnd)
+    val environmentUpdate = Utils.getFormattedClassName(SparkListenerEnvironmentUpdate)
+    val blockManagerAdded = Utils.getFormattedClassName(SparkListenerBlockManagerAdded)
+    val blockManagerRemoved = Utils.getFormattedClassName(SparkListenerBlockManagerRemoved)
+    val unpersistRDD = Utils.getFormattedClassName(SparkListenerUnpersistRDD)
+    val applicationStart = Utils.getFormattedClassName(SparkListenerApplicationStart)
+    val applicationEnd = Utils.getFormattedClassName(SparkListenerApplicationEnd)
+    val executorAdded = Utils.getFormattedClassName(SparkListenerExecutorAdded)
+    val executorRemoved = Utils.getFormattedClassName(SparkListenerExecutorRemoved)
+    val logStart = Utils.getFormattedClassName(SparkListenerLogStart)
+    val metricsUpdate = Utils.getFormattedClassName(SparkListenerExecutorMetricsUpdate)
+    val stageExecutorMetrics = Utils.getFormattedClassName(SparkListenerStageExecutorMetrics)
+    val blockUpdate = Utils.getFormattedClassName(SparkListenerBlockUpdated)
+    val resourceProfileAdded = Utils.getFormattedClassName(SparkListenerResourceProfileAdded)
+  }
+
+  private object TASK_END_REASON_FORMATTED_CLASS_NAMES {
+    val success = Utils.getFormattedClassName(Success)
+    val resubmitted = Utils.getFormattedClassName(Resubmitted)
+    val fetchFailed = Utils.getFormattedClassName(FetchFailed)
+    val exceptionFailure = Utils.getFormattedClassName(ExceptionFailure)
+    val taskResultLost = Utils.getFormattedClassName(TaskResultLost)
+    val taskKilled = Utils.getFormattedClassName(TaskKilled)
+    val taskCommitDenied = Utils.getFormattedClassName(TaskCommitDenied)
+    val executorLostFailure = Utils.getFormattedClassName(ExecutorLostFailure)
+    val unknownReason = Utils.getFormattedClassName(UnknownReason)
   }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileCompactorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileCompactorSuite.scala
@@ -161,7 +161,7 @@ class EventLogFileCompactorSuite extends SparkFunSuite {
         val lines = Source.fromInputStream(is)(Codec.UTF8).getLines().toList
         assert(lines.length === 2, "Compacted file should have only two events being accepted")
         lines.foreach { line =>
-          val event = JsonProtocol.sparkEventFromJson(line)
+          val event = new JsonProtocol(new SparkConf()).sparkEventFromJson(line)
           assert(!event.isInstanceOf[SparkListenerJobStart] &&
             !event.isInstanceOf[SparkListenerJobEnd])
         }

--- a/core/src/test/scala/org/apache/spark/deploy/history/EventLogTestHelper.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/EventLogTestHelper.scala
@@ -108,6 +108,6 @@ object EventLogTestHelper {
   }
 
   def convertEvent(event: SparkListenerEvent): String = {
-    JsonProtocol.sparkEventToJsonString(event)
+    new JsonProtocol(new SparkConf()).sparkEventToJsonString(event)
   }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -1809,15 +1809,16 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     val fstream = new FileOutputStream(file)
     val cstream = codec.map(_.compressedContinuousOutputStream(fstream)).getOrElse(fstream)
     val bstream = new BufferedOutputStream(cstream)
+    val jsonProtocol = new JsonProtocol(new SparkConf())
 
     val metadata = SparkListenerLogStart(org.apache.spark.SPARK_VERSION)
-    val eventJsonString = JsonProtocol.sparkEventToJsonString(metadata)
+    val eventJsonString = jsonProtocol.sparkEventToJsonString(metadata)
     val metadataJson = eventJsonString + "\n"
     bstream.write(metadataJson.getBytes(StandardCharsets.UTF_8))
 
     val writer = new OutputStreamWriter(bstream, StandardCharsets.UTF_8)
     Utils.tryWithSafeFinally {
-      events.foreach(e => writer.write(JsonProtocol.sparkEventToJsonString(e) + "\n"))
+      events.foreach(e => writer.write(jsonProtocol.sparkEventToJsonString(e) + "\n"))
     } {
       writer.close()
     }

--- a/core/src/test/scala/org/apache/spark/scheduler/ReplayListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/ReplayListenerSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.history.EventLogFileReader
 import org.apache.spark.deploy.history.EventLogTestHelper._
 import org.apache.spark.io.{CompressionCodec, LZ4CompressionCodec}
-import org.apache.spark.util.{JsonProtocol, JsonProtocolSuite, Utils}
+import org.apache.spark.util.{jsonProtocolSuite, JsonProtocol, Utils}
 
 /**
  * Test whether ReplayListenerBus replays events from logs correctly.
@@ -39,6 +39,7 @@ import org.apache.spark.util.{JsonProtocol, JsonProtocolSuite, Utils}
 class ReplayListenerSuite extends SparkFunSuite with BeforeAndAfter with LocalSparkContext {
   private val fileSystem = Utils.getHadoopFileSystem("/",
     SparkHadoopUtil.get.newConfiguration(new SparkConf()))
+  private val jsonProtocol = new JsonProtocol(new SparkConf())
   private var testDir: File = _
 
   before {
@@ -58,8 +59,8 @@ class ReplayListenerSuite extends SparkFunSuite with BeforeAndAfter with LocalSp
     val applicationEnd = SparkListenerApplicationEnd(1000L)
     Utils.tryWithResource(new PrintWriter(fwriter)) { writer =>
       // scalastyle:off println
-      writer.println(JsonProtocol.sparkEventToJsonString(applicationStart))
-      writer.println(JsonProtocol.sparkEventToJsonString(applicationEnd))
+      writer.println(jsonProtocol.sparkEventToJsonString(applicationStart))
+      writer.println(jsonProtocol.sparkEventToJsonString(applicationEnd))
       // scalastyle:on println
     }
 
@@ -67,15 +68,15 @@ class ReplayListenerSuite extends SparkFunSuite with BeforeAndAfter with LocalSp
     val logData = fileSystem.open(logFilePath)
     val eventMonster = new EventBufferingListener
     try {
-      val replayer = new ReplayListenerBus()
+      val replayer = new ReplayListenerBus(jsonProtocol)
       replayer.addListener(eventMonster)
       replayer.replay(logData, logFilePath.toString)
     } finally {
       logData.close()
     }
     assert(eventMonster.loggedEvents.size === 2)
-    assert(eventMonster.loggedEvents(0) === JsonProtocol.sparkEventToJsonString(applicationStart))
-    assert(eventMonster.loggedEvents(1) === JsonProtocol.sparkEventToJsonString(applicationEnd))
+    assert(eventMonster.loggedEvents(0) === jsonProtocol.sparkEventToJsonString(applicationStart))
+    assert(eventMonster.loggedEvents(1) === jsonProtocol.sparkEventToJsonString(applicationEnd))
   }
 
   /**
@@ -97,8 +98,8 @@ class ReplayListenerSuite extends SparkFunSuite with BeforeAndAfter with LocalSp
       val applicationEnd = SparkListenerApplicationEnd(1000L)
 
       // scalastyle:off println
-      writer.println(JsonProtocol.sparkEventToJsonString(applicationStart))
-      writer.println(JsonProtocol.sparkEventToJsonString(applicationEnd))
+      writer.println(jsonProtocol.sparkEventToJsonString(applicationStart))
+      writer.println(jsonProtocol.sparkEventToJsonString(applicationEnd))
       // scalastyle:on println
     }
 
@@ -110,7 +111,7 @@ class ReplayListenerSuite extends SparkFunSuite with BeforeAndAfter with LocalSp
 
     // Read the compressed .inprogress file and verify only first event was parsed.
     val conf = getLoggingConf(logFilePath)
-    val replayer = new ReplayListenerBus()
+    val replayer = new ReplayListenerBus(jsonProtocol)
 
     val eventMonster = new EventBufferingListener
     replayer.addListener(eventMonster)
@@ -142,9 +143,9 @@ class ReplayListenerSuite extends SparkFunSuite with BeforeAndAfter with LocalSp
     val applicationEnd = SparkListenerApplicationEnd(1000L)
     Utils.tryWithResource(new PrintWriter(fwriter)) { writer =>
       // scalastyle:off println
-      writer.println(JsonProtocol.sparkEventToJsonString(applicationStart))
+      writer.println(jsonProtocol.sparkEventToJsonString(applicationStart))
       writer.println("""{"Event":"UnrecognizedEventOnlyForTest","Timestamp":1477593059313}""")
-      writer.println(JsonProtocol.sparkEventToJsonString(applicationEnd))
+      writer.println(jsonProtocol.sparkEventToJsonString(applicationEnd))
       // scalastyle:on println
     }
 
@@ -152,15 +153,15 @@ class ReplayListenerSuite extends SparkFunSuite with BeforeAndAfter with LocalSp
     val logData = fileSystem.open(logFilePath)
     val eventMonster = new EventBufferingListener
     try {
-      val replayer = new ReplayListenerBus()
+      val replayer = new ReplayListenerBus(jsonProtocol)
       replayer.addListener(eventMonster)
       replayer.replay(logData, logFilePath.toString)
     } finally {
       logData.close()
     }
     assert(eventMonster.loggedEvents.size === 2)
-    assert(eventMonster.loggedEvents(0) === JsonProtocol.sparkEventToJsonString(applicationStart))
-    assert(eventMonster.loggedEvents(1) === JsonProtocol.sparkEventToJsonString(applicationEnd))
+    assert(eventMonster.loggedEvents(0) === jsonProtocol.sparkEventToJsonString(applicationStart))
+    assert(eventMonster.loggedEvents(1) === jsonProtocol.sparkEventToJsonString(applicationEnd))
   }
 
   // This assumes the correctness of EventLoggingListener
@@ -214,7 +215,7 @@ class ReplayListenerSuite extends SparkFunSuite with BeforeAndAfter with LocalSp
     val logData = EventLogFileReader.openEventLog(eventLog.getPath(), fileSystem)
     val eventMonster = new EventBufferingListener
     try {
-      val replayer = new ReplayListenerBus()
+      val replayer = new ReplayListenerBus(jsonProtocol)
       replayer.addListener(eventMonster)
       replayer.replay(logData, eventLog.getPath().toString)
     } finally {
@@ -224,11 +225,11 @@ class ReplayListenerSuite extends SparkFunSuite with BeforeAndAfter with LocalSp
     // Verify the same events are replayed in the same order
     assert(sc.eventLogger.isDefined)
     val originalEvents = sc.eventLogger.get.loggedEvents
-      .map(JsonProtocol.sparkEventFromJson)
+      .map(jsonProtocol.sparkEventFromJson)
     val replayedEvents = eventMonster.loggedEvents
-      .map(JsonProtocol.sparkEventFromJson)
+      .map(jsonProtocol.sparkEventFromJson)
     originalEvents.zip(replayedEvents).foreach { case (e1, e2) =>
-      JsonProtocolSuite.assertEquals(e1, e1)
+      jsonProtocolSuite.assertEquals(e1, e1)
     }
   }
 
@@ -246,7 +247,7 @@ class ReplayListenerSuite extends SparkFunSuite with BeforeAndAfter with LocalSp
     private[scheduler] val loggedEvents = new ArrayBuffer[String]
 
     override def onEvent(event: SparkListenerEvent): Unit = {
-      val eventJson = JsonProtocol.sparkEventToJsonString(event)
+      val eventJson = jsonProtocol.sparkEventToJsonString(event)
       loggedEvents += eventJson
     }
   }

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -42,9 +42,10 @@ import org.apache.spark.scheduler.cluster.ExecutorInfo
 import org.apache.spark.shuffle.MetadataFetchFailedException
 import org.apache.spark.storage._
 
-class JsonProtocolSuite extends SparkFunSuite {
-  import JsonProtocol._
-  import JsonProtocolSuite._
+class jsonProtocolSuite extends SparkFunSuite {
+  import jsonProtocolSuite._
+
+  private val jsonProtocol = new JsonProtocol(new SparkConf())
 
   test("SparkListenerEvent") {
     val stageSubmitted =
@@ -270,15 +271,15 @@ class JsonProtocolSuite extends SparkFunSuite {
 
   test("ExceptionFailure backward compatibility: full stack trace") {
     val exceptionFailure = ExceptionFailure("To be", "or not to be", stackTrace, null, None)
-    val oldEvent = toJsonString(JsonProtocol.taskEndReasonToJson(exceptionFailure, _))
+    val oldEvent = jsonProtocol.toJsonString(jsonProtocol.taskEndReasonToJson(exceptionFailure, _))
       .removeField("Full Stack Trace")
-    assertEquals(exceptionFailure, JsonProtocol.taskEndReasonFromJson(oldEvent))
+    assertEquals(exceptionFailure, jsonProtocol.taskEndReasonFromJson(oldEvent))
   }
 
   test("StageInfo backward compatibility (details, accumulables)") {
     val info = makeStageInfo(1, 2, 3, 4L, 5L)
-    val newJson = toJsonString(
-      JsonProtocol.stageInfoToJson(info, _, defaultOptions, includeAccumulables = true))
+    val newJson = jsonProtocol.toJsonString(
+      jsonProtocol.stageInfoToJson(info, _, includeAccumulables = true))
 
     // Fields added after 1.0.0.
     assert(info.details.nonEmpty)
@@ -287,7 +288,7 @@ class JsonProtocolSuite extends SparkFunSuite {
       .removeField("Details")
       .removeField("Accumulables")
 
-    val newInfo = JsonProtocol.stageInfoFromJson(oldJson)
+    val newInfo = jsonProtocol.stageInfoFromJson(oldJson)
 
     assert(info.name === newInfo.name)
     assert("" === newInfo.details)
@@ -296,14 +297,14 @@ class JsonProtocolSuite extends SparkFunSuite {
 
   test("StageInfo resourceProfileId") {
     val info = makeStageInfo(1, 2, 3, 4L, 5L, 5)
-    val json = toJsonString(
-      JsonProtocol.stageInfoToJson(info, _, defaultOptions, includeAccumulables = true))
+    val json = jsonProtocol.toJsonString(
+      jsonProtocol.stageInfoToJson(info, _, includeAccumulables = true))
 
     // Fields added after 1.0.0.
     assert(info.details.nonEmpty)
     assert(info.resourceProfileId === 5)
 
-    val newInfo = JsonProtocol.stageInfoFromJson(json)
+    val newInfo = jsonProtocol.stageInfoFromJson(json)
 
     assert(info.name === newInfo.name)
     assert(5 === newInfo.resourceProfileId)
@@ -312,9 +313,9 @@ class JsonProtocolSuite extends SparkFunSuite {
   test("InputMetrics backward compatibility") {
     // InputMetrics were added after 1.0.1.
     val metrics = makeTaskMetrics(1L, 2L, 3L, 4L, 5, 6, 0, hasHadoopInput = true, hasOutput = false)
-    val newJson = toJsonString(JsonProtocol.taskMetricsToJson(metrics, _))
+    val newJson = jsonProtocol.toJsonString(jsonProtocol.taskMetricsToJson(metrics, _))
     val oldJson = newJson.removeField("Input Metrics")
-    val newMetrics = JsonProtocol.taskMetricsFromJson(oldJson)
+    val newMetrics = jsonProtocol.taskMetricsFromJson(oldJson)
     assert(newMetrics.inputMetrics.recordsRead == 0)
     assert(newMetrics.inputMetrics.bytesRead == 0)
   }
@@ -323,11 +324,11 @@ class JsonProtocolSuite extends SparkFunSuite {
     // records read were added after 1.2
     val metrics = makeTaskMetrics(1L, 2L, 3L, 4L, 5, 6, 0,
       hasHadoopInput = true, hasOutput = true, hasRecords = false)
-    val newJson = toJsonString(JsonProtocol.taskMetricsToJson(metrics, _))
+    val newJson = jsonProtocol.toJsonString(jsonProtocol.taskMetricsToJson(metrics, _))
     val oldJson = newJson
       .removeField("Records Read")
       .removeField("Records Written")
-    val newMetrics = JsonProtocol.taskMetricsFromJson(oldJson)
+    val newMetrics = jsonProtocol.taskMetricsFromJson(oldJson)
     assert(newMetrics.inputMetrics.recordsRead == 0)
     assert(newMetrics.outputMetrics.recordsWritten == 0)
   }
@@ -337,12 +338,12 @@ class JsonProtocolSuite extends SparkFunSuite {
     // "Remote Bytes Read To Disk" was added in 2.3.0
     val metrics = makeTaskMetrics(1L, 2L, 3L, 4L, 5, 6, 0,
       hasHadoopInput = false, hasOutput = false, hasRecords = false)
-    val newJson = toJsonString(JsonProtocol.taskMetricsToJson(metrics, _))
+    val newJson = jsonProtocol.toJsonString(jsonProtocol.taskMetricsToJson(metrics, _))
     val oldJson = newJson
       .removeField("Total Records Read")
       .removeField("Shuffle Records Written")
       .removeField("Remote Bytes Read To Disk")
-    val newMetrics = JsonProtocol.taskMetricsFromJson(oldJson)
+    val newMetrics = jsonProtocol.taskMetricsFromJson(oldJson)
     assert(newMetrics.shuffleReadMetrics.recordsRead == 0)
     assert(newMetrics.shuffleReadMetrics.remoteBytesReadToDisk == 0)
     assert(newMetrics.shuffleWriteMetrics.recordsWritten == 0)
@@ -351,9 +352,9 @@ class JsonProtocolSuite extends SparkFunSuite {
   test("OutputMetrics backward compatibility") {
     // OutputMetrics were added after 1.1
     val metrics = makeTaskMetrics(1L, 2L, 3L, 4L, 5, 6, 0, hasHadoopInput = false, hasOutput = true)
-    val newJson = toJsonString(JsonProtocol.taskMetricsToJson(metrics, _))
+    val newJson = jsonProtocol.toJsonString(jsonProtocol.taskMetricsToJson(metrics, _))
     val oldJson = newJson.removeField("Output Metrics")
-    val newMetrics = JsonProtocol.taskMetricsFromJson(oldJson)
+    val newMetrics = jsonProtocol.taskMetricsFromJson(oldJson)
     assert(newMetrics.outputMetrics.recordsWritten == 0)
     assert(newMetrics.outputMetrics.bytesWritten == 0)
   }
@@ -365,12 +366,12 @@ class JsonProtocolSuite extends SparkFunSuite {
     metrics.setExecutorDeserializeCpuTime(100L)
     metrics.setExecutorCpuTime(100L)
     metrics.setPeakExecutionMemory(100L)
-    val newJson = toJsonString(JsonProtocol.taskMetricsToJson(metrics, _))
+    val newJson = jsonProtocol.toJsonString(jsonProtocol.taskMetricsToJson(metrics, _))
     val oldJson = newJson
       .removeField("Executor Deserialize CPU Time")
       .removeField("Executor CPU Time")
       .removeField("Peak Execution Memory")
-    val newMetrics = JsonProtocol.taskMetricsFromJson(oldJson)
+    val newMetrics = jsonProtocol.taskMetricsFromJson(oldJson)
     assert(newMetrics.executorDeserializeCpuTime == 0)
     assert(newMetrics.executorCpuTime == 0)
     assert(newMetrics.peakExecutionMemory == 0)
@@ -385,9 +386,9 @@ class JsonProtocolSuite extends SparkFunSuite {
       deserialized = false,
       replication = 1
     )
-    val newJson = toJsonString(JsonProtocol.storageLevelToJson(level, _))
+    val newJson = jsonProtocol.toJsonString(jsonProtocol.storageLevelToJson(level, _))
     val oldJson = newJson.removeField("Use Off Heap")
-    val newLevel = JsonProtocol.storageLevelFromJson(oldJson)
+    val newLevel = jsonProtocol.storageLevelFromJson(oldJson)
     assert(newLevel.useOffHeap === false)
   }
 
@@ -398,17 +399,19 @@ class JsonProtocolSuite extends SparkFunSuite {
     val blockManagerRemoved = SparkListenerBlockManagerRemoved(2L,
       BlockManagerId("Scarce", "to be counted...", 100))
 
-    val oldBmAdded = toJsonString(JsonProtocol.blockManagerAddedToJson(blockManagerAdded, _))
+    val oldBmAdded = jsonProtocol
+      .toJsonString(jsonProtocol.blockManagerAddedToJson(blockManagerAdded, _))
       .removeField("Timestamp")
 
-    val deserializedBmAdded = JsonProtocol.blockManagerAddedFromJson(oldBmAdded)
+    val deserializedBmAdded = jsonProtocol.blockManagerAddedFromJson(oldBmAdded)
     assert(SparkListenerBlockManagerAdded(-1L, blockManagerAdded.blockManagerId,
       blockManagerAdded.maxMem) === deserializedBmAdded)
 
-    val oldBmRemoved = toJsonString(JsonProtocol.blockManagerRemovedToJson(blockManagerRemoved, _))
+    val oldBmRemoved = jsonProtocol
+      .toJsonString(jsonProtocol.blockManagerRemovedToJson(blockManagerRemoved, _))
       .removeField("Timestamp")
 
-    val deserializedBmRemoved = JsonProtocol.blockManagerRemovedFromJson(oldBmRemoved)
+    val deserializedBmRemoved = jsonProtocol.blockManagerRemovedFromJson(oldBmRemoved)
     assert(SparkListenerBlockManagerRemoved(-1L, blockManagerRemoved.blockManagerId) ===
       deserializedBmRemoved)
   }
@@ -417,31 +420,31 @@ class JsonProtocolSuite extends SparkFunSuite {
     // FetchFailed in Spark 1.1.0 does not have a "Message" property.
     val fetchFailed = FetchFailed(BlockManagerId("With or", "without you", 15), 17, 16L, 18, 19,
       "ignored")
-    val oldEvent = toJsonString(JsonProtocol.taskEndReasonToJson(fetchFailed, _))
+    val oldEvent = jsonProtocol.toJsonString(jsonProtocol.taskEndReasonToJson(fetchFailed, _))
       .removeField("Message")
     val expectedFetchFailed = FetchFailed(BlockManagerId("With or", "without you", 15), 17, 16L,
       18, 19, "Unknown reason")
-    assert(expectedFetchFailed === JsonProtocol.taskEndReasonFromJson(oldEvent))
+    assert(expectedFetchFailed === jsonProtocol.taskEndReasonFromJson(oldEvent))
   }
 
   test("SPARK-32124: FetchFailed Map Index backwards compatibility") {
     // FetchFailed in Spark 2.4.0 does not have "Map Index" property.
     val fetchFailed = FetchFailed(BlockManagerId("With or", "without you", 15), 17, 16L, 18, 19,
       "ignored")
-    val oldEvent = toJsonString(JsonProtocol.taskEndReasonToJson(fetchFailed, _))
+    val oldEvent = jsonProtocol.toJsonString(jsonProtocol.taskEndReasonToJson(fetchFailed, _))
       .removeField("Map Index")
     val expectedFetchFailed = FetchFailed(BlockManagerId("With or", "without you", 15), 17, 16L,
       Int.MinValue, 19, "ignored")
-    assert(expectedFetchFailed === JsonProtocol.taskEndReasonFromJson(oldEvent))
+    assert(expectedFetchFailed === jsonProtocol.taskEndReasonFromJson(oldEvent))
   }
 
   test("ShuffleReadMetrics: Local bytes read backwards compatibility") {
     // Metrics about local shuffle bytes read were added in 1.3.1.
     val metrics = makeTaskMetrics(1L, 2L, 3L, 4L, 5, 6, 0,
       hasHadoopInput = false, hasOutput = false, hasRecords = false)
-    val newJson = toJsonString(JsonProtocol.taskMetricsToJson(metrics, _))
+    val newJson = jsonProtocol.toJsonString(jsonProtocol.taskMetricsToJson(metrics, _))
     val oldJson = newJson.removeField("Local Bytes Read")
-    val newMetrics = JsonProtocol.taskMetricsFromJson(oldJson)
+    val newMetrics = jsonProtocol.taskMetricsFromJson(oldJson)
     assert(newMetrics.shuffleReadMetrics.localBytesRead == 0)
   }
 
@@ -450,20 +453,22 @@ class JsonProtocolSuite extends SparkFunSuite {
     // SparkListenerApplicationStart pre-Spark 1.4 does not have "appAttemptId".
     // SparkListenerApplicationStart pre-Spark 1.5 does not have "driverLogs
     val applicationStart = SparkListenerApplicationStart("test", None, 1L, "user", None, None)
-    val oldEvent = toJsonString(JsonProtocol.applicationStartToJson(applicationStart, _))
+    val oldEvent = jsonProtocol
+      .toJsonString(jsonProtocol.applicationStartToJson(applicationStart, _))
       .removeField("App ID")
       .removeField("App Attempt ID")
       .removeField( "Driver Logs")
-    assert(applicationStart === JsonProtocol.applicationStartFromJson(oldEvent))
+    assert(applicationStart === jsonProtocol.applicationStartFromJson(oldEvent))
   }
 
   test("ExecutorLostFailure backward compatibility") {
     // ExecutorLostFailure in Spark 1.1.0 does not have an "Executor ID" property.
     val executorLostFailure = ExecutorLostFailure("100", true, Some("Induced failure"))
-    val oldEvent = toJsonString(JsonProtocol.taskEndReasonToJson(executorLostFailure, _))
+    val oldEvent = jsonProtocol
+      .toJsonString(jsonProtocol.taskEndReasonToJson(executorLostFailure, _))
       .removeField("Executor ID")
     val expectedExecutorLostFailure = ExecutorLostFailure("Unknown", true, Some("Induced failure"))
-    assert(expectedExecutorLostFailure === JsonProtocol.taskEndReasonFromJson(oldEvent))
+    assert(expectedExecutorLostFailure === jsonProtocol.taskEndReasonFromJson(oldEvent))
   }
 
   test("SparkListenerJobStart backward compatibility") {
@@ -474,10 +479,10 @@ class JsonProtocolSuite extends SparkFunSuite {
       stageIds.map(id => new StageInfo(id, 0, "unknown", 0, Seq.empty, Seq.empty, "unknown",
         resourceProfileId = ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID))
     val jobStart = SparkListenerJobStart(10, jobSubmissionTime, stageInfos, properties)
-    val oldEvent = sparkEventToJsonString(jobStart).removeField("Stage Infos")
+    val oldEvent = jsonProtocol.sparkEventToJsonString(jobStart).removeField("Stage Infos")
     val expectedJobStart =
       SparkListenerJobStart(10, jobSubmissionTime, dummyStageInfos, properties)
-    assertEquals(expectedJobStart, JsonProtocol.jobStartFromJson(oldEvent))
+    assertEquals(expectedJobStart, jsonProtocol.jobStartFromJson(oldEvent))
   }
 
   test("SparkListenerJobStart and SparkListenerJobEnd backward compatibility") {
@@ -486,15 +491,15 @@ class JsonProtocolSuite extends SparkFunSuite {
     val stageIds = Seq[Int](1, 2, 3, 4)
     val stageInfos = stageIds.map(x => makeStageInfo(x * 10, x * 20, x * 30, x * 40L, x * 50L))
     val jobStart = SparkListenerJobStart(11, jobSubmissionTime, stageInfos, properties)
-    val oldStartEvent = sparkEventToJsonString(jobStart).removeField("Submission Time")
+    val oldStartEvent = jsonProtocol.sparkEventToJsonString(jobStart).removeField("Submission Time")
     val expectedJobStart = SparkListenerJobStart(11, -1, stageInfos, properties)
-    assertEquals(expectedJobStart, JsonProtocol.jobStartFromJson(oldStartEvent))
+    assertEquals(expectedJobStart, jsonProtocol.jobStartFromJson(oldStartEvent))
 
     val jobEnd = SparkListenerJobEnd(11, jobCompletionTime, JobSucceeded)
-    val oldEndEvent = toJsonString(JsonProtocol.jobEndToJson(jobEnd, _))
+    val oldEndEvent = jsonProtocol.toJsonString(jsonProtocol.jobEndToJson(jobEnd, _))
       .removeField("Completion Time")
     val expectedJobEnd = SparkListenerJobEnd(11, -1, JobSucceeded)
-    assertEquals(expectedJobEnd, JsonProtocol.jobEndFromJson(oldEndEvent))
+    assertEquals(expectedJobEnd, jsonProtocol.jobEndFromJson(oldEndEvent))
   }
 
   test("RDDInfo backward compatibility") {
@@ -504,7 +509,7 @@ class JsonProtocolSuite extends SparkFunSuite {
     // "DeterministicLevel" was introduced in Spark 3.2.0
     val rddInfo = new RDDInfo(1, "one", 100, StorageLevel.NONE, true, Seq(1, 6, 8),
       "callsite", Some(new RDDOperationScope("fable")), DeterministicLevel.INDETERMINATE)
-    val oldRddInfoJson = toJsonString(JsonProtocol.rddInfoToJson(rddInfo, _))
+    val oldRddInfoJson = jsonProtocol.toJsonString(jsonProtocol.rddInfoToJson(rddInfo, _))
       .removeField("Parent IDs")
       .removeField("Scope")
       .removeField("Callsite")
@@ -513,7 +518,7 @@ class JsonProtocolSuite extends SparkFunSuite {
     val expectedRddInfo = new RDDInfo(
       1, "one", 100, StorageLevel.NONE, false, Seq.empty, "", scope = None,
       outputDeterministicLevel = DeterministicLevel.INDETERMINATE)
-    assertEquals(expectedRddInfo, JsonProtocol.rddInfoFromJson(oldRddInfoJson))
+    assertEquals(expectedRddInfo, jsonProtocol.rddInfoFromJson(oldRddInfoJson))
   }
 
   test("StageInfo backward compatibility (parent IDs)") {
@@ -521,39 +526,40 @@ class JsonProtocolSuite extends SparkFunSuite {
     val stageInfo = new StageInfo(1, 1, "me-stage", 1, Seq.empty, Seq(1, 2, 3), "details",
       resourceProfileId = ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID)
     val oldStageInfo =
-      toJsonString(
-        JsonProtocol.stageInfoToJson(stageInfo, _, defaultOptions, includeAccumulables = true)
+      jsonProtocol.toJsonString(
+        jsonProtocol.stageInfoToJson(stageInfo, _, includeAccumulables = true)
       ).removeField("Parent IDs")
     val expectedStageInfo = new StageInfo(1, 1, "me-stage", 1, Seq.empty, Seq.empty, "details",
       resourceProfileId = ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID)
-    assertEquals(expectedStageInfo, JsonProtocol.stageInfoFromJson(oldStageInfo))
+    assertEquals(expectedStageInfo, jsonProtocol.stageInfoFromJson(oldStageInfo))
   }
 
   // `TaskCommitDenied` was added in 1.3.0 but JSON de/serialization logic was added in 1.5.1
   test("TaskCommitDenied backward compatibility") {
     val denied = TaskCommitDenied(1, 2, 3)
-    val oldDenied = toJsonString(JsonProtocol.taskEndReasonToJson(denied, _))
+    val oldDenied = jsonProtocol.toJsonString(jsonProtocol.taskEndReasonToJson(denied, _))
       .removeField("Job ID")
       .removeField("Partition ID")
       .removeField("Attempt Number")
     val expectedDenied = TaskCommitDenied(-1, -1, -1)
-    assertEquals(expectedDenied, JsonProtocol.taskEndReasonFromJson(oldDenied))
+    assertEquals(expectedDenied, jsonProtocol.taskEndReasonFromJson(oldDenied))
   }
 
   test("AccumulableInfo backward compatibility") {
     // "Internal" property of AccumulableInfo was added in 1.5.1
     val accumulableInfo = makeAccumulableInfo(1, internal = true, countFailedValues = true)
-    val accumulableInfoJson = toJsonString(JsonProtocol.accumulableInfoToJson(accumulableInfo, _))
+    val accumulableInfoJson = jsonProtocol
+      .toJsonString(jsonProtocol.accumulableInfoToJson(accumulableInfo, _))
     val oldJson = accumulableInfoJson.removeField("Internal")
-    val oldInfo = JsonProtocol.accumulableInfoFromJson(oldJson)
+    val oldInfo = jsonProtocol.accumulableInfoFromJson(oldJson)
     assert(!oldInfo.internal)
     // "Count Failed Values" property of AccumulableInfo was added in 2.0.0
     val oldJson2 = accumulableInfoJson.removeField("Count Failed Values")
-    val oldInfo2 = JsonProtocol.accumulableInfoFromJson(oldJson2)
+    val oldInfo2 = jsonProtocol.accumulableInfoFromJson(oldJson2)
     assert(!oldInfo2.countFailedValues)
     // "Metadata" property of AccumulableInfo was added in 2.0.0
     val oldJson3 = accumulableInfoJson.removeField("Metadata")
-    val oldInfo3 = JsonProtocol.accumulableInfoFromJson(oldJson3)
+    val oldInfo3 = jsonProtocol.accumulableInfoFromJson(oldJson3)
     assert(oldInfo3.metadata.isEmpty)
   }
 
@@ -562,17 +568,18 @@ class JsonProtocolSuite extends SparkFunSuite {
     // we should still be able to fallback to constructing the accumulator updates from the
     // "Task Metrics" field, if it exists.
     val tm = makeTaskMetrics(1L, 2L, 3L, 4L, 5, 6, 0, hasHadoopInput = true, hasOutput = true)
-    val tmJson = toJsonString(JsonProtocol.taskMetricsToJson(tm, _))
+    val tmJson = jsonProtocol.toJsonString(jsonProtocol.taskMetricsToJson(tm, _))
     val accumUpdates = tm.accumulators().map(AccumulatorSuite.makeInfo)
     val exception = new SparkException("sentimental")
     val exceptionFailure = new ExceptionFailure(exception, accumUpdates)
-    val exceptionFailureJson = toJsonString(JsonProtocol.taskEndReasonToJson(exceptionFailure, _))
+    val exceptionFailureJson = jsonProtocol
+      .toJsonString(jsonProtocol.taskEndReasonToJson(exceptionFailure, _))
     val oldExceptionFailureJson =
       exceptionFailureJson
         .removeField("Accumulator Updates")
         .addStringField("Task Metrics", tmJson)
     val oldExceptionFailure =
-      JsonProtocol.taskEndReasonFromJson(oldExceptionFailureJson).asInstanceOf[ExceptionFailure]
+      jsonProtocol.taskEndReasonFromJson(oldExceptionFailureJson).asInstanceOf[ExceptionFailure]
     assert(exceptionFailure.className === oldExceptionFailure.className)
     assert(exceptionFailure.description === oldExceptionFailure.description)
     assertSeqEquals[StackTraceElement](
@@ -588,13 +595,13 @@ class JsonProtocolSuite extends SparkFunSuite {
     val tm = makeTaskMetrics(1L, 2L, 3L, 4L, 5, 6, 0, hasHadoopInput = true, hasOutput = true)
     val accumUpdates = tm.accumulators().map(AccumulatorSuite.makeInfo)
     val taskKilled = TaskKilled(reason = "test", accumUpdates)
-    val taskKilledJson = toJsonString(JsonProtocol.taskEndReasonToJson(taskKilled, _))
+    val taskKilledJson = jsonProtocol.toJsonString(jsonProtocol.taskEndReasonToJson(taskKilled, _))
     val oldExceptionFailureJson =
       taskKilledJson
         .removeField("Kill Reason")
         .removeField("Accumulator Updates")
     val oldTaskKilled =
-      JsonProtocol.taskEndReasonFromJson(oldExceptionFailureJson).asInstanceOf[TaskKilled]
+      jsonProtocol.taskEndReasonFromJson(oldExceptionFailureJson).asInstanceOf[TaskKilled]
     assert(oldTaskKilled.reason === "unknown reason")
     assert(oldTaskKilled.accums.isEmpty)
     assert(oldTaskKilled.accumUpdates.isEmpty)
@@ -604,11 +611,11 @@ class JsonProtocolSuite extends SparkFunSuite {
     // executorMetricsUpdate was added in 2.4.0.
     val executorMetricsUpdate = makeExecutorMetricsUpdate("1", true, true)
     val oldExecutorMetricsUpdateJson =
-      toJsonString(JsonProtocol.executorMetricsUpdateToJson(executorMetricsUpdate, _))
+      jsonProtocol.toJsonString(jsonProtocol.executorMetricsUpdateToJson(executorMetricsUpdate, _))
         .removeField("Executor Metrics Updated")
     val expectedExecutorMetricsUpdate = makeExecutorMetricsUpdate("1", true, false)
     assertEquals(expectedExecutorMetricsUpdate,
-      JsonProtocol.executorMetricsUpdateFromJson(oldExecutorMetricsUpdateJson))
+      jsonProtocol.executorMetricsUpdateFromJson(oldExecutorMetricsUpdateJson))
   }
 
   test("executorMetricsFromJson backward compatibility: handle missing metrics") {
@@ -616,24 +623,24 @@ class JsonProtocolSuite extends SparkFunSuite {
     val executorMetrics = new ExecutorMetrics(Array(12L, 23L, 45L, 67L, 78L, 89L,
       90L, 123L, 456L, 789L, 40L, 20L, 20L, 10L, 20L, 10L, 301L))
     val oldExecutorMetricsJson =
-      toJsonString(JsonProtocol.executorMetricsToJson(executorMetrics, _))
+      jsonProtocol.toJsonString(jsonProtocol.executorMetricsToJson(executorMetrics, _))
         .removeField("MappedPoolMemory")
     val expectedExecutorMetrics = new ExecutorMetrics(Array(12L, 23L, 45L, 67L,
       78L, 89L, 90L, 123L, 456L, 0L, 40L, 20L, 20L, 10L, 20L, 10L, 301L))
     assertEquals(expectedExecutorMetrics,
-      JsonProtocol.executorMetricsFromJson(oldExecutorMetricsJson))
+      jsonProtocol.executorMetricsFromJson(oldExecutorMetricsJson))
   }
 
   test("EnvironmentUpdate backward compatibility: handle missing metrics properties") {
     // The "Metrics Properties" field was added in Spark 3.4.0:
     val expectedEvent: SparkListenerEnvironmentUpdate = {
-      val e = JsonProtocol.environmentUpdateFromJson(environmentUpdateJsonString)
+      val e = jsonProtocol.environmentUpdateFromJson(environmentUpdateJsonString)
       e.copy(environmentDetails =
         e.environmentDetails ++ Map("Metrics Properties" -> Seq.empty[(String, String)]))
     }
     val oldEnvironmentUpdateJson = environmentUpdateJsonString
       .removeField("Metrics Properties")
-    assertEquals(expectedEvent, JsonProtocol.environmentUpdateFromJson(oldEnvironmentUpdateJson))
+    assertEquals(expectedEvent, jsonProtocol.environmentUpdateFromJson(oldEnvironmentUpdateJson))
   }
 
   test("ExecutorInfo backward compatibility") {
@@ -653,13 +660,14 @@ class JsonProtocolSuite extends SparkFunSuite {
         resourceProfileId = 123,
         registrationTime = Some(2L),
         requestTime = Some(1L))
-    val oldExecutorInfoJson = toJsonString(JsonProtocol.executorInfoToJson(executorInfo, _))
+    val oldExecutorInfoJson = jsonProtocol
+      .toJsonString(jsonProtocol.executorInfoToJson(executorInfo, _))
       .removeField("Attributes")
       .removeField("Resources")
       .removeField("Resource Profile Id")
       .removeField("Registration Time")
       .removeField("Request Time")
-    val oldEvent = JsonProtocol.executorInfoFromJson(oldExecutorInfoJson)
+    val oldEvent = jsonProtocol.executorInfoFromJson(oldExecutorInfoJson)
     assert(oldEvent.attributes.isEmpty)
     assert(oldEvent.resourcesInfo.isEmpty)
     assert(oldEvent.resourceProfileId == DEFAULT_RESOURCE_PROFILE_ID)
@@ -698,7 +706,7 @@ class JsonProtocolSuite extends SparkFunSuite {
         |}
     """.stripMargin
     val oldJson = newJson.removeField("Partition ID")
-    assert(JsonProtocol.taskInfoFromJson(oldJson).partitionId === -1)
+    assert(jsonProtocol.taskInfoFromJson(oldJson).partitionId === -1)
   }
 
   test("AccumulableInfo value de/serialization") {
@@ -708,7 +716,7 @@ class JsonProtocolSuite extends SparkFunSuite {
       (TestBlockId("feebo"), BlockStatus(StorageLevel.DISK_ONLY, 3L, 4L)))
     val blocksJson = JArray(blocks.toList.map { case (id, status) =>
       ("Block ID" -> id.toString) ~
-      ("Status" -> parse(toJsonString(JsonProtocol.blockStatusToJson(status, _))))
+      ("Status" -> parse(jsonProtocol.toJsonString(jsonProtocol.blockStatusToJson(status, _))))
     })
     testAccumValue(Some(RESULT_SIZE), 3L, JInt(3))
     testAccumValue(Some(shuffleRead.REMOTE_BLOCKS_FETCHED), 2, JInt(2))
@@ -731,8 +739,8 @@ class JsonProtocolSuite extends SparkFunSuite {
       value = value,
       internal = isInternal,
       countFailedValues = false)
-    val json = toJsonString(JsonProtocol.accumulableInfoToJson(accum, _))
-    val newAccum = JsonProtocol.accumulableInfoFromJson(json)
+    val json = jsonProtocol.toJsonString(jsonProtocol.accumulableInfoToJson(accum, _))
+    val newAccum = jsonProtocol.accumulableInfoFromJson(json)
     assert(newAccum == accum.copy(update = expectedValue, value = expectedValue))
   }
 
@@ -775,7 +783,7 @@ class JsonProtocolSuite extends SparkFunSuite {
         |  "bar" : 123,
         |  "unknown" : "unknown"
         |}""".stripMargin
-    assert(JsonProtocol.sparkEventFromJson(unknownFieldsJson) === expected)
+    assert(jsonProtocol.sparkEventFromJson(unknownFieldsJson) === expected)
   }
 
   test("SPARK-30936: backwards compatibility - set default values for missing fields") {
@@ -785,20 +793,20 @@ class JsonProtocolSuite extends SparkFunSuite {
         |  "Event" : "org.apache.spark.util.TestListenerEvent",
         |  "foo" : "foo"
         |}""".stripMargin
-    assert(JsonProtocol.sparkEventFromJson(unknownFieldsJson) === expected)
+    assert(jsonProtocol.sparkEventFromJson(unknownFieldsJson) === expected)
   }
 
   test("SPARK-42204: spark.eventLog.includeTaskMetricsAccumulators config") {
-    val includeConf = new JsonProtocolOptions(
+    val includeProtocol = new JsonProtocol(
       new SparkConf().set(EVENT_LOG_INCLUDE_TASK_METRICS_ACCUMULATORS, true))
-    val excludeConf = new JsonProtocolOptions(
+    val excludeProtocol = new JsonProtocol(
       new SparkConf().set(EVENT_LOG_INCLUDE_TASK_METRICS_ACCUMULATORS, false))
 
     val taskMetricsAccumulables = TaskMetrics
       .empty
       .nameToAccums
       .view
-      .filterKeys(!JsonProtocol.accumulableExcludeList.contains(_))
+      .filterKeys(!jsonProtocol.accumulableExcludeList.contains(_))
       .values
       .map(_.toInfo(Some(1), None))
       .toSeq
@@ -826,11 +834,11 @@ class JsonProtocolSuite extends SparkFunSuite {
           hasHadoopInput = false, hasOutput = false))
       assertEquals(
         originalEvent,
-        sparkEventFromJson(sparkEventToJsonString(originalEvent, includeConf)))
+        jsonProtocol.sparkEventFromJson(includeProtocol.sparkEventToJsonString(originalEvent)))
       val trimmedEvent = originalEvent.copy(taskInfo = taskInfoWithoutTaskMetricsAccums)
       assertEquals(
         trimmedEvent,
-        sparkEventFromJson(sparkEventToJsonString(originalEvent, excludeConf)))
+        jsonProtocol.sparkEventFromJson(excludeProtocol.sparkEventToJsonString(originalEvent)))
     }
 
     // StageCompleted
@@ -838,11 +846,11 @@ class JsonProtocolSuite extends SparkFunSuite {
       val originalEvent = SparkListenerStageCompleted(stageInfoWithTaskMetricsAccums)
       assertEquals(
         originalEvent,
-        sparkEventFromJson(sparkEventToJsonString(originalEvent, includeConf)))
+        jsonProtocol.sparkEventFromJson(includeProtocol.sparkEventToJsonString(originalEvent)))
       val trimmedEvent = originalEvent.copy(stageInfo = stageInfoWithoutTaskMetricsAccums)
       assertEquals(
         trimmedEvent,
-        sparkEventFromJson(sparkEventToJsonString(originalEvent, excludeConf)))
+        jsonProtocol.sparkEventFromJson(excludeProtocol.sparkEventToJsonString(originalEvent)))
     }
 
     // JobStart
@@ -851,21 +859,22 @@ class JsonProtocolSuite extends SparkFunSuite {
         SparkListenerJobStart(1, 1, Seq(stageInfoWithTaskMetricsAccums), properties)
       assertEquals(
         originalEvent,
-        sparkEventFromJson(sparkEventToJsonString(originalEvent, includeConf)))
+        jsonProtocol.sparkEventFromJson(includeProtocol.sparkEventToJsonString(originalEvent)))
       val trimmedEvent = originalEvent.copy(stageInfos = Seq(stageInfoWithoutTaskMetricsAccums))
       assertEquals(
         trimmedEvent,
-        sparkEventFromJson(sparkEventToJsonString(originalEvent, excludeConf)))
+        jsonProtocol.sparkEventFromJson(excludeProtocol.sparkEventToJsonString(originalEvent)))
     }
 
     // ExecutorMetricsUpdate events should be unaffected by the config:
     val executorMetricsUpdate =
       SparkListenerExecutorMetricsUpdate("0", Seq((0, 0, 0, taskMetricsAccumulables)))
     assert(
-      sparkEventToJsonString(executorMetricsUpdate, includeConf) ===
-      sparkEventToJsonString(executorMetricsUpdate, excludeConf))
+      includeProtocol.sparkEventToJsonString(executorMetricsUpdate) ===
+      excludeProtocol.sparkEventToJsonString(executorMetricsUpdate))
     assertEquals(
-      JsonProtocol.sparkEventFromJson(sparkEventToJsonString(executorMetricsUpdate, includeConf)),
+      jsonProtocol.sparkEventFromJson(
+        includeProtocol.sparkEventToJsonString(executorMetricsUpdate)),
       executorMetricsUpdate)
     }
 
@@ -883,7 +892,7 @@ class JsonProtocolSuite extends SparkFunSuite {
         |  }
         |]
         |""".stripMargin
-    val stackTrace = JsonProtocol.stackTraceFromJson(stackTraceJson)
+    val stackTrace = jsonProtocol.stackTraceFromJson(stackTraceJson)
     assert(stackTrace === Array(new StackTraceElement("someClass", "someMethod", null, -1)))
 
     val exceptionFailureJson =
@@ -897,7 +906,7 @@ class JsonProtocolSuite extends SparkFunSuite {
         |}
         |""".stripMargin
     val exceptionFailure =
-      JsonProtocol.taskEndReasonFromJson(exceptionFailureJson).asInstanceOf[ExceptionFailure]
+      jsonProtocol.taskEndReasonFromJson(exceptionFailureJson).asInstanceOf[ExceptionFailure]
     assert(exceptionFailure.description == null)
   }
 
@@ -919,7 +928,7 @@ class JsonProtocolSuite extends SparkFunSuite {
         |  "Message": "Job aborted"
         |}
         |""".stripMargin
-    val exNoStack = JsonProtocol.exceptionFromJson(exNoStackJson)
+    val exNoStack = jsonProtocol.exceptionFromJson(exNoStackJson)
     assert(exNoStack.getStackTrace.isEmpty)
 
     val exEmptyStackJson =
@@ -929,7 +938,7 @@ class JsonProtocolSuite extends SparkFunSuite {
         |  "Stack Trace": []
         |}
         |""".stripMargin
-    val exEmptyStack = JsonProtocol.exceptionFromJson(exEmptyStackJson)
+    val exEmptyStack = jsonProtocol.exceptionFromJson(exEmptyStackJson)
     assert(exEmptyStack.getStackTrace.isEmpty)
 
     // test entire job failure event is equivalent
@@ -962,7 +971,7 @@ class JsonProtocolSuite extends SparkFunSuite {
         |   }
         |}
         |""".stripMargin
-    val jobFailedEvent = JsonProtocol.sparkEventFromJson(exJobFailureNoStackJson)
+    val jobFailedEvent = jsonProtocol.sparkEventFromJson(exJobFailureNoStackJson)
     testEvent(jobFailedEvent, exJobFailureExpectedJson)
   }
 
@@ -984,25 +993,43 @@ class JsonProtocolSuite extends SparkFunSuite {
     val gettingResult = SparkListenerTaskGettingResult(taskInfo)
 
     assert(
-      stageSubmittedFromJson(sparkEventToJsonString(stageSubmitted)).stageInfo.accumulables.isEmpty)
+      jsonProtocol.stageSubmittedFromJson(
+        jsonProtocol.sparkEventToJsonString(stageSubmitted)).stageInfo.accumulables.isEmpty)
     assert(
-      taskStartFromJson(sparkEventToJsonString(taskStart)).taskInfo.accumulables.isEmpty)
+      jsonProtocol.taskStartFromJson(
+        jsonProtocol.sparkEventToJsonString(taskStart)).taskInfo.accumulables.isEmpty)
     assert(
-      taskGettingResultFromJson(sparkEventToJsonString(gettingResult))
+      jsonProtocol.taskGettingResultFromJson(
+          jsonProtocol.sparkEventToJsonString(gettingResult))
         .taskInfo.accumulables.isEmpty)
 
     // Deliberately not fixed for job starts because a job might legitimately reference
     // stages that have completed even before the job start event is emitted.
-    testEvent(jobStart, sparkEventToJsonString(jobStart))
+    testEvent(jobStart, jsonProtocol.sparkEventToJsonString(jobStart))
+  }
+
+  test("SPARK-49872: allow to limit json reader string sizes") {
+    val bigStringEvent = SparkListenerExecutorUnexcluded(
+      executorUnexcludedTime, "a".repeat(10_000))
+    val jsonString = jsonProtocol.sparkEventToJsonString(bigStringEvent)
+    assert(jsonProtocol.sparkEventFromJson(jsonString) == bigStringEvent)
+    val jsonProtocolWithLimit = new JsonProtocol(new SparkConf()
+      .set(EVENT_LOG_READER_MAX_STRING_LENGTH, 1_000))
+    val ex = intercept[com.fasterxml.jackson.core.exc.StreamConstraintsException] {
+      jsonProtocolWithLimit.sparkEventFromJson(jsonString)
+    }
+    assert(ex.getMessage.startsWith(
+      "String value length (10000) exceeds the maximum allowed"
+    ))
   }
 }
 
 
-private[spark] object JsonProtocolSuite extends Assertions {
+private[spark] object jsonProtocolSuite extends Assertions {
   import InternalAccumulator._
-  import JsonProtocol._
 
   private val mapper = new ObjectMapper()
+  private val jsonProtocol = new JsonProtocol(new SparkConf())
 
   private implicit class JsonStringImplicits(json: String) {
     def removeField(field: String): String = {
@@ -1036,59 +1063,59 @@ private[spark] object JsonProtocolSuite extends Assertions {
   }
 
   private def testEvent(event: SparkListenerEvent, jsonString: String): Unit = {
-    val actualJsonString = JsonProtocol.sparkEventToJsonString(event)
-    val newEvent = JsonProtocol.sparkEventFromJson(actualJsonString)
+    val actualJsonString = jsonProtocol.sparkEventToJsonString(event)
+    val newEvent = jsonProtocol.sparkEventFromJson(actualJsonString)
     assertJsonStringEquals(jsonString, actualJsonString, event.getClass.getSimpleName)
     assertEquals(event, newEvent)
   }
 
   private def testRDDInfo(info: RDDInfo): Unit = {
-    val newInfo = JsonProtocol.rddInfoFromJson(
-      toJsonString(JsonProtocol.rddInfoToJson(info, _)))
+    val newInfo = jsonProtocol.rddInfoFromJson(
+      jsonProtocol.toJsonString(jsonProtocol.rddInfoToJson(info, _)))
     assertEquals(info, newInfo)
   }
 
   private def testStageInfo(info: StageInfo): Unit = {
-    val newInfo = JsonProtocol.stageInfoFromJson(
-      toJsonString(
-        JsonProtocol.stageInfoToJson(info, _, defaultOptions, includeAccumulables = true)))
+    val newInfo = jsonProtocol.stageInfoFromJson(
+      jsonProtocol.toJsonString(
+        jsonProtocol.stageInfoToJson(info, _, includeAccumulables = true)))
     assertEquals(info, newInfo)
   }
 
   private def testStorageLevel(level: StorageLevel): Unit = {
-    val newLevel = JsonProtocol.storageLevelFromJson(
-      toJsonString(JsonProtocol.storageLevelToJson(level, _)))
+    val newLevel = jsonProtocol.storageLevelFromJson(
+      jsonProtocol.toJsonString(jsonProtocol.storageLevelToJson(level, _)))
     assertEquals(level, newLevel)
   }
 
   private def testTaskMetrics(metrics: TaskMetrics): Unit = {
-    val newMetrics = JsonProtocol.taskMetricsFromJson(
-      toJsonString(JsonProtocol.taskMetricsToJson(metrics, _)))
+    val newMetrics = jsonProtocol.taskMetricsFromJson(
+      jsonProtocol.toJsonString(jsonProtocol.taskMetricsToJson(metrics, _)))
     assertEquals(metrics, newMetrics)
   }
 
   private def testBlockManagerId(id: BlockManagerId): Unit = {
-    val newId = JsonProtocol.blockManagerIdFromJson(
-      toJsonString(JsonProtocol.blockManagerIdToJson(id, _)))
+    val newId = jsonProtocol.blockManagerIdFromJson(
+      jsonProtocol.toJsonString(jsonProtocol.blockManagerIdToJson(id, _)))
     assert(id === newId)
   }
 
   private def testTaskInfo(info: TaskInfo): Unit = {
-    val newInfo = JsonProtocol.taskInfoFromJson(
-      toJsonString(
-        JsonProtocol.taskInfoToJson(info, _, defaultOptions, includeAccumulables = true)))
+    val newInfo = jsonProtocol.taskInfoFromJson(
+      jsonProtocol.toJsonString(
+        jsonProtocol.taskInfoToJson(info, _, includeAccumulables = true)))
     assertEquals(info, newInfo)
   }
 
   private def testJobResult(result: JobResult): Unit = {
-    val newResult = JsonProtocol.jobResultFromJson(
-      toJsonString(JsonProtocol.jobResultToJson(result, _)))
+    val newResult = jsonProtocol.jobResultFromJson(
+      jsonProtocol.toJsonString(jsonProtocol.jobResultToJson(result, _)))
     assertEquals(result, newResult)
   }
 
   private def testTaskEndReason(reason: TaskEndReason): Unit = {
-    val newReason = JsonProtocol.taskEndReasonFromJson(
-      toJsonString(JsonProtocol.taskEndReasonToJson(reason, _)))
+    val newReason = jsonProtocol.taskEndReasonFromJson(
+      jsonProtocol.toJsonString(jsonProtocol.taskEndReasonToJson(reason, _)))
     assertEquals(reason, newReason)
   }
 
@@ -1098,22 +1125,22 @@ private[spark] object JsonProtocolSuite extends Assertions {
   }
 
   private def testExecutorInfo(info: ExecutorInfo): Unit = {
-    val newInfo = JsonProtocol.executorInfoFromJson(
-      toJsonString(JsonProtocol.executorInfoToJson(info, _)))
+    val newInfo = jsonProtocol.executorInfoFromJson(
+      jsonProtocol.toJsonString(jsonProtocol.executorInfoToJson(info, _)))
     assertEquals(info, newInfo)
   }
 
   private def testAccumValue(name: Option[String], value: Any, expectedJson: JValue): Unit = {
-    val json = parse(toJsonString(JsonProtocol.accumValueToJson(name, value, _)))
+    val json = parse(jsonProtocol.toJsonString(jsonProtocol.accumValueToJson(name, value, _)))
     assert(json === expectedJson)
-    val newValue = JsonProtocol.accumValueFromJson(name, json)
+    val newValue = jsonProtocol.accumValueFromJson(name, json)
     val expectedValue = if (name.exists(_.startsWith(METRICS_PREFIX))) value else value.toString
     assert(newValue === expectedValue)
   }
 
   private def testException(exception: Exception): Unit = {
-    val newException = JsonProtocol.exceptionFromJson(
-      toJsonString(JsonProtocol.exceptionToJson(exception, _)))
+    val newException = jsonProtocol.exceptionFromJson(
+      jsonProtocol.toJsonString(jsonProtocol.exceptionToJson(exception, _)))
     assertEquals(exception, newException)
   }
 
@@ -1167,7 +1194,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
             assert(stageId1 === stageId2)
             assert(stageAttemptId1 === stageAttemptId2)
             val filteredUpdates = updates1
-              .filterNot { acc => acc.name.exists(accumulableExcludeList.contains) }
+              .filterNot { acc => acc.name.exists(jsonProtocol.accumulableExcludeList.contains) }
             assertSeqEquals[AccumulableInfo](filteredUpdates, updates2, (a, b) => a.equals(b))
           })
         assertSeqEquals[((Int, Int), ExecutorMetrics)](
@@ -1302,7 +1329,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
         assertSeqEquals(r1.stackTrace, r2.stackTrace, assertStackTraceElementEquals)
         assert(r1.fullStackTrace === r2.fullStackTrace)
         val filteredUpdates = r1.accumUpdates
-          .filterNot { acc => acc.name.exists(accumulableExcludeList.contains) }
+          .filterNot { acc => acc.name.exists(jsonProtocol.accumulableExcludeList.contains) }
         assertSeqEquals[AccumulableInfo](filteredUpdates, r2.accumUpdates, (a, b) => a.equals(b))
       case (TaskResultLost, TaskResultLost) =>
       case (r1: TaskKilled, r2: TaskKilled) =>

--- a/mllib/src/test/scala/org/apache/spark/ml/MLEventsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/MLEventsSuite.scala
@@ -26,6 +26,7 @@ import org.mockito.Mockito.when
 import org.scalatest.concurrent.Eventually
 import org.scalatestplus.mockito.MockitoSugar.mock
 
+import org.apache.spark.SparkConf
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.util.{DefaultParamsReader, DefaultParamsWriter, MLWriter}
@@ -43,6 +44,7 @@ class MLEventsSuite extends SparkFunSuite with MLlibTestSparkContext with Eventu
       case _ =>
     }
   }
+  private val jsonProtocol = new JsonProtocol(new SparkConf())
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -143,8 +145,8 @@ class MLEventsSuite extends SparkFunSuite with MLlibTestSparkContext with Eventu
     }
     // Test if they can be ser/de via JSON protocol.
     assert(events.nonEmpty)
-    events.map(JsonProtocol.sparkEventToJsonString).foreach { event =>
-      assert(JsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
+    events.map(jsonProtocol.sparkEventToJsonString).foreach { event =>
+      assert(jsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
     }
   }
 
@@ -201,8 +203,8 @@ class MLEventsSuite extends SparkFunSuite with MLlibTestSparkContext with Eventu
     }
     // Test if they can be ser/de via JSON protocol.
     assert(events.nonEmpty)
-    events.map(JsonProtocol.sparkEventToJsonString).foreach { event =>
-      assert(JsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
+    events.map(jsonProtocol.sparkEventToJsonString).foreach { event =>
+      assert(jsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
     }
   }
 
@@ -233,8 +235,8 @@ class MLEventsSuite extends SparkFunSuite with MLlibTestSparkContext with Eventu
       // Test if they can be ser/de via JSON protocol.
       eventually(timeout(10.seconds), interval(1.second)) {
         assert(events.nonEmpty)
-        events.map(JsonProtocol.sparkEventToJsonString).foreach { event =>
-          assert(JsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
+        events.map(jsonProtocol.sparkEventToJsonString).foreach { event =>
+          assert(jsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
         }
       }
       sc.listenerBus.waitUntilEmpty(timeoutMillis = 10000)
@@ -261,8 +263,8 @@ class MLEventsSuite extends SparkFunSuite with MLlibTestSparkContext with Eventu
       // Test if they can be ser/de via JSON protocol.
       eventually(timeout(10.seconds), interval(1.second)) {
         assert(events.nonEmpty)
-        events.map(JsonProtocol.sparkEventToJsonString).foreach { event =>
-          assert(JsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
+        events.map(jsonProtocol.sparkEventToJsonString).foreach { event =>
+          assert(jsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
         }
       }
     }
@@ -296,8 +298,8 @@ class MLEventsSuite extends SparkFunSuite with MLlibTestSparkContext with Eventu
       // Test if they can be ser/de via JSON protocol.
       eventually(timeout(10.seconds), interval(1.second)) {
         assert(events.nonEmpty)
-        events.map(JsonProtocol.sparkEventToJsonString).foreach { event =>
-          assert(JsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
+        events.map(jsonProtocol.sparkEventToJsonString).foreach { event =>
+          assert(jsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
         }
       }
       sc.listenerBus.waitUntilEmpty(timeoutMillis = 10000)
@@ -324,8 +326,8 @@ class MLEventsSuite extends SparkFunSuite with MLlibTestSparkContext with Eventu
       // Test if they can be ser/de via JSON protocol.
       eventually(timeout(10.seconds), interval(1.second)) {
         assert(events.nonEmpty)
-        events.map(JsonProtocol.sparkEventToJsonString).foreach { event =>
-          assert(JsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
+        events.map(jsonProtocol.sparkEventToJsonString).foreach { event =>
+          assert(jsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
         }
       }
     }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ExecuteEventsManagerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ExecuteEventsManagerSuite.scala
@@ -24,7 +24,7 @@ import scala.util.matching.Regex
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 
-import org.apache.spark.{SparkContext, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.{ExecutePlanRequest, Plan, UserContext}
 import org.apache.spark.scheduler.LiveListenerBus
@@ -51,6 +51,7 @@ class ExecuteEventsManagerSuite
   val DEFAULT_SESSION_ID = UUID.randomUUID.toString
   val DEFAULT_QUERY_ID = UUID.randomUUID.toString
   val DEFAULT_CLIENT_TYPE = "clientType"
+  val jsonProtocol = new JsonProtocol(new SparkConf())
 
   test("SPARK-43923: post started") {
     val events = setupEvents(ExecuteStatus.Pending)
@@ -71,8 +72,8 @@ class ExecuteEventsManagerSuite
       .post(expectedEvent)
 
     assert(
-      JsonProtocol
-        .sparkEventFromJson(JsonProtocol.sparkEventToJsonString(expectedEvent))
+      jsonProtocol
+        .sparkEventFromJson(jsonProtocol.sparkEventToJsonString(expectedEvent))
         .isInstanceOf[SparkListenerConnectOperationStarted])
   }
 
@@ -90,8 +91,8 @@ class ExecuteEventsManagerSuite
       .post(expectedEvent)
 
     assert(
-      JsonProtocol
-        .sparkEventFromJson(JsonProtocol.sparkEventToJsonString(expectedEvent))
+      jsonProtocol
+        .sparkEventFromJson(jsonProtocol.sparkEventToJsonString(expectedEvent))
         .isInstanceOf[SparkListenerConnectOperationAnalyzed])
   }
 
@@ -117,8 +118,8 @@ class ExecuteEventsManagerSuite
       .post(expectedEvent)
 
     assert(
-      JsonProtocol
-        .sparkEventFromJson(JsonProtocol.sparkEventToJsonString(expectedEvent))
+      jsonProtocol
+        .sparkEventFromJson(jsonProtocol.sparkEventToJsonString(expectedEvent))
         .isInstanceOf[SparkListenerConnectOperationReadyForExecution])
   }
 
@@ -133,8 +134,8 @@ class ExecuteEventsManagerSuite
       .post(expectedEvent)
 
     assert(
-      JsonProtocol
-        .sparkEventFromJson(JsonProtocol.sparkEventToJsonString(expectedEvent))
+      jsonProtocol
+        .sparkEventFromJson(jsonProtocol.sparkEventToJsonString(expectedEvent))
         .isInstanceOf[SparkListenerConnectOperationCanceled])
   }
 
@@ -151,8 +152,8 @@ class ExecuteEventsManagerSuite
       .post(expectedEvent)
 
     assert(
-      JsonProtocol
-        .sparkEventFromJson(JsonProtocol.sparkEventToJsonString(expectedEvent))
+      jsonProtocol
+        .sparkEventFromJson(jsonProtocol.sparkEventToJsonString(expectedEvent))
         .isInstanceOf[SparkListenerConnectOperationFailed])
   }
 
@@ -167,8 +168,8 @@ class ExecuteEventsManagerSuite
       .post(expectedEvent)
 
     assert(
-      JsonProtocol
-        .sparkEventFromJson(JsonProtocol.sparkEventToJsonString(expectedEvent))
+      jsonProtocol
+        .sparkEventFromJson(jsonProtocol.sparkEventToJsonString(expectedEvent))
         .isInstanceOf[SparkListenerConnectOperationFinished])
   }
 
@@ -208,8 +209,8 @@ class ExecuteEventsManagerSuite
       .post(expectedEvent)
 
     assert(
-      JsonProtocol
-        .sparkEventFromJson(JsonProtocol.sparkEventToJsonString(expectedEvent))
+      jsonProtocol
+        .sparkEventFromJson(jsonProtocol.sparkEventToJsonString(expectedEvent))
         .isInstanceOf[SparkListenerConnectOperationClosed])
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -25,6 +25,7 @@ import scala.util.Random
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.hadoop.mapreduce.{JobContext, TaskAttemptContext}
 
+import org.apache.spark.SparkConf
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{Final, Partial}
@@ -633,9 +634,10 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
     // After serializing to JSON, the original value type is lost, but we can still
     // identify that it's a SQL metric from the metadata
     val mapper = new ObjectMapper()
-    val metricInfoJson = JsonProtocol.toJsonString(
-      JsonProtocol.accumulableInfoToJson(metricInfo, _))
-    val metricInfoDeser = JsonProtocol.accumulableInfoFromJson(mapper.readTree(metricInfoJson))
+    val jsonProtocol = new JsonProtocol(new SparkConf())
+    val metricInfoJson = jsonProtocol.toJsonString(
+      jsonProtocol.accumulableInfoToJson(metricInfo, _))
+    val metricInfoDeser = jsonProtocol.accumulableInfoFromJson(mapper.readTree(metricInfoJson))
     metricInfoDeser.update match {
       case Some(v: String) => assert(v.toLong === 10L)
       case Some(v) => fail(s"deserialized metric value was not a string: ${v.getClass.getName}")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
@@ -610,7 +610,8 @@ abstract class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTes
 
   test("roundtripping SparkListenerDriverAccumUpdates through JsonProtocol (SPARK-18462)") {
     val event = SparkListenerDriverAccumUpdates(1L, Seq((2L, 3L)))
-    val json = JsonProtocol.sparkEventToJsonString(event)
+    val jsonProtocol = new JsonProtocol(new SparkConf())
+    val json = jsonProtocol.sparkEventToJsonString(event)
     assertValidDataInJson(parse(json),
       parse("""
         |{
@@ -619,7 +620,7 @@ abstract class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTes
         |  "accumUpdates": [[2,3]]
         |}
       """.stripMargin))
-    JsonProtocol.sparkEventFromJson(json) match {
+    jsonProtocol.sparkEventFromJson(json) match {
       case SparkListenerDriverAccumUpdates(executionId, accums) =>
         assert(executionId == 1L)
         accums.foreach { case (a, b) =>
@@ -637,7 +638,7 @@ abstract class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTes
         |  "accumUpdates": [[4294967294,3]]
         |}
       """.stripMargin
-    JsonProtocol.sparkEventFromJson(longJson) match {
+    jsonProtocol.sparkEventFromJson(longJson) match {
       case SparkListenerDriverAccumUpdates(executionId, accums) =>
         assert(executionId == 4294967294L)
         accums.foreach { case (a, b) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
@@ -26,6 +26,7 @@ import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.Waiters.Waiter
 
+import org.apache.spark.SparkConf
 import org.apache.spark.SparkException
 import org.apache.spark.scheduler._
 import org.apache.spark.sql.{Encoder, Row, SparkSession}
@@ -45,6 +46,7 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
 
   // To make === between double tolerate inexact values
   implicit val doubleEquality: Equality[Double] = TolerantNumerics.tolerantDoubleEquality(0.01)
+  private val jsonProtocol = new JsonProtocol(new SparkConf())
 
   after {
     spark.streams.active.foreach(_.stop())
@@ -257,8 +259,8 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
 
   test("QueryStartedEvent serialization") {
     def testSerialization(event: QueryStartedEvent): Unit = {
-      val json = JsonProtocol.sparkEventToJsonString(event)
-      val newEvent = JsonProtocol.sparkEventFromJson(json).asInstanceOf[QueryStartedEvent]
+      val json = jsonProtocol.sparkEventToJsonString(event)
+      val newEvent = jsonProtocol.sparkEventFromJson(json).asInstanceOf[QueryStartedEvent]
       assert(newEvent.id === event.id)
       assert(newEvent.runId === event.runId)
       assert(newEvent.name === event.name)
@@ -289,8 +291,8 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
   test("QueryProgressEvent serialization") {
     def testSerialization(event: QueryProgressEvent): Unit = {
       import scala.jdk.CollectionConverters._
-      val json = JsonProtocol.sparkEventToJsonString(event)
-      val newEvent = JsonProtocol.sparkEventFromJson(json).asInstanceOf[QueryProgressEvent]
+      val json = jsonProtocol.sparkEventToJsonString(event)
+      val newEvent = jsonProtocol.sparkEventFromJson(json).asInstanceOf[QueryProgressEvent]
       assert(newEvent.progress.json === event.progress.json)  // json as a proxy for equality
       assert(newEvent.progress.durationMs.asScala === event.progress.durationMs.asScala)
       assert(newEvent.progress.eventTime.asScala === event.progress.eventTime.asScala)
@@ -301,8 +303,8 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
 
   test("QueryTerminatedEvent serialization") {
     def testSerialization(event: QueryTerminatedEvent): Unit = {
-      val json = JsonProtocol.sparkEventToJsonString(event)
-      val newEvent = JsonProtocol.sparkEventFromJson(json).asInstanceOf[QueryTerminatedEvent]
+      val json = jsonProtocol.sparkEventToJsonString(event)
+      val newEvent = jsonProtocol.sparkEventFromJson(json).asInstanceOf[QueryTerminatedEvent]
       assert(newEvent.id === event.id)
       assert(newEvent.runId === event.runId)
       assert(newEvent.exception === event.exception)
@@ -589,7 +591,7 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
     val input = getClass.getResourceAsStream(s"/structured-streaming/$fileName")
     val events = mutable.ArrayBuffer[SparkListenerEvent]()
     try {
-      val replayer = new ReplayListenerBus() {
+      val replayer = new ReplayListenerBus(jsonProtocol) {
         // Redirect all parsed events to `events`
         override def doPostEvent(
             listener: SparkListenerInterface,


### PR DESCRIPTION
For bigger spark runs the json parsed by the history server can contain string sizes which are too big for the default jackson string limit introduced in jackson 2.15.
This patch just disables this filter, to make sure JsonProtocol stays backwards compatible with previous versions.


### What changes were proposed in this pull request?
Remove the Jackson limit on stringlength introduced in Jackson 2.15, preventing us to read the history of complex/bigger jobs in spark 3.5.3.


### Why are the changes needed?

History server crash see SPARK-49872 for stacktrace.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Validated locally.


### Was this patch authored or co-authored using generative AI tooling?
No
