### PR TITLE
[SPARK-50801] [SQL] Improve `PlanLogger.logPlanResolution` so it shows just unresolved and resolved plans

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/PlanLogger.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/PlanLogger.scala
@@ -46,7 +46,7 @@ class PlanLogger extends Logging {
        |${MDC(
                QUERY_PLAN,
                sideBySide(
-                 unresolvedPlan.withNewChildren(resolvedPlan.children).treeString,
+                 unresolvedPlan.treeString,
                  resolvedPlan.treeString
                ).mkString("\n")
              )}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve `PlanLogger.logPlanResolution` so it shows just unresolved and resolved plans.

### Why are the changes needed?
Currently `PlanLogger` dumps `unresolvedPlan.withNewChildren(resolvedPlan.children` and `resolvedPlan` in `logPlanResolution` method. This leads to internal errors because in `withNewChildren` we have `children.size == newChildren.size` check which can fail sometimes (e.g when `UnresolvedRelation` is substituted with `SubqueryAlias(..., child, ...)`).

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests with the `ANALYZER_DUAL_RUN_LEGACY_AND_SINGLE_PASS_RESOLVER` value set to `true`.

### Was this patch authored or co-authored using generative AI tooling?
No.