### PR TITLE
[SPARK-50788][TESTS] Add Benchmark for Large-Row Dataframe

### DIFF
--- a/sql/core/benchmarks/LargeRowBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/LargeRowBenchmark-jdk21-results.txt
@@ -2,25 +2,25 @@
 Large Row Benchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.5+11-LTS on Linux 6.5.0-1025-azure
+OpenJDK 64-Bit Server VM 21.0.5+11-LTS on Linux 6.8.0-1017-azure
 AMD EPYC 7763 64-Core Processor
-#rows: 100, #cols: 10, cell: 1 MB:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+#rows: 100, #cols: 10, cell: 1.3 MB:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-built-in UPPER                                     4477           4485          11          0.0    44774513.6       1.0X
-udf UPPER                                          3094           3096           3          0.0    30942374.6       1.4X
+built-in UPPER                                     5814           6152         478          0.0    58140115.7       1.0X
+udf UPPER                                          4024           4035          16          0.0    40241031.7       1.4X
 
-OpenJDK 64-Bit Server VM 21.0.5+11-LTS on Linux 6.5.0-1025-azure
+OpenJDK 64-Bit Server VM 21.0.5+11-LTS on Linux 6.8.0-1017-azure
 AMD EPYC 7763 64-Core Processor
-#rows: 1, #cols: 1, cell: 300 MB:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+#rows: 1, #cols: 1, cell: 300.0 MB:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-built-in UPPER                                     1309           1326          24          0.0  1309166225.0       1.0X
-udf UPPER                                           987           1005          25          0.0   987339195.0       1.3X
+built-in UPPER                                     1315           1317           2          0.0  1315299564.0       1.0X
+udf UPPER                                          1015           1016           2          0.0  1014585082.0       1.3X
 
-OpenJDK 64-Bit Server VM 21.0.5+11-LTS on Linux 6.5.0-1025-azure
+OpenJDK 64-Bit Server VM 21.0.5+11-LTS on Linux 6.8.0-1017-azure
 AMD EPYC 7763 64-Core Processor
-#rows: 1, #cols: 200, cell: 1 MB:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+#rows: 1, #cols: 200, cell: 1.0 MB:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-built-in UPPER                                     1029           1078          70          0.0  1028873175.0       1.0X
-udf UPPER                                          1221           1266          64          0.0  1220529621.0       0.8X
+built-in UPPER                                     1105           1124          27          0.0  1104599012.0       1.0X
+udf UPPER                                          1263           1303          56          0.0  1263336183.0       0.9X
 
 

--- a/sql/core/benchmarks/LargeRowBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/LargeRowBenchmark-jdk21-results.txt
@@ -6,21 +6,21 @@ OpenJDK 64-Bit Server VM 21.0.5+11-LTS on Linux 6.8.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 #rows: 100, #cols: 10, cell: 1.3 MB:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-built-in UPPER                                     5814           6152         478          0.0    58140115.7       1.0X
-udf UPPER                                          4024           4035          16          0.0    40241031.7       1.4X
+built-in UPPER                                     5909           6154         347          0.0    59088236.5       1.0X
+udf UPPER                                          4106           4364         364          0.0    41062501.9       1.4X
 
 OpenJDK 64-Bit Server VM 21.0.5+11-LTS on Linux 6.8.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 #rows: 1, #cols: 1, cell: 300.0 MB:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-built-in UPPER                                     1315           1317           2          0.0  1315299564.0       1.0X
-udf UPPER                                          1015           1016           2          0.0  1014585082.0       1.3X
+built-in UPPER                                     1317           1319           3          0.0  1317449498.0       1.0X
+udf UPPER                                           954            975          25          0.0   953744994.0       1.4X
 
 OpenJDK 64-Bit Server VM 21.0.5+11-LTS on Linux 6.8.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 #rows: 1, #cols: 200, cell: 1.0 MB:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-built-in UPPER                                     1105           1124          27          0.0  1104599012.0       1.0X
-udf UPPER                                          1263           1303          56          0.0  1263336183.0       0.9X
+built-in UPPER                                     1118           1138          28          0.0  1117901962.0       1.0X
+udf UPPER                                          1145           1210          91          0.0  1145234313.0       1.0X
 
 

