### PR TITLE
[SPARK-49907][ML][CONNECT][FOLLOW-UP] Add ml connect related packages into PyPI packages

### DIFF
--- a/python/packaging/classic/setup.py
+++ b/python/packaging/classic/setup.py
@@ -269,6 +269,7 @@ try:
             "pyspark.mllib.stat",
             "pyspark.ml",
             "pyspark.ml.connect",
+            "pyspark.ml.remote",
             "pyspark.ml.linalg",
             "pyspark.ml.param",
             "pyspark.ml.torch",

--- a/python/packaging/connect/setup.py
+++ b/python/packaging/connect/setup.py
@@ -69,7 +69,6 @@ test_packages = []
 if "SPARK_TESTING" in os.environ:
     test_packages = [
         "pyspark.tests",  # for Memory profiler parity tests
-        "pyspark.testing",
         "pyspark.resource.tests",
         "pyspark.sql.tests",
         "pyspark.sql.tests.arrow",
@@ -82,6 +81,7 @@ if "SPARK_TESTING" in os.environ:
         "pyspark.sql.tests.pandas",
         "pyspark.sql.tests.plot",
         "pyspark.sql.tests.streaming",
+        "pyspark.ml.tests",
         "pyspark.ml.tests.connect",
         "pyspark.pandas.tests",
         "pyspark.pandas.tests.computation",
@@ -147,6 +147,7 @@ try:
         "pyspark.mllib.stat",
         "pyspark.ml",
         "pyspark.ml.connect",
+        "pyspark.ml.remote",
         "pyspark.ml.linalg",
         "pyspark.ml.param",
         "pyspark.ml.torch",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/48791 that adds `pyspark.ml.remote` into PySpark packages.

### Why are the changes needed?

So Spark ML works with PyPi installed PySparks, and in order to fix the broken build: https://github.com/apache/spark/actions/runs/12795239919/job/35672165048

```
python3 version is: Python 3.11.11
Starting test(python3): pyspark.ml.tests.connect.test_connect_classification (temp output: /home/runner/work/spark/spark/python/target/a86[54](https://github.com/apache/spark/actions/runs/12795239919/job/35672165048#step:9:55)09b-4280-495f-bec6-5848a3cd94b8/python3__pyspark.ml.tests.connect.test_connect_classification__77u3wqw_.log)
Traceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
  File "<frozen runpy>", line 112, in _get_module_details
  File "/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/site-packages/pyspark/ml/__init__.py", line 22, in <module>
    from pyspark.ml.base import (
  File "/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/site-packages/pyspark/ml/base.py", line 38, in <module>
    from pyspark.ml.param import P
  File "/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/site-packages/pyspark/ml/param/__init__.py", line 36, in <module>
    from pyspark.ml.util import Identifiable
  File "/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/site-packages/pyspark/ml/util.py", line 40, in <module>
    from pyspark.ml.remote.util import try_remote_intermediate_result, try_remote_write, try_remote_read
ModuleNotFoundError: No module named 'pyspark.ml.remote'
```

### Does this PR introduce _any_ user-facing change?

No, the main change has not been released yet.

### How was this patch tested?

Will monitor the CI.

### Was this patch authored or co-authored using generative AI tooling?

No.
