### PR TITLE
[SPARK-50697][SQL] Enable tail-recursion wherever possible

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffset.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution
 
+import scala.annotation.tailrec
+
 import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -49,6 +51,7 @@ object InsertSortForLimitAndOffset extends Rule[SparkPlan] {
   }
 
   object SinglePartitionShuffleWithGlobalOrdering {
+    @tailrec
     def unapply(plan: SparkPlan): Option[Seq[SortOrder]] = plan match {
       case ShuffleExchangeExec(SinglePartition, SparkPlanWithGlobalOrdering(ordering), _, _) =>
         Some(ordering)
@@ -61,6 +64,7 @@ object InsertSortForLimitAndOffset extends Rule[SparkPlan] {
   // Note: this is not implementing a generalized notion of "global order preservation", but just
   // tackles the regular ORDER BY semantics with optional LIMIT (top-K).
   object SparkPlanWithGlobalOrdering {
+    @tailrec
     def unapply(plan: SparkPlan): Option[Seq[SortOrder]] = plan match {
       case p: SortExec if p.global => Some(p.sortOrder)
       case p: LocalLimitExec => unapply(p.child)

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -790,6 +790,7 @@ class ForStatementExec(
           case ForState.VariableCleanup => dropVariablesExec.getTreeIterator.hasNext
         })
 
+      @scala.annotation.tailrec
       override def next(): CompoundStatementExec = state match {
 
         case ForState.VariableAssignment =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr adds `scala.annotation.tailrec` inspected by IDE (IntelliJ),  these are new cases after Spark 4.0.


### Why are the changes needed?
To improve performance.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
 Pass GItHub Actions

### Was this patch authored or co-authored using generative AI tooling?
 No