### PR TITLE
[MINOR][DOCS][SPARK-50787] Fix typos and add missing semicolons in sql examples

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2850,7 +2850,7 @@ Apart from these, the following properties are also available, and may be useful
     If set to "true", prevent Spark from scheduling tasks on executors that have been excluded
     due to too many task failures. The algorithm used to exclude executors and nodes can be further
     controlled by the other "spark.excludeOnFailure" configuration options.
-    This config will be overriden by "spark.excludeOnFailure.application.enabled" and 
+    This config will be overridden by "spark.excludeOnFailure.application.enabled" and
     "spark.excludeOnFailure.taskAndStage.enabled" to specify exclusion enablement on individual
     levels.
   </td>

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -394,7 +394,7 @@ spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-1.mount.
 spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-1.mount.readOnly=false
 ```
 
-To enable shuffle data recovery feature via the built-in `KubernetesLocalDiskShuffleDataIO` plugin, we need to have the followings. You may want to enable `spark.kubernetes.driver.waitToReusePersistentVolumeClaim` additionally.
+To enable shuffle data recovery feature via the built-in `KubernetesLocalDiskShuffleDataIO` plugin, we need to have the following. You may want to enable `spark.kubernetes.driver.waitToReusePersistentVolumeClaim` additionally.
 
 ```
 spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-1.mount.path=/data/spark-x/executor-x

--- a/docs/sql-ref-syntax-aux-resource-mgmt-add-jar.md
+++ b/docs/sql-ref-syntax-aux-resource-mgmt-add-jar.md
@@ -54,9 +54,9 @@ ADD JAR '/some/other.jar';
 ADD JAR "/path with space/abc.jar";
 ADD JARS "/path with space/def.jar" '/path with space/ghi.jar';
 ADD JAR "ivy://group:module:version";
-ADD JAR "ivy://group:module:version?transitive=false"
-ADD JAR "ivy://group:module:version?transitive=true"
-ADD JAR "ivy://group:module:version?exclude=group:module&transitive=true"
+ADD JAR "ivy://group:module:version?transitive=false";
+ADD JAR "ivy://group:module:version?transitive=true";
+ADD JAR "ivy://group:module:version?exclude=group:module&transitive=true";
 ```
 
 ### Related Statements

--- a/docs/sql-ref-syntax-ddl-alter-table.md
+++ b/docs/sql-ref-syntax-ddl-alter-table.md
@@ -673,12 +673,12 @@ ALTER TABLE loc_orc SET fileformat orc;
 ALTER TABLE p1 partition (month=2, day=2) SET fileformat parquet;
 
 -- Change the file Location
-ALTER TABLE dbx.tab1 PARTITION (a='1', b='2') SET LOCATION '/path/to/part/ways'
+ALTER TABLE dbx.tab1 PARTITION (a='1', b='2') SET LOCATION '/path/to/part/ways';
 
 -- SET SERDE/ SERDE Properties
 ALTER TABLE test_tab SET SERDE 'org.apache.hadoop.hive.serde2.columnar.LazyBinaryColumnarSerDe';
 
-ALTER TABLE dbx.tab1 SET SERDE 'org.apache.hadoop' WITH SERDEPROPERTIES ('k' = 'v', 'kay' = 'vee')
+ALTER TABLE dbx.tab1 SET SERDE 'org.apache.hadoop' WITH SERDEPROPERTIES ('k' = 'v', 'kay' = 'vee');
 
 -- SET TABLE PROPERTIES
 ALTER TABLE dbx.tab1 SET TBLPROPERTIES ('winner' = 'loser');

--- a/docs/sql-ref-syntax-qry-star.md
+++ b/docs/sql-ref-syntax-qry-star.md
@@ -21,7 +21,7 @@ license: |
 
 ### Description
 
-A shorthand to name all the referencable columns in the FROM clause or a specific table reference's columns or fields in the FROM clause.
+A shorthand to name all the referenceable columns in the FROM clause or a specific table reference's columns or fields in the FROM clause.
 The star clause is most frequently used in the SELECT list.
 Spark also supports its use in function invocation and certain n-ary operations within the SELECT list and WHERE clause.
 
@@ -38,11 +38,11 @@ except_clause
 
 * **name**
 
-  If present limits the columns or fields to be named to those in the specified referencable field, column, or table.
+  If present limits the columns or fields to be named to those in the specified referenceable field, column, or table.
 
 * **except_clause**
 
-  Optionally prunes columns or fields from the referencable set of columns identified in the select_star clause.
+  Optionally prunes columns or fields from the referenceable set of columns identified in the select_star clause.
 
   * **column_name**
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Corrected documentation typos
- Added missing semicolons in SQL examples


### Why are the changes needed?
To correct documentation typos and fix SQL syntax examples for clarity.


### Does this PR introduce _any_ user-facing change?
Yes, it updates documentation with corrections to typos and SQL examples.


### How was this patch tested?
Manually, by building and reviewing the updated documentation.


### Was this patch authored or co-authored using generative AI tooling?
No.
