### PR TITLE
[SPARK-50625][BUILD] simplify shell scripts using mvn help:evaluate

### DIFF
--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -126,21 +126,10 @@ if [ ! "$(command -v "$MVN")" ] ; then
     exit -1;
 fi
 
-VERSION=$("$MVN" help:evaluate -Dexpression=project.version $@ \
-    | grep -v "INFO"\
-    | grep -v "WARNING"\
-    | tail -n 1)
-SCALA_VERSION=$("$MVN" help:evaluate -Dexpression=scala.binary.version $@ \
-    | grep -v "INFO"\
-    | grep -v "WARNING"\
-    | tail -n 1)
-SPARK_HADOOP_VERSION=$("$MVN" help:evaluate -Dexpression=hadoop.version $@ \
-    | grep -v "INFO"\
-    | grep -v "WARNING"\
-    | tail -n 1)
-SPARK_HIVE=$("$MVN" help:evaluate -Dexpression=project.activeProfiles -pl sql/hive $@ \
-    | grep -v "INFO"\
-    | grep -v "WARNING"\
+VERSION=$("$MVN" help:evaluate -q -DforceStdout -Dexpression=project.version $@)
+SCALA_VERSION=$("$MVN" help:evaluate -q -DforceStdout -Dexpression=scala.binary.version $@)
+SPARK_HADOOP_VERSION=$("$MVN" help:evaluate -q -DforceStdout -Dexpression=hadoop.version $@)
+SPARK_HIVE=$("$MVN" help:evaluate -q -DforceStdout -Dexpression=project.activeProfiles -pl sql/hive $@ \
     | grep -F --count "<id>hive</id>";\
     # Reset exit status to 0, otherwise the script stops here if the last grep finds nothing\
     # because we use "set -o pipefail"

--- a/resource-managers/kubernetes/integration-tests/dev/dev-run-integration-tests.sh
+++ b/resource-managers/kubernetes/integration-tests/dev/dev-run-integration-tests.sh
@@ -43,10 +43,7 @@ BUILD_DEPENDENCIES_MVN_FLAG="-am"
 HADOOP_PROFILE="hadoop-3"
 MVN="$TEST_ROOT_DIR/build/mvn"
 
-SCALA_VERSION=$("$MVN" help:evaluate -Dexpression=scala.binary.version 2>/dev/null\
-    | grep -v "INFO"\
-    | grep -v "WARNING"\
-    | tail -n 1)
+SCALA_VERSION=$("$MVN" help:evaluate -q -DforceStdout -Dexpression=scala.binary.version)
 
 export SCALA_VERSION
 echo $SCALA_VERSION

--- a/resource-managers/kubernetes/integration-tests/scripts/setup-integration-test-env.sh
+++ b/resource-managers/kubernetes/integration-tests/scripts/setup-integration-test-env.sh
@@ -95,10 +95,7 @@ fi
 # If there is a specific Spark image skip building and extraction/copy
 if [[ $IMAGE_TAG == "N/A" ]];
 then
-  VERSION=$("$MVN" help:evaluate -Dexpression=project.version \
-    | grep -v "INFO"\
-    | grep -v "WARNING"\
-    | tail -n 1)
+  VERSION=$("$MVN" help:evaluate -q -DforceStdout -Dexpression=project.version)
   IMAGE_TAG=${VERSION}_$(uuidgen)
   cd $SPARK_INPUT_DIR
 


### PR DESCRIPTION
see [https://issues.apache.org/jira/browse/SPARK-50625](https://issues.apache.org/jira/browse/SPARK-50625)

this is minor cleanup to use 
     "mvn help:evaluate -q -DforceStdout"
 instead of 
    "mvn help:evaluate  2>/dev/null | grep -v INFO | grep -v WARNING"

This cleaner syntax was already used in few other places, so more consistent and cleaner.