### PR TITLE
[SPARK-50600][SQL] Set analyzed on analysis failure

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -21,6 +21,7 @@ import java.io.{BufferedWriter, OutputStreamWriter}
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 
+import scala.util.Try
 import scala.util.control.NonFatal
 
 import org.apache.hadoop.fs.Path
@@ -92,13 +93,16 @@ class QueryExecution(
   }
 
   private val lazyAnalyzed = LazyTry {
-    val plan = executePhase(QueryPlanningTracker.ANALYSIS) {
-      // We can't clone `logical` here, which will reset the `_analyzed` flag.
-      sparkSession.sessionState.analyzer.executeAndCheck(logical, tracker)
+    val plan = Try {
+      executePhase(QueryPlanningTracker.ANALYSIS) {
+        // We can't clone `logical` here, which will reset the `_analyzed` flag.
+        sparkSession.sessionState.analyzer.executeAndCheck(logical, tracker)
+      }
     }
-    tracker.setAnalyzed(plan)
-    plan
+    plan.toOption.orElse(logical).foreach(tracker.setAnalyzed)
+    plan.get
   }
+
 
   def analyzed: LogicalPlan = lazyAnalyzed.get
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
As part of [SPARK-44145](https://issues.apache.org/jira/browse/SPARK-44145), a callback was added to track completion of analysis and optimization phase of a query. While the analyzed plan is sent when analysis completes successfully it does not when it fail. In that case, we should fallback to the ParsedPlan.

### Why are the changes needed?
The purpose of the analyze event is to track when analysis completes, as such it should also be sent on both success & failure. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit


### Was this patch authored or co-authored using generative AI tooling?
No
