### PR TITLE
[MINOR][CORE] Fix compilation warnings in `UnsafeInMemorySorter.java` 

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeInMemorySorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeInMemorySorter.java
@@ -216,7 +216,7 @@ public final class UnsafeInMemorySorter {
     if (array != null) {
       if (newArray.size() < array.size()) {
         // checkstyle.off: RegexpSinglelineJava
-        throw new SparkOutOfMemoryError("_LEGACY_ERROR_TEMP_3301", new HashMap());
+        throw new SparkOutOfMemoryError("_LEGACY_ERROR_TEMP_3301", new HashMap<>());
         // checkstyle.on: RegexpSinglelineJava
       }
       Platform.copyMemory(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to fix compilation warnings in `UnsafeInMemorySorter.java` as follows:

```
[warn] /home/runner/work/spark/spark/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeInMemorySorter.java:219:1:  [unchecked] unchecked method invocation: constructor <init> in class SparkOutOfMemoryError is applied to given types
[warn]         throw new SparkOutOfMemoryError("_LEGACY_ERROR_TEMP_3301", new HashMap());
[warn]               ^  required: String,Map<String,String>
[warn]   found:    String,HashMap
[warn] /home/runner/work/spark/spark/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeInMemorySorter.java:219:1:  [unchecked] unchecked conversion
[warn]         throw new SparkOutOfMemoryError("_LEGACY_ERROR_TEMP_3301", new HashMap());
[warn]                                                                    ^  required: Map<String,String>
[warn]   found:    HashMap
```

### Why are the changes needed?
Fix compilation warnings in `UnsafeInMemorySorter.java` 


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No