### PR TITLE
[SPARK-50952][BUILD] Include `jjwt`-related libraries and provide `jjwt-provided` profile

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -268,6 +268,8 @@ io.fabric8:kubernetes-model-storageclass
 io.fabric8:zjsonpatch
 io.github.java-diff-utils:java-diff-utils
 io.jsonwebtoken:jjwt-api
+io.jsonwebtoken:jjwt-impl
+io.jsonwebtoken:jjwt-jackson
 io.netty:netty-all
 io.netty:netty-buffer
 io.netty:netty-codec

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -345,11 +345,10 @@
       </properties>
     </profile>
 
-    <!-- Pull in jjwt-impl and jjwt-jackson jars -->
     <profile>
-      <id>jjwt</id>
+      <id>jjwt-provided</id>
       <properties>
-        <jjwt.deps.scope>compile</jjwt.deps.scope>
+        <jjwt.deps.scope>provided</jjwt.deps.scope>
       </properties>
     </profile>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -623,12 +623,6 @@
       </properties>
     </profile>
     <profile>
-      <id>jjwt</id>
-      <properties>
-        <jjwt.deps.scope>compile</jjwt.deps.scope>
-      </properties>
-    </profile>
-    <profile>
       <id>sparkr</id>
       <build>
         <plugins>

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -142,6 +142,8 @@ jettison/1.5.4//jettison-1.5.4.jar
 jetty-util-ajax/11.0.24//jetty-util-ajax-11.0.24.jar
 jetty-util/11.0.24//jetty-util-11.0.24.jar
 jjwt-api/0.12.6//jjwt-api-0.12.6.jar
+jjwt-impl/0.12.6//jjwt-impl-0.12.6.jar
+jjwt-jackson/0.12.6//jjwt-jackson-0.12.6.jar
 jline/2.14.6//jline-2.14.6.jar
 jline/3.26.3//jline-3.26.3.jar
 jna/5.14.0//jna-5.14.0.jar

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1754,10 +1754,6 @@ Apart from these, the following properties are also available, and may be useful
     <br /><code>spark.ui.filters=com.test.filter1</code>
     <br /><code>spark.com.test.filter1.param.name1=foo</code>
     <br /><code>spark.com.test.filter1.param.name2=bar</code>
-    <br />
-    <br />Note that some filter requires additional dependencies. For example,
-    the built-in <code>org.apache.spark.ui.JWSFilter</code> requires
-    <code>jjwt-impl</code> and <code>jjwt-jackson</code> jar files.
   </td>
   <td>1.0.0</td>
 </tr>

--- a/docs/security.md
+++ b/docs/security.md
@@ -55,8 +55,7 @@ To enable authorization, Spark Master should have
 `spark.master.rest.filters=org.apache.spark.ui.JWSFilter` and
 `spark.org.apache.spark.ui.JWSFilter.param.secretKey=BASE64URL-ENCODED-KEY` configurations, and
 client should provide HTTP `Authorization` header which contains JSON Web Token signed by
-the shared secret key. Please note that this feature requires a Spark distribution built with
-`jjwt` profile.
+the shared secret key.
 
 ### YARN
 
@@ -816,7 +815,7 @@ be limited to origin hosts that need to access the services.
 
 However, like the REST Submission port, Spark also supports HTTP `Authorization` header
 with a cryptographically signed JSON Web Token (JWT) for all UI ports.
-To use it, a user needs the Spark distribution built with `jjwt` profile and to configure
+To use it, a user needs to configure
 `spark.ui.filters=org.apache.spark.ui.JWSFilter` and
 `spark.org.apache.spark.ui.JWSFilter.param.secretKey=BASE64URL-ENCODED-KEY`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
     <orc.deps.scope>compile</orc.deps.scope>
     <parquet.deps.scope>compile</parquet.deps.scope>
     <parquet.test.deps.scope>test</parquet.test.deps.scope>
-    <jjwt.deps.scope>test</jjwt.deps.scope>
+    <jjwt.deps.scope>compile</jjwt.deps.scope>
 
     <spark.yarn.isHadoopProvided>false</spark.yarn.isHadoopProvided>
 
@@ -3531,7 +3531,7 @@
       <id>sparkr</id>
     </profile>
     <profile>
-      <id>jjwt</id>
+      <id>jjwt-provided</id>
     </profile>
     <!-- use org.openlabtesting.leveldbjni on aarch64 platform except MacOS -->
     <profile>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to provide `jjwt`-related libraries by default and provide `jjwt-provided` profile instead.

### Why are the changes needed?

To support the security features in the official distribution and Docker images of Apache Spark 4.0 out of the box.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

```
$ dev/make-distribution.sh
$ ls dist/jars/jj*
dist/jars/jjwt-api-0.12.6.jar     dist/jars/jjwt-impl-0.12.6.jar    dist/jars/jjwt-jackson-0.12.6.jar
```

```
$ dev/make-distribution.sh -Pjjwt-provided
$ ls dist/jars/jj*
dist/jars/jjwt-api-0.12.6.jar
```
### Was this patch authored or co-authored using generative AI tooling?

No.