### PR TITLE
[SPARK-50633][FOLLOWUP] Set `CODECOV_TOKEN` with environment variables

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -622,9 +622,10 @@ jobs:
     - name: Upload coverage to Codecov
       if: fromJSON(inputs.envs).PYSPARK_CODECOV == 'true'
       uses: codecov/codecov-action@v5
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: ./python/coverage.xml
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
         name: PySpark
         verbose: true


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to set `CODECOV_TOKEN` with `environment variables` for `codecov/codecov-action`.


### Why are the changes needed?
Based on the suggestions of the `codecov/codecov-action` community, we will try setting it up in a different way to see if `codecov/codecov-action` can succeed.
https://github.com/codecov/codecov-action/issues/1738#issuecomment-2588783885
<img width="947" alt="image" src="https://github.com/user-attachments/assets/1b97875e-c5da-449e-bf01-fc7b73287f45" />


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually check.


### Was this patch authored or co-authored using generative AI tooling?
No.
