### PR TITLE
[MINOR][TESTS] Fix comments on `runIfTestsEnabled` methods

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerIntegrationFunSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerIntegrationFunSuite.scala
@@ -43,7 +43,7 @@ trait DockerIntegrationFunSuite extends SparkFunSuite {
     }
   }
 
-  /** Run the give body of code only if Kinesis tests are enabled */
+  /** Run the given body of code only if ENABLE_DOCKER_INTEGRATION_TESTS is 1. */
   def runIfTestsEnabled(message: String)(body: => Unit): Unit = {
     if (shouldRunTests) {
       body

--- a/connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisFunSuite.scala
+++ b/connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisFunSuite.scala
@@ -35,7 +35,7 @@ trait KinesisFunSuite extends SparkFunSuite  {
     }
   }
 
-  /** Run the give body of code only if Kinesis tests are enabled */
+  /** Run the given body of code only if ENABLE_KINESIS_TESTS is 1. */
   def runIfTestsEnabled(message: String)(body: => Unit): Unit = {
     if (shouldRunTests) {
       body


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix comments on `runIfTestsEnabled` methods.

### Why are the changes needed?

Apache Spark repository has two `runIfTestsEnabled` methods whose comments are wrong or ambiguous.

```
$ git grep -C1 'def runIfTestsEnabled'
connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerIntegrationFunSuite.scala-  /** Run the give body of code only if Kinesis tests are enabled */
connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerIntegrationFunSuite.scala:  def runIfTestsEnabled(message: String)(body: => Unit): Unit = {
connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerIntegrationFunSuite.scala-    if (shouldRunTests) {
--
connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisFunSuite.scala-  /** Run the give body of code only if Kinesis tests are enabled */
connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisFunSuite.scala:  def runIfTestsEnabled(message: String)(body: => Unit): Unit = {
connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisFunSuite.scala-    if (shouldRunTests) {
```

### Does this PR introduce _any_ user-facing change?

No, this is a comment revision.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.