### PR TITLE
[SPARK-50707][SQL][TESTS][FOLLOWUP] Fix `CharVarcharTestSuite` test case assumption

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -761,7 +761,8 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
 
   test("implicitly cast char/varchar into atomics") {
     Seq("char", "varchar").foreach { typ =>
-      withSQLConf(SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true") {
+      withSQLConf(SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
+        SQLConf.ANSI_ENABLED.key -> "true") {
         checkAnswer(sql(
           s"""
              |SELECT


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up to fix `CharVarcharTestSuite` test case assumption.
- #49340 

### Why are the changes needed?

To recover the broken Apache Spark NON-ANSI CI:
- https://github.com/apache/spark/actions/workflows/build_non_ansi.yml

```
org.apache.spark.sql.DSV2CharVarcharTestSuite
org.apache.spark.sql.FileSourceCharVarcharTestSuite
org.apache.spark.sql.HiveCharVarcharTestSuite
```

<img width="691" alt="Screenshot 2025-01-12 at 12 15 33" src="https://github.com/user-attachments/assets/f9205aa0-bae5-4fba-9772-056b1e80a11b" />


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually test with `SPARK_ANSI_SQL_MODE=false`. Previously, the following three commands fail.

```
$ SPARK_ANSI_SQL_MODE=false build/sbt "sql/testOnly *.DSV2CharVarcharTestSuite"
$ SPARK_ANSI_SQL_MODE=false build/sbt "sql/testOnly *.FileSourceCharVarcharTestSuite"
$ SPARK_ANSI_SQL_MODE=false build/sbt "hive/testOnly *.HiveCharVarcharTestSuite" -Phive
```

### Was this patch authored or co-authored using generative AI tooling?

No.