### PR TITLE
[SPARK-50901][ML][PYTHON][CONNECT] Support Transformer `VectorAssembler`

### DIFF
--- a/mllib/src/main/resources/META-INF/services/org.apache.spark.ml.Transformer
+++ b/mllib/src/main/resources/META-INF/services/org.apache.spark.ml.Transformer
@@ -17,6 +17,7 @@
 
 # Spark Connect ML uses ServiceLoader to find out the supported Spark Ml non-model transformer.
 # So register the supported transformer here if you're trying to add a new one.
+########### Transformers
 org.apache.spark.ml.feature.VectorAssembler
 
 ########### Model for loading

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
@@ -191,6 +191,15 @@ private[connect] object MLHandler extends Logging {
                   case other => throw MlUnsupportedException(s"Evaluator $other is not writable")
                 }
 
+              case proto.MlOperator.OperatorType.TRANSFORMER =>
+                val transformer =
+                  MLUtils.getTransformer(sessionHolder, writer.getOperator, params)
+                transformer match {
+                  case writable: MLWritable => MLUtils.write(writable, mlCommand.getWrite)
+                  case other =>
+                    throw MlUnsupportedException(s"Transformer $other is not writable")
+                }
+
               case _ =>
                 throw MlUnsupportedException(s"Operator $operatorName is not supported")
             }
