### PR TITLE
[SPARK-50808][CORE] Fix issue in writeAll with mixed types not getting written properly

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -176,13 +176,11 @@ public class LevelDB implements KVStore {
       final Iterator<byte[]> serializedValueIter;
 
       // Deserialize outside synchronized block
-      {
-        List<byte[]> list = new ArrayList<>(entry.getValue().size());
-        for (Object value : entry.getValue()) {
-          list.add(serializer.serialize(value));
-        }
-        serializedValueIter = list.iterator();
+      List<byte[]> list = new ArrayList<>(entry.getValue().size());
+      for (Object value : entry.getValue()) {
+        list.add(serializer.serialize(value));
       }
+      serializedValueIter = list.iterator();
 
       final Class<?> klass = entry.getKey();
       final LevelDBTypeInfo ti = getTypeInfo(klass);

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -176,11 +176,13 @@ public class LevelDB implements KVStore {
       final Iterator<byte[]> serializedValueIter;
 
       // Deserialize outside synchronized block
-      List<byte[]> list = new ArrayList<>(entry.getValue().size());
-      for (Object value : values) {
-        list.add(serializer.serialize(value));
+      {
+        List<byte[]> list = new ArrayList<>(entry.getValue().size());
+        for (Object value : entry.getValue()) {
+          list.add(serializer.serialize(value));
+        }
+        serializedValueIter = list.iterator();
       }
-      serializedValueIter = list.iterator();
 
       final Class<?> klass = entry.getKey();
       final LevelDBTypeInfo ti = getTypeInfo(klass);
@@ -191,6 +193,7 @@ public class LevelDB implements KVStore {
 
         try (WriteBatch batch = db().createWriteBatch()) {
           while (valueIter.hasNext()) {
+            assert serializedValueIter.hasNext();
             updateBatch(batch, valueIter.next(), serializedValueIter.next(), klass,
               naturalIndex, indices);
           }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDB.java
@@ -208,13 +208,11 @@ public class RocksDB implements KVStore {
       final Iterator<byte[]> serializedValueIter;
 
       // Deserialize outside synchronized block
-      {
-        List<byte[]> list = new ArrayList<>(entry.getValue().size());
-        for (Object value : entry.getValue()) {
-          list.add(serializer.serialize(value));
-        }
-        serializedValueIter = list.iterator();
+      List<byte[]> list = new ArrayList<>(entry.getValue().size());
+      for (Object value : entry.getValue()) {
+        list.add(serializer.serialize(value));
       }
+      serializedValueIter = list.iterator();
 
       final Class<?> klass = entry.getKey();
       final RocksDBTypeInfo ti = getTypeInfo(klass);

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDB.java
@@ -208,11 +208,13 @@ public class RocksDB implements KVStore {
       final Iterator<byte[]> serializedValueIter;
 
       // Deserialize outside synchronized block
-      List<byte[]> list = new ArrayList<>(entry.getValue().size());
-      for (Object value : values) {
-        list.add(serializer.serialize(value));
+      {
+        List<byte[]> list = new ArrayList<>(entry.getValue().size());
+        for (Object value : entry.getValue()) {
+          list.add(serializer.serialize(value));
+        }
+        serializedValueIter = list.iterator();
       }
-      serializedValueIter = list.iterator();
 
       final Class<?> klass = entry.getKey();
       final RocksDBTypeInfo ti = getTypeInfo(klass);
@@ -223,6 +225,7 @@ public class RocksDB implements KVStore {
 
         try (WriteBatch writeBatch = new WriteBatch()) {
           while (valueIter.hasNext()) {
+            assert serializedValueIter.hasNext();
             updateBatch(writeBatch, valueIter.next(), serializedValueIter.next(), klass,
                 naturalIndex, indices);
           }

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -22,7 +22,6 @@ import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -20,7 +20,9 @@ package org.apache.spark.util.kvstore;
 import java.io.File;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -422,6 +424,37 @@ public class LevelDBSuite {
     }
   }
 
+  @Test
+  public void testMultipleTypesWriteAll() throws Exception {
+
+    List<CustomType1> type1List = Arrays.asList(
+      createCustomType1(1),
+      createCustomType1(2),
+      createCustomType1(3),
+      createCustomType1(4)
+    );
+
+    List<CustomType2> type2List = Arrays.asList(
+      createCustomType2(10),
+      createCustomType2(11),
+      createCustomType2(12),
+      createCustomType2(13)
+    );
+
+    List fullList = new ArrayList();
+    fullList.addAll(type1List);
+    fullList.addAll(type2List);
+
+    db.writeAll(fullList);
+    for (CustomType1 value : type1List) {
+      assertEquals(value, db.read(value.getClass(), value.key));
+    }
+    for (CustomType2 value : type2List) {
+      assertEquals(value, db.read(value.getClass(), value.key));
+    }
+  }
+
+
   private CustomType1 createCustomType1(int i) {
     CustomType1 t = new CustomType1();
     t.key = "key" + i;
@@ -429,6 +462,14 @@ public class LevelDBSuite {
     t.name = "name" + i;
     t.num = i;
     t.child = "child" + i;
+    return t;
+  }
+
+  private CustomType2 createCustomType2(int i) {
+    CustomType2 t = new CustomType2();
+    t.key = "key" + i;
+    t.id = "id" + i;
+    t.parentId = "parent_id" + (i / 2);
     return t;
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
@@ -22,7 +22,6 @@ import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
@@ -20,7 +20,9 @@ package org.apache.spark.util.kvstore;
 import java.io.File;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -420,6 +422,36 @@ public class RocksDBSuite {
     }
   }
 
+  @Test
+  public void testMultipleTypesWriteAll() throws Exception {
+
+    List<CustomType1> type1List = Arrays.asList(
+      createCustomType1(1),
+      createCustomType1(2),
+      createCustomType1(3),
+      createCustomType1(4)
+    );
+
+    List<CustomType2> type2List = Arrays.asList(
+      createCustomType2(10),
+      createCustomType2(11),
+      createCustomType2(12),
+      createCustomType2(13)
+    );
+
+    List fullList = new ArrayList();
+    fullList.addAll(type1List);
+    fullList.addAll(type2List);
+
+    db.writeAll(fullList);
+    for (CustomType1 value : type1List) {
+      assertEquals(value, db.read(value.getClass(), value.key));
+    }
+    for (CustomType2 value : type2List) {
+      assertEquals(value, db.read(value.getClass(), value.key));
+    }
+  }
+
   private CustomType1 createCustomType1(int i) {
     CustomType1 t = new CustomType1();
     t.key = "key" + i;
@@ -427,6 +459,14 @@ public class RocksDBSuite {
     t.name = "name" + i;
     t.num = i;
     t.child = "child" + i;
+    return t;
+  }
+
+  private CustomType2 createCustomType2(int i) {
+    CustomType2 t = new CustomType2();
+    t.key = "key" + i;
+    t.id = "id" + i;
+    t.parentId = "parent_id" + (i / 2);
     return t;
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Fix a bug with LevelDB/RocksDB's batched write method (`writeAll`) not using the correct list to serialize values.
Luckily, existing use of this api is for the same class - which avoids this bug in practice.
This PR fixes the issue to ensure the api contract works as expected, and avoids issues in future.


### Why are the changes needed?
Fix existing bug.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
New test introduced. Test fails without proposed changes.

### Was this patch authored or co-authored using generative AI tooling?
No