### PR TITLE
[SPARK-50863][PYTHON][ML][TESTS]Skip slow pytorch tests

### DIFF
--- a/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
+++ b/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
@@ -79,9 +79,11 @@ if not is_remote_only():
                 (None, 3, False, "NONE"),
             ]
 
-    @unittest.skipIf(
-        not have_torch or is_remote_only(), torch_requirement_message or "Requires JVM access"
-    )
+    # @unittest.skipIf(
+    #     not have_torch or is_remote_only(), torch_requirement_message or "Requires JVM access"
+    # )
+    # TODO(SPARK-50864): Re-enable this test after fixing the slowness
+    @unittest.skip("Disabled due to slowness")
     class TorchDistributorLocalUnitTestsIIOnConnect(
         TorchDistributorLocalUnitTestsMixin, unittest.TestCase
     ):
@@ -111,9 +113,11 @@ if not is_remote_only():
                 (None, 3, False, "NONE"),
             ]
 
-    @unittest.skipIf(
-        not have_torch or is_remote_only(), torch_requirement_message or "Requires JVM access"
-    )
+    # @unittest.skipIf(
+    #     not have_torch or is_remote_only(), torch_requirement_message or "Requires JVM access"
+    # )
+    # TODO(SPARK-50864): Re-enable this test after fixing the slowness
+    @unittest.skip("Disabled due to slowness")
     class TorchDistributorDistributedUnitTestsOnConnect(
         TorchDistributorDistributedUnitTestsMixin, unittest.TestCase
     ):

--- a/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
+++ b/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
@@ -48,9 +48,11 @@ if not is_remote_only():
         def tearDownClass(cls):
             cls.spark.stop()
 
-    @unittest.skipIf(
-        not have_torch or is_remote_only(), torch_requirement_message or "Requires JVM access"
-    )
+    # @unittest.skipIf(
+    #     not have_torch or is_remote_only(), torch_requirement_message or "Requires JVM access"
+    # )
+    # TODO(SPARK-50864): Re-enable this test after fixing the slowness
+    @unittest.skip("Disabled due to slowness")
     class TorchDistributorLocalUnitTestsOnConnect(
         TorchDistributorLocalUnitTestsMixin, unittest.TestCase
     ):

--- a/python/pyspark/ml/torch/tests/test_distributor.py
+++ b/python/pyspark/ml/torch/tests/test_distributor.py
@@ -403,7 +403,9 @@ class TorchDistributorLocalUnitTestsMixin:
         self.assertEqual(output, "success" * 4096)
 
 
-@unittest.skipIf(not have_torch, torch_requirement_message)
+# @unittest.skipIf(not have_torch, torch_requirement_message)
+# TODO(SPARK-50864): Re-enable this test after fixing the slowness
+@unittest.skip("Disabled due to slowness")
 class TorchDistributorLocalUnitTests(TorchDistributorLocalUnitTestsMixin, unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/python/pyspark/ml/torch/tests/test_distributor.py
+++ b/python/pyspark/ml/torch/tests/test_distributor.py
@@ -425,7 +425,9 @@ class TorchDistributorLocalUnitTests(TorchDistributorLocalUnitTestsMixin, unitte
         cls.spark.stop()
 
 
-@unittest.skipIf(not have_torch, torch_requirement_message)
+# @unittest.skipIf(not have_torch, torch_requirement_message)
+# TODO(SPARK-50864): Re-enable this test after fixing the slowness
+@unittest.skip("Disabled due to slowness")
 class TorchDistributorLocalUnitTestsII(TorchDistributorLocalUnitTestsMixin, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -496,7 +498,9 @@ class TorchDistributorDistributedUnitTestsMixin:
         self.assertEqual(output, "success" * 4096)
 
 
-@unittest.skipIf(not have_torch, torch_requirement_message)
+# @unittest.skipIf(not have_torch, torch_requirement_message)
+# TODO(SPARK-50864): Re-enable this test after fixing the slowness
+@unittest.skip("Disabled due to slowness")
 class TorchDistributorDistributedUnitTests(
     TorchDistributorDistributedUnitTestsMixin, unittest.TestCase
 ):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Skip slow pytorch tests


### Why are the changes needed?
```
Finished test(python3.11): pyspark.ml.tests.connect.test_parity_torch_distributor (2902s)
Finished test(python3.11): pyspark.ml.torch.tests.test_distributor (2904s)
```

These test were disabled before, and were enabled in https://github.com/apache/spark/commit/dc84e529ba96ba8afc24216e5fc28d95ce8ce290

> So I think the root cause is still related to the resources, since TorchDistributor works on barrier mode, when there is not enough resources in Github Action, the tests just keep waiting.


I think the reason still stand.


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
