### PR TITLE
[SPARK-50691][SQL][FOLLOWUP] Use UnsafeProjection for LocalRelation rows instead of ComparableLocalRelation

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
@@ -46,7 +46,7 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper {
     $"e".boolean, $"f".boolean, $"g".boolean, $"h".boolean)
 
   val testRelationWithData = LocalRelation.fromExternalRows(
-    testRelation.output, Seq(Row(1, 2, 3, "abc"))
+    testRelation.output, Seq(Row(1, 2, 3, "abc", true, true, true, true))
   )
 
   val testNotNullableRelation = LocalRelation($"a".int.notNull, $"b".int.notNull, $"c".int.notNull,
@@ -54,7 +54,7 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper {
     $"h".boolean.notNull)
 
   val testNotNullableRelationWithData = LocalRelation.fromExternalRows(
-    testNotNullableRelation.output, Seq(Row(1, 2, 3, "abc"))
+    testNotNullableRelation.output, Seq(Row(1, 2, 3, "abc", true, true, true, true))
   )
 
   private def checkCondition(input: Expression, expected: LogicalPlan): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use `UnsafeProjection` for `LocalRelation` rows instead of `ComparableLocalRelation`.

### Why are the changes needed?

`UnsafeRow.equals` compares the whole byte sequence under it, so it's a convenient way to compare all kind of row values, including `ArrayBasedMapData`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing test.

### Was this patch authored or co-authored using generative AI tooling?

copilot.nvim.