### PR TITLE
[SPARK-50831][SQL] Enable trimming collation by default

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -880,7 +880,7 @@ object SQLConf {
       )
       .version("4.0.0")
       .booleanConf
-      .createWithDefault(Utils.isTesting)
+      .createWithDefault(true)
 
   val DEFAULT_COLLATION =
     buildConf(SqlApiConfHelper.DEFAULT_COLLATION)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -874,9 +874,8 @@ object SQLConf {
   lazy val TRIM_COLLATION_ENABLED =
     buildConf("spark.sql.collation.trim.enabled")
       .internal()
-      .doc(
-        "Trim collation feature is under development and its use should be done under this" +
-        "feature flag. Trim collation trims trailing whitespaces from strings."
+      .doc("When enabled allows the use of trim collations which trims trailing whitespaces from" +
+        " strings."
       )
       .version("4.0.0")
       .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -874,7 +874,7 @@ object SQLConf {
   lazy val TRIM_COLLATION_ENABLED =
     buildConf("spark.sql.collation.trim.enabled")
       .internal()
-      .doc("When enabled allows the use of trim collations which trims trailing whitespaces from" +
+      .doc("When enabled allows the use of trim collations which trim trailing whitespaces from" +
         " strings."
       )
       .version("4.0.0")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Changed the sql config to enable the trimming collation by default.


### Why are the changes needed?
As per the collation project plan.


### Does this PR introduce _any_ user-facing change?
Yes, the trimming collation will be enabled by default.


### How was this patch tested?
Existing trimming tests.


### Was this patch authored or co-authored using generative AI tooling?
No
