### PR TITLE
[SPARK-50733][K8S][INFRA] Update K8s IT CI to use K8s 1.32

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1226,6 +1226,7 @@ jobs:
       - name: Start Minikube
         uses: medyagh/setup-minikube@v0.0.18
         with:
+          kubernetes-version: "1.32.0"
           # Github Action limit cpu:2, memory: 6947MB, limit to 2U6G for better resource statistic
           cpus: 2
           memory: 6144m


### PR DESCRIPTION
### What changes were proposed in this pull request?

As a part of Apache Spark 4.0.0 preparation, this PR aims to use the latest K8s v1.32.0 (2024-12-11) for K8s integration tests instead of v1.31.0 (August 13, 2024).

### Why are the changes needed?

K8s v1.32 was released on last December.
- https://kubernetes.io/releases/#release-v1-32

Previously, we has been depending on the default version of Minikube because Minikube has a rapid release cycle.

However, the release cycle of Minikube is a little slow in these days. We had better control the test target K8s version explicitly for now.

### Does this PR introduce _any_ user-facing change?

No, this is a infra-only change.

### How was this patch tested?

Pass the CIs and check the K8s CI log. The following is the current log of this PR.

```
  Kubelet Version:            v1.32.0
  Kube-Proxy Version:         v1.32.0
```

### Was this patch authored or co-authored using generative AI tooling?

No.