### PR TITLE
[SPARK-50632][BUILD] Upgrade tink to 1.16.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -269,7 +269,7 @@ stax-api/1.0.1//stax-api-1.0.1.jar
 stream/2.9.8//stream-2.9.8.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
 threeten-extra/1.7.1//threeten-extra-1.7.1.jar
-tink/1.15.0//tink-1.15.0.jar
+tink/1.16.0//tink-1.16.0.jar
 transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar
 wildfly-openssl/1.1.3.Final//wildfly-openssl-1.1.3.Final.jar

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.9.0</commons-cli.version>
     <bouncycastle.version>1.79</bouncycastle.version>
-    <tink.version>1.15.0</tink.version>
+    <tink.version>1.16.0</tink.version>
     <datasketches.version>6.1.1</datasketches.version>
     <netty.version>4.1.115.Final</netty.version>
     <netty-tcnative.version>2.0.69.Final</netty-tcnative.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
 The pr aims to upgrade `tink` from `1.15.0` to `1.16.0`.


### Why are the changes needed?
The full release notes as follows: https://github.com/tink-crypto/tink-java/releases/tag/v1.16.0

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.