### PR TITLE
[SPARK-50711][PS][DOCS] Upgrade the minimum version of Pandas in PS to 2.2.0

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -5,7 +5,7 @@ py4j>=0.10.9.7
 numpy>=1.21
 pyarrow>=11.0.0
 six==1.16.0
-pandas>=2.0.0
+pandas>=2.2.0
 scipy
 plotly>=4.8
 mlflow>=2.3.1

--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -239,7 +239,7 @@ Installable with ``pip install "pyspark[pandas_on_spark]"``.
 ========= ================= ================================
 Package   Supported version Note
 ========= ================= ================================
-`pandas`  >=2.0.0           Required for Pandas API on Spark
+`pandas`  >=2.2.0           Required for Pandas API on Spark
 `pyarrow` >=11.0.0          Required for Pandas API on Spark
 ========= ================= ================================
 


### PR DESCRIPTION


### What changes were proposed in this pull request?
Upgrade the minimum version of Pandas in PS to 2.2.0

But the version used in `require_minimum_pandas_version` is still 2.0.0, because currently this function is used in both PS and non-PS modules.

### Why are the changes needed?
Actually, PS with Pandas < 2.2.0 has already been broken in master branch


### Does this PR introduce _any_ user-facing change?
No, doc-only


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No
