### PR TITLE
[SPARK-50662][PYTHON][WINDOWS] Escape ampersands in command arguments on windows

### DIFF
--- a/bin/spark-class2.cmd
+++ b/bin/spark-class2.cmd
@@ -80,8 +80,13 @@ rem executed by the batch interpreter. So read all the output of the launcher in
 set LAUNCHER_OUTPUT=%temp%\spark-class-launcher-output-%RANDOM_SUFFIX%.txt
 
 rem unset SHELL to indicate non-bash environment to launcher/Main
+setlocal enabledelayedexpansion
+
+set args=%*
+set args="!args:&=^^^&!"
 set SHELL=
-"%RUNNER%" -Xmx128m -cp "%LAUNCH_CLASSPATH%" org.apache.spark.launcher.Main %* > %LAUNCHER_OUTPUT%
+"%RUNNER%" -Xmx128m -cp "%LAUNCH_CLASSPATH%" org.apache.spark.launcher.Main !args:~1,-1! > %LAUNCHER_OUTPUT%
+endlocal
 for /f "tokens=*" %%i in (%LAUNCHER_OUTPUT%) do (
   set SPARK_CMD=%%i
 )

--- a/bin/spark-submit.cmd
+++ b/bin/spark-submit.cmd
@@ -22,4 +22,8 @@ rem environment, it just launches a new cmd to do the real work.
 
 rem The outermost quotes are used to prevent Windows command line parse error
 rem when there are some quotes in parameters, see SPARK-21877.
-cmd /V /E /C ""%~dp0spark-submit2.cmd" %*"
+setlocal enabledelayedexpansion
+set args=%*
+set args="!args:&=^^^&!"
+cmd /V /E /C ""%~dp0spark-submit2.cmd" !args:~1,-1!"
+endlocal

--- a/bin/spark-submit2.cmd
+++ b/bin/spark-submit2.cmd
@@ -23,5 +23,9 @@ rem environment, it just launches a new cmd to do the real work.
 rem disable randomized hash for string in Python 3.3+
 set PYTHONHASHSEED=0
 
+setlocal enabledelayedexpansion
 set CLASS=org.apache.spark.deploy.SparkSubmit
-"%~dp0spark-class2.cmd" %CLASS% %*
+set args=%*
+set args="!args:&=^^^&!"
+"%~dp0spark-class2.cmd" %CLASS% !args:~1,-1!
+endlocal

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -71,7 +71,7 @@ def launch_gateway(conf=None, popen_kwargs=None):
                 # On windows escape & with triple carets to avoid it being removed by cmd.exe
                 if on_windows:
                     v = v.replace("&", "^^^&")
-                
+
                 command += ["--conf", "%s=%s" % (k, v)]
         submit_args = os.environ.get("PYSPARK_SUBMIT_ARGS", "pyspark-shell")
         if os.environ.get("SPARK_TESTING"):

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -68,6 +68,10 @@ def launch_gateway(conf=None, popen_kwargs=None):
         command = [os.path.join(SPARK_HOME, script)]
         if conf:
             for k, v in conf.getAll():
+                # On windows escape & with triple carets to avoid it being removed by cmd.exe
+                if on_windows:
+                    v = v.replace("&", "^^^&")
+                
                 command += ["--conf", "%s=%s" % (k, v)]
         submit_args = os.environ.get("PYSPARK_SUBMIT_ARGS", "pyspark-shell")
         if os.environ.get("SPARK_TESTING"):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Changing `java_gateway.py` and verious .cmd files so ampersands will be escaped using triple carets (^^^) on windows system


### Why are the changes needed?
On windows system, spark-submit is operated by running a chain .cmd files, this flow didn't handled ampersands (&) correctly so in each step, if the arguments that were passed to the next .cmd file/java contained an ampersand, the flags were truncated up to the location of the first ampersand

### Does this PR introduce _any_ user-facing change?
Yes
The previous behaviour couldn't handle configs with parameters, and the new one can


### How was this patch tested?
This patch was tested on multiple windows machines across the company that work at


### Was this patch authored or co-authored using generative AI tooling?
No
