### PR TITLE
[SPARK-50620] Fix dead lock caused by SQLConf$ and SqlApiConf initialization

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
@@ -65,7 +65,11 @@ private[sql] object SqlApiConf {
   def get: SqlApiConf = SqlApiConfHelper.getConfGetter.get()()
 
   // Force load SQLConf. This will trigger the installation of a confGetter that points to SQLConf.
-  Try(SparkClassUtils.classForName("org.apache.spark.sql.internal.SQLConf$"))
+  Try {
+    SqlApiConfHelper.setConfGetter(() =>
+      SparkClassUtils.classForName("org.apache.spark.sql.internal.SQLConf$")
+        .getMethod("get").invoke(null).asInstanceOf[SqlApiConf])
+  }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -182,10 +182,6 @@ object SQLConf {
     confGetter.set(getter)
   }
 
-  // Make sure SqlApiConf is always in sync with SQLConf. SqlApiConf will always try to
-  // load SqlConf to make sure both classes are in sync from the get go.
-  SqlApiConfHelper.setConfGetter(() => SQLConf.get)
-
   /**
    * Returns the active config object within the current scope. If there is an active SparkSession,
    * the proper SQLConf associated with the thread's active session is used. If it's called from


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Thanks @wForget 's suggestion.

This PR call the `SqlApiConfHelper.setConfGetter` in `org.apache.spark.sql.internal.SqlApiConf$` to eliminate deadlock.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

```
"Executor 92 task launch worker for task 2910, task 69.0 in stage 7.0 (TID 2910)" #152 daemon prio=5 os_prio=0 cpu=616.25ms elapsed=258408.34s tid=0x00007f77d67cc330 nid=0x22c9e in Object.wait()  [0x00007f77755fb000]
   java.lang.Thread.State: RUNNABLE
	at org.apache.spark.sql.internal.SQLConf$.<init>(SQLConf.scala:184)
	- waiting on the Class initialization monitor for org.apache.spark.sql.internal.SqlApiConf$
	at org.apache.spark.sql.internal.SQLConf$.<clinit>(SQLConf.scala) 
```






```
"Executor 92 task launch worker for task 5362, task 521.0 in stage 10.0 (TID 5362)" #123 daemon prio=5 os_prio=0 cpu=2443.78ms elapsed=258409.29s tid=0x00007f77d60ecad0 nid=0x22c7c in Object.wait()  [0x00007f777e591000]
   java.lang.Thread.State: RUNNABLE
	at java.lang.Class.forName0(java.base@17.0.6/Native Method)
	- waiting on the Class initialization monitor for org.apache.spark.sql.internal.SQLConf$
	at java.lang.Class.forName(java.base@17.0.6/Class.java:467)
	at org.apache.spark.util.SparkClassUtils.classForName(SparkClassUtils.scala:41)
	at org.apache.spark.util.SparkClassUtils.classForName$(SparkClassUtils.scala:36)
	at org.apache.spark.util.SparkClassUtils$.classForName(SparkClassUtils.scala:83)
	at org.apache.spark.sql.internal.SqlApiConf$.$anonfun$new$1(SqlApiConf.scala:73) 
```


For the first one: `at org.apache.spark.sql.internal.SQLConf$.<clinit>(SQLConf.scala)`  ` - waiting on the Class initialization monitor for org.apache.spark.sql.internal.SqlApiConf$`.

For the second one: `at org.apache.spark.sql.internal.SqlApiConf$.$anonfun$new$1(SqlApiConf.scala:73)`  `- waiting on the Class initialization monitor for org.apache.spark.sql.internal.SQLConf$`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Integration testing with the code provided by @wForget , and unable to add UT because the UTs share the JVM.

```
package org.apache.spark.sql.internal

import org.apache.spark.SparkFunSuite

class SQLConfDeadLockSuite extends SparkFunSuite {
  // scalastyle:off
  test("[SPARK-50620] Fix dead lock caused by SQLConf$ and SqlApiConf initialization") {
    val thread1 = new Thread(() => {
      println(org.apache.spark.sql.internal.SQLConf.ANSI_ENABLED)
    })

    val thread2 = new Thread(() => {
      println(org.apache.spark.sql.internal.SqlApiConf.ANSI_ENABLED_KEY)
    })

    thread1.start()
    thread2.start()

    thread1.join(10000)
    thread2.join(10000)
  }
}
```

Testing command:
```
./build/sbt "clean;sql/testOnly *SQLConfDeadLockSuite"
```

Testing Result:
<img width="1675" alt="image" src="https://github.com/user-attachments/assets/89da4d67-3cec-4eec-b459-eb9ba97ac38e" />


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.