### PR TITLE
[SPARK-50880][SQL] Add a new visitBinaryComparison method to V2ExpressionSQLBuilder

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -98,7 +98,7 @@ public class V2ExpressionSQLBuilder {
         case "ENDS_WITH" -> visitEndsWith(build(e.children()[0]), build(e.children()[1]));
         case "CONTAINS" -> visitContains(build(e.children()[0]), build(e.children()[1]));
         case "=", "<>", "<=>", "<", "<=", ">", ">=" ->
-          visitBinaryComparison(name, inputToSQL(e.children()[0]), inputToSQL(e.children()[1]));
+          visitBinaryComparison(name, e.children()[0], e.children()[1]);
         case "+", "*", "/", "%", "&", "|", "^" ->
           visitBinaryArithmetic(name, inputToSQL(e.children()[0]), inputToSQL(e.children()[1]));
         case "-" -> {
@@ -217,6 +217,10 @@ public class V2ExpressionSQLBuilder {
     } else {
       return build(input);
     }
+  }
+
+  protected String visitBinaryComparison(String name, Expression le, Expression re) {
+    return visitBinaryComparison(name, inputToSQL(le), inputToSQL(re));
   }
 
   protected String visitBinaryComparison(String name, String l, String r) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to add a new `visitBinaryComparison` method to `V2ExpressionSQLBuilder`.


### Why are the changes needed?
The origin `visitBinaryComparison` method is not good for users when the compare predicate is related to the data type.
Such as: Oracle doesn't support predicate '=' for binary and need use `DBMS_LOB.COMPARE` to replace.
So the old `visitBinaryComparison` method is not flexible and introduce some hacker code.


### Does this PR introduce _any_ user-facing change?
'No'.
Just add a new API.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
