### PR TITLE
[SPARK-50745][SQL][TESTS] Use `eventually` in `BufferHolderSparkSubmitSuite`

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
@@ -18,7 +18,9 @@
 package org.apache.spark.sql.catalyst.expressions.codegen
 
 import org.scalatest.{Assertions, BeforeAndAfterEach}
+import org.scalatest.concurrent.Eventually.{eventually, interval, timeout}
 import org.scalatest.matchers.must.Matchers
+import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.{SparkIllegalArgumentException, TestUtils}
 import org.apache.spark.deploy.SparkSubmitTestUtils
@@ -46,7 +48,10 @@ class BufferHolderSparkSubmitSuite
       "--conf", "spark.master.rest.enabled=false",
       "--conf", "spark.driver.extraJavaOptions=-ea",
       unusedJar.toString)
-    runSparkSubmit(argsForSparkSubmit)
+    // Given that the default timeout of runSparkSubmit is 60 seconds, try 3 times in total.
+    eventually(timeout(210.seconds), interval(70.seconds)) {
+      runSparkSubmit(argsForSparkSubmit)
+    }
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `eventually` in `BufferHolderSparkSubmitSuite` to stabilize the long-standing flakiness.

### Why are the changes needed?

- https://github.com/dongjoon-hyun/spark/actions/runs/12638427790/job/35214696371
```
[info] BufferHolderSparkSubmitSuite:
[info] - SPARK-22222: Buffer holder should be able to allocate memory larger than 1GB *** FAILED *** (3 seconds, 721 milliseconds)
```

### Does this PR introduce _any_ user-facing change?

No, this is a test-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.