### PR TITLE
[SPARK-48665][PYTHON][CONNECT] Support providing a dict in pyspark lit to create a map. 

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -159,14 +159,14 @@
       "Calling property or member '<member>' is not supported in PySpark Classic, please use Spark Connect instead."
     ]
   },
-  "COLUMN_IN_DICT" : {
-    "message": [
-      "`<func_name>` does not allow a Column in a dict."
-    ]
-  },
   "COLLATION_INVALID_PROVIDER" : {
     "message" : [
       "The value <provider> does not represent a correct collation provider. Supported providers are: [<supportedProviders>]."
+    ]
+  },
+  "COLUMN_IN_DICT" : {
+    "message": [
+      "`<func_name>` does not allow a Column in a dict."
     ]
   },
   "COLUMN_IN_LIST": {

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -154,14 +154,14 @@
       "Cannot <condition1> without <condition2>."
     ]
   },
-  "COLUMN_IN_DICT" : {
-    "message": [
-      "`<func_name>` does not allow a Column in a dict."
-    ]
-  },
   "CLASSIC_OPERATION_NOT_SUPPORTED_ON_DF": {
     "message": [
       "Calling property or member '<member>' is not supported in PySpark Classic, please use Spark Connect instead."
+    ]
+  },
+  "COLUMN_IN_DICT" : {
+    "message": [
+      "`<func_name>` does not allow a Column in a dict."
     ]
   },
   "COLLATION_INVALID_PROVIDER" : {

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -154,6 +154,11 @@
       "Cannot <condition1> without <condition2>."
     ]
   },
+  "COLUMN_IN_DICT" : {
+    "message": [
+      "`<func_name>` does not allow a Column in a dict."
+    ]
+  },
   "CLASSIC_OPERATION_NOT_SUPPORTED_ON_DF": {
     "message": [
       "Calling property or member '<member>' is not supported in PySpark Classic, please use Spark Connect instead."

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -285,8 +285,13 @@ def lit(col: Any) -> Column:
                 errorClass="COLUMN_IN_DICT", messageParameters={"func_name": "lit"}
             )
         from pyspark.sql import SparkSession
+
         spark = SparkSession.getActiveSession()
-        dict_as_struct = spark.conf.get("spark.sql.pyspark.inferNestedDictAsStruct.enabled") if spark else "false"
+        dict_as_struct = (
+            spark.conf.get("spark.sql.pyspark.inferNestedDictAsStruct.enabled")
+            if spark
+            else "false"
+        )
         if dict_as_struct and dict_as_struct.lower() == "true":
             return struct(*[lit(value).alias(key) for key, value in col.items()])
         else:

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -72,7 +72,6 @@ from pyspark.sql.types import (
 )
 from pyspark.sql.utils import (
     enum_to_value as _enum_to_value,
-    get_active_spark_context as _get_active_spark_context,
 )
 
 # The implementation of pandas_udf is embedded in pyspark.sql.function.pandas_udf

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -285,9 +285,11 @@ def lit(col: Any) -> Column:
             raise PySparkValueError(
                 errorClass="COLUMN_IN_DICT", messageParameters={"func_name": "lit"}
             )
-        sc = _get_active_spark_context()
-        dict_as_struct = bool(sc._conf.get("spark.sql.pyspark.inferNestedDictAsStruct"))
-        if dict_as_struct:
+        from pyspark.sql import SparkSession
+
+        spark = SparkSession.getActiveSession()
+        dict_as_struct = spark.conf.get("spark.sql.pyspark.inferNestedDictAsStruct.enabled")
+        if dict_as_struct.lower() == "true":
             return struct(*[lit(value).alias(key) for key, value in col.items()])
         else:
             return create_map(*[lit(x) for x in chain(*col.items())])

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -260,6 +260,7 @@ column = col
 def lit(col: Any) -> Column:
     from pyspark.sql.connect.column import Column as ConnectColumn
     from itertools import chain
+
     if isinstance(col, Column):
         return col
     elif isinstance(col, list):

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -257,7 +257,7 @@ col.__doc__ = pysparkfuncs.col.__doc__
 column = col
 
 
-def lit(col: Any) -> Column:
+def lit(col: Any, to_struct: bool = False) -> Column:
     from pyspark.sql.connect.column import Column as ConnectColumn
     from itertools import chain
 
@@ -282,7 +282,11 @@ def lit(col: Any) -> Column:
             raise PySparkValueError(
                 errorClass="COLUMN_IN_DICT", messageParameters={"func_name": "lit"}
             )
-        return create_map(*[lit(x) for x in chain(*col.items())])
+        # Convert to struct or map based on the parameter `to_struct`
+        if to_struct:
+            return struct(*[lit(value).alias(key) for key, value in col.items()])
+        else:
+            return create_map(*[lit(x) for x in chain(*col.items())])
     return ConnectColumn(LiteralExpression._from_value(col))
 
 

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -285,10 +285,9 @@ def lit(col: Any) -> Column:
                 errorClass="COLUMN_IN_DICT", messageParameters={"func_name": "lit"}
             )
         from pyspark.sql import SparkSession
