### PR TITLE
[SPARK-50871][BUILD] Upgrade `scala-parallel-collections` to 1.2.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -254,7 +254,7 @@ rocksdbjni/9.7.3//rocksdbjni-9.7.3.jar
 scala-collection-compat_2.13/2.7.0//scala-collection-compat_2.13-2.7.0.jar
 scala-compiler/2.13.15//scala-compiler-2.13.15.jar
 scala-library/2.13.15//scala-library-2.13.15.jar
-scala-parallel-collections_2.13/1.0.4//scala-parallel-collections_2.13-1.0.4.jar
+scala-parallel-collections_2.13/1.2.0//scala-parallel-collections_2.13-1.2.0.jar
 scala-parser-combinators_2.13/2.4.0//scala-parser-combinators_2.13-2.4.0.jar
 scala-reflect/2.13.15//scala-reflect-2.13.15.jar
 scala-xml_2.13/2.3.0//scala-xml_2.13-2.3.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -463,7 +463,7 @@
       <dependency>
         <groupId>org.scala-lang.modules</groupId>
         <artifactId>scala-parallel-collections_${scala.binary.version}</artifactId>
-        <version>1.0.4</version>
+        <version>1.2.0</version>
       </dependency>
       <dependency>
         <groupId>com.twitter</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade `scala-parallel-collections` from 1.0.4 to 1.2.0

### Why are the changes needed?
The new version includes a bug fix for exception merging:

- https://github.com/scala/scala-parallel-collections/pull/205

The full release notes as follows:
- https://github.com/scala/scala-parallel-collections/releases/tag/v1.1.0
- https://github.com/scala/scala-parallel-collections/releases/tag/v1.2.0 

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No