### PR TITLE
[SPARK-50578][PYTHON][SS][FOLLOWUP] Change to use `Thread.interrupt` instead of `Thread.stop` to interrupt the execution of TransformWithStateInPandasPythonPreInitRunner#daemonThread.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,7 +25,7 @@ on:
       java:
         required: false
         type: string
-        default: 17
+        default: 21
       branch:
         description: Branch to run the build against
         required: false

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,7 +25,7 @@ on:
       java:
         required: false
         type: string
-        default: 21
+        default: 17
       branch:
         description: Branch to run the build against
         required: false

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/TransformWithStateInPandasPythonRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/TransformWithStateInPandasPythonRunner.scala
@@ -275,7 +275,7 @@ class TransformWithStateInPandasPythonPreInitRunner(
   override def stop(): Unit = {
     super.stop()
     closeServerSocketChannelSilently(stateServerSocket)
-    daemonThread.stop()
+    daemonThread.interrupt()
   }
 
   private def startStateServer(): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/TransformWithStateInPandasStateServer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/TransformWithStateInPandasStateServer.scala
@@ -146,6 +146,9 @@ class TransformWithStateInPandasStateServer(
 
     while (listeningSocket.isConnected &&
       statefulProcessorHandle.getHandleState != StatefulProcessorHandleState.CLOSED) {
+      if (Thread.currentThread().isInterrupted) {
+        throw new InterruptedException("Thread was interrupted")
+      }
       try {
         val version = inputStream.readInt()
         if (version != -1) {
@@ -157,6 +160,11 @@ class TransformWithStateInPandasStateServer(
       } catch {
         case _: EOFException =>
           logWarning(log"No more data to read from the socket")
+          statefulProcessorHandle.setHandleState(StatefulProcessorHandleState.CLOSED)
+          return
+        case _: InterruptedException =>
+          Thread.currentThread().interrupt()
+          logInfo(log"Thread interrupted, shutting down state server")
           statefulProcessorHandle.setHandleState(StatefulProcessorHandleState.CLOSED)
           return
         case e: Exception =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/TransformWithStateInPandasStateServer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/TransformWithStateInPandasStateServer.scala
@@ -163,8 +163,8 @@ class TransformWithStateInPandasStateServer(
           statefulProcessorHandle.setHandleState(StatefulProcessorHandleState.CLOSED)
           return
         case _: InterruptedException =>
-          Thread.currentThread().interrupt()
           logInfo(log"Thread interrupted, shutting down state server")
+          Thread.currentThread().interrupt()
           statefulProcessorHandle.setHandleState(StatefulProcessorHandleState.CLOSED)
           return
         case e: Exception =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR change to use `Thread.interrupt()` instead of `Thread.stop()` to attempt to interrupt the execution of `TransformWithStateInPandasPythonPreInitRunner#daemonThread`. 

Additionally, logic has been added in `TransformWithStateInPandasStateServer#run` to respond to the interrupt by setting the `CLOSED` state and exiting.


### Why are the changes needed?
The `Thread.stop` method in Java 21 directly throws an `UnsupportedOperationException`, which led to the failure of the Java 21 daily tests:

- https://github.com/apache/spark/actions/runs/12511573912/job/34903859772
- https://github.com/apache/spark/actions/runs/12523542188/job/34933207012
- https://github.com/apache/spark/actions/runs/12592534465/job/35097321533

![image](https://github.com/user-attachments/assets/75cef6d7-d66a-4652-b01d-38412d6db3b0)

So the primary purpose of this change is to restore the daily tests for Java 21.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Pass Java 21 GitHub Action test: https://github.com/LuciferYang/spark/actions/runs/12606699142/job/35137180872

![image](https://github.com/user-attachments/assets/9e5e8b08-d167-4f7a-959c-8ebe6e22f9bc)

### Was this patch authored or co-authored using generative AI tooling?
No