### PR TITLE
[SPARK-XXXXX][CORE] Skip task serialization for local executor backend

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -427,7 +427,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     }
 
     // Launch tasks returned by a set of resource offers
-    private def launchTasks(tasks: Seq[Seq[TaskDescription]]): Unit = {
+    private def launchTasks(tasks: Seq[Seq[TaskDescription[_]]]): Unit = {
       for (task <- tasks.flatten) {
         val serializedTask = TaskDescription.encode(task)
         if (serializedTask.limit() >= maxRpcMessageSize) {

--- a/core/src/test/scala/org/apache/spark/executor/CoarseGrainedExecutorBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/CoarseGrainedExecutorBackendSuite.scala
@@ -324,7 +324,7 @@ class CoarseGrainedExecutorBackendSuite extends SparkFunSuite
       when(executor.runningTasks).thenAnswer(_ => runningTasks)
       when(executor.conf).thenReturn(conf)
 
-      def getFakeTaskRunner(taskDescription: TaskDescription): Executor#TaskRunner = {
+      def getFakeTaskRunner(taskDescription: TaskDescription[_]): Executor#TaskRunner = {
         new executor.TaskRunner(backend, taskDescription, None) {
           override def run(): Unit = {
             logInfo(s"task ${this.taskDescription.taskId} runs.")
@@ -437,7 +437,7 @@ class CoarseGrainedExecutorBackendSuite extends SparkFunSuite
       }
       assert(taskDescriptions.length == numTasks)
 
-      def getFakeTaskRunner(taskDescription: TaskDescription): Executor#TaskRunner = {
+      def getFakeTaskRunner(taskDescription: TaskDescription[_]): Executor#TaskRunner = {
         new executor.TaskRunner(backend, taskDescription, None) {
           override def run(): Unit = {
             tasksExecuted.put(this.taskDescription.taskId, true)
@@ -529,7 +529,7 @@ class CoarseGrainedExecutorBackendSuite extends SparkFunSuite
       }
       assert(taskDescriptions.length == numTasks)
 
-      def getFakeTaskRunner(taskDescription: TaskDescription): Executor#TaskRunner = {
+      def getFakeTaskRunner(taskDescription: TaskDescription[_]): Executor#TaskRunner = {
         new executor.TaskRunner(backend, taskDescription, None) {
           override def run(): Unit = {
             tasksExecuted.put(this.taskDescription.taskId, true)

--- a/core/src/test/scala/org/apache/spark/executor/ExecutorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/ExecutorSuite.scala
@@ -619,7 +619,7 @@ class ExecutorSuite extends SparkFunSuite
       serializer: SerializerInstance,
       taskBinary: Broadcast[Array[Byte]],
       rdd: RDD[Int],
-      stageId: Int): TaskDescription = {
+      stageId: Int): TaskDescription[_] = {
     val serializedTaskMetrics = serializer.serialize(TaskMetrics.registered).array()
     val task = new ResultTask(
       stageId = stageId,
@@ -637,7 +637,7 @@ class ExecutorSuite extends SparkFunSuite
     createFakeTaskDescription(serTask)
   }
 
-  private def createFakeTaskDescription(serializedTask: ByteBuffer): TaskDescription = {
+  private def createFakeTaskDescription(serializedTask: ByteBuffer): TaskDescription[_] = {
     new TaskDescription(
       taskId = 0,
       attemptNumber = 0,
@@ -652,12 +652,12 @@ class ExecutorSuite extends SparkFunSuite
       serializedTask)
   }
 
-  private def runTaskAndGetFailReason(taskDescription: TaskDescription): TaskFailedReason = {
+  private def runTaskAndGetFailReason(taskDescription: TaskDescription[_]): TaskFailedReason = {
     runTaskGetFailReasonAndExceptionHandler(taskDescription, false)._1
   }
 
   private def runTaskGetFailReasonAndExceptionHandler(
-      taskDescription: TaskDescription,
+      taskDescription: TaskDescription[_],
       killTask: Boolean,
       poll: Boolean = false): (TaskFailedReason, UncaughtExceptionHandler) = {
     val mockBackend = mock[ExecutorBackend]

--- a/core/src/test/scala/org/apache/spark/scheduler/CoarseGrainedSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/CoarseGrainedSchedulerBackendSuite.scala
@@ -346,7 +346,7 @@ class CoarseGrainedSchedulerBackendSuite extends SparkFunSuite with LocalSparkCo
 
     val taskResources = Map(GPU -> Map("0" -> ONE_ENTIRE_RESOURCE))
     val taskCpus = 1
-    val taskDescs: Seq[Seq[TaskDescription]] = Seq(Seq(new TaskDescription(1, 0, "1",
+    val taskDescs: Seq[Seq[TaskDescription[_]]] = Seq(Seq(new TaskDescription(1, 0, "1",
       "t1", 0, 1, JobArtifactSet.emptyJobArtifactSet, new Properties(),
       taskCpus, taskResources, bytebuffer)))
     val ts = backend.getTaskSchedulerImpl()
@@ -453,7 +453,7 @@ class CoarseGrainedSchedulerBackendSuite extends SparkFunSuite with LocalSparkCo
 
     val taskResources = Map(GPU -> Map("0" -> ONE_ENTIRE_RESOURCE))
     val taskCpus = 1
-    val taskDescs: Seq[Seq[TaskDescription]] = Seq(Seq(new TaskDescription(1, 0, "1",
+    val taskDescs: Seq[Seq[TaskDescription[_]]] = Seq(Seq(new TaskDescription(1, 0, "1",
       "t1", 0, 1, JobArtifactSet.emptyJobArtifactSet, new Properties(),
       taskCpus, taskResources, bytebuffer)))
     val ts = backend.getTaskSchedulerImpl()
@@ -546,7 +546,7 @@ class CoarseGrainedSchedulerBackendSuite extends SparkFunSuite with LocalSparkCo
     assert(ResourceProfile.getTaskCpusOrDefaultForProfile(defaultRp, conf) == 1)
     // Task cpus can be different from default resource profile when TaskResourceProfile is used.
     val taskCpus = 2
-    val taskDescs: Seq[Seq[TaskDescription]] = Seq(Seq(new TaskDescription(1, 0, "1",
+    val taskDescs: Seq[Seq[TaskDescription[_]]] = Seq(Seq(new TaskDescription(1, 0, "1",
       "t1", 0, 1, JobArtifactSet.emptyJobArtifactSet, new Properties(),
       taskCpus, Map.empty, bytebuffer)))
     when(ts.resourceOffers(any[IndexedSeq[WorkerOffer]], any[Boolean])).thenReturn(taskDescs)

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -732,7 +732,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext
         .isExecutorExcludedForTaskSet(anyString())
     }
 
-    def tasksForStage(stageId: Int): Seq[TaskDescription] = {
+    def tasksForStage(stageId: Int): Seq[TaskDescription[_]] = {
       firstTaskAttempts.filter{_.name.contains(s"stage $stageId")}
     }
     tasksForStage(0).foreach { task =>

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -1324,7 +1324,7 @@ class TaskSetManagerSuite
       task.metrics.internalAccums
     }
     // Offer resources for 5 tasks to start
-    val tasks = new ArrayBuffer[TaskDescription]()
+    val tasks = new ArrayBuffer[TaskDescription[_]]()
     for ((k, v) <- List(
       "exec1" -> "host1",
       "exec1" -> "host1",
@@ -1345,7 +1345,7 @@ class TaskSetManagerSuite
       assert(sched.endedTasks(id) === Success)
     }
 
-    def runningTaskForIndex(index: Int): TaskDescription = {
+    def runningTaskForIndex(index: Int): TaskDescription[_] = {
       tasks.find { task =>
         task.index == index && !sched.endedTasks.contains(task.taskId)
       }.getOrElse {
@@ -2600,7 +2600,7 @@ class TaskSetManagerSuite
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
 
     // Offer resources for 3 task to start
-    val tasks = new ArrayBuffer[TaskDescription]()
+    val tasks = new ArrayBuffer[TaskDescription[_]]()
     for ((k, v) <- List("exec1" -> "host1", "exec2" -> "host2", "exec3" -> "host3")) {
       val taskOption = manager.resourceOffer(k, v, NO_PREF)._1
       assert(taskOption.isDefined)
@@ -2610,7 +2610,7 @@ class TaskSetManagerSuite
     }
     assert(sched.startedTasks.toSet === (0 until 3).toSet)
 
-    def runningTaskForIndex(index: Int): TaskDescription = {
+    def runningTaskForIndex(index: Int): TaskDescription[_] = {
       tasks.find { task =>
         task.index == index && !sched.endedTasks.contains(task.taskId)
       }.getOrElse {

--- a/streaming/src/main/scala/org/apache/spark/streaming/rdd/MapWithStateRDD.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/rdd/MapWithStateRDD.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.streaming.rdd
 
-import java.io.{IOException, ObjectOutputStream}
-
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 
@@ -26,7 +24,6 @@ import org.apache.spark._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.{State, StateImpl, Time}
 import org.apache.spark.streaming.util.{EmptyStateMap, StateMap}
-import org.apache.spark.util.Utils
 
 /**
  * Record storing the keyed-state [[MapWithStateRDD]]. Each record contains a `StateMap` and a
@@ -91,19 +88,14 @@ private[streaming] class MapWithStateRDDPartition(
   private[rdd] var previousSessionRDDPartition: Partition = null
   private[rdd] var partitionedDataRDDPartition: Partition = null
 
+  previousSessionRDDPartition = prevStateRDD.partitions(index)
+  partitionedDataRDDPartition = partitionedDataRDD.partitions(index)
+
   override def hashCode(): Int = index
 
   override def equals(other: Any): Boolean = other match {
     case that: MapWithStateRDDPartition => index == that.index
     case _ => false
-  }
-
-  @throws(classOf[IOException])
-  private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
-    // Update the reference to parent split at the time of task serialization
-    previousSessionRDDPartition = prevStateRDD.partitions(index)
-    partitionedDataRDDPartition = partitionedDataRDD.partitions(index)
-    oos.defaultWriteObject()
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch removes task serialization when scheduling tasks for local executor backend. The tasks are directly passed to the local executor to run.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Spark serializes tasks and attaches serialized tasks in task description before submitting tasks to executors. For remote executor backends, this is necessary. But for local executor backend, it runs in same JVM with master. It seems that task serialization for local executor backend is not necessary.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Manual test local mode.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
