### PR TITLE
[SPARK-50793][SQL] Fix MySQL cast function for DOUBLE, LONGTEXT, BIGINT and BLOB types

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -253,21 +253,16 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
       val doubleValue = 0.0
       val doubleLiteral = "0.0"
       // CREATE table to use types defined in Spark SQL
-      sql(s"""CREATE TABLE $tableName (
-        string_col STRING,
-        long_col LONG,
-        binary_col BINARY,
-        double_col DOUBLE
-      )""")
+      sql(s"CREATE TABLE $tableName (string_col STRING, long_col LONG, " +
+        "binary_col BINARY, double_col DOUBLE)")
       sql(
         s"INSERT INTO $tableName VALUES($stringLiteral, $longValue, $binaryLiteral, $doubleValue)")
 
       def testCast(castType: String, sourceCol: String, targetCol: String,
                    sourceDataType: DataType, sourceValue: Any,
                    targetDataType: DataType, targetValue: Any): Unit = {
-        val sql =
-          s"""SELECT $sourceCol AS source, CAST($sourceCol AS $castType) AS target FROM $tableName
-             |WHERE CAST($sourceCol AS $castType) = $targetCol""".stripMargin
+        val sql = s"SELECT $sourceCol AS source, CAST($sourceCol AS $castType) AS target " +
+          s"FROM $tableName WHERE CAST($sourceCol AS $castType) = $targetCol"
         val df = spark.sql(sql)
         castType match {
           case "SHORT" | "INTEGER" =>

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -253,14 +253,20 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
       val doubleValue = 0.0
       val doubleLiteral = "0.0"
       // CREATE table to use types defined in Spark SQL
-      sql(s"CREATE TABLE $tableName (string_col STRING, long_col LONG, " +
-        "binary_col BINARY, double_col DOUBLE)")
+      sql(
+        s"CREATE TABLE $tableName (string_col STRING, long_col LONG, " +
+          "binary_col BINARY, double_col DOUBLE)")
       sql(
         s"INSERT INTO $tableName VALUES($stringLiteral, $longValue, $binaryLiteral, $doubleValue)")
 
-      def testCast(castType: String, sourceCol: String, targetCol: String,
-                   sourceDataType: DataType, sourceValue: Any,
-                   targetDataType: DataType, targetValue: Any): Unit = {
+      def testCast(
+          castType: String,
+          sourceCol: String,
+          targetCol: String,
+          sourceDataType: DataType,
+          sourceValue: Any,
+          targetDataType: DataType,
+          targetValue: Any): Unit = {
         val sql = s"SELECT $sourceCol AS source, CAST($sourceCol AS $castType) AS target " +
           s"FROM $tableName WHERE CAST($sourceCol AS $castType) = $targetCol"
         val df = spark.sql(sql)
@@ -270,8 +276,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
               exception = intercept[SparkException] {
                 df.collect()
               },
-              condition = null
-            )
+              condition = null)
           case _ =>
             checkFilterPushed(df)
             checkAnswer(df, Seq(Row(sourceValue, targetValue)))
@@ -281,25 +286,44 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
         }
       }
 
-      testCast("BINARY", "string_col", "binary_col",
-        StringType, stringValue, BinaryType, binaryValue);
-      testCast("SHORT", "string_col", "long_col",
-        StringType, stringValue, LongType, longValue)
-      testCast("INTEGER", "string_col", "long_col",
-        StringType, stringValue, LongType, longValue)
-      testCast("LONG", "string_col", "long_col",
-        StringType, stringValue, LongType, longValue)
+      testCast(
+        "BINARY",
+        "string_col",
+        "binary_col",
+        StringType,
+        stringValue,
+        BinaryType,
+        binaryValue);
+      testCast("SHORT", "string_col", "long_col", StringType, stringValue, LongType, longValue)
+      testCast("INTEGER", "string_col", "long_col", StringType, stringValue, LongType, longValue)
+      testCast("LONG", "string_col", "long_col", StringType, stringValue, LongType, longValue)
       // We use stringLiteral to make sure both values are using the same collation
