### PR TITLE
[SPARK-50614][SQL] Fix shredding debug message

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetWriteSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetWriteSupport.scala
@@ -158,7 +158,7 @@ class ParquetWriteSupport extends WriteSupport[InternalRow] with Logging {
         s"""Initialized Parquet WriteSupport with Catalyst schema:
            |${schema.prettyJson}
            |and shredding schema:
-           |$shreddedSchema.prettyJson}
+           |${shreddedSchema.prettyJson}
            |and corresponding Parquet message type:
            |$messageType
          """.stripMargin)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

A debug message added in https://github.com/apache/spark/pull/49234 was missing a brace. As a result, the message was printing the non-pretty string representation of the struct, followed by the string `.prettyJson}`. This PR fixes it.

### Why are the changes needed?

Cleaner debug messages.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually verified in spark-shell that the message looks wrong without the change, and correct with the change.

### Was this patch authored or co-authored using generative AI tooling?

No.