### PR TITLE
[MINOR][SQL][FOLLOWUP] Fix a `mode` test in DataFrameSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2058,7 +2058,7 @@ class DataFrameSuite extends QueryTest
   test("SPARK-29442 Set `default` mode should override the existing mode") {
     val df = Seq(Tuple1(1)).toDF()
     val writer = df.write.mode("overwrite").mode("default")
-    val modeField = classOf[DataFrameWriter[_]].getDeclaredField("mode")
+    val modeField = classOf[DataFrameWriter[_]].getDeclaredField("curmode")
     modeField.setAccessible(true)
     assert(SaveMode.ErrorIfExists === modeField.get(writer).asInstanceOf[SaveMode])
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Rename `mode` in a test in `DataFrameSuite`.

### Why are the changes needed?
To fix the failed test.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the modified test:
```
$ build/sbt "test:testOnly org.apache.spark.sql.DataFrameSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.