### PR TITLE
[SPARK-50645][INFRA] Make more daily builds able to manually trigger

### DIFF
--- a/.github/workflows/build_coverage.yml
+++ b/.github/workflows/build_coverage.yml
@@ -22,6 +22,7 @@ name: "Build / Coverage (master, Scala 2.13, Hadoop 3, JDK 17)"
 on:
   schedule:
     - cron: '0 10 * * *'
+  workflow_dispatch:
 
 jobs:
   run-build:

--- a/.github/workflows/build_infra_images_cache.yml
+++ b/.github/workflows/build_infra_images_cache.yml
@@ -39,6 +39,7 @@ on:
     - '.github/workflows/build_infra_images_cache.yml'
   # Create infra image when cutting down branches/tags
   create:
+  workflow_dispatch:
 jobs:
   main:
     if: github.repository == 'apache/spark'

--- a/.github/workflows/build_java21.yml
+++ b/.github/workflows/build_java21.yml
@@ -22,6 +22,7 @@ name: "Build (master, Scala 2.13, Hadoop 3, JDK 21)"
 on:
   schedule:
     - cron: '0 4 * * *'
+  workflow_dispatch:
 
 jobs:
   run-build:

--- a/.github/workflows/build_maven.yml
+++ b/.github/workflows/build_maven.yml
@@ -22,6 +22,7 @@ name: "Build / Maven (master, Scala 2.13, Hadoop 3, JDK 17)"
 on:
   schedule:
     - cron: '0 13 * * *'
+  workflow_dispatch:
 
 jobs:
   run-build:

--- a/.github/workflows/build_maven_java21.yml
+++ b/.github/workflows/build_maven_java21.yml
@@ -22,6 +22,7 @@ name: "Build / Maven (master, Scala 2.13, Hadoop 3, JDK 21)"
 on:
   schedule:
     - cron: '0 14 * * *'
+  workflow_dispatch:
 
 jobs:
   run-build:

--- a/.github/workflows/build_maven_java21_macos15.yml
+++ b/.github/workflows/build_maven_java21_macos15.yml
@@ -22,6 +22,7 @@ name: "Build / Maven (master, Scala 2.13, Hadoop 3, JDK 21, MacOS-15)"
 on:
   schedule:
     - cron: '0 20 */2 * *'
+  workflow_dispatch:
 
 jobs:
   run-build:

--- a/.github/workflows/build_non_ansi.yml
+++ b/.github/workflows/build_non_ansi.yml
@@ -22,6 +22,7 @@ name: "Build / Non-ANSI (master, Hadoop 3, JDK 17, Scala 2.13)"
 on:
   schedule:
     - cron: '0 1 * * *'
+  workflow_dispatch:
 
 jobs:
   run-build:

--- a/.github/workflows/build_python_3.10.yml
+++ b/.github/workflows/build_python_3.10.yml
@@ -22,6 +22,7 @@ name: "Build / Python-only (master, Python 3.10)"
 on:
   schedule:
     - cron: '0 17 * * *'
+  workflow_dispatch:
 
 jobs:
   run-build:

--- a/.github/workflows/build_python_3.11_macos.yml
+++ b/.github/workflows/build_python_3.11_macos.yml
@@ -22,6 +22,7 @@ name: "Build / Python-only (master, Python 3.11, MacOS)"
 on:
   schedule:
     - cron: '0 21 * * *'
+  workflow_dispatch:
 
 jobs:
   run-build:

--- a/.github/workflows/build_python_3.12.yml
+++ b/.github/workflows/build_python_3.12.yml
@@ -22,6 +22,7 @@ name: "Build / Python-only (master, Python 3.12)"
 on:
   schedule:
     - cron: '0 19 * * *'
+  workflow_dispatch:
 
 jobs:
   run-build:

--- a/.github/workflows/build_python_3.13.yml
+++ b/.github/workflows/build_python_3.13.yml
@@ -22,6 +22,7 @@ name: "Build / Python-only (master, Python 3.13)"
 on:
   schedule:
     - cron: '0 20 * * *'
+  workflow_dispatch:
 
 jobs:
   run-build:

--- a/.github/workflows/build_python_3.9.yml
+++ b/.github/workflows/build_python_3.9.yml
@@ -22,6 +22,7 @@ name: "Build / Python-only (master, Python 3.9)"
 on:
   schedule:
     - cron: '0 21 * * *'
+  workflow_dispatch:
 
 jobs:
   run-build:

--- a/.github/workflows/build_python_connect.yml
+++ b/.github/workflows/build_python_connect.yml
@@ -22,6 +22,7 @@ name: Build / Spark Connect Python-only (master, Python 3.11)
 on:
   schedule:
     - cron: '0 19 * * *'
+  workflow_dispatch:
 
 jobs:
   # Build: build Spark and run the tests for specified modules using SBT

--- a/.github/workflows/build_python_connect35.yml
+++ b/.github/workflows/build_python_connect35.yml
@@ -22,6 +22,7 @@ name: Build / Spark Connect Python-only (master-server, 35-client, Python 3.11)
 on:
   schedule:
     - cron: '0 21 * * *'
+  workflow_dispatch:
 
 jobs:
   # Build: build Spark and run the tests for specified modules using SBT

--- a/.github/workflows/build_python_pypy3.10.yml
+++ b/.github/workflows/build_python_pypy3.10.yml
@@ -22,6 +22,7 @@ name: "Build / Python-only (master, PyPy 3.10)"
 on:
   schedule:
     - cron: '0 15 * * *'
+  workflow_dispatch:
 
 jobs:
   run-build:

--- a/.github/workflows/build_rockdb_as_ui_backend.yml
+++ b/.github/workflows/build_rockdb_as_ui_backend.yml
@@ -22,6 +22,7 @@ name: "Build / RocksDB as UI Backend (master, Hadoop 3, JDK 17, Scala 2.13)"
 on:
   schedule:
     - cron: '0 6 * * *'
+  workflow_dispatch:
 
 jobs:
   run-build:

--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -21,6 +21,7 @@ name: "Build / SparkR-only (master, 4.4.2, windows-2022)"
 on:
   schedule:
     - cron: '0 17 * * *'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
### What changes were proposed in this pull request?
similar to https://github.com/apache/spark/pull/49207, make the rest daily builds able to be executed manually


### Why are the changes needed?
re-run failed tests in a daily build won't fetch the latest code changes, so somethimes we don't have a quick way to test daily build in time.


### Does this PR introduce _any_ user-facing change?
no, infra-only


### How was this patch tested?
will manually check after merge

### Was this patch authored or co-authored using generative AI tooling?
no
