### PR TITLE
[SPARK-50736][INFRA] Enable testing module `pyspark-logger`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -499,7 +499,7 @@ jobs:
           - >-
             pyspark-sql, pyspark-resource, pyspark-testing
           - >-
-            pyspark-core, pyspark-errors, pyspark-streaming
+            pyspark-core, pyspark-errors, pyspark-streaming, pyspark_logging
           - >-
             pyspark-mllib, pyspark-ml, pyspark-ml-connect
           - >-

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -499,7 +499,7 @@ jobs:
           - >-
             pyspark-sql, pyspark-resource, pyspark-testing
           - >-
-            pyspark-core, pyspark-errors, pyspark-streaming, pyspark_logging
+            pyspark-core, pyspark-errors, pyspark-streaming, pyspark-logger
           - >-
             pyspark-mllib, pyspark-ml, pyspark-ml-connect
           - >-

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -1438,7 +1438,7 @@ pyspark_errors = Module(
     ],
 )
 
-pyspark_logging = Module(
+pyspark_logger = Module(
     name="pyspark-logger",
     dependencies=[],
     source_file_regexes=["python/pyspark/logger"],


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable testing module `pyspark-logger`


### Why are the changes needed?
this testing module is missing in CI, so following tests were always skipped

https://github.com/apache/spark/blob/85d92d7c3a6a38b1b6cfc667caac9176fab5813b/dev/sparktestsupport/modules.py#L1441-L1450


### Does this PR introduce _any_ user-facing change?
no, infra-only


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no