### PR TITLE
[SPARK-50809][SQL]JDBC MySQL BIGINT Type Conversion Issue

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -256,7 +256,7 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
     // See SPARK-35446: MySQL treats REAL as a synonym to DOUBLE by default
     // We override getJDBCType so that FloatType is mapped to FLOAT instead
     case FloatType => Option(JdbcType("FLOAT", java.sql.Types.FLOAT))
-    case StringType => Option(JdbcType("LONGTEXT", java.sql.Types.LONGVARCHAR))
+    case StringType => Option(JdbcType("CHAR", java.sql.Types.CHAR))
     case ByteType => Option(JdbcType("TINYINT", java.sql.Types.TINYINT))
     case ShortType => Option(JdbcType("SMALLINT", java.sql.Types.SMALLINT))
     // scalastyle:off line.size.limit

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1396,7 +1396,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       JdbcDialects.get("jdbc:mysql://localhost:3306/temp"),
       df.schema,
       df.sparkSession.sessionState.conf.caseSensitiveAnalysis)
-    assert(schema.contains("`order` LONGTEXT"))
+    assert(schema.contains("`order` CHAR"))
   }
 
   test("SPARK-18141: Predicates on quoted column names in the jdbc data source") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The statement `(CAST(`hgssiteid` AS LONGTEXT) = '101772291401')` is not work in the jdbc MYSQL/TIDB

https://dev.mysql.com/doc/refman/8.4/en/cast-functions.html
Produces a string with the VARCHAR data type, unless the expression expr is empty (zero length), in which case the result type is CHAR(0). If the optional length N is given, CHAR(N) causes the cast to use no more than N characters of the argument. No padding occurs for values shorter than N characters. If the optional length N is not given, MySQL calculates the maximum length from the expression. If the supplied or calculated length is greater than an internal threshold, the result type is TEXT. If the length is still too long, the result type is LONGTEXT.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
1. MYSQL table: canned_report_summary_daily
```
CREATE TABLE `test`.`canned_report_summary_daily` (  
`day` date NOT NULL,  `hgssiteid` bigint NOT NULL,  
`num_of_meetings` bigint DEFAULT NULL,  
`source` varchar(50) NOT NULL,  
`updatetime` timestamp 
DEFAULT CURRENT_TIMESTAMP,  
PRIMARY KEY (`hgssiteid`,`day`)) 
ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin; 
```

2. Try to connect the MYSQL by `spark.sql.catalog.tidb.url`
```
spark.sql("SELECT `day`,`hgssiteid`,`num_of_meetings`,`source`" +
  "FROM  `tidb`.`test`.`canned_report_summary_daily`" +
  "WHERE day >= '2024-12-10' AND day <= '2025-01-09' AND hgssiteid in ('101772291401');") 
```
hgssiteid in ('101772291401') => hgssiteid bigint converted to String '101772291401' to query

3. Spark SQL statement 
(`day` IS NOT NULL) AND (`hgssiteid` IS NOT NULL) AND (`day` >= '2024-12-10') AND (`day` <= '2025-01-09') AND (CAST(`hgssiteid` AS LONGTEXT) = '101772291401')
![image](https://github.com/user-attachments/assets/4af3a3ce-fa22-461c-950e-300fcc9433b7)

`Job aborted due to stage failure: Task 0 in stage 0.0 failed 1 times, most recent failure: Lost task 0.0 in stage 0.0 (TID 0) (10.140.216.204 executor driver): java.sql.SQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'LONGTEXT) = '101772291401')   LIMIT 21' at line 1`

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Local Test
`(CAST(`hgssiteid` AS LONGTEXT) = '101772291401')` => `(CAST(`hgssiteid` AS CHAR) = '101772291401')`
query successfully
<img width="1711" alt="Screenshot 2025-01-14 at 15 50 02" src="https://github.com/user-attachments/assets/356b230e-82fe-4875-9697-e4b3ba3a81a2" />


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
