### PR TITLE
[MINOR][DOCS] Fix miss semicolon on describe sql example

### DIFF
--- a/docs/sql-ref-syntax-aux-describe-function.md
+++ b/docs/sql-ref-syntax-aux-describe-function.md
@@ -85,7 +85,7 @@ DESC FUNCTION max;
 
 -- Describe a builtin user defined aggregate function
 -- Returns function name, implementing class and usage and examples.
-DESC FUNCTION EXTENDED explode
+DESC FUNCTION EXTENDED explode;
 +---------------------------------------------------------------+
 |function_desc                                                  |
 +---------------------------------------------------------------+


### PR DESCRIPTION
### What changes were proposed in this pull request?
 
fix miss semicolon on describe SQL example

### Why are the changes needed?
 
describe SQL example miss semicolon


### Does this PR introduce _any_ user-facing change?

Yes. the patch fix docs miss semicolon SQL.


### How was this patch tested?

Manually by inspecting generated docs.


### Was this patch authored or co-authored using generative AI tooling?

No.