-
         spark = SparkSession.getActiveSession()
-        dict_as_struct = spark.conf.get("spark.sql.pyspark.inferNestedDictAsStruct.enabled")
-        if dict_as_struct.lower() == "true":
+        dict_as_struct = spark.conf.get("spark.sql.pyspark.inferNestedDictAsStruct.enabled") if spark else "false"
+        if dict_as_struct and dict_as_struct.lower() == "true":
             return struct(*[lit(value).alias(key) for key, value in col.items()])
         else:
             return create_map(*[lit(x) for x in chain(*col.items())])

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -72,6 +72,7 @@ from pyspark.sql.types import (
 )
 from pyspark.sql.utils import (
     enum_to_value as _enum_to_value,
+    get_conf as _get_conf,
 )
 
 # The implementation of pandas_udf is embedded in pyspark.sql.function.pandas_udf
@@ -284,14 +285,7 @@ def lit(col: Any) -> Column:
             raise PySparkValueError(
                 errorClass="COLUMN_IN_DICT", messageParameters={"func_name": "lit"}
             )
-        from pyspark.sql import SparkSession
-
-        spark = SparkSession.getActiveSession()
-        dict_as_struct = (
-            spark.conf.get("spark.sql.pyspark.inferNestedDictAsStruct.enabled")
-            if spark
-            else "false"
-        )
+        dict_as_struct = _get_conf("spark.sql.pyspark.inferNestedDictAsStruct.enabled")
         if dict_as_struct and dict_as_struct.lower() == "true":
             return struct(*[lit(value).alias(key) for key, value in col.items()])
         else:

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -260,13 +260,14 @@ def lit(col: Any) -> Column:
 
     >>> import pyspark.sql.functions as sf
     >>> spark.range(1).select(
-    >>>    sf.lit({"a": 1, "b": 2}).alias("map_col")
-    >>> ).show()
+    ...    sf.lit({"a": 1, "b": 2}).alias("map_col")
+    ... ).show() # doctest: +SKIP
     +----------------+
     |         map_col|
     +----------------+
     |{a -> 1, b -> 2}|
     +----------------+
