### PR TITLE
[SPARK-50310][CONNECT][PYTHON][FOLLOW-UP] Delay is_debugging_enabled call after modules are initialized 

### DIFF
--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -255,7 +255,8 @@ def _with_origin(func: FuncT) -> FuncT:
         from pyspark.sql.utils import is_remote
 
         spark = SparkSession.getActiveSession()
-        if spark is not None and hasattr(func, "__name__"):
+
+        if spark is not None and hasattr(func, "__name__") and is_debugging_enabled():
             if is_remote():
                 global current_origin
 
@@ -313,10 +314,7 @@ def with_origin_to_class(
         return lambda cls: with_origin_to_class(cls, ignores)
     else:
         cls = cls_or_ignores
-        if (
-            os.environ.get("PYSPARK_PIN_THREAD", "true").lower() == "true"
-            and is_debugging_enabled()
-        ):
+        if os.environ.get("PYSPARK_PIN_THREAD", "true").lower() == "true":
             skipping = set(
                 ["__init__", "__new__", "__iter__", "__nonzero__", "__repr__", "__bool__"]
                 + (ignores or [])


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a retry of https://github.com/apache/spark/pull/49054 that avoids hacky monkey patch.

### Why are the changes needed?

- This disables DataFrameQueryContext for `pyspark.sql.functions` too
- It avoids circular import in pyspark-connect package.

### Does this PR introduce _any_ user-facing change?

Yes, after this followup, `spark.python.sql.dataFrameDebugging.enabled` also works with `pyspark.sql.functions.*`.

### How was this patch tested?

Manually ran profilers:

```python
import cProfile

from pyspark.sql.functions import col


def foo():
    for _ in range(1000):
        col("id")


cProfile.run('foo()', sort='tottime')
```

### Was this patch authored or co-authored using generative AI tooling?

No.