### PR TITLE
[SPARK-47081][CONNECT][FOLLOW-UP] Respect spark.connect.progress.reportInterval over timeout

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteGrpcResponseSender.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteGrpcResponseSender.scala
@@ -241,13 +241,13 @@ private[connect] class ExecuteGrpcResponseSender[T <: Message](
           // The state of interrupted, response and lastIndex are changed under executionObserver
           // monitor, and will notify upon state change.
           if (response.isEmpty) {
-            val timeout = Math.max(1, deadlineTimeMillis - System.currentTimeMillis())
+            var timeout = Math.max(1, deadlineTimeMillis - System.currentTimeMillis())
             // Wake up more frequently to send the progress updates.
             val progressTimeout = executeHolder.sessionHolder.session.sessionState.conf
               .getConf(CONNECT_PROGRESS_REPORT_INTERVAL)
             // If the progress feature is disabled, wait for the deadline.
             if (progressTimeout > 0L) {
-              Math.min(progressTimeout, timeout)
+              timeout = Math.min(progressTimeout, timeout)
             }
             logTrace(s"Wait for response to become available with timeout=$timeout ms.")
             executionObserver.responseLock.wait(timeout)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/49474 that properly assigns the value to `timeout`.

### Why are the changes needed?

It was a mistake that did not assign the value back.

### Does this PR introduce _any_ user-facing change?

Yes, same as https://github.com/apache/spark/pull/49474

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No