### PR TITLE
[SPARK-48745][INFRA][PYTHON][TESTS][FOLLOWUP] use `conda-incubator/setup-miniconda` action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -609,6 +609,7 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       run: |
         if [[ "$MODULES_TO_TEST" == *"pyspark-errors"* ]]; then
+          export PATH=/github/home/miniconda3/bin:$PATH
           export SKIP_PACKAGING=false
           echo "Python Packaging Tests Enabled!"
         fi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -607,16 +607,21 @@ jobs:
     - name: Bash
       shell: bash -el {0}
       run: |
-        ls -al $GITHUB_WORKSPACE/miniforge-latest
-        conda info
-        conda list
+        if [[ "$MODULES_TO_TEST" == *"pyspark-errors"* ]]; then
+          ls -al $GITHUB_WORKSPACE/miniforge-latest
+          ls -al $GITHUB_WORKSPACE/miniforge-latest/condabin
+          ls -al $GITHUB_WORKSPACE/miniforge-latest/bin
+          conda info
+          conda list
+          hash conda
+        fi
     # Run the tests.
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}
       shell: 'script -q -e -c "bash {0}"'
       run: |
         if [[ "$MODULES_TO_TEST" == *"pyspark-errors"* ]]; then
-          export PATH=$PATH:$GITHUB_WORKSPACE/miniforge-latest/bin
+          hash conda
           env
           which conda
           export SKIP_PACKAGING=false

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -603,19 +603,6 @@ jobs:
       uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-version: latest
-    - name: Bash
-      shell: bash -el {0}
-      run: |
-        if [[ "$MODULES_TO_TEST" == *"pyspark-errors"* ]]; then
-          echo "hash conda"
-          hash conda
-          echo "conda info"
-          conda info
-          echo "conda list"
-          conda list
-          echo "env"
-          env
-        fi
     # Run the tests.
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -600,17 +600,17 @@ jobs:
         done
     - name: Install Conda for pip packaging test
       if: contains(matrix.modules, 'pyspark-errors')
-      run: |
-        curl -s -L "https://github.com/conda-forge/miniforge/releases/download/24.11.2-1/Miniforge3-Linux-x86_64.sh" > miniforge3.sh
-        bash miniforge3.sh -b -p $HOME/miniforge3
-        rm miniforge3.sh
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        miniforge-version: latest
+        installation-dir: $HOME/miniforge-latest
     # Run the tests.
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}
       shell: 'script -q -e -c "bash {0}"'
       run: |
         if [[ "$MODULES_TO_TEST" == *"pyspark-errors"* ]]; then
-          export PATH=$PATH:$HOME/miniforge3/bin
+          export PATH=$PATH:$HOME/miniforge-latest/bin
           env
           which conda
           export SKIP_PACKAGING=false

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -499,7 +499,7 @@ jobs:
           - >-
             pyspark-sql, pyspark-resource, pyspark-testing
           - >-
-            pyspark-errors
+            pyspark-core, pyspark-errors, pyspark-streaming, pyspark-logger
           - >-
             pyspark-mllib, pyspark-ml, pyspark-ml-connect
           - >-
@@ -609,7 +609,7 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       run: |
         if [[ "$MODULES_TO_TEST" == *"pyspark-errors"* ]]; then
-          export PATH=/github/home/miniconda3/bin:$PATH
+          export PATH=$CONDA/bin:$PATH
           export SKIP_PACKAGING=false
           echo "Python Packaging Tests Enabled!"
         fi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -499,7 +499,7 @@ jobs:
           - >-
             pyspark-sql, pyspark-resource, pyspark-testing
           - >-
-            pyspark-core, pyspark-errors, pyspark-streaming, pyspark-logger
+            pyspark-errors, pyspark-core, pyspark-streaming, pyspark-logger
           - >-
             pyspark-mllib, pyspark-ml, pyspark-ml-connect
           - >-
@@ -603,14 +603,20 @@ jobs:
       uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-version: latest
-        installation-dir: $HOME/miniforge-latest
+        installation-dir: ${{ github.workspace }}/miniforge-latest
+    - name: Bash
+      shell: bash -el {0}
+      run: |
+        ls -al $GITHUB_WORKSPACE/miniforge-latest
+        conda info
+        conda list
     # Run the tests.
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}
       shell: 'script -q -e -c "bash {0}"'
       run: |
         if [[ "$MODULES_TO_TEST" == *"pyspark-errors"* ]]; then
-          export PATH=$PATH:$HOME/miniforge-latest/bin
+          export PATH=$PATH:$GITHUB_WORKSPACE/miniforge-latest/bin
           env
           which conda
           export SKIP_PACKAGING=false

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -499,7 +499,7 @@ jobs:
           - >-
             pyspark-sql, pyspark-resource, pyspark-testing
           - >-
-            pyspark-errors, pyspark-core, pyspark-streaming, pyspark-logger
+            pyspark-errors
           - >-
             pyspark-mllib, pyspark-ml, pyspark-ml-connect
           - >-
@@ -603,17 +603,18 @@ jobs:
       uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-version: latest
-        installation-dir: ${{ github.workspace }}/miniforge-latest
     - name: Bash
       shell: bash -el {0}
       run: |
         if [[ "$MODULES_TO_TEST" == *"pyspark-errors"* ]]; then
-          ls -al $GITHUB_WORKSPACE/miniforge-latest
-          ls -al $GITHUB_WORKSPACE/miniforge-latest/condabin
-          ls -al $GITHUB_WORKSPACE/miniforge-latest/bin
-          conda info
-          conda list
+          echo "hash conda"
           hash conda
+          echo "conda info"
+          conda info
+          echo "conda list"
+          conda list
+          echo "env"
+          env
         fi
     # Run the tests.
     - name: Run tests
@@ -621,9 +622,6 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       run: |
         if [[ "$MODULES_TO_TEST" == *"pyspark-errors"* ]]; then
-          hash conda
-          env
-          which conda
           export SKIP_PACKAGING=false
           echo "Python Packaging Tests Enabled!"
         fi


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR follows the PR https://github.com/apache/spark/pull/49441, use `conda-incubator/setup-miniconda` instead of manual installation.


### Why are the changes needed?
Reduce complexity.
- The `Apache Arrow` also used this action, as follows:
https://github.com/apache/arrow/blob/5109c0c485d5dc53c83d189a2f4a27119708a957/dev/tasks/verify-rc/github.win.yml#L37
<img width="611" alt="image" src="https://github.com/user-attachments/assets/5654deec-7109-4e6b-bee5-280aa642cad8" />

- `apache/infrastructure-actions` also allows `conda-incubator/setup-miniconda@*`
https://github.com/apache/infrastructure-actions/blob/cacf961f13a58f4f0e178e7663e11394b88581e8/approved_patterns.yml#L14
<img width="575" alt="image" src="https://github.com/user-attachments/assets/9da3b7c6-d598-4ee8-b777-9dda477e45c0" />

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually check.


### Was this patch authored or co-authored using generative AI tooling?
No.
