### PR TITLE
[SPARK-50676][SQL] Remove unused `private lazy val mapValueContainsNull` from `ElementAt`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2609,9 +2609,6 @@ case class ElementAt(
 
   @transient private lazy val mapKeyType = left.dataType.asInstanceOf[MapType].keyType
 
-  @transient private lazy val mapValueContainsNull =
-    left.dataType.asInstanceOf[MapType].valueContainsNull
-
   @transient private lazy val arrayElementNullable =
     left.dataType.asInstanceOf[ArrayType].containsNull
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
SPARK-33460 added `mapValueContainsNull` to `ElementAt`, but after SPARK-40066, this private lazy val is no longer used, so this pr removes it from `ElementAt`.

### Why are the changes needed?
Cleanup unused code.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No