### PR TITLE
[SPARK-50690][SQL] Fix discrepancy in DESCRIBE TABLE view query output columns quoting

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -559,7 +559,8 @@ case class CatalogTable(
         map.put("View Catalog and Namespace", viewCatalogAndNamespace.quoted)
       }
       if (viewQueryColumnNames.nonEmpty) {
-        map.put("View Query Output Columns", viewQueryColumnNames.mkString("[", ", ", "]"))
+        map.put("View Query Output Columns",
+          viewQueryColumnNames.map(quoteIdentifier).mkString("[", ", ", "]"))
       }
     }
 

--- a/sql/core/src/test/resources/sql-tests/results/charvarchar.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/charvarchar.sql.out
@@ -195,7 +195,7 @@ View Text           	select * from char_tbl
 View Original Text  	select * from char_tbl	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c, v]
+View Query Output Columns	[`c`, `v`]
 
 
 -- !query
@@ -366,7 +366,7 @@ View Text           	select * from char_tbl2
 View Original Text  	select * from char_tbl2	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c, v]
+View Query Output Columns	[`c`, `v`]
 
 
 -- !query
@@ -427,7 +427,7 @@ View Text           	select * from char_tbl2
 View Original Text  	select * from char_tbl2	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c, v]              	                    
+View Query Output Columns	[`c`, `v`]          	                    
 Table Properties    	[yes=no]
 
 
@@ -488,7 +488,7 @@ View Text           	select * from char_tbl2
 View Original Text  	select * from char_tbl2	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c, v]
+View Query Output Columns	[`c`, `v`]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/describe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/describe.sql.out
@@ -538,7 +538,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[a, b, c, d]
+View Query Output Columns	[`a`, `b`, `c`, `d`]
 
 
 -- !query
@@ -563,7 +563,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[a, b, c, d]
+View Query Output Columns	[`a`, `b`, `c`, `d`]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/create_view.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/create_view.sql.out
@@ -269,7 +269,7 @@ View Text           	SELECT * FROM base_table
 View Original Text  	SELECT * FROM base_table	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.temp_view_test	                    
-View Query Output Columns	[a, id]
+View Query Output Columns	[`a`, `id`]
 
 
 -- !query
@@ -335,7 +335,7 @@ View Text           	SELECT * FROM base_table
 View Original Text  	SELECT * FROM base_table	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.temp_view_test	                    
-View Query Output Columns	[a, id]
+View Query Output Columns	[`a`, `id`]
 
 
 -- !query
@@ -391,7 +391,7 @@ View Original Text  	SELECT t1.a AS t1_a, t2.a AS t2_a
     WHERE t1.id = t2.id	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.temp_view_test	                    
-View Query Output Columns	[t1_a, t2_a]
+View Query Output Columns	[`t1_a`, `t2_a`]
 
 
 -- !query
