### PR TITLE
[SPARK-50758][K8S]Mounts the krb5 config map on the executor pod

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
@@ -113,6 +113,7 @@ object Constants {
   val ENV_HADOOP_CONF_DIR = "HADOOP_CONF_DIR"
   val HADOOP_CONFIG_MAP_NAME =
     "spark.kubernetes.executor.hadoopConfigMapName"
+  val KRB_FILE_MAP_NAME = "spark.kubernetes.executor.krbFileMapName"
 
   // Kerberos Configuration
   val KERBEROS_DT_SECRET_NAME =

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStep.scala
@@ -211,12 +211,20 @@ private[spark] class KerberosConfDriverFeatureStep(kubernetesConf: KubernetesDri
   override def getAdditionalPodSystemProperties(): Map[String, String] = {
     // If a submission-local keytab is provided, update the Spark config so that it knows the
     // path of the keytab in the driver container.
-    if (needKeytabUpload) {
+    val keytabConfig = if (needKeytabUpload) {
       val ktName = new File(keytab.get).getName()
       Map(KEYTAB.key -> s"$KERBEROS_KEYTAB_MOUNT_POINT/$ktName")
     } else {
       Map.empty
     }
+
+    val kbr5Config = if (hasKerberosConf) {
+      Map(KRB_FILE_MAP_NAME -> krb5CMap.getOrElse(newConfigMapName))
+    } else {
+      Map.empty
+    }
+
+    keytabConfig ++ kbr5Config
   }
 
   override def getAdditionalKubernetesResources(): Seq[HasMetadata] = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfExecutorFeatureStep.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s.features
+
+import io.fabric8.kubernetes.api.model._
+
+import org.apache.spark.deploy.k8s.{KubernetesConf, SparkPod}
+import org.apache.spark.deploy.k8s.Constants._
+
+/**
+ * Mounts the krb5 config map on the executor pod.
+ */
+private[spark] class KerberosConfExecutorFeatureStep(conf: KubernetesConf)
+  extends KubernetesFeatureConfigStep {
+
+  private def krb5FileMapName: Option[String] = conf.getOption(KRB_FILE_MAP_NAME)
+
+  override def configurePod(original: SparkPod): SparkPod = {
+    original.transform { case pod if krb5FileMapName.isDefined =>
+      val configMapVolume = new VolumeBuilder()
+        .withName(KRB_FILE_VOLUME)
+        .withNewConfigMap()
+          .withName(krb5FileMapName.get)
+          .endConfigMap()
+        .build()
+
+      val podWithVolume = new PodBuilder(pod.pod)
+        .editSpec()
+          .addNewVolumeLike(configMapVolume)
+            .endVolume()
+          .endSpec()
+        .build()
+
+      val containerWithMount = new ContainerBuilder(pod.container)
+        .addNewVolumeMount()
+          .withName(KRB_FILE_VOLUME)
+          .withMountPath(KRB_FILE_DIR_PATH + "/krb5.conf")
+          .withSubPath("krb5.conf")
+          .endVolumeMount()
+        .build()
+
+      SparkPod(podWithVolume, containerWithMount)
+    }
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
@@ -72,6 +72,7 @@ private[spark] class KubernetesExecutorBuilder {
       new EnvSecretsFeatureStep(conf),
       new MountVolumesFeatureStep(conf),
       new HadoopConfExecutorFeatureStep(conf),
+      new KerberosConfExecutorFeatureStep(conf),
       new LocalDirsFeatureStep(conf)) ++ userFeatures
 
     val spec = KubernetesExecutorSpec(

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
@@ -89,5 +89,4 @@ private[spark] class KubernetesExecutorBuilder {
         spec.executorKubernetesResources ++ addedResources)
     }
   }
-
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStepSuite.scala
@@ -166,5 +166,4 @@ class KerberosConfDriverFeatureStepSuite extends SparkFunSuite {
     val kconf = KubernetesTestConf.createDriverConf(sparkConf = conf)
     new KerberosConfDriverFeatureStep(kconf)
   }
-
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStepSuite.scala
@@ -49,7 +49,7 @@ class KerberosConfDriverFeatureStepSuite extends SparkFunSuite {
       new SparkConf(false).set(KUBERNETES_KERBEROS_KRB5_CONFIG_MAP, configMap))
 
     checkPodForKrbConf(step.configurePod(SparkPod.initialPod()), configMap)
-    assert(step.getAdditionalPodSystemProperties().isEmpty)
+    assert(step.getAdditionalPodSystemProperties().contains(Constants.KRB_FILE_MAP_NAME))
     assert(filter[ConfigMap](step.getAdditionalKubernetesResources()).isEmpty)
   }
 
@@ -65,7 +65,7 @@ class KerberosConfDriverFeatureStepSuite extends SparkFunSuite {
     assert(confMap.getData().keySet().asScala === Set(krbConf.getName()))
 
     checkPodForKrbConf(step.configurePod(SparkPod.initialPod()), confMap.getMetadata().getName())
-    assert(step.getAdditionalPodSystemProperties().isEmpty)
+    assert(step.getAdditionalPodSystemProperties().contains(Constants.KRB_FILE_MAP_NAME))
   }
 
   test("create keytab secret if client keytab file used") {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfExecutorFeatureStepSuite.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.k8s.features
+
+import java.io.File
+import java.nio.charset.StandardCharsets.UTF_8
+
+import com.google.common.io.Files
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.k8s._
+import org.apache.spark.deploy.k8s.Config._
+import org.apache.spark.deploy.k8s.Constants._
+import org.apache.spark.util.Utils
+
+class KerberosConfExecutorFeatureStepSuite extends SparkFunSuite  {
+  import SecretVolumeUtils._
+
+  test("SPARK-50758: mounts the krb5 config map on the executor pod") {
+    val tmpDir = Utils.createTempDir()
+    val krbConf = File.createTempFile("krb5", ".conf", tmpDir)
+    Files.write("some data", krbConf, UTF_8)
+
+    Seq(
+      new SparkConf(false)
+        .set(KUBERNETES_KERBEROS_KRB5_CONFIG_MAP, "testConfigMap"),
+      new SparkConf(false)
+        .set(KUBERNETES_KERBEROS_KRB5_FILE, krbConf.getAbsolutePath()),
+      new SparkConf(false)).foreach { sparkConf =>
+
+      val driverConf = KubernetesTestConf.createDriverConf(sparkConf = sparkConf)
+      val driverStep = new KerberosConfDriverFeatureStep(driverConf)
+
+      val additionalPodSystemProperties = driverStep.getAdditionalPodSystemProperties()
+      val executorSparkConf = new SparkConf(false)
+      if (hasKerberosConf(driverConf)) {
+        assert(additionalPodSystemProperties.contains(Constants.KRB_FILE_MAP_NAME))
+        additionalPodSystemProperties.foreach { case (key, value) =>
+          executorSparkConf.set(key, value)
+        }
+      } else {
+        assert(additionalPodSystemProperties.isEmpty)
+      }
+
+      val executorConf = KubernetesTestConf.createExecutorConf(sparkConf = executorSparkConf)
+      val executorStep = new KerberosConfExecutorFeatureStep(executorConf)
+      val executorPod = executorStep.configurePod(SparkPod.initialPod())
+
+      checkPod(executorPod, hasKerberosConf(driverConf))
+    }
+  }
+
+  private def hasKerberosConf(conf: KubernetesConf): Boolean = {
+    val krb5File = conf.get(KUBERNETES_KERBEROS_KRB5_FILE)
+    val krb5CMap = conf.get(KUBERNETES_KERBEROS_KRB5_CONFIG_MAP)
+    krb5CMap.isDefined | krb5File.isDefined
+  }
+
+  private def checkPod(pod: SparkPod, hasKerberosConf: Boolean): Unit = {
+    if (hasKerberosConf) {
+      assert(podHasVolume(pod.pod, KRB_FILE_VOLUME))
+      assert(containerHasVolume(pod.container, KRB_FILE_VOLUME, KRB_FILE_DIR_PATH + "/krb5.conf"))
+    } else {
+      assert(!podHasVolume(pod.pod, KRB_FILE_VOLUME))
+      assert(!containerHasVolume(pod.container, KRB_FILE_VOLUME, KRB_FILE_DIR_PATH + "/krb5.conf"))
+    }
+  }
+
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
In this pr, for spark on k8s, the krb5.conf config map will be mounted in executor side as well.
Before, the krb5.conf config map is only mounted in driver side. But according to the parameter description, the krb5.conf file should be mounted on both the driver and the executor.
```
  val KUBERNETES_KERBEROS_KRB5_FILE =
    ConfigBuilder("spark.kubernetes.kerberos.krb5.path")
      .doc("Specify the local location of the krb5.conf file to be mounted on the driver " +
        "and executors for Kerberos. Note: The KDC defined needs to be " +
        "visible from inside the containers ")
      .version("3.0.0")
      .stringConf
      .createOptional

  val KUBERNETES_KERBEROS_KRB5_CONFIG_MAP =
    ConfigBuilder("spark.kubernetes.kerberos.krb5.configMapName")
      .doc("Specify the name of the ConfigMap, containing the krb5.conf file, to be mounted " +
        "on the driver and executors for Kerberos. Note: The KDC defined" +
        "needs to be visible from inside the containers ")
      .version("3.0.0")
      .stringConf
      .createOptional
```


### Why are the changes needed?
After [SPARK-43504](https://issues.apache.org/jira/browse/SPARK-43504), the hadoop config map will be mounted on the executor pod.
Now the executor pod fails to start because the hadoop conf file contains Kerberos authentication configuration, but the executor does not mount krb5.conf correctly.
See the  https://github.com/apache/spark/pull/41181 discuss.



### Does this PR introduce _any_ user-facing change?
Yes, users do not need to take workarounds to make executors load the krb5.conf.
Such as: 
- including krb5.conf in executor image
- placing krb5.conf in executor working directory using --files


### How was this patch tested?
UT.
Authored-by: lifumao lifumao@tencent.com

