### PR TITLE
[SPARK-50633][INFRA][FOLLOWUP] Let CODECOV_TOKEN transfer to build_and_test.yml

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,6 +49,10 @@ on:
         required: false
         type: string
         default: ''
+    secrets:
+      codecov_token:
+        description: The upload token of codecov.
+        required: false
 jobs:
   precondition:
     name: Check changes
@@ -623,7 +627,7 @@ jobs:
       if: fromJSON(inputs.envs).PYSPARK_CODECOV == 'true'
       uses: codecov/codecov-action@v5
       env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        CODECOV_TOKEN: ${{ secrets.codecov_token }}
       with:
         files: ./python/coverage.xml
         flags: unittests

--- a/.github/workflows/build_coverage.yml
+++ b/.github/workflows/build_coverage.yml
@@ -45,3 +45,5 @@ jobs:
         {
           "pyspark": "true"
         }
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -30,3 +30,5 @@ jobs:
       packages: write
     name: Run
     uses: ./.github/workflows/build_and_test.yml
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to let `CODECOV_TOKEN` transfer from `build_coverage.yml`/`build_main.yml` to `build_and_test.yml`.


### Why are the changes needed?
Currently, `codecov/codecov-action` is unable to obtain `CODECOV_TOKEN`.
I checked and it seems that the usage below is similar to ours. 
https://stackoverflow.com/questions/78298827/why-is-codecov-upload-step-in-github-actions-not-finding-the-token
Let's continue to try it out.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually check.


### Was this patch authored or co-authored using generative AI tooling?
No.