@@ -217,12 +226,15 @@ private[connect] object MLHandler extends Logging {
             .build()
 
         } else if (operator.getType == proto.MlOperator.OperatorType.ESTIMATOR ||
-          operator.getType == proto.MlOperator.OperatorType.EVALUATOR) {
+          operator.getType == proto.MlOperator.OperatorType.EVALUATOR ||
+          operator.getType == proto.MlOperator.OperatorType.TRANSFORMER) {
           val mlOperator = {
             if (operator.getType == proto.MlOperator.OperatorType.ESTIMATOR) {
               MLUtils.loadEstimator(sessionHolder, name, path).asInstanceOf[Params]
-            } else {
+            } else if (operator.getType == proto.MlOperator.OperatorType.EVALUATOR) {
               MLUtils.loadEvaluator(sessionHolder, name, path).asInstanceOf[Params]
+            } else {
+              MLUtils.loadTransformer(sessionHolder, name, path).asInstanceOf[Params]
             }
           }
           proto.MlCommandResult

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -339,6 +339,30 @@ private[ml] object MLUtils {
   }
 
   /**
+   * Get the Transformer instance according to the proto information
+   *
+   * @param sessionHolder
+   *   session holder to hold the Spark Connect session state
+   * @param operator
+   *   MlOperator information
+   * @param params
+   *   The optional parameters of the transformer
+   * @return
+   *   the transformer
+   */
+  def getTransformer(
+      sessionHolder: SessionHolder,
+      operator: proto.MlOperator,
+      params: Option[proto.MlParams]): Transformer = {
+    val name = replaceOperator(sessionHolder, operator.getName)
+    val uid = operator.getUid
+
+    // Load the transformers by ServiceLoader everytime
+    val transformers = loadOperators(classOf[Transformer])
+    getInstance[Transformer](name, uid, transformers, params)
+  }
+
+  /**
    * Get the Evaluator instance according to the proto information
    *
    * @param sessionHolder

--- a/sql/connect/server/src/test/resources/META-INF/services/org.apache.spark.ml.Transformer
+++ b/sql/connect/server/src/test/resources/META-INF/services/org.apache.spark.ml.Transformer
@@ -18,3 +18,4 @@
 # Spark Connect ML uses ServiceLoader to find out the supported Spark Ml estimators.
 # So register the supported estimator here if you're trying to add a new one.
 org.apache.spark.sql.connect.ml.MyLogisticRegressionModel
+org.apache.spark.sql.connect.ml.MyVectorAssembler

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ml/MLBackendSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ml/MLBackendSuite.scala
@@ -17,11 +17,10 @@
 
 package org.apache.spark.sql.connect.ml
 
-import java.io.File
+import scala.jdk.CollectionConverters.ListHasAsScala
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.connect.proto
-import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.sql.connect.SparkConnectTestUtils
 import org.apache.spark.sql.connect.config.Connect
 import org.apache.spark.util.Utils
@@ -79,43 +78,12 @@ class MLBackendSuite extends MLHelper {
       assert(model.intercept == 3.5f)
       assert(model.coefficients == 4.6f)
 
-      // read/write
-      val tempDir = Utils.createTempDir(namePrefix = this.getClass.getName)
-      try {
-        val path = new File(tempDir, Identifiable.randomUID("LogisticRegression")).getPath
-        val writeCmd = proto.MlCommand
-          .newBuilder()
-          .setWrite(
-            proto.MlCommand.Write
-              .newBuilder()
-              .setOperator(getLogisticRegressionBuilder)
-              .setParams(getMaxIterBuilder)
-              .setPath(path)
-              .setShouldOverwrite(true))
-          .build()
-        MLHandler.handleMlCommand(sessionHolder, writeCmd)
+      val ret = readWrite(sessionHolder, getLogisticRegressionBuilder, getMaxIterBuilder)
 
-        val readCmd = proto.MlCommand
-          .newBuilder()
-          .setRead(
-            proto.MlCommand.Read
-              .newBuilder()
-              .setOperator(getLogisticRegressionBuilder)
-              .setPath(path))
-          .build()
-
-        val ret = MLHandler.handleMlCommand(sessionHolder, readCmd)
-        assert(ret.getOperatorInfo.getParams.getParamsMap.containsKey("fakeParam"))
-        assert(ret.getOperatorInfo.getParams.getParamsMap.containsKey("maxIter"))
-        assert(
-          ret.getOperatorInfo.getParams.getParamsMap.get("maxIter").getInteger
-            == 2)
-        assert(
-          ret.getOperatorInfo.getParams.getParamsMap.get("fakeParam").getInteger
-            == 101010)
-      } finally {
-        Utils.deleteRecursively(tempDir)
-      }
+      assert(ret.getOperatorInfo.getParams.getParamsMap.containsKey("fakeParam"))
+      assert(ret.getOperatorInfo.getParams.getParamsMap.containsKey("maxIter"))
+      assert(ret.getOperatorInfo.getParams.getParamsMap.get("maxIter").getInteger == 2)
+      assert(ret.getOperatorInfo.getParams.getParamsMap.get("fakeParam").getInteger == 101010)
     }
   }
 
@@ -138,37 +106,11 @@ class MLBackendSuite extends MLHelper {
               .setParams(getMaxIterBuilder))
           .build()
         val fitRet = MLHandler.handleMlCommand(sessionHolder, fitCommand)
-        val modelId = fitRet.getOperatorInfo.getObjRef.getId
 
-        // Write a model
-        val path = new File(tempDir, Identifiable.randomUID("LogisticRegression")).getPath
-        val writeCmd = proto.MlCommand
-          .newBuilder()
-          .setWrite(
-            proto.MlCommand.Write
-              .newBuilder()
-              .setObjRef(proto.ObjectRef.newBuilder().setId(modelId))
-              .setPath(path)
-              .setShouldOverwrite(true))
-          .build()
-        MLHandler.handleMlCommand(sessionHolder, writeCmd)
-
-        // read a model
-        val readCmd = proto.MlCommand
-          .newBuilder()
-          .setRead(
-            proto.MlCommand.Read
-              .newBuilder()
-              .setOperator(proto.MlOperator
-                .newBuilder()
-                .setName("org.apache.spark.ml.classification.LogisticRegressionModel")
-                .setType(proto.MlOperator.OperatorType.MODEL))
-              .setPath(path))
-          .build()
-
-        val ret = MLHandler.handleMlCommand(sessionHolder, readCmd)
-        assert(ret.getOperatorInfo.getParams.getParamsMap.containsKey("fakeParam"))
-        assert(ret.getOperatorInfo.getParams.getParamsMap.containsKey("maxIter"))
+        val ret = readWrite(
+          sessionHolder,
+          fitRet.getOperatorInfo.getObjRef.getId,
+          "org.apache.spark.ml.classification.LogisticRegressionModel")
         assert(
           ret.getOperatorInfo.getParams.getParamsMap.get("maxIter").getInteger
             == 2)
@@ -203,43 +145,54 @@ class MLBackendSuite extends MLHelper {
       val evalResult = MLHandler.handleMlCommand(sessionHolder, evalCmd)
       assert(evalResult.getParam.getDouble == 1.11)
 
-      // read/write
-      val tempDir = Utils.createTempDir(namePrefix = this.getClass.getName)
-      try {
-        val path = new File(tempDir, Identifiable.randomUID("Evaluator")).getPath
-        val writeCmd = proto.MlCommand
-          .newBuilder()
-          .setWrite(
-            proto.MlCommand.Write
-              .newBuilder()
-              .setOperator(getRegressorEvaluator)
-              .setParams(getMetricName)
-              .setPath(path)
-              .setShouldOverwrite(true))
-          .build()
-        MLHandler.handleMlCommand(sessionHolder, writeCmd)
+      val ret = readWrite(sessionHolder, getRegressorEvaluator, getMetricName)
 
-        val readCmd = proto.MlCommand
-          .newBuilder()
-          .setRead(
-            proto.MlCommand.Read
-              .newBuilder()
-              .setOperator(getRegressorEvaluator)
-              .setPath(path))
-          .build()
+      assert(ret.getOperatorInfo.getParams.getParamsMap.containsKey("fakeParam"))
+      assert(ret.getOperatorInfo.getParams.getParamsMap.containsKey("metricName"))
+      assert(
+        ret.getOperatorInfo.getParams.getParamsMap.get("metricName").getString
+          == "mae")
+      assert(
+        ret.getOperatorInfo.getParams.getParamsMap.get("fakeParam").getInteger
+          == 101010)
+    }
+  }
 
-        val ret = MLHandler.handleMlCommand(sessionHolder, readCmd)
-        assert(ret.getOperatorInfo.getParams.getParamsMap.containsKey("fakeParam"))
-        assert(ret.getOperatorInfo.getParams.getParamsMap.containsKey("metricName"))
-        assert(
-          ret.getOperatorInfo.getParams.getParamsMap.get("metricName").getString
-            == "mae")
-        assert(
-          ret.getOperatorInfo.getParams.getParamsMap.get("fakeParam").getInteger
-            == 101010)
-      } finally {
-        Utils.deleteRecursively(tempDir)
-      }
+  test("ML backend: transformer works") {
+    withSparkConf(
+      Connect.CONNECT_ML_BACKEND_CLASSES.key ->
+        "org.apache.spark.sql.connect.ml.MyMlBackend") {
+      val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+
+      val transformerRelation = proto.MlRelation
+        .newBuilder()
+        .setTransform(
+          proto.MlRelation.Transform
+            .newBuilder()
+            .setTransformer(getVectorAssembler)
+            .setParams(getVectorAssemblerParams)
+            .setInput(createMultiColumnLocalRelationProto))
+        .build()
+
+      val transRet = MLHandler.transformMLRelation(transformerRelation, sessionHolder)
+      // MyVectorAssembler has hacked the transform function
+      Seq("a", "b", "c", "new").foreach(n => assert(transRet.schema.names.contains(n)))
+
+      val ret = readWrite(sessionHolder, getVectorAssembler, getVectorAssemblerParams)
+      assert(
+        ret.getOperatorInfo.getParams.getParamsMap.get("handleInvalid").getString
+          == "skip")
+      assert(
+        ret.getOperatorInfo.getParams.getParamsMap.get("fakeParam").getInteger
+          == 101010)
+      assert(
+        ret.getOperatorInfo.getParams.getParamsMap
+          .get("inputCols")
+          .getArray
+          .getElementsList
+          .asScala
+          .map(_.getString)
+          .toArray sameElements Array("a", "b", "c"))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds support transformer on ml connect. Currently, VectorAssembler is fully supported.


### Why are the changes needed?

for feature parity


### Does this PR introduce _any_ user-facing change?
Yes, new algorithms supported on connect


### How was this patch tested?
The newly added test can pass

### Was this patch authored or co-authored using generative AI tooling?
No