### PR TITLE
[SPARK-50578][PYTHON][SS][FOLLOWUP] Remove unnecessary if block

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/TransformWithStateInPandasStateServer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/TransformWithStateInPandasStateServer.scala
@@ -146,9 +146,6 @@ class TransformWithStateInPandasStateServer(
 
     while (listeningSocket.isConnected &&
       statefulProcessorHandle.getHandleState != StatefulProcessorHandleState.CLOSED) {
-      if (Thread.currentThread().isInterrupted) {
-        throw new InterruptedException("Thread was interrupted")
-      }
       try {
         val version = inputStream.readInt()
         if (version != -1) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR removes the `if` block at the beginning of the while loop since `InterruptedException` is handled in the try / catch block.

### Why are the changes needed?
This change makes the code easier to follow.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing Java 21 daily tests

### Was this patch authored or co-authored using generative AI tooling?
No.