### PR TITLE
[SPARK-50608][SQL][DOCS] Fix malformed configuration page caused by unclosed tags

### DIFF
--- a/sql/gen-sql-config-docs.py
+++ b/sql/gen-sql-config-docs.py
@@ -106,7 +106,8 @@ def generate_sql_configs_table_html(sql_configs, path):
             if config.name == "spark.sql.files.ignoreInvalidPartitionPaths":
                 description = config.description.replace("<", "&lt;").replace(">", "&gt;")
             elif config.name == "spark.sql.hive.quoteHiveStructFieldName":
-                description = config.description.replace("<", "&lt;").replace(">", "&gt;").replace("`", "&#96;")
+                description = config.description.replace(
+                    "<", "&lt;").replace(">", "&gt;").replace("`", "&#96;")
             else:
                 description = config.description
 

--- a/sql/gen-sql-config-docs.py
+++ b/sql/gen-sql-config-docs.py
@@ -103,6 +103,13 @@ def generate_sql_configs_table_html(sql_configs, path):
                     )
                 )
 
+            if config.name == "spark.sql.files.ignoreInvalidPartitionPaths":
+                description = config.description.replace("<", "&lt;").replace(">", "&gt;")
+            elif config.name == "spark.sql.hive.quoteHiveStructFieldName":
+                description = config.description.replace("<", "&lt;").replace(">", "&gt;").replace("`", "&#96;")
+            else:
+                description = config.description
+
             f.write(dedent(
                 """
                 <tr>
@@ -115,7 +122,7 @@ def generate_sql_configs_table_html(sql_configs, path):
                 .format(
                     name=config.name,
                     default=default,
-                    description=markdown.markdown(config.description),
+                    description=markdown.markdown(description),
                     version=config.version
                 )
             ))


### PR DESCRIPTION


### What changes were proposed in this pull request?

Fix the malformed configuration page caused by unclosed tags

### Why are the changes needed?
docfix

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

#### Before

![image](https://github.com/user-attachments/assets/d5fe7630-a26f-48cb-8bc3-9a93155eeef1)


#### After

![image](https://github.com/user-attachments/assets/57bcbfdf-b5b5-43ba-ab60-89dc062f6016)

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no