### PR TITLE
[SPARK-50875][SQL] Add RTRIM collations to TVF

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
@@ -446,6 +446,8 @@ public final class CollationFactory {
 
       protected abstract String normalizedCollationName();
 
+      protected abstract String getPaddingAttributeString();
+
       static List<CollationIdentifier> listCollations() {
         return Stream.concat(
           CollationSpecUTF8.listCollations().stream(),
@@ -638,7 +640,7 @@ public final class CollationFactory {
             /* language = */ null,
             /* country = */ null,
             /* icuVersion = */ null,
-            COLLATION_PAD_ATTRIBUTE,
+            spaceTrimming == SpaceTrimming.RTRIM ? PAD_ATTRIBUTE_EMPTY : PAD_ATTRIBUTE_RTRIM,
             /* accentSensitivity = */ true,
             /* caseSensitivity = */ true,
             spaceTrimming.toString());
@@ -656,6 +658,8 @@ public final class CollationFactory {
             spaceTrimming.toString());
         }
       }
+
+      protected String
 
       /**
        * Compute normalized collation name. Components of collation name are given in order:
@@ -689,7 +693,18 @@ public final class CollationFactory {
             CollationNames.UTF8_LCASE,
             CollationSpecICU.ICU_VERSION
         );
-        return Arrays.asList(UTF8_BINARY_COLLATION_IDENT, UTF8_LCASE_COLLATION_IDENT);
+        CollationIdentifier UTF8_BINARY_RTRIM_COLLATION_IDENT = new CollationIdentifier(
+            PROVIDER_SPARK,
+            CollationNames.UTF8_BINARY + "_RTRIM",
+            CollationSpecICU.ICU_VERSION
+        );
+        CollationIdentifier UTF8_LCASE_RTRIM_COLLATION_IDENT = new CollationIdentifier(
+            PROVIDER_SPARK,
+            CollationNames.UTF8_LCASE + "_RTRIM",
+            CollationSpecICU.ICU_VERSION
+        );
+        return Arrays.asList(UTF8_BINARY_COLLATION_IDENT, UTF8_LCASE_COLLATION_IDENT,
+            UTF8_BINARY_RTRIM_COLLATION_IDENT, UTF8_LCASE_RTRIM_COLLATION_IDENT);
       }
 
       static CollationMeta loadCollationMeta(CollationIdentifier collationIdentifier) {
@@ -1068,10 +1083,13 @@ public final class CollationFactory {
       private static List<String> allCollationNames() {
         List<String> collationNames = new ArrayList<>();
         List<String> caseAccentSpecifiers = Arrays.asList("", "_AI", "_CI", "_CI_AI");
+        List<String> trimmingSpecifiers = Arrays.asList("", "_RTRIM");
         for (String locale : ICULocaleToId.keySet()) {
           for (String caseAccent : caseAccentSpecifiers) {
-            String collationName = locale + caseAccent;
-            collationNames.add(collationName);
+            for (String trimming : trimmingSpecifiers) {
+              String collationName = locale + caseAccent + trimming;
+              collationNames.add(collationName);
+            }
           }
         }
         return collationNames.stream().sorted().toList();
@@ -1161,7 +1179,8 @@ public final class CollationFactory {
   public static final String PROVIDER_ICU = "icu";
   public static final String PROVIDER_NULL = "null";
   public static final List<String> SUPPORTED_PROVIDERS = List.of(PROVIDER_SPARK, PROVIDER_ICU);
-  public static final String COLLATION_PAD_ATTRIBUTE = "NO_PAD";
+  public static final String PAD_ATTRIBUTE_EMPTY = "NO_PAD";
+  public static final String PAD_ATTRIBUTE_RTRIM = "RTRIM";
 
   public static final int UTF8_BINARY_COLLATION_ID =
     Collation.CollationSpecUTF8.UTF8_BINARY_COLLATION_ID;

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
@@ -710,7 +710,7 @@ public final class CollationFactory {
             CollationSpecICU.ICU_VERSION
         );
         return Arrays.asList(UTF8_BINARY_COLLATION_IDENT, UTF8_LCASE_COLLATION_IDENT,
-            UTF8_BINARY_RTRIM_COLLATION_IDENT, UTF8_LCASE_RTRIM_COLLATION_IDENT);
+          UTF8_BINARY_RTRIM_COLLATION_IDENT, UTF8_LCASE_RTRIM_COLLATION_IDENT);
       }
 
       static CollationMeta loadCollationMeta(CollationIdentifier collationIdentifier) {

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
@@ -440,13 +440,20 @@ public final class CollationFactory {
         }
       }
 
+      protected String getPadding() {
+        if (spaceTrimming == SpaceTrimming.RTRIM) {
+          return PAD_ATTRIBUTE_RTRIM;
+        } else {
+          assert spaceTrimming == SpaceTrimming.NONE;
+          return PAD_ATTRIBUTE_EMPTY;
+        }
+      }
+
       protected abstract Collation buildCollation();
 
       protected abstract CollationMeta buildCollationMeta();
 
       protected abstract String normalizedCollationName();
-
-      protected abstract String getPaddingAttributeString();
 
       static List<CollationIdentifier> listCollations() {
         return Stream.concat(
@@ -462,6 +469,8 @@ public final class CollationFactory {
         }
         return collationSpecUTF8;
       }
+
+      protected SpaceTrimming spaceTrimming;
     }
 
     private static class CollationSpecUTF8 extends CollationSpec {
@@ -494,7 +503,6 @@ public final class CollationFactory {
         new CollationSpecUTF8(CaseSensitivity.LCASE, SpaceTrimming.NONE).buildCollation();
 
       private final CaseSensitivity caseSensitivity;
-      private final SpaceTrimming spaceTrimming;
       private final int collationId;
 
       private CollationSpecUTF8(
@@ -640,7 +648,7 @@ public final class CollationFactory {
             /* language = */ null,
             /* country = */ null,
             /* icuVersion = */ null,
-            spaceTrimming == SpaceTrimming.RTRIM ? PAD_ATTRIBUTE_EMPTY : PAD_ATTRIBUTE_RTRIM,
+            getPadding(),
             /* accentSensitivity = */ true,
             /* caseSensitivity = */ true,
             spaceTrimming.toString());
