### PR TITLE
[SPARK-49014][BUILD][DOCS][FOLLOWUP] Synchronize the Avro version in `SparkBuild.scala/docs/comments to` 1.12.0.

### DIFF
--- a/docs/sql-data-sources-avro.md
+++ b/docs/sql-data-sources-avro.md
@@ -477,7 +477,7 @@ Submission Guide for more details.
 [adm]: submitting-applications.html#advanced-dependency-management
 
 ## Supported types for Avro -> Spark SQL conversion
-Currently Spark supports reading all [primitive types](https://avro.apache.org/docs/1.11.3/specification/#primitive-types) and [complex types](https://avro.apache.org/docs/1.11.3/specification/#complex-types) under records of Avro.
+Currently Spark supports reading all [primitive types](https://avro.apache.org/docs/1.12.0/specification/#primitive-types) and [complex types](https://avro.apache.org/docs/1.12.0/specification/#complex-types) under records of Avro.
 <table>
   <thead><tr><th><b>Avro type</b></th><th><b>Spark SQL type</b></th></tr></thead>
   <tr>
@@ -541,7 +541,7 @@ In addition to the types listed above, it supports reading `union` types. The fo
 3. `union(something, null)`, where something is any supported Avro type. This will be mapped to the same Spark SQL type as that of something, with nullable set to true.
 All other union types are considered complex. They will be mapped to StructType where field names are member0, member1, etc., in accordance with members of the union. This is consistent with the behavior when converting between Avro and Parquet.
 
-It also supports reading the following Avro [logical types](https://avro.apache.org/docs/1.11.3/specification/#logical-types):
+It also supports reading the following Avro [logical types](https://avro.apache.org/docs/1.12.0/specification/#logical-types):
 
 <table>
   <thead><tr><th><b>Avro logical type</b></th><th><b>Avro type</b></th><th><b>Spark SQL type</b></th></tr></thead>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1061,7 +1061,7 @@ object DependencyOverrides {
   lazy val settings = Seq(
     dependencyOverrides += "com.google.guava" % "guava" % guavaVersion,
     dependencyOverrides += "jline" % "jline" % "2.14.6",
-    dependencyOverrides += "org.apache.avro" % "avro" % "1.11.3")
+    dependencyOverrides += "org.apache.avro" % "avro" % "1.12.0")
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -82,14 +82,14 @@ private[sql] class AvroOptions(
 
   /**
    * Top level record name in write result, which is required in Avro spec.
-   * See https://avro.apache.org/docs/1.11.3/specification/#schema-record .
+   * See https://avro.apache.org/docs/1.12.0/specification/#schema-record .
    * Default value is "topLevelRecord"
    */
   val recordName: String = parameters.getOrElse(RECORD_NAME, "topLevelRecord")
 
   /**
    * Record namespace in write result. Default value is "".
-   * See Avro spec for details: https://avro.apache.org/docs/1.11.3/specification/#schema-record .
+   * See Avro spec for details: https://avro.apache.org/docs/1.12.0/specification/#schema-record .
    */
   val recordNamespace: String = parameters.getOrElse(RECORD_NAMESPACE, "")
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
@@ -814,7 +814,7 @@ class HiveClientSuite(version: String) extends HiveVersionSuite(version) {
   test("Decimal support of Avro Hive serde") {
     val tableName = "tab1"
     // TODO: add the other logical types. For details, see the link:
-    // https://avro.apache.org/docs/1.11.3/specification/#logical-types
+    // https://avro.apache.org/docs/1.12.0/specification/#logical-types
     val avroSchema =
     """{
       |  "name": "test_record",


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/47498 has upgraded Avro to version 1.12.0, Synchronize the Avro version in `SparkBuild.scala/docs/comments to` 1.12.0.

### Why are the changes needed?
The Avro version within the project should be consistent.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No