### PR TITLE
[SPARK-50912][PYTHON][TESTS] Skip FrameTakeAdvParityTests.test_take_adv because of OOM for now

### DIFF
--- a/python/pyspark/pandas/tests/connect/frame/test_parity_take_adv.py
+++ b/python/pyspark/pandas/tests/connect/frame/test_parity_take_adv.py
@@ -16,11 +16,13 @@
 #
 import unittest
 
+from pyspark import is_remote_only
 from pyspark.pandas.tests.frame.test_take_adv import FrameTakeAdvMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
+@unittest.skipIf(is_remote_only(), "Flaky with OOM")
 class FrameTakeAdvParityTests(
     FrameTakeAdvMixin,
     PandasOnSparkTestUtils,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip `test_take_adv` in Spark Connect only build. Similar with https://github.com/apache/spark/pull/49565

### Why are the changes needed?

This particular test is flaky (https://github.com/apache/spark/actions/runs/12835248061/job/35794283521 and fails with OOM, which results in stopping all following tests. We should at least fix this build, and run other tests.

The build reuses single JVM for running all tests so it consumes more memory.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Will monitor the build.

### Was this patch authored or co-authored using generative AI tooling?

No.