### PR TITLE
[SPARK-50633][FOLLOWUP] Turn on options `verbose` for `codecov/codecov-action`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -621,10 +621,11 @@ jobs:
       if: fromJSON(inputs.envs).PYSPARK_CODECOV == 'true'
       uses: codecov/codecov-action@v5
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         files: ./python/coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
         name: PySpark
+        verbose: true
     - name: Upload test results to report
       env: ${{ fromJSON(inputs.envs) }}
       if: always()


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to turn on options `verbose` for `codecov/codecov-action` to identify issues.


### Why are the changes needed?
The issue is that I have added `token: ${{ secrets.CODECOV_TOKEN }}` in the configuration, but the workflow does not display it like the below:
<img width="593" alt="image" src="https://github.com/user-attachments/assets/6795f472-d144-40bb-aaf1-8294435201da" />

Furthermore, the workflow below was not successful.
https://github.com/apache/spark/actions/runs/12705043568/job/35415465795
<img width="623" alt="image" src="https://github.com/user-attachments/assets/9e88f5f9-fa28-4411-9099-2aed23aaa3bf" />
<img width="832" alt="image" src="https://github.com/user-attachments/assets/6b9fc620-263d-4bdf-a039-64b369d8bc68" />

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
No.


### Was this patch authored or co-authored using generative AI tooling?
No.
