### PR TITLE
[SPARK-50812][ML][PYTHON][CONNECT][TESTS] refactor some tests

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -1078,7 +1078,7 @@ class LogisticRegressionModel private[spark] (
 
   // For ml connect only
   @Since("4.0.0")
-  private[ml] def this() = this(Identifiable.randomUID("logreg"), Vectors.zeros(0), 0)
+  private[ml] def this() = this(Identifiable.randomUID("logreg"), Vectors.empty, 0)
 
   /**
    * A vector of model coefficients for "binomial" logistic regression. If this model was trained

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -704,7 +704,7 @@ class LinearRegressionModel private[ml] (
 
   // For ml connect only
   @Since("4.0.0")
-  private[ml] def this() = this(Identifiable.randomUID("linReg"), Vectors.zeros(0), 0.0, 0.0)
+  private[ml] def this() = this(Identifiable.randomUID("linReg"), Vectors.empty, 0.0, 0.0)
 
   override val numFeatures: Int = coefficients.size
 

--- a/python/pyspark/ml/tests/test_clustering.py
+++ b/python/pyspark/ml/tests/test_clustering.py
@@ -63,12 +63,6 @@ class ClusteringTestsMixin:
         self.assertEqual(km.getMaxIter(), 2)
         self.assertEqual(km.getWeightCol(), "weight")
 
-        # Estimator save & load
-        with tempfile.TemporaryDirectory(prefix="kmeans") as d:
-            km.write().overwrite().save(d)
-            km2 = KMeans.load(d)
-            self.assertEqual(str(km), str(km2))
-
         model = km.fit(df)
         # TODO: support KMeansModel.numFeatures in Python
         # self.assertEqual(model.numFeatures, 2)
@@ -102,8 +96,12 @@ class ClusteringTestsMixin:
         self.assertEqual(summary.predictions.columns, expected_cols)
         self.assertEqual(summary.predictions.count(), 6)
 
-        # Model save & load
+        # save & load
         with tempfile.TemporaryDirectory(prefix="kmeans_model") as d:
+            km.write().overwrite().save(d)
+            km2 = KMeans.load(d)
+            self.assertEqual(str(km), str(km2))
+
             model.write().overwrite().save(d)
             model2 = KMeansModel.load(d)
             self.assertEqual(str(model), str(model2))
@@ -121,12 +119,6 @@ class ClusteringTestsMixin:
         self.assertEqual(bkm.getMaxIter(), 2)
         self.assertEqual(bkm.getMinDivisibleClusterSize(), 1.0)
         self.assertEqual(bkm.getWeightCol(), "weight")
-
-        # Estimator save & load
-        with tempfile.TemporaryDirectory(prefix="bisecting_kmeans") as d:
-            bkm.write().overwrite().save(d)
-            bkm2 = BisectingKMeans.load(d)
-            self.assertEqual(str(bkm), str(bkm2))
 
         model = bkm.fit(df)
         # TODO: support KMeansModel.numFeatures in Python
@@ -164,8 +156,12 @@ class ClusteringTestsMixin:
         self.assertEqual(summary.predictions.columns, expected_cols)
         self.assertEqual(summary.predictions.count(), 6)
 
-        # Model save & load
-        with tempfile.TemporaryDirectory(prefix="bisecting_kmeans_model") as d:
+        # save & load
+        with tempfile.TemporaryDirectory(prefix="bisecting_kmeans") as d:
+            bkm.write().overwrite().save(d)
+            bkm2 = BisectingKMeans.load(d)
+            self.assertEqual(str(bkm), str(bkm2))
+
             model.write().overwrite().save(d)
             model2 = BisectingKMeansModel.load(d)
             self.assertEqual(str(model), str(model2))

--- a/python/pyspark/ml/tests/test_evaluation.py
+++ b/python/pyspark/ml/tests/test_evaluation.py
@@ -54,7 +54,7 @@ class EvaluatorTestsMixin:
         self.assertTrue(np.allclose(precision_at_k, 0.3333, atol=1e-4))
 
         # read/write
-        with tempfile.TemporaryDirectory(prefix="save") as tmp_dir:
+        with tempfile.TemporaryDirectory(prefix="ranking_evaluator") as tmp_dir:
             # Save the evaluator
             evaluator.write().overwrite().save(tmp_dir)
             # Load the saved evaluator
@@ -86,7 +86,7 @@ class EvaluatorTestsMixin:
         self.assertTrue(np.allclose(accuracy, 0.5476, atol=1e-4))
 
         # read/write
-        with tempfile.TemporaryDirectory(prefix="save") as tmp_dir:
+        with tempfile.TemporaryDirectory(prefix="multi_label_class_eval") as tmp_dir:
             # Save the evaluator
             evaluator.write().overwrite().save(tmp_dir)
             # Load the saved evaluator
@@ -133,7 +133,7 @@ class EvaluatorTestsMixin:
         self.assertTrue(np.allclose(hamming_loss, 0.3333, atol=1e-4))
 
         # read/write
-        with tempfile.TemporaryDirectory(prefix="save") as tmp_dir:
+        with tempfile.TemporaryDirectory(prefix="multi_class_classification_evaluator") as tmp_dir:
             # Save the evaluator
             evaluator.write().overwrite().save(tmp_dir)
             # Load the saved evaluator
@@ -188,7 +188,7 @@ class EvaluatorTestsMixin:
         self.assertTrue(np.allclose(auc_pr, 0.8339, atol=1e-4))
 
         # read/write
-        with tempfile.TemporaryDirectory(prefix="save") as tmp_dir:
+        with tempfile.TemporaryDirectory(prefix="binary_classification_evaluator") as tmp_dir:
             # Save the evaluator
             evaluator.write().overwrite().save(tmp_dir)
             # Load the saved evaluator
@@ -236,12 +236,13 @@ class EvaluatorTestsMixin:
         self.assertTrue(np.allclose(score_with_weight, 0.9079, atol=1e-4))
 
         # read/write
-        with tempfile.TemporaryDirectory(prefix="save") as tmp_dir:
+        with tempfile.TemporaryDirectory(prefix="clustering_evaluator") as tmp_dir:
             # Save the evaluator
             evaluator.write().overwrite().save(tmp_dir)
             # Load the saved evaluator
             evaluator2 = ClusteringEvaluator.load(tmp_dir)
             self.assertEqual(evaluator2.getPredictionCol(), "prediction")
+            self.assertTrue(str(evaluator) == str(evaluator2))
 
     def test_clustering_evaluator_with_cosine_distance(self):
         featureAndPredictions = map(
@@ -291,6 +292,7 @@ class EvaluatorTestsMixin:
             # Load the saved evaluator
             evaluator2 = RegressionEvaluator.load(tmp_dir)
             self.assertEqual(evaluator2.getPredictionCol(), "raw")
+            self.assertTrue(str(evaluator) == str(evaluator2))
 
         evaluator_with_weights = RegressionEvaluator(predictionCol="raw", weightCol="weight")
         weighted_rmse = evaluator_with_weights.evaluate(dataset)

--- a/python/pyspark/ml/tests/test_feature.py
+++ b/python/pyspark/ml/tests/test_feature.py
@@ -75,7 +75,7 @@ class FeatureTestsMixin:
         model = si.fit(df.select("label1"))
 
         # read/write
-        with tempfile.TemporaryDirectory(prefix="read_write") as tmp_dir:
+        with tempfile.TemporaryDirectory(prefix="string_indexer") as tmp_dir:
             si.write().overwrite().save(tmp_dir)
             si2 = StringIndexer.load(tmp_dir)
             self.assertEqual(str(si), str(si2))
@@ -147,7 +147,7 @@ class FeatureTestsMixin:
         )
 
         # read/write
-        with tempfile.TemporaryDirectory(prefix="read_write") as tmp_dir:
+        with tempfile.TemporaryDirectory(prefix="pca") as tmp_dir:
             pca.write().overwrite().save(tmp_dir)
             pca2 = PCA.load(tmp_dir)
             self.assertEqual(str(pca), str(pca2))
@@ -188,7 +188,7 @@ class FeatureTestsMixin:
         )
 
         # read/write
-        with tempfile.TemporaryDirectory(prefix="read_write") as tmp_dir:
+        with tempfile.TemporaryDirectory(prefix="vector_assembler") as tmp_dir:
             vec_assembler.write().overwrite().save(tmp_dir)
             vec_assembler2 = VectorAssembler.load(tmp_dir)
             self.assertEqual(str(vec_assembler), str(vec_assembler2))
@@ -221,12 +221,6 @@ class FeatureTestsMixin:
         self.assertEqual(scaler.getInputCol(), "features")
         self.assertEqual(scaler.getOutputCol(), "scaled")
 
-        # Estimator save & load
-        with tempfile.TemporaryDirectory(prefix="standard_scaler") as d:
-            scaler.write().overwrite().save(d)
-            scaler2 = StandardScaler.load(d)
-            self.assertEqual(str(scaler), str(scaler2))
-
         model = scaler.fit(df)
         self.assertTrue(np.allclose(model.mean.toArray(), [1.66666667], atol=1e-4))
         self.assertTrue(np.allclose(model.std.toArray(), [1.52752523], atol=1e-4))
@@ -236,10 +230,16 @@ class FeatureTestsMixin:
         self.assertEqual(output.count(), 3)
 
         # Model save & load
-        with tempfile.TemporaryDirectory(prefix="standard_scaler_model") as d:
+        with tempfile.TemporaryDirectory(prefix="standard_scaler") as d:
+            scaler.write().overwrite().save(d)
+            scaler2 = StandardScaler.load(d)
+            self.assertEqual(str(scaler), str(scaler2))
+            self.assertEqual(scaler2.getOutputCol(), "scaled")
+
             model.write().overwrite().save(d)
             model2 = StandardScalerModel.load(d)
             self.assertEqual(str(model), str(model2))
+            self.assertEqual(model2.getOutputCol(), "scaled")
 
     def test_maxabs_scaler(self):
         df = (
@@ -260,12 +260,6 @@ class FeatureTestsMixin:
         self.assertEqual(scaler.getInputCol(), "features")
         self.assertEqual(scaler.getOutputCol(), "scaled")
 
-        # Estimator save & load
-        with tempfile.TemporaryDirectory(prefix="maxabs_scaler") as d:
-            scaler.write().overwrite().save(d)
-            scaler2 = MaxAbsScaler.load(d)
-            self.assertEqual(str(scaler), str(scaler2))
-
         model = scaler.fit(df)
         self.assertTrue(np.allclose(model.maxAbs.toArray(), [3.0], atol=1e-4))
 
@@ -273,11 +267,17 @@ class FeatureTestsMixin:
         self.assertEqual(output.columns, ["features", "scaled"])
         self.assertEqual(output.count(), 3)
 
-        # Model save & load
-        with tempfile.TemporaryDirectory(prefix="standard_scaler_model") as d:
+        # save & load
+        with tempfile.TemporaryDirectory(prefix="standard_scaler") as d:
+            scaler.write().overwrite().save(d)
+            scaler2 = MaxAbsScaler.load(d)
+            self.assertEqual(str(scaler), str(scaler2))
+            self.assertEqual(scaler2.getOutputCol(), "scaled")
+
             model.write().overwrite().save(d)
             model2 = MaxAbsScalerModel.load(d)
             self.assertEqual(str(model), str(model2))
+            self.assertEqual(model2.getOutputCol(), "scaled")
 
     def test_minmax_scaler(self):
         df = (
@@ -298,12 +298,6 @@ class FeatureTestsMixin:
         self.assertEqual(scaler.getInputCol(), "features")
         self.assertEqual(scaler.getOutputCol(), "scaled")
 
-        # Estimator save & load
-        with tempfile.TemporaryDirectory(prefix="maxabs_scaler") as d:
-            scaler.write().overwrite().save(d)
-            scaler2 = MinMaxScaler.load(d)
-            self.assertEqual(str(scaler), str(scaler2))
-
         model = scaler.fit(df)
         self.assertTrue(np.allclose(model.originalMax.toArray(), [3.0], atol=1e-4))
         self.assertTrue(np.allclose(model.originalMin.toArray(), [0.0], atol=1e-4))
@@ -312,11 +306,17 @@ class FeatureTestsMixin:
         self.assertEqual(output.columns, ["features", "scaled"])
         self.assertEqual(output.count(), 3)
 
-        # Model save & load
-        with tempfile.TemporaryDirectory(prefix="standard_scaler_model") as d:
+        # save & load
+        with tempfile.TemporaryDirectory(prefix="min_max_scaler") as d:
+            scaler.write().overwrite().save(d)
+            scaler2 = MinMaxScaler.load(d)
+            self.assertEqual(str(scaler), str(scaler2))
+            self.assertEqual(scaler2.getOutputCol(), "scaled")
+
             model.write().overwrite().save(d)
             model2 = MinMaxScalerModel.load(d)
             self.assertEqual(str(model), str(model2))
+            self.assertEqual(model2.getOutputCol(), "scaled")
 
     def test_robust_scaler(self):
         df = (
@@ -337,12 +337,6 @@ class FeatureTestsMixin:
         self.assertEqual(scaler.getInputCol(), "features")
         self.assertEqual(scaler.getOutputCol(), "scaled")
 
-        # Estimator save & load
-        with tempfile.TemporaryDirectory(prefix="robust_scaler") as d:
-            scaler.write().overwrite().save(d)
-            scaler2 = RobustScaler.load(d)
-            self.assertEqual(str(scaler), str(scaler2))
-
         model = scaler.fit(df)
         self.assertTrue(np.allclose(model.range.toArray(), [3.0], atol=1e-4))
         self.assertTrue(np.allclose(model.median.toArray(), [2.0], atol=1e-4))
@@ -351,11 +345,17 @@ class FeatureTestsMixin:
         self.assertEqual(output.columns, ["features", "scaled"])
         self.assertEqual(output.count(), 3)
 
-        # Model save & load
-        with tempfile.TemporaryDirectory(prefix="robust_scaler_model") as d:
+        # save & load
+        with tempfile.TemporaryDirectory(prefix="robust_scaler") as d:
+            scaler.write().overwrite().save(d)
+            scaler2 = RobustScaler.load(d)
+            self.assertEqual(str(scaler), str(scaler2))
+            self.assertEqual(scaler2.getOutputCol(), "scaled")
+
             model.write().overwrite().save(d)
             model2 = RobustScalerModel.load(d)
             self.assertEqual(str(model), str(model2))
+            self.assertEqual(model2.getOutputCol(), "scaled")
 
     def test_binarizer(self):
         b0 = Binarizer()

--- a/python/pyspark/ml/tests/test_fpm.py
+++ b/python/pyspark/ml/tests/test_fpm.py
@@ -46,12 +46,6 @@ class FPMTestsMixin:
         self.assertEqual(fp.getMinConfidence(), 0.7)
         self.assertEqual(fp.getNumPartitions(), 1)
 
-        # Estimator save & load
-        with tempfile.TemporaryDirectory(prefix="fp_growth") as d:
-            fp.write().overwrite().save(d)
-            fp2 = FPGrowth.load(d)
-            self.assertEqual(str(fp), str(fp2))
-
         model = fp.fit(df)
 
         self.assertEqual(model.freqItemsets.columns, ["items", "freq"])
@@ -67,8 +61,12 @@ class FPMTestsMixin:
         self.assertEqual(output.columns, ["items", "prediction"])
         self.assertEqual(output.count(), 6)
 
-        # Model save & load
-        with tempfile.TemporaryDirectory(prefix="fp_growth_model") as d:
+        # save & load
+        with tempfile.TemporaryDirectory(prefix="fp_growth") as d:
+            fp.write().overwrite().save(d)
+            fp2 = FPGrowth.load(d)
+            self.assertEqual(str(fp), str(fp2))
+
             model.write().overwrite().save(d)
             model2 = FPGrowthModel.load(d)
             self.assertEqual(str(model), str(model2))

--- a/python/pyspark/ml/tests/test_regression.py
+++ b/python/pyspark/ml/tests/test_regression.py
@@ -66,12 +66,6 @@ class RegressionTestsMixin:
         self.assertEqual(lr.getSolver(), "normal")
         self.assertEqual(lr.getWeightCol(), "weight")
 
-        # Estimator save & load
-        with tempfile.TemporaryDirectory(prefix="linear_regression") as d:
-            lr.write().overwrite().save(d)
-            lr2 = LinearRegression.load(d)
-            self.assertEqual(str(lr), str(lr2))
-
         model = lr.fit(df)
         self.assertEqual(model.numFeatures, 2)
         self.assertTrue(np.allclose(model.scale, 1.0, atol=1e-4))
@@ -160,7 +154,11 @@ class RegressionTestsMixin:
         self.assertTrue(np.allclose(summary2.r2adj, -0.6718362282878414, atol=1e-4))
 
         # Model save & load
-        with tempfile.TemporaryDirectory(prefix="linear_regression_model") as d:
+        with tempfile.TemporaryDirectory(prefix="linear_regression") as d:
+            lr.write().overwrite().save(d)
+            lr2 = LinearRegression.load(d)
+            self.assertEqual(str(lr), str(lr2))
+
             model.write().overwrite().save(d)
             model2 = LinearRegressionModel.load(d)
             self.assertEqual(str(model), str(model2))
@@ -178,12 +176,6 @@ class RegressionTestsMixin:
         self.assertEqual(dt.getSeed(), 1)
         self.assertEqual(dt.getLabelCol(), "label")
         self.assertEqual(dt.getLeafCol(), "leaf")
-
-        # Estimator save & load
-        with tempfile.TemporaryDirectory(prefix="decision_tree_regressor") as d:
-            dt.write().overwrite().save(d)
-            dt2 = DecisionTreeRegressor.load(d)
-            self.assertEqual(str(dt), str(dt2))
 
         model = dt.fit(df)
         self.assertEqual(model.numFeatures, 2)
@@ -216,7 +208,11 @@ class RegressionTestsMixin:
         self.assertEqual(output.count(), 4)
 
         # Model save & load
-        with tempfile.TemporaryDirectory(prefix="decision_tree_regression_model") as d:
+        with tempfile.TemporaryDirectory(prefix="decision_tree_regression") as d:
+            dt.write().overwrite().save(d)
+            dt2 = DecisionTreeRegressor.load(d)
+            self.assertEqual(str(dt), str(dt2))
+
             model.write().overwrite().save(d)
             model2 = DecisionTreeRegressionModel.load(d)
             self.assertEqual(str(model), str(model2))
@@ -237,12 +233,6 @@ class RegressionTestsMixin:
         self.assertEqual(gbt.getSeed(), 1)
         self.assertEqual(gbt.getLabelCol(), "label")
         self.assertEqual(gbt.getLeafCol(), "leaf")
-
-        # Estimator save & load
-        with tempfile.TemporaryDirectory(prefix="gbt_regressor") as d:
-            gbt.write().overwrite().save(d)
-            gbt2 = GBTRegressor.load(d)
-            self.assertEqual(str(gbt), str(gbt2))
 
         model = gbt.fit(df)
         self.assertEqual(model.numFeatures, 2)
@@ -292,8 +282,12 @@ class RegressionTestsMixin:
         self.assertEqual(output.columns, expected_cols)
         self.assertEqual(output.count(), 4)
 
-        # Model save & load
-        with tempfile.TemporaryDirectory(prefix="gbt_regression_model") as d:
+        # save & load
+        with tempfile.TemporaryDirectory(prefix="gbt_regression") as d:
+            gbt.write().overwrite().save(d)
+            gbt2 = GBTRegressor.load(d)
+            self.assertEqual(str(gbt), str(gbt2))
+
             model.write().overwrite().save(d)
             model2 = GBTRegressionModel.load(d)
             self.assertEqual(str(model), str(model2))
@@ -314,12 +308,6 @@ class RegressionTestsMixin:
         self.assertEqual(rf.getSeed(), 1)
         self.assertEqual(rf.getLabelCol(), "label")
         self.assertEqual(rf.getLeafCol(), "leaf")
-
-        # Estimator save & load
-        with tempfile.TemporaryDirectory(prefix="random_forest_regressor") as d:
-            rf.write().overwrite().save(d)
-            rf2 = RandomForestRegressor.load(d)
-            self.assertEqual(str(rf), str(rf2))
 
         model = rf.fit(df)
         self.assertEqual(model.numFeatures, 2)
@@ -353,8 +341,11 @@ class RegressionTestsMixin:
         self.assertEqual(output.columns, expected_cols)
         self.assertEqual(output.count(), 4)
 
-        # Model save & load
-        with tempfile.TemporaryDirectory(prefix="random_forest_regression_model") as d:
+        with tempfile.TemporaryDirectory(prefix="random_forest_regression") as d:
+            rf.write().overwrite().save(d)
+            rf2 = RandomForestRegressor.load(d)
+            self.assertEqual(str(rf), str(rf2))
+
             model.write().overwrite().save(d)
             model2 = RandomForestRegressionModel.load(d)
             self.assertEqual(str(model), str(model2))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR refactors some tests to combine the estimator/mode read/write together in the same directory which could avoid creating directory twice.


### Why are the changes needed?

Tests enhancement.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
The existing tests pass

### Was this patch authored or co-authored using generative AI tooling?
No