+
     """
     if isinstance(col, Column):
         return col

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -297,9 +297,11 @@ def lit(col: Any) -> Column:
             raise PySparkValueError(
                 errorClass="COLUMN_IN_DICT", messageParameters={"func_name": "lit"}
             )
-        sc = _get_active_spark_context()
-        dict_as_struct = bool(sc._conf.get("spark.sql.pyspark.inferNestedDictAsStruct"))
-        if dict_as_struct:
+        from pyspark.sql import SparkSession
+
+        spark = SparkSession.getActiveSession()
+        dict_as_struct = spark.conf.get("spark.sql.pyspark.inferNestedDictAsStruct.enabled")
+        if dict_as_struct.lower() == "true":
             return struct(*[lit(value).alias(key) for key, value in col.items()])
         else:
             return create_map(*[lit(x) for x in chain(*col.items())])

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -39,7 +39,6 @@ from typing import (
     ValuesView,
 )
 from itertools import chain
-from functools import lru_cache
 from pyspark.errors import PySparkTypeError, PySparkValueError
 from pyspark.errors.utils import _with_origin
 from pyspark.sql.column import Column

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -165,8 +165,8 @@ def lit(col: Any) -> Column:
 
     Parameters
     ----------
-    col : :class:`~pyspark.sql.Column`, str, int, float, bool or list, NumPy literals, ndarray or dict.
-        the value to make it as a PySpark literal. If a column is passed,
+    col : :class:`~pyspark.sql.Column`, str, int, float, bool or list, NumPy literals, ndarray
+        or dict. the value to make it as a PySpark literal. If a column is passed,
         it returns the column as is.
 
         .. versionchanged:: 4.0.0

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -255,7 +255,7 @@ def lit(col: Any) -> Column:
     +------------------+-------+-----------------+--------------------+
     |     [true, false]|     []|       [1.5, 0.1]|           [a, b, c]|
     +------------------+-------+-----------------+--------------------+
-    
+
     Example 7: Creating a literal column from a dict.
 
     >>> import pyspark.sql.functions as sf
@@ -275,13 +275,13 @@ def lit(col: Any) -> Column:
             )
         return array(*[lit(item) for item in col])
     elif isinstance(col, dict):
-         # Skip checking if the keys are column as Columns are not hashable
-         # and cannot be used as dict keys in the first place.
-         if any(isinstance(value, Column) for value in col.values()):
-             raise PySparkValueError(
-                 errorClass="COLUMN_IN_DICT", messageParameters={"func_name": "lit"}
-             )
-         return create_map(*[lit(x) for x in chain(*col.items())])
+        # Skip checking if the keys are column as Columns are not hashable
+        # and cannot be used as dict keys in the first place.
+        if any(isinstance(value, Column) for value in col.values()):
+            raise PySparkValueError(
+                errorClass="COLUMN_IN_DICT", messageParameters={"func_name": "lit"}
+            )
+        return create_map(*[lit(x) for x in chain(*col.items())])
     elif _has_numpy:
         if isinstance(col, np.generic):
             dt = _from_numpy_type(col.dtype)

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -259,7 +259,9 @@ def lit(col: Any) -> Column:
     Example 7: Creating a literal column from a dict.
 
     >>> import pyspark.sql.functions as sf
-    >>> spark.range(1).select(sf.lit({"a": 1, "b": 2}).alias("map_col")).show()
+    >>> spark.range(1).select(
+    >>>    sf.lit({"a": 1, "b": 2}).alias("map_col")
+    >>> ).show()
     +----------------+
     |         map_col|
     +----------------+

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -168,7 +168,7 @@ def lit(col: Any, to_struct: bool = False) -> Column:
     col : :class:`~pyspark.sql.Column`, str, int, float, bool or list, NumPy literals, ndarray
         or dict. the value to make it as a PySpark literal. If a column is passed,
         it returns the column as is.
-        
+
     to_struct: bool, optional, default False
         If True, the column will be converted to a struct column. If False, the column will be
         converted to a map column. Default is False. only has an effect when col is a dict.
@@ -271,7 +271,7 @@ def lit(col: Any, to_struct: bool = False) -> Column:
     +----------------+
     |{a -> 1, b -> 2}|
     +----------------+
-    
+
     Example 8: Creating a literal column as a struct from a dict.
 
     >>> import pyspark.sql.functions as sf

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -300,7 +300,11 @@ def lit(col: Any) -> Column:
         from pyspark.sql import SparkSession
 
         spark = SparkSession.getActiveSession()
-        dict_as_struct = spark.conf.get("spark.sql.pyspark.inferNestedDictAsStruct.enabled") if spark else "false"
+        dict_as_struct = (
+            spark.conf.get("spark.sql.pyspark.inferNestedDictAsStruct.enabled")
+            if spark
+            else "false"
+        )
         if dict_as_struct and dict_as_struct.lower() == "true":
             return struct(*[lit(value).alias(key) for key, value in col.items()])
         else:

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -154,7 +154,7 @@ def _options_to_str(options: Optional[Mapping[str, Any]] = None) -> Mapping[str,
 
 
 @_try_remote_functions
-def lit(col: Any, to_struct: bool = False) -> Column:
+def lit(col: Any) -> Column:
     """
     Creates a :class:`~pyspark.sql.Column` of literal value.
 
@@ -168,10 +168,6 @@ def lit(col: Any, to_struct: bool = False) -> Column:
     col : :class:`~pyspark.sql.Column`, str, int, float, bool or list, NumPy literals, ndarray
         or dict. the value to make it as a PySpark literal. If a column is passed,
         it returns the column as is.
