### PR TITLE
[SPARK-50747][SQL][TESTS] Fix `DockerJDBCIntegrationSuite` to retry `startContainerCmd` in case of `InternalServerErrorException`

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -211,7 +211,7 @@ abstract class DockerJDBCIntegrationSuite
         case e: InternalServerErrorException =>
           // Try once more in order to mitigate port binding error
           docker.startContainerCmd(container.getId).exec()
-        case e =>
+        case e: Throwable =>
           throw e
       }
       eventually(timeout(startContainerTimeout.seconds), interval(1.second)) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `DockerJDBCIntegrationSuite` to retry `startContainerCmd` in case of `InternalServerErrorException`.

### Why are the changes needed?

JDBC Integration Test is flaky in GitHub Action environment due to `bind: address already in use` error.
- https://github.com/apache/spark/actions/runs/12643490224/job/35229574243

```
[info] MySQLOverMariaConnectorIntegrationSuite:
[info] org.apache.spark.sql.jdbc.v2.MySQLOverMariaConnectorIntegrationSuite *** ABORTED *** (11 seconds, 115 milliseconds)
[info]   com.github.dockerjava.api.exception.InternalServerErrorException: Status 500: {"message":"driver failed programming external connectivity on endpoint intelligent_sammet (e57487b8c5c892c5d5e877f86a4b0915e853749cf25622962909c457dc974365): Error starting userland proxy: listen tcp4 0.0.0.0:44477: bind: address already in use"}
[info]   at com.github.dockerjava.core.DefaultInvocationBuilder.execute(DefaultInvocationBuilder.java:247)
[info]   at com.github.dockerjava.core.DefaultInvocationBuilder.post(DefaultInvocationBuilder.java:102)
[info]   at com.github.dockerjava.core.exec.StartContainerCmdExec.execute(StartContainerCmdExec.java:31)
[info]   at com.github.dockerjava.core.exec.StartContainerCmdExec.execute(StartContainerCmdExec.java:13)
[info]   at com.github.dockerjava.core.exec.AbstrSyncDockerCmdExec.exec(AbstrSyncDockerCmdExec.java:21)
[info]   at com.github.dockerjava.core.command.AbstrDockerCmd.exec(AbstrDockerCmd.java:33)
[info]   at com.github.dockerjava.core.command.StartContainerCmdImpl.exec(StartContainerCmdImpl.java:42)
[info]   at org.apache.spark.sql.jdbc.DockerJDBCIntegrationSuite.$anonfun$beforeAll$1(DockerJDBCIntegrationSuite.scala:208)
```

### Does this PR introduce _any_ user-facing change?

No. This is a test-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.