### PR TITLE
[SPARK-50853][CORE] Close temp shuffle file writable channel

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/DownloadFileWritableChannel.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/DownloadFileWritableChannel.java
@@ -19,6 +19,7 @@ package org.apache.spark.network.shuffle;
 
 import org.apache.spark.network.buffer.ManagedBuffer;
 
+import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
 
 /**
@@ -26,5 +27,5 @@ import java.nio.channels.WritableByteChannel;
  * after the writer has been closed.  Used with DownloadFile and DownloadFileManager.
  */
 public interface DownloadFileWritableChannel extends WritableByteChannel {
-  ManagedBuffer closeAndRead();
+  ManagedBuffer closeAndRead() throws IOException;
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/SimpleDownloadFile.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/SimpleDownloadFile.java
@@ -69,7 +69,8 @@ public class SimpleDownloadFile implements DownloadFile {
     }
 
     @Override
-    public ManagedBuffer closeAndRead() {
+    public ManagedBuffer closeAndRead() throws IOException {
+      channel.close();
       return new FileSegmentManagedBuffer(transportConf, file, 0, file.length());
     }
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SimpleDownloadFileSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SimpleDownloadFileSuite.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Assertions;
 
 public class SimpleDownloadFileSuite {
   @Test
-  public void testChanenlIsClosedAfterCloseAndRead() throws IOException {
+  public void testChannelIsClosedAfterCloseAndRead() throws IOException {
     File tempFile = File.createTempFile("testChannelIsClosed", ".tmp");
     tempFile.deleteOnExit();
     TransportConf conf = new TransportConf("test", MapConfigProvider.EMPTY);

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SimpleDownloadFileSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SimpleDownloadFileSuite.java
@@ -1,0 +1,31 @@
+package org.apache.spark.network.shuffle;
+
+import org.apache.spark.network.util.MapConfigProvider;
+import org.apache.spark.network.util.TransportConf;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Assertions;
+
+public class SimpleDownloadFileSuite {
+    @Test
+    public void testChanenlIsClosedAfterCloseAndRead() throws IOException {
+        File tempFile = File.createTempFile("testChannelIsClosed", ".tmp");
+        tempFile.deleteOnExit();
+        TransportConf conf = new TransportConf("test", MapConfigProvider.EMPTY);
+
+        DownloadFile downloadFile = null;
+        try {
+            downloadFile = new SimpleDownloadFile(tempFile, conf);
+            DownloadFileWritableChannel channel = downloadFile.openForWriting();
+            channel.closeAndRead();
+            Assertions.assertFalse(channel.isOpen(), "Channel should be closed after closeAndRead.");
+        } finally {
+            if (downloadFile != null) {
+                downloadFile.delete();
+            }
+        }
+    }
+}

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SimpleDownloadFileSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SimpleDownloadFileSuite.java
@@ -27,22 +27,22 @@ import java.io.IOException;
 import org.junit.jupiter.api.Assertions;
 
 public class SimpleDownloadFileSuite {
-    @Test
-    public void testChanenlIsClosedAfterCloseAndRead() throws IOException {
-        File tempFile = File.createTempFile("testChannelIsClosed", ".tmp");
-        tempFile.deleteOnExit();
-        TransportConf conf = new TransportConf("test", MapConfigProvider.EMPTY);
+  @Test
+  public void testChanenlIsClosedAfterCloseAndRead() throws IOException {
+    File tempFile = File.createTempFile("testChannelIsClosed", ".tmp");
+    tempFile.deleteOnExit();
+    TransportConf conf = new TransportConf("test", MapConfigProvider.EMPTY);
 
-        DownloadFile downloadFile = null;
-        try {
-            downloadFile = new SimpleDownloadFile(tempFile, conf);
-            DownloadFileWritableChannel channel = downloadFile.openForWriting();
-            channel.closeAndRead();
-            Assertions.assertFalse(channel.isOpen(), "Channel should be closed after closeAndRead.");
-        } finally {
-            if (downloadFile != null) {
-                downloadFile.delete();
-            }
-        }
+    DownloadFile downloadFile = null;
+    try {
+      downloadFile = new SimpleDownloadFile(tempFile, conf);
+      DownloadFileWritableChannel channel = downloadFile.openForWriting();
+      channel.closeAndRead();
+      Assertions.assertFalse(channel.isOpen(), "Channel should be closed after closeAndRead.");
+    } finally {
+      if (downloadFile != null) {
+        downloadFile.delete();
+      }
     }
+  }
 }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SimpleDownloadFileSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SimpleDownloadFileSuite.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.network.shuffle;
 
 import org.apache.spark.network.util.MapConfigProvider;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently, there are two implementations of DownloadFileWritableChannel (which is used for writing data fetched to disk), SimpleDownloadWritableChannel and EncryptedDownloadWritableChannel. The latter closes the writable channel in it's implementation of closeAndRead method while the former does not. As a result, SimpleDownloadWritableChannel channel is never closed and is relying on either the finalizer in FileOutputStream or the phantom cleanable in FileDescriptor to close the file descriptor. The change in this PR is to close the channel in SimpleDownloadWritableChannel closeAndRead method.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Should be closing file handles when they are not needed anymore instead of relying on finalizer/cleanables to do it.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing spark tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
