### PR TITLE
[SPARK-50677][BUILD] Upgrade jupiter-interface to 0.13.3 and Junit5 to 5.11.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,13 +217,13 @@
     <netty.version>4.1.115.Final</netty.version>
     <netty-tcnative.version>2.0.69.Final</netty-tcnative.version>
     <icu4j.version>76.1</icu4j.version>
-    <junit-jupiter.version>5.11.3</junit-jupiter.version>
-    <junit-platform.version>1.11.3</junit-platform.version>
+    <junit-jupiter.version>5.11.4</junit-jupiter.version>
+    <junit-platform.version>1.11.4</junit-platform.version>
     <!--
       SPARK-50299: When updating `sbt-jupiter-interface.version`,
       also need to update the version in `SparkBuild.scala` and `plugins.sbt`.
     -->
-    <sbt-jupiter-interface.version>0.13.1</sbt-jupiter-interface.version>
+    <sbt-jupiter-interface.version>0.13.3</sbt-jupiter-interface.version>
     <!--
     If you are changing Arrow version specification, please check
     ./python/pyspark/sql/pandas/utils.py, ./python/packaging/classic/setup.py

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1724,7 +1724,7 @@ object TestSettings {
     (Test / testOptions) += Tests.Argument(TestFrameworks.ScalaTest, "-W", "120", "300"),
     (Test / testOptions) += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
     // Enable Junit testing.
-    libraryDependencies += "com.github.sbt.junit" % "jupiter-interface" % "0.13.1" % "test",
+    libraryDependencies += "com.github.sbt.junit" % "jupiter-interface" % "0.13.3" % "test",
     // `parallelExecutionInTest` controls whether test suites belonging to the same SBT project
     // can run in parallel with one another. It does NOT control whether tests execute in parallel
     // within the same JVM (which is controlled by `testForkedParallel`) or whether test cases

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -44,6 +44,6 @@ addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
 
 addSbtPlugin("com.github.sbt" % "sbt-pom-reader" % "2.4.0")
 
-addSbtPlugin("com.github.sbt.junit" % "sbt-jupiter-interface" % "0.13.1")
+addSbtPlugin("com.github.sbt.junit" % "sbt-jupiter-interface" % "0.13.3")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.7")


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade `jupiter-interface` from 0.13.1 to 0.13.3 and Junit5 to the latest version（Platform 1.11.4 + Jupiter 5.11.4）.

### Why are the changes needed?
The new version of `jupiter-interface` brings two fixes:

- https://github.com/sbt/sbt-jupiter-interface/pull/126
- https://github.com/sbt/sbt-jupiter-interface/pull/128

The full release notes of `jupiter-interface` as follows:

- https://github.com/sbt/sbt-jupiter-interface/releases/tag/v0.13.3

and the full release notes between Junit 5.11.3 to 5.11.4 as follows:

- https://junit.org/junit5/docs/5.11.4/release-notes/#release-notes-5.11.4


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
