### PR TITLE
[SPARK-50968][PYTHON] Fix the usage of `Column.__new__`

### DIFF
--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -957,6 +957,18 @@ def spark_column_equals(left: Column, right: Column) -> bool:
             )
         return repr(left).replace("`", "") == repr(right).replace("`", "")
     else:
+        from pyspark.sql.classic.column import Column as ClassicColumn
+
+        if not isinstance(left, ClassicColumn):
+            raise PySparkTypeError(
+                errorClass="NOT_COLUMN",
+                messageParameters={"arg_name": "left", "arg_type": type(left).__name__},
+            )
+        if not isinstance(right, ClassicColumn):
+            raise PySparkTypeError(
+                errorClass="NOT_COLUMN",
+                messageParameters={"arg_name": "right", "arg_type": type(right).__name__},
+            )
         return left._jc.equals(right._jc)
 
 

--- a/python/pyspark/sql/classic/column.py
+++ b/python/pyspark/sql/classic/column.py
@@ -177,13 +177,11 @@ def _reverse_op(
 
 @with_origin_to_class
 class Column(ParentColumn):
-    def __new__(
-        cls,
-        jc: "JavaObject",
-    ) -> "Column":
-        self = object.__new__(cls)
-        self.__init__(jc)  # type: ignore[misc]
-        return self
+    def __new__(cls, *args: Any, **kwargs: Any) -> "Column":
+        return object.__new__(cls)
+
+    def __getnewargs__(self) -> Tuple[Any, ...]:
+        return (self._jc,)
 
     def __init__(self, jc: "JavaObject") -> None:
         self._jc = jc

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -31,7 +31,6 @@ from pyspark.sql.types import DataType
 from pyspark.errors import PySparkValueError
 
 if TYPE_CHECKING:
-    from py4j.java_gateway import JavaObject
     from pyspark.sql._typing import LiteralType, DecimalLiteral, DateTimeLiteral
     from pyspark.sql.window import WindowSpec
 
@@ -72,16 +71,10 @@ class Column(TableValuedFunctionArgument):
     # HACK ALERT!! this is to reduce the backward compatibility concern, and returns
     # Spark Classic Column by default. This is NOT an API, and NOT supposed to
     # be directly invoked. DO NOT use this constructor.
-    def __new__(
-        cls,
-        jc: "JavaObject",
-    ) -> "Column":
+    def __new__(cls, *args: Any, **kwargs: Any) -> "Column":
         from pyspark.sql.classic.column import Column
 
-        return Column.__new__(Column, jc)
-
-    def __init__(self, jc: "JavaObject") -> None:
-        self._jc = jc
+        return Column.__new__(Column, *args, **kwargs)
 
     # arithmetic operators
     @dispatch_col_method

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -27,6 +27,7 @@ from typing import (
     Any,
     Union,
     Optional,
+    Tuple,
 )
 
 from pyspark.sql.column import Column as ParentColumn
@@ -109,13 +110,11 @@ def _to_expr(v: Any) -> Expression:
 
 @with_origin_to_class(["to_plan"])
 class Column(ParentColumn):
-    def __new__(
-        cls,
-        expr: "Expression",
-    ) -> "Column":
-        self = object.__new__(cls)
-        self.__init__(expr)  # type: ignore[misc]
-        return self
+    def __new__(cls, *args: Any, **kwargs: Any) -> "Column":
+        return object.__new__(cls)
+
+    def __getnewargs__(self) -> Tuple[Any, ...]:
+        return (self._expr,)
 
     def __init__(self, expr: "Expression") -> None:
         if not isinstance(expr, Expression):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes the usage of `Column.__new__`.

### Why are the changes needed?

Currently `Column.__init__` is called in `Column.__new__`, but it will call `__init__` twice, because it will be automatically called from Python, so it doesn't need to be explicitly called in `__new__`.

```py
>>> class A:
...   def __new__(cls, *args, **kwargs):
...     print(f"__NEW__: {args}, {kwargs}")
...     obj = object.__new__(cls)
...     obj.__init__(*args, **kwargs)
...     return obj
...   def __init__(self, *args, **kwargs):
...     print(f"__INIT__: {args}, {kwargs}")
...
>>> A(1,2,3, k=4)
__NEW__: (1, 2, 3), {'k': 4}
__INIT__: (1, 2, 3), {'k': 4}
__INIT__: (1, 2, 3), {'k': 4}
<__main__.A object at 0x102ccab90>

>>> class B:
...   def __new__(cls, *args, **kwargs):
...     print(f"__NEW__: {args}, {kwargs}")
...     return object.__new__(cls)
...   def __init__(self, *args, **kwargs):
...     print(f"__INIT__: {args}, {kwargs}")
...
>>> B(1,2,3, k=4)
__NEW__: (1, 2, 3), {'k': 4}
__INIT__: (1, 2, 3), {'k': 4}
<__main__.B object at 0x102b2b970>
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing tests should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.
