### PR TITLE
[MINOR][SQL] Avoid importing java.util at DataFrameWriter

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql
 
-import java.util
+import java.util.{Locale, Map, Properties}
 
 import scala.jdk.CollectionConverters._
 
@@ -56,7 +56,7 @@ abstract class DataFrameWriter[T] {
    * @since 1.4.0
    */
   def mode(saveMode: String): this.type = {
-    saveMode.toLowerCase(util.Locale.ROOT) match {
+    saveMode.toLowerCase(Locale.ROOT) match {
       case "overwrite" => mode(SaveMode.Overwrite)
       case "append" => mode(SaveMode.Append)
       case "ignore" => mode(SaveMode.Ignore)
@@ -139,7 +139,7 @@ abstract class DataFrameWriter[T] {
    *
    * @since 1.4.0
    */
-  def options(options: util.Map[String, String]): this.type = {
+  def options(options: Map[String, String]): this.type = {
     this.options(options.asScala)
     this
   }
@@ -323,7 +323,7 @@ abstract class DataFrameWriter[T] {
    *   "READ_UNCOMMITTED".
    * @since 1.4.0
    */
-  def jdbc(url: String, table: String, connectionProperties: util.Properties): Unit = {
+  def jdbc(url: String, table: String, connectionProperties: Properties): Unit = {
     assertNotPartitioned("jdbc")
     assertNotBucketed("jdbc")
     assertNotClustered("jdbc")

--- a/sql/api/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -503,7 +503,8 @@ abstract class DataFrameWriter[T] {
 
   protected var mode: SaveMode = SaveMode.ErrorIfExists
 
-  protected var extraOptions: CaseInsensitiveMap[String] = CaseInsensitiveMap[String](Map.empty)
+  protected var extraOptions: CaseInsensitiveMap[String] = CaseInsensitiveMap[String](
+    scala.collection.immutable.Map.empty)
 
   protected var partitioningColumns: Option[Seq[String]] = None
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -503,8 +503,8 @@ abstract class DataFrameWriter[T] {
 
   protected var mode: SaveMode = SaveMode.ErrorIfExists
 
-  protected var extraOptions: CaseInsensitiveMap[String] = CaseInsensitiveMap[String](
-    scala.collection.immutable.Map.empty)
+  protected var extraOptions: CaseInsensitiveMap[String] =
+    CaseInsensitiveMap[String](scala.collection.immutable.Map.empty)
 
   protected var partitioningColumns: Option[Seq[String]] = None
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR avoids importing java.util at DataFrameWriter.

### Why are the changes needed?

Using `util` in the codebase is confusing and confusing if it requires Spark utils or other utils.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.