### PR TITLE
[SPARK-50797][SQL][TESTS] Move `HiveCharVarcharTestSuite` from `o/a/s/sql` to `o/a/s/sql/hive`

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveCharVarcharTestSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveCharVarcharTestSuite.scala
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql
+package org.apache.spark.sql.hive
 
+import org.apache.spark.sql.{CharVarcharTestSuite, Row}
 import org.apache.spark.sql.execution.command.CharVarcharDDLTestBase
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to move `HiveCharVarcharTestSuite` from `o/a/s/sql` to `o/a/s/sql/hive`.

### Why are the changes needed?

All source codes of `hive` module should have `org.apache.spark.hive` package prefix.

### Does this PR introduce _any_ user-facing change?

No. This is a test class relocation.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.