### PR TITLE
[MINOR][DOCS] Modify a link in running-on-yarn.md

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -853,7 +853,7 @@ will include a list of all tokens obtained, and their expiry details
 To start the Spark Shuffle Service on each `NodeManager` in your YARN cluster, follow these
 instructions:
 
-1. Build Spark with the [YARN profile](building-spark.html). Skip this step if you are using a
+1. Build Spark with the [YARN profile](building-spark.html#specifying-the-hadoop-version-and-enabling-yarn). Skip this step if you are using a
 pre-packaged distribution.
 1. Locate the `spark-<version>-yarn-shuffle.jar`. This should be under
 `$SPARK_HOME/common/network-yarn/target/scala-<version>` if you are building Spark yourself, and under


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes a minor issue that a link in `running-on-yarn.md`.
The linked page should be about building with YARN profile. 

### Why are the changes needed?
To make the doc better.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Built the doc and generated html files, then confirmed the modified link worked.

### Was this patch authored or co-authored using generative AI tooling?
No.