### PR TITLE
[SPARK-48745][INFRA][PYTHON][TESTS][FOLLOWUP] Fix the `pyspark-error` testing environment in GA

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -601,10 +601,11 @@ jobs:
     - name: Install Conda for pip packaging test
       if: contains(matrix.modules, 'pyspark-errors')
       run: |
-        curl -s https://github.com/conda-forge/miniforge/releases/download/24.11.2-1/Miniforge3-Linux-x86_64.sh > miniforge3.sh
+        curl -s -L "https://github.com/conda-forge/miniforge/releases/download/24.11.2-1/Miniforge3-Linux-x86_64.sh" > miniforge3.sh
         bash miniforge3.sh -b -p $HOME/miniforge3
         ls -al $HOME/miniforge3
         ls -al $HOME/miniforge3/bin
+        $HOME/miniforge3/bin/conda env list
         rm miniforge3.sh
     # Run the tests.
     - name: Run tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -603,9 +603,6 @@ jobs:
       run: |
         curl -s -L "https://github.com/conda-forge/miniforge/releases/download/24.11.2-1/Miniforge3-Linux-x86_64.sh" > miniforge3.sh
         bash miniforge3.sh -b -p $HOME/miniforge3
-        ls -al $HOME/miniforge3
-        ls -al $HOME/miniforge3/bin
-        $HOME/miniforge3/bin/conda env list
         rm miniforge3.sh
     # Run the tests.
     - name: Run tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -608,6 +608,7 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       run: |
         if [[ "$MODULES_TO_TEST" == *"pyspark-errors"* ]]; then
+          export PATH=$PATH:$CONDA_PREFIX/bin
           export SKIP_PACKAGING=false
           echo "Python Packaging Tests Enabled!"
         fi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -295,8 +295,6 @@ jobs:
       INCLUDED_TAGS: ${{ matrix.included-tags }}
       HADOOP_PROFILE: ${{ matrix.hadoop }}
       HIVE_PROFILE: ${{ matrix.hive }}
-      # GitHub Actions' default miniconda to use in pip packaging test.
-      CONDA_PREFIX: /usr/share/miniconda
       GITHUB_PREV_SHA: ${{ github.event.before }}
       SPARK_LOCAL_IP: localhost
       NOLINT_ON_COMPILE: true
@@ -539,8 +537,6 @@ jobs:
       MODULES_TO_TEST: ${{ matrix.modules }}
       HADOOP_PROFILE: ${{ inputs.hadoop }}
       HIVE_PROFILE: hive2.3
-      # GitHub Actions' default miniconda to use in pip packaging test.
-      CONDA_PREFIX: /usr/share/miniconda
       GITHUB_PREV_SHA: ${{ github.event.before }}
       SPARK_LOCAL_IP: localhost
       SKIP_UNIDOC: true
@@ -602,6 +598,12 @@ jobs:
           echo $py
           $py -m pip list
         done
+    - name: Install Conda for pip packaging test
+      if: contains(matrix.modules, 'pyspark-errors')
+      run: |
+        curl -s https://github.com/conda-forge/miniforge/releases/download/24.11.2-1/Miniforge3-Linux-x86_64.sh > miniforge3.sh
+        bash miniforge3.sh -b -p $HOME/miniforge3
+        rm miniforge3.sh
     # Run the tests.
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}
@@ -609,7 +611,7 @@ jobs:
       run: |
         if [[ "$MODULES_TO_TEST" == *"pyspark-errors"* ]]; then
           env
-          export PATH=$PATH:$CONDA_PREFIX/bin
+          export PATH=$PATH:$HOME/miniforge3/bin
           export SKIP_PACKAGING=false
           echo "Python Packaging Tests Enabled!"
         fi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -608,6 +608,7 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       run: |
         if [[ "$MODULES_TO_TEST" == *"pyspark-errors"* ]]; then
+          env
           export PATH=$PATH:$CONDA_PREFIX/bin
           export SKIP_PACKAGING=false
           echo "Python Packaging Tests Enabled!"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -603,6 +603,8 @@ jobs:
       run: |
         curl -s https://github.com/conda-forge/miniforge/releases/download/24.11.2-1/Miniforge3-Linux-x86_64.sh > miniforge3.sh
         bash miniforge3.sh -b -p $HOME/miniforge3
+        ls -al $HOME/miniforge3
+        ls -al $HOME/miniforge3/bin
         rm miniforge3.sh
     # Run the tests.
     - name: Run tests
@@ -610,8 +612,9 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       run: |
         if [[ "$MODULES_TO_TEST" == *"pyspark-errors"* ]]; then
