### PR TITLE
[SPARK-50587][INFRA][3.5] Remove unsupported `curl` option `--retry-all-errors` from `release-build.sh`

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -505,7 +505,7 @@ if [[ "$1" == "publish-release" ]]; then
       file_short=$(echo $file | sed -e "s/\.\///")
       dest_url="$nexus_upload/org/apache/spark/$file_short"
       echo "  Uploading $file_short"
-      curl --retry 3 --retry-all-errors -u $ASF_USERNAME:$ASF_PASSWORD --upload-file $file_short $dest_url
+      curl --retry 3 -u $ASF_USERNAME:$ASF_PASSWORD --upload-file $file_short $dest_url
     done
 
     echo "Closing nexus staging repository"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to remove unsupported `curl` option `--retry-all-errors` from branch-3.5's `release-build.sh`  

### Why are the changes needed?
branch-3.5 uses Ubuntu 20.04 for release, and the `curl` installed via `apt-get install` on Ubuntu 20.04 does not yet support `--retry-all-errors`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual tested


### Was this patch authored or co-authored using generative AI tooling?
No