### PR TITLE
[SPARK-50749][SQL] Fix ordering bug in CommutativeExpression.gatherCommutative method

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -1354,19 +1354,24 @@ trait UserDefinedExpression {
 }
 
 trait CommutativeExpression extends Expression {
-  /** Collects adjacent commutative operations. */
-  private def gatherCommutative(
+  /**
+   * Collects adjacent commutative operations.
+   *
+   * Exposed for testing
+   */
+  private[spark] def gatherCommutative(
       e: Expression,
       f: PartialFunction[CommutativeExpression, Seq[Expression]]): Seq[Expression] = {
     val resultBuffer = scala.collection.mutable.Buffer[Expression]()
-    val stack = scala.collection.mutable.Stack[Expression](e)
+    val queue = scala.collection.mutable.Queue[Expression](e)
 
     // [SPARK-49977]: Use iterative approach to avoid creating many temporary List objects
     // for deep expression trees through recursion.
-    while (stack.nonEmpty) {
-      stack.pop() match {
+    while (queue.nonEmpty) {
+      val current = queue.dequeue()
+      current match {
         case c: CommutativeExpression if f.isDefinedAt(c) =>
-          stack.pushAll(f(c))
+          queue ++= f(c)
         case other =>
           resultBuffer += other.canonicalized
       }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
@@ -1086,17 +1086,4 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     checkEvaluation(IntegralDivide(Literal(Duration.ofDays(1)),
       Literal(Duration.ofHours(-5))), -4L)
   }
-
-  test("unit test for gatherCommutative()") {
-    val addExpression = Add(
-      Literal(1),
-      Add(
-        Literal(2),
-        Literal(3)
-      )
-    )
-    val commutativeExpressions = addExpression.gatherCommutative(addExpression,
-      { case Add(l, r, _) => Seq(l, r)})
-    assert(commutativeExpressions == Seq(Literal(1), Literal(2), Literal(3)))
-  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
@@ -1086,4 +1086,17 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     checkEvaluation(IntegralDivide(Literal(Duration.ofDays(1)),
       Literal(Duration.ofHours(-5))), -4L)
   }
+
+  test("unit test for gatherCommutative()") {
+    val addExpression = Add(
+      Literal(1),
+      Add(
+        Literal(2),
+        Literal(3)
+      )
+    )
+    val commutativeExpressions = addExpression.gatherCommutative(addExpression,
+      { case Add(l, r, _) => Seq(l, r)})
+    assert(commutativeExpressions == Seq(Literal(1), Literal(2), Literal(3)))
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CanonicalizeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CanonicalizeSuite.scala
@@ -479,4 +479,17 @@ class CanonicalizeSuite extends SparkFunSuite {
         }
     }
   }
+
+  test("unit test for gatherCommutative()") {
+    val addExpression = Add(
+      Literal(1),
+      Add(
+        Literal(2),
+        Literal(3)
+      )
+    )
+    val commutativeExpressions = addExpression.gatherCommutative(addExpression,
+      { case Add(l, r, _) => Seq(l, r)})
+    assert(commutativeExpressions == Seq(Literal(1), Literal(2), Literal(3)))
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

[SPARK-49977](https://issues.apache.org/jira/browse/SPARK-49977) introduced a bug in the `CommutativeExpression.gatherCommutative()` method, changing the function's output order.
Consider the following concrete example:

```
val addExpression = Add(
  Literal(1),
  Add(
    Literal(2),
    Literal(3)
  )
)
val commutativeExpressions = addExpression.gatherCommutative(addExpression,
  { case Add(l, r, _) => Seq(l, r)})

```

Consider the output of the `gatherCommutative` method. [SPARK-49977](https://issues.apache.org/jira/browse/SPARK-49977) introduced a bug that reversed the output order. This PR fixes the bug in `gatherCommutative()` to restore the original correct ordered output.

```
// Prior to [SPARK-49977](https://issues.apache.org/jira/browse/SPARK-49977) and after this fix
// commutativeExpressions -> Seq(Literal(1), Literal(2), Literal(3)))
// Post [SPARK-49977](https://issues.apache.org/jira/browse/SPARK-49977) and before this fix
// commutativeExpressions -> Seq(Literal(3), Literal(2), Literal(1)))
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fixing a bug

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added a test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: ChatGPT