### PR TITLE
[SPARK-50651][SQL][DOCS] Add note about octal representation for characters

### DIFF
--- a/docs/sql-ref-literals.md
+++ b/docs/sql-ref-literals.md
@@ -79,7 +79,7 @@ SELECT "SPARK SQL" AS col;
 +---------+
 |      col|
 +---------+
-|Spark SQL|
+|SPARK SQL|
 +---------+
 
 SELECT 'it\'s $10.' AS col;

--- a/docs/sql-ref-literals.md
+++ b/docs/sql-ref-literals.md
@@ -46,6 +46,7 @@ A string literal is used to specify a character string value.
     One character from the character set. Use `\` to escape special characters (e.g., `'` or `\`).
     To represent unicode characters, use 16-bit or 32-bit unicode escape of the form `\uxxxx` or `\Uxxxxxxxx`,
     where xxxx and xxxxxxxx are 16-bit and 32-bit code points in hexadecimal respectively (e.g., `\u3042` for `あ` and `\U0001F44D` for `👍`).
+    An ASCII character can also be represented as an octal number preceded by `\` like `\101`, which represents `A`.
 
 * **r**
 
@@ -85,7 +86,7 @@ SELECT 'it\'s $10.' AS col;
 +---------+
 |      col|
 +---------+
-|It's $10.|
+|it's $10.|
 +---------+
 
 SELECT r"'\n' represents newline character." AS col;


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR modifies `docs/sql-ref-literals.md` to mention about octal representation for characters.
Currently there is no mention of it anywhere.

This change includes a trivial typo too which is in the same file.

### Why are the changes needed?
It's a public feature.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Built the doc, then confirmed the result.

### Was this patch authored or co-authored using generative AI tooling?
No.
