### PR TITLE
[SPARK-50756][SQL] Use error class for exceptions in SparkConf.validateSettings

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2387,6 +2387,12 @@
     ],
     "sqlState" : "42604"
   },
+  "INVALID_EXECUTOR_HEARTBEAT_INTERVAL" : {
+    "message" : [
+      "The value of <networkTimeoutKey>=<networkTimeoutValue>ms must be greater than the value of <executorHeartbeatIntervalKey>=<executorHeartbeatIntervalValue>ms."
+    ],
+    "sqlState" : "42616"
+  },
   "INVALID_EXECUTOR_MEMORY" : {
     "message" : [
       "Executor memory <executorMemory> must be at least <minSystemMemory>.",
@@ -3686,6 +3692,12 @@
       "Nested EXECUTE IMMEDIATE commands are not allowed. Please ensure that the SQL query provided (<sqlString>) does not contain another EXECUTE IMMEDIATE command."
     ],
     "sqlState" : "07501"
+  },
+  "NETWORK_AUTH_MUST_BE_ENABLED" : {
+    "message" : [
+      "<networkAuthEnabledConf> must be enabled when enabling encryption."
+    ],
+    "sqlState" : "42616"
   },
   "NONEXISTENT_FIELD_NAME_IN_LIST" : {
     "message" : [

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -607,17 +607,23 @@ class SparkConf(loadDefaults: Boolean)
     }
 
     val encryptionEnabled = get(NETWORK_CRYPTO_ENABLED) || get(SASL_ENCRYPTION_ENABLED)
-    require(!encryptionEnabled || get(NETWORK_AUTH_ENABLED),
-      s"${NETWORK_AUTH_ENABLED.key} must be enabled when enabling encryption.")
+    SparkException.require(
+      !encryptionEnabled || get(NETWORK_AUTH_ENABLED),
+      "NETWORK_AUTH_MUST_BE_ENABLED",
+      Map("networkAuthEnabledConf" -> NETWORK_AUTH_ENABLED.key))
 
     val executorTimeoutThresholdMs = get(NETWORK_TIMEOUT) * 1000
     val executorHeartbeatIntervalMs = get(EXECUTOR_HEARTBEAT_INTERVAL)
-    val networkTimeout = NETWORK_TIMEOUT.key
     // If spark.executor.heartbeatInterval bigger than spark.network.timeout,
     // it will almost always cause ExecutorLostFailure. See SPARK-22754.
-    require(executorTimeoutThresholdMs > executorHeartbeatIntervalMs, "The value of " +
-      s"${networkTimeout}=${executorTimeoutThresholdMs}ms must be greater than the value of " +
-      s"${EXECUTOR_HEARTBEAT_INTERVAL.key}=${executorHeartbeatIntervalMs}ms.")
+    SparkException.require(
+      executorTimeoutThresholdMs > executorHeartbeatIntervalMs,
+      "INVALID_EXECUTOR_HEARTBEAT_INTERVAL",
+      Map(
+        "networkTimeoutKey" -> NETWORK_TIMEOUT.key,
+        "networkTimeoutValue" -> executorTimeoutThresholdMs.toString,
+        "executorHeartbeatIntervalKey" -> EXECUTOR_HEARTBEAT_INTERVAL.key,
+        "executorHeartbeatIntervalValue" -> executorHeartbeatIntervalMs.toString))
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change is to use error class for exceptions thrown in SparkConf.validateSettings.

### Why are the changes needed?
To adapt to the error class framework.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No
