### PR TITLE
[SPARK-50813][SQL] Allow only unqualified label names inside SQL Scripts

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2782,6 +2782,11 @@
         "message" : [
           "ITERATE statement cannot be used with a label that belongs to a compound (BEGIN...END) body."
         ]
+      },
+      "QUALIFIED_LABEL_NAME" : {
+        "message" : [
+          "Label cannot be qualified."
+        ]
       }
     },
     "sqlState" : "42K0L"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -163,6 +163,14 @@ class SqlScriptingLabelContext {
             bl.multipartIdentifier().getText,
             el.multipartIdentifier().getText)
         }
+      case (Some(bl: BeginLabelContext), _)
+        if bl.multipartIdentifier().parts.size() > 1 =>
+        withOrigin(bl) {
+          throw SqlScriptingErrors.labelCannotBeQualified(
+            CurrentOrigin.get,
+            bl.multipartIdentifier().getText.toLowerCase(Locale.ROOT)
+          )
+        }
       case (None, Some(el: EndLabelContext)) =>
         withOrigin(el) {
           throw SqlScriptingErrors.endLabelWithoutBeginLabel(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -133,4 +133,14 @@ private[sql] object SqlScriptingErrors {
       cause = null,
       messageParameters = Map("labelName" -> toSQLStmt(labelName)))
   }
+
+  def labelCannotBeQualified(
+      origin: Origin,
+      labelName: String): Throwable = {
+    new SqlScriptingException(
+      origin = origin,
+      errorClass = "INVALID_LABEL_USAGE.QUALIFIED_LABEL_NAME",
+      cause = null,
+      messageParameters = Map("labelName" -> toSQLStmt(labelName)))
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -2000,6 +2000,21 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     assert(tree.collection(4).asInstanceOf[ForStatement].label.get == "lbl")
   }
 
+  test("qualified label name: label cannot be qualified") {
+    val sqlScriptText =
+      """
+        |BEGIN
+        |  part1.part2: BEGIN
+        |  END;
+        |END""".stripMargin
+    checkError(
+      exception = intercept[SqlScriptingException] {
+        parsePlan(sqlScriptText)
+      },
+      condition = "INVALID_LABEL_USAGE.QUALIFIED_LABEL_NAME",
+      parameters = Map("labelName" -> "PART1.PART2"))
+  }
+
   test("unique label names: nested labeled scope statements") {
     val sqlScriptText =
       """BEGIN


### PR DESCRIPTION
### What changes were proposed in this pull request?
Allow only unqualified label names inside SQL Scripts.

Valid examples:
- `label`
- `label_1`

Invalid examples:
- `part1.part2`
- `lbl.1`

### Why are the changes needed?
This change fixed the introduced bug in label behavior.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
New and existing tests in `SqlScriptingParserSuite`.


### Was this patch authored or co-authored using generative AI tooling?
No
