### PR TITLE
[SPARK-50784][TESTS] Fix `lint-scala` not to ignore `scalastyle` errors

### DIFF
--- a/dev/lint-scala
+++ b/dev/lint-scala
@@ -20,8 +20,10 @@
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 SPARK_ROOT_DIR="$(dirname $SCRIPT_DIR)"
 
+set -e
 "$SCRIPT_DIR/scalastyle" "$1"
 
+set +e
 # For Spark Connect, we actively enforce scalafmt and check that the produced diff is empty.
 ERRORS=$(./build/mvn \
     -Pscala-2.13 \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `lint-scala` script not to ignore `scalastyle` errors.

### Why are the changes needed?

This bug was introduced via the following PR at Apache Spark 3.4.0.
- #38258

After the above PR, `lint-scala` ignores `scalastyle` error and only considers the exit code of `scalafmt` like the following CI result.
- https://github.com/apache/spark/pull/49428#issuecomment-2582935831

![Screenshot 2025-01-10 at 07 14 31](https://github.com/user-attachments/assets/bdaa3be3-5daf-401b-a46f-7c02b7610158)

### Does this PR introduce _any_ user-facing change?

No, this is a dev-only tool change.

### How was this patch tested?

Manual review. 

### Was this patch authored or co-authored using generative AI tooling?

No.