-
-    to_struct: bool, optional, default False
-        If True, the column will be converted to a struct column. If False, the column will be
-        converted to a map column. Default is False. only has an effect when col is a dict.
 
         .. versionchanged:: 4.0.0
             Since 3.4.0, it supports the list type.
@@ -261,6 +257,7 @@ def lit(col: Any, to_struct: bool = False) -> Column:
     +------------------+-------+-----------------+--------------------+
 
     Example 7: Creating a literal column as a map from a dict.
+        if spark.sql.pyspark.inferNestedDictAsStruct is False
 
     >>> import pyspark.sql.functions as sf
     >>> spark.range(1).select(
@@ -273,6 +270,7 @@ def lit(col: Any, to_struct: bool = False) -> Column:
     +----------------+
 
     Example 8: Creating a literal column as a struct from a dict.
+        if spark.sql.pyspark.inferNestedDictAsStruct is True
 
     >>> import pyspark.sql.functions as sf
     >>> spark.range(1).select(
@@ -299,8 +297,9 @@ def lit(col: Any, to_struct: bool = False) -> Column:
             raise PySparkValueError(
                 errorClass="COLUMN_IN_DICT", messageParameters={"func_name": "lit"}
             )
-        # Convert to struct or map based on the parameter `to_struct`
-        if to_struct:
+        sc = _get_active_spark_context()
+        dict_as_struct = bool(sc._conf.get("spark.sql.pyspark.inferNestedDictAsStruct"))
+        if dict_as_struct:
             return struct(*[lit(value).alias(key) for key, value in col.items()])
         else:
             return create_map(*[lit(x) for x in chain(*col.items())])
@@ -12885,7 +12884,7 @@ def to_unix_timestamp(
 
     Example 3: Using a format column to represent different formats.
 
-    >>> import pyspark.sql.functions as sf
+    >>> import pyspark.sql.functions as sff
     >>> df = spark.createDataFrame(
     ...     [('2015-04-08', 'yyyy-MM-dd'), ('2025+01+09', 'yyyy+MM+dd')], ['dt', 'fmt'])
     >>> df.select('*', sf.to_unix_timestamp('dt', 'fmt')).show()

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -300,8 +300,8 @@ def lit(col: Any) -> Column:
         from pyspark.sql import SparkSession
 
         spark = SparkSession.getActiveSession()
-        dict_as_struct = spark.conf.get("spark.sql.pyspark.inferNestedDictAsStruct.enabled")
-        if dict_as_struct.lower() == "true":
+        dict_as_struct = spark.conf.get("spark.sql.pyspark.inferNestedDictAsStruct.enabled") if spark else "false"
+        if dict_as_struct and dict_as_struct.lower() == "true":
             return struct(*[lit(value).alias(key) for key, value in col.items()])
         else:
             return create_map(*[lit(x) for x in chain(*col.items())])

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -260,7 +260,7 @@ def lit(col: Any, to_struct: bool = False) -> Column:
     |     [true, false]|     []|       [1.5, 0.1]|           [a, b, c]|
     +------------------+-------+-----------------+--------------------+
 
-    Example 7: Creating a literal column from a dict.
+    Example 7: Creating a literal column as a map from a dict.
 
     >>> import pyspark.sql.functions as sf
     >>> spark.range(1).select(
@@ -268,6 +268,18 @@ def lit(col: Any, to_struct: bool = False) -> Column:
     ... ).show() # doctest: +SKIP
     +----------------+
     |         map_col|
+    +----------------+
+    |{a -> 1, b -> 2}|
+    +----------------+
+    
+    Example 8: Creating a literal column as a struct from a dict.
+
+    >>> import pyspark.sql.functions as sf
+    >>> spark.range(1).select(
+    ...    sf.lit({"a": 1, "b": 2}, true).alias("struct_col")
+    ... ).show() # doctest: +SKIP
+    +----------------+
+    |      struct_col|
     +----------------+
     |{a -> 1, b -> 2}|
     +----------------+

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1319,6 +1319,12 @@ class FunctionsTestsMixin:
     # SPARK-48665: added support for dict type
     def test_lit_dict(self):
         test_dict = {"a": 1, "b": 2}
+        actual = self.spark.range(1).select(F.lit(test_dict), to_struct=True).first()[0]
+        # Convert struct return to dict
+        actual = actual.asDict()
+        self.assertEqual(actual, test_dict)
+
+        test_dict = {"a": 1, "b": 2}
         actual = self.spark.range(1).select(F.lit(test_dict)).first()[0]
         self.assertEqual(actual, test_dict)
 

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -36,6 +36,7 @@ from pyspark.testing.sqlutils import ReusedSQLTestCase, SQLTestUtils
 from pyspark.testing.utils import have_numpy, assertDataFrameEqual
 from pyspark.sql.utils import get_conf as _get_conf
 
+
 class FunctionsTestsMixin:
     def test_function_parity(self):
         # This test compares the available list of functions in pyspark.sql.functions with those

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1315,7 +1315,7 @@ class FunctionsTestsMixin:
             errorClass="COLUMN_IN_LIST",
             messageParameters={"func_name": "lit"},
         )
-    
+
     # SPARK-48665: added support for dict type
     def test_lit_dict(self):
         test_dict = {"a": 1, "b": 2}

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -34,7 +34,7 @@ from pyspark.sql.functions.builtin import nullifzero, randstr, uniform, zeroifnu
 from pyspark.sql.types import StructType, StructField, StringType, MapType, IntegerType, LongType
 from pyspark.testing.sqlutils import ReusedSQLTestCase, SQLTestUtils
 from pyspark.testing.utils import have_numpy, assertDataFrameEqual
-
+from pyspark.sql.utils import get_conf as _get_conf
 
 class FunctionsTestsMixin:
     def test_function_parity(self):
@@ -1319,6 +1319,7 @@ class FunctionsTestsMixin:
 
     # SPARK-48665: added support for dict type
     def test_lit_dict_struct(self):
+        _get_conf.cache_clear()
         with self.sql_conf({"spark.sql.pyspark.inferNestedDictAsStruct.enabled": True}):
             # Not nested dict
             expected_types = StructType(
@@ -1351,6 +1352,7 @@ class FunctionsTestsMixin:
 
     # SPARK-48665: added support for dict type
     def test_lit_dict_map(self):
+        _get_conf.cache_clear()
         with self.sql_conf({"spark.sql.pyspark.inferNestedDictAsStruct.enabled": False}):
             # Not nested dict
             test_dict = {"a": 1, "b": 2}
@@ -1382,6 +1384,7 @@ class FunctionsTestsMixin:
 
     # SPARK-48665: added support for dict type
     def test_lit_dict_raise_error(self):
+        _get_conf.cache_clear()
         df = self.spark.range(10)
         dicts = [
             {"a": df.id},

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -30,7 +30,7 @@ from pyspark.sql import Row, Window, functions as F, types
 from pyspark.sql.avro.functions import from_avro, to_avro
 from pyspark.sql.column import Column
 
-# from pyspark.sql.functions.builtin import nullifzero, randstr, uniform, zeroifnull
+from pyspark.sql.functions.builtin import nullifzero, randstr, uniform, zeroifnull
 from pyspark.sql.types import StructType, StructField, StringType, MapType, IntegerType, LongType
 from pyspark.testing.sqlutils import ReusedSQLTestCase, SQLTestUtils
 from pyspark.testing.utils import have_numpy, assertDataFrameEqual

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1344,8 +1344,8 @@ class FunctionsTestsMixin:
 
             self.check_error(
                 exception=pe.exception,
-                error_class="COLUMN_IN_DICT",
-                message_parameters={"func_name": "lit"},
+                errorClass="COLUMN_IN_DICT",
+                messageParameters={"func_name": "lit"},
             )
 
     # Test added for SPARK-39832; change Python API to accept both col & str as input

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1319,7 +1319,7 @@ class FunctionsTestsMixin:
     # SPARK-48665: added support for dict type
     def test_lit_dict(self):
         test_dict = {"a": 1, "b": 2}
-        actual = self.spark.range(1).select(F.lit(test_dict), to_struct=True).first()[0]
+        actual = self.spark.range(1).select(F.lit(test_dict, to_struct=True)).first()[0]
         # Convert struct return to dict
         actual = actual.asDict()
         self.assertEqual(actual, test_dict)

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1318,12 +1318,14 @@ class FunctionsTestsMixin:
 
     # SPARK-48665: added support for dict type
     def test_lit_dict(self):
+        self.spark.conf.set("spark.sql.pyspark.inferNestedDictAsStruct", "true")
         test_dict = {"a": 1, "b": 2}
-        actual = self.spark.range(1).select(F.lit(test_dict, to_struct=True)).first()[0]
+        actual = self.spark.range(1).select(F.lit(test_dict)).first()[0]
         # Convert struct return to dict
         actual = actual.asDict()
         self.assertEqual(actual, test_dict)
 
+        self.spark.conf.set("spark.sql.pyspark.inferNestedDictAsStruct", "false")
         test_dict = {"a": 1, "b": 2}
         actual = self.spark.range(1).select(F.lit(test_dict)).first()[0]
         self.assertEqual(actual, test_dict)

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -477,9 +477,13 @@ def remote_only(func: Union[Callable, property]) -> Union[Callable, property]:
 
 
 @functools.lru_cache()
-def get_conf(config_requested: str) -> str:
-    from pyspark.sql import SparkSession
+def get_conf(config_requested: str, default: str) -> Optional[str]:
+    from pyspark.sql import SparkSession, SparkConf
 
     spark = SparkSession.getActiveSession()
-    conf_rq = spark.conf.get(config_requested) if spark else "false"
-    return conf_rq
+    if spark:
+        return spark.conf.get(config_requested)
+    conf = SparkConf()
+    if conf:
+        return conf.get(config_requested)
+    return None

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -478,11 +478,13 @@ def remote_only(func: Union[Callable, property]) -> Union[Callable, property]:
 
 @functools.lru_cache()
 def get_conf(config_requested: str) -> Optional[str]:
-    from pyspark.sql import SparkSession, SparkConf
+    from pyspark.sql import SparkSession
 
     spark = SparkSession.getActiveSession()
     if spark:
         return spark.conf.get(config_requested)
+    from pyspark import SparkConf
+
     conf = SparkConf()
     if conf:
         return conf.get(config_requested)

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -477,7 +477,7 @@ def remote_only(func: Union[Callable, property]) -> Union[Callable, property]:
 
 
 @functools.lru_cache()
-def get_conf(config_requested: str, default: str) -> Optional[str]:
+def get_conf(config_requested: str) -> Optional[str]:
     from pyspark.sql import SparkSession, SparkConf
 
     spark = SparkSession.getActiveSession()

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -474,3 +474,12 @@ def remote_only(func: Union[Callable, property]) -> Union[Callable, property]:
     else:
         func._remote_only = True  # type: ignore[attr-defined]
         return func
+
+
+@functools.lru_cache()
+def get_conf(config_requested: str) -> str:
+    from pyspark.sql import SparkSession
+
+    spark = SparkSession.getActiveSession()
+    conf_rq = spark.conf.get(config_requested) if spark else "false"
+    return conf_rq


### PR DESCRIPTION
# What changes were proposed in this pull request?

Reopening the [PR ](https://github.com/apache/spark/pull/47031)done by [Ronserruya](https://github.com/Ronserruya)  and addidng small changes.

Added the option to provide a dict to `pyspark.sql.functions.lit` in order to create a map

## Why are the changes needed?

To make it easier to create a map in pyspark.
Currently, it is only possible via `create_map` which requires a sequence of key,value,key,value...
Scala already supports such functionality using `typedLit`

A [similar PR](https://github.com/apache/spark/pull/37722) was done in the past to add similar functionality for the creating of an array using a list, so I tried to follow all the changes done there as well.

## Does this PR introduce any user-facing change?

Yes, docstring of `lit` was edited, and new functionality was added

Before:
```
from pyspark.sql import functions as F
F.lit({"a":1})
# pyspark.errors.exceptions.captured.SparkRuntimeException: [UNSUPPORTED_FEATURE.LITERAL_TYPE] The feature is not supported: Literal for '{asd=2}' of class java.util.HashMap.
```
After:
```
from pyspark.sql import functions as F
F.lit({"a":1, "b": 2})
# Column<'map(a, 1, b, 2)'>
```
## How was this patch tested?

Manual tests + unittest in CI

## Was this patch authored or co-authored using generative AI tooling?

No