@@ -652,14 +660,12 @@ public final class CollationFactory {
             /* language = */ null,
             /* country = */ null,
             /* icuVersion = */ null,
-            COLLATION_PAD_ATTRIBUTE,
+            getPadding(),
             /* accentSensitivity = */ true,
             /* caseSensitivity = */ false,
             spaceTrimming.toString());
         }
       }
-
-      protected String
 
       /**
        * Compute normalized collation name. Components of collation name are given in order:
@@ -846,7 +852,6 @@ public final class CollationFactory {
 
       private final CaseSensitivity caseSensitivity;
       private final AccentSensitivity accentSensitivity;
-      private final SpaceTrimming spaceTrimming;
       private final String locale;
       private final int collationId;
 
@@ -1047,7 +1052,7 @@ public final class CollationFactory {
           language.isEmpty() ? null : language,
           country.isEmpty() ? null : country,
           VersionInfo.ICU_VERSION.toString(),
-          COLLATION_PAD_ATTRIBUTE,
+          getPadding(),
           accentSensitivity == AccentSensitivity.AS,
           caseSensitivity == CaseSensitivity.CS,
           spaceTrimming.toString());

--- a/python/pyspark/sql/tvf.py
+++ b/python/pyspark/sql/tvf.py
@@ -554,6 +554,7 @@ class TableValuedFunction:
         | SYSTEM|BUILTIN|        af_CI_RTRIM|Afrikaans|   NULL|  ACCENT_SENSITIVE|CASE_INSENSITIVE|        RTRIM|   76.1.0.0|
         | SYSTEM|BUILTIN|           af_RTRIM|Afrikaans|   NULL|  ACCENT_SENSITIVE|  CASE_SENSITIVE|        RTRIM|   76.1.0.0|
         +-------+-------+-------------------+---------+-------+------------------+----------------+-------------+-----------+
+        only showing top 20 rows
         """
         return self._fn("collations")
 

--- a/python/pyspark/sql/tvf.py
+++ b/python/pyspark/sql/tvf.py
@@ -530,31 +530,11 @@ class TableValuedFunction:
         Examples
         --------
         >>> spark.tvf.collations().show()
-        +-------+-------+-------------------+---------+-------+------------------+----------------+-------------+-----------+
-        |CATALOG| SCHEMA|               NAME| LANGUAGE|COUNTRY|ACCENT_SENSITIVITY|CASE_SENSITIVITY|PAD_ATTRIBUTE|ICU_VERSION|
-        +-------+-------+-------------------+---------+-------+------------------+----------------+-------------+-----------+
-        | SYSTEM|BUILTIN|        UTF8_BINARY|     NULL|   NULL|  ACCENT_SENSITIVE|  CASE_SENSITIVE|       NO_PAD|       NULL|
-        | SYSTEM|BUILTIN|         UTF8_LCASE|     NULL|   NULL|  ACCENT_SENSITIVE|CASE_INSENSITIVE|       NO_PAD|       NULL|
-        | SYSTEM|BUILTIN|  UTF8_BINARY_RTRIM|     NULL|   NULL|  ACCENT_SENSITIVE|  CASE_SENSITIVE|        RTRIM|       NULL|
-        | SYSTEM|BUILTIN|   UTF8_LCASE_RTRIM|     NULL|   NULL|  ACCENT_SENSITIVE|CASE_INSENSITIVE|        RTRIM|       NULL|
-        | SYSTEM|BUILTIN|            UNICODE|     NULL|   NULL|  ACCENT_SENSITIVE|  CASE_SENSITIVE|       NO_PAD|   76.1.0.0|
-        | SYSTEM|BUILTIN|         UNICODE_AI|     NULL|   NULL|ACCENT_INSENSITIVE|  CASE_SENSITIVE|       NO_PAD|   76.1.0.0|
-        | SYSTEM|BUILTIN|   UNICODE_AI_RTRIM|     NULL|   NULL|ACCENT_INSENSITIVE|  CASE_SENSITIVE|        RTRIM|   76.1.0.0|
-        | SYSTEM|BUILTIN|         UNICODE_CI|     NULL|   NULL|  ACCENT_SENSITIVE|CASE_INSENSITIVE|       NO_PAD|   76.1.0.0|
-        | SYSTEM|BUILTIN|      UNICODE_CI_AI|     NULL|   NULL|ACCENT_INSENSITIVE|CASE_INSENSITIVE|       NO_PAD|   76.1.0.0|
-        | SYSTEM|BUILTIN|UNICODE_CI_AI_RTRIM|     NULL|   NULL|ACCENT_INSENSITIVE|CASE_INSENSITIVE|        RTRIM|   76.1.0.0|
-        | SYSTEM|BUILTIN|   UNICODE_CI_RTRIM|     NULL|   NULL|  ACCENT_SENSITIVE|CASE_INSENSITIVE|        RTRIM|   76.1.0.0|
-        | SYSTEM|BUILTIN|      UNICODE_RTRIM|     NULL|   NULL|  ACCENT_SENSITIVE|  CASE_SENSITIVE|        RTRIM|   76.1.0.0|
-        | SYSTEM|BUILTIN|                 af|Afrikaans|   NULL|  ACCENT_SENSITIVE|  CASE_SENSITIVE|       NO_PAD|   76.1.0.0|
-        | SYSTEM|BUILTIN|              af_AI|Afrikaans|   NULL|ACCENT_INSENSITIVE|  CASE_SENSITIVE|       NO_PAD|   76.1.0.0|
-        | SYSTEM|BUILTIN|        af_AI_RTRIM|Afrikaans|   NULL|ACCENT_INSENSITIVE|  CASE_SENSITIVE|        RTRIM|   76.1.0.0|
-        | SYSTEM|BUILTIN|              af_CI|Afrikaans|   NULL|  ACCENT_SENSITIVE|CASE_INSENSITIVE|       NO_PAD|   76.1.0.0|
-        | SYSTEM|BUILTIN|           af_CI_AI|Afrikaans|   NULL|ACCENT_INSENSITIVE|CASE_INSENSITIVE|       NO_PAD|   76.1.0.0|
-        | SYSTEM|BUILTIN|     af_CI_AI_RTRIM|Afrikaans|   NULL|ACCENT_INSENSITIVE|CASE_INSENSITIVE|        RTRIM|   76.1.0.0|
-        | SYSTEM|BUILTIN|        af_CI_RTRIM|Afrikaans|   NULL|  ACCENT_SENSITIVE|CASE_INSENSITIVE|        RTRIM|   76.1.0.0|
-        | SYSTEM|BUILTIN|           af_RTRIM|Afrikaans|   NULL|  ACCENT_SENSITIVE|  CASE_SENSITIVE|        RTRIM|   76.1.0.0|
-        +-------+-------+-------------------+---------+-------+------------------+----------------+-------------+-----------+
-        only showing top 20 rows
+        +-------+-------+-------------------+...
+        |CATALOG| SCHEMA|               NAME|...
+        +-------+-------+-------------------+...
+        ...
+        +-------+-------+-------------------+...
         """
         return self._fn("collations")
 

--- a/python/pyspark/sql/tvf.py
+++ b/python/pyspark/sql/tvf.py
@@ -530,11 +530,30 @@ class TableValuedFunction:
         Examples
         --------
         >>> spark.tvf.collations().show()
-        +-------+-------+-------------+...
-        |CATALOG| SCHEMA|         NAME|...
-        +-------+-------+-------------+...
-        ...
-        +-------+-------+-------------+...
+        +-------+-------+-------------------+---------+-------+------------------+----------------+-------------+-----------+
+        |CATALOG| SCHEMA|               NAME| LANGUAGE|COUNTRY|ACCENT_SENSITIVITY|CASE_SENSITIVITY|PAD_ATTRIBUTE|ICU_VERSION|
+        +-------+-------+-------------------+---------+-------+------------------+----------------+-------------+-----------+
+        | SYSTEM|BUILTIN|        UTF8_BINARY|     NULL|   NULL|  ACCENT_SENSITIVE|  CASE_SENSITIVE|       NO_PAD|       NULL|
+        | SYSTEM|BUILTIN|         UTF8_LCASE|     NULL|   NULL|  ACCENT_SENSITIVE|CASE_INSENSITIVE|       NO_PAD|       NULL|
+        | SYSTEM|BUILTIN|  UTF8_BINARY_RTRIM|     NULL|   NULL|  ACCENT_SENSITIVE|  CASE_SENSITIVE|        RTRIM|       NULL|
+        | SYSTEM|BUILTIN|   UTF8_LCASE_RTRIM|     NULL|   NULL|  ACCENT_SENSITIVE|CASE_INSENSITIVE|        RTRIM|       NULL|
+        | SYSTEM|BUILTIN|            UNICODE|     NULL|   NULL|  ACCENT_SENSITIVE|  CASE_SENSITIVE|       NO_PAD|   76.1.0.0|
+        | SYSTEM|BUILTIN|         UNICODE_AI|     NULL|   NULL|ACCENT_INSENSITIVE|  CASE_SENSITIVE|       NO_PAD|   76.1.0.0|
+        | SYSTEM|BUILTIN|   UNICODE_AI_RTRIM|     NULL|   NULL|ACCENT_INSENSITIVE|  CASE_SENSITIVE|        RTRIM|   76.1.0.0|
+        | SYSTEM|BUILTIN|         UNICODE_CI|     NULL|   NULL|  ACCENT_SENSITIVE|CASE_INSENSITIVE|       NO_PAD|   76.1.0.0|
+        | SYSTEM|BUILTIN|      UNICODE_CI_AI|     NULL|   NULL|ACCENT_INSENSITIVE|CASE_INSENSITIVE|       NO_PAD|   76.1.0.0|
+        | SYSTEM|BUILTIN|UNICODE_CI_AI_RTRIM|     NULL|   NULL|ACCENT_INSENSITIVE|CASE_INSENSITIVE|        RTRIM|   76.1.0.0|
+        | SYSTEM|BUILTIN|   UNICODE_CI_RTRIM|     NULL|   NULL|  ACCENT_SENSITIVE|CASE_INSENSITIVE|        RTRIM|   76.1.0.0|
+        | SYSTEM|BUILTIN|      UNICODE_RTRIM|     NULL|   NULL|  ACCENT_SENSITIVE|  CASE_SENSITIVE|        RTRIM|   76.1.0.0|
+        | SYSTEM|BUILTIN|                 af|Afrikaans|   NULL|  ACCENT_SENSITIVE|  CASE_SENSITIVE|       NO_PAD|   76.1.0.0|
+        | SYSTEM|BUILTIN|              af_AI|Afrikaans|   NULL|ACCENT_INSENSITIVE|  CASE_SENSITIVE|       NO_PAD|   76.1.0.0|
+        | SYSTEM|BUILTIN|        af_AI_RTRIM|Afrikaans|   NULL|ACCENT_INSENSITIVE|  CASE_SENSITIVE|        RTRIM|   76.1.0.0|
+        | SYSTEM|BUILTIN|              af_CI|Afrikaans|   NULL|  ACCENT_SENSITIVE|CASE_INSENSITIVE|       NO_PAD|   76.1.0.0|
+        | SYSTEM|BUILTIN|           af_CI_AI|Afrikaans|   NULL|ACCENT_INSENSITIVE|CASE_INSENSITIVE|       NO_PAD|   76.1.0.0|
+        | SYSTEM|BUILTIN|     af_CI_AI_RTRIM|Afrikaans|   NULL|ACCENT_INSENSITIVE|CASE_INSENSITIVE|        RTRIM|   76.1.0.0|
+        | SYSTEM|BUILTIN|        af_CI_RTRIM|Afrikaans|   NULL|  ACCENT_SENSITIVE|CASE_INSENSITIVE|        RTRIM|   76.1.0.0|
+        | SYSTEM|BUILTIN|           af_RTRIM|Afrikaans|   NULL|  ACCENT_SENSITIVE|  CASE_SENSITIVE|        RTRIM|   76.1.0.0|
+        +-------+-------+-------------------+---------+-------+------------------+----------------+-------------+-----------+
         """
         return self._fn("collations")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
@@ -1965,7 +1965,6 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
     }
   }
 
-
   test("TVF collations()") {
     assert(sql("SELECT * FROM collations()").collect().length >= 562)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
@@ -1965,6 +1965,7 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
     }
   }
 
+
   test("TVF collations()") {
     assert(sql("SELECT * FROM collations()").collect().length >= 562)
 
@@ -1974,48 +1975,66 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
     checkAnswer(df,
       Seq(Row("SYSTEM", "BUILTIN", "UTF8_BINARY", null, null,
         "ACCENT_SENSITIVE", "CASE_SENSITIVE", "NO_PAD", null),
+        Row("SYSTEM", "BUILTIN", "UTF8_BINARY_RTRIM", null, null,
+          "ACCENT_SENSITIVE", "CASE_SENSITIVE", "RTRIM", null),
         Row("SYSTEM", "BUILTIN", "UTF8_LCASE", null, null,
           "ACCENT_SENSITIVE", "CASE_INSENSITIVE", "NO_PAD", null),
+        Row("SYSTEM", "BUILTIN", "UTF8_LCASE_RTRIM", null, null,
+          "ACCENT_SENSITIVE", "CASE_INSENSITIVE", "RTRIM", null),
         Row("SYSTEM", "BUILTIN", "UNICODE", null, null,
           "ACCENT_SENSITIVE", "CASE_SENSITIVE", "NO_PAD", icvVersion),
         Row("SYSTEM", "BUILTIN", "UNICODE_AI", null, null,
           "ACCENT_INSENSITIVE", "CASE_SENSITIVE", "NO_PAD", icvVersion),
+        Row("SYSTEM", "BUILTIN", "UNICODE_AI_RTRIM", null, null,
+          "ACCENT_INSENSITIVE", "CASE_SENSITIVE", "RTRIM", icvVersion),
         Row("SYSTEM", "BUILTIN", "UNICODE_CI", null, null,
           "ACCENT_SENSITIVE", "CASE_INSENSITIVE", "NO_PAD", icvVersion),
         Row("SYSTEM", "BUILTIN", "UNICODE_CI_AI", null, null,
           "ACCENT_INSENSITIVE", "CASE_INSENSITIVE", "NO_PAD", icvVersion),
-        Row("SYSTEM", "BUILTIN", "af", "Afrikaans", null,
-          "ACCENT_SENSITIVE", "CASE_SENSITIVE", "NO_PAD", icvVersion),
-        Row("SYSTEM", "BUILTIN", "af_AI", "Afrikaans", null,
-          "ACCENT_INSENSITIVE", "CASE_SENSITIVE", "NO_PAD", icvVersion),
-        Row("SYSTEM", "BUILTIN", "af_CI", "Afrikaans", null,
-          "ACCENT_SENSITIVE", "CASE_INSENSITIVE", "NO_PAD", icvVersion),
-        Row("SYSTEM", "BUILTIN", "af_CI_AI", "Afrikaans", null,
-          "ACCENT_INSENSITIVE", "CASE_INSENSITIVE", "NO_PAD", icvVersion)))
+        Row("SYSTEM", "BUILTIN", "UNICODE_CI_AI_RTRIM", null, null,
+          "ACCENT_INSENSITIVE", "CASE_INSENSITIVE", "RTRIM", icvVersion)))
 
     checkAnswer(sql("SELECT * FROM collations() WHERE NAME LIKE '%UTF8_BINARY%'"),
-      Row("SYSTEM", "BUILTIN", "UTF8_BINARY", null, null,
-        "ACCENT_SENSITIVE", "CASE_SENSITIVE", "NO_PAD", null))
+      Seq(Row("SYSTEM", "BUILTIN", "UTF8_BINARY", null, null,
+        "ACCENT_SENSITIVE", "CASE_SENSITIVE", "NO_PAD", null),
+      Row("SYSTEM", "BUILTIN", "UTF8_BINARY_RTRIM", null, null,
+        "ACCENT_SENSITIVE", "CASE_SENSITIVE", "RTRIM", null)))
 
     checkAnswer(sql("SELECT * FROM collations() WHERE NAME LIKE '%zh_Hant_HKG%'"),
       Seq(Row("SYSTEM", "BUILTIN", "zh_Hant_HKG", "Chinese", "Hong Kong SAR China",
         "ACCENT_SENSITIVE", "CASE_SENSITIVE", "NO_PAD", icvVersion),
         Row("SYSTEM", "BUILTIN", "zh_Hant_HKG_AI", "Chinese", "Hong Kong SAR China",
           "ACCENT_INSENSITIVE", "CASE_SENSITIVE", "NO_PAD", icvVersion),
+        Row("SYSTEM", "BUILTIN", "zh_Hant_HKG_AI_RTRIM", "Chinese", "Hong Kong SAR China",
+          "ACCENT_INSENSITIVE", "CASE_SENSITIVE", "RTRIM", icvVersion),
         Row("SYSTEM", "BUILTIN", "zh_Hant_HKG_CI", "Chinese", "Hong Kong SAR China",
           "ACCENT_SENSITIVE", "CASE_INSENSITIVE", "NO_PAD", icvVersion),
         Row("SYSTEM", "BUILTIN", "zh_Hant_HKG_CI_AI", "Chinese", "Hong Kong SAR China",
-          "ACCENT_INSENSITIVE", "CASE_INSENSITIVE", "NO_PAD", icvVersion)))
+          "ACCENT_INSENSITIVE", "CASE_INSENSITIVE", "NO_PAD", icvVersion),
+        Row("SYSTEM", "BUILTIN", "zh_Hant_HKG_CI_AI_RTRIM", "Chinese", "Hong Kong SAR China",
+          "ACCENT_INSENSITIVE", "CASE_INSENSITIVE", "RTRIM", icvVersion),
+        Row("SYSTEM", "BUILTIN", "zh_Hant_HKG_CI_RTRIM", "Chinese", "Hong Kong SAR China",
+          "ACCENT_SENSITIVE", "CASE_INSENSITIVE", "RTRIM", icvVersion),
+        Row("SYSTEM", "BUILTIN", "zh_Hant_HKG_RTRIM", "Chinese", "Hong Kong SAR China",
+          "ACCENT_SENSITIVE", "CASE_SENSITIVE", "RTRIM", icvVersion)))
 
     checkAnswer(sql("SELECT * FROM collations() WHERE COUNTRY = 'Singapore'"),
       Seq(Row("SYSTEM", "BUILTIN", "zh_Hans_SGP", "Chinese", "Singapore",
         "ACCENT_SENSITIVE", "CASE_SENSITIVE", "NO_PAD", icvVersion),
         Row("SYSTEM", "BUILTIN", "zh_Hans_SGP_AI", "Chinese", "Singapore",
           "ACCENT_INSENSITIVE", "CASE_SENSITIVE", "NO_PAD", icvVersion),
+        Row("SYSTEM", "BUILTIN", "zh_Hans_SGP_AI_RTRIM", "Chinese", "Singapore",
+          "ACCENT_INSENSITIVE", "CASE_SENSITIVE", "RTRIM", icvVersion),
         Row("SYSTEM", "BUILTIN", "zh_Hans_SGP_CI", "Chinese", "Singapore",
           "ACCENT_SENSITIVE", "CASE_INSENSITIVE", "NO_PAD", icvVersion),
         Row("SYSTEM", "BUILTIN", "zh_Hans_SGP_CI_AI", "Chinese", "Singapore",
-          "ACCENT_INSENSITIVE", "CASE_INSENSITIVE", "NO_PAD", icvVersion)))
+          "ACCENT_INSENSITIVE", "CASE_INSENSITIVE", "NO_PAD", icvVersion),
+        Row("SYSTEM", "BUILTIN", "zh_Hans_SGP_CI_AI_RTRIM", "Chinese", "Singapore",
+          "ACCENT_INSENSITIVE", "CASE_INSENSITIVE", "RTRIM", icvVersion),
+        Row("SYSTEM", "BUILTIN", "zh_Hans_SGP_CI_RTRIM", "Chinese", "Singapore",
+          "ACCENT_SENSITIVE", "CASE_INSENSITIVE", "RTRIM", icvVersion),
+        Row("SYSTEM", "BUILTIN", "zh_Hans_SGP_RTRIM", "Chinese", "Singapore",
+          "ACCENT_SENSITIVE", "CASE_SENSITIVE", "RTRIM", icvVersion)))
 
     checkAnswer(sql("SELECT * FROM collations() WHERE LANGUAGE = 'English' " +
       "and COUNTRY = 'United States'"),
@@ -2023,20 +2042,33 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
         "ACCENT_SENSITIVE", "CASE_SENSITIVE", "NO_PAD", icvVersion),
         Row("SYSTEM", "BUILTIN", "en_USA_AI", "English", "United States",
           "ACCENT_INSENSITIVE", "CASE_SENSITIVE", "NO_PAD", icvVersion),
+        Row("SYSTEM", "BUILTIN", "en_USA_AI_RTRIM", "English", "United States",
+          "ACCENT_INSENSITIVE", "CASE_SENSITIVE", "RTRIM", icvVersion),
         Row("SYSTEM", "BUILTIN", "en_USA_CI", "English", "United States",
           "ACCENT_SENSITIVE", "CASE_INSENSITIVE", "NO_PAD", icvVersion),
         Row("SYSTEM", "BUILTIN", "en_USA_CI_AI", "English", "United States",
-          "ACCENT_INSENSITIVE", "CASE_INSENSITIVE", "NO_PAD", icvVersion)))
+          "ACCENT_INSENSITIVE", "CASE_INSENSITIVE", "NO_PAD", icvVersion),
+        Row("SYSTEM", "BUILTIN", "en_USA_CI_AI_RTRIM", "English", "United States",
+          "ACCENT_INSENSITIVE", "CASE_INSENSITIVE", "RTRIM", icvVersion),
+        Row("SYSTEM", "BUILTIN", "en_USA_CI_RTRIM", "English", "United States",
+          "ACCENT_SENSITIVE", "CASE_INSENSITIVE", "RTRIM", icvVersion),
+        Row("SYSTEM", "BUILTIN", "en_USA_RTRIM", "English", "United States",
+          "ACCENT_SENSITIVE", "CASE_SENSITIVE", "RTRIM", icvVersion)))
 
     checkAnswer(sql("SELECT NAME, LANGUAGE, ACCENT_SENSITIVITY, CASE_SENSITIVITY " +
       "FROM collations() WHERE COUNTRY = 'United States'"),
       Seq(Row("en_USA", "English", "ACCENT_SENSITIVE", "CASE_SENSITIVE"),
         Row("en_USA_AI", "English", "ACCENT_INSENSITIVE", "CASE_SENSITIVE"),
+        Row("en_USA_AI_RTRIM", "English", "ACCENT_INSENSITIVE", "CASE_SENSITIVE"),
         Row("en_USA_CI", "English", "ACCENT_SENSITIVE", "CASE_INSENSITIVE"),
-        Row("en_USA_CI_AI", "English", "ACCENT_INSENSITIVE", "CASE_INSENSITIVE")))
+        Row("en_USA_CI_AI", "English", "ACCENT_INSENSITIVE", "CASE_INSENSITIVE"),
+        Row("en_USA_CI_AI_RTRIM", "English", "ACCENT_INSENSITIVE", "CASE_INSENSITIVE"),
+        Row("en_USA_CI_RTRIM", "English", "ACCENT_SENSITIVE", "CASE_INSENSITIVE"),
+        Row("en_USA_RTRIM", "English", "ACCENT_SENSITIVE", "CASE_SENSITIVE")))
 
     checkAnswer(sql("SELECT NAME FROM collations() WHERE ICU_VERSION is null"),
-      Seq(Row("UTF8_BINARY"), Row("UTF8_LCASE")))
+      Seq(Row("UTF8_BINARY"), Row("UTF8_LCASE"), Row("UTF8_BINARY_RTRIM"),
+        Row("UTF8_LCASE_RTRIM")))
   }
 
   test("fully qualified name") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added all RTRIM collations to TVF when using `Collations` generator.


### Why are the changes needed?
Since RTRIM collation is enabled by default, we need to add it to the list.


### Does this PR introduce _any_ user-facing change?
Yes, using the `collations` function will include `rtrim` collations.

### How was this patch tested?
Modified TVF collation tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
