### PR TITLE
[SPARK-50835][INFRA][FOLLOWUP] Use Python 3.11 in `branch-4.0` `Python-only` Daily CI

### DIFF
--- a/.github/workflows/build_branch40_python.yml
+++ b/.github/workflows/build_branch40_python.yml
@@ -37,8 +37,8 @@ jobs:
       hadoop: hadoop3
       envs: >-
         {
-          "PYSPARK_IMAGE_TO_TEST": "",
-          "PYTHON_TO_TEST": ""
+          "PYSPARK_IMAGE_TO_TEST": "python-311",
+          "PYTHON_TO_TEST": "python3.11"
         }
       jobs: >-
         {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to specify Python version for `branch-4.0` `Python-only` Daily CI.

### Why are the changes needed?

To match with `branch-4.0`'s `build_and_test.yml`.
- https://github.com/apache/spark/blob/cab1d94ddec882b905759bda4360c405956ca7ca/.github/workflows/build_and_test.yml#L43

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.