### PR TITLE
[SPARK-50798][SQL] Improve `NormalizePlan`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/NormalizePlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/NormalizePlan.scala
@@ -25,8 +25,34 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.logical._
 
 object NormalizePlan extends PredicateHelper {
-  def apply(plan: LogicalPlan): LogicalPlan =
-    normalizePlan(normalizeExprIds(plan))
+  def apply(plan: LogicalPlan): LogicalPlan = {
+    val withNormalizedInheritAnalysis = normalizeInheritAnalysisRules(plan)
+    val withNormalizedExprIds = normalizeExprIds(withNormalizedInheritAnalysis)
+    normalizePlan(withNormalizedExprIds)
+  }
+
+  /**
+   * Normalize [[InheritAnalysisRules]] nodes by replacing them with their replacement expressions.
+   * This is necessary because fixed-point analyzer may produce non-deterministic results when
+   * resolving original expressions. For example, in a query like:
+   *
+   * {{{ SELECT assert_true(1) }}}
+   *
+   * Before resolution, we have [[UnresolvedFunction]] whose child is Literal(1). This child will
+   * first be converted to Cast(Literal(1), BooleanType) by type coercion. Because in this case
+   * [[Cast]] doesn't require timezone, the expression will be implicitly resolved. Because the
+   * child of initially unresolved function is resolved, the function can be converted to
+   * [[AssertTrue]], which is of type [[InheritAnalysisRules]]. However, because the only child of
+   * [[InheritAnalysisRules]] is the replacement expression, the original expression will be lost
+   * timezone will never be applied. This causes inconsistencies, because fixed-point semantic is
+   * to ALWAYS apply timezone, regardless of whether or not the Cast actually needs it.
+   */
+  def normalizeInheritAnalysisRules(plan: LogicalPlan): LogicalPlan = {
+    plan transformAllExpressions {
+      case inheritAnalysisRules: InheritAnalysisRules =>
+        inheritAnalysisRules.child
+    }
+  }
 
   /**
    * Since attribute references are given globally unique ids during analysis,
@@ -102,14 +128,15 @@ object NormalizePlan extends PredicateHelper {
             .sortBy(_.hashCode())
             .reduce(And)
         Join(left, right, newJoinType, Some(newCondition), hint)
-      case Project(outerProjectList, innerProject: Project) =>
-        val normalizedInnerProjectList = normalizeProjectList(innerProject.projectList)
-        val orderedInnerProjectList = normalizedInnerProjectList.sortBy(_.name)
-        val newInnerProject =
-          Project(orderedInnerProjectList, innerProject.child)
-        Project(normalizeProjectList(outerProjectList), newInnerProject)
       case Project(projectList, child) =>
-        Project(normalizeProjectList(projectList), child)
+        val projList = projectList
+          .map { e =>
+            e.transformUp {
+              case g: GetViewColumnByNameAndOrdinal => g.copy(viewDDL = None)
+            }
+          }
+          .asInstanceOf[Seq[NamedExpression]]
+        Project(projList, child)
       case c: KeepAnalyzedQuery => c.storeAnalyzedQuery()
       case localRelation: LocalRelation if !localRelation.data.isEmpty =>
         /**
@@ -125,16 +152,6 @@ object NormalizePlan extends PredicateHelper {
       case cteRelationRef: CTERelationRef =>
         cteIdNormalizer.normalizeRef(cteRelationRef)
     }
-  }
-
-  private def normalizeProjectList(projectList: Seq[NamedExpression]): Seq[NamedExpression] = {
-    projectList
-      .map { e =>
-        e.transformUp {
-          case g: GetViewColumnByNameAndOrdinal => g.copy(viewDDL = None)
-        }
-      }
-      .asInstanceOf[Seq[NamedExpression]]
   }
 
   /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
@@ -18,29 +18,62 @@
 package org.apache.spark.sql.catalyst.plans
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
+import org.apache.spark.sql.catalyst.expressions.{AssertTrue, Cast, If, Literal, TimeZoneAwareExpression}
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.types.BooleanType
 
-class NormalizePlanSuite extends SparkFunSuite{
+class NormalizePlanSuite extends SparkFunSuite with SQLConfHelper {
 
-  test("Normalize Project") {
-    val baselineCol1 = $"col1".int
-    val testCol1 = baselineCol1.newInstance()
-    val baselinePlan = LocalRelation(baselineCol1).select(baselineCol1)
-    val testPlan = LocalRelation(testCol1).select(testCol1)
+  test("Normalize InheritAnalysisRules expressions") {
+    val castWithoutTimezone =
+      Cast(child = Literal(1), dataType = BooleanType, ansiEnabled = conf.ansiEnabled)
+    val castWithTimezone = castWithoutTimezone.withTimeZone(conf.sessionLocalTimeZone)
 
-    assert(baselinePlan != testPlan)
-    assert(NormalizePlan(baselinePlan) == NormalizePlan(testPlan))
+    val baselineExpression = AssertTrue(castWithTimezone)
+    val baselinePlan = LocalRelation().select(baselineExpression)
+
+    val testExpression = AssertTrue(castWithoutTimezone)
+    val testPlan = LocalRelation().select(testExpression)
+
+    // Before calling [[setTimezoneForAllExpression]], [[AssertTrue]] node will look like:
+    //
+    // AssertTrue(Cast(Literal(1)), message, If(Cast(Literal(1)), Literal(null), error))
+    //
+    // Calling [[setTimezoneForAllExpression]] will only apply timezone to the second Cast node
+    // because [[InheritAnalysisRules]] only sees replacement expression as its child. This will
+    // cause the difference when comparing [[resolvedBaselinePlan]] and [[resolvedTestPlan]],
+    // therefore we need normalization.
+
+    // Before applying timezone, no timezone is set.
+    testPlan.expressions.foreach {
+      case _ @ AssertTrue(firstCast: Cast, _, _ @ If(secondCast: Cast, _, _)) =>
+        assert(firstCast.timeZoneId.isEmpty)
+        assert(secondCast.timeZoneId.isEmpty)
+      case _ =>
+    }
+
+    val resolvedBaselinePlan = setTimezoneForAllExpression(baselinePlan)
+    val resolvedTestPlan = setTimezoneForAllExpression(testPlan)
+
+    // After applying timezone, only the second cast gets timezone.
+    resolvedTestPlan.expressions.foreach {
+      case _ @ AssertTrue(firstCast: Cast, _, _ @ If(secondCast: Cast, _, _)) =>
+        assert(firstCast.timeZoneId.isEmpty)
+        assert(secondCast.timeZoneId.isDefined)
+      case _ =>
+    }
+
+    // However, plans are still different.
+    assert(resolvedBaselinePlan != resolvedTestPlan)
+    assert(NormalizePlan(resolvedBaselinePlan) == NormalizePlan(resolvedTestPlan))
   }
 
-  test("Normalize ordering in a project list of an inner Project") {
-    val baselinePlan =
-      LocalRelation($"col1".int, $"col2".string).select($"col1", $"col2").select($"col1")
-    val testPlan =
-      LocalRelation($"col1".int, $"col2".string).select($"col2", $"col1").select($"col1")
-
-    assert(baselinePlan != testPlan)
-    assert(NormalizePlan(baselinePlan) == NormalizePlan(testPlan))
+  private def setTimezoneForAllExpression(plan: LogicalPlan): LogicalPlan = {
+    plan.transformAllExpressions {
+      case e: TimeZoneAwareExpression if e.timeZoneId.isEmpty =>
+        e.withTimeZone(conf.sessionLocalTimeZone)
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Improvement: Normalize `InheritAnalysisRules` nodes to avoid  non-deterministic behavior when comparing plans.

This PR also reverts #49230 as that change is no longer necessary
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
To compare single-pass and fixed-point analyzer results. 
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Added a new test case to `NormalizePlanSuite`.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
