### PR TITLE
[SPARK-50685][PYTHON][FOLLOW-UP] Improve Py4J performance by leveraging getattr

### DIFF
--- a/python/pyspark/core/context.py
+++ b/python/pyspark/core/context.py
@@ -1206,7 +1206,7 @@ class SparkContext:
 
     def _dictToJavaMap(self, d: Optional[Dict[str, str]]) -> JavaMap:
         assert self._jvm is not None
-        jm = self._jvm.java.lang.HashMap()
+        jm = getattr(self._jvm, "java.util.HashMap")()
         if not d:
             d = {}
         for k, v in d.items():

--- a/python/pyspark/core/context.py
+++ b/python/pyspark/core/context.py
@@ -1206,7 +1206,7 @@ class SparkContext:
 
     def _dictToJavaMap(self, d: Optional[Dict[str, str]]) -> JavaMap:
         assert self._jvm is not None
-        jm = getattr(self._jvm, "java.lang").HashMap()
+        jm = self._jvm.java.lang.HashMap()
         if not d:
             d = {}
         for k, v in d.items():

--- a/python/pyspark/core/context.py
+++ b/python/pyspark/core/context.py
@@ -559,7 +559,7 @@ class SparkContext:
         """
         SparkContext._ensure_initialized()
         assert SparkContext._jvm is not None
-        SparkContext._jvm.java.lang.System.setProperty(key, value)
+        getattr(SparkContext._jvm, "java.lang.System").setProperty(key, value)
 
     @classmethod
     def getSystemProperty(cls, key: str) -> str:
@@ -581,7 +581,7 @@ class SparkContext:
         """
         SparkContext._ensure_initialized()
         assert SparkContext._jvm is not None
-        return SparkContext._jvm.java.lang.System.getProperty(key)
+        return getattr(SparkContext._jvm, "java.lang.System").getProperty(key)
 
     @property
     def version(self) -> str:
@@ -1206,7 +1206,7 @@ class SparkContext:
 
     def _dictToJavaMap(self, d: Optional[Dict[str, str]]) -> JavaMap:
         assert self._jvm is not None
-        jm = self._jvm.java.util.HashMap()
+        jm = getattr(self._jvm, "java.lang").HashMap()
         if not d:
             d = {}
         for k, v in d.items():
