### PR TITLE
[SPARK-50833][INFRA] Update `buf` GitHub Action job to compare against branch-4.0

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -745,12 +745,11 @@ jobs:
       uses: bufbuild/buf-lint-action@v1
       with:
         input: core/src/main/protobuf
-    # Change 'branch-3.5' to 'branch-4.0' in master branch after cutting branch-4.0 branch.
-    - name: Breaking change detection against branch-3.5
+    - name: Breaking change detection against branch-4.0
       uses: bufbuild/buf-breaking-action@v1
       with:
         input: sql/connect/common/src/main
-        against: 'https://github.com/apache/spark.git#branch=branch-3.5,subdir=connector/connect/common/src/main'
+        against: 'https://github.com/apache/spark.git#branch=branch-4.0,subdir=sql/connect/common/src/main'
     - name: Install Python 3.11
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `buf` GitHub Action job to compare against branch-4.0.

### Why are the changes needed?

Since master branch is now Apache Spark 4.1.0-SNAPSHOT, we need to compare against `branch-4.0` eventually.
- #49495

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs in this PR.
- https://github.com/dongjoon-hyun/spark/actions/runs/12795653647/job/35673535773
![Screenshot 2025-01-15 at 12 42 13](https://github.com/user-attachments/assets/7338f154-a275-4fdc-8edb-5663edab08d3)


### Was this patch authored or co-authored using generative AI tooling?

No.