-          env
           export PATH=$PATH:$HOME/miniforge3/bin
+          env
+          which conda
           export SKIP_PACKAGING=false
           echo "Python Packaging Tests Enabled!"
         fi

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -42,6 +42,10 @@ function delete_virtualenv() {
 }
 trap delete_virtualenv EXIT
 
+which conda
+conda env list
+/usr/share/miniconda/bin/conda env list
+
 PYTHON_EXECS=()
 # Some systems don't have pip or virtualenv - in those cases our tests won't work.
 if hash virtualenv 2>/dev/null && [ ! -n "$USE_CONDA" ]; then

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -42,11 +42,11 @@ function delete_virtualenv() {
 }
 trap delete_virtualenv EXIT
 
-echo "......."
-echo "$HOME/miniforge3"
-ls -al "$HOME/miniforge3"
-$HOME/miniforge3/bin/conda env list
-echo "......."
+# echo "......."
+# echo "$HOME/miniforge3"
+# ls -al "$HOME/miniforge3"
+# $HOME/miniforge3/bin/conda env list
+# echo "......."
 
 PYTHON_EXECS=()
 # Some systems don't have pip or virtualenv - in those cases our tests won't work.

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -42,9 +42,11 @@ function delete_virtualenv() {
 }
 trap delete_virtualenv EXIT
 
-echo $CONDA
-ls -al $CONDA
-/usr/share/miniconda/bin/conda env list
+echo "......."
+echo $CONDA_PREFIX
+ls -al $CONDA_PREFIX
+# /usr/share/miniconda/bin/conda env list
+echo "......."
 
 PYTHON_EXECS=()
 # Some systems don't have pip or virtualenv - in those cases our tests won't work.

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -43,9 +43,9 @@ function delete_virtualenv() {
 trap delete_virtualenv EXIT
 
 echo "......."
-echo $CONDA_PREFIX
-ls -al $CONDA_PREFIX
-# /usr/share/miniconda/bin/conda env list
+echo "$HOME/miniforge3"
+ls -al "$HOME/miniforge3"
+$HOME/miniforge3/bin/conda env list
 echo "......."
 
 PYTHON_EXECS=()
@@ -93,10 +93,6 @@ for python in "${PYTHON_EXECS[@]}"; do
     VIRTUALENV_PATH="$VIRTUALENV_BASE"/$python
     rm -rf "$VIRTUALENV_PATH"
     if [ -n "$USE_CONDA" ]; then
-      if [ -f "$CONDA_PREFIX/etc/profile.d/conda.sh" ]; then
-        # See also https://github.com/conda/conda/issues/7980
-        source "$CONDA_PREFIX/etc/profile.d/conda.sh"
-      fi
       conda create -y -p "$VIRTUALENV_PATH" python=$python numpy pandas pip setuptools
       source activate "$VIRTUALENV_PATH" || conda activate "$VIRTUALENV_PATH"
     else

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -42,8 +42,8 @@ function delete_virtualenv() {
 }
 trap delete_virtualenv EXIT
 
-which conda
-conda env list
+echo $CONDA
+ls -al $CONDA
 /usr/share/miniconda/bin/conda env list
 
 PYTHON_EXECS=()

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -42,12 +42,6 @@ function delete_virtualenv() {
 }
 trap delete_virtualenv EXIT
 
-# echo "......."
-# echo "$HOME/miniforge3"
-# ls -al "$HOME/miniforge3"
-# $HOME/miniforge3/bin/conda env list
-# echo "......."
-
 PYTHON_EXECS=()
 # Some systems don't have pip or virtualenv - in those cases our tests won't work.
 if hash virtualenv 2>/dev/null && [ ! -n "$USE_CONDA" ]; then


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix the `pyspark-error` testing environment in GA.


### Why are the changes needed?
- The GitHub community promised to install `conda`, but it has not been fulfilled. 
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
<img width="504" alt="image" src="https://github.com/user-attachments/assets/d926d39f-5cb8-40b6-ac7c-f02685be1aad" />

- Let's install it manually, otherwise `pyspark-error` testing will be ignored.
https://github.com/apache/spark/actions/runs/12705030478/job/35415431049
<img width="507" alt="image" src="https://github.com/user-attachments/assets/af8ae44c-e2c9-42e1-a7ec-bbce530acdd0" />

- Why install `Miniforge3` instead of `Miniconda` ?
![image](https://github.com/user-attachments/assets/d3c91f54-85b1-4f2e-94be-6742c33e8779)
https://github.com/conda-forge/miniforge

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