-      testCast("STRING", "long_col", stringLiteral,
-        LongType, longValue, StringType, stringValue)
-      testCast("STRING", "binary_col", stringLiteral,
-        BinaryType, binaryValue, StringType, stringValue)
-      testCast("STRING", "double_col", stringLiteral,
-        DoubleType, doubleValue, StringType, doubleLiteral)
-      testCast("DOUBLE", "string_col", "double_col",
-        StringType, stringValue, DoubleType, doubleValue)
-      testCast("DOUBLE", "long_col", "double_col",
-        LongType, longValue, DoubleType, doubleValue)
+      testCast("STRING", "long_col", stringLiteral, LongType, longValue, StringType, stringValue)
+      testCast(
+        "STRING",
+        "binary_col",
+        stringLiteral,
+        BinaryType,
+        binaryValue,
+        StringType,
+        stringValue)
+      testCast(
+        "STRING",
+        "double_col",
+        stringLiteral,
+        DoubleType,
+        doubleValue,
+        StringType,
+        doubleLiteral)
+      testCast(
+        "DOUBLE",
+        "string_col",
+        "double_col",
+        StringType,
+        stringValue,
+        DoubleType,
+        doubleValue)
+      testCast("DOUBLE", "long_col", "double_col", LongType, longValue, DoubleType, doubleValue)
     }
   }
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -247,8 +247,6 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
     withTable(tableName) {
       val stringValue = "0"
       val stringLiteral = "'0'"
-      val shortValue = 0.toShort
-      val integerValue = 0
       val longValue = 0L
       val binaryValue = Array[Byte](0x30)
       val binaryLiteral = "x'30'"
@@ -257,15 +255,12 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
       // CREATE table to use types defined in Spark SQL
       sql(s"""CREATE TABLE $tableName (
         string_col STRING,
-        short_col SHORT,
-        integer_col INTEGER,
         long_col LONG,
         binary_col BINARY,
         double_col DOUBLE
       )""")
       sql(
-        s"""INSERT INTO $tableName VALUES($stringLiteral, $shortValue, $integerValue,
-           |$longValue, $binaryLiteral, $doubleValue)""".stripMargin)
+        s"INSERT INTO $tableName VALUES($stringLiteral, $longValue, $binaryLiteral, $doubleValue)")
 
       def testCast(castType: String, sourceCol: String, targetCol: String,
                    sourceValue: Any, targetValue: Any): Unit = {
@@ -285,18 +280,12 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
       }
 
       testCast("BINARY", "string_col", "binary_col", stringValue, binaryValue);
-      testCast("SHORT", "string_col", "short_col", stringValue, shortValue)
-      testCast("INTEGER", "string_col", "integer_col", stringValue, integerValue)
       testCast("LONG", "string_col", "long_col", stringValue, longValue)
       // We use stringLiteral to make sure both values are using the same collation
-      testCast("STRING", "short_col", stringLiteral, shortValue, stringValue)
-      testCast("STRING", "integer_col", stringLiteral, integerValue, stringValue)
       testCast("STRING", "long_col", stringLiteral, longValue, stringValue)
       testCast("STRING", "binary_col", stringLiteral, binaryValue, stringValue)
       testCast("STRING", "double_col", stringLiteral, doubleValue, doubleLiteral)
       testCast("DOUBLE", "string_col", "double_col", stringValue, doubleValue)
-      testCast("DOUBLE", "short_col", "double_col", shortValue, doubleValue)
-      testCast("DOUBLE", "integer_col", "double_col", integerValue, doubleValue)
       testCast("DOUBLE", "long_col", "double_col", longValue, doubleValue)
     }
   }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -267,7 +267,9 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
         val sql =
           s"""SELECT $sourceCol, CAST($sourceCol AS $castType) FROM $tableName
              |WHERE CAST($sourceCol AS $castType) = $targetCol""".stripMargin
-        val rows = spark.sql(sql).collect()
+        val df = spark.sql(sql)
+        checkFilterPushed(df)
+        val rows = df.collect()
         assert(rows.length === 1, s"Failed to cast $sourceCol to $castType")
         val row = rows(0)
         assert(row.get(0) === sourceValue, s"$sourceCol does not equal to $sourceValue")

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -276,8 +276,12 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
         assert(rows.length === 1, s"Failed to cast $sourceCol to $castType")
         val row = rows(0)
         assert(row.get(0) === sourceValue, s"$sourceCol does not equal to $sourceValue")
