### PR TITLE
[SPARK-50967][SS] Document the case where keys part of the initial state df are also emitted as part of the output

### DIFF
--- a/docs/streaming/apis-on-dataframes-and-datasets.md
+++ b/docs/streaming/apis-on-dataframes-and-datasets.md
@@ -1736,6 +1736,8 @@ Many usecases require more advanced stateful operations than aggregations. For e
 
 Though Spark cannot check and force it, the state function should be implemented with respect to the semantics of the output mode. For example, in Update mode Spark doesn't expect that the state function will emit rows which are older than current watermark plus allowed late record delay, whereas in Append mode the state function can emit these rows.
 
+Note also that for the initial state feature within flatMapGroupsWithState, the keys that are part of the initial state dataFrame are also emitted as part of the output. In case the user does not want these to be part of the output, they need to be filtered explicitly.  
+
 ### Unsupported Operations
 There are a few DataFrame/Dataset operations that are not supported with streaming DataFrames/Datasets.
 Some of them are as follows.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document the case where keys part of the initial state df are also emitted as part of the output

### Why are the changes needed?
Explain the case where the initial state might generate unexpected output


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Docs only change


### Was this patch authored or co-authored using generative AI tooling?
No
