### PR TITLE
[SPARK-50574][DOCS] Upgrade `rexml` to 3.3.9

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -27,3 +27,4 @@ gem "jekyll-redirect-from", "~> 0.16"
 # This resolves a build issue on Apple Silicon.
 # See: https://issues.apache.org/jira/browse/SPARK-38488
 gem "ffi", "~> 1.15"
+gem "rexml", "~> 3.3.9"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.6)
+    rexml (3.3.9)
     rouge (4.5.1)
     safe_yaml (1.0.5)
     sass-embedded (1.63.6)
@@ -71,6 +71,7 @@ DEPENDENCIES
   ffi (~> 1.15)
   jekyll (~> 4.3)
   jekyll-redirect-from (~> 0.16)
+  rexml (~> 3.3.9)
 
 BUNDLED WITH
    2.4.22


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `rexml` to 3.3.9.

### Why are the changes needed?

To use the latest bug fixed version in Apache Spark documentation generation.

As a side note, this will resolve the following doc-generation Dependabot alerts.
- https://github.com/apache/spark/security/dependabot/92 (Fixed in 3.2.7+)
- https://github.com/apache/spark/security/dependabot/96 (Fixed in 3.3.2+)
- https://github.com/apache/spark/security/dependabot/97 (Fixed in 3.3.3+)
- https://github.com/apache/spark/security/dependabot/98 (Fixed in 3.3.3+)
- https://github.com/apache/spark/security/dependabot/100 (Fixed in 3.3.6+)
- https://github.com/apache/spark/security/dependabot/107 (Fixed in 3.3.9+)

### Does this PR introduce _any_ user-facing change?

No, there is no behavior change. This is a doc-generation-related change.

### How was this patch tested?

```
$ cd docs
$ SKIP_API=1 bundle exec jekyll build
```

### Was this patch authored or co-authored using generative AI tooling?

No.