### PR TITLE
[SPARK-39903][SQL][TESTS] Reenable TPCDS q72 of `TPCDSQuerySuite` in GitHub Actions

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQuerySuite.scala
@@ -33,8 +33,7 @@ class TPCDSQuerySuite extends BenchmarkQueryTest with TPCDSBase {
     // Disable read-side char padding so that the generated code is less than 8000.
     super.sparkConf.set(SQLConf.READ_SIDE_CHAR_PADDING, false)
 
-  // q72 is skipped due to GitHub Actions' memory limit.
-  tpcdsQueries.filterNot(sys.env.contains("GITHUB_ACTIONS") && _ == "q72").foreach { name =>
+  tpcdsQueries.foreach { name =>
     val queryString = resourceToString(s"tpcds/$name.sql",
       classLoader = Thread.currentThread().getContextClassLoader)
     test(name) {
@@ -44,8 +43,7 @@ class TPCDSQuerySuite extends BenchmarkQueryTest with TPCDSBase {
     }
   }
 
-  // q72 is skipped due to GitHub Actions' memory limit.
-  tpcdsQueriesV2_7_0.filterNot(sys.env.contains("GITHUB_ACTIONS") && _ == "q72").foreach { name =>
+  tpcdsQueriesV2_7_0.foreach { name =>
     val queryString = resourceToString(s"tpcds-v2.7.0/$name.sql",
       classLoader = Thread.currentThread().getContextClassLoader)
     test(s"$name-v2.7") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to re-enable TPCDS q72 test of `TPCDSQuerySuite` in GitHub Actions.

### Why are the changes needed?

We have been running q72 query already in other test suites like `TPCDSQueryTestSuite`) in these days.
- https://github.com/apache/spark/actions/runs/12624895360/job/35175796403
```
[info] - q72 (57 seconds, 895 milliseconds)
[info] - q72-v2.7 (58 seconds, 223 milliseconds)
```

### Does this PR introduce _any_ user-facing change?

No, this is a test-only change.

### How was this patch tested?

Pass the CIs and check the log.

- https://github.com/dongjoon-hyun/spark/actions/runs/12639834198/job/35219025146

```
[info] TPCDSQuerySuite:
...
[info] - q72 (40 milliseconds)
```

### Was this patch authored or co-authored using generative AI tooling?

No.