### PR TITLE
[SPARK-50730][SQL][TESTS] Skip TPC-DS collation benchmark in branch-3.5

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1094,6 +1094,7 @@ jobs:
           spark.sql.autoBroadcastJoinThreshold=-1
           spark.sql.join.forceApplyShuffledHashJoin=true
     - name: Run TPC-DS queries on collated data
+      if: inputs.branch != 'branch-3.5'
       run: |
         SPARK_TPCDS_DATA=`pwd`/tpcds-sf-1 build/sbt "sql/testOnly org.apache.spark.sql.TPCDSCollationQueryTestSuite"
     - name: Upload test results to report


### PR DESCRIPTION


### What changes were proposed in this pull request?
This PR aims to skip TPC-DS collation benchmark in branch-3.5

### Why are the changes needed?
TPS-DS collation benchmark was added by the following PR at Spark 4.0
- https://github.com/apache/spark/pull/45739

However, branch-3.5 daily CI is trying to run non-existing tests. 
- https://github.com/apache/spark/actions/runs/12618956363/job/35162950623

<img width="366" alt="Screenshot 2025-01-05 at 2 48 54 PM" src="https://github.com/user-attachments/assets/80e4013a-132e-4e92-b4b9-4c5581295c43" />

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Check manually after merge.


### Was this patch authored or co-authored using generative AI tooling?
No.
