### PR TITLE
[SPARK-50679][SQL] Duplicated common expressions in different With should be projected only once

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
@@ -404,17 +404,16 @@ class RewriteWithExpressionSuite extends PlanTest {
       Optimizer.execute(plan),
       testRelation
         .select(a, b, (b + 2).as("_common_expr_0"))
-        .select(a, b, $"_common_expr_0", (b + 2).as("_common_expr_1"))
         .window(
           Seq(windowExpr(count(a), windowSpec(Seq($"_common_expr_0" * $"_common_expr_0"), Nil,
             frame)).as("col2")),
-          Seq($"_common_expr_1" * $"_common_expr_1"),
+          Seq($"_common_expr_0" * $"_common_expr_0"),
           Nil
         )
         .select(a, b, $"col2")
-        .select(a, b, $"col2", (a + 1).as("_common_expr_2"))
+        .select(a, b, $"col2", (a + 1).as("_common_expr_1"))
         .window(
-          Seq(windowExpr(sum($"_common_expr_2" * $"_common_expr_2"),
+          Seq(windowExpr(sum($"_common_expr_1" * $"_common_expr_1"),
             windowSpec(Seq(a), Nil, frame)).as("col3")),
           Seq(a),
           Nil
@@ -466,5 +465,29 @@ class RewriteWithExpressionSuite extends PlanTest {
       Optimizer.execute(plan),
       testRelation.groupBy($"b")(avg("a").as("a")).where($"a" === 1).analyze
     )
+  }
+
+  test("SPARK-50679: duplicated common expressions in different With") {
+    val a = testRelation.output.head
+    val exprDef = CommonExpressionDef(a + a)
+    val exprRef = new CommonExpressionRef(exprDef)
+    val expr1 = With(exprRef * exprRef, Seq(exprDef))
+    val expr2 = With(exprRef - exprRef, Seq(exprDef))
+    val plan = testRelation.select(expr1.as("c1"), expr2.as("c2")).analyze
+    comparePlans(
+      Optimizer.execute(plan),
+      testRelation
+        .select(star(), (a + a).as("_common_expr_0"))
+        .select(
+          ($"_common_expr_0" * $"_common_expr_0").as("c1"),
+          ($"_common_expr_0" - $"_common_expr_0").as("c2"))
+        .analyze
+    )
+
+    val wrongExprDef = CommonExpressionDef(a * a, exprDef.id)
+    val wrongExprRef = new CommonExpressionRef(wrongExprDef)
+    val expr3 = With(wrongExprRef + wrongExprRef, Seq(wrongExprDef))
+    val wrongPlan = testRelation.select(expr1.as("c1"), expr3.as("c3")).analyze
+    intercept[AssertionError](Optimizer.execute(wrongPlan))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Sometimes we may need to duplicate the `With` expression with some shared common expressions. This PR improves the `With` rewriting rule to recognize it and only project the duplicated common expressions once.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Produce better plans.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
a new test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no