### PR TITLE
[SPARK-50890][PYTHON][TESTS][CONNECT] Skip test_take in Spark Connect only build

### DIFF
--- a/python/pyspark/pandas/tests/connect/frame/test_parity_take.py
+++ b/python/pyspark/pandas/tests/connect/frame/test_parity_take.py
@@ -16,11 +16,13 @@
 #
 import unittest
 
+from pyspark import is_remote_only
 from pyspark.pandas.tests.frame.test_take import FrameTakeMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
+@unittest.skipIf(is_remote_only(), "Flaky with OOM")
 class FrameTakeParityTests(
     FrameTakeMixin,
     PandasOnSparkTestUtils,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip test_take in Spark Connect only build.

### Why are the changes needed?

This particular test is flaky (https://github.com/apache/spark/actions/runs/12857135589/job/35844649654) and fails with OOM, which results in stopping all following tests. We should at least fix this build, and run other tests.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Will monitor the build.

### Was this patch authored or co-authored using generative AI tooling?

No.
