### PR TITLE
[SPARK-50563][BUILD] Upgrade `protobuf-java` to 4.29.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.4.1</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->
-    <protobuf.version>4.28.3</protobuf.version>
+    <protobuf.version>4.29.1</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <zookeeper.version>3.9.3</zookeeper.version>
     <curator.version>5.7.1</curator.version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -89,7 +89,7 @@ object BuildCommons {
 
   // Google Protobuf version used for generating the protobuf.
   // SPARK-41247: needs to be consistent with `protobuf.version` in `pom.xml`.
-  val protoVersion = "4.28.3"
+  val protoVersion = "4.29.1"
   // GRPC version used for Spark Connect.
   val grpcVersion = "1.67.1"
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr  aims to upgrade `protobuf-java` from 4.28.3 to 4.29.1

### Why are the changes needed?
The new version bring some bug fix like:
- CodedOutputStream: avoid updating position to go beyond end of array. (https://github.com/protocolbuffers/protobuf/commit/76ab5f2b109fbd03c160b27a41935ad132287c88)
- Fix packed reflection handling bug in edition 2023. (https://github.com/protocolbuffers/protobuf/commit/4c923285a32ebcb53ce2ba03144e50d4dbedaf7b)
- Bugfix: Make extensions beyond n=16 immutable. (https://github.com/protocolbuffers/protobuf/commit/ee419f22e0eec21243540d4b7ffe40bd194ed293)

Full release notes as follows:
- https://github.com/protocolbuffers/protobuf/releases/tag/v29.0-rc1
- https://github.com/protocolbuffers/protobuf/releases/tag/v29.0-rc2
- https://github.com/protocolbuffers/protobuf/releases/tag/v29.0-rc3
- https://github.com/protocolbuffers/protobuf/releases/tag/v29.0
- https://github.com/protocolbuffers/protobuf/releases/tag/v29.1

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No