@@ -1938,7 +1938,7 @@ class SparkContext:
         :meth:`SparkContext.addFile`
         """
         return list(
-            self._jvm.scala.jdk.javaapi.CollectionConverters.asJava(  # type: ignore[union-attr]
+            getattr(self._jvm, "scala.jdk.javaapi.CollectionConverters").asJava(
                 self._jsc.sc().listFiles()
             )
         )
@@ -2066,7 +2066,7 @@ class SparkContext:
         :meth:`SparkContext.addArchive`
         """
         return list(
-            self._jvm.scala.jdk.javaapi.CollectionConverters.asJava(  # type: ignore[union-attr]
+            getattr(self._jvm, "scala.jdk.javaapi.CollectionConverters").asJava(
                 self._jsc.sc().listArchives()
             )
         )

--- a/python/pyspark/core/rdd.py
+++ b/python/pyspark/core/rdd.py
@@ -3286,7 +3286,9 @@ class RDD(Generic[T_co]):
         assert self.ctx._jvm is not None
 
         if compressionCodecClass:
-            compressionCodec = self.ctx._jvm.java.lang.Class.forName(compressionCodecClass)
+            compressionCodec = getattr(self.ctx._jvm, "java.lang.Class").forName(
+                compressionCodecClass
+            )
             keyed._jrdd.map(self.ctx._jvm.BytesToString()).saveAsTextFile(path, compressionCodec)
         else:
             keyed._jrdd.map(self.ctx._jvm.BytesToString()).saveAsTextFile(path)

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -1208,7 +1208,7 @@ class CountVectorizerModel(
 
         sc = SparkContext._active_spark_context
         assert sc is not None and sc._gateway is not None
-        java_class = sc._gateway.jvm.java.lang.String
+        java_class = getattr(sc._gateway.jvm, "jvm.java.lang.String")
         jvocab = CountVectorizerModel._new_java_array(vocabulary, java_class)
         model = CountVectorizerModel._create_from_java_class(
             "org.apache.spark.ml.feature.CountVectorizerModel", jvocab
@@ -4799,7 +4799,7 @@ class StringIndexerModel(
 
         sc = SparkContext._active_spark_context
         assert sc is not None and sc._gateway is not None
-        java_class = sc._gateway.jvm.java.lang.String
+        java_class = getattr(sc._gateway.jvm, "jvm.java.lang.String")
         jlabels = StringIndexerModel._new_java_array(labels, java_class)
         model = StringIndexerModel._create_from_java_class(
             "org.apache.spark.ml.feature.StringIndexerModel", jlabels
@@ -4828,7 +4828,7 @@ class StringIndexerModel(
 
         sc = SparkContext._active_spark_context
         assert sc is not None and sc._gateway is not None
-        java_class = sc._gateway.jvm.java.lang.String
+        java_class = getattr(sc._gateway.jvm, "jvm.java.lang.String")
         jlabels = StringIndexerModel._new_java_array(arrayOfLabels, java_class)
         model = StringIndexerModel._create_from_java_class(
             "org.apache.spark.ml.feature.StringIndexerModel", jlabels
@@ -5198,7 +5198,7 @@ class StopWordsRemover(
         Supported languages: danish, dutch, english, finnish, french, german, hungarian,
         italian, norwegian, portuguese, russian, spanish, swedish, turkish
         """
-        stopWordsObj = _jvm().org.apache.spark.ml.feature.StopWordsRemover
+        stopWordsObj = getattr(_jvm(), "org.apache.spark.ml.feature.StopWordsRemover")
         return list(stopWordsObj.loadDefaultStopWords(language))
 
 

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -1208,7 +1208,7 @@ class CountVectorizerModel(
 
         sc = SparkContext._active_spark_context
         assert sc is not None and sc._gateway is not None
-        java_class = getattr(sc._gateway.jvm, "jvm.java.lang.String")
+        java_class = getattr(sc._gateway.jvm, "java.lang.String")
         jvocab = CountVectorizerModel._new_java_array(vocabulary, java_class)
         model = CountVectorizerModel._create_from_java_class(
             "org.apache.spark.ml.feature.CountVectorizerModel", jvocab
@@ -4799,7 +4799,7 @@ class StringIndexerModel(
 
         sc = SparkContext._active_spark_context
         assert sc is not None and sc._gateway is not None
-        java_class = getattr(sc._gateway.jvm, "jvm.java.lang.String")
+        java_class = getattr(sc._gateway.jvm, "java.lang.String")
         jlabels = StringIndexerModel._new_java_array(labels, java_class)
         model = StringIndexerModel._create_from_java_class(
             "org.apache.spark.ml.feature.StringIndexerModel", jlabels
@@ -4828,7 +4828,7 @@ class StringIndexerModel(
 
         sc = SparkContext._active_spark_context
         assert sc is not None and sc._gateway is not None
-        java_class = getattr(sc._gateway.jvm, "jvm.java.lang.String")
+        java_class = getattr(sc._gateway.jvm, "java.lang.String")
         jlabels = StringIndexerModel._new_java_array(arrayOfLabels, java_class)
         model = StringIndexerModel._create_from_java_class(
             "org.apache.spark.ml.feature.StringIndexerModel", jlabels

--- a/python/pyspark/ml/stat.py
+++ b/python/pyspark/ml/stat.py
@@ -107,7 +107,7 @@ class ChiSquareTest:
         sc = SparkContext._active_spark_context
         assert sc is not None
 
-        javaTestObj = _jvm().org.apache.spark.ml.stat.ChiSquareTest
+        javaTestObj = getattr(_jvm(), "org.apache.spark.ml.stat.ChiSquareTest")
         args = [_py2java(sc, arg) for arg in (dataset, featuresCol, labelCol, flatten)]
         return _java2py(sc, javaTestObj.test(*args))
 
@@ -178,7 +178,7 @@ class Correlation:
         sc = SparkContext._active_spark_context
         assert sc is not None
 
-        javaCorrObj = _jvm().org.apache.spark.ml.stat.Correlation
+        javaCorrObj = getattr(_jvm(), "org.apache.spark.ml.stat.Correlation")
         args = [_py2java(sc, arg) for arg in (dataset, column, method)]
         return _java2py(sc, javaCorrObj.corr(*args))
 
@@ -248,7 +248,7 @@ class KolmogorovSmirnovTest:
         sc = SparkContext._active_spark_context
         assert sc is not None
 
-        javaTestObj = _jvm().org.apache.spark.ml.stat.KolmogorovSmirnovTest
+        javaTestObj = getattr(_jvm(), "org.apache.spark.ml.stat.KolmogorovSmirnovTest")
         dataset = _py2java(sc, dataset)
         params = [float(param) for param in params]  # type: ignore[assignment]
         return _java2py(

--- a/python/pyspark/resource/requests.py
+++ b/python/pyspark/resource/requests.py
@@ -173,9 +173,9 @@ class ExecutorResourceRequests:
             jvm = _jvm or SparkContext._jvm
 
         if jvm is not None:
-            self._java_executor_resource_requests = (
-                jvm.org.apache.spark.resource.ExecutorResourceRequests()
-            )
+            self._java_executor_resource_requests = getattr(
+                jvm, "org.apache.spark.resource"
+            ).ExecutorResourceRequests()
             if _requests is not None:
                 for k, v in _requests.items():
                     if k == self._MEMORY:
@@ -474,9 +474,9 @@ class TaskResourceRequests:
             jvm = _jvm or SparkContext._jvm
 
         if jvm is not None:
-            self._java_task_resource_requests: Optional[
-                "JavaObject"
-            ] = jvm.org.apache.spark.resource.TaskResourceRequests()
+            self._java_task_resource_requests: Optional["JavaObject"] = getattr(
+                jvm, "org.apache.spark.resource"
+            ).TaskResourceRequests()
             if _requests is not None:
                 for k, v in _requests.items():
                     if k == self._CPUS:

--- a/python/pyspark/resource/requests.py
+++ b/python/pyspark/resource/requests.py
@@ -174,8 +174,8 @@ class ExecutorResourceRequests:
 
         if jvm is not None:
             self._java_executor_resource_requests = getattr(
-                jvm, "org.apache.spark.resource"
-            ).ExecutorResourceRequests()
+                jvm, "org.apache.spark.resource.ExecutorResourceRequests"
+            )()
             if _requests is not None:
                 for k, v in _requests.items():
                     if k == self._MEMORY:
@@ -475,8 +475,8 @@ class TaskResourceRequests:
 
         if jvm is not None:
             self._java_task_resource_requests: Optional["JavaObject"] = getattr(
-                jvm, "org.apache.spark.resource"
-            ).TaskResourceRequests()
+                jvm, "org.apache.spark.resource.TaskResourceRequests"
+            )()
             if _requests is not None:
                 for k, v in _requests.items():
                     if k == self._CPUS:

--- a/python/pyspark/sql/avro/functions.py
+++ b/python/pyspark/sql/avro/functions.py
@@ -102,7 +102,7 @@ def from_avro(
 
     sc = get_active_spark_context()
     try:
-        jc = cast(JVMView, sc._jvm).org.apache.spark.sql.avro.functions.from_avro(
+        jc = getattr(cast(JVMView, sc._jvm), "org.apache.spark.sql.avro.functions").from_avro(
             _to_java_column(data), jsonFormatSchema, options or {}
         )
     except TypeError as e:
@@ -168,11 +168,11 @@ def to_avro(data: "ColumnOrName", jsonFormatSchema: str = "") -> Column:
     sc = get_active_spark_context()
     try:
         if jsonFormatSchema == "":
-            jc = cast(JVMView, sc._jvm).org.apache.spark.sql.avro.functions.to_avro(
+            jc = getattr(cast(JVMView, sc._jvm), "org.apache.spark.sql.avro.functions").to_avro(
                 _to_java_column(data)
             )
         else:
-            jc = cast(JVMView, sc._jvm).org.apache.spark.sql.avro.functions.to_avro(
+            jc = getattr(cast(JVMView, sc._jvm), "org.apache.spark.sql.avro.functions").to_avro(
                 _to_java_column(data), jsonFormatSchema
             )
     except TypeError as e:

--- a/python/pyspark/sql/classic/window.py
+++ b/python/pyspark/sql/classic/window.py
@@ -48,9 +48,9 @@ class Window(ParentWindow):
         from py4j.java_gateway import JVMView
 
         sc = get_active_spark_context()
-        jspec = cast(JVMView, sc._jvm).org.apache.spark.sql.expressions.Window.partitionBy(
-            _to_java_cols(cols)
-        )
+        jspec = getattr(
+            cast(JVMView, sc._jvm), "org.apache.spark.sql.expressions.Window"
+        ).partitionBy(_to_java_cols(cols))
         return WindowSpec(jspec)
 
     @staticmethod
@@ -58,7 +58,7 @@ class Window(ParentWindow):
         from py4j.java_gateway import JVMView
 
         sc = get_active_spark_context()
-        jspec = cast(JVMView, sc._jvm).org.apache.spark.sql.expressions.Window.orderBy(
+        jspec = getattr(cast(JVMView, sc._jvm), "org.apache.spark.sql.expressions.Window").orderBy(
             _to_java_cols(cols)
         )
         return WindowSpec(jspec)
@@ -72,9 +72,9 @@ class Window(ParentWindow):
         if end >= Window._FOLLOWING_THRESHOLD:
             end = Window.unboundedFollowing
         sc = get_active_spark_context()
-        jspec = cast(JVMView, sc._jvm).org.apache.spark.sql.expressions.Window.rowsBetween(
-            start, end
-        )
+        jspec = getattr(
+            cast(JVMView, sc._jvm), "org.apache.spark.sql.expressions.Window"
+        ).rowsBetween(start, end)
         return WindowSpec(jspec)
 
     @staticmethod
@@ -86,9 +86,9 @@ class Window(ParentWindow):
         if end >= Window._FOLLOWING_THRESHOLD:
             end = Window.unboundedFollowing
         sc = get_active_spark_context()
-        jspec = cast(JVMView, sc._jvm).org.apache.spark.sql.expressions.Window.rangeBetween(
-            start, end
-        )
+        jspec = getattr(
+            cast(JVMView, sc._jvm), "org.apache.spark.sql.expressions.Window"
+        ).rangeBetween(start, end)
         return WindowSpec(jspec)
 
 

--- a/python/pyspark/sql/protobuf/functions.py
+++ b/python/pyspark/sql/protobuf/functions.py
@@ -149,13 +149,13 @@ def from_protobuf(
         elif descFilePath is not None:
             binary_proto = _read_descriptor_set_file(descFilePath)
         if binary_proto is not None:
-            jc = cast(JVMView, sc._jvm).org.apache.spark.sql.protobuf.functions.from_protobuf(
-                _to_java_column(data), messageName, binary_proto, options or {}
-            )
+            jc = getattr(
+                cast(JVMView, sc._jvm), "org.apache.spark.sql.protobuf.functions"
+            ).from_protobuf(_to_java_column(data), messageName, binary_proto, options or {})
         else:
-            jc = cast(JVMView, sc._jvm).org.apache.spark.sql.protobuf.functions.from_protobuf(
-                _to_java_column(data), messageName, options or {}
-            )
+            jc = getattr(
+                cast(JVMView, sc._jvm), "org.apache.spark.sql.protobuf.functions"
+            ).from_protobuf(_to_java_column(data), messageName, options or {})
     except TypeError as e:
         if str(e) == "'JavaPackage' object is not callable":
             _print_missing_jar("Protobuf", "protobuf", "protobuf", sc.version)
@@ -271,13 +271,13 @@ def to_protobuf(
         elif descFilePath is not None:
             binary_proto = _read_descriptor_set_file(descFilePath)
         if binary_proto is not None:
-            jc = cast(JVMView, sc._jvm).org.apache.spark.sql.protobuf.functions.to_protobuf(
-                _to_java_column(data), messageName, binary_proto, options or {}
-            )
+            jc = getattr(
+                cast(JVMView, sc._jvm), "org.apache.spark.sql.protobuf.functions"
+            ).to_protobuf(_to_java_column(data), messageName, binary_proto, options or {})
         else:
-            jc = cast(JVMView, sc._jvm).org.apache.spark.sql.protobuf.functions.to_protobuf(
-                _to_java_column(data), messageName, options or {}
-            )
+            jc = getattr(
+                cast(JVMView, sc._jvm), "org.apache.spark.sql.protobuf.functions"
+            ).to_protobuf(_to_java_column(data), messageName, options or {})
 
     except TypeError as e:
         if str(e) == "'JavaPackage' object is not callable":

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -1174,7 +1174,9 @@ class DataFrameReader(OptionUtils):
         if predicates is not None:
             gateway = self._spark._sc._gateway
             assert gateway is not None
-            jpredicates = utils.to_java_array(gateway, gateway.jvm.java.lang.String, predicates)
+            jpredicates = utils.to_java_array(
+                gateway, getattr(gateway.jvm, "java.lang.String"), predicates
+            )
             return self._df(self._jreader.jdbc(url, table, jpredicates, jprop))
         return self._df(self._jreader.jdbc(url, table, jprop))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is. a followup of https://github.com/apache/spark/pull/49313 that fixes more places missed.

This PR fixes Core, SQL, ML and Structured Streaming. Tests codes, MLLib and DStream are not affected.

### Why are the changes needed?

To reduce the overhead of Py4J calls.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually tested as demonstrated in https://github.com/apache/spark/pull/49312

### Was this patch authored or co-authored using generative AI tooling?

No.
