### PR TITLE
[SPARK-50685][PYTHON] Improve Py4J performance by leveraging getattr

### DIFF
--- a/python/pyspark/core/context.py
+++ b/python/pyspark/core/context.py
@@ -362,10 +362,14 @@ class SparkContext:
 
         # Create a temporary directory inside spark.local.dir:
         assert self._jvm is not None
-        local_dir = self._jvm.org.apache.spark.util.Utils.getLocalDir(self._jsc.sc().conf())
-        self._temp_dir = self._jvm.org.apache.spark.util.Utils.createTempDir(
-            local_dir, "pyspark"
-        ).getAbsolutePath()
+        local_dir = getattr(self._jvm, "org.apache.spark.util.Utils").getLocalDir(
+            self._jsc.sc().conf()
+        )
+        self._temp_dir = (
+            getattr(self._jvm, "org.apache.spark.util.Utils")
+            .createTempDir(local_dir, "pyspark")
+            .getAbsolutePath()
+        )
 
         # profiling stats collected for each PythonRDD
         if (
@@ -1740,9 +1744,9 @@ class SparkContext:
         assert gw is not None
         jvm = SparkContext._jvm
         assert jvm is not None
-        jrdd_cls = jvm.org.apache.spark.api.java.JavaRDD
-        jpair_rdd_cls = jvm.org.apache.spark.api.java.JavaPairRDD
-        jdouble_rdd_cls = jvm.org.apache.spark.api.java.JavaDoubleRDD
+        jrdd_cls = getattr(jvm, "org.apache.spark.api.java.JavaRDD")
+        jpair_rdd_cls = getattr(jvm, "org.apache.spark.api.java.JavaPairRDD")
+        jdouble_rdd_cls = getattr(jvm, "org.apache.spark.api.java.JavaDoubleRDD")
         if is_instance_of(gw, rdds[0]._jrdd, jrdd_cls):
             cls = jrdd_cls
         elif is_instance_of(gw, rdds[0]._jrdd, jpair_rdd_cls):
@@ -2111,7 +2115,7 @@ class SparkContext:
         if not isinstance(storageLevel, StorageLevel):
             raise TypeError("storageLevel must be of type pyspark.StorageLevel")
         assert self._jvm is not None
-        newStorageLevel = self._jvm.org.apache.spark.storage.StorageLevel
+        newStorageLevel = getattr(self._jvm, "org.apache.spark.storage.StorageLevel")
         return newStorageLevel(
             storageLevel.useDisk,
             storageLevel.useMemory,

--- a/python/pyspark/core/files.py
+++ b/python/pyspark/core/files.py
@@ -145,7 +145,7 @@ class SparkFiles:
             # This will have to change if we support multiple SparkContexts:
             assert cls._sc is not None
             assert cls._sc._jvm is not None
-            return cls._sc._jvm.org.apache.spark.SparkFiles.getRootDirectory()
+            return getattr(cls._sc._jvm, "org.apache.spark.SparkFiles").getRootDirectory()
 
 
 def _test() -> None:

--- a/python/pyspark/core/rdd.py
+++ b/python/pyspark/core/rdd.py
@@ -5044,7 +5044,7 @@ class RDD(Generic[T_co]):
         else:
             assert self.ctx._jvm is not None
 
-            builder = self.ctx._jvm.org.apache.spark.resource.ResourceProfileBuilder()
+            builder = getattr(self.ctx._jvm, "org.apache.spark.resource.ResourceProfileBuilder")()
             ereqs = ExecutorResourceRequests(self.ctx._jvm, profile._executor_resource_requests)
             treqs = TaskResourceRequests(self.ctx._jvm, profile._task_resource_requests)
             builder.require(ereqs._java_executor_resource_requests)

--- a/python/pyspark/errors/exceptions/captured.py
+++ b/python/pyspark/errors/exceptions/captured.py
@@ -67,7 +67,7 @@ class CapturedException(PySparkException):
         self._stackTrace = (
             stackTrace
             if stackTrace is not None
-            else (SparkContext._jvm.org.apache.spark.util.Utils.exceptionString(origin))
+            else (getattr(SparkContext._jvm, "org.apache.spark.util.Utils").exceptionString(origin))
         )
         self._cause = convert_exception(cause) if cause is not None else None
         if self._cause is None and origin is not None and origin.getCause() is not None:
@@ -85,7 +85,7 @@ class CapturedException(PySparkException):
         # SPARK-42752: default to True to see issues with initialization
         debug_enabled = True
         try:
-            sql_conf = jvm.org.apache.spark.sql.internal.SQLConf.get()
+            sql_conf = getattr(jvm, "org.apache.spark.sql.internal.SQLConf").get()
             debug_enabled = sql_conf.pysparkJVMStacktraceEnabled()
         except BaseException:
             pass
@@ -149,7 +149,7 @@ class CapturedException(PySparkException):
             errorClass = self._origin.getErrorClass()
             messageParameters = self._origin.getMessageParameters()
 
-            error_message = gw.jvm.org.apache.spark.SparkThrowableHelper.getMessage(
+            error_message = getattr(gw.jvm, "org.apache.spark.SparkThrowableHelper").getMessage(
                 errorClass, messageParameters
             )
 
@@ -220,7 +220,7 @@ def convert_exception(e: "Py4JJavaError") -> CapturedException:
         return SparkNoSuchElementException(origin=e)
 
     c: "Py4JJavaError" = e.getCause()
-    stacktrace: str = jvm.org.apache.spark.util.Utils.exceptionString(e)
+    stacktrace: str = getattr(jvm, "org.apache.spark.util.Utils").exceptionString(e)
     if c is not None and (
         is_instance_of(gw, c, "org.apache.spark.api.python.PythonException")
         # To make sure this only catches Python UDFs.

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -3788,7 +3788,8 @@ class OneVsRestModel(
         assert sc is not None and sc._gateway is not None
 
         java_models_array = JavaWrapper._new_java_array(
-            java_models, sc._gateway.jvm.org.apache.spark.ml.classification.ClassificationModel
+            java_models,
+            getattr(sc._gateway.jvm, "org.apache.spark.ml.classification.ClassificationModel"),
         )
         # TODO: need to set metadata
         metadata = JavaParams._new_java_obj("org.apache.spark.sql.types.Metadata")
@@ -3928,7 +3929,8 @@ class OneVsRestModel(
 
         java_models = [cast(_JavaClassificationModel, model)._to_java() for model in self.models]
         java_models_array = JavaWrapper._new_java_array(
-            java_models, sc._gateway.jvm.org.apache.spark.ml.classification.ClassificationModel
+            java_models,
+            getattr(sc._gateway.jvm, "org.apache.spark.ml.classification.ClassificationModel"),
         )
         metadata = JavaParams._new_java_obj("org.apache.spark.sql.types.Metadata")
         _java_obj = JavaParams._new_java_obj(

--- a/python/pyspark/ml/common.py
+++ b/python/pyspark/ml/common.py
@@ -74,7 +74,7 @@ def _to_java_object_rdd(rdd: "RDD") -> "JavaObject":
     """
     rdd = rdd._reserialize(AutoBatchedSerializer(CPickleSerializer()))
     assert rdd.ctx._jvm is not None
-    return rdd.ctx._jvm.org.apache.spark.ml.python.MLSerDe.pythonToJava(rdd._jrdd, True)
+    return getattr(rdd.ctx._jvm, "org.apache.spark.ml.python.MLSerDe").pythonToJava(rdd._jrdd, True)
 
 
 def _py2java(sc: "SparkContext", obj: Any) -> "JavaObject":
@@ -98,7 +98,7 @@ def _py2java(sc: "SparkContext", obj: Any) -> "JavaObject":
     else:
         data = bytearray(CPickleSerializer().dumps(obj))
         assert sc._jvm is not None
-        obj = sc._jvm.org.apache.spark.ml.python.MLSerDe.loads(data)
+        obj = getattr(sc._jvm, "org.apache.spark.ml.python.MLSerDe").loads(data)
     return obj
 
 
@@ -117,17 +117,17 @@ def _java2py(sc: "SparkContext", r: "JavaObjectOrPickleDump", encoding: str = "b
         assert sc._jvm is not None
 
         if clsName == "JavaRDD":
-            jrdd = sc._jvm.org.apache.spark.ml.python.MLSerDe.javaToPython(r)
+            jrdd = getattr(sc._jvm, "org.apache.spark.ml.python.MLSerDe").javaToPython(r)
             return RDD(jrdd, sc)
 
         if clsName == "Dataset":
             return DataFrame(r, SparkSession._getActiveSessionOrCreate())
 
         if clsName in _picklable_classes:
-            r = sc._jvm.org.apache.spark.ml.python.MLSerDe.dumps(r)
+            r = getattr(sc._jvm, "org.apache.spark.ml.python.MLSerDe").dumps(r)
         elif isinstance(r, (JavaArray, JavaList)):
             try:
-                r = sc._jvm.org.apache.spark.ml.python.MLSerDe.dumps(r)
+                r = getattr(sc._jvm, "org.apache.spark.ml.python.MLSerDe").dumps(r)
             except Py4JJavaError:
                 pass  # not picklable
 

--- a/python/pyspark/ml/connect/io_utils.py
+++ b/python/pyspark/ml/connect/io_utils.py
@@ -38,7 +38,9 @@ def _copy_file_from_local_to_fs(local_path: str, dest_path: str) -> None:
         session.copyFromLocalToFs(local_path, dest_path)
     else:
         jvm = session.sparkContext._gateway.jvm  # type: ignore[union-attr]
-        jvm.org.apache.spark.ml.python.MLUtil.copyFileFromLocalToFs(local_path, dest_path)
+        getattr(jvm, "org.apache.spark.ml.python.MLUtil").copyFileFromLocalToFs(
+            local_path, dest_path
+        )
 
 
 def _copy_dir_from_local_to_fs(local_path: str, dest_path: str) -> None:

--- a/python/pyspark/ml/functions.py
+++ b/python/pyspark/ml/functions.py
@@ -121,7 +121,9 @@ def vector_to_array(col: Column, dtype: str = "float64") -> Column:
     sc = SparkContext._active_spark_context
     assert sc is not None and sc._jvm is not None
     return Column(
-        sc._jvm.org.apache.spark.ml.functions.vector_to_array(_to_java_column(col), dtype)
+        getattr(sc._jvm, "org.apache.spark.ml.functions").vector_to_array(
+            _to_java_column(col), dtype
+        )
     )
 
 
@@ -164,7 +166,9 @@ def array_to_vector(col: Column) -> Column:
 
     sc = SparkContext._active_spark_context
     assert sc is not None and sc._jvm is not None
-    return Column(sc._jvm.org.apache.spark.ml.functions.array_to_vector(_to_java_column(col)))
+    return Column(
+        getattr(sc._jvm, "org.apache.spark.ml.functions").array_to_vector(_to_java_column(col))
+    )
 
 
 def _batched(

--- a/python/pyspark/ml/image.py
+++ b/python/pyspark/ml/image.py
@@ -60,7 +60,7 @@ class _ImageSchema:
 
         ctx = SparkContext._active_spark_context
         assert ctx is not None and ctx._jvm is not None
-        jschema = ctx._jvm.org.apache.spark.ml.image.ImageSchema.imageSchema()
+        jschema = getattr(ctx._jvm, "org.apache.spark.ml.image.ImageSchema").imageSchema()
         return cast(StructType, _parse_datatype_json_string(jschema.json()))
 
     @cached_property
@@ -79,7 +79,7 @@ class _ImageSchema:
 
         ctx = SparkContext._active_spark_context
         assert ctx is not None and ctx._jvm is not None
-        return dict(ctx._jvm.org.apache.spark.ml.image.ImageSchema.javaOcvTypes())
+        return dict(getattr(ctx._jvm, "org.apache.spark.ml.image.ImageSchema").javaOcvTypes())
 
     @cached_property
     def columnSchema(self) -> StructType:
@@ -98,7 +98,7 @@ class _ImageSchema:
 
         ctx = SparkContext._active_spark_context
         assert ctx is not None and ctx._jvm is not None
-        jschema = ctx._jvm.org.apache.spark.ml.image.ImageSchema.columnSchema()
+        jschema = getattr(ctx._jvm, "org.apache.spark.ml.image.ImageSchema").columnSchema()
         return cast(StructType, _parse_datatype_json_string(jschema.json()))
 
     @cached_property
@@ -117,7 +117,7 @@ class _ImageSchema:
 
         ctx = SparkContext._active_spark_context
         assert ctx is not None and ctx._jvm is not None
-        return list(ctx._jvm.org.apache.spark.ml.image.ImageSchema.imageFields())
+        return list(getattr(ctx._jvm, "org.apache.spark.ml.image.ImageSchema").imageFields())
 
     @cached_property
     def undefinedImageType(self) -> str:
@@ -130,7 +130,7 @@ class _ImageSchema:
 
         ctx = SparkContext._active_spark_context
         assert ctx is not None and ctx._jvm is not None
-        return ctx._jvm.org.apache.spark.ml.image.ImageSchema.undefinedImageType()
+        return getattr(ctx._jvm, "org.apache.spark.ml.image.ImageSchema").undefinedImageType()
 
     def toNDArray(self, image: Row) -> np.ndarray:
         """

--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -207,7 +207,7 @@ class Pipeline(Estimator["PipelineModel"], MLReadable["Pipeline"], MLWritable):
         gateway = SparkContext._gateway
         assert gateway is not None and SparkContext._jvm is not None
 
-        cls = SparkContext._jvm.org.apache.spark.ml.PipelineStage
+        cls = getattr(SparkContext._jvm, "org.apache.spark.ml.PipelineStage")
         java_stages = gateway.new_array(cls, len(self.getStages()))
         for idx, stage in enumerate(self.getStages()):
             java_stages[idx] = cast(JavaParams, stage)._to_java()
@@ -361,7 +361,7 @@ class PipelineModel(Model, MLReadable["PipelineModel"], MLWritable):
         gateway = SparkContext._gateway
         assert gateway is not None and SparkContext._jvm is not None
 
-        cls = SparkContext._jvm.org.apache.spark.ml.Transformer
+        cls = getattr(SparkContext._jvm, "org.apache.spark.ml.Transformer")
         java_stages = gateway.new_array(cls, len(self.stages))
         for idx, stage in enumerate(self.stages):
             java_stages[idx] = cast(JavaParams, stage)._to_java()

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -278,7 +278,7 @@ class _ValidatorParams(HasSeed):
         gateway = SparkContext._gateway
         assert gateway is not None and SparkContext._jvm is not None
 
-        cls = SparkContext._jvm.org.apache.spark.ml.param.ParamMap
+        cls = getattr(SparkContext._jvm, "org.apache.spark.ml.param.ParamMap")
 
         estimator = self.getEstimator()
         if isinstance(estimator, JavaEstimator):
@@ -313,7 +313,7 @@ class _ValidatorSharedReadWrite:
             sc is not None and SparkContext._jvm is not None and SparkContext._gateway is not None
         )
 
-        paramMapCls = SparkContext._jvm.org.apache.spark.ml.param.ParamMap
+        paramMapCls = getattr(SparkContext._jvm, "org.apache.spark.ml.param.ParamMap")
         javaParamMaps = SparkContext._gateway.new_array(paramMapCls, len(pyParamMaps))
 
         for idx, pyParamMap in enumerate(pyParamMaps):

--- a/python/pyspark/resource/profile.py
+++ b/python/pyspark/resource/profile.py
@@ -211,9 +211,9 @@ class ResourceProfileBuilder:
 
         if _jvm is not None:
             self._jvm = _jvm
-            self._java_resource_profile_builder = (
-                _jvm.org.apache.spark.resource.ResourceProfileBuilder()
-            )
+            self._java_resource_profile_builder = getattr(
+                _jvm, "org.apache.spark.resource.ResourceProfileBuilder"
+            )()
         else:
             self._jvm = None
             self._java_resource_profile_builder = None

--- a/python/pyspark/sql/classic/column.py
+++ b/python/pyspark/sql/classic/column.py
@@ -522,7 +522,9 @@ class Column(ParentColumn):
         if len(alias) == 1:
             if metadata:
                 assert sc._jvm is not None
-                jmeta = sc._jvm.org.apache.spark.sql.types.Metadata.fromJson(json.dumps(metadata))
+                jmeta = getattr(sc._jvm, "org.apache.spark.sql.types.Metadata").fromJson(
+                    json.dumps(metadata)
+                )
                 return Column(getattr(self._jc, "as")(alias[0], jmeta))
             else:
                 return Column(getattr(self._jc, "as")(alias[0]))

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -329,8 +329,8 @@ class DefaultChannelBuilder(ChannelBuilder):
                 jvm = PySparkSession._instantiatedSession._jvm  # type: ignore[union-attr]
                 return getattr(
                     getattr(
-                        jvm.org.apache.spark.sql.connect.service,  # type: ignore[union-attr]
-                        "SparkConnectService$",
+                        jvm,
+                        "org.apache.spark.sql.connect.service.SparkConnectService$",
                     ),
                     "MODULE$",
                 ).localPort()

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -822,9 +822,9 @@ class DataSourceRegistration:
         wrapped = _wrap_function(sc, dataSource)
         assert sc._jvm is not None
         jvm = sc._jvm
-        ds = jvm.org.apache.spark.sql.execution.datasources.v2.python.UserDefinedPythonDataSource(
-            wrapped
-        )
+        ds = getattr(
+            jvm, "org.apache.spark.sql.execution.datasources.v2.python.UserDefinedPythonDataSource"
+        )(wrapped)
         self.sparkSession._jsparkSession.dataSource().registerPython(name, ds)
 
 

--- a/python/pyspark/sql/observation.py
+++ b/python/pyspark/sql/observation.py
@@ -122,7 +122,7 @@ class Observation:
 
         self._jvm = df._sc._jvm
         assert self._jvm is not None
-        cls = self._jvm.org.apache.spark.sql.Observation
+        cls = getattr(self._jvm, "org.apache.spark.sql.Observation")
         self._jo = cls(self._name) if self._name is not None else cls()
         observed_df = df._jdf.observe(
             self._jo, exprs[0]._jc, _to_seq(df._sc, [c._jc for c in exprs[1:]])

--- a/python/pyspark/sql/pandas/map_ops.py
+++ b/python/pyspark/sql/pandas/map_ops.py
@@ -94,7 +94,7 @@ class PandasMapOpsMixin:
                 jvm = self.sparkSession.sparkContext._jvm
                 assert jvm is not None
 
-                builder = jvm.org.apache.spark.resource.ResourceProfileBuilder()
+                builder = getattr(jvm, "org.apache.spark.resource.ResourceProfileBuilder")()
                 ereqs = ExecutorResourceRequests(jvm, profile._executor_resource_requests)
                 treqs = TaskResourceRequests(jvm, profile._task_resource_requests)
                 builder.require(ereqs._java_executor_resource_requests)

--- a/python/pyspark/sql/streaming/readwriter.py
+++ b/python/pyspark/sql/streaming/readwriter.py
@@ -1317,9 +1317,9 @@ class DataStreamWriter:
                     },
                 )
             interval = processingTime.strip()
-            jTrigger = self._spark._sc._jvm.org.apache.spark.sql.streaming.Trigger.ProcessingTime(
-                interval
-            )
+            jTrigger = getattr(
+                self._spark._sc._jvm, "org.apache.spark.sql.streaming.Trigger.ProcessingTime"
+            )(interval)
 
         elif once is not None:
             if once is not True:
@@ -1328,7 +1328,9 @@ class DataStreamWriter:
                     messageParameters={"arg_name": "once", "arg_value": str(once)},
                 )
 
-            jTrigger = self._spark._sc._jvm.org.apache.spark.sql.streaming.Trigger.Once()
+            jTrigger = getattr(
+                self._spark._sc._jvm, "org.apache.spark.sql.streaming.Trigger.Once"
+            )()
 
         elif continuous is not None:
             if type(continuous) != str or len(continuous.strip()) == 0:
@@ -1337,16 +1339,18 @@ class DataStreamWriter:
                     messageParameters={"arg_name": "continuous", "arg_value": str(continuous)},
                 )
             interval = continuous.strip()
-            jTrigger = self._spark._sc._jvm.org.apache.spark.sql.streaming.Trigger.Continuous(
-                interval
-            )
+            jTrigger = getattr(
+                self._spark._sc._jvm, "org.apache.spark.sql.streaming.Trigger.Continuous"
+            )(interval)
         else:
             if availableNow is not True:
                 raise PySparkValueError(
                     errorClass="VALUE_NOT_TRUE",
                     messageParameters={"arg_name": "availableNow", "arg_value": str(availableNow)},
                 )
-            jTrigger = self._spark._sc._jvm.org.apache.spark.sql.streaming.Trigger.AvailableNow()
+            jTrigger = getattr(
+                self._spark._sc._jvm, "org.apache.spark.sql.streaming.Trigger.AvailableNow"
+            )()
 
         self._jwrite = self._jwrite.trigger(jTrigger)
         return self
@@ -1557,11 +1561,9 @@ class DataStreamWriter:
         serializer = AutoBatchedSerializer(CPickleSerializer())
         wrapped_func = _wrap_function(self._spark._sc, func, serializer, serializer)
         assert self._spark._sc._jvm is not None
-        jForeachWriter = (
-            self._spark._sc._jvm.org.apache.spark.sql.execution.python.PythonForeachWriter(
-                wrapped_func, self._df._jdf.schema()
-            )
-        )
+        jForeachWriter = getattr(
+            self._spark._sc._jvm, "org.apache.spark.sql.execution.python.PythonForeachWriter"
+        )(wrapped_func, self._df._jdf.schema())
         self._jwrite.foreach(jForeachWriter)
         return self
 

--- a/python/pyspark/sql/streaming/readwriter.py
+++ b/python/pyspark/sql/streaming/readwriter.py
@@ -1318,8 +1318,8 @@ class DataStreamWriter:
                 )
             interval = processingTime.strip()
             jTrigger = getattr(
-                self._spark._sc._jvm, "org.apache.spark.sql.streaming.Trigger.ProcessingTime"
-            )(interval)
+                self._spark._sc._jvm, "org.apache.spark.sql.streaming.Trigger"
+            ).ProcessingTime(interval)
 
         elif once is not None:
             if once is not True:
@@ -1329,8 +1329,8 @@ class DataStreamWriter:
                 )
 
             jTrigger = getattr(
-                self._spark._sc._jvm, "org.apache.spark.sql.streaming.Trigger.Once"
-            )()
+                self._spark._sc._jvm, "org.apache.spark.sql.streaming.Trigger"
+            ).Once()
 
         elif continuous is not None:
             if type(continuous) != str or len(continuous.strip()) == 0:
