### PR TITLE
[SPARK-50576][BUILD] Upgrade `commons-text` to `1.13.0`

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -49,7 +49,7 @@ commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-math3/3.6.1//commons-math3-3.6.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
-commons-text/1.12.0//commons-text-1.12.0.jar
+commons-text/1.13.0//commons-text-1.13.0.jar
 compress-lzf/1.1.2//compress-lzf-1.1.2.jar
 curator-client/5.7.1//curator-client-5.7.1.jar
 curator-framework/5.7.1//curator-framework-5.7.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -631,7 +631,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.12.0</version>
+        <version>1.13.0</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade `common-text` from `1.12.0` to `1.13.0`.

### Why are the changes needed?
The full release notes as follows:
- https://github.com/apache/commons-text/blob/rel/commons-text-1.13.0/RELEASE-NOTES.txt

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
