### PR TITLE
[SPARK-50667][PYTHON][TESTS] Make `jinja2` optional in PySpark Tests

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -13779,11 +13779,15 @@ def _test() -> None:
     import tempfile
     import uuid
     from pyspark.sql import SparkSession
+    from pyspark.testing.utils import have_jinja2
     import pyspark.pandas.frame
 
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.frame.__dict__.copy()
+    if not have_jinja2:
+        del pyspark.pandas.frame.DataFrame.to_latex.__doc__
+
     globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]").appName("pyspark.pandas.frame tests").getOrCreate()

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -2632,7 +2632,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ...                    'mask': ['red', 'purple'],
         ...                    'weapon': ['sai', 'bo staff']},
         ...                   columns=['name', 'mask', 'weapon'])
-        >>> print(df.to_latex(index=False)) # doctest: +NORMALIZE_WHITESPACE
+        >>> print(df.to_latex(index=False))  # doctest: +SKIP
         \begin{tabular}{lll}
         \toprule
               name &    mask &    weapon \\
@@ -13779,15 +13779,11 @@ def _test() -> None:
     import tempfile
     import uuid
     from pyspark.sql import SparkSession
-    from pyspark.testing.utils import have_jinja2
     import pyspark.pandas.frame
 
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.frame.__dict__.copy()
-    if not have_jinja2:
-        del pyspark.pandas.frame.DataFrame.to_latex.__doc__
-
     globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]").appName("pyspark.pandas.frame tests").getOrCreate()

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -7335,15 +7335,11 @@ def _test() -> None:
     import doctest
     import sys
     from pyspark.sql import SparkSession
-    from pyspark.testing.utils import have_jinja2
     import pyspark.pandas.series
 
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.series.__dict__.copy()
-    if not have_jinja2:
-        del pyspark.pandas.series.Series.to_latex.__doc__
-
     globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]").appName("pyspark.pandas.series tests").getOrCreate()

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -7335,11 +7335,15 @@ def _test() -> None:
     import doctest
     import sys
     from pyspark.sql import SparkSession
+    from pyspark.testing.utils import have_jinja2
     import pyspark.pandas.series
 
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.series.__dict__.copy()
+    if not have_jinja2:
+        del pyspark.pandas.series.Series.to_latex.__doc__
+
     globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]").appName("pyspark.pandas.series tests").getOrCreate()

--- a/python/pyspark/pandas/tests/io/test_dataframe_conversion.py
+++ b/python/pyspark/pandas/tests/io/test_dataframe_conversion.py
@@ -26,6 +26,7 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 from pyspark.testing.sqlutils import SQLTestUtils
+from pyspark.testing.utils import have_jinja2, jinja2_requirement_message
 
 
 class DataFrameConversionMixin:
@@ -199,6 +200,7 @@ class DataFrameConversionMixin:
             psdf.to_clipboard(sep=";", index=False), pdf.to_clipboard(sep=";", index=False)
         )
 
+    @unittest.skipIf(not have_jinja2, jinja2_requirement_message)
     def test_to_latex(self):
         pdf = self.pdf
         psdf = self.psdf

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -94,6 +94,9 @@ graphviz_requirement_message = None if have_graphviz else "No module named 'grap
 have_flameprof = have_package("flameprof")
 flameprof_requirement_message = None if have_flameprof else "No module named 'flameprof'"
 
+have_jinja2 = have_package("jinja2")
+jinja2_requirement_message = None if have_jinja2 else "No module named 'jinja2'"
+
 pandas_requirement_message = None
 try:
     from pyspark.sql.pandas.utils import require_minimum_pandas_version


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `jinja2` optional in PySpark Tests


### Why are the changes needed?
`jinja2` is an optional dependency of `pandas`

https://pypi.org/pypi/pandas/2.2.0/json

```
'jinja2>=3.1.2; extra == "output-formatting"'
```



It is not a mandatory requirement of pyspark, so PySpark tests should succeed even it is not installed


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
manually test after uninstalling it


### Was this patch authored or co-authored using generative AI tooling?
no