### PR TITLE
[SPARK-50742][CORE] Remove `spark.hadoop.fs.s3a.connection.establish.timeout` setting

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -423,9 +423,6 @@ class SparkContext(config: SparkConf) extends Logging {
     if (!_conf.contains("spark.app.name")) {
       throw new SparkException("An application name must be set in your configuration")
     }
-    // HADOOP-19097 Set fs.s3a.connection.establish.timeout to 30s
-    // We can remove this after Apache Hadoop 3.4.1 releases
-    conf.setIfMissing("spark.hadoop.fs.s3a.connection.establish.timeout", "30000")
     // This should be set as early as possible.
     SparkContext.fillMissingMagicCommitterConfsIfNeeded(_conf)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `spark.hadoop.fs.s3a.connection.establish.timeout` setting from `SparkContext` because Apache Spark 4.0.0 uses Apache Hadoop 3.4.1 which has the same default value.

- #48295

### Why are the changes needed?

This is a logical cleanup by reverting two patches.

- #45710
- #46874

### Does this PR introduce _any_ user-facing change?

No. There is no behavior change because we will use the same `fs.s3a.connection.establish.timeout` value.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.