### PR TITLE
[MINOR][DOCS] Use SBT slash syntax in `ExternalAppendOnlyUnsafeRowArrayBenchmark` doc

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArrayBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArrayBenchmark.scala
@@ -32,10 +32,10 @@ import org.apache.spark.util.collection.unsafe.sort.UnsafeExternalSorter
  * {{{
  *   1. without sbt:
  *      bin/spark-submit --class <this class> --jars <spark core test jar> <spark sql test jar>
- *   2. build/sbt build/sbt ";project sql;set javaOptions
- *        in Test += \"-Dspark.memory.debugFill=false\";Test/runMain <this class>"
- *   3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt ";project sql;set javaOptions
- *        in Test += \"-Dspark.memory.debugFill=false\";Test/runMain <this class>"
+ *   2. build/sbt build/sbt ";project sql;
+ *        set Test / javaOptions += \"-Dspark.memory.debugFill=false\";Test/runMain <this class>"
+ *   3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt ";project sql;
+ *        set Test / javaOptions += \"-Dspark.memory.debugFill=false\";Test/runMain <this class>"
  *      Results will be written to
  *      "benchmarks/ExternalAppendOnlyUnsafeRowArrayBenchmark-results.txt".
  * }}}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `slash` syntax in `ExternalAppendOnlyUnsafeRowArrayBenchmark` doc instead of the deprecated syntax.
- https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash

### Why are the changes needed?

This PR is aligned with our previous efforts. It seems that this is a leftover which we missed the documentation.
- #32115
- #37326
- #37754

### Does this PR introduce _any_ user-facing change?

No. This is a doc-only update.

### How was this patch tested?

Manual review.

```
$ build/sbt "project sql; set Test / javaOptions += \"-Dspark.memory.debugFill=false\";Test/runMain org.apache.spark.sql.execution.ExternalAppendOnlyUnsafeRowArrayBenchmark"
```

### Was this patch authored or co-authored using generative AI tooling?

No.