### PR TITLE
[MINOR][SS] Minor update to watermark propagation comments

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/WatermarkPropagator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/WatermarkPropagator.scala
@@ -124,12 +124,14 @@ class UseSingleWatermarkPropagator extends WatermarkPropagator {
 /**
  * This implementation simulates propagation of watermark among operators.
  *
- * The simulation algorithm traverses the physical plan tree via post-order (children first) to
- * calculate (input watermark, output watermark) for all nodes.
+ * It is considered a "simulation" because watermarks are not being physically sent between
+ * operators, but rather propagated up the tree via post-order (children first) traversal of
+ * the query plan. This allows Structured Streaming to determine the new (input watermark, output
+ * watermark) for all nodes.
  *
  * For each node, below logic is applied:
  *
- * - Input watermark for specific node is decided by `min(input watermarks from all children)`.
+ * - Input watermark for specific node is decided by `min(output watermarks from all children)`.
  *   -- Children providing no input watermark (DEFAULT_WATERMARK_MS) are excluded.
  *   -- If there is no valid input watermark from children, input watermark = DEFAULT_WATERMARK_MS.
  * - Output watermark for specific node is decided as following:


### PR DESCRIPTION
### What changes were proposed in this pull request?

A few minor changes to clarify (and fix one typo) in the comments for watermark propagation in Structured Streaming.

### Why are the changes needed?

I found some of the terminology around "simulation" confusing, and the current comment describes incorrect logic for output watermark calculation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A.


### Was this patch authored or co-authored using generative AI tooling?

No