### PR TITLE
[SPARK-50646][PYTHON][DOCS] Document explicit style of pyspark plotting

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -6785,6 +6785,9 @@ class DataFrame:
         Notes
         -----
         This API is experimental.
+        It provides two ways to create plots:
+        1. Chaining style (e.g., `df.plot.line(...)`).
+        2. Explicit style (e.g., `df.plot(kind="line", ...)`).
 
         Examples
         --------
@@ -6794,6 +6797,7 @@ class DataFrame:
         >>> type(df.plot)
         <class 'pyspark.sql.plot.core.PySparkPlotAccessor'>
         >>> df.plot.line(x="category", y=["int_val", "float_val"])  # doctest: +SKIP
+        >>> df.plot(kind="line", x="category", y=["int_val", "float_val"])  # doctest: +SKIP
         """
         ...
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document explicit style of pyspark plotting.

### Why are the changes needed?
To improve documentation by explicitly showing both chaining (df.plot.line(...)) and explicit (df.plot(kind="line", ...)) styles, ensuring clarity for users

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.