### PR TITLE
[SPARK-50885][BUILD] Change to use `SbtPomKeys` to obtain `io.grpc.version` in `SparkBuild.scala` 

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -90,8 +90,6 @@ object BuildCommons {
   // Google Protobuf version used for generating the protobuf.
   // SPARK-41247: needs to be consistent with `protobuf.version` in `pom.xml`.
   val protoVersion = "4.29.3"
-  // GRPC version used for Spark Connect.
-  val grpcVersion = "1.67.1"
 }
 
 object SparkBuild extends PomBuild {
@@ -646,8 +644,11 @@ object SparkConnectCommon {
       val guavaFailureaccessVersion =
         SbtPomKeys.effectivePom.value.getProperties.get(
           "guava.failureaccess.version").asInstanceOf[String]
+      val grpcVersion =
+        SbtPomKeys.effectivePom.value.getProperties.get(
+          "io.grpc.version").asInstanceOf[String]
       Seq(
-        "io.grpc" % "protoc-gen-grpc-java" % BuildCommons.grpcVersion asProtocPlugin(),
+        "io.grpc" % "protoc-gen-grpc-java" % grpcVersion asProtocPlugin(),
         "com.google.guava" % "guava" % guavaVersion,
         "com.google.guava" % "failureaccess" % guavaFailureaccessVersion,
         "com.google.protobuf" % "protobuf-java" % protoVersion % "protobuf"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr chanage to use 

```
SbtPomKeys.effectivePom.value.getProperties.get("io.grpc.version").asInstanceOf[String]
```

to get `io.grpc.version`, so that when upgrading gRPC in the future, there will be no need to modify both `pom.xml` and `SparkBuild.scala` simultaneously.

On the other hand, this PR moves the version retrieval from `BuildCommons` to `SparkConnectCommon`, because currently only `SparkConnectCommon` requires the definition of this version.

### Why are the changes needed?
Simplify the management of the `grpcVersion`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
