### PR TITLE
[SPARK-50693][CONNECT] The inputs for TypedScalaUdf should be analyzed

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/UserDefinedFunctionE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/UserDefinedFunctionE2ETestSuite.scala
@@ -301,6 +301,14 @@ class UserDefinedFunctionE2ETestSuite extends QueryTest with RemoteSparkSession 
     checkDataset(df.filter(r => r.getInt(1) > 5), Row("a", 10), Row("a", 20))
   }
 
+  test("SPARK-50693: Filter with row input encoder on unresolved plan") {
+    val session: SparkSession = spark
+    import session.implicits._
+    val df = Seq(("a", 10), ("a", 20), ("b", 1), ("b", 2), ("c", 1)).toDF("c1", "c2")
+
+    checkDataset(df.select("*").filter(r => r.getInt(1) > 5), Row("a", 10), Row("a", 20))
+  }
+
   test("mapPartitions with row input encoder") {
     val session: SparkSession = spark
     import session.implicits._


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `SparkConnectPlanner` to analyze the inputs for `TypedScalaUdf`.

### Why are the changes needed?

The inputs for `TypedScalaUdf` should be analyzed.

For example:

```scala
val df = Seq(("a", 10), ("a", 20), ("b", 1), ("b", 2), ("c", 1)).toDF("c1", "c2")
df.select("*").filter(r => r.getInt(1) > 5)
```

fails with:

```
org.apache.spark.SparkException: [INTERNAL_ERROR] Invalid call to toAttribute on unresolved object SQLSTATE: XX000
  at org.apache.spark.sql.catalyst.analysis.Star.toAttribute(unresolved.scala:438)
  at org.apache.spark.sql.catalyst.plans.logical.Project.$anonfun$output$1(basicLogicalOperators.scala:74)
  at scala.collection.immutable.List.map(List.scala:247)
  at scala.collection.immutable.List.map(List.scala:79)
  at org.apache.spark.sql.catalyst.plans.logical.Project.output(basicLogicalOperators.scala:74)
  at org.apache.spark.sql.connect.planner.SparkConnectPlanner.transformTypedFilter(SparkConnectPlanner.scala:1460)
  at org.apache.spark.sql.connect.planner.SparkConnectPlanner.transformFilter(SparkConnectPlanner.scala:1437)
...
```

### Does this PR introduce _any_ user-facing change?

The failure will not appear.

### How was this patch tested?

Added the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
