### PR TITLE
[SPARK-50734][SQL][FOLLOWUP] Replace `ScalaObjectMapper` with `ClassTagExtensions` to fix compilation warning

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/UserDefinedFunction.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/UserDefinedFunction.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.catalog
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
-import com.fasterxml.jackson.module.scala.{DefaultScalaModule, ScalaObjectMapper}
+import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.FunctionIdentifier
@@ -118,7 +118,7 @@ object UserDefinedFunction {
    * Get a object mapper to serialize and deserialize function properties.
    */
   private def getObjectMapper: ObjectMapper = {
-    val mapper = new ObjectMapper with ScalaObjectMapper
+    val mapper = new ObjectMapper with ClassTagExtensions
     mapper.setSerializationInclusion(Include.NON_ABSENT)
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     mapper.registerModule(DefaultScalaModule)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to replace `ScalaObjectMapper` with `ClassTagExtensions` to fix compilation warning:

```
[warn] /Users/yangjie01/SourceCode/git/spark-mine-sbt/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/UserDefinedFunction.scala:121:40: trait ScalaObjectMapper in package scala is deprecated (since 2.12.1): ScalaObjectMapper is deprecated because Manifests are not supported in Scala3, you might want to use ClassTagExtensions as a replacement
[warn] Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=deprecation, site=org.apache.spark.sql.catalyst.catalog.UserDefinedFunction.getObjectMapper.mapper, origin=com.fasterxml.jackson.module.scala.ScalaObjectMapper, version=2.12.1
[warn]     val mapper = new ObjectMapper with ScalaObjectMapper
```

the change is refer to:

https://github.com/FasterXML/jackson-module-scala/blob/ae04d9f16a2524123c2c083bf981cecdbfc7c72f/src/main/scala-2.%2B/com/fasterxml/jackson/module/scala/ScalaObjectMapper.scala#L23-L24

```
@deprecated("ScalaObjectMapper is deprecated because Manifests are not supported in Scala3, you might want to use ClassTagExtensions as a replacement", "2.12.1")
trait ScalaObjectMapper {
```

### Why are the changes needed?
Clean up the use of deprecated APIs. 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
