### PR TITLE
[SPARK-50799][PYTHON] Refine the docstring of rlike, length, octet_length, bit_length, and transform

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -15211,6 +15211,13 @@ def rlike(str: "ColumnOrName", regexp: "ColumnOrName") -> Column:
     +---------+------+------------------+
     |1a 2b 14m| (\d+)|              true|
     +---------+------+------------------+
+
+    >>> df.select('*', sf.rlike("str", "regexp")).show()
+    +---------+------+------------------+
+    |      str|regexp|RLIKE(str, regexp)|
+    +---------+------+------------------+
+    |1a 2b 14m| (\d+)|              true|
+    +---------+------+------------------+
     """
     return _invoke_function_over_columns("rlike", str, regexp)
 
@@ -16067,14 +16074,14 @@ def octet_length(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> from pyspark.sql import functions as sf
-    >>> spark.createDataFrame([('cat',), ( '\U0001F408',)], ['cat']) \\
-    ...      .select(sf.octet_length('cat')).show()
-    +-----------------+
-    |octet_length(cat)|
-    +-----------------+
-    |                3|
-    |                4|
-    +-----------------+
+    >>> df = spark.createDataFrame([('cat',), ( '\U0001F408',)], ['cat'])
+    >>> df.select('*', sf.octet_length('cat')).show()
+    +---+-----------------+
+    |cat|octet_length(cat)|
+    +---+-----------------+
+    |cat|                3|
+    | 🐈|                4|
+    +---+-----------------+
     """
     return _invoke_function_over_columns("octet_length", col)
 
