### PR TITLE
[SPARK-50753][PYTHON] Add CachedAccessor for PySpark Plotting

### DIFF
--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1804,12 +1804,6 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             messageParameters={"member": "queryExecution"},
         )
 
-    @property
-    def plot(self) -> "PySparkPlotAccessor":  # type: ignore[name-defined] # noqa: F821
-        from pyspark.sql.plot import PySparkPlotAccessor
-
-        return PySparkPlotAccessor(self)
-
 
 class DataFrameNaFunctions(ParentDataFrameNaFunctions):
     def __init__(self, df: ParentDataFrame):

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -2198,12 +2198,6 @@ class DataFrame(ParentDataFrame):
     def executionInfo(self) -> Optional["ExecutionInfo"]:
         return self._execution_info
 
-    @property
-    def plot(self) -> "PySparkPlotAccessor":  # type: ignore[name-defined] # noqa: F821
-        from pyspark.sql.plot import PySparkPlotAccessor
-
-        return PySparkPlotAccessor(self)
-
 
 class DataFrameNaFunctions(ParentDataFrameNaFunctions):
     def __init__(self, df: ParentDataFrame):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -44,7 +44,7 @@ from pyspark.sql.merge import MergeIntoWriter
 from pyspark.sql.streaming import DataStreamWriter
 from pyspark.sql.table_arg import TableArg
 from pyspark.sql.types import StructType, Row
-from pyspark.sql.utils import dispatch_df_method
+from pyspark.sql.utils import dispatch_df_method, CachedAccessor
 
 
 if TYPE_CHECKING:
@@ -69,7 +69,6 @@ if TYPE_CHECKING:
         ArrowMapIterFunction,
         DataFrameLike as PandasDataFrameLike,
     )
-    from pyspark.sql.plot import PySparkPlotAccessor
     from pyspark.sql.metrics import ExecutionInfo
 
 
@@ -6794,35 +6793,7 @@ class DataFrame:
         """
         ...
 
-    @property
-    def plot(self) -> "PySparkPlotAccessor":
-        """
-        Returns a :class:`PySparkPlotAccessor` for plotting functions.
-
-        .. versionadded:: 4.0.0
-
-        Returns
-        -------
-        :class:`PySparkPlotAccessor`
-
-        Notes
-        -----
-        This API is experimental.
-        It provides two ways to create plots:
-        1. Chaining style (e.g., `df.plot.line(...)`).
-        2. Explicit style (e.g., `df.plot(kind="line", ...)`).
-
-        Examples
-        --------
-        >>> data = [("A", 10, 1.5), ("B", 30, 2.5), ("C", 20, 3.5)]
-        >>> columns = ["category", "int_val", "float_val"]
-        >>> df = spark.createDataFrame(data, columns)
-        >>> type(df.plot)
-        <class 'pyspark.sql.plot.core.PySparkPlotAccessor'>
-        >>> df.plot.line(x="category", y=["int_val", "float_val"])  # doctest: +SKIP
-        >>> df.plot(kind="line", x="category", y=["int_val", "float_val"])  # doctest: +SKIP
-        """
-        ...
+    plot: CachedAccessor = CachedAccessor("plot", "pyspark.sql.plot.core.PySparkPlotAccessor")
 
 
 class DataFrameNaFunctions:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add CachedAccessor for PySpark Plotting.

### Why are the changes needed?
Previously, `plot` is defined as a property:
```py
>>> from pyspark.sql import DataFrame
>>> DataFrame.plot
<property object at 0x10543fd60>
```

This caused an issue where Sphinx, the documentation generator, could not recognize its chaining methods (e.g., bar, barh, etc.). As a result, it failed to populate the documentation for the available plot methods.

It should reach parity with Pandas API on Spark
```py
>>> import pyspark.pandas as ps
>>> ps.DataFrame.plot
<class 'pyspark.pandas.plot.core.PandasOnSparkPlotAccessor'>
```


### Does this PR introduce _any_ user-facing change?
No user-facing changes.

From
```py
>>> from pyspark.sql import DataFrame
>>> DataFrame.plot
<property object at 0x10543fd60>
```

TO
```py
>>> from pyspark.sql import DataFrame
>>> DataFrame.plot
<class 'pyspark.sql.plot.core.PySparkPlotAccessor'>
```

### How was this patch tested?
Existing tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
