### PR TITLE
[SPARK-50811] Support enabling JVM profiler on driver

### DIFF
--- a/connector/profiler/README.md
+++ b/connector/profiler/README.md
@@ -50,6 +50,14 @@ Then enable the profiling in the configuration.
 <table class="spark-config">
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr>
 <tr>
+  <td><code>spark.profiler.driver.enabled</code></td>
+  <td><code>false</code></td>
+  <td>
+    If true, turn on profiling in driver.
+  </td>
+  <td>4.0.0</td>
+</tr>
+<tr>
   <td><code>spark.profiler.executor.enabled</code></td>
   <td><code>false</code></td>
   <td>

--- a/connector/profiler/src/main/scala/org/apache/spark/profiler/SparkAsyncProfiler.scala
+++ b/connector/profiler/src/main/scala/org/apache/spark/profiler/SparkAsyncProfiler.scala
@@ -42,13 +42,10 @@ private[spark] class SparkAsyncProfiler(conf: SparkConf, executorId: String) ext
   private val profilerLocalDir = conf.get(PROFILER_LOCAL_DIR)
   private val writeInterval = conf.get(PROFILER_DFS_WRITE_INTERVAL)
 
-  private val appId = try {
-    conf.getAppId
-  } catch {
-    case _: NoSuchElementException => "local-" + System.currentTimeMillis
-  }
-  private val appAttemptId = conf.getOption("spark.app.attempt.id")
-  private val baseName = Utils.nameForAppAndAttempt(appId, appAttemptId)
+  // app_id and app_attempt_id is unavailable during drvier plugin initialization
+  private def getAppId: Option[String] = conf.getOption("spark.app.id")
+  private def getAttemptId: Option[String] = conf.getOption("spark.app.attempt.id")
+
   private val profileFile = if (executorId == DRIVER_IDENTIFIER) {
     s"profile-$executorId.jfr"
   } else {
@@ -63,7 +60,7 @@ private[spark] class SparkAsyncProfiler(conf: SparkConf, executorId: String) ext
   private val PROFILER_FOLDER_PERMISSIONS = new FsPermission(Integer.parseInt("770", 8).toShort)
   private val PROFILER_FILE_PERMISSIONS = new FsPermission(Integer.parseInt("660", 8).toShort)
   private val UPLOAD_SIZE = 8 * 1024 * 1024 // 8 MB
-  private var outputStream: FSDataOutputStream = _
+  @volatile private var outputStream: FSDataOutputStream = _
   private var inputStream: InputStream = _
   private val dataBuffer = new Array[Byte](UPLOAD_SIZE)
   private var threadpool: ScheduledExecutorService = _
@@ -112,24 +109,8 @@ private[spark] class SparkAsyncProfiler(conf: SparkConf, executorId: String) ext
   }
 
   private def startWriting(): Unit = {
-    profilerDfsDirOpt.foreach { profilerDfsDir =>
-      val profilerDirForApp = s"$profilerDfsDir/$baseName"
-      val profileOutputFile = s"$profilerDirForApp/$profileFile"
-
-      val hadoopConf = SparkHadoopUtil.get.newConfiguration(conf)
-      val fs = Utils.getHadoopFileSystem(profilerDfsDir, hadoopConf)
-
-      requireProfilerBaseDirAsDirectory(fs, profilerDfsDir)
-
-      val profilerDirForAppPath = new Path(profilerDirForApp)
-      if (!fs.exists(profilerDirForAppPath)) {
-        // SPARK-30860: use the class method to avoid the umask causing permission issues
-        FileSystem.mkdirs(fs, profilerDirForAppPath, PROFILER_FOLDER_PERMISSIONS)
-      }
-
-      outputStream = FileSystem.create(fs, new Path(profileOutputFile), PROFILER_FILE_PERMISSIONS)
+    profilerDfsDirOpt.foreach { _ =>
       try {
-        logInfo(log"Copying profiling file to ${MDC(PATH, profileOutputFile)}")
         inputStream = new BufferedInputStream(
           new FileInputStream(s"$profilerLocalDir/$profileFile"))
         threadpool = ThreadUtils.newDaemonSingleThreadScheduledExecutor("profilerOutputThread")
@@ -161,6 +142,31 @@ private[spark] class SparkAsyncProfiler(conf: SparkConf, executorId: String) ext
     if (!writing) {
       return
     }
+
+    if (outputStream == null) {
+      while (getAppId.isEmpty) {
+        logDebug("Waiting for Spark application started")
+        Thread.sleep(1000L)
+      }
+      val baseName = Utils.nameForAppAndAttempt(getAppId.get, getAttemptId)
+      val profilerDirForApp = s"${profilerDfsDirOpt.get}/$baseName"
+      val profileOutputFile = s"$profilerDirForApp/$profileFile"
+
+      val hadoopConf = SparkHadoopUtil.get.newConfiguration(conf)
+      val fs = Utils.getHadoopFileSystem(profilerDfsDirOpt.get, hadoopConf)
+
+      requireProfilerBaseDirAsDirectory(fs, profilerDfsDirOpt.get)
+
+      val profilerDirForAppPath = new Path(profilerDirForApp)
+      if (!fs.exists(profilerDirForAppPath)) {
+        // SPARK-30860: use the class method to avoid the umask causing permission issues
+        FileSystem.mkdirs(fs, profilerDirForAppPath, PROFILER_FOLDER_PERMISSIONS)
+      }
+
+      logInfo(log"Copying profiling file to ${MDC(PATH, profileOutputFile)}")
+      outputStream = FileSystem.create(fs, new Path(profileOutputFile), PROFILER_FILE_PERMISSIONS)
+    }
+
     try {
       // stop (pause) the profiler, dump the results and then resume. This is not ideal as we miss
       // the events while the file is being dumped, but that is the only way to make sure that

--- a/connector/profiler/src/main/scala/org/apache/spark/profiler/SparkAsyncProfiler.scala
+++ b/connector/profiler/src/main/scala/org/apache/spark/profiler/SparkAsyncProfiler.scala
@@ -24,11 +24,11 @@ import org.apache.hadoop.fs.{FileSystem, FSDataOutputStream, Path}
 import org.apache.hadoop.fs.permission.FsPermission
 
 import org.apache.spark.SparkConf
+import org.apache.spark.SparkContext.DRIVER_IDENTIFIER
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys.PATH
 import org.apache.spark.util.{ThreadUtils, Utils}
-
 
 /**
  * A class that wraps AsyncProfiler
@@ -49,7 +49,11 @@ private[spark] class SparkAsyncProfiler(conf: SparkConf, executorId: String) ext
   }
   private val appAttemptId = conf.getOption("spark.app.attempt.id")
   private val baseName = Utils.nameForAppAndAttempt(appId, appAttemptId)
-  private val profileFile = s"profile-exec-$executorId.jfr"
+  private val profileFile = if (executorId == DRIVER_IDENTIFIER) {
+    s"profile-$executorId.jfr"
+  } else {
+    s"profile-exec-$executorId.jfr"
+  }
 
   private val startcmd = s"start,$profilerOptions,file=$profilerLocalDir/$profileFile"
   private val stopcmd = s"stop,$profilerOptions,file=$profilerLocalDir/$profileFile"

--- a/connector/profiler/src/main/scala/org/apache/spark/profiler/package.scala
+++ b/connector/profiler/src/main/scala/org/apache/spark/profiler/package.scala
@@ -22,6 +22,13 @@ import org.apache.spark.internal.config.ConfigBuilder
 
 package object profiler {
 
+  private[profiler] val PROFILER_DRIVER_ENABLED =
+    ConfigBuilder("spark.profiler.driver.enabled")
+      .doc("Turn on profiling in driver.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
   private[profiler] val PROFILER_EXECUTOR_ENABLED =
     ConfigBuilder("spark.profiler.executor.enabled")
       .doc("Turn on profiling in executors.")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
SPARK-46094 added JVM profiling support for the executor, this PR extends it to support the driver. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It's also valuable to profile the driver when hits some driver-side performance issues, for example, some catalyst rules may not be efficient and occupy too much CPU time.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, new feature.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
I tested the functionality works well on both YARN client and cluster modes.


YARN client mode
```
bin/spark-submit run-example \
  --master yarn \
  --deploy-mode client \
  --conf spark.plugins=org.apache.spark.profiler.ProfilerPlugin \
  --conf spark.profiler.driver.enabled=true \
  --conf spark.profiler.executor.enabled=true \
  --conf spark.profiler.executor.fraction=1 \
  --conf spark.profiler.dfsDir=hdfs:///spark-profiling \
  SparkPi 100000
```
```
$ hadoop fs -ls /spark-profiling/application_1736320707252_0035
Found 49 items
-rw-rw----   3 hadoop supergroup   16335722 2025-01-16 11:00 /spark-profiling/application_1736320707252_0035/profile-driver.jfr
-rw-rw----   3 hadoop supergroup    4861636 2025-01-16 11:00 /spark-profiling/application_1736320707252_0035/profile-exec-1.jfr
-rw-rw----   3 hadoop supergroup    3321751 2025-01-16 11:00 /spark-profiling/application_1736320707252_0035/profile-exec-10.jfr
-rw-rw----   3 hadoop supergroup    3084930 2025-01-16 11:00 /spark-profiling/application_1736320707252_0035/profile-exec-11.jfr
...
```

YARN cluster mode
```
bin/spark-submit run-example \
  --master yarn \
  --deploy-mode cluster \
  --conf spark.plugins=org.apache.spark.profiler.ProfilerPlugin \
  --conf spark.profiler.driver.enabled=true \
  --conf spark.profiler.executor.enabled=true \
  --conf spark.profiler.executor.fraction=1 \
  --conf spark.profiler.dfsDir=hdfs:///spark-profiling \
  SparkPi 100000
```

```
$ hadoop fs -ls /spark-profiling/application_1736320707252_0036_1
Found 49 items
-rw-rw----   3 hadoop supergroup   14579297 2025-01-16 11:04 /spark-profiling/application_1736320707252_0036_1/profile-driver.jfr
-rw-rw----   3 hadoop supergroup    4615154 2025-01-16 11:04 /spark-profiling/application_1736320707252_0036_1/profile-exec-1.jfr
-rw-rw----   3 hadoop supergroup    3043193 2025-01-16 11:04 /spark-profiling/application_1736320707252_0036_1/profile-exec-10.jfr
-rw-rw----   3 hadoop supergroup    2969970 2025-01-16 11:04 /spark-profiling/application_1736320707252_0036_1/profile-exec-11.jfr
...
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.