### PR TITLE
Check pyspark test after revert SPARK-50768

### DIFF
--- a/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark
 
-import java.io.Closeable
 import java.util.{Properties, TimerTask}
 import java.util.concurrent.{ScheduledThreadPoolExecutor, TimeUnit}
 
@@ -274,18 +273,6 @@ class BarrierTaskContext private[spark] (
   }
 
   override private[spark] def getLocalProperties: Properties = taskContext.getLocalProperties
-
-  override private[spark] def interruptible(): Boolean = taskContext.interruptible()
-
-  override private[spark] def pendingInterrupt(threadToInterrupt: Option[Thread], reason: String)
-  : Unit = {
-    taskContext.pendingInterrupt(threadToInterrupt, reason)
-  }
-
-  override private[spark] def createResourceUninterruptibly[T <: Closeable](resourceBuilder: => T)
-  : T = {
-    taskContext.createResourceUninterruptibly(resourceBuilder)
-  }
 }
 
 @Experimental

--- a/core/src/main/scala/org/apache/spark/TaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContext.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark
 
-import java.io.Closeable
+import java.io.Serializable
 import java.util.Properties
 
 import org.apache.spark.annotation.{DeveloperApi, Evolving, Since}
@@ -305,24 +305,4 @@ abstract class TaskContext extends Serializable {
 
   /** Gets local properties set upstream in the driver. */
   private[spark] def getLocalProperties: Properties
-
-  /** Whether the current task is allowed to interrupt. */
-  private[spark] def interruptible(): Boolean
-
-  /**
-   * Pending the interruption request until the task is able to
-   * interrupt after creating the resource uninterruptibly.
-   */
-  private[spark] def pendingInterrupt(threadToInterrupt: Option[Thread], reason: String): Unit
-
-  /**
-   * Creating a closeable resource uninterruptibly. A task is not allowed to interrupt in this
-   * state until the resource creation finishes. E.g.,
-   * {{{
-   *  val linesReader = TaskContext.get().createResourceUninterruptibly {
-   *    new HadoopFileLinesReader(file, parser.options.lineSeparatorInRead, conf)
-   *  }
-   * }}}
-   */
-  private[spark] def createResourceUninterruptibly[T <: Closeable](resourceBuilder: => T): T
 }

--- a/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark
 
-import java.io.Closeable
 import java.util.{Properties, Stack}
 import javax.annotation.concurrent.GuardedBy
 
