### PR TITLE
[SPARK-45013][CORE][TEST][3.5] Flaky Test with NPE: track allocated resources by taskId

### DIFF
--- a/core/src/test/scala/org/apache/spark/executor/CoarseGrainedExecutorBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/CoarseGrainedExecutorBackendSuite.scala
@@ -339,6 +339,7 @@ class CoarseGrainedExecutorBackendSuite extends SparkFunSuite
       backend.self.send(LaunchTask(new SerializableBuffer(serializedTaskDescription)))
       eventually(timeout(10.seconds)) {
         assert(backend.taskResources.size == 1)
+        assert(runningTasks.size == 1)
         val resources = backend.taskResources.get(taskId)
         assert(resources(GPU).addresses sameElements Array("0", "1"))
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR ensures the runningTasks to be updated before subsequent tasks causing NPE

### Why are the changes needed?
fix flakey tests 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
It shall fix
```
- track allocated resources by taskId *** FAILED *** (36 milliseconds)
[info]   java.lang.NullPointerException: Cannot invoke "org.apache.spark.executor.Executor$TaskRunner.taskDescription()" because the return value of "java.util.concurrent.ConcurrentHashMap.get(Object)" is null
[info]   at org.apache.spark.executor.CoarseGrainedExecutorBackend.statusUpdate(CoarseGrainedExecutorBackend.scala:275)
[info]   at org.apache.spark.executor.CoarseGrainedExecutorBackendSuite.$anonfun$new$22(CoarseGrainedExecutorBackendSuite.scala:351)
[info]
```

### Was this patch authored or co-authored using generative AI tooling?
no