### PR TITLE
[SPARK-50819] Refactor Spark profiler module

### DIFF
--- a/connector/profiler/README.md
+++ b/connector/profiler/README.md
@@ -39,7 +39,7 @@ For more information on async_profiler see the [Async Profiler Manual](https://k
 To enable code profiling, first enable the code profiling plugin via
 
 ```
-spark.plugins=org.apache.spark.executor.profiler.ExecutorProfilerPlugin
+spark.plugins=org.apache.spark.profiler.ProfilerPlugin
 ```
 
 Then enable the profiling in the configuration.
@@ -50,15 +50,23 @@ Then enable the profiling in the configuration.
 <table class="spark-config">
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr>
 <tr>
-  <td><code>spark.executor.profiling.enabled</code></td>
+  <td><code>spark.profiler.executor.enabled</code></td>
   <td><code>false</code></td>
   <td>
-    If true, will enable code profiling
+    If true, turn on profiling in executors.
   </td>
   <td>4.0.0</td>
 </tr>
 <tr>
-  <td><code>spark.executor.profiling.dfsDir</code></td>
+  <td><code>spark.profiler.executor.fraction</code></td>
+  <td>0.10</td>
+  <td>
+    The fraction of executors on which to enable profiling. The executors to be profiled are picked at random.
+  </td>
+  <td>4.0.0</td>
+</tr>
+<tr>
+  <td><code>spark.profiler.dfsDir</code></td>
   <td>(none)</td>
   <td>
       An HDFS compatible path to which the profiler's output files are copied. The output files will be written as <i>dfsDir/{{APP_ID}}/profile-exec-{{EXECUTOR_ID}}.jfr</i> <br/>
@@ -67,7 +75,7 @@ Then enable the profiling in the configuration.
   <td>4.0.0</td>
 </tr>
 <tr>
-  <td><code>spark.executor.profiling.localDir</code></td>
+  <td><code>spark.profiler.localDir</code></td>
   <td><code>.</code> i.e. the executor's working dir</td>
   <td>
    The local directory in the executor container to write the jfr files to. If not specified the file will be written to the executor's working directory. Users should ensure there is sufficient disk space available on the system as running out of space may result in corrupt jfr file and even cause jobs to fail on systems like K8s.  
@@ -75,28 +83,20 @@ Then enable the profiling in the configuration.
   <td>4.0.0</td>
 </tr>
 <tr>
-  <td><code>spark.executor.profiling.options</code></td>
+  <td><code>spark.profiler.asyncProfiler.args</code></td>
   <td>event=wall,interval=10ms,alloc=2m,lock=10ms,chunktime=300s</td>
   <td>
-      Options to pass to the profiler. Detailed options are documented in the comments here:
+      Arguments to pass to the Async Profiler. Detailed options are documented in the comments here:
       <a href="https://github.com/async-profiler/async-profiler/blob/v3.0/src/arguments.cpp#L44">Profiler arguments</a>.  
-       Note that the options to start, stop, specify output format, and output file do not have to be specified.
+       Note that the arguments to start, stop, specify output format, and output file do not have to be specified.
   </td>
   <td>4.0.0</td>
 </tr>
 <tr>
-  <td><code>spark.executor.profiling.fraction</code></td>
-  <td>0.10</td>
-  <td>
-    The fraction of executors on which to enable code profiling. The executors to be profiled are picked at random.
-  </td>
-  <td>4.0.0</td>
-</tr>
-<tr>
-  <td><code>spark.executor.profiling.writeInterval</code></td>
+  <td><code>spark.profiler.dfsWriteInterval</code></td>
   <td>30</td>
   <td>
-    Time interval, in seconds, after which the profiler output will be synced to dfs.
+    Time interval, in seconds, after which the profiler output will be synced to DFS.
   </td>
   <td>4.0.0</td>
 </tr>
@@ -115,11 +115,11 @@ On Kubernetes, spark will try to shut down the executor pods while the profiler 
   --master <master-url> \
   --deploy-mode <deploy-mode> \
   -c spark.executor.extraJavaOptions="-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:+PreserveFramePointer" \
-  -c spark.plugins=org.apache.spark.executor.profiler.ExecutorProfilerPlugin \
-  -c spark.executor.profiling.enabled=true \
-  -c spark.executor.profiling.dfsDir=s3a://my-bucket/spark/profiles/  \
-  -c spark.executor.profiling.options=event=wall,interval=10ms,alloc=2m,lock=10ms,chunktime=300s \
-  -c spark.executor.profiling.fraction=0.10  \
+  -c spark.plugins=org.apache.spark.profiler.ProfilerPlugin \
+  -c spark.profiler.executor.enabled=true \
+  -c spark.profiler.executor.fraction=0.10 \
+  -c spark.profiler.dfsDir=s3a://my-bucket/spark/profiles/ \
+  -c spark.profiler.asyncProfiler.args=event=wall,interval=10ms,alloc=2m,lock=10ms,chunktime=300s \
   -c spark.kubernetes.executor.deleteOnTermination=false \
   <application-jar> \
   [application-arguments]

--- a/connector/profiler/src/main/scala/org/apache/spark/profiler/SparkAsyncProfiler.scala
+++ b/connector/profiler/src/main/scala/org/apache/spark/profiler/SparkAsyncProfiler.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.executor.profiler
+package org.apache.spark.profiler
 
 import java.io.{BufferedInputStream, FileInputStream, InputStream, IOException}
 import java.util.concurrent.{ScheduledExecutorService, TimeUnit}
@@ -31,16 +31,16 @@ import org.apache.spark.util.{ThreadUtils, Utils}
 
 
 /**
- * A class that enables the async JVM code profiler
+ * A class that wraps AsyncProfiler
  */
-private[spark] class ExecutorJVMProfiler(conf: SparkConf, executorId: String) extends Logging {
+private[spark] class SparkAsyncProfiler(conf: SparkConf, executorId: String) extends Logging {
 
   private var running = false
-  private val enableProfiler = conf.get(EXECUTOR_PROFILING_ENABLED)
-  private val profilerOptions = conf.get(EXECUTOR_PROFILING_OPTIONS)
-  private val profilerDfsDirOpt = conf.get(EXECUTOR_PROFILING_DFS_DIR)
-  private val profilerLocalDir = conf.get(EXECUTOR_PROFILING_LOCAL_DIR)
-  private val writeInterval = conf.get(EXECUTOR_PROFILING_WRITE_INTERVAL)
+  private val enableProfiler = conf.get(PROFILER_EXECUTOR_ENABLED)
+  private val profilerOptions = conf.get(PROFILER_ASYNC_PROFILER_OPTIONS)
+  private val profilerDfsDirOpt = conf.get(PROFILER_DFS_DIR)
+  private val profilerLocalDir = conf.get(PROFILER_LOCAL_DIR)
+  private val writeInterval = conf.get(PROFILER_DFS_WRITE_INTERVAL)
 
   private val appId = try {
     conf.getAppId
@@ -76,14 +76,14 @@ private[spark] class ExecutorJVMProfiler(conf: SparkConf, executorId: String) ex
       try {
         profiler.foreach(p => {
           p.execute(startcmd)
-          logInfo("Executor JVM profiling started.")
+          logInfo("Profiling started.")
           running = true
           startWriting()
         })
       } catch {
         case e @ (_: IllegalArgumentException | _: IllegalStateException | _: IOException) =>
-          logError("JVM profiling aborted. Exception occurred in profiler native code: ", e)
-        case e: Exception => logWarning("Executor JVM profiling aborted due to exception: ", e)
+          logError("Profiling aborted. Exception occurred in async-profiler native code: ", e)
+        case e: Exception => logWarning("Profiling aborted due to exception: ", e)
       }
     }
   }
@@ -93,7 +93,7 @@ private[spark] class ExecutorJVMProfiler(conf: SparkConf, executorId: String) ex
     if (running) {
       profiler.foreach(p => {
         p.execute(stopcmd)
-        logInfo("JVM profiler stopped")
+        logInfo("Profiler stopped")
         running = false
         finishWriting()
       })
@@ -125,7 +125,7 @@ private[spark] class ExecutorJVMProfiler(conf: SparkConf, executorId: String) ex
 
       outputStream = FileSystem.create(fs, new Path(profileOutputFile), PROFILER_FILE_PERMISSIONS)
       try {
-        logInfo(log"Copying executor profiling file to ${MDC(PATH, profileOutputFile)}")
+        logInfo(log"Copying profiling file to ${MDC(PATH, profileOutputFile)}")
         inputStream = new BufferedInputStream(
           new FileInputStream(s"$profilerLocalDir/$profileFile"))
         threadpool = ThreadUtils.newDaemonSingleThreadScheduledExecutor("profilerOutputThread")
@@ -139,7 +139,7 @@ private[spark] class ExecutorJVMProfiler(conf: SparkConf, executorId: String) ex
         writing = true
       } catch {
         case e: Exception =>
-          logError("Failed to start JVM profiler", e)
+          logError("Failed to start profiler", e)
           if (threadpool != null) {
             threadpool.shutdownNow()
           }

--- a/connector/profiler/src/main/scala/org/apache/spark/profiler/package.scala
+++ b/connector/profiler/src/main/scala/org/apache/spark/profiler/package.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.executor
+package org.apache.spark
 
 import java.util.concurrent.TimeUnit
 
@@ -22,37 +22,15 @@ import org.apache.spark.internal.config.ConfigBuilder
 
 package object profiler {
 
-  private[profiler] val EXECUTOR_PROFILING_ENABLED =
-    ConfigBuilder("spark.executor.profiling.enabled")
-      .doc("Turn on code profiling via async_profiler in executors.")
+  private[profiler] val PROFILER_EXECUTOR_ENABLED =
+    ConfigBuilder("spark.profiler.executor.enabled")
+      .doc("Turn on profiling in executors.")
       .version("4.0.0")
       .booleanConf
       .createWithDefault(false)
 
-  private[profiler] val EXECUTOR_PROFILING_DFS_DIR =
-    ConfigBuilder("spark.executor.profiling.dfsDir")
-      .doc("HDFS compatible file-system path to where the profiler will write output jfr files.")
-      .version("4.0.0")
-      .stringConf
-      .createOptional
-
-  private[profiler] val EXECUTOR_PROFILING_LOCAL_DIR =
-    ConfigBuilder("spark.executor.profiling.localDir")
-      .doc("Local file system path on executor where profiler output is saved. Defaults to the " +
-        "working directory of the executor process.")
-      .version("4.0.0")
-      .stringConf
-      .createWithDefault(".")
-
-  private[profiler] val EXECUTOR_PROFILING_OPTIONS =
-    ConfigBuilder("spark.executor.profiling.options")
-      .doc("Options to pass on to the async profiler.")
-      .version("4.0.0")
-      .stringConf
-      .createWithDefault("event=wall,interval=10ms,alloc=2m,lock=10ms,chunktime=300s")
-
-  private[profiler] val EXECUTOR_PROFILING_FRACTION =
-    ConfigBuilder("spark.executor.profiling.fraction")
+  private[profiler] val PROFILER_EXECUTOR_FRACTION =
+    ConfigBuilder("spark.profiler.executor.fraction")
       .doc("Fraction of executors to profile")
       .version("4.0.0")
       .doubleConf
@@ -60,9 +38,31 @@ package object profiler {
         "Fraction of executors to profile must be in [0,1]")
       .createWithDefault(0.1)
 
-  private[profiler] val EXECUTOR_PROFILING_WRITE_INTERVAL =
-    ConfigBuilder("spark.executor.profiling.writeInterval")
-      .doc("Time interval in seconds after which the profiler output will be synced to dfs")
+  private[profiler] val PROFILER_DFS_DIR =
+    ConfigBuilder("spark.profiler.dfsDir")
+      .doc("HDFS compatible file-system path to where the profiler will write output jfr files.")
+      .version("4.0.0")
+      .stringConf
+      .createOptional
+
+  private[profiler] val PROFILER_LOCAL_DIR =
+    ConfigBuilder("spark.profiler.localDir")
+      .doc("Local file system path on executor where profiler output is saved. Defaults to the " +
+        "working directory of the executor process.")
+      .version("4.0.0")
+      .stringConf
+      .createWithDefault(".")
+
+  private[profiler] val PROFILER_ASYNC_PROFILER_OPTIONS =
+    ConfigBuilder("spark.profiler.asyncProfiler.args")
+      .doc("Arguments to pass on to the Async Profiler.")
+      .version("4.0.0")
+      .stringConf
+      .createWithDefault("event=wall,interval=10ms,alloc=2m,lock=10ms,chunktime=300s")
+
+  private[profiler] val PROFILER_DFS_WRITE_INTERVAL =
+    ConfigBuilder("spark.profiler.dfsWriteInterval")
+      .doc("Time interval in seconds after which the profiler output will be synced to DFS.")
       .version("4.0.0")
       .timeConf(TimeUnit.SECONDS)
       .checkValue(_ >= 0, "Write interval should be non-negative")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR refactors the `ExecutorProfilerPlugin` to prepare to support driver profiling, it 

- re-organize the classes from `o.a.s.executor.profiler` to `o.a.s.profiler` package, with some class renaming.
- re-organize the configuration namespace from `spark.executor.profiling.` to `spark.profiler.`, and tune some configuration keys.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The profiler could be more generic to
- extend the scope to support driver profiling, see https://github.com/apache/spark/pull/49483
- maybe support other profilers like JDK built-in JFR

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, it's an unreleased feature.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
GHA verifies code compilation, and I tested it on a YARN cluster
```
bin/spark-submit run-example \
   --deploy-mode client \
   --conf spark.plugins=org.apache.spark.profiler.ProfilerPlugin \
   --conf spark.profiler.executor.enabled=true \
   --conf spark.profiler.executor.fraction=1 \
   --conf spark.profiler.dfsDir=hdfs:///spark-profiling \
   SparkPi 100000
```
```
$ hadoop fs -ls /spark-profiling/application_1736320707252_0029
Found 48 items
-rw-rw----   3 hadoop supergroup    4944251 2025-01-15 11:21 /spark-profiling/application_1736320707252_0029/profile-exec-1.jfr
-rw-rw----   3 hadoop supergroup    3527597 2025-01-15 11:21 /spark-profiling/application_1736320707252_0029/profile-exec-10.jfr
-rw-rw----   3 hadoop supergroup    3352900 2025-01-15 11:21 /spark-profiling/application_1736320707252_0029/profile-exec-11.jfr
-rw-rw----   3 hadoop supergroup    3464907 2025-01-15 11:21 /spark-profiling/application_1736320707252_0029/profile-exec-12.jfr
...
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.