@@ -82,13 +81,6 @@ private[spark] class TaskContextImpl(
 
   // If defined, the corresponding task has been killed and this option contains the reason.
   @volatile private var reasonIfKilled: Option[String] = None
-
-  // The pending interruption request, which is blocked by uninterruptible resource creation.
-  // Should be protected by `TaskContext.synchronized`.
-  private var pendingInterruptRequest: Option[(Option[Thread], String)] = None
-
-  // Whether this task is able to be interrupted. Should be protected by `TaskContext.synchronized`.
-  private var _interruptible = true
 
   // Whether the task has completed.
   private var completed: Boolean = false
@@ -304,39 +296,4 @@ private[spark] class TaskContextImpl(
   private[spark] override def fetchFailed: Option[FetchFailedException] = _fetchFailedException
 
   private[spark] override def getLocalProperties: Properties = localProperties
-
-
-  override def interruptible(): Boolean = TaskContext.synchronized(_interruptible)
-
-  override def pendingInterrupt(threadToInterrupt: Option[Thread], reason: String): Unit = {
-    TaskContext.synchronized {
-      pendingInterruptRequest = Some((threadToInterrupt, reason))
-    }
-  }
-
-  def createResourceUninterruptibly[T <: Closeable](resourceBuilder: => T): T = {
-
-    @inline def interruptIfRequired(): Unit = {
-      pendingInterruptRequest.foreach { case (threadToInterrupt, reason) =>
-        markInterrupted(reason)
-        threadToInterrupt.foreach(_.interrupt())
-      }
-      killTaskIfInterrupted()
-    }
-
-    TaskContext.synchronized {
-      interruptIfRequired()
-      _interruptible = false
-    }
-    try {
-      val resource = resourceBuilder
-      addTaskCompletionListener[Unit](_ => resource.close())
-      resource
-    } finally {
-      TaskContext.synchronized {
-        _interruptible = true
-        interruptIfRequired()
-      }
-    }
-  }
 }

--- a/core/src/test/scala/org/apache/spark/JobCancellationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/JobCancellationSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark
 
-import java.io.{File, FileOutputStream, InputStream, ObjectOutputStream}
 import java.util.concurrent.{Semaphore, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -36,7 +35,7 @@ import org.apache.spark.executor.ExecutorExitCode
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Deploy._
 import org.apache.spark.scheduler.{JobFailed, SparkListener, SparkListenerExecutorRemoved, SparkListenerJobEnd, SparkListenerJobStart, SparkListenerStageCompleted, SparkListenerTaskEnd, SparkListenerTaskStart}
-import org.apache.spark.util.{ThreadUtils, Utils}
+import org.apache.spark.util.ThreadUtils
 
 /**
  * Test suite for cancelling running jobs. We run the cancellation tasks for single job action
@@ -712,142 +711,6 @@ class JobCancellationSuite extends SparkFunSuite with Matchers with BeforeAndAft
     taskCompletedSem.acquire()
     assert(executionOfInterruptibleCounter.get() < numElements)
  }
-
-  Seq(true, false).foreach { interruptible =>
-
-    val (hint1, hint2) = if (interruptible) {
-      (" not", "")
-    } else {
-      ("", " not")
-    }
-
-    val testName = s"SPARK-50768:$hint1 use TaskContext.createResourceUninterruptibly " +
-      s"would$hint2 cause stream leak on task interruption"
-
-    test(testName) {
-      import org.apache.spark.JobCancellationSuite._
-      withTempDir { dir =>
-
-        // `InterruptionSensitiveInputStream` is designed to easily leak the underlying
-        // stream when task thread interruption happens during its initialization, as
-        // the reference to the underlying stream is intentionally not available to
-        // `InterruptionSensitiveInputStream` at that point.
-        class InterruptionSensitiveInputStream(fileHint: String) extends InputStream {
-          private var underlying: InputStream = _
-
-          def initialize(): InputStream = {
-            val in: InputStream = new InputStream {
-
-              open()
-
-              private def dumpFile(typeName: String): Unit = {
-                var fileOut: FileOutputStream = null
-                var objOut: ObjectOutputStream = null
-                try {
-                  val file = new File(dir, s"$typeName.$fileHint")
-                  fileOut = new FileOutputStream(file)
-                  objOut = new ObjectOutputStream(fileOut)
-                  objOut.writeBoolean(true)
-                  objOut.flush()
-                } finally {
-                  if (fileOut != null) {
-                    fileOut.close()
-                  }
-                  if (objOut != null) {
-                    objOut.close()
-                  }
-                }
-
-              }
-
-              private def open(): Unit = {
-                dumpFile("open")
-              }
-
-              override def close(): Unit = {
-                dumpFile("close")
-              }
-
-              override def read(): Int = -1
-            }
-
-            // Leave some time for the task to be interrupted during the
-            // creation of `InterruptionSensitiveInputStream`.
-            Thread.sleep(10000)
-
-            underlying = in
-            underlying
-          }
-
-          override def read(): Int = -1
-
-          override def close(): Unit = {
-            if (underlying != null) {
-              underlying.close()
-            }
-          }
-        }
-
-        def createStream(fileHint: String): Unit = {
-          if (interruptible) {
-              Utils.tryInitializeResource {
-                new InterruptionSensitiveInputStream(fileHint)
-              } {
-                _.initialize()
-              }
-          } else {
-            TaskContext.get().createResourceUninterruptibly[java.io.InputStream] {
-              Utils.tryInitializeResource {
-                new InterruptionSensitiveInputStream(fileHint)
-              } {
-                _.initialize()
-              }
-            }
-          }
-        }
-
-        sc = new SparkContext("local[2]", "test interrupt streams")
-
-        sc.addSparkListener(new SparkListener {
-          override def onTaskStart(taskStart: SparkListenerTaskStart): Unit = {
-            // Sleep some time to ensure task has started
-            Thread.sleep(2000)
-            taskStartedSemaphore.release()
-          }
-
-          override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
-            if (taskEnd.reason.isInstanceOf[TaskKilled]) {
-              taskCancelledSemaphore.release()
-            }
-          }
-        })
-
-        sc.setLocalProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL, "true")
-
-        val fileHint = if (interruptible) "interruptible" else "uninterruptible"
-        val future = sc.parallelize(1 to 100, 1).mapPartitions { _ =>
-          createStream(fileHint)
-          Iterator.single(1)
-        }.collectAsync()
-
-        taskStartedSemaphore.acquire()
-        future.cancel()
-        taskCancelledSemaphore.acquire()
-
-        val fileOpen = new File(dir, s"open.$fileHint")
-        val fileClose = new File(dir, s"close.$fileHint")
-        assert(fileOpen.exists())
-
-        if (interruptible) {
-          // The underlying stream leaks when the stream creation is interruptible.
-          assert(!fileClose.exists())
-        } else {
-          // The underlying stream won't leak when the stream creation is uninterruptible.
-          assert(fileClose.exists())
-        }
-      }
-    }
-  }
 
   def testCount(): Unit = {
     // Cancel before launching any tasks

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -201,11 +201,6 @@ object MimaExcludes {
 
     // SPARK-50112: Moving avro files from connector to sql/core
     ProblemFilters.exclude[Problem]("org.apache.spark.sql.avro.*"),
-
-    // SPARK-50768: Introduce TaskContext.createResourceUninterruptibly to avoid stream leak by task interruption
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.TaskContext.interruptible"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.TaskContext.pendingInterrupt"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.TaskContext.createResourceUninterruptibly"),
   ) ++ loggingExcludes("org.apache.spark.sql.DataFrameReader") ++
     loggingExcludes("org.apache.spark.sql.streaming.DataStreamReader") ++
     loggingExcludes("org.apache.spark.sql.SparkSession#Builder")


### PR DESCRIPTION
…erruptibly to avoid stream leak by task interruption"

This reverts commit 6f3b778e1a12901726c2a35072904f36f46f7888.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
