### PR TITLE
[SPARK-50897][ML][CONNECT] Avoiding instance creation in ServiceLoader

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -38,9 +38,6 @@ import org.apache.spark.sql.connect.plugin.SparkConnectPluginRegistry
 import org.apache.spark.sql.connect.service.SessionHolder
 import org.apache.spark.util.{SparkClassUtils, Utils}
 
-
-
-
 private[ml] object MLUtils {
 
   /**
@@ -58,9 +55,14 @@ private[ml] object MLUtils {
     // to iterate over a collection of providers that do not instantiate the class
     // directly. Since there is no good way to convert a Java stream to a Scala stream,
     // we collect the Java stream to a Java map and then convert it to a Scala map.
-    serviceLoader.stream().collect(
-      Collectors.toMap((est: ServiceLoader.Provider[_]) => est.`type`().getName,
-        (est: ServiceLoader.Provider[_]) => est.`type`())).asScala.toMap
+    serviceLoader
+      .stream()
+      .collect(
+        Collectors.toMap(
+          (est: ServiceLoader.Provider[_]) => est.`type`().getName,
+          (est: ServiceLoader.Provider[_]) => est.`type`()))
+      .asScala
+      .toMap
   }
 
   private def parseInts(ints: proto.Ints): Array[Int] = {

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.connect.ml
 
 import java.util.{Optional, ServiceLoader}
+import java.util.stream.Collectors
 
 import scala.collection.immutable.HashSet
 import scala.jdk.CollectionConverters._
@@ -37,6 +38,9 @@ import org.apache.spark.sql.connect.plugin.SparkConnectPluginRegistry
 import org.apache.spark.sql.connect.service.SessionHolder
 import org.apache.spark.util.{SparkClassUtils, Utils}
 
+
+
+
 private[ml] object MLUtils {
 
   /**
@@ -50,8 +54,13 @@ private[ml] object MLUtils {
   private def loadOperators(mlCls: Class[_]): Map[String, Class[_]] = {
     val loader = Utils.getContextOrSparkClassLoader
     val serviceLoader = ServiceLoader.load(mlCls, loader)
-    val providers = serviceLoader.asScala.toList
-    providers.map(est => est.getClass.getName -> est.getClass).toMap
+    // Instead of using the iterator, we use the "stream()" method that allows
+    // to iterate over a collection of providers that do not instantiate the class
+    // directly. Since there is no good way to convert a Java stream to a Scala stream,
+    // we collect the Java stream to a Java map and then convert it to a Scala map.
+    serviceLoader.stream().collect(
+      Collectors.toMap((est: ServiceLoader.Provider[_]) => est.`type`().getName,
+        (est: ServiceLoader.Provider[_]) => est.`type`())).asScala.toMap
   }
 
   private def parseInts(ints: proto.Ints): Array[Int] = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
When converting the iterator of the ServiceLoader call to Scala, we explicitly instantiate all classes that the service loader provides. Since we do not need the instances, this PR uses the `steam()` of the ServiceLoader to iterate over the list of providers and just extracts the clasess.

### Why are the changes needed?
Performance / Stability

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests

### Was this patch authored or co-authored using generative AI tooling?
No