### PR TITLE
[SPARK-50628] fix stop error on windows

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -467,6 +467,7 @@ private[spark] class Executor(
       if (!isLocal) {
         env.stop()
       }
+      defaultSessionState.urlClassLoader.close(); // see [SPARK-50628]
     }
   }
 


### PR DESCRIPTION
see [https://issues.apache.org/jira/browse/SPARK-50628](https://issues.apache.org/jira/browse/SPARK-50628)
spark stop failed to delete temp dir when running spark-submit on Windows with local[*] mode

By adding at the end of Executor stop() method  the line  
{noformat}
private[spark] class Executor {
  def stop(): Unit = {
    ...
    defaultSessionState.urlClassLoader.close();  // see [SPARK-50628]
  }
{noformat}

 .. it solves the error (which occurs only on windows in "spark-submit --master local[*]" mode).