### PR TITLE
[SPARK-50798][SQL][FOLLOWUP] Further improvements to `NormalizePlan`

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
@@ -20,7 +20,16 @@ package org.apache.spark.sql.catalyst.plans
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.expressions.{AssertTrue, Cast, If, Literal, TimeZoneAwareExpression}
+import org.apache.spark.sql.catalyst.expressions.{
+  AssertTrue,
+  Cast,
+  CommonExpressionDef,
+  CommonExpressionId,
+  CommonExpressionRef,
+  If,
+  Literal,
+  TimeZoneAwareExpression
+}
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.types.BooleanType
 
@@ -68,6 +77,27 @@ class NormalizePlanSuite extends SparkFunSuite with SQLConfHelper {
     // However, plans are still different.
     assert(resolvedBaselinePlan != resolvedTestPlan)
     assert(NormalizePlan(resolvedBaselinePlan) == NormalizePlan(resolvedTestPlan))
+  }
+
+  test("Normalize CommonExpressionId") {
+    val baselineCommonExpressionRef =
+      CommonExpressionRef(id = new CommonExpressionId, dataType = BooleanType, nullable = false)
+    val baselineCommonExpressionDef = CommonExpressionDef(child = Literal(0))
+    val testCommonExpressionRef =
+      CommonExpressionRef(id = new CommonExpressionId, dataType = BooleanType, nullable = false)
+    val testCommonExpressionDef = CommonExpressionDef(child = Literal(0))
+
+    val baselinePlanRef = LocalRelation().select(baselineCommonExpressionRef)
+    val testPlanRef = LocalRelation().select(testCommonExpressionRef)
+
+    assert(baselinePlanRef != testPlanRef)
+    assert(NormalizePlan(baselinePlanRef) == NormalizePlan(testPlanRef))
+
+    val baselinePlanDef = LocalRelation().select(baselineCommonExpressionDef)
+    val testPlanDef = LocalRelation().select(testCommonExpressionDef)
+
+    assert(baselinePlanDef != testPlanDef)
+    assert(NormalizePlan(baselinePlanDef) == NormalizePlan(testPlanDef))
   }
 
   private def setTimezoneForAllExpression(plan: LogicalPlan): LogicalPlan = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Improve `NormalizePlan` by fixing normalization of `InheritAnalysisRules` and add normalization for `CommonExpressionId` and expressions that use it. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
PR #49460 mishandled normalization of `RuntimeReplaceable` because it copied original expression's tags to the replacement. This PR fixes that.

### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Added a test case to `NormalizePlanSuite`.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
