### PR TITLE
[SPARK-50913][PYTHON][TESTS] Skip flaky EvaluationTestsOnConnect.test_binary_classifier_evaluator

### DIFF
--- a/python/pyspark/ml/tests/connect/test_connect_evaluation.py
+++ b/python/pyspark/ml/tests/connect/test_connect_evaluation.py
@@ -38,6 +38,10 @@ if should_test_connect:
         def tearDown(self) -> None:
             self.spark.stop()
 
+        @unittest.skip("SPARK-50913: Flaky with RetriesExceeded")
+        def test_binary_classifier_evaluator(self):
+            self._test_binary_classifier_evaluator()
+
 
 if __name__ == "__main__":
     from pyspark.ml.tests.connect.test_connect_evaluation import *  # noqa: F401,F403


### PR DESCRIPTION
### What changes were proposed in this pull request?
Skip flaky EvaluationTestsOnConnect.test_binary_classifier_evaluator


### Why are the changes needed?
the corresponding module `pyspark.ml.connect` has been drepecated and this test is flaky


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no