### PR TITLE
[SPARK-50883][SQL] Support altering multiple columns in the same command

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3938,6 +3938,18 @@
     ],
     "sqlState" : "0A000"
   },
+  "NOT_SUPPORTED_CHANGE_PARENT_CHILD_COLUMN" : {
+    "message" : [
+      "ALTER TABLE ALTER/CHANGE COLUMN is not supported for changing <table>'s parent field <parentField> and child field <childField> in the same command."
+    ],
+    "sqlState" : "0A000"
+  },
+  "NOT_SUPPORTED_CHANGE_SAME_COLUMN" : {
+    "message" : [
+      "ALTER TABLE ALTER/CHANGE COLUMN is not supported for changing <table>'s column <fieldName> multiple times in the same command."
+    ],
+    "sqlState" : "0A000"
+  },
   "NOT_SUPPORTED_COMMAND_FOR_V2_TABLE" : {
     "message" : [
       "<cmd> is not supported for v2 tables."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3938,15 +3938,9 @@
     ],
     "sqlState" : "0A000"
   },
-  "NOT_SUPPORTED_CHANGE_PARENT_CHILD_COLUMN" : {
-    "message" : [
-      "ALTER TABLE ALTER/CHANGE COLUMN is not supported for changing <table>'s parent field <parentField> and child field <childField> in the same command."
-    ],
-    "sqlState" : "0A000"
-  },
   "NOT_SUPPORTED_CHANGE_SAME_COLUMN" : {
     "message" : [
-      "ALTER TABLE ALTER/CHANGE COLUMN is not supported for changing <table>'s column <fieldName> multiple times in the same command."
+      "ALTER TABLE ALTER/CHANGE COLUMN is not supported for changing <table>'s column <fieldName> including its nested fields multiple times in the same command."
     ],
     "sqlState" : "0A000"
   },

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -212,8 +212,7 @@ statement
     | ALTER (TABLE | VIEW) identifierReference
         UNSET TBLPROPERTIES (IF EXISTS)? propertyList                  #unsetTableProperties
     | ALTER TABLE table=identifierReference
-        (ALTER | CHANGE) COLUMN? column=multipartIdentifier
-        alterColumnAction?                                             #alterTableAlterColumn
+        (ALTER | CHANGE) COLUMN? columns=alterColumnSpecList           #alterTableAlterColumn
     | ALTER TABLE table=identifierReference partitionSpec?
         CHANGE COLUMN?
         colName=multipartIdentifier colType colPosition?               #hiveChangeColumn
@@ -1487,6 +1486,14 @@ number
     | MINUS? DOUBLE_LITERAL           #doubleLiteral
     | MINUS? FLOAT_LITERAL            #floatLiteral
     | MINUS? BIGDECIMAL_LITERAL       #bigDecimalLiteral
+    ;
+
+alterColumnSpecList
+    : alterColumnSpec (COMMA alterColumnSpec)*
+    ;
+
+alterColumnSpec
+    : column=multipartIdentifier alterColumnAction?
     ;
 
 alterColumnAction

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3847,24 +3847,29 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         resolved.copyTagsFrom(a)
         resolved
 
-      case a @ AlterColumn(
-          table: ResolvedTable, ResolvedFieldName(path, field), dataType, _, _, position, _) =>
-        val newDataType = dataType.flatMap { dt =>
-          // Hive style syntax provides the column type, even if it may not have changed.
-          val existing = CharVarcharUtils.getRawType(field.metadata).getOrElse(field.dataType)
-          if (existing == dt) None else Some(dt)
+      case a @ AlterColumns(table: ResolvedTable, columns, specs) =>
+        val resolvedSpecs = columns.zip(specs).map {
+          case (ResolvedFieldName(path, field), s @ AlterColumnSpec(dataType, _, _, position, _)) =>
+            val newDataType = dataType.flatMap { dt =>
+              // Hive style syntax provides the column type, even if it may not have changed.
+              val existing = CharVarcharUtils.getRawType(field.metadata).getOrElse(field.dataType)
+              if (existing == dt) None else Some(dt)
+            }
+            val newPosition = position map {
+              case u @ UnresolvedFieldPosition(after: After) =>
+                // TODO: since the field name is already resolved, it's more efficient if
+                //       `ResolvedFieldName` carries the parent struct and we resolve column
+                //       position based on the parent struct, instead of re-resolving the entire
+                //       column path.
+                val resolved = resolveFieldNames(table, path :+ after.column(), u)
+                ResolvedFieldPosition(ColumnPosition.after(resolved.field.name))
+              case u: UnresolvedFieldPosition => ResolvedFieldPosition(u.position)
+              case other => other
+            }
+            s.copy(dataType = newDataType, position = newPosition)
+          case (_, spec) => spec
         }
-        val newPosition = position map {
-          case u @ UnresolvedFieldPosition(after: After) =>
-            // TODO: since the field name is already resolved, it's more efficient if
-            //       `ResolvedFieldName` carries the parent struct and we resolve column position
-            //       based on the parent struct, instead of re-resolving the entire column path.
-            val resolved = resolveFieldNames(table, path :+ after.column(), u)
-            ResolvedFieldPosition(ColumnPosition.after(resolved.field.name))
-          case u: UnresolvedFieldPosition => ResolvedFieldPosition(u.position)
-          case other => other
-        }
-        val resolved = a.copy(dataType = newDataType, position = newPosition)
+        val resolved = a.copy(specs = resolvedSpecs)
         resolved.copyTagsFrom(a)
         resolved
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3847,9 +3847,9 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         resolved.copyTagsFrom(a)
         resolved
 
-      case a @ AlterColumns(table: ResolvedTable, columns, specs) =>
-        val resolvedSpecs = columns.zip(specs).map {
-          case (ResolvedFieldName(path, field), s @ AlterColumnSpec(dataType, _, _, position, _)) =>
+      case a @ AlterColumns(table: ResolvedTable, specs) =>
+        val resolvedSpecs = specs.map {
+          case s @ AlterColumnSpec(ResolvedFieldName(path, field), dataType, _, _, position, _) =>
             val newDataType = dataType.flatMap { dt =>
               // Hive style syntax provides the column type, even if it may not have changed.
               val existing = CharVarcharUtils.getRawType(field.metadata).getOrElse(field.dataType)
@@ -3866,8 +3866,8 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
               case u: UnresolvedFieldPosition => ResolvedFieldPosition(u.position)
               case other => other
             }
-            s.copy(dataType = newDataType, position = newPosition)
-          case (_, spec) => spec
+            s.copy(newDataType = newDataType, newPosition = newPosition)
+          case spec => spec
         }
         val resolved = a.copy(specs = resolvedSpecs)
         resolved.copyTagsFrom(a)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultStringTypes.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, Literal}
-import org.apache.spark.sql.catalyst.plans.logical.{AddColumns, AlterColumn, AlterViewAs, ColumnDefinition, CreateView, LogicalPlan, QualifiedColType, ReplaceColumns, V1CreateTablePlan, V2CreateTablePlan}
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumns, AlterColumns, AlterColumnSpec, AlterViewAs, ColumnDefinition, CreateView, LogicalPlan, QualifiedColType, ReplaceColumns, V1CreateTablePlan, V2CreateTablePlan}
 import org.apache.spark.sql.catalyst.rules.{Rule, RuleExecutor}
 import org.apache.spark.sql.types.{DataType, StringType}
 
