### PR TITLE
[MINOR][INFRA] Skip step `List Python packages` when `PYTHON_TO_TEST` is not specified

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -584,6 +584,7 @@ jobs:
         distribution: zulu
         java-version: ${{ matrix.java }}
     - name: List Python packages (${{ env.PYTHON_TO_TEST }})
+      if: ${{ env.PYTHON_TO_TEST != '' }}
       env: ${{ fromJSON(inputs.envs) }}
       shell: 'script -q -e -c "bash {0}"'
       run: |


### PR DESCRIPTION
### What changes were proposed in this pull request?
Skip step `List Python packages` when `PYTHON_TO_TEST` is not specified


### Why are the changes needed?
in 3.5 daily build, the `PYTHON_TO_TEST` is empty

https://github.com/apache/spark/actions/runs/12465764579/job/34792186424

![image](https://github.com/user-attachments/assets/d7da529c-8273-4065-9bef-a29a93ab53aa)



### Does this PR introduce _any_ user-facing change?
no, infra-only


### How was this patch tested?
will manually check


### Was this patch authored or co-authored using generative AI tooling?
no
