### PR TITLE
[SPARK-50392][PYTHON][FOLLOWUP] Move `import`s into methods to fix `connect-only` builds

### DIFF
--- a/python/pyspark/sql/table_arg.py
+++ b/python/pyspark/sql/table_arg.py
@@ -17,7 +17,6 @@
 
 from typing import TYPE_CHECKING
 
-from pyspark.sql.classic.column import _to_java_column, _to_seq
 from pyspark.sql.tvf_argument import TableValuedFunctionArgument
 from pyspark.sql.utils import get_active_spark_context
 
@@ -32,6 +31,8 @@ class TableArg(TableValuedFunctionArgument):
         self._j_table_arg = j_table_arg
 
     def partitionBy(self, *cols: "ColumnOrName") -> "TableArg":
+        from pyspark.sql.classic.column import _to_java_column, _to_seq
+
         sc = get_active_spark_context()
         if len(cols) == 1 and isinstance(cols[0], list):
             cols = cols[0]
@@ -40,6 +41,8 @@ class TableArg(TableValuedFunctionArgument):
         return TableArg(new_j_table_arg)
 
     def orderBy(self, *cols: "ColumnOrName") -> "TableArg":
+        from pyspark.sql.classic.column import _to_java_column, _to_seq
+
         sc = get_active_spark_context()
         if len(cols) == 1 and isinstance(cols[0], list):
             cols = cols[0]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Move imports into methods to fix connect-only builds.

### Why are the changes needed?

#49055 broke the connect-only builds: https://github.com/apache/spark/pull/49055#pullrequestreview-2545547927

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.