### PR TITLE
[SPARK-50767][SQL] Remove codegen of `from_json`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodegenFallback, CodeGenerator, ExprCode}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, CodegenFallback, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.codegen.Block.BlockHelper
 import org.apache.spark.sql.catalyst.expressions.json.{GetJsonObjectEvaluator, JsonExpressionUtils, JsonToStructsEvaluator, JsonTupleEvaluator, SchemaOfJsonEvaluator, StructsToJsonEvaluator}
 import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, StaticInvoke}

--- a/sql/core/benchmarks/SubExprEliminationBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/SubExprEliminationBenchmark-jdk21-results.txt
@@ -3,23 +3,23 @@ Benchmark for performance of subexpression elimination
 ================================================================================================
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
+OpenJDK 64-Bit Server VM 21.0.5+11-LTS on Linux 6.8.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 from_json as subExpr in Project:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-subExprElimination false, codegen: true            6313           6431         120          0.0    63134831.3       1.0X
-subExprElimination false, codegen: false           6093           6348         288          0.0    60930747.6       1.0X
-subExprElimination true, codegen: true             1387           1425          33          0.0    13872525.5       4.6X
-subExprElimination true, codegen: false            1218           1332          99          0.0    12182992.7       5.2X
+subExprElimination false, codegen: true            6718           6878         139          0.0    67179725.6       1.0X
+subExprElimination false, codegen: false           6625           6735          96          0.0    66248098.7       1.0X
+subExprElimination true, codegen: true             1266           1344          69          0.0    12657825.7       5.3X
+subExprElimination true, codegen: false            1157           1266          97          0.0    11572844.8       5.8X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
+OpenJDK 64-Bit Server VM 21.0.5+11-LTS on Linux 6.8.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 from_json as subExpr in Filter:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-subExprElimination false, codegen: true            6610           6705          85          0.0    66104698.4       1.0X
-subExprElimination false, codegen: false           6647           6730          76          0.0    66469463.5       1.0X
-subExprElimination true, codegen: true             2077           2126          43          0.0    20769220.1       3.2X
-subExprElimination true, codegen: false            1949           2000          64          0.0    19489004.0       3.4X
+subExprElimination false, codegen: true            7124           7198          82          0.0    71241460.4       1.0X
+subExprElimination false, codegen: false           7249           7315          77          0.0    72491188.6       1.0X
+subExprElimination true, codegen: true             1759           1800          55          0.0    17587483.7       4.1X
+subExprElimination true, codegen: false            1655           1753          85          0.0    16552026.0       4.3X
 
 

--- a/sql/core/benchmarks/SubExprEliminationBenchmark-results.txt
+++ b/sql/core/benchmarks/SubExprEliminationBenchmark-results.txt
@@ -3,23 +3,23 @@ Benchmark for performance of subexpression elimination
 ================================================================================================
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
+OpenJDK 64-Bit Server VM 17.0.13+11-LTS on Linux 6.8.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 from_json as subExpr in Project:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-subExprElimination false, codegen: true            6438           6551          98          0.0    64378783.5       1.0X
-subExprElimination false, codegen: false           6216           6320         175          0.0    62161826.1       1.0X
-subExprElimination true, codegen: true             1480           1518          39          0.0    14799890.8       4.3X
-subExprElimination true, codegen: false            1321           1429          94          0.0    13212919.6       4.9X
+subExprElimination false, codegen: true            6288           6420         114          0.0    62883657.2       1.0X
+subExprElimination false, codegen: false           5868           5966          85          0.0    58678139.0       1.1X
+subExprElimination true, codegen: true             1331           1363          30          0.0    13309925.2       4.7X
+subExprElimination true, codegen: false            1241           1250           8          0.0    12407893.0       5.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
+OpenJDK 64-Bit Server VM 17.0.13+11-LTS on Linux 6.8.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 from_json as subExpr in Filter:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-subExprElimination false, codegen: true            7107           7310         207          0.0    71066752.8       1.0X
-subExprElimination false, codegen: false           6738           6781          41          0.0    67375897.0       1.1X
-subExprElimination true, codegen: true             2052           2110          51          0.0    20519152.3       3.5X
-subExprElimination true, codegen: false            2053           2079          33          0.0    20526629.8       3.5X
+subExprElimination false, codegen: true            6683           6806         106          0.0    66830801.7       1.0X
+subExprElimination false, codegen: false           6410           6517          99          0.0    64098396.7       1.0X
+subExprElimination true, codegen: true             1721           1804          74          0.0    17208176.1       3.9X
+subExprElimination true, codegen: false            1685           1783          86          0.0    16851546.7       4.0X
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to remove codegen of `from_json`.


### Why are the changes needed?
Based on the discussion and testing with `SubExprEliminationBenchmark` https://github.com/apache/spark/pull/48466#issuecomment-2576504614, 
after implementing codegen for `from_json`, there is a performance regression in the withFilter scenario with `subExprElimination` = true, `codegen` = true
Let's remove it first and will submit it after we solve the above issue.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA & Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
