### PR TITLE
[SPARK-50902][CORE][K8S][TESTS] Add `CRC32C` test cases

### DIFF
--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalBlockHandlerSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalBlockHandlerSuite.java
@@ -220,6 +220,11 @@ public class ExternalBlockHandlerSuite {
   }
 
   @Test
+  public void testShuffleCorruptionDiagnosisCRC32C() throws IOException {
+    checkDiagnosisResult("CRC32C", Cause.CHECKSUM_VERIFY_PASS);
+  }
+
+  @Test
   public void testFetchShuffleBlocks() {
     when(blockResolver.getBlockData("app0", "exec1", 0, 0, 0)).thenReturn(blockMarkers[0]);
     when(blockResolver.getBlockData("app0", "exec1", 0, 0, 1)).thenReturn(blockMarkers[1]);

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/shuffle/KubernetesLocalDiskShuffleDataIOSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/shuffle/KubernetesLocalDiskShuffleDataIOSuite.scala
@@ -230,7 +230,7 @@ class KubernetesLocalDiskShuffleDataIOSuite extends SparkFunSuite with LocalRoot
       conf.get("spark.local.dir") + "/spark-x/executor-y")
     val dir = sparkConf.get("spark.local.dir") + "/blockmgr-z/00"
     Files.createDirectories(new File(dir).toPath())
-    Seq("ADLER32", "CRC32").foreach { algorithm =>
+    Seq("ADLER32", "CRC32", "CRC32C").foreach { algorithm =>
       new File(dir, s"1.checksum.$algorithm").createNewFile()
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `CRC32C` test cases.

### Why are the changes needed?

Apache Spark supports `CRC32C`. We had better add more test coverage like `CRC32`.
- #47929

### Does this PR introduce _any_ user-facing change?

No. This is a test case addition.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.