### PR TITLE
[SPARK-50612][SQL][FOLLOWUP] Put normalization of inner project lists under a flag

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 
-class NormalizePlanSuite extends SparkFunSuite{
+class NormalizePlanSuite extends SparkFunSuite {
 
   test("Normalize Project") {
     val baselineCol1 = $"col1".int
@@ -31,7 +31,11 @@ class NormalizePlanSuite extends SparkFunSuite{
     val testPlan = LocalRelation(testCol1).select(testCol1)
 
     assert(baselinePlan != testPlan)
-    assert(NormalizePlan(baselinePlan) == NormalizePlan(testPlan))
+    assert(
+      NormalizePlan(baselinePlan)
+      ==
+      NormalizePlan(testPlan)
+    )
   }
 
   test("Normalize ordering in a project list of an inner Project") {
@@ -41,6 +45,17 @@ class NormalizePlanSuite extends SparkFunSuite{
       LocalRelation($"col1".int, $"col2".string).select($"col2", $"col1").select($"col1")
 
     assert(baselinePlan != testPlan)
-    assert(NormalizePlan(baselinePlan) == NormalizePlan(testPlan))
+
+    assert(
+      NormalizePlan(baselinePlan, normalizeInnerProjectListOrder = false)
+      !=
+      NormalizePlan(testPlan, normalizeInnerProjectListOrder = false)
+    )
+
+    assert(
+      NormalizePlan(baselinePlan, normalizeInnerProjectListOrder = true)
+      ==
+      NormalizePlan(testPlan, normalizeInnerProjectListOrder = true)
+    )
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Put the change made in https://github.com/apache/spark/pull/49230 under a flag so that it can be only turned on for single-pass analyzer. This is done in order to protect the Optimizer, in case Optimizer expects certain ordering in the inner project lists.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Modified existing tests.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
