### PR TITLE
[SPARK-50786][SQL] Remove `removeWhitespace helper` for DESCRIBE TABLE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -63,29 +63,25 @@ trait MetadataMapSupport {
 
   protected def jsonToString(
       jsonMap: mutable.LinkedHashMap[String, JValue]): mutable.LinkedHashMap[String, String] = {
-    def removeWhitespace(str: String): String = {
-      str.replaceAll("\\s+$", "")
-    }
-
     val map = new mutable.LinkedHashMap[String, String]()
     jsonMap.foreach { case (key, jValue) =>
       val stringValue = jValue match {
-        case JString(value) => removeWhitespace(value)
+        case JString(value) => value
         case JArray(values) =>
           values.map(_.values)
             .map {
-              case str: String => quoteIdentifier(removeWhitespace(str))
-              case other => removeWhitespace(other.toString)
+              case str: String => quoteIdentifier(str)
+              case other => other.toString
             }
             .mkString("[", ", ", "]")
         case JObject(fields) =>
           fields.map { case (k, v) =>
-            s"$k=${removeWhitespace(v.values.toString)}"
+            s"$k=${v.values.toString}"
           }
             .mkString("[", ", ", "]")
         case JInt(value) => value.toString
         case JDouble(value) => value.toString
-        case _ => removeWhitespace(jValue.values.toString)
+        case _ => jValue.values.toString
       }
       map.put(key, stringValue)
     }

--- a/sql/core/src/test/resources/sql-tests/results/show-tables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/show-tables.sql.out
@@ -128,6 +128,7 @@ View Schema Mode: BINDING
 Schema: root
  |-- e: integer (nullable = true)
 
+
 showdb	show_t1	false	Catalog: spark_catalog
 Database: showdb
 Table: show_t1
@@ -144,6 +145,7 @@ Schema: root
  |-- b: integer (nullable = true)
  |-- c: string (nullable = true)
  |-- d: string (nullable = true)
+
 
 showdb	show_t2	false	Catalog: spark_catalog
 Database: showdb


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

When converting from `toJsonLinkedHashMap` result to `DESCRIBE TABLE`, `removeWhitespace` helper is unnecessary. This PR removes the helper util to ensure equivalent behavior of `DESCRIBE TABLE` output.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Ensure backwards compatibility for `DESCRIBE TABLE`, after introduction of `DESCRIBE TABLE AS JSON`


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No, it maintains the original output of `DESCRIBE TABLE`.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing tests.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