+        assert(row.get(0).getClass == sourceValue.getClass,
+          s"$sourceCol has different type from $sourceValue")
         assert(row.get(1) === targetValue,
           s"CAST($sourceCol AS $castType) does not equal to $targetValue")
+        assert(row.get(1).getClass == targetValue.getClass,
+          s"CAST($sourceCol AS $castType) has different type from $targetValue")
       }
 
       testCast("BINARY", "string_col", "binary_col", stringValue, binaryValue);

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -263,11 +263,9 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
           castType: String,
           sourceCol: String,
           targetCol: String,
-          sourceDataType: DataType,
-          sourceValue: Any,
           targetDataType: DataType,
           targetValue: Any): Unit = {
-        val sql = s"SELECT $sourceCol AS source, CAST($sourceCol AS $castType) AS target " +
+        val sql = s"SELECT CAST($sourceCol AS $castType) AS target " +
           s"FROM $tableName WHERE CAST($sourceCol AS $castType) = $targetCol"
         val df = spark.sql(sql)
         castType match {
@@ -279,51 +277,23 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
               condition = null)
           case _ =>
             checkFilterPushed(df)
-            checkAnswer(df, Seq(Row(sourceValue, targetValue)))
-            val expectedTypes = Array(sourceDataType, targetDataType)
+            checkAnswer(df, Seq(Row(targetValue)))
+            val expectedTypes = Array(targetDataType)
             val resultTypes = df.schema.fields.map(_.dataType)
             assert(resultTypes === expectedTypes, s"Failed to cast $sourceCol to $castType")
         }
       }
 
-      testCast(
-        "BINARY",
-        "string_col",
-        "binary_col",
-        StringType,
-        stringValue,
-        BinaryType,
-        binaryValue);
-      testCast("SHORT", "string_col", "long_col", StringType, stringValue, LongType, longValue)
-      testCast("INTEGER", "string_col", "long_col", StringType, stringValue, LongType, longValue)
-      testCast("LONG", "string_col", "long_col", StringType, stringValue, LongType, longValue)
+      testCast("BINARY", "string_col", "binary_col", BinaryType, binaryValue);
+      testCast("SHORT", "string_col", "long_col", LongType, longValue)
+      testCast("INTEGER", "string_col", "long_col", LongType, longValue)
+      testCast("LONG", "string_col", "long_col", LongType, longValue)
       // We use stringLiteral to make sure both values are using the same collation
-      testCast("STRING", "long_col", stringLiteral, LongType, longValue, StringType, stringValue)
-      testCast(
-        "STRING",
-        "binary_col",
-        stringLiteral,
-        BinaryType,
-        binaryValue,
-        StringType,
-        stringValue)
-      testCast(
-        "STRING",
-        "double_col",
-        stringLiteral,
-        DoubleType,
-        doubleValue,
-        StringType,
-        doubleLiteral)
-      testCast(
-        "DOUBLE",
-        "string_col",
-        "double_col",
-        StringType,
-        stringValue,
-        DoubleType,
-        doubleValue)
-      testCast("DOUBLE", "long_col", "double_col", LongType, longValue, DoubleType, doubleValue)
+      testCast("STRING", "long_col", stringLiteral, StringType, stringValue)
+      testCast("STRING", "binary_col", stringLiteral, StringType, stringValue)
+      testCast("STRING", "double_col", stringLiteral, StringType, doubleLiteral)
+      testCast("DOUBLE", "string_col", "double_col", DoubleType, doubleValue)
+      testCast("DOUBLE", "long_col", "double_col", DoubleType, doubleValue)
     }
   }
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -242,11 +242,6 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
     assert(rows10(1).getString(0) === "alex")
   }
 
