### PR TITLE
[SPARK-50792][SQL] Format binary data as a binary literal in JDBC.

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -1000,7 +1000,9 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
 
       def testBinaryLiteral(operator: String, literal: String, expected: Int): Unit = {
         val sql = s"SELECT * FROM $tableName WHERE binary_col $operator $literal"
-        val rows = spark.sql(sql).collect()
+        val df = spark.sql(sql)
+        checkFilterPushed(df)
+        val rows = df.collect()
         assert(rows.length === expected, s"Failed to run $sql")
         if (expected == 1) {
           assert(rows(0)(0) === Array(0x12, 0x34, 0x56).map(_.toByte))

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -988,15 +988,15 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
   }
 
   test("SPARK-50792 Format binary data as a binary literal in JDBC.") {
-    withTable(s"$catalogName.test_binary_literal") {
+    val tableName = s"$catalogName.test_binary_literal"
+    withTable(tableName) {
       // Create a table with binary column
       val binary = "X'123456'"
-      val tableName = "test_binary_literal"
 
-      sql(s"CREATE TABLE $catalogName.$tableName (binary_col BINARY)")
-      sql(s"INSERT INTO $catalogName.$tableName VALUES ($binary)")
+      sql(s"CREATE TABLE $tableName (binary_col BINARY)")
+      sql(s"INSERT INTO $tableName VALUES ($binary)")
 
-      val select = s"SELECT * FROM $catalogName.$tableName WHERE binary_col = $binary"
+      val select = s"SELECT * FROM $tableName WHERE binary_col = $binary"
       assert(spark.sql(select).collect().length === 1, s"Binary literal test failed: $select")
     }
   }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -1000,7 +1000,11 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
 
       def testBinaryLiteral(operator: String, literal: String, expected: Int): Unit = {
         val sql = s"SELECT * FROM $tableName WHERE binary_col $operator $literal"
-        assert(spark.sql(sql).collect().length === expected, s"Failed to run $sql")
+        val rows = spark.sql(sql).collect()
+        assert(rows.length === expected, s"Failed to run $sql")
+        if (expected == 1) {
+          assert(rows(0)(0) === Array(0x12, 0x34, 0x56).map(_.toByte))
+        }
       }
 
       testBinaryLiteral("=", binary, 1)

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -986,4 +986,18 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
   test("scan with filter push-down with date time functions") {
     testDatetime(s"$catalogAndNamespace.${caseConvert("datetime")}")
   }
+
+  test("SPARK-50792 Format binary data as a binary literal in JDBC.") {
+    withTable(s"$catalogName.test_binary_literal") {
+      // Create a table with binary column
+      val binary = "X'123456'"
+      val tableName = "test_binary_literal"
+
+      sql(s"CREATE TABLE $catalogName.$tableName (binary_col BINARY)")
+      sql(s"INSERT INTO $catalogName.$tableName VALUES ($binary)")
+
+      val select = s"SELECT * FROM $catalogName.$tableName WHERE binary_col = $binary"
+      assert(spark.sql(select).collect().length === 1, s"Binary literal test failed: $select")
+    }
+  }
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -990,19 +990,14 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
   test("SPARK-50792 Format binary data as a binary literal in JDBC.") {
     val tableName = s"$catalogName.test_binary_literal"
     withTable(tableName) {
-      // Unfornately, Oracle can only compare two BLOBs with a special function dbms_lob.compare
-      // The V2ExpressionSQLBuilder can not support rewriting the '=' operator.
-      // We don't test binary data on Oracle and do not support binary data on Oracle.
-      if (!this.isInstanceOf[OracleIntegrationSuite]) {
-        // Create a table with binary column
-        val binary = "X'123456'"
+      // Create a table with binary column
+      val binary = "X'123456'"
 
-        sql(s"CREATE TABLE $tableName (binary_col BINARY)")
-        sql(s"INSERT INTO $tableName VALUES ($binary)")
+      sql(s"CREATE TABLE $tableName (binary_col BINARY)")
+      sql(s"INSERT INTO $tableName VALUES ($binary)")
 
-        val select = s"SELECT * FROM $tableName WHERE binary_col = $binary"
-        assert(spark.sql(select).collect().length === 1, s"Binary literal test failed: $select")
-      }
+      val select = s"SELECT * FROM $tableName WHERE binary_col = $binary"
+      assert(spark.sql(select).collect().length === 1, s"Binary literal test failed: $select")
     }
   }
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -987,7 +987,7 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
     testDatetime(s"$catalogAndNamespace.${caseConvert("datetime")}")
   }
 
-  test("SPARK-50792 Format binary data as a binary literal in JDBC.") {
+  test("SPARK-50792: Format binary data as a binary literal in JDBC.") {
     val tableName = s"$catalogName.test_binary_literal"
     withTable(tableName) {
       // Create a table with binary column

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
@@ -82,6 +82,12 @@ private case class DB2Dialect() extends JdbcDialect with SQLConfHelper with NoLe
     }
   }
 
+  override def compileValue(value: Any): Any = value match {
+    case binaryValue: Array[Byte] =>
+      binaryValue.map("%02X".format(_)).mkString("BLOB(X'", "", "')")
+    case other => super.compileValue(other)
+  }
+
   override def getCatalystType(
       sqlType: Int,
       typeName: String,

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -374,6 +374,7 @@ abstract class JdbcDialect extends Serializable with Logging {
     case dateValue: Date => "'" + dateValue + "'"
     case dateValue: LocalDate => s"'${DateFormatter().format(dateValue)}'"
     case arrayValue: Array[Any] => arrayValue.map(compileValue).mkString(", ")
+    case binaryValue: Array[Byte] => binaryValue.map("%02X".format(_)).mkString("X'", "", "'")
     case _ => value
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -45,6 +45,7 @@ private case class MsSqlServerDialect() extends JdbcDialect with NoLegacyJDBCErr
   // scalastyle:on line.size.limit
   override def compileValue(value: Any): Any = value match {
     case booleanValue: Boolean => if (booleanValue) 1 else 0
+    case binaryValue: Array[Byte] => binaryValue.map("%02X".format(_)).mkString("0x", "", "")
     case other => super.compileValue(other)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -138,6 +138,7 @@ private case class OracleDialect() extends JdbcDialect with SQLConfHelper with N
     case timestampValue: Timestamp => "{ts '" + timestampValue + "'}"
     case dateValue: Date => "{d '" + dateValue + "'}"
     case arrayValue: Array[Any] => arrayValue.map(compileValue).mkString(", ")
+    case binaryValue: Array[Byte] => binaryValue.map("%02X".format(_)).mkString("X'", "", "'")
     case _ => value
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -138,7 +138,8 @@ private case class OracleDialect() extends JdbcDialect with SQLConfHelper with N
     case timestampValue: Timestamp => "{ts '" + timestampValue + "'}"
     case dateValue: Date => "{d '" + dateValue + "'}"
     case arrayValue: Array[Any] => arrayValue.map(compileValue).mkString(", ")
-    case binaryValue: Array[Byte] => binaryValue.map("%02X".format(_)).mkString("X'", "", "'")
+    case binaryValue: Array[Byte] =>
+      binaryValue.map("%02X".format(_)).mkString("HEXTORAW('", "", "')")
     case _ => value
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -138,8 +138,6 @@ private case class OracleDialect() extends JdbcDialect with SQLConfHelper with N
     case timestampValue: Timestamp => "{ts '" + timestampValue + "'}"
     case dateValue: Date => "{d '" + dateValue + "'}"
     case arrayValue: Array[Any] => arrayValue.map(compileValue).mkString(", ")
-    case binaryValue: Array[Byte] =>
-      binaryValue.map("%02X".format(_)).mkString("HEXTORAW('", "", "')")
     case _ => value
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -327,6 +327,12 @@ private case class PostgresDialect()
     }
   }
 
+  override def compileValue(value: Any): Any = value match {
+    case binaryValue: Array[Byte] =>
+      binaryValue.map("%02X".format(_)).mkString("'\\x", "", "'::bytea")
+    case other => super.compileValue(other)
+  }
+
   override def supportsLimit: Boolean = true
 
   override def supportsOffset: Boolean = true

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -3097,4 +3097,19 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     assert(rows.contains(Row(null)))
     assert(rows.contains(Row("a a a")))
   }
+
+  test("SPARK-50792 Format binary data as a binary literal in JDBC.") {
+    withTable(s"h2.test.binary_literal") {
+      // Create a table with binary column
+      val binary = "X'123456'"
+      val tableName = "h2.test.binary_literal"
+
+      sql(s"CREATE TABLE $tableName (binary_col BLOB)")
+      sql(s"INSERT INTO $tableName VALUES ($binary)")
+
+      val select = s"SELECT * FROM $tableName WHERE binary_col = $binary"
+      assert(spark.sql(select).collect().length === 1, s"Binary literal test failed: $select")
+    }
+  }
+
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -3098,7 +3098,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     assert(rows.contains(Row("a a a")))
   }
 
-  test("SPARK-50792 Format binary data as a binary literal in JDBC.") {
+  test("SPARK-50792: Format binary data as a binary literal in JDBC.") {
     val tableName = "h2.test.binary_literal"
     withTable(tableName) {
       // Create a table with binary column

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -3099,12 +3099,12 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
   }
 
   test("SPARK-50792 Format binary data as a binary literal in JDBC.") {
-    withTable(s"h2.test.binary_literal") {
+    val tableName = "h2.test.binary_literal"
+    withTable(tableName) {
       // Create a table with binary column
       val binary = "X'123456'"
-      val tableName = "h2.test.binary_literal"
 
-      sql(s"CREATE TABLE $tableName (binary_col BLOB)")
+      sql(s"CREATE TABLE $tableName (binary_col BINARY)")
       sql(s"INSERT INTO $tableName VALUES ($binary)")
 
       val select = s"SELECT * FROM $tableName WHERE binary_col = $binary"

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -3108,7 +3108,12 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       sql(s"INSERT INTO $tableName VALUES ($binary)")
 
       val select = s"SELECT * FROM $tableName WHERE binary_col = $binary"
-      assert(spark.sql(select).collect().length === 1, s"Binary literal test failed: $select")
+      val df = sql(select)
+      val filter = df.queryExecution.optimizedPlan.collect {
+        case f: Filter => f
+      }
+      assert(filter.isEmpty, "Filter is not pushed")
+      assert(df.collect().length === 1, s"Binary literal test failed: $select")
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Format binary data as a binary literal in JDBC.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The binary data is not handled to format it as binary literal in JDBC connectors
These are the steps to reproduce.
1. CREATE TABLE test_binary_literal(b BINARY);
2. INSERT INTO test_binary_literal VALUES(x'010203');
3. SELECT * FROM test_binary_literal WHERE b=x'010203';
<img width="1180" alt="image" src="https://github.com/user-attachments/assets/92800c55-5400-46b0-b3f1-d95b85d89cb5" />


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
'No'


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added new integration tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
'No'