### PR TITLE
[SPARK-50900][ML][CONNECT] Add VectorUDT and MatrixUDT to ProtoDataTypes

### DIFF
--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
@@ -302,20 +302,31 @@ object DataTypeProtoConverter {
 
       case udt: UserDefinedType[_] =>
         // Scala/Java UDT
-        val builder = proto.DataType.UDT.newBuilder()
-        builder
-          .setType("udt")
-          .setJvmClass(udt.getClass.getName)
-          .setSqlType(toConnectProtoType(udt.sqlType))
+        udt.getClass.getName match {
+          // To avoid make connect-common depends on ml,
+          // we use class name to identify VectorUDT and MatrixUDT.
+          case "org.apache.spark.ml.linalg.VectorUDT" =>
+            ProtoDataTypes.VectorUDT
 
-        if (udt.pyUDT != null) {
-          builder.setPythonClass(udt.pyUDT)
+          case "org.apache.spark.ml.linalg.MatrixUDT" =>
+            ProtoDataTypes.MatrixUDT
+
+          case className =>
+            val builder = proto.DataType.UDT.newBuilder()
+            builder
+              .setType("udt")
+              .setJvmClass(className)
+              .setSqlType(toConnectProtoType(udt.sqlType))
+
+            if (udt.pyUDT != null) {
+              builder.setPythonClass(udt.pyUDT)
+            }
+
+            proto.DataType
+              .newBuilder()
+              .setUdt(builder.build())
+              .build()
         }
-
-        proto.DataType
-          .newBuilder()
-          .setUdt(builder.build())
-          .build()
 
       case _ =>
         throw InvalidPlanInput(s"Does not support convert ${t.typeName} to connect proto types.")

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
@@ -303,7 +303,7 @@ object DataTypeProtoConverter {
       case udt: UserDefinedType[_] =>
         // Scala/Java UDT
         udt.getClass.getName match {
-          // To avoid make connect-common depends on ml,
+          // To avoid making connect-common depend on ml,
           // we use class name to identify VectorUDT and MatrixUDT.
           case "org.apache.spark.ml.linalg.VectorUDT" =>
             ProtoDataTypes.VectorUDT

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoDataTypes.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoDataTypes.scala
@@ -109,4 +109,28 @@ private[sql] object ProtoDataTypes {
       .newBuilder()
       .setVariant(proto.DataType.Variant.getDefaultInstance)
       .build()
+
+  val VectorUDT: proto.DataType =
+    proto.DataType
+      .newBuilder()
+      .setUdt(
+        proto.DataType.UDT
+          .newBuilder()
+          .setType("udt")
+          .setJvmClass("org.apache.spark.ml.linalg.VectorUDT")
+          .setPythonClass("pyspark.ml.linalg.VectorUDT")
+          .build())
+      .build()
+
+  val MatrixUDT: proto.DataType =
+    proto.DataType
+      .newBuilder()
+      .setUdt(
+        proto.DataType.UDT
+          .newBuilder()
+          .setType("udt")
+          .setJvmClass("org.apache.spark.ml.linalg.MatrixUDT")
+          .setPythonClass("pyspark.ml.linalg.MatrixUDT")
+          .build())
+      .build()
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add VectorUDT and MatrixUDT to ProtoDataTypes


### Why are the changes needed?
1, to avoid recreating the protobuf messages;
2, for the two builtin UDTs, field `sqlType` can be ignored.

### Does this PR introduce _any_ user-facing change?
NO, internal change


### How was this patch tested?
Existing tests

### Was this patch authored or co-authored using generative AI tooling?
No
