### PR TITLE
[SPARK-50806][SQL] Support InputRDDCodegen interruption on task cancellation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2048,6 +2048,16 @@ object SQLConf {
     .checkValue(threshold => threshold > 0, "The threshold must be a positive integer.")
     .createWithDefault(1024)
 
+  val INPUT_CODEGEN_RDD_INTERRUPT_ON_CANCEL =
+    buildConf("spark.sql.codegen.inputCodegenRDD.interruptOnCancel")
+      .internal()
+      .doc("Whether to interrupt InputCodegenRDD on the task cancellation. Interrupt " +
+        "InputCodegenRDD would be useful to stop task and release resource quickly, " +
+        "and also reduce the task killing timeout failures by task reaper.")
+      .version("3.5.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val WHOLESTAGE_SPLIT_CONSUME_FUNC_BY_OPERATOR =
     buildConf("spark.sql.codegen.splitConsumeFuncByOperator")
       .internal()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2049,12 +2049,12 @@ object SQLConf {
     .createWithDefault(1024)
 
   val INPUT_CODEGEN_RDD_INTERRUPT_ON_CANCEL =
-    buildConf("spark.sql.codegen.inputCodegenRDD.interruptOnCancel")
+    buildConf("spark.sql.codegen.interruptInputRDDOnCancel")
       .internal()
       .doc("Whether to interrupt InputCodegenRDD on the task cancellation. Interrupt " +
         "InputCodegenRDD would be useful to stop task and release resource quickly, " +
         "and also reduce the task killing timeout failures by task reaper.")
-      .version("3.5.0")
+      .version("4.1.0")
       .booleanConf
       .createWithDefault(true)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
@@ -102,7 +102,7 @@ trait HashJoin extends JoinCodegenSupport {
       }
   }
 
-  protected lazy val (buildPlan, streamedPlan) = buildSide match {
+  protected[sql] lazy val (buildPlan, streamedPlan) = buildSide match {
     case BuildLeft => (left, right)
     case BuildRight => (right, left)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/HashAggregateCodegenInterruptionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/HashAggregateCodegenInterruptionSuite.scala
@@ -64,6 +64,9 @@ class HashAggregateCodegenInterruptionSuite extends QueryTest with SharedSparkSe
       val logAppender = new LogAppender("")
       withLogAppender(logAppender, level = Some(Level.INFO)) {
         spark.sparkContext.setJobGroup("SPARK-50806", "SPARK-50806", false)
+        // The dataset is set to 100k as we are monitoring interruptions for every 1k rows. Two
+        // tasks (50 seconds each, totaling 100k / 2) exceed `spark.task.reaper.killTimeout` (10s),
+        // which should provide a proper test for the interruption behavior.
         val slowDF = spark.range(1, 100000).rdd.mapPartitions { iter =>
           new Iterator[Long] {
             var cnt = 0

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/HashAggregateCodegenInterruptionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/HashAggregateCodegenInterruptionSuite.scala
@@ -67,7 +67,7 @@ class HashAggregateCodegenInterruptionSuite extends QueryTest with SharedSparkSe
         // The dataset is set to 100k as we are monitoring interruptions for every 1k rows. Two
         // tasks (50 seconds each, totaling 100k / 2) exceed `spark.task.reaper.killTimeout` (10s),
         // which should provide a proper test for the interruption behavior.
-        val slowDF = spark.range(1, 100000).rdd.mapPartitions { iter =>
+        val slowDF = spark.range(1, 100000, 1, 2).rdd.mapPartitions { iter =>
           new Iterator[Long] {
             var cnt = 0
             override def hasNext: Boolean = iter.hasNext

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/HashAggregateCodegenInterruptionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/HashAggregateCodegenInterruptionSuite.scala
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import scala.collection.mutable
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import org.apache.logging.log4j.Level
+
+import org.apache.spark.{SparkConf, TaskEndReason, TaskKilled}
+import org.apache.spark.scheduler.{SparkListenerJobEnd, SparkListenerTaskEnd, SparkListenerTaskStart}
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.functions.sum
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class HashAggregateCodegenInterruptionSuite extends QueryTest with SharedSparkSession {
+
+  override def sparkConf: SparkConf = {
+    super
+      .sparkConf
+      .set("spark.task.reaper.enabled", "true")
+      .set("spark.task.reaper.killTimeout", "10s")
+  }
+
+  test("SPARK-50806: HashAggregate codegen should be interrupted on task cancellation") {
+    import testImplicits._
+    withSQLConf(
+      SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> true.toString,
+      SQLConf.INTERRUPT_ON_CANCEL.key -> false.toString) {
+      var taskId = -1L
+      var isJobEnded = false
+      var taskEndReasons = new mutable.ArrayBuffer[TaskEndReason]
+      spark.sparkContext.addSparkListener(new org.apache.spark.scheduler.SparkListener {
+        override def onTaskStart(taskStart: SparkListenerTaskStart): Unit = {
+          taskId = taskStart.taskInfo.taskId
+        }
+
+        override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
+          taskEndReasons += taskEnd.reason
+        }
+
+        override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
+          isJobEnded = true
+        }
+      })
+
+      val logAppender = new LogAppender("")
+      withLogAppender(logAppender, level = Some(Level.INFO)) {
+        spark.sparkContext.setJobGroup("SPARK-50806", "SPARK-50806", false)
+        val slowDF = spark.range(1, 100000).rdd.mapPartitions { iter =>
+          new Iterator[Long] {
+            var cnt = 0
+            override def hasNext: Boolean = iter.hasNext
+            override def next(): Long = {
+              if (cnt % 1000 == 0) {
+                Thread.sleep(1000)
+              }
+              cnt += 1
+              iter.next()
+            }
+          }
+        }.toDF("id")
+        val aggDF = slowDF.selectExpr("id % 10 as key").groupBy("key").agg(sum("key"))
+        import scala.concurrent.ExecutionContext.global
+        Future {
+          aggDF.collect()
+        }(global)
+        // Leave some time for the query to start running
+        Thread.sleep(5000)
+        spark.sparkContext.cancelJobGroup("SPARK-50806")
+        eventually(timeout(1.minute)) {
+          assert(isJobEnded)
+          assert(taskEndReasons.length  === 2)
+          assert(taskEndReasons.forall(_.isInstanceOf[TaskKilled]))
+          val logs = logAppender.loggingEvents.map(_.getMessage.getFormattedMessage)
+          assert(!logs.exists(
+            _.contains(s"Killed task $taskId could not be stopped within 10000 ms"))
+          )
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds a new mutable state `taskInterrupted` in `InputRDDCodegen`. The state indicates whether the task thread is interrupted or not. `InputRDDCodegen` would check the state each time when it produces a record and stops immediately if `taskInterrupted=true`. `taskInterrupted` would be updated by `TaskContext.isInterrupted()` per 1000 output rows processed.



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This facilitates the resource release when there is a task killing request.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added unit test.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.