--- a/sql/core/benchmarks/LargeRowBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/LargeRowBenchmark-jdk21-results.txt
@@ -1,0 +1,26 @@
+================================================================================================
+Large Row Benchmark
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.5+11-LTS on Linux 6.5.0-1025-azure
+AMD EPYC 7763 64-Core Processor
+#rows: 100, #cols: 10, cell: 1 MB:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+built-in UPPER                                     4477           4485          11          0.0    44774513.6       1.0X
+udf UPPER                                          3094           3096           3          0.0    30942374.6       1.4X
+
+OpenJDK 64-Bit Server VM 21.0.5+11-LTS on Linux 6.5.0-1025-azure
+AMD EPYC 7763 64-Core Processor
+#rows: 1, #cols: 1, cell: 300 MB:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+built-in UPPER                                     1309           1326          24          0.0  1309166225.0       1.0X
+udf UPPER                                           987           1005          25          0.0   987339195.0       1.3X
+
+OpenJDK 64-Bit Server VM 21.0.5+11-LTS on Linux 6.5.0-1025-azure
+AMD EPYC 7763 64-Core Processor
+#rows: 1, #cols: 200, cell: 1 MB:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+built-in UPPER                                     1029           1078          70          0.0  1028873175.0       1.0X
+udf UPPER                                          1221           1266          64          0.0  1220529621.0       0.8X
+
+

--- a/sql/core/benchmarks/LargeRowBenchmark-results.txt
+++ b/sql/core/benchmarks/LargeRowBenchmark-results.txt
@@ -2,25 +2,25 @@
 Large Row Benchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.13+11-LTS on Linux 6.5.0-1025-azure
+OpenJDK 64-Bit Server VM 17.0.13+11-LTS on Linux 6.8.0-1017-azure
 AMD EPYC 7763 64-Core Processor
-#rows: 100, #cols: 10, cell: 1 MB:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+#rows: 100, #cols: 10, cell: 1.3 MB:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-built-in UPPER                                     5163           5169           9          0.0    51626690.7       1.0X
-udf UPPER                                          3373           3403          43          0.0    33727744.1       1.5X
+built-in UPPER                                     6544           6552          11          0.0    65443277.9       1.0X
+udf UPPER                                          4199           4234          49          0.0    41994885.3       1.6X
 
-OpenJDK 64-Bit Server VM 17.0.13+11-LTS on Linux 6.5.0-1025-azure
+OpenJDK 64-Bit Server VM 17.0.13+11-LTS on Linux 6.8.0-1017-azure
 AMD EPYC 7763 64-Core Processor
-#rows: 1, #cols: 1, cell: 300 MB:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+#rows: 1, #cols: 1, cell: 300.0 MB:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-built-in UPPER                                     1533           1537           6          0.0  1532961360.0       1.0X
-udf UPPER                                           989            998           9          0.0   989188142.0       1.5X
+built-in UPPER                                     1489           1507          25          0.0  1488818589.0       1.0X
+udf UPPER                                          1198           1208          14          0.0  1198348818.0       1.2X
 
-OpenJDK 64-Bit Server VM 17.0.13+11-LTS on Linux 6.5.0-1025-azure
+OpenJDK 64-Bit Server VM 17.0.13+11-LTS on Linux 6.8.0-1017-azure
 AMD EPYC 7763 64-Core Processor
-#rows: 1, #cols: 200, cell: 1 MB:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+#rows: 1, #cols: 200, cell: 1.0 MB:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-built-in UPPER                                     1284           1295          16          0.0  1283987389.0       1.0X
-udf UPPER                                          1331           1348          24          0.0  1330934751.0       1.0X
+built-in UPPER                                     1169           1200          43          0.0  1169248916.0       1.0X
+udf UPPER                                          1332           1360          40          0.0  1331543765.0       0.9X
 
 

