### PR TITLE
[MINOR] Remove TODO comment about `ExecutorAdded` message

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -205,7 +205,6 @@ private[deploy] object DeployMessages {
 
   case class RegisteredApplication(appId: String, master: RpcEndpointRef) extends DeployMessage
 
-  // TODO(matei): replace hostPort with host
   case class ExecutorAdded(id: Int, workerId: String, hostPort: String, cores: Int, memory: Int) {
     Utils.checkHostPort(hostPort)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `TODO` comment about `ExecutorAdded` message.

```
// TODO(matei): replace hostPort with host
```

### Why are the changes needed?

`ExecutorAdded` message has been stable over 12 years with no change.
It's unlikely for us to change this in Spark 4 or in the future.
Thus, we had better remove this TODO message from Spark 4.

### Does this PR introduce _any_ user-facing change?

No, this is a comment removal.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.