### PR TITLE
[SPARK-50964][SQL] Use StaticInvoke to implement `VariantGet` codegen

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/ToVariantPathSegmentArray.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/ToVariantPathSegmentArray.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions.variant
+
+import scala.util.parsing.combinator.RegexParsers
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, RuntimeReplaceable, UnaryExpression}
+import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
+import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.types.{DataType, ObjectType, StringType}
+import org.apache.spark.unsafe.types.UTF8String
+
+case class ToVariantPathSegmentArray(path: Expression, funcName: String)
+  extends UnaryExpression
+  with RuntimeReplaceable {
+
+  override def foldable: Boolean = path.foldable
+  override def nullIntolerant: Boolean = true
+  override def child: Expression = path
+  override def prettyName: String = "to_variant_path_segment_array"
+
+  override def dataType: DataType = ObjectType(classOf[Array[VariantPathSegment]])
+
+  override def replacement: Expression =
+    StaticInvoke(
+      VariantPathParser.getClass,
+      dataType,
+      "parse",
+      Seq(path, Literal(UTF8String.fromString(funcName), StringType)),
+      Seq(path.dataType, StringType)
+    )
+
+  override protected def withNewChildInternal(newChild: Expression): Expression =
+    copy(path = newChild)
+}
+
+object VariantPathParser extends RegexParsers {
+  private def root: Parser[Char] = '$'
+
+  // Parse index segment like `[123]`.
+  private def index: Parser[VariantPathSegment] =
+    for {
+      index <- '[' ~> "\\d+".r <~ ']'
+    } yield {
+      ArrayExtraction(index.toInt)
+    }
+
+  // Parse key segment like `.name`, `['name']`, or `["name"]`.
+  private def key: Parser[VariantPathSegment] =
+    for {
+      key <- '.' ~> "[^\\.\\[]+".r | "['" ~> "[^\\'\\?]+".r <~ "']" |
+        "[\"" ~> "[^\\\"\\?]+".r <~ "\"]"
+    } yield {
+      ObjectExtraction(key)
+    }
+
+  private val parser: Parser[List[VariantPathSegment]] = phrase(root ~> rep(key | index))
+
+  def parse(str: UTF8String, funcName: UTF8String): Array[VariantPathSegment] = {
+    if (str == null) return null
+    parseAll(parser, str.toString) match {
+      case Success(result, _) => result.toArray
+      case _ => throw QueryExecutionErrors.invalidVariantGetPath(str.toString, funcName.toString)
+    }
+  }
+}

--- a/sql/connect/common/src/test/resources/query-tests/explain-results/function_try_variant_get.explain
+++ b/sql/connect/common/src/test/resources/query-tests/explain-results/function_try_variant_get.explain
@@ -1,2 +1,2 @@
-Project [try_variant_get(static_invoke(VariantExpressionEvalUtils.parseJson(g#0, false, true)), $, IntegerType, false, Some(America/Los_Angeles)) AS try_variant_get(parse_json(g), $)#0]
+Project [static_invoke(VariantGet.variantGet(static_invoke(VariantExpressionEvalUtils.parseJson(g#0, false, true)), static_invoke(VariantPathParser.parse($, try_variant_get)), IntegerType, VariantCastArgs(false,Some(America/Los_Angeles),America/Los_Angeles))) AS try_variant_get(parse_json(g), $)#0]
 +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/sql/connect/common/src/test/resources/query-tests/explain-results/function_variant_get.explain
+++ b/sql/connect/common/src/test/resources/query-tests/explain-results/function_variant_get.explain
@@ -1,2 +1,2 @@
-Project [variant_get(static_invoke(VariantExpressionEvalUtils.parseJson(g#0, false, true)), $, IntegerType, true, Some(America/Los_Angeles)) AS variant_get(parse_json(g), $)#0]
+Project [static_invoke(VariantGet.variantGet(static_invoke(VariantExpressionEvalUtils.parseJson(g#0, false, true)), static_invoke(VariantPathParser.parse($, variant_get)), IntegerType, VariantCastArgs(true,Some(America/Los_Angeles),America/Los_Angeles))) AS variant_get(parse_json(g), $)#0]
 +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PushVariantIntoScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PushVariantIntoScan.scala
@@ -26,10 +26,10 @@ import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project, Subquery}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns
-import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
 
 // A metadata class of a struct field. All struct fields in a struct must either all have this
 // metadata, or all don't have it.
@@ -55,10 +55,8 @@ case class VariantMetadata(
     ).build()
 
   def parsedPath(): Array[VariantPathSegment] = {
-    VariantPathParser.parse(path).getOrElse {
-      val name = if (failOnError) "variant_get" else "try_variant_get"
-      throw QueryExecutionErrors.invalidVariantGetPath(path, name)
-    }
+    val name = if (failOnError) "variant_get" else "try_variant_get"
+    VariantPathParser.parse(UTF8String.fromString(path), UTF8String.fromString(name))
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to 
- use `StaticInvoke` to implement `VariantGet` codegen.
- support for `non-literal` paths in `VariantGet`.

### Why are the changes needed?
Based on @cloud-fan's suggestion, using `StaticInvoke` to implement `VariantGet` codegen, it  can simplify the code.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Pass GA.
- Manually check, eg: `VariantSuite`, `VariantExpressionSuite`


### Was this patch authored or co-authored using generative AI tooling?
No.
