### PR TITLE
[SPARK-50602][SQL] Fix transpose to show a proper error message when invalid index columns are specified

### DIFF
--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -1044,6 +1044,18 @@ class DataFrameTestsMixin:
             messageParameters={"dt1": '"STRING"', "dt2": '"BIGINT"'},
         )
 
+    def test_transpose_with_invalid_index_columns(self):
+        # SPARK-50602: invalid index columns
+        df = self.spark.createDataFrame([{"a": "x", "b": "y", "c": "z"}])
+
+        with self.assertRaises(AnalysisException) as pe:
+            df.transpose(col("a") + 1).collect()
+        self.check_error(
+            exception=pe.exception,
+            errorClass="TRANSPOSE_INVALID_INDEX_COLUMN",
+            messageParameters={"reason": "Index column must be an atomic attribute"},
+        )
+
 
 class DataFrameTests(DataFrameTestsMixin, ReusedSQLTestCase):
     def test_query_execution_unsupported_in_classic(self):

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1013,7 +1013,7 @@ class Dataset[T] private[sql](
   /** @inheritdoc */
   def transpose(indexColumn: Column): DataFrame = withPlan {
     UnresolvedTranspose(
-      Seq(indexColumn.named),
+      Seq(indexColumn.expr),
       logicalPlan
     )
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `transpose` to show a proper error message when invalid index columns are specified.

### Why are the changes needed?

When invalid index columns are specified, it shows `INTERNAL_ERROR`.

```py
>>> df = spark.range(10).transpose(sf.col("id") + 1)
Traceback (most recent call last):
...
py4j.protocol.Py4JJavaError: An error occurred while calling o40.transpose.
: org.apache.spark.SparkException: [INTERNAL_ERROR] Found the unresolved operator: 'UnresolvedTranspose [unresolvedalias((id#0L + cast(1 as bigint)))] SQLSTATE: XX000
...
```

### Does this PR introduce _any_ user-facing change?

Yes, the proper error message will be shown.

```py
>>> df = spark.range(10).transpose(sf.col("id") + 1)
Traceback (most recent call last):
...
pyspark.errors.exceptions.captured.AnalysisException: [TRANSPOSE_INVALID_INDEX_COLUMN] Invalid index column for TRANSPOSE because: Index column must be an atomic attribute SQLSTATE: 42804
```

### How was this patch tested?

Added the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.