### PR TITLE
[SPARK-50592][INFRA] Make 3.5 daily build able to manually trigger

### DIFF
--- a/.github/workflows/build_branch35.yml
+++ b/.github/workflows/build_branch35.yml
@@ -22,6 +22,7 @@ name: "Build (branch-3.5, Scala 2.13, Hadoop 3, JDK 8)"
 on:
   schedule:
     - cron: '0 11 * * *'
+  workflow_dispatch:
 
 jobs:
   run-build:

--- a/.github/workflows/build_branch35_python.yml
+++ b/.github/workflows/build_branch35_python.yml
@@ -22,6 +22,7 @@ name: "Build / Python-only (branch-3.5)"
 on:
   schedule:
     - cron: '0 11 * * *'
+  workflow_dispatch:
 
 jobs:
   run-build:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make 3.5 daily build able to manually trigger

https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow

```
workflow_dispatch:
```

should be a valid syntax, see [example](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-of-jobsjob_idsecretsinherit)


### Why are the changes needed?
for ease of debugging


### Does this PR introduce _any_ user-facing change?
no, infra-only


### How was this patch tested?
will manually check


### Was this patch authored or co-authored using generative AI tooling?
no