### PR TITLE
[MINOR][SQL] Rename the internal var DataFrameWriter.mode to DataFrameWriter.curmode

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/internal/DataFrameWriterImpl.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/internal/DataFrameWriterImpl.scala
@@ -103,7 +103,7 @@ final class DataFrameWriterImpl[T] private[sql] (ds: Dataset[T]) extends DataFra
     // Cannot both be set
     require(!(builder.hasPath && builder.hasTable))
 
-    builder.setMode(mode match {
+    builder.setMode(curmode match {
       case SaveMode.Append => proto.WriteOperation.SaveMode.SAVE_MODE_APPEND
       case SaveMode.Overwrite => proto.WriteOperation.SaveMode.SAVE_MODE_OVERWRITE
       case SaveMode.Ignore => proto.WriteOperation.SaveMode.SAVE_MODE_IGNORE

--- a/sql/api/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -43,7 +43,7 @@ abstract class DataFrameWriter[T] {
    * @since 1.4.0
    */
   def mode(saveMode: SaveMode): this.type = {
-    this.mode = saveMode
+    this.curmode = saveMode
     this
   }
 
@@ -501,7 +501,7 @@ abstract class DataFrameWriter[T] {
 
   protected var source: String = ""
 
-  protected var mode: SaveMode = SaveMode.ErrorIfExists
+  protected var curmode: SaveMode = SaveMode.ErrorIfExists
 
   protected var extraOptions: CaseInsensitiveMap[String] =
     CaseInsensitiveMap[String](scala.collection.immutable.Map.empty)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to rename the internal var `DataFrameWriter.mode` to `DataFrameWriter.curmode`.


### Why are the changes needed?

It's confusing if it refers the method name `mode` or a `var`, `mode` in its parent.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests cases.

### Was this patch authored or co-authored using generative AI tooling?

No.