### PR TITLE
[SPARK-50947][PYTHON][SQL][CONNECT] Assign appropriate error class and SparkException for duplicated artifacts

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -82,6 +82,12 @@
     ],
     "sqlState" : "22003"
   },
+  "ARTIFACT_ALREADY_EXISTS" : {
+    "message" : [
+      "The artifact <normalizedRemoteRelativePath> already exists. Please choose a different name for the new artifact because it cannot be overwritten."
+    ],
+    "sqlState" : "42713"
+  },
   "ASSIGNMENT_ARITY_MISMATCH" : {
     "message" : [
       "The number of columns or variables assigned or aliased: <numTarget> does not match the number of source expressions: <numExpr>."
@@ -1228,12 +1234,6 @@
       "However multiple instances of metrics with with same result and name are allowed (e.g. self-joins)."
     ],
     "sqlState" : "42710"
-  },
-  "DUPLICATED_ARTIFACT" : {
-    "message" : [
-      "Duplicate Artifact: <normalizedRemoteRelativePath>. Artifacts cannot be overwritten."
-    ],
-    "sqlState" : "42713"
   },
   "DUPLICATE_ASSIGNMENTS" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1229,6 +1229,12 @@
     ],
     "sqlState" : "42710"
   },
+  "DUPLICATED_ARTIFACT" : {
+    "message" : [
+      "Duplicate Artifact: <normalizedRemoteRelativePath>. Artifacts cannot be overwritten."
+    ],
+    "sqlState" : "42713"
+  },
   "DUPLICATE_ASSIGNMENTS" : {
     "message" : [
       "The columns or variables <nameList> appear more than once as assignment targets."

--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -29,7 +29,7 @@ from pyspark.sql.functions import udf, assert_true, lit
 if should_test_connect:
     from pyspark.sql.connect.client.artifact import ArtifactManager
     from pyspark.sql.connect.client import DefaultChannelBuilder
-    from pyspark.errors.exceptions.connect import SparkConnectGrpcException
+    from pyspark.errors import SparkRuntimeException
 
 
 class ArtifactTestsMixin:
@@ -73,10 +73,14 @@ class ArtifactTestsMixin:
             with open(pyfile_path, "w+") as f:
                 f.write("my_func = lambda: 11")
 
-            with self.assertRaisesRegex(
-                SparkConnectGrpcException, "\\(java.lang.RuntimeException\\) Duplicate Artifact"
-            ):
+            with self.assertRaises(SparkRuntimeException) as pe:
                 self.spark.addArtifacts(pyfile_path, pyfile=True)
+
+            self.check_error(
+                exception=pe.exception,
+                errorClass="DUPLICATED_ARTIFACT",
+                messageParameters={"normalizedRemoteRelativePath": "pyfiles/my_pyfile.py"},
+            )
 
     def check_add_zipped_package(self, spark_session):
         with tempfile.TemporaryDirectory(prefix="check_add_zipped_package") as d:

--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -78,7 +78,7 @@ class ArtifactTestsMixin:
 
             self.check_error(
                 exception=pe.exception,
-                errorClass="DUPLICATED_ARTIFACT",
+                errorClass="ARTIFACT_ALREADY_EXISTS",
                 messageParameters={"normalizedRemoteRelativePath": "pyfiles/my_pyfile.py"},
             )
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/artifact/ArtifactManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/artifact/ArtifactManager.scala
@@ -217,7 +217,7 @@ class ArtifactManager(session: SparkSession) extends AutoCloseable with Logging 
         }
 
         throw new SparkRuntimeException(
-          "DUPLICATED_ARTIFACT",
+          "ARTIFACT_ALREADY_EXISTS",
           Map("normalizedRemoteRelativePath" -> normalizedRemoteRelativePath.toString)
         )
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/artifact/ArtifactManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/artifact/ArtifactManager.scala
@@ -31,7 +31,7 @@ import scala.reflect.ClassTag
 import org.apache.commons.io.{FilenameUtils, FileUtils}
 import org.apache.hadoop.fs.{LocalFileSystem, Path => FSPath}
 
-import org.apache.spark.{JobArtifactSet, JobArtifactState, SparkContext, SparkEnv, SparkException, SparkUnsupportedOperationException}
+import org.apache.spark.{JobArtifactSet, JobArtifactState, SparkContext, SparkEnv, SparkException, SparkRuntimeException, SparkUnsupportedOperationException}
 import org.apache.spark.internal.{Logging, LogKeys, MDC}
 import org.apache.spark.internal.config.{CONNECT_SCALA_UDF_STUB_PREFIXES, EXECUTOR_USER_CLASS_PATH_FIRST}
 import org.apache.spark.sql.{Artifact, SparkSession}
@@ -216,8 +216,10 @@ class ArtifactManager(session: SparkSession) extends AutoCloseable with Logging 
           return
         }
 
-        throw new RuntimeException(s"Duplicate Artifact: $normalizedRemoteRelativePath. " +
-            "Artifacts cannot be overwritten.")
+        throw new SparkRuntimeException(
+          "DUPLICATED_ARTIFACT",
+          Map("normalizedRemoteRelativePath" -> normalizedRemoteRelativePath.toString)
+        )
       }
       transferFile(serverLocalStagingPath, target, deleteSource = deleteStagedFile)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to assign appropriate error class and SparkException for duplicated artifacts.


### Why are the changes needed?

To convert SparkConnectGrpcException into proper PySparkException so that we can ensure handling exceptions from Spark Connect Server properly.


### Does this PR introduce _any_ user-facing change?

No API changes, but the user-facing error message would be improved.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Updated the existing test.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.