### PR TITLE
[SPARK-50872][SQL][UI] Makes ToPrettyString expression not affect UI presentation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToPrettyString.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToPrettyString.scala
@@ -73,4 +73,6 @@ case class ToPrettyString(child: Expression, timeZoneId: Option[String] = None)
          |""".stripMargin
     ev.copy(code = finalCode, isNull = FalseLiteral)
   }
+
+  override def sql: String = child.sql
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ToPrettyStringSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ToPrettyStringSuite.scala
@@ -128,4 +128,10 @@ class ToPrettyStringSuite extends SparkFunSuite with ExpressionEvalHelper {
     val v = new VariantVal(Array[Byte](1, 2, 3), Array[Byte](1, 1))
     checkEvaluation(ToPrettyString(Literal(v)), UTF8String.fromString(v.toString))
   }
+
+  test("sql method is equalivalent to child's sql") {
+    val child = Literal(1)
+    val prettyString = ToPrettyString(child)
+    assert(prettyString.sql === child.sql)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

The Plan graph and plan detail are affected by the injected ToPrettyString expression. They are not consistent with the output of our `explain` API. If there are a lot of output columns, the UI looks malformed.
![image](https://github.com/user-attachments/assets/f7f32369-b5c5-47d3-b320-ffaff55867a6)



### Why are the changes needed?

It's not good to keep noise on the user's daily debug tool


### Does this PR introduce _any_ user-facing change?

No, this only changes the ongoing 4.0


### How was this patch tested?

Added UT and UI manual test

![image](https://github.com/user-attachments/assets/f851096a-b952-419e-9062-3995e6b1697c)



### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no