### PR TITLE
[SPARK-50613][CONNECT] Support Configurable Idle Timeout of Connect Server

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_idle_timeout.py
+++ b/python/pyspark/sql/tests/connect/test_connect_idle_timeout.py
@@ -36,7 +36,11 @@ class IdleTimeoutTests(ReusedConnectTestCase):
         # Any call now should raise a SparkConnectException because there's no active session.
         with self.assertRaises(SparkConnectException) as e:
             self.spark.range(1).collect()
-            self.check_error(exception=e.exception, errorClass="NO_ACTIVE_SESSION", messageParameters={})
+            self.check_error(
+                exception=e.exception,
+                errorClass="NO_ACTIVE_SESSION",
+                messageParameters={},
+            )
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/test_connect_idle_timeout.py
+++ b/python/pyspark/sql/tests/connect/test_connect_idle_timeout.py
@@ -14,6 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+import unittest
+
+from pyspark.errors.exceptions.connect import SparkConnectException
+from pyspark.testing.connectutils import (
+    should_test_connect,
+    connect_requirement_message,
+    ReusedConnectTestCase,
+)
+
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
 class IdleTimeoutTests(ReusedConnectTestCase):

--- a/python/pyspark/sql/tests/connect/test_connect_idle_timeout.py
+++ b/python/pyspark/sql/tests/connect/test_connect_idle_timeout.py
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
+class IdleTimeoutTests(ReusedConnectTestCase):
+    """
+    This test class ensures that Spark Connect respects the configured idle timeout
+    and shuts down after the specified period of inactivity.
+    """
+
+    def conf(self):
+        conf = super().conf()
+        conf["spark.connect.server.idleTimeout"] = "2000"
+        return conf
+
+    def test_idle_timeout_shutdown(self):
+        result = self.spark.range(1).collect()
+        self.assertEqual(len(result), 1)
+
+        time.sleep(3)
+
+        # Any call now should raise a SparkConnectException because there's no active session.
+        with self.assertRaises(SparkConnectException) as e:
+            self.spark.range(1).collect()
+            self.check_error(exception=e.exception, errorClass="NO_ACTIVE_SESSION", messageParameters={})
+
+
+if __name__ == "__main__":
+    import xmlrunner
+
+    testRunner = None
+    try:
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        pass
+
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -313,5 +313,4 @@ object Connect {
       .internal()
       .booleanConf
       .createWithDefault(true)
-
 }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -265,6 +265,20 @@ object Connect {
       .booleanConf
       .createWithDefault(true)
 
+  val CONNECT_SERVER_IDLE_TIMEOUT =
+    buildConf("spark.connect.server.idleTimeout")
+      .doc(
+        """
+          |Configures idle timeout of Spark  Connect Server.
+          |If the server does not receive any new RPC requests or sessions within
+          |this timeout duration, it will shut down automatically.
+          |Set to 0 to disable.
+          |""".stripMargin
+      )
+      .version("4.0.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("0")
+
   val CONNECT_GRPC_MAX_METADATA_SIZE =
     buildStaticConf("spark.connect.grpc.maxMetadataSize")
       .doc(
@@ -301,4 +315,5 @@ object Connect {
       .internal()
       .booleanConf
       .createWithDefault(true)
+
 }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -273,7 +273,7 @@ object Connect {
           |this timeout duration, it will shut down automatically.
           |Set to 0 to disable.
           |""".stripMargin)
-      .version("4.0.0")
+      .version("3.5.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("0")
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -267,14 +267,12 @@ object Connect {
 
   val CONNECT_SERVER_IDLE_TIMEOUT =
     buildConf("spark.connect.server.idleTimeout")
-      .doc(
-        """
+      .doc("""
           |Configures idle timeout of Spark  Connect Server.
           |If the server does not receive any new RPC requests or sessions within
           |this timeout duration, it will shut down automatically.
           |Set to 0 to disable.
-          |""".stripMargin
-      )
+          |""".stripMargin)
       .version("4.0.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("0")

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -411,15 +411,19 @@ object SparkConnectService extends Logging {
   }
   def startIdleMonitor(globalIdleTimeoutMs: Long): Unit = {
     if (globalIdleTimeoutMs > 0) {
-      idleMonitorExecutor.scheduleAtFixedRate(() => {
-        val lastActivityTime = SparkConnectService.sessionManager.getLastActivityTime
-        val currentTime = System.currentTimeMillis()
+      idleMonitorExecutor.scheduleAtFixedRate(
+        () => {
+          val lastActivityTime = SparkConnectService.sessionManager.getLastActivityTime
+          val currentTime = System.currentTimeMillis()
 
-        if (currentTime - lastActivityTime > globalIdleTimeoutMs) {
-          logInfo("Global idle timeout reached. Shutting down Spark Connect service.")
-          stop()
-        }
-      }, globalIdleTimeoutMs, globalIdleTimeoutMs, TimeUnit.MILLISECONDS)
+          if (currentTime - lastActivityTime > globalIdleTimeoutMs) {
+            logInfo("Global idle timeout reached. Shutting down Spark Connect service.")
+            stop()
+          }
+        },
+        globalIdleTimeoutMs,
+        globalIdleTimeoutMs,
+        TimeUnit.MILLISECONDS)
     }
   }
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -38,7 +38,6 @@ import org.apache.spark.internal.config.UI.UI_ENABLED
 import org.apache.spark.scheduler.{LiveListenerBus, SparkListenerEvent}
 import org.apache.spark.sql.connect.config.Connect.{CONNECT_GRPC_BINDING_ADDRESS, CONNECT_GRPC_BINDING_PORT, CONNECT_GRPC_MARSHALLER_RECURSION_LIMIT, CONNECT_GRPC_MAX_INBOUND_MESSAGE_SIZE, CONNECT_GRPC_PORT_MAX_RETRIES, CONNECT_SERVER_IDLE_TIMEOUT}
 import org.apache.spark.sql.connect.execution.ConnectProgressExecutionListener
-import org.apache.spark.sql.connect.service.SparkConnectService.stop
 import org.apache.spark.sql.connect.ui.{SparkConnectServerAppStatusStore, SparkConnectServerListener, SparkConnectServerTab}
 import org.apache.spark.sql.connect.utils.ErrorUtils
 import org.apache.spark.status.ElementTrackingStore

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -19,7 +19,9 @@ package org.apache.spark.sql.connect.service
 
 import java.net.InetSocketAddress
 import java.util.concurrent.{Executors, TimeUnit}
+
 import scala.jdk.CollectionConverters._
+
 import com.google.protobuf.Message
 import io.grpc.{BindableService, MethodDescriptor, Server, ServerMethodDefinition, ServerServiceDefinition}
 import io.grpc.MethodDescriptor.PrototypeMarshaller
@@ -28,6 +30,7 @@ import io.grpc.protobuf.ProtoUtils
 import io.grpc.protobuf.services.ProtoReflectionService
 import io.grpc.stub.StreamObserver
 import org.apache.commons.lang3.StringUtils
+
 import org.apache.spark.{SparkContext, SparkEnv}
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.{AddArtifactsRequest, AddArtifactsResponse, SparkConnectServiceGrpc}

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -275,7 +275,6 @@ class SparkConnectService(debug: Boolean) extends AsyncService with BindableServ
     // Build the final ServerServiceDefinition and return it.
     builder.build()
   }
-
 }
 
 /**

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -36,7 +36,7 @@ import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys.HOST
 import org.apache.spark.internal.config.UI.UI_ENABLED
 import org.apache.spark.scheduler.{LiveListenerBus, SparkListenerEvent}
-import org.apache.spark.sql.connect.config.Connect.{CONNECT_GRPC_BINDING_ADDRESS, CONNECT_GRPC_BINDING_PORT, CONNECT_GRPC_MARSHALLER_RECURSION_LIMIT, CONNECT_GRPC_MAX_INBOUND_MESSAGE_SIZE, CONNECT_GRPC_PORT_MAX_RETRIES, CONNECT_SERVER_IDLE_TIMEOUT, CONNECT_SESSION_MANAGER_DEFAULT_SESSION_TIMEOUT}
+import org.apache.spark.sql.connect.config.Connect.{CONNECT_GRPC_BINDING_ADDRESS, CONNECT_GRPC_BINDING_PORT, CONNECT_GRPC_MARSHALLER_RECURSION_LIMIT, CONNECT_GRPC_MAX_INBOUND_MESSAGE_SIZE, CONNECT_GRPC_PORT_MAX_RETRIES, CONNECT_SERVER_IDLE_TIMEOUT}
 import org.apache.spark.sql.connect.execution.ConnectProgressExecutionListener
 import org.apache.spark.sql.connect.service.SparkConnectService.stop
 import org.apache.spark.sql.connect.ui.{SparkConnectServerAppStatusStore, SparkConnectServerListener, SparkConnectServerTab}

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectSessionManager.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectSessionManager.scala
@@ -187,6 +187,15 @@ class SparkConnectSessionManager extends Logging {
   }
 
   /**
+   * Returns the most recent last access time across all active sessions.
+   */
+  def getLastActivityTime: Long = {
+    sessionStore.values().asScala
+      .map(_.getSessionHolderInfo.lastAccessTimeMs)
+      .foldLeft(0L)(Math.max)
+  }
+
+  /**
    * Schedules periodic maintenance checks if it is not already scheduled.
    *
    * The checks are looking to remove sessions that expired.

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectSessionManager.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectSessionManager.scala
@@ -190,7 +190,9 @@ class SparkConnectSessionManager extends Logging {
    * Returns the most recent last access time across all active sessions.
    */
   def getLastActivityTime: Long = {
-    sessionStore.values().asScala
+    sessionStore
+      .values()
+      .asScala
       .map(_.getSessionHolderInfo.lastAccessTimeMs)
       .foldLeft(0L)(Math.max)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR introduces a new configurable idle timeout feature for the Spark Connect server. Specifically, it adds a configuration option (`spark.connect.server.idleTimeout`) that allows administrators to specify a duration after which the Spark Connect server will automatically shut down if no new sessions or requests are received. By default, this value is set to 0 (disabled), preserving current behavior.
When enabled (i.e., set to a positive value), the Spark Connect service periodically checks for activity based on recorded session access times. If the server remains idle beyond the configured timeout, it triggers a graceful shutdown of the service.

### Why are the changes needed?
Currently, the Spark Connect server remains running indefinitely until manually terminated. In managed environments (e.g., Amazon EMR), the lack of a natural stopping condition means the cluster may never be marked as idle and thus never shut down, leading to unnecessary resource consumption and cost.
By introducing this idle timeout:
1. Clusters can automatically terminate when no active Spark Connect sessions are ongoing, leading to better resource utilization.
2. Administrators have more control over lifecycle management, improving operational efficiency in hosted or on-demand environments.

### Does this PR introduce _any_ user-facing change?
**Yes**. A new configuration parameter `spark.connect.server.idleTimeout` is introduced. When set to a positive duration (e.g., 10m), the Spark Connect server will monitor inactivity and stop after the specified period with no requests or active sessions.
By default, it is disabled (0).

### How was this patch tested?
- Added unit tests for PySpark

### Was this patch authored or co-authored using generative AI tooling?
No