--- a/sql/core/benchmarks/LargeRowBenchmark-results.txt
+++ b/sql/core/benchmarks/LargeRowBenchmark-results.txt
@@ -6,21 +6,21 @@ OpenJDK 64-Bit Server VM 17.0.13+11-LTS on Linux 6.8.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 #rows: 100, #cols: 10, cell: 1.3 MB:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-built-in UPPER                                     6544           6552          11          0.0    65443277.9       1.0X
-udf UPPER                                          4199           4234          49          0.0    41994885.3       1.6X
+built-in UPPER                                     6610           6651          58          0.0    66101681.9       1.0X
+udf UPPER                                          4289           4291           3          0.0    42892607.0       1.5X
 
 OpenJDK 64-Bit Server VM 17.0.13+11-LTS on Linux 6.8.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 #rows: 1, #cols: 1, cell: 300.0 MB:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-built-in UPPER                                     1489           1507          25          0.0  1488818589.0       1.0X
-udf UPPER                                          1198           1208          14          0.0  1198348818.0       1.2X
+built-in UPPER                                     1492           1510          26          0.0  1492292577.0       1.0X
+udf UPPER                                          1033           1034           1          0.0  1032584220.0       1.4X
 
 OpenJDK 64-Bit Server VM 17.0.13+11-LTS on Linux 6.8.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 #rows: 1, #cols: 200, cell: 1.0 MB:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-built-in UPPER                                     1169           1200          43          0.0  1169248916.0       1.0X
-udf UPPER                                          1332           1360          40          0.0  1331543765.0       0.9X
+built-in UPPER                                     1271           1290          28          0.0  1270654457.0       1.0X
+udf UPPER                                          1397           1558         228          0.0  1396607518.0       0.9X
 
 

