### PR TITLE
[SPARK-50794][BUILD] Upgrade Ivy to 2.5.3

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1285,9 +1285,3 @@ jobs:
           cd ui-test
           npm install --save-dev
           node --experimental-vm-modules node_modules/.bin/jest
-
-  maven-test:
-    name: "Run Maven Test"
-    permissions:
-      packages: write
-    uses: ./.github/workflows/maven_test.yml

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1285,3 +1285,9 @@ jobs:
           cd ui-test
           npm install --save-dev
           node --experimental-vm-modules node_modules/.bin/jest
+
+  maven-test:
+    name: "Run Maven Test"
+    permissions:
+      packages: write
+    uses: ./.github/workflows/maven_test.yml

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -103,7 +103,7 @@ httpcore/4.4.16//httpcore-4.4.16.jar
 icu4j/76.1//icu4j-76.1.jar
 ini4j/0.5.4//ini4j-0.5.4.jar
 istack-commons-runtime/3.0.8//istack-commons-runtime-3.0.8.jar
-ivy/2.5.2//ivy-2.5.2.jar
+ivy/2.5.3//ivy-2.5.3.jar
 j2objc-annotations/3.0.0//j2objc-annotations-3.0.0.jar
 jackson-annotations/2.18.2//jackson-annotations-2.18.2.jar
 jackson-core-asl/1.9.13//jackson-core-asl-1.9.13.jar

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <!-- SPARK-46938: Required by Hive / LibThrift libs -->
     <javaxservlet.version>4.0.1</javaxservlet.version>
     <chill.version>0.10.0</chill.version>
-    <ivy.version>2.5.2</ivy.version>
+    <ivy.version>2.5.3</ivy.version>
     <oro.version>2.0.8</oro.version>
     <!--
     If you change codahale.metrics.version, you also need to change


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade ivy from 2.5.2 to 2.5.3.

### Why are the changes needed?
The new version bring some bug fix:
- FIX: trying to set safe XML features causes SAXExceptions when used with certain XML parsers ([IVY-1647](https://issues.apache.org/jira/browse/IVY-1647))
- FIX: cached Ivy files were not valid in some scenarios ([IVY-1649](https://issues.apache.org/jira/browse/IVY-1649), [IVY-1650](https://issues.apache.org/jira/browse/IVY-1650))

The full release notes as follow:

- https://ant.apache.org/ivy/history/2.5.3/release-notes.html


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Run maven test on GitHub Action: https://github.com/LuciferYang/spark/runs/35474430380

![image](https://github.com/user-attachments/assets/079eed98-82c3-4bfe-b42f-358182b7551d)



### Was this patch authored or co-authored using generative AI tooling?
No