### PR TITLE
[SPARK-50732][SQL][TESTS] Mark `DataFrameAggregateSuite` and its derived classes as `SlowSQLTest`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/AggregateHashMapSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/AggregateHashMapSuite.scala
@@ -21,7 +21,9 @@ import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.tags.SlowSQLTest
 
+@SlowSQLTest
 class SingleLevelAggregateHashMapSuite extends DataFrameAggregateSuite with BeforeAndAfter {
   override protected def sparkConf: SparkConf = super.sparkConf
     .set(SQLConf.CODEGEN_FALLBACK.key, "false")
@@ -37,6 +39,7 @@ class SingleLevelAggregateHashMapSuite extends DataFrameAggregateSuite with Befo
   }
 }
 
+@SlowSQLTest
 class TwoLevelAggregateHashMapSuite extends DataFrameAggregateSuite with BeforeAndAfter {
   override protected def sparkConf: SparkConf = super.sparkConf
     .set(SQLConf.CODEGEN_FALLBACK.key, "false")
@@ -52,6 +55,7 @@ class TwoLevelAggregateHashMapSuite extends DataFrameAggregateSuite with BeforeA
   }
 }
 
+@SlowSQLTest
 class TwoLevelAggregateHashMapWithVectorizedMapSuite
   extends DataFrameAggregateSuite
   with BeforeAndAfter {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -39,10 +39,12 @@ import org.apache.spark.sql.test.SQLTestData.DecimalData
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.DayTimeIntervalType.{DAY, HOUR, MINUTE, SECOND}
 import org.apache.spark.sql.types.YearMonthIntervalType.{MONTH, YEAR}
+import org.apache.spark.tags.SlowSQLTest
 import org.apache.spark.unsafe.types.CalendarInterval
 
 case class Fact(date: Int, hour: Int, minute: Int, room_name: String, temp: Double)
 
+@SlowSQLTest
 class DataFrameAggregateSuite extends QueryTest
   with SharedSparkSession
   with AdaptiveSparkPlanHelper {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to mark `DataFrameAggregateSuite` and its derived classes as `SlowSQLTest`.

```
$ git grep DataFrameAggregateSuite
sql/core/src/test/scala/org/apache/spark/sql/AggregateHashMapSuite.scala:class SingleLevelAggregateHashMapSuite extends DataFrameAggregateSuite with BeforeAndAfter {
sql/core/src/test/scala/org/apache/spark/sql/AggregateHashMapSuite.scala:class TwoLevelAggregateHashMapSuite extends DataFrameAggregateSuite with BeforeAndAfter {
sql/core/src/test/scala/org/apache/spark/sql/AggregateHashMapSuite.scala:  extends DataFrameAggregateSuite
sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala:class DataFrameAggregateSuite extends QueryTest
```

### Why are the changes needed?

When we are adding more tests into `DataFrameAggregateSuite`, its derived three classes also grow together.

To balance the test pipelines by moving this long-running test suite group. The following is the AS-IS run time before this PR.

<img width="538" alt="Screenshot 2025-01-05 at 20 58 15" src="https://github.com/user-attachments/assets/a5717c5f-a6da-4853-9657-07fccd5bce7e" />


### Does this PR introduce _any_ user-facing change?

No, this is a test-only change.

### How was this patch tested?

Manually check the CI logs.

### Was this patch authored or co-authored using generative AI tooling?

No.