### PR TITLE
[SPARK-50836][INFRA] Add non-ANSI SQL Daily CI for `branch-4.0`

### DIFF
--- a/.github/workflows/build_branch40_non_ansi.yml
+++ b/.github/workflows/build_branch40_non_ansi.yml
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Build / Non-ANSI (branch-4.0, Hadoop 3, JDK 17, Scala 2.13)"
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-build:
+    permissions:
+      packages: write
+    name: Run
+    uses: ./.github/workflows/build_and_test.yml
+    if: github.repository == 'apache/spark'
+    with:
+      java: 17
+      branch: branch-4.0
+      hadoop: hadoop3
+      envs: >-
+        {
+          "PYSPARK_IMAGE_TO_TEST": "python-311",
+          "PYTHON_TO_TEST": "python3.11",
+          "SPARK_ANSI_SQL_MODE": "false",
+        }
+      jobs: >-
+        {
+          "build": "true",
+          "docs": "true",
+          "pyspark": "true",
+          "sparkr": "true",
+          "tpcds-1g": "true",
+          "docker-integration-tests": "true",
+          "yarn": "true"
+        }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add non-ANSI SQL Daily CI for `branch-4.0`.

### Why are the changes needed?

This should be in `master` branch like `build_non_ansi.yml`.

https://github.com/apache/spark/blob/master/.github/workflows/build_non_ansi.yml

### Does this PR introduce _any_ user-facing change?

No, this is a test infra addition to ensure non-ANSI feature during Apache Spark 4.0.x lifecycle.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.