### PR TITLE
[SPARK-50861][BUILD] Upgrade dropwizard metrics to 4.2.30

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -194,11 +194,11 @@ log4j-core/2.24.3//log4j-core-2.24.3.jar
 log4j-layout-template-json/2.24.3//log4j-layout-template-json-2.24.3.jar
 log4j-slf4j2-impl/2.24.3//log4j-slf4j2-impl-2.24.3.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
-metrics-core/4.2.29//metrics-core-4.2.29.jar
-metrics-graphite/4.2.29//metrics-graphite-4.2.29.jar
-metrics-jmx/4.2.29//metrics-jmx-4.2.29.jar
-metrics-json/4.2.29//metrics-json-4.2.29.jar
-metrics-jvm/4.2.29//metrics-jvm-4.2.29.jar
+metrics-core/4.2.30//metrics-core-4.2.30.jar
+metrics-graphite/4.2.30//metrics-graphite-4.2.30.jar
+metrics-jmx/4.2.30//metrics-jmx-4.2.30.jar
+metrics-json/4.2.30//metrics-json-4.2.30.jar
+metrics-jvm/4.2.30//metrics-jvm-4.2.30.jar
 minlog/1.3.0//minlog-1.3.0.jar
 netty-all/4.1.115.Final//netty-all-4.1.115.Final.jar
 netty-buffer/4.1.115.Final//netty-buffer-4.1.115.Final.jar

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     If you change codahale.metrics.version, you also need to change
     the link to metrics.dropwizard.io in docs/monitoring.md.
     -->
-    <codahale.metrics.version>4.2.29</codahale.metrics.version>
+    <codahale.metrics.version>4.2.30</codahale.metrics.version>
     <!-- Should be consistent with SparkBuild.scala and docs -->
     <avro.version>1.12.0</avro.version>
     <aws.kinesis.client.version>1.12.0</aws.kinesis.client.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade `dropwizard metrics` from `4.2.29` to  `4.2.30`.


### Why are the changes needed?
v4.2.29 VS v.4.2.30
https://github.com/dropwizard/metrics/compare/v4.2.29...v4.2.30

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
