### PR TITLE
[SPARK-50607][SQL] Passdown fileLength when reading parquet footer to avoid call HDFS namenode in executor side

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetFooterReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetFooterReader.java
@@ -63,7 +63,22 @@ public class ParquetFooterReader {
           .build()
           .getMetadataFilter();
     }
-    return readFooter(configuration, file.toPath(), filter);
+    if (file.fileSize() > 0) {
+      // If we have already known the file size, we don't need to get fileStatus
+      // from HDFS name node again.
+      // Note that the blockReplication and blockSize in FileStatus is useless here,
+      // since we only need to known the file length when reading parquet footer.
+      FileStatus fileStatus = new FileStatus(
+        file.fileSize(),
+        false,
+        1,
+        0,
+        file.modificationTime(),
+        file.toPath());
+      return readFooter(configuration, fileStatus, filter);
+    } else {
+      return readFooter(configuration, file.toPath(), filter);
+    }
   }
 
   public static ParquetMetadata readFooter(Configuration configuration,


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
When reading parquet footers, we need to know the file length, by requesting hdfs namenode in executor side for each task. 

```
// ParquetFooterReader.java
public static ParquetMetadata readFooter(Configuration configuration,
    Path file, ParquetMetadataConverter.MetadataFilter filter) throws IOException {
    return readFooter(HadoopInputFile.fromPath(file, configuration), filter);
}

-----------------------------

public static HadoopInputFile fromPath(Path path, Configuration conf) throws IOException {
  FileSystem fs = path.getFileSystem(conf);
  return new HadoopInputFile(fs, fs.getFileStatus(path), conf);
}
```

But in fact, the file length is already known in driver side from `PartitionedFile`.  By pass down this, we can avoid lots of namenode requests


### Why are the changes needed?
Reduce hdfs namenode requests, optimize the latency


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually


### Was this patch authored or co-authored using generative AI tooling?
No
