### PR TITLE
[SPARK-50765][PYTHON] Remove invalid test for spark.sql.execution.arrow.useLargeVarTypes

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_map.py
@@ -99,23 +99,6 @@ class MapInPandasTestsMixin:
         expected = df.collect()
         self.assertEqual(actual, expected)
 
-    def test_large_variable_types(self):
-        with self.sql_conf({"spark.sql.execution.arrow.useLargeVarTypes": True}):
-
-            def func(iterator):
-                for pdf in iterator:
-                    assert isinstance(pdf, pd.DataFrame)
-                    yield pdf
-
-            df = (
-                self.spark.range(10, numPartitions=3)
-                .select(col("id").cast("string").alias("str"))
-                .withColumn("bin", encode(col("str"), "utf-8"))
-            )
-            actual = df.mapInPandas(func, "str string, bin binary").collect()
-            expected = df.collect()
-            self.assertEqual(actual, expected)
-
     def test_no_column_names(self):
         data = [(1, "foo"), (2, None), (3, "bar"), (4, "bar")]
         df = self.spark.createDataFrame(data, "a int, b string")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to remove the invalid test `test_large_variable_types`.

### Why are the changes needed?

This test does not actually test `spark.sql.execution.arrow.useLargeVarTypes`, see https://github.com/apache/spark/pull/39572#discussion_r1227660209.

I wanted to try to fix it but currently this is blocked by Arrow implementation, see also https://github.com/apache/spark/pull/41569

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Removed test.

### Was this patch authored or co-authored using generative AI tooling?

No.