-  // MySQL Connector/J uses collation 'utf8mb4_0900_ai_ci' as collation for connection.
-  // The MySQL server 9.1.0 uses collation 'utf8mb4_0900_ai_ci' for database by default.
-  // This method uses string colume directly as the result of cast has the same collation.
-  def testCastStringTarget(stringLiteral: String, stringCol: String): String = stringCol
-
   test("SPARK-50793: MySQL JDBC Connector failed to cast some types") {
     val tableName = catalogName + ".test_cast_function"
     withTable(tableName) {
@@ -297,24 +292,9 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
       testCast("SHORT", stringCol, longCol, LongType, longValue)
       testCast("INTEGER", stringCol, longCol, LongType, longValue)
       testCast("LONG", stringCol, longCol, LongType, longValue)
-      testCast(
-        "STRING",
-        longCol,
-        testCastStringTarget(stringLiteral, stringCol),
-        StringType,
-        stringValue)
-      testCast(
-        "STRING",
-        binaryCol,
-        testCastStringTarget(stringLiteral, stringCol),
-        StringType,
-        stringValue)
-      testCast(
-        "STRING",
-        doubleCol,
-        testCastStringTarget(stringLiteral, stringCol),
-        StringType,
-        doubleLiteral)
+      testCast("STRING", longCol, stringCol, StringType, stringValue)
+      testCast("STRING", binaryCol, stringCol, StringType, stringValue)
+      testCast("STRING", doubleCol, stringCol, StringType, doubleLiteral)
       testCast("DOUBLE", stringCol, doubleCol, DoubleType, doubleValue)
       testCast("DOUBLE", longCol, doubleCol, DoubleType, doubleValue)
     }
@@ -340,12 +320,6 @@ class MySQLOverMariaConnectorIntegrationSuite extends MySQLIntegrationSuite {
   override val db = new MySQLDatabaseOnDocker {
     override def getJdbcUrl(ip: String, port: Int): String =
       s"jdbc:mysql://$ip:$port/mysql?user=root&password=rootpass&allowPublicKeyRetrieval=true" +
-        s"&useSSL=false"
+        s"&useSSL=false&sessionVariables=collation_connection='utf8mb4_0900_ai_ci'"
   }
-
-  // MariaDB Connector/J uses collation 'utf8mb4_unicode_ci' as collation for connection.
-  // The MySQL server 9.1.0 uses collation 'utf8mb4_0900_ai_ci' for database by default.
-  // This method uses string literal so the result of cast and literal have the same collation.
-  override def testCastStringTarget(stringLiteral: String, stringCol: String): String =
-    stringLiteral
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -242,6 +242,9 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
     assert(rows10(1).getString(0) === "alex")
   }
 
+  // MySQL Connector/J uses collation 'utf8mb4_0900_ai_ci' as collation for connection.
+  // The MySQL server 9.1.0 uses collation 'utf8mb4_0900_ai_ci' for database by default.
+  // This method uses string colume directly as the result of cast has the same collation.
   def testCastStringTarget(stringLiteral: String, stringCol: String): String = stringCol
 
   test("SPARK-50793: MySQL JDBC Connector failed to cast some types") {
@@ -340,6 +343,9 @@ class MySQLOverMariaConnectorIntegrationSuite extends MySQLIntegrationSuite {
         s"&useSSL=false"
   }
 
+  // MariaDB Connector/J uses collation 'utf8mb4_unicode_ci' as collation for connection.
+  // The MySQL server 9.1.0 uses collation 'utf8mb4_0900_ai_ci' for database by default.
+  // This method uses string literal so the result of cast and literal have the same collation.
   override def testCastStringTarget(stringLiteral: String, stringCol: String): String =
     stringLiteral
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -272,6 +272,8 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
     case StringType => Option(JdbcType("LONGTEXT", java.sql.Types.LONGVARCHAR))
     case ByteType => Option(JdbcType("TINYINT", java.sql.Types.TINYINT))
     case ShortType => Option(JdbcType("SMALLINT", java.sql.Types.SMALLINT))
+    // We override getJDBCType so that DoubleType is mapped to DOUBLE instead.
+    case DoubleType => Option(JdbcType("DOUBLE", java.sql.Types.DOUBLE))
     // scalastyle:off line.size.limit
     // In MYSQL, DATETIME is TIMESTAMP WITHOUT TIME ZONE
     // https://github.com/mysql/mysql-connector-j/blob/8.3.0/src/main/core-api/java/com/mysql/cj/MysqlType.java#L251

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -117,8 +117,10 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
       val databaseTypeDefinition = dataType match {
         // MySQL uses CHAR in the cast function for the type LONGTEXT
         case StringType => "CHAR"
-        // MySQL uses SIGNED INTEGER in the cast function for the types SMALLINT, INTEGER and BIGINT
-        case ShortType | IntegerType | LongType => "SIGNED INTEGER"
+        // MySQL uses SIGNED INTEGER in the cast function for SMALLINT, INTEGER and BIGINT.
+        // To avoid breaking code relying on ResultSet metadata, we support BIGINT only at
+        // this time.
+        case LongType => "SIGNED INTEGER"
         // MySQL uses BINARY in the cast function for the type BLOB
         case BinaryType => "BINARY"
         case _ => getJDBCType(dataType).map(_.databaseTypeDefinition).getOrElse(dataType.typeName)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -272,7 +272,9 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
     case StringType => Option(JdbcType("LONGTEXT", java.sql.Types.LONGVARCHAR))
     case ByteType => Option(JdbcType("TINYINT", java.sql.Types.TINYINT))
     case ShortType => Option(JdbcType("SMALLINT", java.sql.Types.SMALLINT))
-    // We override getJDBCType so that DoubleType is mapped to DOUBLE instead.
+    // Because MySQL 5.7 only supports DOUBLE in the CAST function, and DOUBLE is a
+    // synonym for DOUBLE PRECISION, we override getJDBCType so that DoubleType is
+    // mapped to DOUBLE for better compatibility with MySQL 5.7.
     case DoubleType => Option(JdbcType("DOUBLE", java.sql.Types.DOUBLE))
     // scalastyle:off line.size.limit
     // In MYSQL, DATETIME is TIMESTAMP WITHOUT TIME ZONE

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -121,7 +121,8 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
         // To avoid breaking code relying on ResultSet metadata, we support BIGINT only at
         // this time.
         case LongType => "SIGNED INTEGER"
-        case ShortType | IntegerType => QueryExecutionErrors.notSupportTypeError(dataType)
+        case ShortType | IntegerType =>
+            QueryExecutionErrors.unsupportedJdbcTypeError(dataType.catalogString)
         // MySQL uses BINARY in the cast function for the type BLOB
         case BinaryType => "BINARY"
         case _ => getJDBCType(dataType).map(_.databaseTypeDefinition).getOrElse(dataType.typeName)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -121,6 +121,7 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
         // To avoid breaking code relying on ResultSet metadata, we support BIGINT only at
         // this time.
         case LongType => "SIGNED INTEGER"
+        case ShortType | IntegerType => QueryExecutionErrors.notSupportTypeError(dataType)
         // MySQL uses BINARY in the cast function for the type BLOB
         case BinaryType => "BINARY"
         case _ => getJDBCType(dataType).map(_.databaseTypeDefinition).getOrElse(dataType.typeName)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix MySQL cast function for DOUBLE, LONGTEXT, SMALLINT, INTEGER, BIGINT and BLOB types

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In MySQL, the type identifier used in cast function is different from their type name. MySQL connector generates SQL which fails with cast.
These are the steps to reproduce.
1. CREATE TABLE test_cast(string_col STRING, long_col LONG, binary_col BINARY, double_col DOUBLE);
2. INSERT INTO test_cast VALUES('0', 0, x'30', 0.0);
3. SELECT * FROM test_cast WHERE CAST(string_col AS BINARY) = binary_col;
4. SELECT * FROM test_cast WHERE CAST(string_col AS LONG) = long_col;
5. SELECT * FROM test_cast WHERE CAST(long_col AS STRING) = '0';
6. SELECT * FROM test_cast WHERE CAST(binary_col AS STRING) = '0';
7. SELECT * FROM test_cast WHERE CAST(double_col AS STRING) = '0';
8. SELECT * FROM test_cast WHERE CAST(string_col AS DOUBLE) = double_col;
9. SELECT * FROM test_cast WHERE CAST(long_col AS DOUBLE) = double_col;

<img width="1236" alt="image" src="https://github.com/user-attachments/assets/d09623f7-947e-4185-b0bb-e0631f54a513" />
<img width="1260" alt="image" src="https://github.com/user-attachments/assets/262c7248-e184-4fe3-b2e5-946554f786f1" />
<img width="1260" alt="image" src="https://github.com/user-attachments/assets/242e8ee6-b62e-4cc8-9ed8-f0456d293593" />
<img width="1260" alt="image" src="https://github.com/user-attachments/assets/a5889f68-d1b5-436f-8c6e-30026a5089f1" />
<img width="1208" alt="image" src="https://github.com/user-attachments/assets/18c2906a-8487-4e02-bfa8-0514f4ea2283" />

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
'No'

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added new integration test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
'No'
