### PR TITLE
[SPARK-50575][SS] Modifying OperatorStateMetadataV2 to enable schema evolution

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
@@ -270,7 +270,7 @@ class StateMetadataPartitionReader(
               operatorStateMetadata.version,
               v2.operatorPropertiesJson,
               -1, // numColsPrefixKey is not available in OperatorStateMetadataV2
-              Some(stateStoreMetadata.stateSchemaFilePath)
+              Some(stateStoreMetadata.stateSchemaFilePaths(stateStoreMetadata.stateSchemaId))
             )
           }
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -228,7 +228,8 @@ case class StreamingSymmetricHashJoinExec(
     SymmetricHashJoinStateManager.allStateStoreNames(LeftSide, RightSide)
 
   override def operatorStateMetadata(
-      stateSchemaPaths: List[String] = List.empty): OperatorStateMetadata = {
+      stateSchemaPaths: List[Map[Int, String]] = List.empty
+  ): OperatorStateMetadata = {
     val info = getStateInfo
     val operatorInfo = OperatorInfoV1(info.operatorId, shortName)
     val stateStoreInfo =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -228,7 +228,7 @@ case class StreamingSymmetricHashJoinExec(
     SymmetricHashJoinStateManager.allStateStoreNames(LeftSide, RightSide)
 
   override def operatorStateMetadata(
-      stateSchemaPaths: List[Map[Int, String]] = List.empty
+      stateSchemaPaths: List[Map[Short, String]] = List.empty
   ): OperatorStateMetadata = {
     val info = getStateInfo
     val operatorInfo = OperatorInfoV1(info.operatorId, shortName)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -496,7 +496,7 @@ case class TransformWithStateExec(
 
   /** Metadata of this stateful operator and its states stores. */
   override def operatorStateMetadata(
-      stateSchemaPaths: List[Map[Int, String]]): OperatorStateMetadata = {
+      stateSchemaPaths: List[Map[Short, String]]): OperatorStateMetadata = {
     val info = getStateInfo
     val operatorInfo = OperatorInfoV1(info.operatorId, shortName)
     // stateSchemaFilePath should be populated at this point

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
@@ -301,7 +301,6 @@ class OperatorStateMetadataV2Writer(
     if (fm.exists(metadataFilePath)) return
 
     fm.mkdirs(metadataFilePath.getParent)
-    logError(s"### metadataFilePath: $metadataFilePath")
     val outputStream = fm.createAtomic(metadataFilePath, overwriteIfPossible = false)
     OperatorStateMetadataUtils.writeMetadata(outputStream, operatorMetadata, metadataFilePath)
   }
@@ -348,7 +347,6 @@ class OperatorStateMetadataV2Reader(
 
   override def read(): Option[OperatorStateMetadata] = {
     val batches = listOperatorMetadataBatches()
-    logError(s"### batches: ${batches.mkString("Array(", ", ", ")")}")
     val lastBatchId = batches.filter(_ <= batchId).lastOption
     if (lastBatchId.isEmpty) {
       throw StateDataSourceErrors.failedToReadOperatorMetadata(stateCheckpointPath.toString,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
@@ -288,7 +288,7 @@ class OperatorStateMetadataV1Reader(
 class OperatorStateMetadataV2Writer(
     stateCheckpointPath: Path,
     hadoopConf: Configuration,
-    currentBatchId: Long) extends OperatorStateMetadataWriter {
+    currentBatchId: Long) extends OperatorStateMetadataWriter with Logging {
 
   private val metadataFilePath = OperatorStateMetadataV2.metadataFilePath(
     stateCheckpointPath, currentBatchId)
@@ -301,6 +301,7 @@ class OperatorStateMetadataV2Writer(
     if (fm.exists(metadataFilePath)) return
 
     fm.mkdirs(metadataFilePath.getParent)
+    logError(s"### metadataFilePath: $metadataFilePath")
     val outputStream = fm.createAtomic(metadataFilePath, overwriteIfPossible = false)
     OperatorStateMetadataUtils.writeMetadata(outputStream, operatorMetadata, metadataFilePath)
   }
@@ -309,7 +310,7 @@ class OperatorStateMetadataV2Writer(
 class OperatorStateMetadataV2Reader(
     stateCheckpointPath: Path,
     hadoopConf: Configuration,
-    batchId: Long) extends OperatorStateMetadataReader {
+    batchId: Long) extends OperatorStateMetadataReader with Logging {
 
   // Check that the requested batchId is available in the checkpoint directory
   val baseCheckpointDir = stateCheckpointPath.getParent.getParent
@@ -347,6 +348,7 @@ class OperatorStateMetadataV2Reader(
 
   override def read(): Option[OperatorStateMetadata] = {
     val batches = listOperatorMetadataBatches()
+    logError(s"### batches: ${batches.mkString("Array(", ", ", ")")}")
     val lastBatchId = batches.filter(_ <= batchId).lastOption
     if (lastBatchId.isEmpty) {
       throw StateDataSourceErrors.failedToReadOperatorMetadata(stateCheckpointPath.toString,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
@@ -51,7 +51,8 @@ case class StateStoreMetadataV2(
     storeName: String,
     numColsPrefixKey: Int,
     numPartitions: Int,
-    stateSchemaFilePath: String)
+    stateSchemaId: Int,
+    stateSchemaFilePaths: Map[Int, String])
   extends StateStoreMetadata with Serializable
 
 object StateStoreMetadataV2 {
@@ -468,7 +469,8 @@ class OperatorStateMetadataV2FileManager(
     // find the batchId of the earliest schema file we need to keep
     val earliestBatchToKeep = latestMetadata match {
       case Some(OperatorStateMetadataV2(_, stateStoreInfo, _)) =>
-        val schemaFilePath = stateStoreInfo.head.stateSchemaFilePath
+        val ssInfo = stateStoreInfo.head
+        val schemaFilePath = ssInfo.stateSchemaFilePaths.minBy(_._1)._2
         new Path(schemaFilePath).getName.split("_").head.toLong
       case _ => 0
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
@@ -51,8 +51,8 @@ case class StateStoreMetadataV2(
     storeName: String,
     numColsPrefixKey: Int,
     numPartitions: Int,
-    stateSchemaId: Int,
-    stateSchemaFilePaths: Map[Int, String])
+    stateSchemaId: Short,
+    stateSchemaFilePaths: Map[Short, String])
   extends StateStoreMetadata with Serializable
 
 object StateStoreMetadataV2 {
@@ -288,7 +288,7 @@ class OperatorStateMetadataV1Reader(
 class OperatorStateMetadataV2Writer(
     stateCheckpointPath: Path,
     hadoopConf: Configuration,
-    currentBatchId: Long) extends OperatorStateMetadataWriter with Logging {
+    currentBatchId: Long) extends OperatorStateMetadataWriter {
 
   private val metadataFilePath = OperatorStateMetadataV2.metadataFilePath(
     stateCheckpointPath, currentBatchId)
@@ -309,7 +309,7 @@ class OperatorStateMetadataV2Writer(
 class OperatorStateMetadataV2Reader(
     stateCheckpointPath: Path,
     hadoopConf: Configuration,
-    batchId: Long) extends OperatorStateMetadataReader with Logging {
+    batchId: Long) extends OperatorStateMetadataReader {
 
   // Check that the requested batchId is available in the checkpoint directory
   val baseCheckpointDir = stateCheckpointPath.getParent.getParent

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -319,7 +319,7 @@ trait StateStoreWriter
 
   /** Metadata of this stateful operator and its states stores. */
   def operatorStateMetadata(
-      stateSchemaPaths: List[Map[Int, String]] = List.empty): OperatorStateMetadata = {
+      stateSchemaPaths: List[Map[Short, String]] = List.empty): OperatorStateMetadata = {
     val info = getStateInfo
     val operatorInfo = OperatorInfoV1(info.operatorId, shortName)
     val stateStoreInfo =
@@ -329,11 +329,11 @@ trait StateStoreWriter
 
   def stateSchemaMapping(
       stateSchemaValidationResults: List[StateSchemaValidationResult],
-      oldMetadata: Option[OperatorStateMetadata]): List[Map[Int, String]] = {
+      oldMetadata: Option[OperatorStateMetadata]): List[Map[Short, String]] = {
     val validationResult = stateSchemaValidationResults.head
     val evolvedSchema = validationResult.evolvedSchema
     if (evolvedSchema) {
-      val (oldSchemaId, oldSchemaPaths): (Int, Map[Int, String]) = oldMetadata match {
+      val (oldSchemaId, oldSchemaPaths): (Short, Map[Short, String]) = oldMetadata match {
         case Some(v2: OperatorStateMetadataV2) =>
           val ssInfo = v2.stateStoreInfo.head
           (ssInfo.stateSchemaId, ssInfo.stateSchemaFilePaths)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -1097,7 +1097,7 @@ case class SessionWindowStateStoreSaveExec(
   }
 
   override def operatorStateMetadata(
-      stateSchemaPaths: List[Map[Int, String]] = List.empty): OperatorStateMetadata = {
+      stateSchemaPaths: List[Map[Short, String]] = List.empty): OperatorStateMetadata = {
     val info = getStateInfo
     val operatorInfo = OperatorInfoV1(info.operatorId, shortName)
     val stateStoreInfo = Array(StateStoreMetadataV1(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -319,12 +319,38 @@ trait StateStoreWriter
 
   /** Metadata of this stateful operator and its states stores. */
   def operatorStateMetadata(
-      stateSchemaPaths: List[String] = List.empty): OperatorStateMetadata = {
+      stateSchemaPaths: List[Map[Int, String]] = List.empty): OperatorStateMetadata = {
     val info = getStateInfo
     val operatorInfo = OperatorInfoV1(info.operatorId, shortName)
     val stateStoreInfo =
       Array(StateStoreMetadataV1(StateStoreId.DEFAULT_STORE_NAME, 0, info.numPartitions))
     OperatorStateMetadataV1(operatorInfo, stateStoreInfo)
+  }
+
+  def stateSchemaMapping(
+      stateSchemaValidationResults: List[StateSchemaValidationResult],
+      oldMetadata: Option[OperatorStateMetadata]): List[Map[Int, String]] = {
+    val validationResult = stateSchemaValidationResults.head
+    val evolvedSchema = validationResult.evolvedSchema
+    if (evolvedSchema) {
+      val (oldSchemaId, oldSchemaPaths): (Int, Map[Int, String]) = oldMetadata match {
+        case Some(v2: OperatorStateMetadataV2) =>
+          val ssInfo = v2.stateStoreInfo.head
+          (ssInfo.stateSchemaId, ssInfo.stateSchemaFilePaths)
+        case _ => (-1, Map.empty)
+      }
+      List(oldSchemaPaths + (oldSchemaId + 1 -> validationResult.schemaPath))
+    } else {
+      oldMetadata match {
+        case Some(v2: OperatorStateMetadataV2) =>
+          // If schema hasn't evolved, keep existing mappings
+          val ssInfo = v2.stateStoreInfo.head
+          List(ssInfo.stateSchemaFilePaths)
+        case _ =>
+          // If no previous metadata and no evolution, start with schema ID 0
+          List(Map(0 -> validationResult.schemaPath))
+      }
+    }
   }
 
   /** Set the operator level metrics */
@@ -1071,7 +1097,7 @@ case class SessionWindowStateStoreSaveExec(
   }
 
   override def operatorStateMetadata(
-      stateSchemaPaths: List[String] = List.empty): OperatorStateMetadata = {
+      stateSchemaPaths: List[Map[Int, String]] = List.empty): OperatorStateMetadata = {
     val info = getStateInfo
     val operatorInfo = OperatorInfoV1(info.operatorId, shortName)
     val stateStoreInfo = Array(StateStoreMetadataV1(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadataSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadataSuite.scala
@@ -62,7 +62,7 @@ class OperatorStateMetadataSuite extends StreamTest with SharedSparkSession {
       assert(operatorMetadataV2.operatorPropertiesJson.nonEmpty)
       val stateStoreInfo = operatorMetadataV2.stateStoreInfo.head
       val expectedStateStoreInfo = expectedMetadataV2.stateStoreInfo.head
-      assert(stateStoreInfo.stateSchemaFilePath.nonEmpty)
+      assert(stateStoreInfo.stateSchemaFilePaths.nonEmpty)
       assert(stateStoreInfo.storeName == expectedStateStoreInfo.storeName)
       assert(stateStoreInfo.numPartitions == expectedStateStoreInfo.numPartitions)
     }
@@ -151,8 +151,8 @@ class OperatorStateMetadataSuite extends StreamTest with SharedSparkSession {
       // Assign some placeholder values to the state store metadata since they are generated
       // dynamically by the operator.
       val expectedMetadata = OperatorStateMetadataV2(OperatorInfoV1(0, "transformWithStateExec"),
-        Array(StateStoreMetadataV2("default", 0, numShufflePartitions, checkpointDir.toString)),
-        "")
+        Array(StateStoreMetadataV2(
+          "default", 0, numShufflePartitions, 0, Map(0 -> checkpointDir.toString))), "")
       checkOperatorStateMetadata(checkpointDir.toString, 0, expectedMetadata, 2)
 
       // Verify that the state store metadata is not available for invalid batches.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Modifying OperatorStateMetadataV2 to keep track of currentSchemaId and all active schemas in the StateStore to enable schema evolution, via a mapping of schemaId to schema.
Works with this change: https://github.com/apache/spark/pull/49171

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Because we are enabling schema evolution via an 'internal schema registry' instead of full rewrite, we need some way to keep track of all active schemas currently in the StateStore. This change enables us to do this

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Amended unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No