--- a/sql/core/benchmarks/LargeRowBenchmark-results.txt
+++ b/sql/core/benchmarks/LargeRowBenchmark-results.txt
@@ -1,0 +1,26 @@
+================================================================================================
+Large Row Benchmark
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.13+11-LTS on Linux 6.5.0-1025-azure
+AMD EPYC 7763 64-Core Processor
+#rows: 100, #cols: 10, cell: 1 MB:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+built-in UPPER                                     5163           5169           9          0.0    51626690.7       1.0X
+udf UPPER                                          3373           3403          43          0.0    33727744.1       1.5X
+
+OpenJDK 64-Bit Server VM 17.0.13+11-LTS on Linux 6.5.0-1025-azure
+AMD EPYC 7763 64-Core Processor
+#rows: 1, #cols: 1, cell: 300 MB:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+built-in UPPER                                     1533           1537           6          0.0  1532961360.0       1.0X
+udf UPPER                                           989            998           9          0.0   989188142.0       1.5X
+
+OpenJDK 64-Bit Server VM 17.0.13+11-LTS on Linux 6.5.0-1025-azure
+AMD EPYC 7763 64-Core Processor
+#rows: 1, #cols: 200, cell: 1 MB:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+built-in UPPER                                     1284           1295          16          0.0  1283987389.0       1.0X
+udf UPPER                                          1331           1348          24          0.0  1330934751.0       1.0X
+
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
@@ -63,11 +63,11 @@ object LargeRowBenchmark extends SqlBasedBenchmark {
       )
 
       benchmarks.foreach { b =>
-        val rows = b("rows")
-        val cols = b("cols")
+        val rows = b("rows").asInstanceOf[Int]
+        val cols = b("cols").asInstanceOf[Int]
         val cellSize_mb = b("cellSize_mb")
-        runLargeRowBenchmark(rows.toInt, cols.toInt, cellSize_mb)
-        runLargeRowBenchmark(rows.toInt, cols.toInt, cellSize_mb)
+        runLargeRowBenchmark(rows, cols, cellSize_mb)
+        runLargeRowBenchmark(rows, cols, cellSize_mb)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
@@ -65,7 +65,7 @@ object LargeRowBenchmark extends SqlBasedBenchmark {
       benchmarks.foreach { b =>
         val rows = b("rows").asInstanceOf[Int]
         val cols = b("cols").asInstanceOf[Int]
-        val cellSize_mb = b("cellSize_mb")
+        val cellSize_mb = b("cellSize_mb").asInstanceOf[Double]
         runLargeRowBenchmark(rows, cols, cellSize_mb)
         runLargeRowBenchmark(rows, cols, cellSize_mb)
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.benchmark
+
+import org.apache.spark.benchmark.Benchmark
+
+/**
+ * Benchmark to measure performance for wide table.
+ * {{{
+ *   To run this benchmark:
+ *   1. without sbt: bin/spark-submit --class <this class>
+ *        --jars <spark core test jar>,<spark catalyst test jar> <spark sql test jar>
+ *   2. build/sbt "sql/Test/runMain <this class>"
+ *   3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
+ *      Results will be written to "benchmarks/WideTableBenchmark-results.txt".
+ * }}}
+ */
+object LargeRowBenchmark extends SqlBasedBenchmark {
+
+  def runLargeRowBenchmark(rowsNum: Int, numCols: Int, cellSize_mb: Int): Unit = {
+    withTempPath { path =>
+      val benchmark = new Benchmark(
+        s"#rows: $rowsNum, #cols: $numCols, cell: $cellSize_mb MB", rowsNum, output = output)
+      writeLargeRow(path.getAbsolutePath, rowsNum, numCols, cellSize_mb)
+      val df = spark.read.parquet(path.getAbsolutePath)
+      df.createOrReplaceTempView("T")
+      benchmark.addCase("built-in UPPER") { _ =>
+        val sql_select = df.columns.map(c => s"UPPER($c) as $c").mkString(", ")
+        spark.sql(s"SELECT $sql_select FROM T").noop()
+      }
+      benchmark.addCase("udf UPPER") { _ =>
+        val sql_select = df.columns.map(c => s"udf_upper($c) as $c").mkString(", ")
+        spark.sql(s"SELECT $sql_select FROM T").noop()
+      }
+      benchmark.run()
+    }
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    runBenchmark("Large Row Benchmark") {
+      val udf_upper = (s: String) => s.toUpperCase()
+      spark.udf.register("udf_upper", udf_upper(_: String): String)
+
+      val benchmarks = Array(
+        Map("rows" -> 100, "cols" -> 10, "cellSize_mb" -> 1), //  OutOfMemory @ 100, 10, 2
+        Map("rows" -> 1, "cols" -> 1, "cellSize_mb" -> 300), //  OutOfMemory @ 1, 1, 400
+        Map("rows" -> 1, "cols" -> 200, "cellSize_mb" -> 1) //  OutOfMemory @ 1, 300, 1
+      )
+
+      benchmarks.foreach { b =>
+        val rows = b("rows")
+        val cols = b("cols")
+        val cellSize_mb = b("cellSize_mb")
+        runLargeRowBenchmark(rows, cols, cellSize_mb)
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
@@ -57,7 +57,7 @@ object LargeRowBenchmark extends SqlBasedBenchmark {
       spark.udf.register("udf_upper", udf_upper(_: String): String)
 
       val benchmarks = Array(
-        Map("rows" -> 100, "cols" -> 10, "cellSize_mb" -> 1.2) //  OutOfMemory @ 100, 10, 2
+        Map("rows" -> 100, "cols" -> 10, "cellSize_mb" -> 1.4) //  OutOfMemory @ 100, 10, 2
         //        Map("rows" -> 1, "cols" -> 1, "cellSize_mb" -> 300), //  OutOfMemory @ 1, 1, 400
         //        Map("rows" -> 1, "cols" -> 200, "cellSize_mb" -> 1) //  OutOfMemory @ 1, 300, 1
       )
@@ -66,7 +66,6 @@ object LargeRowBenchmark extends SqlBasedBenchmark {
         val rows = b("rows").asInstanceOf[Int]
         val cols = b("cols").asInstanceOf[Int]
         val cellSize_mb = b("cellSize_mb").asInstanceOf[Double]
-        runLargeRowBenchmark(rows, cols, cellSize_mb)
         runLargeRowBenchmark(rows, cols, cellSize_mb)
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
@@ -57,9 +57,9 @@ object LargeRowBenchmark extends SqlBasedBenchmark {
       spark.udf.register("udf_upper", udf_upper(_: String): String)
 
       val benchmarks = Array(
-        Map("rows" -> 100, "cols" -> 10, "cellSize_mb" -> 1.3) //  OutOfMemory @ 100, 10, 2
-        //        Map("rows" -> 1, "cols" -> 1, "cellSize_mb" -> 300), //  OutOfMemory @ 1, 1, 400
-        //        Map("rows" -> 1, "cols" -> 200, "cellSize_mb" -> 1) //  OutOfMemory @ 1, 300, 1
+        Map("rows" -> 100, "cols" -> 10, "cellSize_mb" -> 1.3), //  OutOfMemory @ 100, 10, 1.4
+        Map("rows" -> 1, "cols" -> 1, "cellSize_mb" -> 300.0), //  OutOfMemory @ 1, 1, 400
+        Map("rows" -> 1, "cols" -> 200, "cellSize_mb" -> 1.0) //  OutOfMemory @ 1, 300, 1
       )
 
       benchmarks.foreach { b =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
@@ -18,34 +18,46 @@
 package org.apache.spark.sql.execution.benchmark
 
 import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.functions.lit
 
 /**
- * Benchmark to measure performance for wide table.
+ * Benchmark to measure performance for large row table.
  * {{{
  *   To run this benchmark:
  *   1. without sbt: bin/spark-submit --class <this class>
  *        --jars <spark core test jar>,<spark catalyst test jar> <spark sql test jar>
  *   2. build/sbt "sql/Test/runMain <this class>"
  *   3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
- *      Results will be written to "benchmarks/WideTableBenchmark-results.txt".
+ *      Results will be written to "benchmarks/LargeRowBenchmark-results.txt".
  * }}}
  */
 object LargeRowBenchmark extends SqlBasedBenchmark {
 
-  def runLargeRowBenchmark(rowsNum: Int, numCols: Int, cellSize_mb: Double): Unit = {
+  /**
+   * Prepares a table with large row for benchmarking. The table will be written into
+   * the given path.
+   */
+  private def writeLargeRow(path: String, rowsNum: Int, numCols: Int, cellSizeMb: Double): Unit = {
+    val stringLength = (cellSizeMb * 1024 * 1024).toInt
+    spark.range(rowsNum)
+      .select(Seq.tabulate(numCols)(i => lit("a" * stringLength).as(s"col$i")): _*)
+      .write.parquet(path)
+  }
+
+  private def runLargeRowBenchmark(rowsNum: Int, numCols: Int, cellSizeMb: Double): Unit = {
     withTempPath { path =>
       val benchmark = new Benchmark(
-        s"#rows: $rowsNum, #cols: $numCols, cell: $cellSize_mb MB", rowsNum, output = output)
-      writeLargeRow(path.getAbsolutePath, rowsNum, numCols, cellSize_mb)
+        s"#rows: $rowsNum, #cols: $numCols, cell: $cellSizeMb MB", rowsNum, output = output)
+      writeLargeRow(path.getAbsolutePath, rowsNum, numCols, cellSizeMb)
       val df = spark.read.parquet(path.getAbsolutePath)
       df.createOrReplaceTempView("T")
       benchmark.addCase("built-in UPPER") { _ =>
-        val sql_select = df.columns.map(c => s"UPPER($c) as $c").mkString(", ")
-        spark.sql(s"SELECT $sql_select FROM T").noop()
+        val sqlSelect = df.columns.map(c => s"UPPER($c) as $c").mkString(", ")
+        spark.sql(s"SELECT $sqlSelect FROM T").noop()
       }
       benchmark.addCase("udf UPPER") { _ =>
-        val sql_select = df.columns.map(c => s"udf_upper($c) as $c").mkString(", ")
-        spark.sql(s"SELECT $sql_select FROM T").noop()
+        val sqlSelect = df.columns.map(c => s"udfUpper($c) as $c").mkString(", ")
+        spark.sql(s"SELECT $sqlSelect FROM T").noop()
       }
       benchmark.run()
     }
@@ -53,20 +65,20 @@ object LargeRowBenchmark extends SqlBasedBenchmark {
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
     runBenchmark("Large Row Benchmark") {
-      val udf_upper = (s: String) => s.toUpperCase()
-      spark.udf.register("udf_upper", udf_upper(_: String): String)
+      val udfUpper = (s: String) => s.toUpperCase()
+      spark.udf.register("udfUpper", udfUpper(_: String): String)
 
       val benchmarks = Array(
-        Map("rows" -> 100, "cols" -> 10, "cellSize_mb" -> 1.3), //  OutOfMemory @ 100, 10, 1.4
-        Map("rows" -> 1, "cols" -> 1, "cellSize_mb" -> 300.0), //  OutOfMemory @ 1, 1, 400
-        Map("rows" -> 1, "cols" -> 200, "cellSize_mb" -> 1.0) //  OutOfMemory @ 1, 300, 1
+        Map("rows" -> 100, "cols" -> 10, "cellSizeMb" -> 1.3), //  OutOfMemory @ 100, 10, 1.4
+        Map("rows" -> 1, "cols" -> 1, "cellSizeMb" -> 300.0), //  OutOfMemory @ 1, 1, 400
+        Map("rows" -> 1, "cols" -> 200, "cellSizeMb" -> 1.0) //  OutOfMemory @ 1, 300, 1
       )
 
       benchmarks.foreach { b =>
         val rows = b("rows").asInstanceOf[Int]
         val cols = b("cols").asInstanceOf[Int]
-        val cellSize_mb = b("cellSize_mb").asInstanceOf[Double]
-        runLargeRowBenchmark(rows, cols, cellSize_mb)
+        val cellSizeMb = b("cellSizeMb").asInstanceOf[Double]
+        runLargeRowBenchmark(rows, cols, cellSizeMb)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
@@ -57,7 +57,7 @@ object LargeRowBenchmark extends SqlBasedBenchmark {
       spark.udf.register("udf_upper", udf_upper(_: String): String)
 
       val benchmarks = Array(
-        Map("rows" -> 100, "cols" -> 10, "cellSize_mb" -> 1.4) //  OutOfMemory @ 100, 10, 2
+        Map("rows" -> 100, "cols" -> 10, "cellSize_mb" -> 1.3) //  OutOfMemory @ 100, 10, 2
         //        Map("rows" -> 1, "cols" -> 1, "cellSize_mb" -> 300), //  OutOfMemory @ 1, 1, 400
         //        Map("rows" -> 1, "cols" -> 200, "cellSize_mb" -> 1) //  OutOfMemory @ 1, 300, 1
       )

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
@@ -57,7 +57,7 @@ object LargeRowBenchmark extends SqlBasedBenchmark {
       spark.udf.register("udf_upper", udf_upper(_: String): String)
 
       val benchmarks = Array(
-        Map("rows" -> 100, "cols" -> 10, "cellSize_mb" -> 1.6) //  OutOfMemory @ 100, 10, 2
+        Map("rows" -> 100, "cols" -> 10, "cellSize_mb" -> 1.2) //  OutOfMemory @ 100, 10, 2
         //        Map("rows" -> 1, "cols" -> 1, "cellSize_mb" -> 300), //  OutOfMemory @ 1, 1, 400
         //        Map("rows" -> 1, "cols" -> 200, "cellSize_mb" -> 1) //  OutOfMemory @ 1, 300, 1
       )

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LargeRowBenchmark.scala
@@ -32,7 +32,7 @@ import org.apache.spark.benchmark.Benchmark
  */
 object LargeRowBenchmark extends SqlBasedBenchmark {
 
-  def runLargeRowBenchmark(rowsNum: Int, numCols: Int, cellSize_mb: Int): Unit = {
+  def runLargeRowBenchmark(rowsNum: Int, numCols: Int, cellSize_mb: Double): Unit = {
     withTempPath { path =>
       val benchmark = new Benchmark(
         s"#rows: $rowsNum, #cols: $numCols, cell: $cellSize_mb MB", rowsNum, output = output)
@@ -57,16 +57,17 @@ object LargeRowBenchmark extends SqlBasedBenchmark {
       spark.udf.register("udf_upper", udf_upper(_: String): String)
 
       val benchmarks = Array(
-        Map("rows" -> 100, "cols" -> 10, "cellSize_mb" -> 1), //  OutOfMemory @ 100, 10, 2
-        Map("rows" -> 1, "cols" -> 1, "cellSize_mb" -> 300), //  OutOfMemory @ 1, 1, 400
-        Map("rows" -> 1, "cols" -> 200, "cellSize_mb" -> 1) //  OutOfMemory @ 1, 300, 1
+        Map("rows" -> 100, "cols" -> 10, "cellSize_mb" -> 1.6) //  OutOfMemory @ 100, 10, 2
+        //        Map("rows" -> 1, "cols" -> 1, "cellSize_mb" -> 300), //  OutOfMemory @ 1, 1, 400
+        //        Map("rows" -> 1, "cols" -> 200, "cellSize_mb" -> 1) //  OutOfMemory @ 1, 300, 1
       )
 
       benchmarks.foreach { b =>
         val rows = b("rows")
         val cols = b("cols")
         val cellSize_mb = b("cellSize_mb")
-        runLargeRowBenchmark(rows, cols, cellSize_mb)
+        runLargeRowBenchmark(rows.toInt, cols.toInt, cellSize_mb)
+        runLargeRowBenchmark(rows.toInt, cols.toInt, cellSize_mb)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/SqlBasedBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/SqlBasedBenchmark.scala
@@ -96,9 +96,10 @@ trait SqlBasedBenchmark extends BenchmarkBase with SQLHelper {
    * Prepares a table with large row for benchmarking. The table will be written into
    * the given path.
    */
-  protected def writeLargeRow(path: String, rowsNum: Int, numCols: Int, cellSize: Int): Unit = {
+  protected def writeLargeRow(path: String, rowsNum: Int, numCols: Int, cellSize: Double): Unit = {
+    val stringLength = (cellSize * 1024 * 1024).toInt
     spark.range(rowsNum)
-      .select(Seq.tabulate(numCols)(i => lit("a" * cellSize * 1024 * 1024).as(s"col$i")): _*)
+      .select(Seq.tabulate(numCols)(i => lit("a" * stringLength).as(s"col$i")): _*)
       .write.parquet(path)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/SqlBasedBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/SqlBasedBenchmark.scala
@@ -92,17 +92,6 @@ trait SqlBasedBenchmark extends BenchmarkBase with SQLHelper {
     schema
   }
 
-  /**
-   * Prepares a table with large row for benchmarking. The table will be written into
-   * the given path.
-   */
-  protected def writeLargeRow(path: String, rowsNum: Int, numCols: Int, cellSize: Double): Unit = {
-    val stringLength = (cellSize * 1024 * 1024).toInt
-    spark.range(rowsNum)
-      .select(Seq.tabulate(numCols)(i => lit("a" * stringLength).as(s"col$i")): _*)
-      .write.parquet(path)
-  }
-
   override def afterAll(): Unit = {
     spark.stop()
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/SqlBasedBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/SqlBasedBenchmark.scala
@@ -92,6 +92,16 @@ trait SqlBasedBenchmark extends BenchmarkBase with SQLHelper {
     schema
   }
 
+  /**
+   * Prepares a table with large row for benchmarking. The table will be written into
+   * the given path.
+   */
+  protected def writeLargeRow(path: String, rowsNum: Int, numCols: Int, cellSize: Int): Unit = {
+    spark.range(rowsNum)
+      .select(Seq.tabulate(numCols)(i => lit("a" * cellSize * 1024 * 1024).as(s"col$i")): _*)
+      .write.parquet(path)
+  }
+
   override def afterAll(): Unit = {
     spark.stop()
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR introduces LargeRowBenchmark, a micro benchmark to the suite of spark.sql.execution.benchmark. A corresponding function is also added to create large-row dataframes during the benchmark running time. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Large-row dataframes, especially dataframes with large string cells are becoming common with business like online customer chatting. However, it is unknown how well/bad Spark would be able to support them. 

This benchmark aims to provide a baseline to indicate Spark's performance and limitation on large-row dataframes. It will also be included in future performance regression check. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
It is tested in Github Action and manual reviewed. 
https://github.com/yhuang-db/spark/actions/runs/12716337093 (Java 17)
https://github.com/yhuang-db/spark/actions/runs/12716339158 (Java 21)

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.