### PR TITLE
[SPARK-50633][INFRA] Fix `codecov/codecov-action@v4` daily scheduling failure

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -609,6 +609,7 @@ jobs:
       if: fromJSON(inputs.envs).PYSPARK_CODECOV == 'true'
       uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: ./python/coverage.xml
         flags: unittests
         name: PySpark


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix `Build / Coverage (master, Scala 2.13, Hadoop 3, JDK 17) (`build_coverage.yml`)` `codecov/codecov-action@v4` job daily scheduling failure.


### Why are the changes needed?
- 1.https://app.codecov.io/github/apache?search=spark
  <img width="1389" alt="image" src="https://github.com/user-attachments/assets/af5028ab-f81a-4b03-8c70-88b19936bd5b" />

- 2.After clicking in above https://app.codecov.io/github/apache/spark
  <img width="1393" alt="image" src="https://github.com/user-attachments/assets/71dffdc6-cbe7-4846-95c6-f55651342aa7" />
  The last successful commit trigger was: [78f7c30](https://app.codecov.io/github/apache/spark/commit/78f7c30e140fd8cf4a80b783dd7e9ee4d1b4d7e2)
```shell
(base) ➜  spark-community git:(master) ✗ GLA | grep 78f7c30
78f7c30e140fd8cf4a80b783dd7e9ee4d1b4d7e2 - Nikola Mandic, nikola.mandic@databricks.com, 10 months ago : 
[SPARK-42328][SQL] Remove _LEGACY_ERROR_TEMP_1175 from error classes
```

- 3.This job should have failed every day for the past 10 months, as shown below:
  https://github.com/apache/spark/actions/runs/12410482233/job/34646325911
  <img width="1014" alt="image" src="https://github.com/user-attachments/assets/7005ca1b-e7ca-4846-8b5b-fe1be7aa7266" />

- 4.Currently, `codecov/codecov-action@v4` no longer supports without a token.
  https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token
  <img width="730" alt="image" src="https://github.com/user-attachments/assets/acb0538d-5b3c-4e96-a6c8-5c56c2fb9762" />

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manual daily continuous observation.


### Was this patch authored or co-authored using generative AI tooling?
No.
