### PR TITLE
Revert "[SPARK-50716][CORE] Fix the cleanup logic for symbolic links in `JavaUtils.deleteRecursivelyUsingJavaIO` method"

### DIFF
--- a/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -22,7 +22,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -126,11 +125,10 @@ public class JavaUtils {
   private static void deleteRecursivelyUsingJavaIO(
       File file,
       FilenameFilter filter) throws IOException {
+    if (!file.exists()) return;
     BasicFileAttributes fileAttributes =
-      Files.readAttributes(file.toPath(), BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-    // SPARK-50716: If the file does not exist and not a broken symbolic link, return directly.
-    if (!file.exists() && !fileAttributes.isSymbolicLink()) return;
-    if (fileAttributes.isDirectory()) {
+      Files.readAttributes(file.toPath(), BasicFileAttributes.class);
+    if (fileAttributes.isDirectory() && !isSymlink(file)) {
       IOException savedIOException = null;
       for (File child : listFilesSafely(file, filter)) {
         try {
@@ -145,8 +143,8 @@ public class JavaUtils {
       }
     }
 
-    // Delete file only when it's a normal file, a symbolic link, or an empty directory.
-    if (fileAttributes.isRegularFile() || fileAttributes.isSymbolicLink() ||
+    // Delete file only when it's a normal file or an empty directory.
+    if (fileAttributes.isRegularFile() ||
       (fileAttributes.isDirectory() && listFilesSafely(file, null).length == 0)) {
       boolean deleted = file.delete();
       // Delete can also fail if the file simply did not exist.
@@ -192,6 +190,17 @@ public class JavaUtils {
     } else {
       return new File[0];
     }
+  }
+
+  private static boolean isSymlink(File file) throws IOException {
+    Objects.requireNonNull(file);
+    File fileInCanonicalDir = null;
+    if (file.getParent() == null) {
+      fileInCanonicalDir = file;
+    } else {
+      fileInCanonicalDir = new File(file.getParentFile().getCanonicalFile(), file.getName());
+    }
+    return !fileInCanonicalDir.getCanonicalFile().equals(fileInCanonicalDir.getAbsoluteFile());
   }
 
   private static final Map<String, TimeUnit> timeSuffixes;

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -22,7 +22,6 @@ import java.lang.reflect.Field
 import java.net.{BindException, ServerSocket, URI}
 import java.nio.{ByteBuffer, ByteOrder}
 import java.nio.charset.StandardCharsets.UTF_8
-import java.nio.file.{Files => JFiles}
 import java.text.DecimalFormatSymbols
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -730,43 +729,6 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     assert(!tempDir2.exists())
     assert(!tempDir3.exists())
     assert(!sourceFile2.exists())
-  }
-
-  test("SPARK-50716: deleteRecursively - SymbolicLink To File") {
-    val tempDir = Utils.createTempDir()
-    val sourceFile = new File(tempDir, "foo.txt")
-    JFiles.write(sourceFile.toPath, "Some content".getBytes)
-    assert(sourceFile.exists())
-
-    val symlinkFile = new File(tempDir, "bar.txt")
-    JFiles.createSymbolicLink(symlinkFile.toPath, sourceFile.toPath)
-
-    // Check that the symlink was created successfully
-    assert(JFiles.isSymbolicLink(symlinkFile.toPath))
-    Utils.deleteRecursively(tempDir)
-
-    // Verify that everything is deleted
-    assert(!tempDir.exists)
-  }
-
-  test("SPARK-50716: deleteRecursively - SymbolicLink To Dir") {
-    val tempDir = Utils.createTempDir()
-    val sourceDir = new File(tempDir, "sourceDir")
-    assert(sourceDir.mkdir())
-    val sourceFile = new File(sourceDir, "file.txt")
-    JFiles.write(sourceFile.toPath, "Some content".getBytes)
-
-    val symlinkDir = new File(tempDir, "targetDir")
-    JFiles.createSymbolicLink(symlinkDir.toPath, sourceDir.toPath)
-
-    // Check that the symlink was created successfully
-    assert(JFiles.isSymbolicLink(symlinkDir.toPath))
-
-    // Now delete recursively
-    Utils.deleteRecursively(tempDir)
-
-    // Verify that everything is deleted
-    assert(!tempDir.exists)
   }
 
   test("loading properties from file") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This reverts commit 98dc76364ffab660b52fb8a22e5d2fbce4bd8c47.


### Why are the changes needed?
To restore macos daily Tests


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Git Hub Actions

### Was this patch authored or co-authored using generative AI tooling?
No