### PR TITLE
[DRAFT] Resolve default string producing expressions in analyzer

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultStringTypes.scala
@@ -156,11 +156,10 @@ object ResolveDefaultStringTypes extends Rule[LogicalPlan] {
     case expression if needsCast(expression) =>
       expression.setTagValue(CAST_ADDED_TAG, ())
       newType => {
-        val replacedType = replaceDefaultStringType(expression.dataType, newType)
-        if (newType == StringType || replacedType.sameType(newType)) {
+        if (newType == StringType) {
           expression
         } else {
-          Cast(expression, replacedType)
+          Cast(expression, replaceDefaultStringType(expression.dataType, newType))
         }
       }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultStringTypes.scala
@@ -156,10 +156,11 @@ object ResolveDefaultStringTypes extends Rule[LogicalPlan] {
     case expression if needsCast(expression) =>
       expression.setTagValue(CAST_ADDED_TAG, ())
       newType => {
-        if (expression.dataType.sameType(newType)) {
+        val replacedType = replaceDefaultStringType(expression.dataType, newType)
+        if (newType == StringType || replacedType.sameType(newType)) {
           expression
         } else {
-          Cast(expression, replaceDefaultStringType(expression.dataType, newType))
+          Cast(expression, replacedType)
         }
       }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -1467,5 +1467,5 @@ case class MultiCommutativeOp(
  * Trait for expressions whose data type should be a default string type.
  */
 trait DefaultStringProducingExpression extends Expression {
-  override def dataType: DataType = SQLConf.get.defaultStringType
+  override def dataType: DataType = StringType
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
@@ -858,11 +858,12 @@ case class SchemaOfVariantAgg(
     extends TypedImperativeAggregate[DataType]
     with ExpectsInputTypes
     with QueryErrorsBase
-    with DefaultStringProducingExpression
     with UnaryLike[Expression] {
   def this(child: Expression) = this(child, 0, 0)
 
   override def inputTypes: Seq[AbstractDataType] = Seq(VariantType)
+
+  override def dataType: DataType = SQLConf.get.defaultStringType
 
   override def nullable: Boolean = false
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -152,7 +152,7 @@ case class ReplaceCurrentLike(catalogManager: CatalogManager) extends Rule[Logic
     val currentCatalog = catalogManager.currentCatalog.name()
     val currentUser = CurrentUserContext.getCurrentUser
 
-    val res = plan.transformAllExpressionsWithPruning(_.containsPattern(CURRENT_LIKE)) {
+    plan.transformAllExpressionsWithPruning(_.containsPattern(CURRENT_LIKE)) {
       case CurrentDatabase() =>
         Literal.create(currentNamespace)
       case CurrentCatalog() =>
@@ -160,7 +160,6 @@ case class ReplaceCurrentLike(catalogManager: CatalogManager) extends Rule[Logic
       case CurrentUser() =>
         Literal.create(currentUser)
     }
-    res
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -33,7 +33,6 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{convertSpecialDate, convertSpecialTimestamp, convertSpecialTimestampNTZ, instantToMicros, localDateTimeToMicros}
 import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLExpr
 import org.apache.spark.sql.connector.catalog.CatalogManager
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 
@@ -153,14 +152,15 @@ case class ReplaceCurrentLike(catalogManager: CatalogManager) extends Rule[Logic
     val currentCatalog = catalogManager.currentCatalog.name()
     val currentUser = CurrentUserContext.getCurrentUser
 
-    plan.transformAllExpressionsWithPruning(_.containsPattern(CURRENT_LIKE)) {
+    val res = plan.transformAllExpressionsWithPruning(_.containsPattern(CURRENT_LIKE)) {
       case CurrentDatabase() =>
-        Literal.create(currentNamespace, SQLConf.get.defaultStringType)
+        Literal.create(currentNamespace)
       case CurrentCatalog() =>
-        Literal.create(currentCatalog, SQLConf.get.defaultStringType)
+        Literal.create(currentCatalog)
       case CurrentUser() =>
-        Literal.create(currentUser, SQLConf.get.defaultStringType)
+        Literal.create(currentUser)
     }
+    res
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Changing `DefaultStringProducingExpression` expressions to return the proper default collation (of either the session or the object for DDL commands)

### Why are the changes needed?
Previously, `DefaultStringProducingExpression` would always return the collation of the session, however for DDL commands they should return the collation of the object.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
New unit tests.

### Was this patch authored or co-authored using generative AI tooling?
No.
