### PR TITLE
[SPARK-50792][SQL][FOLLOWUP] Improve the push down information for binary

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
-import org.apache.spark.sql.types.{DataType, IntegerType, StringType}
+import org.apache.spark.sql.types.{BinaryType, DataType, IntegerType, StringType}
 import org.apache.spark.util.ArrayImplicits._
 
 /**
@@ -388,12 +388,13 @@ private[sql] object HoursTransform {
 }
 
 private[sql] final case class LiteralValue[T](value: T, dataType: DataType) extends Literal[T] {
-  override def toString: String = {
-    if (dataType.isInstanceOf[StringType]) {
-      s"'${StringUtils.replace(s"$value", "'", "''")}'"
-    } else {
-      s"$value"
-    }
+  override def toString: String = dataType match {
+    case StringType => s"'${StringUtils.replace(s"$value", "'", "''")}'"
+    case BinaryType =>
+      assert(value.isInstanceOf[Array[Byte]])
+      val bytes = value.asInstanceOf[Array[Byte]]
+      bytes.map("%02X".format(_)).mkString("X'", "", "'")
+    case _ => s"$value"
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.connector.expressions
 
+import org.apache.commons.codec.binary.Hex
 import org.apache.commons.lang3.StringUtils
 
 import org.apache.spark.SparkException
@@ -393,7 +394,7 @@ private[sql] final case class LiteralValue[T](value: T, dataType: DataType) exte
     case BinaryType =>
       assert(value.isInstanceOf[Array[Byte]])
       val bytes = value.asInstanceOf[Array[Byte]]
-      bytes.map("%02X".format(_)).mkString("X'", "", "'")
+      "0x" + Hex.encodeHexString(bytes, false)
     case _ => s"$value"
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -3107,13 +3107,10 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       sql(s"CREATE TABLE $tableName (binary_col BINARY)")
       sql(s"INSERT INTO $tableName VALUES ($binary)")
 
-      val select = s"SELECT * FROM $tableName WHERE binary_col = $binary"
-      val df = sql(select)
-      val filter = df.queryExecution.optimizedPlan.collect {
-        case f: Filter => f
-      }
-      assert(filter.isEmpty, "Filter is not pushed")
-      assert(df.collect().length === 1, s"Binary literal test failed: $select")
+      val df = sql(s"SELECT * FROM $tableName WHERE binary_col = $binary")
+      checkFiltersRemoved(df)
+      checkPushedInfo(df, "PushedFilters: [binary_col IS NOT NULL, binary_col = X'123456']")
+      checkAnswer(df, Row(Array(18, 52, 86)))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -3109,7 +3109,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
 
       val df = sql(s"SELECT * FROM $tableName WHERE binary_col = $binary")
       checkFiltersRemoved(df)
-      checkPushedInfo(df, "PushedFilters: [binary_col IS NOT NULL, binary_col = X'123456']")
+      checkPushedInfo(df, "PushedFilters: [binary_col IS NOT NULL, binary_col = 0x123456]")
       checkAnswer(df, Row(Array(18, 52, 86)))
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to improve the push down information for binary.


### Why are the changes needed?
Before this PR. the push down information for binary looks like below.
`PushedFilters: [binary_col IS NOT NULL, binary_col = [B@6e5af973]`

After this PR, the push down information will be:
`PushedFilters: [binary_col IS NOT NULL, binary_col = X'123456']`


### Does this PR introduce _any_ user-facing change?
'Yes'.
Fix the bug.


### How was this patch tested?
GA


### Was this patch authored or co-authored using generative AI tooling?
'No'.
