### PR TITLE
[SPARK-50835][INFRA] Add `Python-only` Daily CI to branch-4.0

### DIFF
--- a/.github/workflows/build_branch40_python.yml
+++ b/.github/workflows/build_branch40_python.yml
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Build / Python-only (branch-4.0)"
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-build:
+    permissions:
+      packages: write
+    name: Run
+    uses: ./.github/workflows/build_and_test.yml
+    if: github.repository == 'apache/spark'
+    with:
+      java: 17
+      branch: branch-4.0
+      hadoop: hadoop3
+      envs: >-
+        {
+          "PYSPARK_IMAGE_TO_TEST": "",
+          "PYTHON_TO_TEST": ""
+        }
+      jobs: >-
+        {
+          "pyspark": "true",
+          "pyspark-pandas": "true"
+        }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Python-only Daily CI` to `branch-4.0`.

### Why are the changes needed?

Like `build_branch35_python`, this should be defined in `master` branch due to the GitHub Action requirement.
- https://github.com/apache/spark/blob/master/.github/workflows/build_branch35_python.yml

### Does this PR introduce _any_ user-facing change?

No. This is a test-only change.

### How was this patch tested?

Manual review. This should be tested after merging because it's a daily CI.

### Was this patch authored or co-authored using generative AI tooling?

No.