@@ -1340,8 +1340,8 @@ class DataStreamWriter:
                 )
             interval = continuous.strip()
             jTrigger = getattr(
-                self._spark._sc._jvm, "org.apache.spark.sql.streaming.Trigger.Continuous"
-            )(interval)
+                self._spark._sc._jvm, "org.apache.spark.sql.streaming.Trigger"
+            ).Continuous(interval)
         else:
             if availableNow is not True:
                 raise PySparkValueError(
@@ -1349,8 +1349,8 @@ class DataStreamWriter:
                     messageParameters={"arg_name": "availableNow", "arg_value": str(availableNow)},
                 )
             jTrigger = getattr(
-                self._spark._sc._jvm, "org.apache.spark.sql.streaming.Trigger.AvailableNow"
-            )()
+                self._spark._sc._jvm, "org.apache.spark.sql.streaming.Trigger"
+            ).AvailableNow()
 
         self._jwrite = self._jwrite.trigger(jTrigger)
         return self

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -391,7 +391,7 @@ class UserDefinedFunction:
         wrapped_func = _wrap_function(sc, func, self.returnType)
         jdt = spark._jsparkSession.parseDataType(self.returnType.json())
         assert sc._jvm is not None
-        judf = sc._jvm.org.apache.spark.sql.execution.python.UserDefinedPythonFunction(
+        judf = getattr(sc._jvm, "org.apache.spark.sql.execution.python.UserDefinedPythonFunction")(
             self._name, wrapped_func, jdt, self.evalType, self.deterministic
         )
         return judf

--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -362,14 +362,14 @@ class UserDefinedTableFunction:
 
         assert sc._jvm is not None
         if self.returnType is None:
-            judtf = sc._jvm.org.apache.spark.sql.execution.python.UserDefinedPythonTableFunction(
-                self._name, wrapped_func, self.evalType, self.deterministic
-            )
+            judtf = getattr(
+                sc._jvm, "org.apache.spark.sql.execution.python.UserDefinedPythonTableFunction"
+            )(self._name, wrapped_func, self.evalType, self.deterministic)
         else:
             jdt = spark._jsparkSession.parseDataType(self.returnType.json())
-            judtf = sc._jvm.org.apache.spark.sql.execution.python.UserDefinedPythonTableFunction(
-                self._name, wrapped_func, jdt, self.evalType, self.deterministic
-            )
+            judtf = getattr(
+                sc._jvm, "org.apache.spark.sql.execution.python.UserDefinedPythonTableFunction"
+            )(self._name, wrapped_func, jdt, self.evalType, self.deterministic)
         return judtf
 
     def __call__(self, *args: "ColumnOrName", **kwargs: "ColumnOrName") -> "DataFrame":


### PR DESCRIPTION
### What changes were proposed in this pull request?

This Pr proposes to improve Py4J performance by leveraging `getattr`, see also https://github.com/apache/spark/pull/46809

This PR fixes Core, SQL, ML and Structured Streaming. Tests codes, MLLib and DStream are not affected.

### Why are the changes needed?

To reduce the overhead of Py4J calls.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually tested as demonstrated in https://github.com/apache/spark/pull/49312

### Was this patch authored or co-authored using generative AI tooling?

No.
