### PR TITLE
[SPARK-50243][SQL][TESTS][FOLLOWUP] Remove `ARTIFACTS_SESSION_ISOLATION_ALWAYS_APPLY_CLASSLOADER` setting from `AdaptiveQueryExecSuite`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -749,7 +749,6 @@ class AdaptiveQueryExecSuite
     // so retry several times here to avoid unit test failure.
     eventually(timeout(15.seconds), interval(500.milliseconds)) {
       withSQLConf(
-        SQLConf.ARTIFACTS_SESSION_ISOLATION_ALWAYS_APPLY_CLASSLOADER.key -> "true",
         SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
         SQLConf.NON_EMPTY_PARTITION_RATIO_FOR_BROADCAST_JOIN.key -> "0.5") {
         // `testData` is small enough to be broadcast but has empty partition ratio over the config.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up to revert one line from the irrelevant test case of `AdaptiveQueryExecSuite`.
- #49007

### Why are the changes needed?

`AdaptiveQueryExecSuite` has been a flaky test and was designed to repeat the test logic many times. It's irrelevant to #49007 .

### Does this PR introduce _any_ user-facing change?

No, this is a revert to the original code.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.