@@ -93,7 +93,7 @@ object ResolveDefaultStringTypes extends Rule[LogicalPlan] {
     StringType(conf.defaultStringType.collationId)
 
   private def isDDLCommand(plan: LogicalPlan): Boolean = plan exists {
-    case _: AddColumns | _: ReplaceColumns | _: AlterColumn => true
+    case _: AddColumns | _: ReplaceColumns | _: AlterColumns => true
     case _ => isCreateOrAlterPlan(plan)
   }
 
@@ -115,9 +115,13 @@ object ResolveDefaultStringTypes extends Rule[LogicalPlan] {
       case replaceCols: ReplaceColumns =>
         replaceCols.copy(columnsToAdd = replaceColumnTypes(replaceCols.columnsToAdd, newType))
 
-      case alter: AlterColumn
-        if alter.dataType.isDefined && hasDefaultStringType(alter.dataType.get) =>
-        alter.copy(dataType = Some(replaceDefaultStringType(alter.dataType.get, newType)))
+      case a @ AlterColumns(_, _, specs: Seq[AlterColumnSpec]) =>
+        val newSpecs = specs.map {
+          case spec if spec.dataType.isDefined && hasDefaultStringType(spec.dataType.get) =>
+            spec.copy(dataType = Some(replaceDefaultStringType(spec.dataType.get, newType)))
+          case col => col
+        }
+        a.copy(specs = newSpecs)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultStringTypes.scala
@@ -115,10 +115,10 @@ object ResolveDefaultStringTypes extends Rule[LogicalPlan] {
       case replaceCols: ReplaceColumns =>
         replaceCols.copy(columnsToAdd = replaceColumnTypes(replaceCols.columnsToAdd, newType))
 
-      case a @ AlterColumns(_, _, specs: Seq[AlterColumnSpec]) =>
+      case a @ AlterColumns(_, specs: Seq[AlterColumnSpec]) =>
         val newSpecs = specs.map {
-          case spec if spec.dataType.isDefined && hasDefaultStringType(spec.dataType.get) =>
-            spec.copy(dataType = Some(replaceDefaultStringType(spec.dataType.get, newType)))
+          case spec if spec.newDataType.isDefined && hasDefaultStringType(spec.newDataType.get) =>
+            spec.copy(newDataType = Some(replaceDefaultStringType(spec.newDataType.get, newType)))
           case col => col
         }
         a.copy(specs = newSpecs)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -4909,7 +4909,7 @@ class AstBuilder extends DataTypeAstBuilder
   }
 
   /**
-   * Parse a [[AlterColumn]] command to alter a column's property.
+   * Parse a [[AlterColumns]] command to alter a column's property.
    *
    * For example:
    * {{{
@@ -4919,67 +4919,76 @@ class AstBuilder extends DataTypeAstBuilder
    *   ALTER TABLE table1 ALTER COLUMN a.b.c COMMENT 'new comment'
    *   ALTER TABLE table1 ALTER COLUMN a.b.c FIRST
    *   ALTER TABLE table1 ALTER COLUMN a.b.c AFTER x
+   *   ALTER TABLE table1 ALTER COLUMN a.b.c TYPE bigint, x COMMENT 'new comment', y FIRST
    * }}}
    */
   override def visitAlterTableAlterColumn(
       ctx: AlterTableAlterColumnContext): LogicalPlan = withOrigin(ctx) {
-    val action = ctx.alterColumnAction
     val verb = if (ctx.CHANGE != null) "CHANGE" else "ALTER"
-    if (action == null) {
-      operationNotAllowed(
-        s"ALTER TABLE table $verb COLUMN requires a TYPE, a SET/DROP, a COMMENT, or a FIRST/AFTER",
-        ctx)
-    }
-    val dataType = if (action.dataType != null) {
-      Some(typedVisit[DataType](action.dataType))
-    } else {
-      None
-    }
-    val nullable = if (action.setOrDrop != null) {
-      action.setOrDrop.getType match {
-        case SqlBaseParser.SET => Some(false)
-        case SqlBaseParser.DROP => Some(true)
+    val (columns, specs) = ctx.columns.alterColumnSpec.asScala.map { spec =>
+      val action = spec.alterColumnAction
+      if (action == null) {
+        operationNotAllowed(
+          s"ALTER TABLE table $verb COLUMN requires " +
+          "a TYPE, a SET/DROP, a COMMENT, or a FIRST/AFTER",
+          ctx)
       }
-    } else {
-      None
-    }
-    val comment = if (action.commentSpec != null) {
-      Some(visitCommentSpec(action.commentSpec()))
-    } else {
-      None
-    }
-    val position = if (action.colPosition != null) {
-      Some(UnresolvedFieldPosition(typedVisit[ColumnPosition](action.colPosition)))
-    } else {
-      None
-    }
-    val setDefaultExpression: Option[String] =
-      if (action.defaultExpression != null) {
-        Option(action.defaultExpression()).map(visitDefaultExpression).map(_.originalSQL)
-      } else if (action.dropDefault != null) {
-        Some("")
+      val dataType = if (action.dataType != null) {
+        Some(typedVisit[DataType](action.dataType))
       } else {
         None
       }
-    if (setDefaultExpression.isDefined && !conf.getConf(SQLConf.ENABLE_DEFAULT_COLUMNS)) {
-      throw QueryParsingErrors.defaultColumnNotEnabledError(ctx)
-    }
+      val nullable = if (action.setOrDrop != null) {
+        action.setOrDrop.getType match {
+          case SqlBaseParser.SET => Some(false)
+          case SqlBaseParser.DROP => Some(true)
+        }
+      } else {
+        None
+      }
+      val comment = if (action.commentSpec != null) {
+        Some(visitCommentSpec(action.commentSpec()))
+      } else {
+        None
+      }
+      val position = if (action.colPosition != null) {
+        Some(UnresolvedFieldPosition(typedVisit[ColumnPosition](action.colPosition)))
+      } else {
+        None
+      }
+      val setDefaultExpression: Option[String] =
+        if (action.defaultExpression != null) {
+          Option(action.defaultExpression()).map(visitDefaultExpression).map(_.originalSQL)
+        } else if (action.dropDefault != null) {
+          Some("")
+        } else {
+          None
+        }
+      if (setDefaultExpression.isDefined && !conf.getConf(SQLConf.ENABLE_DEFAULT_COLUMNS)) {
+        throw QueryParsingErrors.defaultColumnNotEnabledError(ctx)
+      }
 
-    assert(Seq(dataType, nullable, comment, position, setDefaultExpression)
-      .count(_.nonEmpty) == 1)
+      assert(Seq(dataType, nullable, comment, position, setDefaultExpression)
+        .count(_.nonEmpty) == 1)
 
-    AlterColumn(
+      (
+        UnresolvedFieldName(typedVisit[Seq[String]](spec.column)),
+        AlterColumnSpec(
+          dataType,
+          nullable,
+          comment,
+          position,
+          setDefaultExpression)
+      )
+    }.unzip
+    AlterColumns(
       createUnresolvedTable(ctx.table, s"ALTER TABLE ... $verb COLUMN"),
-      UnresolvedFieldName(typedVisit[Seq[String]](ctx.column)),
-      dataType = dataType,
-      nullable = nullable,
-      comment = comment,
-      position = position,
-      setDefaultExpression = setDefaultExpression)
+      columns.toSeq,
+      specs.toSeq)
   }
 
   /**
-   * Parse a [[AlterColumn]] command. This is Hive SQL syntax.
+   * Parse a [[AlterColumns]] command. This is Hive SQL syntax.
    *
    * For example:
    * {{{
@@ -5003,15 +5012,16 @@ class AstBuilder extends DataTypeAstBuilder
         Some("please run ALTER COLUMN ... SET/DROP NOT NULL instead"))
     }
 
-    AlterColumn(
+    AlterColumns(
       createUnresolvedTable(ctx.table, "ALTER TABLE ... CHANGE COLUMN"),
-      UnresolvedFieldName(columnNameParts),
-      dataType = Option(ctx.colType().dataType()).map(typedVisit[DataType]),
-      nullable = None,
-      comment = Option(ctx.colType().commentSpec()).map(visitCommentSpec),
-      position = Option(ctx.colPosition).map(
-        pos => UnresolvedFieldPosition(typedVisit[ColumnPosition](pos))),
-      setDefaultExpression = None)
+      Seq(UnresolvedFieldName(columnNameParts)),
+      Seq(AlterColumnSpec(
+        dataType = Option(ctx.colType().dataType()).map(typedVisit[DataType]),
+        nullable = None,
+        comment = Option(ctx.colType().commentSpec()).map(visitCommentSpec),
+        position = Option(ctx.colPosition).map(
+          pos => UnresolvedFieldPosition(typedVisit[ColumnPosition](pos))),
+        setDefaultExpression = None)))
   }
 
   override def visitHiveReplaceColumns(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
@@ -249,7 +249,8 @@ case class AlterColumns(
     }
   }
 
-  override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan = copy(newChild)
+  override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan =
+    copy(table = newChild)
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
@@ -17,9 +17,10 @@
 
 package org.apache.spark.sql.catalyst.plans.logical
 
-import org.apache.spark.sql.catalyst.analysis.{FieldName, FieldPosition, ResolvedFieldName}
+import org.apache.spark.sql.catalyst.analysis.{FieldName, FieldPosition, ResolvedFieldName, UnresolvedException}
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.catalog.ClusterBySpec
+import org.apache.spark.sql.catalyst.expressions.{Expression, Unevaluable}
 import org.apache.spark.sql.catalyst.util.{ResolveDefaultColumns, TypeUtils}
 import org.apache.spark.sql.connector.catalog.{TableCatalog, TableChange}
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -202,43 +203,50 @@ case class RenameColumn(
 }
 
 case class AlterColumnSpec(
-    dataType: Option[DataType],
-    nullable: Option[Boolean],
-    comment: Option[String],
-    position: Option[FieldPosition],
-    setDefaultExpression: Option[String])
+    column: FieldName,
+    newDataType: Option[DataType],
+    newNullability: Option[Boolean],
+    newComment: Option[String],
+    newPosition: Option[FieldPosition],
+    newDefaultExpression: Option[String]) extends Expression with Unevaluable {
+
+  override def children: Seq[Expression] = Seq(column)
+  override def nullable: Boolean = false
+  override def dataType: DataType = throw new UnresolvedException("dataType")
+  override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression =
+    copy(column = newChildren(0).asInstanceOf[FieldName])
+}
 
 /**
  * The logical plan of the ALTER TABLE ... ALTER COLUMN command.
  */
 case class AlterColumns(
     table: LogicalPlan,
-    columns: Seq[FieldName],
     specs: Seq[AlterColumnSpec]) extends AlterTableCommand {
   override def changes: Seq[TableChange] = {
-    assert(columns.size == specs.size)
-    columns.zip(specs).flatMap { case (column, spec) =>
+    specs.flatMap { spec =>
+      val column = spec.column
       require(column.resolved, "FieldName should be resolved before it's converted to TableChange.")
       val colName = column.name.toArray
-      val typeChange = spec.dataType.map { newDataType =>
+      val typeChange = spec.newDataType.map { newDataType =>
         TableChange.updateColumnType(colName, newDataType)
       }
-      val nullabilityChange = spec.nullable.map { nullable =>
+      val nullabilityChange = spec.newNullability.map { nullable =>
         TableChange.updateColumnNullability(colName, nullable)
       }
-      val commentChange = spec.comment.map { newComment =>
+      val commentChange = spec.newComment.map { newComment =>
         TableChange.updateColumnComment(colName, newComment)
       }
-      val positionChange = spec.position.map { newPosition =>
+      val positionChange = spec.newPosition.map { newPosition =>
         require(newPosition.resolved,
           "FieldPosition should be resolved before it's converted to TableChange.")
         TableChange.updateColumnPosition(colName, newPosition.position)
       }
-      val defaultValueChange = spec.setDefaultExpression.map { newDefaultExpression =>
+      val defaultValueChange = spec.newDefaultExpression.map { newDefaultExpression =>
         if (newDefaultExpression.nonEmpty) {
           // SPARK-45075: We call 'ResolveDefaultColumns.analyze' here to make sure that the default
           // value parses successfully, and return an error otherwise
-          val newDataType = spec.dataType.getOrElse(
+          val newDataType = spec.newDataType.getOrElse(
             column.asInstanceOf[ResolvedFieldName].field.dataType)
           ResolveDefaultColumns.analyze(column.name.last, newDataType, newDefaultExpression,
             "ALTER TABLE ALTER COLUMN")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -823,7 +823,7 @@ object MergeIntoTable {
 sealed abstract class MergeAction extends Expression with Unevaluable {
   def condition: Option[Expression]
   override def nullable: Boolean = false
-  override def dataType: DataType = throw new UnresolvedException("nullable")
+  override def dataType: DataType = throw new UnresolvedException("dataType")
   override def children: Seq[Expression] = condition.toSeq
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -1218,14 +1218,15 @@ class DDLParserSuite extends AnalysisTest {
   test("alter table: update column type using ALTER") {
     comparePlans(
       parsePlan("ALTER TABLE table_name ALTER COLUMN a.b.c TYPE bigint"),
-      AlterColumn(
+      AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... ALTER COLUMN"),
-        UnresolvedFieldName(Seq("a", "b", "c")),
-        Some(LongType),
-        None,
-        None,
-        None,
-        None))
+        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
+        Seq(AlterColumnSpec(
+          Some(LongType),
+          None,
+          None,
+          None,
+          None))))
   }
 
   test("alter table: update column type invalid type") {
@@ -1244,40 +1245,43 @@ class DDLParserSuite extends AnalysisTest {
   test("alter table: update column type") {
     comparePlans(
       parsePlan("ALTER TABLE table_name CHANGE COLUMN a.b.c TYPE bigint"),
-      AlterColumn(
+      AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... CHANGE COLUMN"),
-        UnresolvedFieldName(Seq("a", "b", "c")),
-        Some(LongType),
-        None,
-        None,
-        None,
-        None))
+        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
+        Seq(AlterColumnSpec(
+          Some(LongType),
+          None,
+          None,
+          None,
+          None))))
   }
 
   test("alter table: update column comment") {
     comparePlans(
       parsePlan("ALTER TABLE table_name CHANGE COLUMN a.b.c COMMENT 'new comment'"),
-      AlterColumn(
+      AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... CHANGE COLUMN"),
-        UnresolvedFieldName(Seq("a", "b", "c")),
-        None,
-        None,
-        Some("new comment"),
-        None,
-        None))
+        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
+        Seq(AlterColumnSpec(
+          None,
+          None,
+          Some("new comment"),
+          None,
+          None))))
   }
 
   test("alter table: update column position") {
     comparePlans(
       parsePlan("ALTER TABLE table_name CHANGE COLUMN a.b.c FIRST"),
-      AlterColumn(
+      AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... CHANGE COLUMN"),
-        UnresolvedFieldName(Seq("a", "b", "c")),
-        None,
-        None,
-        None,
-        Some(UnresolvedFieldPosition(first())),
-        None))
+        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
+        Seq(AlterColumnSpec(
+          None,
+          None,
+          None,
+          Some(UnresolvedFieldPosition(first())),
+          None))))
   }
 
   test("alter table: multiple property changes are not allowed") {
@@ -1303,25 +1307,69 @@ class DDLParserSuite extends AnalysisTest {
   test("alter table: SET/DROP NOT NULL") {
     comparePlans(
       parsePlan("ALTER TABLE table_name ALTER COLUMN a.b.c SET NOT NULL"),
-      AlterColumn(
+      AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... ALTER COLUMN"),
-        UnresolvedFieldName(Seq("a", "b", "c")),
-        None,
-        Some(false),
-        None,
-        None,
-        None))
+        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
+        Seq(AlterColumnSpec(
+          None,
+          Some(false),
+          None,
+          None,
+          None))))
 
     comparePlans(
       parsePlan("ALTER TABLE table_name ALTER COLUMN a.b.c DROP NOT NULL"),
-      AlterColumn(
+      AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... ALTER COLUMN"),
-        UnresolvedFieldName(Seq("a", "b", "c")),
-        None,
-        Some(true),
-        None,
-        None,
-        None))
+        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
+        Seq(AlterColumnSpec(
+          None,
+          Some(true),
+          None,
+          None,
+          None))))
+  }
+
+  test("alter table: bulk alter column") {
+    comparePlans(
+      parsePlan(
+        """ALTER TABLE table_name ALTER COLUMN
+          | a.b.c SET NOT NULL,
+          | d.e.f COMMENT 'new comment',
+          | x TYPE INT,
+          | y FIRST""".stripMargin),
+      AlterColumns(
+        UnresolvedTable(Seq("table_name"), "ALTER TABLE ... ALTER COLUMN"),
+        Seq(
+          UnresolvedFieldName(Seq("a", "b", "c")),
+          UnresolvedFieldName(Seq("d", "e", "f")),
+          UnresolvedFieldName(Seq("x")),
+          UnresolvedFieldName(Seq("y"))),
+        Seq(
+          AlterColumnSpec(
+            None,
+            Some(false),
+            None,
+            None,
+            None),
+          AlterColumnSpec(
+            None,
+            None,
+            Some("new comment"),
+            None,
+            None),
+          AlterColumnSpec(
+            Some(IntegerType),
+            None,
+            None,
+            None,
+            None),
+          AlterColumnSpec(
+            None,
+            None,
+            None,
+            Some(UnresolvedFieldPosition(first())),
+            None))))
   }
 
   test("alter table: hive style change column") {
@@ -1331,36 +1379,39 @@ class DDLParserSuite extends AnalysisTest {
 
     comparePlans(
       parsePlan(sql1),
-      AlterColumn(
+      AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... CHANGE COLUMN"),
-        UnresolvedFieldName(Seq("a", "b", "c")),
-        Some(IntegerType),
-        None,
-        None,
-        None,
-        None))
+        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
+        Seq(AlterColumnSpec(
+          Some(IntegerType),
+          None,
+          None,
+          None,
+          None))))
 
     comparePlans(
       parsePlan(sql2),
-      AlterColumn(
+      AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... CHANGE COLUMN"),
-        UnresolvedFieldName(Seq("a", "b", "c")),
-        Some(IntegerType),
-        None,
-        Some("new_comment"),
-        None,
-        None))
+        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
+        Seq(AlterColumnSpec(
+          Some(IntegerType),
+          None,
+          Some("new_comment"),
+          None,
+          None))))
 
     comparePlans(
       parsePlan(sql3),
-      AlterColumn(
+      AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... CHANGE COLUMN"),
-        UnresolvedFieldName(Seq("a", "b", "c")),
-        Some(IntegerType),
-        None,
-        None,
-        Some(UnresolvedFieldPosition(after("other_col"))),
-        None))
+        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
+        Seq(AlterColumnSpec(
+          Some(IntegerType),
+          None,
+          None,
+          Some(UnresolvedFieldPosition(after("other_col"))),
+          None))))
 
     // renaming column not supported in hive style ALTER COLUMN.
     val sql4 = "ALTER TABLE table_name CHANGE COLUMN a.b.c new_name INT"
@@ -2676,25 +2727,27 @@ class DDLParserSuite extends AnalysisTest {
         Seq(QualifiedColType(None, "x", IntegerType, false, None, None, Some("42")))))
     comparePlans(
       parsePlan("ALTER TABLE t1 ALTER COLUMN a.b.c SET DEFAULT 42"),
-      AlterColumn(
+      AlterColumns(
         UnresolvedTable(Seq("t1"), "ALTER TABLE ... ALTER COLUMN"),
-        UnresolvedFieldName(Seq("a", "b", "c")),
-        None,
-        None,
-        None,
-        None,
-        Some("42")))
+        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
+        Seq(AlterColumnSpec(
+          None,
+          None,
+          None,
+          None,
+          Some("42")))))
     // It is possible to pass an empty string default value using quotes.
     comparePlans(
       parsePlan("ALTER TABLE t1 ALTER COLUMN a.b.c SET DEFAULT ''"),
-      AlterColumn(
+      AlterColumns(
         UnresolvedTable(Seq("t1"), "ALTER TABLE ... ALTER COLUMN"),
-        UnresolvedFieldName(Seq("a", "b", "c")),
-        None,
-        None,
-        None,
-        None,
-        Some("''")))
+        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
+        Seq(AlterColumnSpec(
+          None,
+          None,
+          None,
+          None,
+          Some("''")))))
     // It is not possible to pass an empty string default value without using quotes.
     // This results in a parsing error.
     val sql1 = "ALTER TABLE t1 ALTER COLUMN a.b.c SET DEFAULT "
@@ -2712,14 +2765,15 @@ class DDLParserSuite extends AnalysisTest {
 
     comparePlans(
       parsePlan("ALTER TABLE t1 ALTER COLUMN a.b.c DROP DEFAULT"),
-      AlterColumn(
+      AlterColumns(
         UnresolvedTable(Seq("t1"), "ALTER TABLE ... ALTER COLUMN"),
-        UnresolvedFieldName(Seq("a", "b", "c")),
-        None,
-        None,
-        None,
-        None,
-        Some("")))
+        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
+        Seq(AlterColumnSpec(
+          None,
+          None,
+          None,
+          None,
+          Some("")))))
     // Make sure that the parser returns an exception when the feature is disabled.
     withSQLConf(SQLConf.ENABLE_DEFAULT_COLUMNS.key -> "false") {
       val sql = "CREATE TABLE my_tab(a INT, b STRING NOT NULL DEFAULT \"abc\") USING parquet"

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -1220,8 +1220,8 @@ class DDLParserSuite extends AnalysisTest {
       parsePlan("ALTER TABLE table_name ALTER COLUMN a.b.c TYPE bigint"),
       AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... ALTER COLUMN"),
-        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
         Seq(AlterColumnSpec(
+          UnresolvedFieldName(Seq("a", "b", "c")),
           Some(LongType),
           None,
           None,
@@ -1247,8 +1247,8 @@ class DDLParserSuite extends AnalysisTest {
       parsePlan("ALTER TABLE table_name CHANGE COLUMN a.b.c TYPE bigint"),
       AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... CHANGE COLUMN"),
-        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
         Seq(AlterColumnSpec(
+          UnresolvedFieldName(Seq("a", "b", "c")),
           Some(LongType),
           None,
           None,
@@ -1261,8 +1261,8 @@ class DDLParserSuite extends AnalysisTest {
       parsePlan("ALTER TABLE table_name CHANGE COLUMN a.b.c COMMENT 'new comment'"),
       AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... CHANGE COLUMN"),
-        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
         Seq(AlterColumnSpec(
+          UnresolvedFieldName(Seq("a", "b", "c")),
           None,
           None,
           Some("new comment"),
@@ -1275,8 +1275,8 @@ class DDLParserSuite extends AnalysisTest {
       parsePlan("ALTER TABLE table_name CHANGE COLUMN a.b.c FIRST"),
       AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... CHANGE COLUMN"),
-        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
         Seq(AlterColumnSpec(
+          UnresolvedFieldName(Seq("a", "b", "c")),
           None,
           None,
           None,
@@ -1309,8 +1309,8 @@ class DDLParserSuite extends AnalysisTest {
       parsePlan("ALTER TABLE table_name ALTER COLUMN a.b.c SET NOT NULL"),
       AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... ALTER COLUMN"),
-        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
         Seq(AlterColumnSpec(
+          UnresolvedFieldName(Seq("a", "b", "c")),
           None,
           Some(false),
           None,
@@ -1321,8 +1321,8 @@ class DDLParserSuite extends AnalysisTest {
       parsePlan("ALTER TABLE table_name ALTER COLUMN a.b.c DROP NOT NULL"),
       AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... ALTER COLUMN"),
-        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
         Seq(AlterColumnSpec(
+          UnresolvedFieldName(Seq("a", "b", "c")),
           None,
           Some(true),
           None,
@@ -1341,30 +1341,29 @@ class DDLParserSuite extends AnalysisTest {
       AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... ALTER COLUMN"),
         Seq(
-          UnresolvedFieldName(Seq("a", "b", "c")),
-          UnresolvedFieldName(Seq("d", "e", "f")),
-          UnresolvedFieldName(Seq("x")),
-          UnresolvedFieldName(Seq("y"))),
-        Seq(
           AlterColumnSpec(
+            UnresolvedFieldName(Seq("a", "b", "c")),
             None,
             Some(false),
             None,
             None,
             None),
           AlterColumnSpec(
+            UnresolvedFieldName(Seq("d", "e", "f")),
             None,
             None,
             Some("new comment"),
             None,
             None),
           AlterColumnSpec(
+            UnresolvedFieldName(Seq("x")),
             Some(IntegerType),
             None,
             None,
             None,
             None),
           AlterColumnSpec(
+            UnresolvedFieldName(Seq("y")),
             None,
             None,
             None,
@@ -1381,8 +1380,8 @@ class DDLParserSuite extends AnalysisTest {
       parsePlan(sql1),
       AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... CHANGE COLUMN"),
-        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
         Seq(AlterColumnSpec(
+          UnresolvedFieldName(Seq("a", "b", "c")),
           Some(IntegerType),
           None,
           None,
@@ -1393,8 +1392,8 @@ class DDLParserSuite extends AnalysisTest {
       parsePlan(sql2),
       AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... CHANGE COLUMN"),
-        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
         Seq(AlterColumnSpec(
+          UnresolvedFieldName(Seq("a", "b", "c")),
           Some(IntegerType),
           None,
           Some("new_comment"),
@@ -1405,8 +1404,8 @@ class DDLParserSuite extends AnalysisTest {
       parsePlan(sql3),
       AlterColumns(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... CHANGE COLUMN"),
-        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
         Seq(AlterColumnSpec(
+          UnresolvedFieldName(Seq("a", "b", "c")),
           Some(IntegerType),
           None,
           None,
@@ -2729,8 +2728,8 @@ class DDLParserSuite extends AnalysisTest {
       parsePlan("ALTER TABLE t1 ALTER COLUMN a.b.c SET DEFAULT 42"),
       AlterColumns(
         UnresolvedTable(Seq("t1"), "ALTER TABLE ... ALTER COLUMN"),
-        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
         Seq(AlterColumnSpec(
+          UnresolvedFieldName(Seq("a", "b", "c")),
           None,
           None,
           None,
@@ -2741,8 +2740,8 @@ class DDLParserSuite extends AnalysisTest {
       parsePlan("ALTER TABLE t1 ALTER COLUMN a.b.c SET DEFAULT ''"),
       AlterColumns(
         UnresolvedTable(Seq("t1"), "ALTER TABLE ... ALTER COLUMN"),
-        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
         Seq(AlterColumnSpec(
+          UnresolvedFieldName(Seq("a", "b", "c")),
           None,
           None,
           None,
@@ -2767,8 +2766,8 @@ class DDLParserSuite extends AnalysisTest {
       parsePlan("ALTER TABLE t1 ALTER COLUMN a.b.c DROP DEFAULT"),
       AlterColumns(
         UnresolvedTable(Seq("t1"), "ALTER TABLE ... ALTER COLUMN"),
-        Seq(UnresolvedFieldName(Seq("a", "b", "c"))),
         Seq(AlterColumnSpec(
+          UnresolvedFieldName(Seq("a", "b", "c")),
           None,
           None,
           None,

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ReplaceCharWithVarchar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ReplaceCharWithVarchar.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.plans.logical.{AddColumns, AlterColumn, ColumnDefinition, CreateTable, LogicalPlan, ReplaceColumns, ReplaceTable}
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumns, AlterColumns, ColumnDefinition, CreateTable, LogicalPlan, ReplaceColumns, ReplaceTable}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.execution.command.{AlterTableAddColumnsCommand, AlterTableChangeColumnCommand, CreateDataSourceTableCommand, CreateTableCommand}
@@ -39,8 +39,10 @@ object ReplaceCharWithVarchar extends Rule[LogicalPlan] {
         cmd.copy(columnsToAdd = cmd.columnsToAdd.map { col =>
           col.copy(dataType = CharVarcharUtils.replaceCharWithVarchar(col.dataType))
         })
-      case cmd: AlterColumn =>
-        cmd.copy(dataType = cmd.dataType.map(CharVarcharUtils.replaceCharWithVarchar))
+      case cmd: AlterColumns =>
+        cmd.copy(specs = cmd.specs.map { spec =>
+          spec.copy(dataType = spec.dataType.map(CharVarcharUtils.replaceCharWithVarchar))
+        })
       case cmd: ReplaceColumns =>
         cmd.copy(columnsToAdd = cmd.columnsToAdd.map { col =>
           col.copy(dataType = CharVarcharUtils.replaceCharWithVarchar(col.dataType))

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ReplaceCharWithVarchar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ReplaceCharWithVarchar.scala
@@ -41,7 +41,7 @@ object ReplaceCharWithVarchar extends Rule[LogicalPlan] {
         })
       case cmd: AlterColumns =>
         cmd.copy(specs = cmd.specs.map { spec =>
-          spec.copy(dataType = spec.dataType.map(CharVarcharUtils.replaceCharWithVarchar))
+          spec.copy(newDataType = spec.newDataType.map(CharVarcharUtils.replaceCharWithVarchar))
         })
       case cmd: ReplaceColumns =>
         cmd.copy(columnsToAdd = cmd.columnsToAdd.map { col =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -74,9 +74,15 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
     case ReplaceColumns(ResolvedV1TableIdentifier(ident), _) =>
       throw QueryCompilationErrors.unsupportedTableOperationError(ident, "REPLACE COLUMNS")
 
-    case a @ AlterColumn(ResolvedTable(catalog, ident, table: V1Table, _), _, _, _, _, _, _)
+    case AlterColumns(ResolvedTable(catalog, ident, table: V1Table, _), columns, specs)
         if supportsV1Command(catalog) =>
-      if (a.column.name.length > 1) {
+      if (columns.size > 1) {
+        throw QueryCompilationErrors.unsupportedTableOperationError(
+          catalog, ident, "ALTER COLUMN in bulk")
+      }
+      val column = columns.head
+      val a = specs.head
+      if (column.name.length > 1) {
         throw QueryCompilationErrors.unsupportedTableOperationError(
           catalog, ident, "ALTER COLUMN with qualified column")
       }
@@ -91,7 +97,7 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
       val builder = new MetadataBuilder
       // Add comment to metadata
       a.comment.map(c => builder.putString("comment", c))
-      val colName = a.column.name(0)
+      val colName = column.name.head
       val dataType = a.dataType.getOrElse {
         table.schema.findNestedField(Seq(colName), resolver = conf.resolver)
           .map {
@@ -101,7 +107,7 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
           }
           .getOrElse {
             throw QueryCompilationErrors.unresolvedColumnError(
-              toSQLId(a.column.name), table.schema.fieldNames)
+              toSQLId(column.name), table.schema.fieldNames)
           }
       }
       // Add the current default column value string (if any) to the column metadata.

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -74,31 +74,30 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
     case ReplaceColumns(ResolvedV1TableIdentifier(ident), _) =>
       throw QueryCompilationErrors.unsupportedTableOperationError(ident, "REPLACE COLUMNS")
 
-    case AlterColumns(ResolvedTable(catalog, ident, table: V1Table, _), columns, specs)
+    case AlterColumns(ResolvedTable(catalog, ident, table: V1Table, _), specs)
         if supportsV1Command(catalog) =>
-      if (columns.size > 1) {
+      if (specs.size > 1) {
         throw QueryCompilationErrors.unsupportedTableOperationError(
           catalog, ident, "ALTER COLUMN in bulk")
       }
-      val column = columns.head
-      val a = specs.head
-      if (column.name.length > 1) {
+      val s = specs.head
+      if (s.column.name.length > 1) {
         throw QueryCompilationErrors.unsupportedTableOperationError(
           catalog, ident, "ALTER COLUMN with qualified column")
       }
-      if (a.nullable.isDefined) {
+      if (s.newNullability.isDefined) {
         throw QueryCompilationErrors.unsupportedTableOperationError(
           catalog, ident, "ALTER COLUMN ... SET NOT NULL")
       }
-      if (a.position.isDefined) {
+      if (s.newPosition.isDefined) {
         throw QueryCompilationErrors.unsupportedTableOperationError(
           catalog, ident, "ALTER COLUMN ... FIRST | AFTER")
       }
       val builder = new MetadataBuilder
       // Add comment to metadata
-      a.comment.map(c => builder.putString("comment", c))
-      val colName = column.name.head
-      val dataType = a.dataType.getOrElse {
+      s.newComment.map(c => builder.putString("comment", c))
+      val colName = s.column.name.head
+      val dataType = s.newDataType.getOrElse {
         table.schema.findNestedField(Seq(colName), resolver = conf.resolver)
           .map {
             case (_, StructField(_, st: StringType, _, metadata)) =>
@@ -107,11 +106,11 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
           }
           .getOrElse {
             throw QueryCompilationErrors.unresolvedColumnError(
-              toSQLId(column.name), table.schema.fieldNames)
+              toSQLId(s.column.name), table.schema.fieldNames)
           }
       }
       // Add the current default column value string (if any) to the column metadata.
-      a.setDefaultExpression.map { c => builder.putString(CURRENT_DEFAULT_COLUMN_METADATA_KEY, c) }
+      s.newDefaultExpression.map { c => builder.putString(CURRENT_DEFAULT_COLUMN_METADATA_KEY, c) }
       val newColumn = StructField(
         colName,
         dataType,

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTableTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTableTests.scala
@@ -24,8 +24,8 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.util.quoteIdentifier
+import org.apache.spark.sql.connector.catalog.{Column, Table}
 import org.apache.spark.sql.connector.catalog.CatalogV2Util.withDefaultOwnership
-import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.errors.QueryErrorsBase
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -1014,6 +1014,85 @@ trait AlterTableTests extends SharedSparkSession with QueryErrorsBase {
           "objectName" -> "`point`.`x`",
           "proposal" -> "`id`"),
         context = ExpectedContext(fragment = sqlText, start = 0, stop = sqlText.length - 1))
+    }
+  }
+
+  test("AlterTable: alter multiple columns/fields in the same command") {
+    withSQLConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS.key -> s"$v2Format, ") {
+      val t = fullTableName("table_name")
+      withTable(t) {
+        sql(s"""CREATE TABLE $t (
+             |  id int,
+             |  data string,
+             |  ts timestamp NOT NULL,
+             |  points array<struct<x: double, y: double>>) USING $v2Format""".stripMargin)
+        sql(s"""ALTER TABLE $t ALTER COLUMN
+             |  id TYPE bigint,
+             |  data FIRST,
+             |  ts DROP NOT NULL,
+             |  points.element.x SET DEFAULT (1.0 + 2.0),
+             |  points.element.y COMMENT 'comment on y'""".stripMargin)
+
+        val table = getTableMetadata(t)
+
+        assert(table.name === t)
+        assert(
+          table.columns() === Array(
+            Column.create("data", StringType),
+            Column.create("id", LongType),
+            Column.create("ts", TimestampType, true),
+            Column.create("points", ArrayType(
+              StructType(
+                Seq(
+                  StructField("x", DoubleType).withCurrentDefaultValue("(1.0 + 2.0)"),
+                  StructField("y", DoubleType).withComment("comment on y")
+                ))))))
+      }
+    }
+  }
+
+  test("AlterTable: cannot alter the same column in the same command") {
+    val t = fullTableName("table_name")
+    withTable(t) {
+      sql(s"CREATE TABLE $t (id int, data string, ts timestamp) USING $v2Format")
+      val sqlText = s"ALTER TABLE $t ALTER COLUMN id TYPE bigint, id COMMENT 'id', data FIRST"
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql(sqlText)
+        },
+        condition = "NOT_SUPPORTED_CHANGE_SAME_COLUMN",
+        parameters = Map(
+          "table" -> s"${toSQLId(prependCatalogName(t))}",
+          "fieldName" -> "`id`"),
+        context = ExpectedContext(fragment = sqlText, start = 0, stop = sqlText.length - 1)
+      )
+    }
+  }
+
+  test("AlterTable: cannot alter parent and child fields in the same command") {
+    withSQLConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS.key -> s"$v2Format, ") {
+      val t = fullTableName("table_name")
+      withTable(t) {
+        sql(s"CREATE TABLE $t (parent array<struct<child: int>>) USING $v2Format")
+        val sqlText = s"""ALTER TABLE $t ALTER COLUMN
+                         | parent.element.child TYPE string,
+                         | parent SET DEFAULT array(struct(1000))""".stripMargin
+
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql(sqlText)
+          },
+          condition = "NOT_SUPPORTED_CHANGE_PARENT_CHILD_COLUMN",
+          parameters = Map(
+            "table" -> s"${toSQLId(prependCatalogName(t))}",
+            "parentField" -> "`parent`",
+            "childField" -> "`parent`.`element`.`child`"),
+          context = ExpectedContext(
+            fragment = sqlText,
+            start = 0,
+            stop = sqlText.length - 1)
+        )
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTableTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTableTests.scala
@@ -1082,11 +1082,10 @@ trait AlterTableTests extends SharedSparkSession with QueryErrorsBase {
           exception = intercept[AnalysisException] {
             sql(sqlText)
           },
-          condition = "NOT_SUPPORTED_CHANGE_PARENT_CHILD_COLUMN",
+          condition = "NOT_SUPPORTED_CHANGE_SAME_COLUMN",
           parameters = Map(
             "table" -> s"${toSQLId(prependCatalogName(t))}",
-            "parentField" -> "`parent`",
-            "childField" -> "`parent`.`element`.`child`"),
+            "fieldName" -> "`parent`"),
           context = ExpectedContext(
             fragment = sqlText,
             start = 0,

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/V2CommandsCaseSensitivitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/V2CommandsCaseSensitivitySuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector
 
 import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, CreateTablePartitioningValidationSuite, ResolvedTable, TestRelation2, TestTable2, UnresolvedFieldName, UnresolvedFieldPosition, UnresolvedIdentifier}
-import org.apache.spark.sql.catalyst.plans.logical.{AddColumns, AlterColumn, AlterTableCommand, CreateTableAsSelect, DropColumns, LogicalPlan, OptionList, QualifiedColType, RenameColumn, ReplaceColumns, ReplaceTableAsSelect, UnresolvedTableSpec}
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumns, AlterColumns, AlterColumnSpec, AlterTableCommand, CreateTableAsSelect, DropColumns, LogicalPlan, OptionList, QualifiedColType, RenameColumn, ReplaceColumns, ReplaceTableAsSelect, UnresolvedTableSpec}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.connector.catalog.Identifier
@@ -368,8 +368,8 @@ class V2CommandsCaseSensitivitySuite
   test("AlterTable: drop column nullability resolution") {
     Seq(Array("ID"), Array("point", "X"), Array("POINT", "X"), Array("POINT", "x")).foreach { ref =>
       alterTableTest(
-        AlterColumn(table, UnresolvedFieldName(ref.toImmutableArraySeq),
-          None, Some(true), None, None, None),
+        AlterColumns(table, Seq(UnresolvedFieldName(ref.toImmutableArraySeq)),
+          Seq(AlterColumnSpec(None, Some(true), None, None, None))),
         expectedErrorCondition = "UNRESOLVED_COLUMN.WITH_SUGGESTION",
         expectedMessageParameters = Map(
           "objectName" -> s"${toSQLId(ref.toImmutableArraySeq)}",
@@ -381,8 +381,8 @@ class V2CommandsCaseSensitivitySuite
   test("AlterTable: change column type resolution") {
     Seq(Array("ID"), Array("point", "X"), Array("POINT", "X"), Array("POINT", "x")).foreach { ref =>
       alterTableTest(
-        AlterColumn(table, UnresolvedFieldName(ref.toImmutableArraySeq),
-          Some(StringType), None, None, None, None),
+        AlterColumns(table, Seq(UnresolvedFieldName(ref.toImmutableArraySeq)),
+          Seq(AlterColumnSpec(Some(StringType), None, None, None, None))),
         expectedErrorCondition = "UNRESOLVED_COLUMN.WITH_SUGGESTION",
         expectedMessageParameters = Map(
           "objectName" -> s"${toSQLId(ref.toImmutableArraySeq)}",
@@ -394,8 +394,8 @@ class V2CommandsCaseSensitivitySuite
   test("AlterTable: change column comment resolution") {
     Seq(Array("ID"), Array("point", "X"), Array("POINT", "X"), Array("POINT", "x")).foreach { ref =>
       alterTableTest(
-        AlterColumn(table, UnresolvedFieldName(ref.toImmutableArraySeq),
-          None, None, Some("comment"), None, None),
+        AlterColumns(table, Seq(UnresolvedFieldName(ref.toImmutableArraySeq)),
+          Seq(AlterColumnSpec(None, None, Some("comment"), None, None))),
         expectedErrorCondition = "UNRESOLVED_COLUMN.WITH_SUGGESTION",
         expectedMessageParameters = Map(
           "objectName" -> s"${toSQLId(ref.toImmutableArraySeq)}",

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/V2CommandsCaseSensitivitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/V2CommandsCaseSensitivitySuite.scala
@@ -368,8 +368,8 @@ class V2CommandsCaseSensitivitySuite
   test("AlterTable: drop column nullability resolution") {
     Seq(Array("ID"), Array("point", "X"), Array("POINT", "X"), Array("POINT", "x")).foreach { ref =>
       alterTableTest(
-        AlterColumns(table, Seq(UnresolvedFieldName(ref.toImmutableArraySeq)),
-          Seq(AlterColumnSpec(None, Some(true), None, None, None))),
+        AlterColumns(table, Seq(AlterColumnSpec(
+          UnresolvedFieldName(ref.toImmutableArraySeq), None, Some(true), None, None, None))),
         expectedErrorCondition = "UNRESOLVED_COLUMN.WITH_SUGGESTION",
         expectedMessageParameters = Map(
           "objectName" -> s"${toSQLId(ref.toImmutableArraySeq)}",
@@ -381,8 +381,8 @@ class V2CommandsCaseSensitivitySuite
   test("AlterTable: change column type resolution") {
     Seq(Array("ID"), Array("point", "X"), Array("POINT", "X"), Array("POINT", "x")).foreach { ref =>
       alterTableTest(
-        AlterColumns(table, Seq(UnresolvedFieldName(ref.toImmutableArraySeq)),
-          Seq(AlterColumnSpec(Some(StringType), None, None, None, None))),
+        AlterColumns(table, Seq(AlterColumnSpec(
+          UnresolvedFieldName(ref.toImmutableArraySeq), Some(StringType), None, None, None, None))),
         expectedErrorCondition = "UNRESOLVED_COLUMN.WITH_SUGGESTION",
         expectedMessageParameters = Map(
           "objectName" -> s"${toSQLId(ref.toImmutableArraySeq)}",
@@ -394,8 +394,8 @@ class V2CommandsCaseSensitivitySuite
   test("AlterTable: change column comment resolution") {
     Seq(Array("ID"), Array("point", "X"), Array("POINT", "X"), Array("POINT", "x")).foreach { ref =>
       alterTableTest(
-        AlterColumns(table, Seq(UnresolvedFieldName(ref.toImmutableArraySeq)),
-          Seq(AlterColumnSpec(None, None, Some("comment"), None, None))),
+        AlterColumns(table, Seq(AlterColumnSpec(
+          UnresolvedFieldName(ref.toImmutableArraySeq), None, None, Some("comment"), None, None))),
         expectedErrorCondition = "UNRESOLVED_COLUMN.WITH_SUGGESTION",
         expectedMessageParameters = Map(
           "objectName" -> s"${toSQLId(ref.toImmutableArraySeq)}",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat, 
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Cast, EqualTo, Expression, InSubquery, IntegerLiteral, ListQuery, Literal, StringLiteral}
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.parser.ParseException
-import org.apache.spark.sql.catalyst.plans.logical.{AlterColumn, AnalysisOnlyCommand, AppendData, Assignment, CreateTable, CreateTableAsSelect, DeleteAction, DeleteFromTable, DescribeRelation, DropTable, InsertAction, InsertIntoStatement, LocalRelation, LogicalPlan, MergeIntoTable, OneRowRelation, OverwriteByExpression, OverwritePartitionsDynamic, Project, SetTableLocation, SetTableProperties, ShowTableProperties, SubqueryAlias, UnsetTableProperties, UpdateAction, UpdateTable}
+import org.apache.spark.sql.catalyst.plans.logical.{AlterColumns, AlterColumnSpec, AnalysisOnlyCommand, AppendData, Assignment, CreateTable, CreateTableAsSelect, DeleteAction, DeleteFromTable, DescribeRelation, DropTable, InsertAction, InsertIntoStatement, LocalRelation, LogicalPlan, MergeIntoTable, OneRowRelation, OverwriteByExpression, OverwritePartitionsDynamic, Project, SetTableLocation, SetTableProperties, ShowTableProperties, SubqueryAlias, UnsetTableProperties, UpdateAction, UpdateTable}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLId
 import org.apache.spark.sql.connector.FakeV2Provider
@@ -1317,6 +1317,10 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
       case (tblName, useV1Command) =>
         val sql1 = s"ALTER TABLE $tblName ALTER COLUMN i TYPE bigint"
         val sql2 = s"ALTER TABLE $tblName ALTER COLUMN i COMMENT 'new comment'"
+        val sql3 =
+          s"""ALTER TABLE $tblName ALTER COLUMN
+             |  i TYPE bigint,
+             |  s SET DEFAULT 'value'""".stripMargin
 
         val parsed1 = parseAndResolve(sql1)
         val parsed2 = parseAndResolve(sql2)
@@ -1333,21 +1337,30 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
           comparePlans(parsed1, expected1)
           comparePlans(parsed2, expected2)
 
-          val sql3 = s"ALTER TABLE $tblName ALTER COLUMN j COMMENT 'new comment'"
           checkError(
             exception = intercept[AnalysisException] {
               parseAndResolve(sql3)
+            },
+            condition = "UNSUPPORTED_FEATURE.TABLE_OPERATION",
+            sqlState = "0A000",
+            parameters = Map("tableName" -> "`spark_catalog`.`default`.`v1Table`",
+              "operation" -> "ALTER COLUMN in bulk"))
+
+          val sql4 = s"ALTER TABLE $tblName ALTER COLUMN j COMMENT 'new comment'"
+          checkError(
+            exception = intercept[AnalysisException] {
+              parseAndResolve(sql4)
             },
             condition = "UNRESOLVED_COLUMN.WITH_SUGGESTION",
             sqlState = "42703",
             parameters = Map(
               "objectName" -> "`j`",
               "proposal" -> "`i`, `s`, `point`"),
-            context = ExpectedContext(fragment = sql3, start = 0, stop = 55))
+            context = ExpectedContext(fragment = sql4, start = 0, stop = 55))
 
-          val sql4 = s"ALTER TABLE $tblName ALTER COLUMN point.x TYPE bigint"
+          val sql5 = s"ALTER TABLE $tblName ALTER COLUMN point.x TYPE bigint"
           val e2 = intercept[AnalysisException] {
-            parseAndResolve(sql4)
+            parseAndResolve(sql5)
           }
           checkError(
             exception = e2,
@@ -1366,28 +1379,45 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
               "operation" -> "ALTER COLUMN ... SET NOT NULL"))
         } else {
           parsed1 match {
-            case AlterColumn(
+            case AlterColumns(
                 _: ResolvedTable,
-                column: ResolvedFieldName,
-                Some(LongType),
-                None,
-                None,
-                None,
-                None) =>
+                Seq(column: ResolvedFieldName),
+                Seq(AlterColumnSpec(
+                  Some(LongType),
+                  None,
+                  None,
+                  None,
+                  None))) =>
               assert(column.name == Seq("i"))
             case _ => fail("expect AlterTableAlterColumn")
           }
 
           parsed2 match {
-            case AlterColumn(
+            case AlterColumns(
                 _: ResolvedTable,
-                column: ResolvedFieldName,
-                None,
-                None,
-                Some("new comment"),
-                None,
-                None) =>
+                Seq(column: ResolvedFieldName),
+                Seq(AlterColumnSpec(
+                  None,
+                  None,
+                  Some("new comment"),
+                  None,
+                  None))) =>
               assert(column.name == Seq("i"))
+            case _ => fail("expect AlterTableAlterColumn")
+          }
+
+          val parsed3 = parseAndResolve(sql3)
+          parsed3 match {
+            case AlterColumns(
+                _: ResolvedTable,
+                Seq(
+                  column1: ResolvedFieldName,
+                  column2: ResolvedFieldName),
+                Seq(
+                  AlterColumnSpec(Some(LongType), None, None, None, None),
+                  AlterColumnSpec(None, None, None, None, Some("'value'")))) =>
+              assert(column1.name == Seq("i"))
+              assert(column2.name == Seq("s"))
             case _ => fail("expect AlterTableAlterColumn")
           }
         }
@@ -1445,16 +1475,19 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
   test("alter table: hive style change column") {
     Seq("v2Table", "testcat.tab").foreach { tblName =>
       parseAndResolve(s"ALTER TABLE $tblName CHANGE COLUMN i i int COMMENT 'an index'") match {
-        case AlterColumn(
-            _: ResolvedTable, _: ResolvedFieldName, None, None, Some(comment), None, None) =>
+        case AlterColumns(
+            _: ResolvedTable,
+            Seq(_: ResolvedFieldName),
+            Seq(AlterColumnSpec(None, None, Some(comment), None, None))) =>
           assert(comment == "an index")
         case _ => fail("expect AlterTableAlterColumn with comment change only")
       }
 
       parseAndResolve(s"ALTER TABLE $tblName CHANGE COLUMN i i long COMMENT 'an index'") match {
-        case AlterColumn(
-            _: ResolvedTable, _: ResolvedFieldName, Some(dataType), None, Some(comment), None,
-            None) =>
+        case AlterColumns(
+            _: ResolvedTable,
+            Seq(_: ResolvedFieldName),
+            Seq(AlterColumnSpec(Some(dataType), None, Some(comment), None, None))) =>
           assert(comment == "an index")
           assert(dataType == LongType)
         case _ => fail("expect AlterTableAlterColumn with type and comment changes")
@@ -1489,14 +1522,14 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
       val catalog = if (isSessionCatalog) v2SessionCatalog else testCat
       val tableIdent = if (isSessionCatalog) "v2Table" else "tab"
       parsed match {
-        case AlterColumn(r: ResolvedTable, _, _, _, _, _, _) =>
+        case AlterColumns(r: ResolvedTable, _, _) =>
           assert(r.catalog == catalog)
           assert(r.identifier.name() == tableIdent)
         case Project(_, AsDataSourceV2Relation(r)) =>
-          assert(r.catalog.exists(_ == catalog))
+          assert(r.catalog.contains(catalog))
           assert(r.identifier.exists(_.name() == tableIdent))
         case AppendData(r: DataSourceV2Relation, _, _, _, _, _) =>
-          assert(r.catalog.exists(_ == catalog))
+          assert(r.catalog.contains(catalog))
           assert(r.identifier.exists(_.name() == tableIdent))
         case DescribeRelation(r: ResolvedTable, _, _, _) =>
           assert(r.catalog == catalog)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -1381,8 +1381,8 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
           parsed1 match {
             case AlterColumns(
                 _: ResolvedTable,
-                Seq(column: ResolvedFieldName),
                 Seq(AlterColumnSpec(
+                  column: ResolvedFieldName,
                   Some(LongType),
                   None,
                   None,
@@ -1395,8 +1395,8 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
           parsed2 match {
             case AlterColumns(
                 _: ResolvedTable,
-                Seq(column: ResolvedFieldName),
                 Seq(AlterColumnSpec(
+                  column: ResolvedFieldName,
                   None,
                   None,
                   Some("new comment"),
@@ -1411,11 +1411,20 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
             case AlterColumns(
                 _: ResolvedTable,
                 Seq(
-                  column1: ResolvedFieldName,
-                  column2: ResolvedFieldName),
-                Seq(
-                  AlterColumnSpec(Some(LongType), None, None, None, None),
-                  AlterColumnSpec(None, None, None, None, Some("'value'")))) =>
+                  AlterColumnSpec(
+                    column1: ResolvedFieldName,
+                    Some(LongType),
+                    None,
+                    None,
+                    None,
+                    None),
+                  AlterColumnSpec(
+                    column2: ResolvedFieldName,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some("'value'")))) =>
               assert(column1.name == Seq("i"))
               assert(column2.name == Seq("s"))
             case _ => fail("expect AlterTableAlterColumn")
@@ -1477,8 +1486,13 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
       parseAndResolve(s"ALTER TABLE $tblName CHANGE COLUMN i i int COMMENT 'an index'") match {
         case AlterColumns(
             _: ResolvedTable,
-            Seq(_: ResolvedFieldName),
-            Seq(AlterColumnSpec(None, None, Some(comment), None, None))) =>
+            Seq(AlterColumnSpec(
+              _: ResolvedFieldName,
+              None,
+              None,
+              Some(comment),
+              None,
+              None))) =>
           assert(comment == "an index")
         case _ => fail("expect AlterTableAlterColumn with comment change only")
       }
@@ -1486,8 +1500,13 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
       parseAndResolve(s"ALTER TABLE $tblName CHANGE COLUMN i i long COMMENT 'an index'") match {
         case AlterColumns(
             _: ResolvedTable,
-            Seq(_: ResolvedFieldName),
-            Seq(AlterColumnSpec(Some(dataType), None, Some(comment), None, None))) =>
+            Seq(AlterColumnSpec(
+              _: ResolvedFieldName,
+              Some(dataType),
+              None,
+              Some(comment),
+              None,
+              None))) =>
           assert(comment == "an index")
           assert(dataType == LongType)
         case _ => fail("expect AlterTableAlterColumn with type and comment changes")
@@ -1522,7 +1541,7 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
       val catalog = if (isSessionCatalog) v2SessionCatalog else testCat
       val tableIdent = if (isSessionCatalog) "v2Table" else "tab"
       parsed match {
-        case AlterColumns(r: ResolvedTable, _, _) =>
+        case AlterColumns(r: ResolvedTable, _) =>
           assert(r.catalog == catalog)
           assert(r.identifier.name() == tableIdent)
         case Project(_, AsDataSourceV2Relation(r)) =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

We propose the following new syntax for altering multiple columns at the same time:

```
ALTER TABLE table_name ALTER COLUMN { 
  { column_identifier | field_name }
  { COMMENT comment |
  { FIRST | AFTER identifier } |
  { SET | DROP } NOT NULL |
  TYPE data_type |
  SET DEFAULT clause |
  DROP DEFAULT }
} [, ...]  
```

For example:

```
ALTER TABLE test_table ALTER COLUMN
  a COMMENT "new comment",
  b TYPE BIGINT,
  x.y.z FIRST
```

This new syntax is backward compatible with the current syntax. To bound the complexity of the initial support of this syntax we place the following restrictions:

+ Altering the same column multiple times is not allowed
+ Altering a parent and a child column (for nested data type) is not allowed.
+ Altering v1 tables with this new syntax is not allowed.

In terms of implementation, we modify the current `AlterColumn` logical plan to be `AlterColumns` that can take in multiple columns and `AlterColumnSpec`s. 

All `AlterColumnSpec`s are checked during analyzing phase, so if one of them is invalid (e.g., non-existent column, wrong type conversion, etc), the entire command will fail.

The `AlterColumnSpec`s are transformed into `TableChange`s, which are passed to the `TableCatalog::alterTable` method. Therefore, the semantics of this new command (atomic vs non-atomic) depends on the implementation of this method.

The `V2SessionCatalog::alterTable` currently applies all table changes to the catalog table and then send to the catalog in one request. As a result, column changes are by default applied to the catalog (HMS) atomically: either all changes are made or none are.

For example, the above command produces the following plans:

```
== Physical Plan ==
AlterTable org.apache.spark.sql.delta.catalog.DeltaCatalog@6d89c923, default.test_table, [org.apache.spark.sql.connector.catalog.TableChange$UpdateColumnComment@ff58ec42, org.apache.spark.sql.connector.catalog.TableChange$UpdateColumnType@7e7c730c, org.apache.spark.sql.connector.catalog.TableChange$UpdateColumnPosition@bc842915]

== Parsed Logical Plan ==
'AlterColumns [unresolvedfieldname(a), unresolvedfieldname(b), unresolvedfieldname(x, y, z)], [AlterColumnSpec(None,None,Some(new comment),None,None), AlterColumnSpec(Some(LongType),None,None,None,None), AlterColumnSpec(None,None,None,Some(unresolvedfieldposition(FIRST)),None)]
+- 'UnresolvedTable [test_table], ALTER TABLE ... ALTER COLUMN

== Analyzed Logical Plan ==
AlterColumns [resolvedfieldname(StructField(a,IntegerType,true)), resolvedfieldname(StructField(b,IntegerType,true)), resolvedfieldname(x, y, StructField(z,IntegerType,true))], [AlterColumnSpec(None,None,Some(new comment),None,None), AlterColumnSpec(Some(LongType),None,None,None,None), AlterColumnSpec(None,None,None,Some(resolvedfieldposition(FIRST)),None)]
+- ResolvedTable org.apache.spark.sql.delta.catalog.DeltaCatalog@6d89c923, default.test_table, DeltaTableV2(...)),Some(default.test_table),None,Map()), [a#163, b#164, x#165]

== Physical Plan ==
AlterTable org.apache.spark.sql.delta.catalog.DeltaCatalog@6d89c923, default.test_table, [org.apache.spark.sql.connector.catalog.TableChange$UpdateColumnComment@ff58ec42, org.apache.spark.sql.connector.catalog.TableChange$UpdateColumnType@7e7c730c, org.apache.spark.sql.connector.catalog.TableChange$UpdateColumnPosition@bc842915]
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The current ALTER TABLE ... ALTER COLUMN syntax allows altering only one column at a time. For a large table with many columns, a command must be run for each column, which can be slow due to the repeated preprocessing and I/O costs. A new syntax that enables specifying multiple columns could allow these costs to be shared across multiple column changes.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No