### PR TITLE
[SPARK-50720][CORE] Support external shuffle service enablement in local-cluster mode

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
@@ -35,6 +35,8 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import org.apache.commons.lang3.SystemUtils;
 
+import org.apache.spark.internal.LogKeys;
+import org.apache.spark.internal.MDC;
 import org.apache.spark.internal.SparkLogger;
 import org.apache.spark.internal.SparkLoggerFactory;
 import org.apache.spark.network.TransportContext;
@@ -151,7 +153,10 @@ public class TransportServer implements Closeable {
 
     InetSocketAddress localAddress = (InetSocketAddress) channelFuture.channel().localAddress();
     port = localAddress.getPort();
-    logger.debug("Shuffle server started on {} with port {}", localAddress.getHostString(), port);
+    logger.info("{} server started on {} with port {}",
+      MDC.of(LogKeys.MODULE_NAME$.MODULE$, conf.getModuleName()),
+      MDC.of(LogKeys.HOST$.MODULE$, localAddress.getHostString()),
+      MDC.of(LogKeys.PORT$.MODULE$, port));
   }
 
   public MetricSet getAllMetrics() {

--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -182,6 +182,10 @@ private[deploy] object DeployMessages {
 
   case class ApplicationFinished(id: String)
 
+  // Used for test only. This removes the app in external shuffle service
+  // directly without any checks.
+  case class ApplicationRemoveTest(id: String, cleanupLocalDirs: Boolean)
+
   // Worker internal
 
   case object WorkDirCleanup // Sent to Worker endpoint periodically for cleaning up app folders

--- a/core/src/main/scala/org/apache/spark/deploy/ExternalShuffleService.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ExternalShuffleService.scala
@@ -146,7 +146,7 @@ class ExternalShuffleService(sparkConf: SparkConf, securityManager: SecurityMana
 
   /** Clean up all shuffle files associated with an application that has exited. */
   def applicationRemoved(appId: String, cleanupLocalDirs: Boolean = true): Unit = {
-    blockHandler.applicationRemoved(appId, true /* cleanupLocalDirs */)
+    blockHandler.applicationRemoved(appId, cleanupLocalDirs)
   }
 
   /** Clean up all the non-shuffle files associated with an executor that has exited. */

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
@@ -172,10 +172,12 @@ private[deploy] class ExecutorRunner(
       // parent process for the executor command
       builder.environment.put("SPARK_LAUNCH_WITH_SCALA", "0")
 
-      if (shuffleServicePort.isDefined && Utils.isTesting && LocalSparkCluster.get.isDefined) {
-        builder.environment().put(
-          ExternalShuffleService.TESTING_ESS_PORT_ENV, shuffleServicePort.get.toString
-        )
+      if (LocalSparkCluster.get.isDefined) {
+        shuffleServicePort.foreach { port =>
+          builder.environment().put(
+            ExternalShuffleService.TESTING_ESS_PORT_ENV, port.toString
+          )
+        }
       }
 
       // Add webUI log urls

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
@@ -172,7 +172,7 @@ private[deploy] class ExecutorRunner(
       // parent process for the executor command
       builder.environment.put("SPARK_LAUNCH_WITH_SCALA", "0")
 
-      if (LocalSparkCluster.get.isDefined) {
+      if (shuffleServicePort.isDefined && LocalSparkCluster.get.isDefined) {
         builder.environment().put(
           ExternalShuffleService.TESTING_ESS_PORT_ENV, shuffleServicePort.get.toString
         )

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
@@ -172,7 +172,7 @@ private[deploy] class ExecutorRunner(
       // parent process for the executor command
       builder.environment.put("SPARK_LAUNCH_WITH_SCALA", "0")
 
-      if (shuffleServicePort.isDefined && LocalSparkCluster.get.isDefined) {
+      if (shuffleServicePort.isDefined && Utils.isTesting && LocalSparkCluster.get.isDefined) {
         builder.environment().put(
           ExternalShuffleService.TESTING_ESS_PORT_ENV, shuffleServicePort.get.toString
         )

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
@@ -173,7 +173,9 @@ private[deploy] class ExecutorRunner(
       builder.environment.put("SPARK_LAUNCH_WITH_SCALA", "0")
 
       if (LocalSparkCluster.get.isDefined) {
-        builder.environment().put(ExternalShuffleService.TESTING_ESS_PORT_ENV, shuffleServicePort.get.toString)
+        builder.environment().put(
+          ExternalShuffleService.TESTING_ESS_PORT_ENV, shuffleServicePort.get.toString
+        )
       }
 
       // Add webUI log urls

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -39,7 +39,6 @@ import com.google.common.cache.CacheBuilder
 import org.apache.commons.io.IOUtils
 
 import org.apache.spark._
-import org.apache.spark.deploy.ExternalShuffleService
 import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.executor.{DataReadMethod, ExecutorExitCode}
 import org.apache.spark.internal.{config, Logging, MDC}
@@ -245,9 +244,6 @@ private[spark] class BlockManager(
   private lazy val maxOnHeapMemory = memoryManager.maxOnHeapStorageMemory
   private lazy val maxOffHeapMemory = memoryManager.maxOffHeapStorageMemory
 
-  // Whether we are launched in a local Spark cluster.
-  private[spark] val isLocalSparkCluster = Utils.isTesting &&
-    sys.env.contains(ExternalShuffleService.TESTING_ESS_PORT_ENV)
   private[spark] val externalShuffleServicePort = StorageUtils.externalShuffleServicePort(conf)
 
   var blockManagerId: BlockManagerId = _
@@ -1125,7 +1121,7 @@ private[spark] class BlockManager(
     // all the storage endpoints to get block status.
     val locationsAndStatusOption = master.getLocationsAndStatus(blockId, blockManagerId.host)
     if (locationsAndStatusOption.isEmpty) {
-      logWarning(log"Block ${MDC(BLOCK_ID, blockId)} is unknown by block manager master")
+      logDebug(s"Block $blockId is unknown by block manager master")
       None
     } else {
       val locationsAndStatus = locationsAndStatusOption.get

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -39,6 +39,7 @@ import com.google.common.cache.CacheBuilder
 import org.apache.commons.io.IOUtils
 
 import org.apache.spark._
+import org.apache.spark.deploy.ExternalShuffleService
 import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.executor.{DataReadMethod, ExecutorExitCode}
 import org.apache.spark.internal.{config, Logging, MDC}
@@ -244,6 +245,9 @@ private[spark] class BlockManager(
   private lazy val maxOnHeapMemory = memoryManager.maxOnHeapStorageMemory
   private lazy val maxOffHeapMemory = memoryManager.maxOffHeapStorageMemory
 
+  // Whether we are launched in a local Spark cluster.
+  private[spark] val isLocalSparkCluster = Utils.isTesting &&
+    sys.env.contains(ExternalShuffleService.TESTING_ESS_PORT_ENV)
   private[spark] val externalShuffleServicePort = StorageUtils.externalShuffleServicePort(conf)
 
   var blockManagerId: BlockManagerId = _

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -1121,7 +1121,7 @@ private[spark] class BlockManager(
     // all the storage endpoints to get block status.
     val locationsAndStatusOption = master.getLocationsAndStatus(blockId, blockManagerId.host)
     if (locationsAndStatusOption.isEmpty) {
-      logDebug(s"Block $blockId is unknown by block manager master")
+      logWarning(s"Block $blockId is unknown by block manager master")
       None
     } else {
       val locationsAndStatus = locationsAndStatusOption.get

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -1125,7 +1125,7 @@ private[spark] class BlockManager(
     // all the storage endpoints to get block status.
     val locationsAndStatusOption = master.getLocationsAndStatus(blockId, blockManagerId.host)
     if (locationsAndStatusOption.isEmpty) {
-      logWarning(s"Block $blockId is unknown by block manager master")
+      logWarning(log"Block ${MDC(BLOCK_ID, blockId)} is unknown by block manager master")
       None
     } else {
       val locationsAndStatus = locationsAndStatusOption.get

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -674,7 +674,8 @@ class BlockManagerMasterEndpoint(
   private def externalShuffleServiceIdOnHost(
       blockManagerId: BlockManagerId,
       blockManagerRef: RpcEndpointRef): BlockManagerId = {
-    val essPort = if (LocalSparkCluster.get.isDefined) {
+    val isLocalClusterEss = LocalSparkCluster.get.isDefined
+    val essPort = if (isLocalClusterEss) {
       blockManagerRef.askSync[Int](GetShuffleServicePort)
     } else {
       externalShuffleServicePort
@@ -682,7 +683,9 @@ class BlockManagerMasterEndpoint(
     // we need to keep the executor ID of the original executor to let the shuffle service know
     // which local directories should be used to look for the file
     val essId = BlockManagerId(blockManagerId.executorId, blockManagerId.host, essPort)
-    shuffleServiceIdSet.add(essId)
+    if (isLocalClusterEss) {
+      shuffleServiceIdSet.add(essId)
+    }
     essId
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMessages.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMessages.scala
@@ -61,6 +61,9 @@ private[spark] object BlockManagerMessages {
    */
   case object TriggerHeapHistogram extends ToBlockManagerMasterStorageEndpoint
 
+  // Test only
+  case object GetShuffleServicePort extends ToBlockManagerMasterStorageEndpoint
+
   //////////////////////////////////////////////////////////////////////////////////
   // Messages from storage endpoints to the master.
   //////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerStorageEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerStorageEndpoint.scala
@@ -101,6 +101,9 @@ class BlockManagerStorageEndpoint(
       // 2. Once a replica of a visible block is cached and reported, driver will also ask the
       //    the block manager to mark the block as visible immediately.
       context.reply(blockManager.blockInfoManager.tryMarkBlockAsVisible(blockId))
+
+    case GetShuffleServicePort =>
+      context.reply(blockManager.externalShuffleServicePort)
   }
 
   private def doAsync[T](

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -195,7 +195,7 @@ final class ShuffleBlockFetcherIterator(
   private[this] val isTestingExternalShuffleInLocalClusterMode = {
     Utils.isTesting &&
       blockManager.externalShuffleServiceEnabled &&
-      blockManager.conf.getOption("spark.master").exists(_.startsWith("local-cluster"))
+      Utils.isLocalSparkCluster(blockManager.conf)
   }
 
   initialize()

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -192,8 +192,7 @@ final class ShuffleBlockFetcherIterator(
   private[this] val pushBasedFetchHelper = new PushBasedFetchHelper(
     this, shuffleClient, blockManager, mapOutputTracker, shuffleMetrics)
 
-  private[this] val isTestingExternalShuffleInLocalClusterMode = {
-    Utils.isTesting &&
+  private[this] val isExternalShuffleServiceInLocalClusterMode = {
       blockManager.externalShuffleServiceEnabled &&
       Utils.isLocalSparkCluster(blockManager.conf)
   }
@@ -414,7 +413,7 @@ final class ShuffleBlockFetcherIterator(
     @inline def isHostLocal(blockAddress: BlockManagerId): Boolean = {
       if (blockManager.hostLocalDirManager.isDefined
         && blockAddress.host == blockManager.blockManagerId.host) {
-        if (isTestingExternalShuffleInLocalClusterMode) {
+        if (isExternalShuffleServiceInLocalClusterMode) {
           blockAddress.hostPort == blockManager.shuffleServerId.hostPort
         } else {
           true

--- a/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
+++ b/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
@@ -224,7 +224,9 @@ private[spark] object StorageUtils extends Logging {
    * set through the Hadoop configuration as the server is launched in the Yarn NM.
    */
   def externalShuffleServicePort(conf: SparkConf): Int = {
-    if (Utils.isTesting && sys.env.contains(ExternalShuffleService.TESTING_ESS_PORT_ENV)) {
+    if (Utils.isTesting && Utils.isLocalSparkCluster(conf)) {
+      assert(sys.env.contains(ExternalShuffleService.TESTING_ESS_PORT_ENV),
+        s"${ExternalShuffleService.TESTING_ESS_PORT_ENV} is not available")
       val port = sys.env(ExternalShuffleService.TESTING_ESS_PORT_ENV).toInt
       if (conf.contains(config.SHUFFLE_SERVICE_PORT.key)) {
         logWarning(log"Setting external shuffle service port in Spark local cluster " +

--- a/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
+++ b/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
@@ -224,9 +224,9 @@ private[spark] object StorageUtils extends Logging {
    * set through the Hadoop configuration as the server is launched in the Yarn NM.
    */
   def externalShuffleServicePort(conf: SparkConf): Int = {
-    if (Utils.isLocalSparkCluster(conf)) {
-      assert(sys.env.contains(ExternalShuffleService.TESTING_ESS_PORT_ENV),
-        s"${ExternalShuffleService.TESTING_ESS_PORT_ENV} is not available")
+    if (sys.env.contains(ExternalShuffleService.TESTING_ESS_PORT_ENV)) {
+      assert(Utils.isLocalSparkCluster(conf), s"${ExternalShuffleService.TESTING_ESS_PORT_ENV} " +
+        s"should only be set in local Spark cluster")
       val port = sys.env(ExternalShuffleService.TESTING_ESS_PORT_ENV).toInt
       if (conf.contains(config.SHUFFLE_SERVICE_PORT.key)) {
         logWarning(log"Setting external shuffle service port in Spark local cluster " +

--- a/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
+++ b/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
@@ -224,7 +224,7 @@ private[spark] object StorageUtils extends Logging {
    * set through the Hadoop configuration as the server is launched in the Yarn NM.
    */
   def externalShuffleServicePort(conf: SparkConf): Int = {
-    if (Utils.isTesting && Utils.isLocalSparkCluster(conf)) {
+    if (Utils.isLocalSparkCluster(conf)) {
       assert(sys.env.contains(ExternalShuffleService.TESTING_ESS_PORT_ENV),
         s"${ExternalShuffleService.TESTING_ESS_PORT_ENV} is not available")
       val port = sys.env(ExternalShuffleService.TESTING_ESS_PORT_ENV).toInt

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -67,7 +67,7 @@ import org.eclipse.jetty.util.MultiException
 import org.slf4j.Logger
 
 import org.apache.spark._
-import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.deploy.{LocalSparkCluster, SparkHadoopUtil}
 import org.apache.spark.internal.{Logging, MDC, MessageWithContext}
 import org.apache.spark.internal.LogKeys
 import org.apache.spark.internal.LogKeys._
@@ -2525,6 +2525,14 @@ private[spark] object Utils
   def isLocalMaster(conf: ReadOnlySparkConf): Boolean = {
     val master = conf.get("spark.master", "")
     master == "local" || master.startsWith("local[")
+  }
+
+  def isLocalSparkCluster(conf: ReadOnlySparkConf): Boolean = {
+    if (LocalSparkCluster.get.isDefined) {
+      true
+    } else {
+      conf.getOption("spark.master").exists(_.startsWith("local-cluster"))
+    }
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/deploy/ExternalShuffleServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/ExternalShuffleServiceSuite.scala
@@ -36,7 +36,11 @@ import org.apache.spark.storage.{RDDBlockId, ShuffleBlockId, ShuffleDataBlockId,
 import org.apache.spark.util.ThreadUtils
 
 /**
- * This suite creates an external shuffle server and routes all shuffle fetches through it.
+ * This suite tests the external shuffle service by starting the services in Spark Workers of
+ * the local Spark cluster. `spark.shuffle.service.port` is not allowed to set in local-cluster
+ * mode as a fixed port can conflict among multiple services on the same host. Dynamic ports
+ * would be used instead.
+ *
  * Note that failures in this suite may arise due to changes in Spark that invalidate expectations
  * set up in `ExternalBlockHandler`, such as changing the format of shuffle files or how
  * we hash files into folders.

--- a/core/src/test/scala/org/apache/spark/deploy/ExternalShuffleServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/ExternalShuffleServiceSuite.scala
@@ -83,12 +83,10 @@ class ExternalShuffleServiceSuite extends ShuffleSuite with BeforeAndAfterAll wi
 
     // Now Spark will receive FetchFailed, and not retry the stage due to "spark.test.noStageRetry"
     // being set.
-    eventually(timeout(60.seconds), interval(100.milliseconds)) {
-      val e = intercept[SparkException] {
-        rdd.count()
-      }
-      e.getMessage should include("Fetch failure will not retry stage due to testing config")
+    val e = intercept[SparkException] {
+      rdd.count()
     }
+    e.getMessage should include("Fetch failure will not retry stage due to testing config")
   }
 
   test("SPARK-25888: using external shuffle service fetching disk persisted blocks") {

--- a/core/src/test/scala/org/apache/spark/deploy/ExternalShuffleServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/ExternalShuffleServiceSuite.scala
@@ -77,9 +77,9 @@ class ExternalShuffleServiceSuite extends ShuffleSuite with BeforeAndAfterAll wi
 
     // Invalidate the registered executors, disallowing access to their shuffle blocks (without
     // deleting the actual shuffle files, so we could access them without the shuffle service).
-    LocalSparkCluster.get.get.workers.head.askSync[Boolean](
+    LocalSparkCluster.get.get.workers.foreach(_.askSync[Boolean](
       ApplicationRemoveTest(sc.conf.getAppId, false)
-    )
+    ))
 
     // Now Spark will receive FetchFailed, and not retry the stage due to "spark.test.noStageRetry"
     // being set.
@@ -155,7 +155,7 @@ class ExternalShuffleServiceSuite extends ShuffleSuite with BeforeAndAfterAll wi
       assert(sc.env.blockManager.getRemoteValues(blockId).isEmpty)
     } finally {
       LocalSparkCluster.get.get
-        .workers.head.askSync[Boolean](ApplicationRemoveTest(sc.conf.getAppId, true))
+        .workers.foreach(_.askSync[Boolean](ApplicationRemoveTest(sc.conf.getAppId, true)))
     }
   }
 
@@ -234,7 +234,7 @@ class ExternalShuffleServiceSuite extends ShuffleSuite with BeforeAndAfterAll wi
         }
       } finally {
         LocalSparkCluster.get.get
-          .workers.head.askSync[Boolean](ApplicationRemoveTest(sc.conf.getAppId, true))
+          .workers.foreach(_.askSync[Boolean](ApplicationRemoveTest(sc.conf.getAppId, true)))
         sc.stop()
       }
     }
@@ -257,7 +257,7 @@ class ExternalShuffleServiceSuite extends ShuffleSuite with BeforeAndAfterAll wi
         assert(sc.persistentRdds.isEmpty)
       } finally {
         LocalSparkCluster.get.get
-          .workers.head.askSync[Boolean](ApplicationRemoveTest(sc.conf.getAppId, true))
+          .workers.foreach(_.askSync[Boolean](ApplicationRemoveTest(sc.conf.getAppId, true)))
         sc.stop()
       }
     }

--- a/core/src/test/scala/org/apache/spark/deploy/SslExternalShuffleServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SslExternalShuffleServiceSuite.scala
@@ -15,13 +15,8 @@
  * limitations under the License.
  */
 
-package org.apache.spark
+package org.apache.spark.deploy
 
-import org.apache.spark.deploy.SparkHadoopUtil
-import org.apache.spark.internal.config
-import org.apache.spark.network.TransportContext
-import org.apache.spark.network.netty.SparkTransportConf
-import org.apache.spark.network.shuffle.ExternalBlockHandler
 import org.apache.spark.util.SslTestUtils
 
 /**
@@ -32,22 +27,8 @@ import org.apache.spark.util.SslTestUtils
  */
 class SslExternalShuffleServiceSuite extends ExternalShuffleServiceSuite {
 
-  override def initializeHandlers(): Unit = {
+  override def beforeAll(): Unit = {
     SslTestUtils.updateWithSSLConfig(conf)
-    val hadoopConf = SparkHadoopUtil.get.newConfiguration(conf);
-    // Show that we can successfully inherit options defined in the `spark.ssl` namespace
-    val defaultSslOptions = SSLOptions.parse(conf, hadoopConf, "spark.ssl")
-    val sslOptions = SSLOptions.parse(
-      conf, hadoopConf, "spark.ssl.rpc", defaults = Some(defaultSslOptions))
-    val transportConf = SparkTransportConf.fromSparkConf(
-      conf, "shuffle", numUsableCores = 2, sslOptions = Some(sslOptions))
-
-    rpcHandler = new ExternalBlockHandler(transportConf, null)
-    transportContext = new TransportContext(transportConf, rpcHandler)
-    server = transportContext.createServer()
-
-    conf.set(config.SHUFFLE_MANAGER, "sort")
-    conf.set(config.SHUFFLE_SERVICE_ENABLED, true)
-    conf.set(config.SHUFFLE_SERVICE_PORT, server.getPort)
+    super.beforeAll()
   }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/worker/WorkerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/worker/WorkerSuite.scala
@@ -371,7 +371,7 @@ class WorkerSuite extends SparkFunSuite with Matchers with BeforeAndAfter with P
     val appId = "app1"
     val execId = "exec1"
     val cleanupCalled = new AtomicBoolean(false)
-    when(shuffleService.applicationRemoved(any[String])).thenAnswer(
+    when(shuffleService.applicationRemoved(any[String], any[Boolean])).thenAnswer(
       (_: InvocationOnMock) => cleanupCalled.set(true))
     val externalShuffleServiceSupplier = new Supplier[ExternalShuffleService] {
       override def get: ExternalShuffleService = shuffleService

--- a/core/src/test/scala/org/apache/spark/shuffle/HostLocalShuffleReadingSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/HostLocalShuffleReadingSuite.scala
@@ -78,7 +78,13 @@ class HostLocalShuffleReadingSuite extends SparkFunSuite with Matchers with Loca
     test(s"host local shuffle reading with external shuffle service $essStatus") {
       conf.set(SHUFFLE_SERVICE_ENABLED, isESSEnabled)
         .set(STORAGE_LOCAL_DISK_BY_EXECUTORS_CACHE_SIZE, 5)
-      sc = new SparkContext("local-cluster[2,1,1024]", "test-host-local-shuffle-reading", conf)
+      val master = if (isESSEnabled) {
+        conf.set(EXECUTOR_CORES, 1)
+        "local-cluster[1,2,2048]"
+      } else {
+        "local-cluster[2,1,1024]"
+      }
+      sc = new SparkContext(master, "test-host-local-shuffle-reading", conf)
       // In a slow machine, one executor may register hundreds of milliseconds ahead of the other
       // one. If we don't wait for all executors, it's possible that only one executor runs all
       // jobs. Then all shuffle blocks will be in this executor, ShuffleBlockFetcherIterator will


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR supports external shuffle service enablement in local-cluster mode. Unlike the real cluster, where there is only one external shuffle service in each node, there could be multiple shuffle service in a local cluster. To support this, we have to use the dynamic port rather than the fixed port (`spark.shuffle.service.port`) to start the shuffle servieces. And so, worker would pass this dynamic port via a environment variable (`TESTING_EXTERNAL_SHUFFLE_SERVICE_PORT`) to the executor process since the fixed shuffle service port is no-longer valid. This also becomes an issue to `BlockManagerMaster`, which could also not use the fixed port anymore. So this PR adds a new RPC `GetShuffleServicePort` for retrieving the dynamic port from executor to driver. Another similar issue is that `DBProvider` uses the fixed persist file name in shuffle service. This PR changes it be unique by inserting a uuid under test mode only.



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This allows Spark developers to test features (e.g., shuffle data / rdd fetch via shuffle service) with the real external shuffle service, which is more close to the production environment.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Updated `ExternalShuffleServiceSuite` (removed the mock of the external shuffle service).


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.
