### PR TITLE
[SPARK-50882][SQL][TESTS] Skip `TPCDSCollationQueryTestSuite.q22-v2.7` test in GitHub Action CI

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSCollationQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSCollationQueryTestSuite.scala
@@ -251,7 +251,10 @@ class TPCDSCollationQueryTestSuite extends QueryTest with TPCDSBase with SQLQuer
       test(name)(runQuery(queryString, Map.empty, emptyResults.contains(name)))
     }
 
-    tpcdsQueriesV2_7_0.foreach { name =>
+    // Skip q22-v2.7 in GitHub Action environment because it takes 14 minutes.
+    tpcdsQueriesV2_7_0
+      .filterNot(sys.env.contains("GITHUB_ACTIONS") && _.equals("q22"))
+      .foreach { name =>
       val queryString = resourceToString(
         s"tpcds-v2.7.0/$name.sql",
         classLoader = Thread.currentThread().getContextClassLoader)

--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSCollationQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSCollationQueryTestSuite.scala
@@ -252,6 +252,7 @@ class TPCDSCollationQueryTestSuite extends QueryTest with TPCDSBase with SQLQuer
     }
 
     // Skip q22-v2.7 in GitHub Action environment because it takes 14 minutes.
+    // TODO(SPARK-50887) Re-enable q22-v2.7 in GitHub Action environment.
     tpcdsQueriesV2_7_0
       .filterNot(sys.env.contains("GITHUB_ACTIONS") && _.equals("q22"))
       .foreach { name =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to skip `TPCDSCollationQueryTestSuite.q22-v2.7` test in GitHub Action CI environment.

### Why are the changes needed?

`TPCDSCollationQueryTestSuite` was added. However, it almost doubled the TPCDS 1g CI runtime by adding 44 minutes.
- #45739

The root cause is a slowness on `q22-v2.7`. Given that the whole `TPCDSQueryTestSuite` took 6min, 16min, and 17min respectively per conbination, a single query runtime of `q22-v2.7` is relatively too long (14 minutes). Since we know that the collation slowness is not specific this query, we had better skip this test case until we resolve the performance perspective.
<img width="735" alt="Screenshot 2025-01-17 at 11 56 33" src="https://github.com/user-attachments/assets/d90fcd5c-d2c5-4f78-b711-830b6df5b628" />

```
[info] *** Test still running after 2 minutes, 31 seconds: suite name: TPCDSCollationQueryTestSuite, test name: q22-v2.7. 
[info] *** Test still running after 7 minutes, 31 seconds: suite name: TPCDSCollationQueryTestSuite, test name: q22-v2.7. 
[info] *** Test still running after 12 minutes, 31 seconds: suite name: TPCDSCollationQueryTestSuite, test name: q22-v2.7. 
[info] - q22-v2.7 (14 minutes, 18 seconds)
```

### Does this PR introduce _any_ user-facing change?

No, this is a test-only change.

### How was this patch tested?

Pass the CIs. Check the log of this PR.
- https://github.com/dongjoon-hyun/spark/actions/runs/12838889791/job/35805325417
<img width="779" alt="Screenshot 2025-01-17 at 20 35 10" src="https://github.com/user-attachments/assets/edc7e401-f980-4f07-87cd-92d0f70a0b49" />

```
[info] - q20-v2.7 (1 second, 797 milliseconds)
[info] - q22a-v2.7 (1 minute, 10 seconds)
```

### Was this patch authored or co-authored using generative AI tooling?

No.