### PR TITLE
[SPARK-50847] [SQL] Deny ApplyCharTypePadding from applying on specific In expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyCharTypePaddingHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyCharTypePaddingHelper.scala
@@ -99,7 +99,7 @@ object ApplyCharTypePaddingHelper {
           .getOrElse(b)
 
       case i @ In(e @ AttrOrOuterRef(attr), list)
-          if attr.dataType == StringType && list.forall(_.foldable) =>
+          if i.resolved && attr.dataType == StringType && list.forall(_.foldable) =>
         CharVarcharUtils
           .getRawType(attr.metadata)
           .flatMap {


### PR DESCRIPTION
### What changes were proposed in this pull request?
`ApplyCharTypePadding` rule shouldn't be applied to `In` expressions where elements of the `In.list` are not `StringType`s and in this PR we fix it.

### Why are the changes needed?
Users should get a proper `DATATYPE_MISMATCH.DATA_DIFF_TYPES` error message instead of an `java.lang.ClassCastException` internal one.

### Does this PR introduce _any_ user-facing change?
Users will now get a proper message instead of an internal one.

### How was this patch tested?
Added test.

### Was this patch authored or co-authored using generative AI tooling?
No.