@@ -16102,14 +16109,14 @@ def bit_length(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> from pyspark.sql import functions as sf
-    >>> spark.createDataFrame([('cat',), ( '\U0001F408',)], ['cat']) \\
-    ...      .select(sf.bit_length('cat')).show()
-    +---------------+
-    |bit_length(cat)|
-    +---------------+
-    |             24|
-    |             32|
-    +---------------+
+    >>> df = spark.createDataFrame([('cat',), ( '\U0001F408',)], ['cat'])
+    >>> df.select('*', sf.bit_length('cat')).show()
+    +---+---------------+
+    |cat|bit_length(cat)|
+    +---+---------------+
+    |cat|             24|
+    | 🐈|             32|
+    +---+---------------+
     """
     return _invoke_function_over_columns("bit_length", col)
 
@@ -16144,8 +16151,8 @@ def translate(srcCol: "ColumnOrName", matching: str, replace: str) -> Column:
     Examples
     --------
     >>> from pyspark.sql import functions as sf
-    >>> spark.createDataFrame([('translate',)], ['a']) \\
-    ...     .select('*', sf.translate('a', "rnlt", "123")).show()
+    >>> df = spark.createDataFrame([('translate',)], ['a'])
+    >>> df.select('*', sf.translate('a', "rnlt", "123")).show()
     +---------+-----------------------+
     |        a|translate(a, rnlt, 123)|
     +---------+-----------------------+

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -15177,9 +15177,9 @@ def rlike(str: "ColumnOrName", regexp: "ColumnOrName") -> Column:
 
     Parameters
     ----------
-    str : :class:`~pyspark.sql.Column` or str
+    str : :class:`~pyspark.sql.Column` or column name
         target column to work on.
-    regexp : :class:`~pyspark.sql.Column` or str
+    regexp : :class:`~pyspark.sql.Column` or column name
         regex pattern to apply.
 
     Returns
@@ -15189,13 +15189,28 @@ def rlike(str: "ColumnOrName", regexp: "ColumnOrName") -> Column:
 
     Examples
     --------
+    >>> import pyspark.sql.functions as sf
     >>> df = spark.createDataFrame([("1a 2b 14m", r"(\d+)")], ["str", "regexp"])
-    >>> df.select(rlike('str', lit(r'(\d+)')).alias('d')).collect()
-    [Row(d=True)]
-    >>> df.select(rlike('str', lit(r'\d{2}b')).alias('d')).collect()
-    [Row(d=False)]
-    >>> df.select(rlike("str", col("regexp")).alias('d')).collect()
-    [Row(d=True)]
+    >>> df.select('*', sf.rlike('str', sf.lit(r'(\d+)'))).show()
+    +---------+------+-----------------+
+    |      str|regexp|RLIKE(str, (\d+))|
+    +---------+------+-----------------+
+    |1a 2b 14m| (\d+)|             true|
+    +---------+------+-----------------+
+
+    >>> df.select('*', sf.rlike('str', sf.lit(r'\d{2}b'))).show()
+    +---------+------+------------------+
+    |      str|regexp|RLIKE(str, \d{2}b)|
+    +---------+------+------------------+
+    |1a 2b 14m| (\d+)|             false|
+    +---------+------+------------------+
+
+    >>> df.select('*', sf.rlike("str", sf.col("regexp"))).show()
+    +---------+------+------------------+
+    |      str|regexp|RLIKE(str, regexp)|
+    +---------+------+------------------+
+    |1a 2b 14m| (\d+)|              true|
+    +---------+------+------------------+
     """
     return _invoke_function_over_columns("rlike", str, regexp)
 
@@ -16008,7 +16023,7 @@ def length(col: "ColumnOrName") -> Column:
 
     Parameters
     ----------
-    col : :class:`~pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or column name
         target column to work on.
 
     Returns
@@ -16018,8 +16033,13 @@ def length(col: "ColumnOrName") -> Column:
 
     Examples
     --------
-    >>> spark.createDataFrame([('ABC ',)], ['a']).select(length('a').alias('length')).collect()
-    [Row(length=4)]
+    >>> from pyspark.sql import functions as sf
+    >>> spark.createDataFrame([('ABC ',)], ['a']).select('*', sf.length('a')).show()
+    +----+---------+
+    |   a|length(a)|
+    +----+---------+
+    |ABC |        4|
+    +----+---------+
     """
     return _invoke_function_over_columns("length", col)
 
@@ -16036,7 +16056,7 @@ def octet_length(col: "ColumnOrName") -> Column:
 
     Parameters
     ----------
-    col : :class:`~pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or column name
         Source column or strings
 
     Returns
@@ -16046,10 +16066,15 @@ def octet_length(col: "ColumnOrName") -> Column:
 
     Examples
     --------
-    >>> from pyspark.sql.functions import octet_length
+    >>> from pyspark.sql import functions as sf
     >>> spark.createDataFrame([('cat',), ( '\U0001F408',)], ['cat']) \\
-    ...      .select(octet_length('cat')).collect()
-        [Row(octet_length(cat)=3), Row(octet_length(cat)=4)]
+    ...      .select(sf.octet_length('cat')).show()
+    +-----------------+
+    |octet_length(cat)|
+    +-----------------+
+    |                3|
+    |                4|
+    +-----------------+
     """
     return _invoke_function_over_columns("octet_length", col)
 
@@ -16066,7 +16091,7 @@ def bit_length(col: "ColumnOrName") -> Column:
 
     Parameters
     ----------
-    col : :class:`~pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or column name
         Source column or strings
 
     Returns
@@ -16076,10 +16101,15 @@ def bit_length(col: "ColumnOrName") -> Column:
 
     Examples
     --------
-    >>> from pyspark.sql.functions import bit_length
+    >>> from pyspark.sql import functions as sf
     >>> spark.createDataFrame([('cat',), ( '\U0001F408',)], ['cat']) \\
-    ...      .select(bit_length('cat')).collect()
-        [Row(bit_length(cat)=24), Row(bit_length(cat)=32)]
+    ...      .select(sf.bit_length('cat')).show()
+    +---------------+
+    |bit_length(cat)|
+    +---------------+
+    |             24|
+    |             32|
+    +---------------+
     """
     return _invoke_function_over_columns("bit_length", col)
 
@@ -16098,7 +16128,7 @@ def translate(srcCol: "ColumnOrName", matching: str, replace: str) -> Column:
 
     Parameters
     ----------
-    srcCol : :class:`~pyspark.sql.Column` or str
+    srcCol : :class:`~pyspark.sql.Column` or column name
         Source column or strings
     matching : str
         matching characters.
@@ -16113,9 +16143,14 @@ def translate(srcCol: "ColumnOrName", matching: str, replace: str) -> Column:
 
     Examples
     --------
-    >>> spark.createDataFrame([('translate',)], ['a']).select(translate('a', "rnlt", "123") \\
-    ...     .alias('r')).collect()
-    [Row(r='1a2s3ae')]
+    >>> from pyspark.sql import functions as sf
+    >>> spark.createDataFrame([('translate',)], ['a']) \\
+    ...     .select('*', sf.translate('a', "rnlt", "123")).show()
+    +---------+-----------------------+
+    |        a|translate(a, rnlt, 123)|
+    +---------+-----------------------+
+    |translate|                1a2s3ae|
+    +---------+-----------------------+
     """
     from pyspark.sql.classic.column import _to_java_column
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Refine docstring `rlike`, `length`, `octet_length`, `bit_length`, and `transform`.


### Why are the changes needed?
to improve docs and test coverage

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
doctests

### Was this patch authored or co-authored using generative AI tooling?
No