@@ -464,7 +464,7 @@ View Text           	SELECT * FROM base_table WHERE id IN (SELECT id FROM base_t
 View Original Text  	SELECT * FROM base_table WHERE id IN (SELECT id FROM base_table2)	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.temp_view_test	                    
-View Query Output Columns	[a, id]
+View Query Output Columns	[`a`, `id`]
 
 
 -- !query
@@ -495,7 +495,7 @@ View Text           	SELECT t1.id, t2.a FROM base_table t1, (SELECT * FROM base_
 View Original Text  	SELECT t1.id, t2.a FROM base_table t1, (SELECT * FROM base_table2) t2	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.temp_view_test	                    
-View Query Output Columns	[id, a]
+View Query Output Columns	[`id`, `a`]
 
 
 -- !query
@@ -526,7 +526,7 @@ View Text           	SELECT * FROM base_table WHERE EXISTS (SELECT 1 FROM base_t
 View Original Text  	SELECT * FROM base_table WHERE EXISTS (SELECT 1 FROM base_table2)	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.temp_view_test	                    
-View Query Output Columns	[a, id]
+View Query Output Columns	[`a`, `id`]
 
 
 -- !query
@@ -557,7 +557,7 @@ View Text           	SELECT * FROM base_table WHERE NOT EXISTS (SELECT 1 FROM ba
 View Original Text  	SELECT * FROM base_table WHERE NOT EXISTS (SELECT 1 FROM base_table2)	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.temp_view_test	                    
-View Query Output Columns	[a, id]
+View Query Output Columns	[`a`, `id`]
 
 
 -- !query
@@ -588,7 +588,7 @@ View Text           	SELECT * FROM base_table WHERE EXISTS (SELECT 1)
 View Original Text  	SELECT * FROM base_table WHERE EXISTS (SELECT 1)	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.temp_view_test	                    
-View Query Output Columns	[a, id]
+View Query Output Columns	[`a`, `id`]
 
 
 -- !query
@@ -800,7 +800,7 @@ View Text           	SELECT * FROM t1 CROSS JOIN t2
 View Original Text  	SELECT * FROM t1 CROSS JOIN t2	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.testviewschm2	                    
-View Query Output Columns	[num, name, num2, value]
+View Query Output Columns	[`num`, `name`, `num2`, `value`]
 
 
 -- !query
@@ -851,7 +851,7 @@ View Text           	SELECT * FROM t1 INNER JOIN t2 ON t1.num = t2.num2
 View Original Text  	SELECT * FROM t1 INNER JOIN t2 ON t1.num = t2.num2	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.testviewschm2	                    
-View Query Output Columns	[num, name, num2, value]
+View Query Output Columns	[`num`, `name`, `num2`, `value`]
 
 
 -- !query
@@ -902,7 +902,7 @@ View Text           	SELECT * FROM t1 LEFT JOIN t2 ON t1.num = t2.num2
 View Original Text  	SELECT * FROM t1 LEFT JOIN t2 ON t1.num = t2.num2	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.testviewschm2	                    
-View Query Output Columns	[num, name, num2, value]
+View Query Output Columns	[`num`, `name`, `num2`, `value`]
 
 
 -- !query
@@ -953,7 +953,7 @@ View Text           	SELECT * FROM t1 LEFT JOIN t2 ON t1.num = t2.num2 AND t2.va
 View Original Text  	SELECT * FROM t1 LEFT JOIN t2 ON t1.num = t2.num2 AND t2.value = 'xxx'	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.testviewschm2	                    
-View Query Output Columns	[num, name, num2, value]
+View Query Output Columns	[`num`, `name`, `num2`, `value`]
 
 
 -- !query
@@ -1074,7 +1074,7 @@ BETWEEN (SELECT d FROM tbl2 WHERE c = 1) AND (SELECT e FROM tbl3 WHERE f = 2)
 AND EXISTS (SELECT g FROM tbl4 LEFT JOIN tbl3 ON tbl4.h = tbl3.f)	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.testviewschm2	                    
-View Query Output Columns	[a, b]
+View Query Output Columns	[`a`, `b`]
 
 
 -- !query
@@ -1114,7 +1114,7 @@ AND EXISTS (SELECT g FROM tbl4 LEFT JOIN tbl3 ON tbl4.h = tbl3.f)
 AND NOT EXISTS (SELECT g FROM tbl4 LEFT JOIN tmptbl ON tbl4.h = tmptbl.j)	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.testviewschm2	                    
-View Query Output Columns	[a, b]
+View Query Output Columns	[`a`, `b`]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/view-schema-binding-config.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/view-schema-binding-config.sql.out
@@ -137,7 +137,7 @@ Type                	VIEW
 View Text           	SELECT 1            	                    
 View Original Text  	SELECT 1            	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[1]
+View Query Output Columns	[`1`]
 
 
 -- !query
@@ -155,7 +155,7 @@ Type: VIEW
 View Text: SELECT 1
 View Original Text: SELECT 1
 View Catalog and Namespace: spark_catalog.default
-View Query Output Columns: [1]
+View Query Output Columns: [`1`]
 Schema: root
  |-- 1: integer (nullable = false)
 
@@ -206,7 +206,7 @@ Created By [not included in comparison]
 Type: VIEW
 View Text: SELECT 1
 View Catalog and Namespace: spark_catalog.default
-View Query Output Columns: [1]
+View Query Output Columns: [`1`]
 Schema: root
  |-- 1: integer (nullable = false)
 
@@ -269,7 +269,7 @@ Type                	VIEW
 View Text           	SELECT * FROM t     	                    
 View Original Text  	SELECT * FROM t     	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -324,7 +324,7 @@ Type                	VIEW
 View Text           	SELECT * FROM t     	                    
 View Original Text  	SELECT * FROM t     	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -402,7 +402,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	BINDING             	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -477,7 +477,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	BINDING             	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -550,7 +550,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -615,7 +615,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -680,7 +680,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -774,7 +774,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -837,7 +837,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -895,7 +895,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -953,7 +953,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -1007,7 +1007,7 @@ View Text           	SELECT 1
 View Original Text  	SELECT 1            	                    
 View Schema Mode    	BINDING             	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[1]
+View Query Output Columns	[`1`]
 
 
 -- !query
@@ -1026,7 +1026,7 @@ View Text: SELECT 1
 View Original Text: SELECT 1
 View Schema Mode: BINDING
 View Catalog and Namespace: spark_catalog.default
-View Query Output Columns: [1]
+View Query Output Columns: [`1`]
 Schema: root
  |-- 1: integer (nullable = false)
 
@@ -1069,7 +1069,7 @@ View Text           	SELECT 1
 View Original Text  	SELECT 1            	                    
 View Schema Mode    	BINDING             	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[1]
+View Query Output Columns	[`1`]
 
 
 -- !query
@@ -1088,7 +1088,7 @@ View Text: SELECT 1
 View Original Text: SELECT 1
 View Schema Mode: BINDING
 View Catalog and Namespace: spark_catalog.default
-View Query Output Columns: [1]
+View Query Output Columns: [`1`]
 Schema: root
  |-- 1: integer (nullable = false)
 
@@ -1165,7 +1165,7 @@ Type: VIEW
 View Text: SELECT 1
 View Schema Mode: BINDING
 View Catalog and Namespace: spark_catalog.default
-View Query Output Columns: [1]
+View Query Output Columns: [`1`]
 Schema: root
  |-- 1: integer (nullable = false)
 
@@ -1199,7 +1199,7 @@ Type: VIEW
 View Text: SELECT 1
 View Schema Mode: BINDING
 View Catalog and Namespace: spark_catalog.default
-View Query Output Columns: [1]
+View Query Output Columns: [`1`]
 Schema: root
  |-- 1: integer (nullable = false)
 

--- a/sql/core/src/test/resources/sql-tests/results/view-schema-binding.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/view-schema-binding.sql.out
@@ -50,7 +50,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	BINDING             	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -106,7 +106,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	BINDING             	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -161,7 +161,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	BINDING             	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -219,7 +219,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	BINDING             	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -281,7 +281,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	BINDING             	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -311,7 +311,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	BINDING             	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -367,7 +367,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	BINDING             	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/view-schema-compensation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/view-schema-compensation.sql.out
@@ -58,7 +58,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -112,7 +112,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -166,7 +166,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -260,7 +260,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -323,7 +323,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -381,7 +381,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -439,7 +439,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -493,7 +493,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	BINDING             	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -565,7 +565,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/view-schema-evolution.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/view-schema-evolution.sql.out
@@ -59,7 +59,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	EVOLUTION           	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -114,7 +114,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	EVOLUTION           	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c4, c5]
+View Query Output Columns	[`c4`, `c5`]
 
 
 -- !query
@@ -170,7 +170,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	EVOLUTION           	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c4, c5, c6]
+View Query Output Columns	[`c4`, `c5`, `c6`]
 
 
 -- !query
@@ -233,7 +233,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	EVOLUTION           	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -279,7 +279,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	EVOLUTION           	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -342,7 +342,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -397,7 +397,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -452,7 +452,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -515,7 +515,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -573,7 +573,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -631,7 +631,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -678,7 +678,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -709,7 +709,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -756,7 +756,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -787,7 +787,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -834,7 +834,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -865,7 +865,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	EVOLUTION           	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -912,7 +912,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	EVOLUTION           	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -1094,7 +1094,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	EVOLUTION           	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/view-schema-type-evolution.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/view-schema-type-evolution.sql.out
@@ -59,7 +59,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -114,7 +114,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -169,7 +169,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -232,7 +232,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -290,7 +290,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -348,7 +348,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -395,7 +395,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -442,7 +442,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -473,7 +473,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -520,7 +520,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1, c2]
+View Query Output Columns	[`c1`, `c2`]
 
 
 -- !query
@@ -606,7 +606,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	COMPENSATION        	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query
@@ -644,7 +644,7 @@ View Text           	SELECT * FROM t
 View Original Text  	SELECT * FROM t     	                    
 View Schema Mode    	TYPE EVOLUTION      	                    
 View Catalog and Namespace	spark_catalog.default	                    
-View Query Output Columns	[c1]
+View Query Output Columns	[`c1`]
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuiteBase.scala
@@ -353,7 +353,7 @@ trait ShowTablesSuiteBase extends QueryTest with DDLCommandTestUtils {
              |View Text: SELECT id FROM $catalog.$namespace.$table
              |View Schema Mode: BINDING
              |View Catalog and Namespace: spark_catalog.default
-             |View Query Output Columns: [id]
+             |View Query Output Columns: [`id`]
              |Schema: root
              | |-- id: integer (nullable = true)""".stripMargin
         assert(actualLocalResult === expectedLocalResult)
@@ -380,7 +380,7 @@ trait ShowTablesSuiteBase extends QueryTest with DDLCommandTestUtils {
              |View Text: SELECT id FROM $catalog.$namespace.$table
              |View Schema Mode: BINDING
              |View Catalog and Namespace: spark_catalog.default
-             |View Query Output Columns: [id]
+             |View Query Output Columns: [`id`]
              |Schema: root
              | |-- id: integer (nullable = true)""".stripMargin
         assert(actualGlobalResult1 === expectedGlobalResult1)
@@ -398,7 +398,7 @@ trait ShowTablesSuiteBase extends QueryTest with DDLCommandTestUtils {
              |View Text: SELECT id FROM $catalog.$namespace.$table
              |View Schema Mode: BINDING
              |View Catalog and Namespace: spark_catalog.default
-             |View Query Output Columns: [id]
+             |View Query Output Columns: [`id`]
              |Schema: root
              | |-- id: integer (nullable = true)""".stripMargin
         assert(actualLocalResult2 === expectedLocalResult2)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -207,7 +207,7 @@ class ShowTablesSuite extends ShowTablesSuiteBase with CommandSuiteBase {
              |View Original Text: SELECT id FROM $catalog.$namespace.$table
              |View Schema Mode: COMPENSATION
              |View Catalog and Namespace: $catalog.$namespace
-             |View Query Output Columns: [id]
+             |View Query Output Columns: [`id`]
              |Schema: root
              | |-- id: integer (nullable = true)""".stripMargin
         assert(actualResult === expectedResult)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowTablesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowTablesSuite.scala
@@ -99,7 +99,7 @@ class ShowTablesSuite extends v1.ShowTablesSuiteBase with CommandSuiteBase {
              |View Original Text: SELECT id FROM $catalog.$namespace.$table
              |View Schema Mode: COMPENSATION
              |View Catalog and Namespace: $catalog.$namespace
-             |View Query Output Columns: [id]
+             |View Query Output Columns: [`id`]
              |Table Properties: <table properties>
              |Serde Library: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
              |InputFormat: org.apache.hadoop.mapred.SequenceFileInputFormat


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Previously, the `DESCRIBE TABLE` SQL command displayed column lists such as bucket and sort columns as so:

```
Bucket Columns          [`a`]                                       
Sort Columns            [`b`] 
```
 
However view query output columns were not quoted:

```
View Query Output Columns      [c1] 
```

This PR fixes the discrepancy by quoting the view query output columns with ``:

```
View Query Output Columns      [`c1`] 
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The change ensures cohesive `DESCRIBE TABLE` output, which can improve parsing and readability.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, this modifies the view query output columns portion of the `DESCRIBE TABLE` output.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing SQL tests, including golden file output


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
