### PR TITLE
[SPARK-50606][CONNECT] Fix NPE on uninitiated SessionHolder

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
@@ -87,8 +87,8 @@ class SparkConnectAddArtifactsHandler(val responseObserver: StreamObserver[AddAr
     ErrorUtils.handleError(
       "addArtifacts.onNext",
       responseObserver,
-      holder.userId,
-      holder.sessionId,
+      req.getUserContext.getUserId,
+      req.getSessionId,
       None,
       false,
       Some(() => {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes NPE like,

```scala
{"ts":"2024-12-18T05:41:52.977Z","level":"ERROR","msg":"Exception while executing runnable org.sparkproject.connect.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1MessagesAvailable@418f1536","exception":{"class":"java.lang.NullPointerException","msg":"Cannot invoke \"org.apache.spark.sql.connect.service.SessionHolder.userId()\" because the return value of \"org.apache.spark.sql.connect.service.SparkConnectAddArtifactsHandler.holder()\" is null","stacktrace":[{"class":"org.apache.spark.sql.connect.service.SparkConnectAddArtifactsHandler","method":"onNext","file":"SparkConnectAddArtifactsHandler.scala","line":90},{"class":"org.apache.spark.sql.connect.service.SparkConnectAddArtifactsHandler","method":"onNext","file":"SparkConnectAddArtifactsHandler.scala","line":42},{"class":"org.sparkproject.connect.grpc.stub.ServerCalls$StreamingServerCallHandler$StreamingServerCallListener","method":"onMessage","file":"ServerCalls.java","line":262},{"class":"org.sparkproject.connect.grpc.internal.ServerCallImpl$ServerStreamListenerImpl","method":"messagesAvailableInternal","file":"ServerCallImpl.java","line":334},{"class":"org.sparkproject.connect.grpc.internal.ServerCallImpl$ServerStreamListenerImpl","method":"messagesAvailable","file":"ServerCallImpl.java","line":319},{"class":"org.sparkproject.connect.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1MessagesAvailable","method":"runInContext","file":"ServerImpl.java","line":834},{"class":"org.sparkproject.connect.grpc.internal.ContextRunnable","method":"run","file":"ContextRunnable.java","line":37},{"class":"org.sparkproject.connect.grpc.internal.SerializingExecutor","method":"run","file":"SerializingExecutor.java","line":133},{"class":"java.util.concurrent.ThreadPoolExecutor","method":"runWorker","file":"ThreadPoolExecutor.java","line":1136},{"class":"java.util.concurrent.ThreadPoolExecutor$Worker","method":"run","file":"ThreadPoolExecutor.java","line":635},{"class":"java.lang.Thread","method":"run","file":"Thread.java","line":840}]},"logger":"SerializingExecutor"}
``` 

When I simply run case like,

```
scala> spark.sql("SHOW TABLES").schema
org.apache.spark.SparkException: org.sparkproject.io.grpc.StatusRuntimeException: UNKNOWN: Application error processing RPC
  org.apache.spark.sql.connect.client.ArtifactManager.addArtifacts(ArtifactManager.scala:242)
  org.apache.spark.sql.connect.client.ArtifactManager.uploadAllClassFileArtifacts(ArtifactManager.scala:205)
  org.apache.spark.sql.connect.client.SparkConnectClient.execute(SparkConnectClient.scala:121)
  org.apache.spark.sql.SparkSession.$anonfun$sql$3(SparkSession.scala:247)
  org.apache.spark.sql.SparkSession.$anonfun$sql$3$adapted(SparkSession.scala:243)
  org.apache.spark.sql.SparkSession.newDataset(SparkSession.scala:337)
  org.apache.spark.sql.SparkSession.newDataFrame(SparkSession.scala:329)
  org.apache.spark.sql.SparkSession.sql(SparkSession.scala:243)
  org.apache.spark.sql.SparkSession.sql(SparkSession.scala:220)
  org.apache.spark.sql.SparkSession.sql(SparkSession.scala:240)
  ammonite.$sess.cmd6$Helper.<init>(cmd6.sc:1)
  ammonite.$sess.cmd6$.<clinit>(cmd6.sc:7)
```

I believe it suppressed the actual cause 

### Why are the changes needed?
bugfix


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

existing tests, (I do not know how to trigger this NPE in UT)
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->no
