### PR TITLE
[SPARK-50970][PYTHON][SS] Unify naming convention for stateful processor APIs

### DIFF
--- a/python/pyspark/sql/pandas/group_ops.py
+++ b/python/pyspark/sql/pandas/group_ops.py
@@ -566,8 +566,8 @@ class PandasGroupedOpsMixin:
                     statefulProcessorApiClient.set_implicit_key(key_obj)
                     for pd in statefulProcessor.handleExpiredTimer(
                         key=key_obj,
-                        timer_values=TimerValues(batch_timestamp, watermark_timestamp),
-                        expired_timer_info=ExpiredTimerInfo(expiry_timestamp),
+                        timerValues=TimerValues(batch_timestamp, watermark_timestamp),
+                        expiredTimerInfo=ExpiredTimerInfo(expiry_timestamp),
                     ):
                         yield pd
                     statefulProcessorApiClient.delete_timer(expiry_timestamp)

--- a/python/pyspark/sql/streaming/stateful_processor.py
+++ b/python/pyspark/sql/streaming/stateful_processor.py
@@ -45,33 +45,33 @@ class ValueState:
     .. versionadded:: 4.0.0
     """
 
-    def __init__(self, value_state_client: ValueStateClient, state_name: str) -> None:
-        self._value_state_client = value_state_client
-        self._state_name = state_name
+    def __init__(self, valueStateClient: ValueStateClient, stateName: str) -> None:
+        self._valueStateClient = valueStateClient
+        self._stateName = stateName
 
     def exists(self) -> bool:
         """
         Whether state exists or not.
         """
-        return self._value_state_client.exists(self._state_name)
+        return self._valueStateClient.exists(self._stateName)
 
     def get(self) -> Optional[Tuple]:
         """
         Get the state value if it exists. Returns None if the state variable does not have a value.
         """
-        return self._value_state_client.get(self._state_name)
+        return self._valueStateClient.get(self._stateName)
 
-    def update(self, new_value: Tuple) -> None:
+    def update(self, newValue: Tuple) -> None:
         """
         Update the value of the state.
         """
-        self._value_state_client.update(self._state_name, new_value)
+        self._valueStateClient.update(self._stateName, newValue)
 
     def clear(self) -> None:
         """
         Remove this state.
         """
-        self._value_state_client.clear(self._state_name)
+        self._valueStateClient.clear(self._stateName)
 
 
 class TimerValues:
@@ -82,22 +82,22 @@ class TimerValues:
     """
 
     def __init__(
-        self, current_processing_time_in_ms: int = -1, current_watermark_in_ms: int = -1
+        self, currentProcessingTimeInMs: int = -1, currentWatermarkInMs: int = -1
     ) -> None:
-        self._current_processing_time_in_ms = current_processing_time_in_ms
-        self._current_watermark_in_ms = current_watermark_in_ms
+        self._currentProcessingTimeInMs = currentProcessingTimeInMs
+        self._currentWatermarkInMs = currentWatermarkInMs
 
-    def get_current_processing_time_in_ms(self) -> int:
+    def getCurrentProcessingTimeInMs(self) -> int:
         """
         Get processing time for current batch, return timestamp in millisecond.
         """
-        return self._current_processing_time_in_ms
+        return self._currentProcessingTimeInMs
 
-    def get_current_watermark_in_ms(self) -> int:
+    def getCurrentWatermarkInMs(self) -> int:
         """
         Get watermark for current batch, return timestamp in millisecond.
         """
-        return self._current_watermark_in_ms
+        return self._currentWatermarkInMs
 
 
 class ExpiredTimerInfo:
@@ -106,14 +106,14 @@ class ExpiredTimerInfo:
     .. versionadded:: 4.0.0
     """
 
-    def __init__(self, expiry_time_in_ms: int = -1) -> None:
-        self._expiry_time_in_ms = expiry_time_in_ms
+    def __init__(self, expiryTimeInMs: int = -1) -> None:
+        self._expiryTimeInMs = expiryTimeInMs
 
-    def get_expiry_time_in_ms(self) -> int:
+    def getExpiryTimeInMs(self) -> int:
         """
         Get the timestamp for expired timer, return timestamp in millisecond.
         """
-        return self._expiry_time_in_ms
+        return self._expiryTimeInMs
 
 
 class ListState:
@@ -124,45 +124,45 @@ class ListState:
     .. versionadded:: 4.0.0
     """
 
-    def __init__(self, list_state_client: ListStateClient, state_name: str) -> None:
-        self._list_state_client = list_state_client
-        self._state_name = state_name
+    def __init__(self, listStateClient: ListStateClient, stateName: str) -> None:
+        self._listStateClient = listStateClient
+        self._stateName = stateName
 
     def exists(self) -> bool:
         """
         Whether list state exists or not.
         """
-        return self._list_state_client.exists(self._state_name)
+        return self._listStateClient.exists(self._stateName)
 
     def get(self) -> Iterator[Tuple]:
         """
         Get list state with an iterator.
         """
-        return ListStateIterator(self._list_state_client, self._state_name)
+        return ListStateIterator(self._listStateClient, self._stateName)
 
-    def put(self, new_state: List[Tuple]) -> None:
+    def put(self, newState: List[Tuple]) -> None:
         """
         Update the values of the list state.
         """
-        self._list_state_client.put(self._state_name, new_state)
+        self._listStateClient.put(self._stateName, newState)
 
-    def append_value(self, new_state: Tuple) -> None:
+    def appendValue(self, newState: Tuple) -> None:
         """
         Append a new value to the list state.
         """
-        self._list_state_client.append_value(self._state_name, new_state)
+        self._listStateClient.append_value(self._stateName, newState)
 
-    def append_list(self, new_state: List[Tuple]) -> None:
+    def appendList(self, newState: List[Tuple]) -> None:
         """
         Append a list of new values to the list state.
         """
-        self._list_state_client.append_list(self._state_name, new_state)
+        self._listStateClient.append_list(self._stateName, newState)
 
     def clear(self) -> None:
         """
         Remove this state.
         """
-        self._list_state_client.clear(self._state_name)
+        self._listStateClient.clear(self._stateName)
 
 
 class MapState:
@@ -175,65 +175,65 @@ class MapState:
 
     def __init__(
         self,
-        map_state_client: MapStateClient,
-        state_name: str,
+        MapStateClient: MapStateClient,
+        stateName: str,
     ) -> None:
-        self._map_state_client = map_state_client
-        self._state_name = state_name
+        self._mapStateClient = MapStateClient
+        self._stateName = stateName
 
     def exists(self) -> bool:
         """
         Whether state exists or not.
         """
-        return self._map_state_client.exists(self._state_name)
+        return self._mapStateClient.exists(self._stateName)
 
-    def get_value(self, key: Tuple) -> Optional[Tuple]:
+    def getValue(self, key: Tuple) -> Optional[Tuple]:
         """
         Get the state value for given user key if it exists.
         """
-        return self._map_state_client.get_value(self._state_name, key)
+        return self._mapStateClient.get_value(self._stateName, key)
 
-    def contains_key(self, key: Tuple) -> bool:
+    def containsKey(self, key: Tuple) -> bool:
         """
         Check if the user key is contained in the map.
         """
-        return self._map_state_client.contains_key(self._state_name, key)
+        return self._mapStateClient.contains_key(self._stateName, key)
 
-    def update_value(self, key: Tuple, value: Tuple) -> None:
+    def updateValue(self, key: Tuple, value: Tuple) -> None:
         """
         Update value for given user key.
         """
-        return self._map_state_client.update_value(self._state_name, key, value)
+        return self._mapStateClient.update_value(self._stateName, key, value)
 
     def iterator(self) -> Iterator[Tuple[Tuple, Tuple]]:
         """
         Get the map associated with grouping key.
         """
-        return MapStateKeyValuePairIterator(self._map_state_client, self._state_name)
+        return MapStateKeyValuePairIterator(self._mapStateClient, self._stateName)
 
     def keys(self) -> Iterator[Tuple]:
         """
         Get the list of keys present in map associated with grouping key.
         """
-        return MapStateIterator(self._map_state_client, self._state_name, True)
+        return MapStateIterator(self._mapStateClient, self._stateName, True)
 
     def values(self) -> Iterator[Tuple]:
         """
         Get the list of values present in map associated with grouping key.
         """
-        return MapStateIterator(self._map_state_client, self._state_name, False)
+        return MapStateIterator(self._mapStateClient, self._stateName, False)
 
-    def remove_key(self, key: Tuple) -> None:
+    def removeKey(self, key: Tuple) -> None:
         """
         Remove user key from map state.
         """
-        return self._map_state_client.remove_key(self._state_name, key)
+        return self._mapStateClient.remove_key(self._stateName, key)
 
     def clear(self) -> None:
         """
         Remove this state.
         """
-        self._map_state_client.clear(self._state_name)
+        self._mapStateClient.clear(self._stateName)
 
 
 class StatefulProcessorHandle:
@@ -244,11 +244,11 @@ class StatefulProcessorHandle:
     .. versionadded:: 4.0.0
     """
 
-    def __init__(self, stateful_processor_api_client: StatefulProcessorApiClient) -> None:
-        self.stateful_processor_api_client = stateful_processor_api_client
+    def __init__(self, statefulProcessorApiClient: StatefulProcessorApiClient) -> None:
+        self._statefulProcessorApiClient = statefulProcessorApiClient
 
     def getValueState(
-        self, state_name: str, schema: Union[StructType, str], ttl_duration_ms: Optional[int] = None
+        self, stateName: str, schema: Union[StructType, str], ttlDurationMs: Optional[int] = None
     ) -> ValueState:
         """
         Function to create new or return existing single value state variable of given type.
@@ -257,7 +257,7 @@ class StatefulProcessorHandle:
 
         Parameters
         ----------
-        state_name : str
+        stateName : str
             name of the state variable
         schema : :class:`pyspark.sql.types.DataType` or str
             The schema of the state variable. The value can be either a
@@ -268,11 +268,11 @@ class StatefulProcessorHandle:
             resets the expiration time to current processing time plus ttlDuration.
             If ttl is not specified the state will never expire.
         """
-        self.stateful_processor_api_client.get_value_state(state_name, schema, ttl_duration_ms)
-        return ValueState(ValueStateClient(self.stateful_processor_api_client, schema), state_name)
+        self._statefulProcessorApiClient.get_value_state(stateName, schema, ttlDurationMs)
+        return ValueState(ValueStateClient(self._statefulProcessorApiClient, schema), stateName)
 
     def getListState(
-        self, state_name: str, schema: Union[StructType, str], ttl_duration_ms: Optional[int] = None
+        self, stateName: str, schema: Union[StructType, str], ttlDurationMs: Optional[int] = None
     ) -> ListState:
         """
         Function to create new or return existing single value state variable of given type.
@@ -281,7 +281,7 @@ class StatefulProcessorHandle:
 
         Parameters
         ----------
-        state_name : str
+        stateName : str
             name of the state variable
         schema : :class:`pyspark.sql.types.DataType` or str
             The schema of the state variable. The value can be either a
@@ -292,15 +292,15 @@ class StatefulProcessorHandle:
             resets the expiration time to current processing time plus ttlDuration.
             If ttl is not specified the state will never expire.
         """
-        self.stateful_processor_api_client.get_list_state(state_name, schema, ttl_duration_ms)
-        return ListState(ListStateClient(self.stateful_processor_api_client, schema), state_name)
+        self._statefulProcessorApiClient.get_list_state(stateName, schema, ttlDurationMs)
+        return ListState(ListStateClient(self._statefulProcessorApiClient, schema), stateName)
 
     def getMapState(
         self,
-        state_name: str,
-        user_key_schema: Union[StructType, str],
-        value_schema: Union[StructType, str],
-        ttl_duration_ms: Optional[int] = None,
+        stateName: str,
+        userKeySchema: Union[StructType, str],
+        valueSchema: Union[StructType, str],
+        ttlDurationMs: Optional[int] = None,
     ) -> MapState:
         """
         Function to create new or return existing single map state variable of given type.
@@ -309,51 +309,51 @@ class StatefulProcessorHandle:
 
         Parameters
         ----------
-        state_name : str
+        stateName : str
             name of the state variable
-        user_key_schema : :class:`pyspark.sql.types.DataType` or str
+        userKeySchema : :class:`pyspark.sql.types.DataType` or str
             The schema of the key of map state. The value can be either a
             :class:`pyspark.sql.types.DataType` object or a DDL-formatted type string.
-        value_schema : :class:`pyspark.sql.types.DataType` or str
+        valueSchema : :class:`pyspark.sql.types.DataType` or str
             The schema of the value of map state The value can be either a
             :class:`pyspark.sql.types.DataType` object or a DDL-formatted type string.
-        ttl_duration_ms: int
+        ttlDurationMs: int
             Time to live duration of the state in milliseconds. State values will not be returned
             past ttlDuration and will be eventually removed from the state store. Any state update
             resets the expiration time to current processing time plus ttlDuration.
             If ttl is not specified the state will never expire.
         """
-        self.stateful_processor_api_client.get_map_state(
-            state_name, user_key_schema, value_schema, ttl_duration_ms
+        self._statefulProcessorApiClient.get_map_state(
+            stateName, userKeySchema, valueSchema, ttlDurationMs
         )
         return MapState(
-            MapStateClient(self.stateful_processor_api_client, user_key_schema, value_schema),
-            state_name,
+            MapStateClient(self._statefulProcessorApiClient, userKeySchema, valueSchema),
+            stateName,
         )
 
-    def registerTimer(self, expiry_time_stamp_ms: int) -> None:
+    def registerTimer(self, expiryTimestampMs: int) -> None:
         """
         Register a timer for a given expiry timestamp in milliseconds for the grouping key.
         """
-        self.stateful_processor_api_client.register_timer(expiry_time_stamp_ms)
+        self._statefulProcessorApiClient.register_timer(expiryTimestampMs)
 
-    def deleteTimer(self, expiry_time_stamp_ms: int) -> None:
+    def deleteTimer(self, expiryTimestampMs: int) -> None:
         """
         Delete a timer for a given expiry timestamp in milliseconds for the grouping key.
         """
-        self.stateful_processor_api_client.delete_timer(expiry_time_stamp_ms)
+        self._statefulProcessorApiClient.delete_timer(expiryTimestampMs)
 
     def listTimers(self) -> Iterator[int]:
         """
         List all timers of their expiry timestamps in milliseconds for the grouping key.
         """
-        return ListTimerIterator(self.stateful_processor_api_client)
+        return ListTimerIterator(self._statefulProcessorApiClient)
 
-    def deleteIfExists(self, state_name: str) -> None:
+    def deleteIfExists(self, stateName: str) -> None:
         """
         Function to delete and purge state variable if defined previously
         """
-        self.stateful_processor_api_client.delete_if_exists(state_name)
+        self._statefulProcessorApiClient.delete_if_exists(stateName)
 
 
 class StatefulProcessor(ABC):
@@ -383,7 +383,7 @@ class StatefulProcessor(ABC):
         self,
         key: Any,
         rows: Iterator["PandasDataFrameLike"],
-        timer_values: TimerValues,
+        timerValues: TimerValues,
     ) -> Iterator["PandasDataFrameLike"]:
         """
         Function that will allow users to interact with input data rows along with the grouping key.
@@ -402,14 +402,14 @@ class StatefulProcessor(ABC):
             grouping key.
         rows : iterable of :class:`pandas.DataFrame`
             iterator of input rows associated with grouping key
-        timer_values: TimerValues
-                      Timer value for the current batch that process the input rows.
-                      Users can get the processing or event time timestamp from TimerValues.
+        timerValues: TimerValues
+                     Timer value for the current batch that process the input rows.
+                     Users can get the processing or event time timestamp from TimerValues.
         """
         ...
 
     def handleExpiredTimer(
-        self, key: Any, timer_values: TimerValues, expired_timer_info: ExpiredTimerInfo
+        self, key: Any, timerValues: TimerValues, expiredTimerInfo: ExpiredTimerInfo
     ) -> Iterator["PandasDataFrameLike"]:
         """
         Optional to implement. Will act return an empty iterator if not defined.
@@ -420,11 +420,11 @@ class StatefulProcessor(ABC):
         ----------
         key : Any
             grouping key.
-        timer_values: TimerValues
-                      Timer value for the current batch that process the input rows.
-                      Users can get the processing or event time timestamp from TimerValues.
-        expired_timer_info: ExpiredTimerInfo
-                            Instance of ExpiredTimerInfo that provides access to expired timer.
+        timerValues: TimerValues
+                   Timer value for the current batch that process the input rows.
+                   Users can get the processing or event time timestamp from TimerValues.
+        expiredTimerInfo: ExpiredTimerInfo
+                        Instance of ExpiredTimerInfo that provides access to expired timer.
         """
         return iter([])
 
@@ -437,7 +437,7 @@ class StatefulProcessor(ABC):
         ...
 
     def handleInitialState(
-        self, key: Any, initialState: "PandasDataFrameLike", timer_values: TimerValues
+        self, key: Any, initialState: "PandasDataFrameLike", timerValues: TimerValues
     ) -> None:
         """
         Optional to implement. Will act as no-op if not defined or no initial state input.
@@ -449,8 +449,8 @@ class StatefulProcessor(ABC):
             grouping key.
         initialState: :class:`pandas.DataFrame`
                       One dataframe in the initial state associated with the key.
-        timer_values: TimerValues
-                      Timer value for the current batch that process the input rows.
-                      Users can get the processing or event time timestamp from TimerValues.
+        timerValues: TimerValues
+                     Timer value for the current batch that process the input rows.
+                     Users can get the processing or event time timestamp from TimerValues.
         """
         pass

--- a/python/pyspark/sql/streaming/stateful_processor.py
+++ b/python/pyspark/sql/streaming/stateful_processor.py
@@ -81,9 +81,7 @@ class TimerValues:
     .. versionadded:: 4.0.0
     """
 
-    def __init__(
-        self, currentProcessingTimeInMs: int = -1, currentWatermarkInMs: int = -1
-    ) -> None:
+    def __init__(self, currentProcessingTimeInMs: int = -1, currentWatermarkInMs: int = -1) -> None:
         self._currentProcessingTimeInMs = currentProcessingTimeInMs
         self._currentWatermarkInMs = currentWatermarkInMs
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
@@ -1518,9 +1518,7 @@ class StatefulProcessorWithInitialStateTimers(SimpleStatefulProcessorWithInitial
     def handleExpiredTimer(self, key, timerValues, expiredTimerInfo) -> Iterator[pd.DataFrame]:
         self.handle.deleteTimer(expiredTimerInfo.getExpiryTimeInMs())
         str_key = f"{str(key[0])}-expired"
-        yield pd.DataFrame(
-            {"id": (str_key,), "value": str(expiredTimerInfo.getExpiryTimeInMs())}
-        )
+        yield pd.DataFrame({"id": (str_key,), "value": str(expiredTimerInfo.getExpiryTimeInMs())})
 
     def handleInitialState(self, key, initialState, timerValues) -> None:
         super().handleInitialState(key, initialState, timerValues)

--- a/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
@@ -1481,7 +1481,7 @@ class SimpleStatefulProcessorWithInitialState(StatefulProcessor):
         self.value_state = handle.getValueState("value_state", state_schema)
         self.handle = handle
 
-    def handleInputRows(self, key, rows, timer_values) -> Iterator[pd.DataFrame]:
+    def handleInputRows(self, key, rows, timerValues) -> Iterator[pd.DataFrame]:
         exists = self.value_state.exists()
         if exists:
             value_row = self.value_state.get()
@@ -1504,7 +1504,7 @@ class SimpleStatefulProcessorWithInitialState(StatefulProcessor):
         else:
             yield pd.DataFrame({"id": key, "value": str(accumulated_value)})
 
-    def handleInitialState(self, key, initialState, timer_values) -> None:
+    def handleInitialState(self, key, initialState, timerValues) -> None:
         init_val = initialState.at[0, "initVal"]
         self.value_state.update((init_val,))
         if len(key) == 1:
@@ -1515,16 +1515,16 @@ class SimpleStatefulProcessorWithInitialState(StatefulProcessor):
 
 
 class StatefulProcessorWithInitialStateTimers(SimpleStatefulProcessorWithInitialState):
-    def handleExpiredTimer(self, key, timer_values, expired_timer_info) -> Iterator[pd.DataFrame]:
-        self.handle.deleteTimer(expired_timer_info.get_expiry_time_in_ms())
+    def handleExpiredTimer(self, key, timerValues, expiredTimerInfo) -> Iterator[pd.DataFrame]:
+        self.handle.deleteTimer(expiredTimerInfo.getExpiryTimeInMs())
         str_key = f"{str(key[0])}-expired"
         yield pd.DataFrame(
-            {"id": (str_key,), "value": str(expired_timer_info.get_expiry_time_in_ms())}
+            {"id": (str_key,), "value": str(expiredTimerInfo.getExpiryTimeInMs())}
         )
 
-    def handleInitialState(self, key, initialState, timer_values) -> None:
-        super().handleInitialState(key, initialState, timer_values)
-        self.handle.registerTimer(timer_values.get_current_processing_time_in_ms() - 1)
+    def handleInitialState(self, key, initialState, timerValues) -> None:
+        super().handleInitialState(key, initialState, timerValues)
+        self.handle.registerTimer(timerValues.getCurrentProcessingTimeInMs() - 1)
 
 
 class StatefulProcessorWithListStateInitialState(SimpleStatefulProcessorWithInitialState):
@@ -1533,9 +1533,9 @@ class StatefulProcessorWithListStateInitialState(SimpleStatefulProcessorWithInit
         list_ele_schema = StructType([StructField("value", IntegerType(), True)])
         self.list_state = handle.getListState("list_state", list_ele_schema)
 
-    def handleInitialState(self, key, initialState, timer_values) -> None:
+    def handleInitialState(self, key, initialState, timerValues) -> None:
         for val in initialState["initVal"].tolist():
-            self.list_state.append_value((val,))
+            self.list_state.appendValue((val,))
 
 
 # A stateful processor that output the max event time it has seen. Register timer for
@@ -1546,15 +1546,15 @@ class EventTimeStatefulProcessor(StatefulProcessor):
         self.handle = handle
         self.max_state = handle.getValueState("max_state", state_schema)
 
-    def handleExpiredTimer(self, key, timer_values, expired_timer_info) -> Iterator[pd.DataFrame]:
+    def handleExpiredTimer(self, key, timerValues, expiredTimerInfo) -> Iterator[pd.DataFrame]:
         self.max_state.clear()
-        self.handle.deleteTimer(expired_timer_info.get_expiry_time_in_ms())
+        self.handle.deleteTimer(expiredTimerInfo.getExpiryTimeInMs())
         str_key = f"{str(key[0])}-expired"
         yield pd.DataFrame(
-            {"id": (str_key,), "timestamp": str(expired_timer_info.get_expiry_time_in_ms())}
+            {"id": (str_key,), "timestamp": str(expiredTimerInfo.getExpiryTimeInMs())}
         )
 
-    def handleInputRows(self, key, rows, timer_values) -> Iterator[pd.DataFrame]:
+    def handleInputRows(self, key, rows, timerValues) -> Iterator[pd.DataFrame]:
         timestamp_list = []
         for pdf in rows:
             # int64 will represent timestamp in nanosecond, restore to second
@@ -1567,7 +1567,7 @@ class EventTimeStatefulProcessor(StatefulProcessor):
         max_event_time = str(max(cur_max, max(timestamp_list)))
 
         self.max_state.update((max_event_time,))
-        self.handle.registerTimer(timer_values.get_current_watermark_in_ms())
+        self.handle.registerTimer(timerValues.getCurrentWatermarkInMs())
 
         yield pd.DataFrame({"id": key, "timestamp": max_event_time})
 
@@ -1583,7 +1583,7 @@ class ProcTimeStatefulProcessor(StatefulProcessor):
         self.handle = handle
         self.count_state = handle.getValueState("count_state", state_schema)
 
-    def handleExpiredTimer(self, key, timer_values, expired_timer_info) -> Iterator[pd.DataFrame]:
+    def handleExpiredTimer(self, key, timerValues, expiredTimerInfo) -> Iterator[pd.DataFrame]:
         # reset count state each time the timer is expired
         timer_list_1 = [e for e in self.handle.listTimers()]
         timer_list_2 = []
@@ -1597,23 +1597,23 @@ class ProcTimeStatefulProcessor(StatefulProcessor):
         if len(timer_list_1) > 0:
             assert len(timer_list_1) == 2
         self.count_state.clear()
-        self.handle.deleteTimer(expired_timer_info.get_expiry_time_in_ms())
+        self.handle.deleteTimer(expiredTimerInfo.getExpiryTimeInMs())
         yield pd.DataFrame(
             {
                 "id": key,
                 "countAsString": str("-1"),
-                "timeValues": str(expired_timer_info.get_expiry_time_in_ms()),
+                "timeValues": str(expiredTimerInfo.getExpiryTimeInMs()),
             }
         )
 
-    def handleInputRows(self, key, rows, timer_values) -> Iterator[pd.DataFrame]:
+    def handleInputRows(self, key, rows, timerValues) -> Iterator[pd.DataFrame]:
         if not self.count_state.exists():
             count = 0
         else:
             count = int(self.count_state.get()[0])
 
         if key == ("0",):
-            self.handle.registerTimer(timer_values.get_current_processing_time_in_ms() + 1)
+            self.handle.registerTimer(timerValues.getCurrentProcessingTimeInMs() + 1)
 
         rows_count = 0
         for pdf in rows:
@@ -1623,7 +1623,7 @@ class ProcTimeStatefulProcessor(StatefulProcessor):
         count = count + rows_count
 
         self.count_state.update((str(count),))
-        timestamp = str(timer_values.get_current_processing_time_in_ms())
+        timestamp = str(timerValues.getCurrentProcessingTimeInMs())
 
         yield pd.DataFrame({"id": key, "countAsString": str(count), "timeValues": timestamp})
 
@@ -1642,7 +1642,7 @@ class SimpleStatefulProcessor(StatefulProcessor, unittest.TestCase):
         self.temp_state = handle.getValueState("tempState", state_schema)
         handle.deleteIfExists("tempState")
 
-    def handleInputRows(self, key, rows, timer_values) -> Iterator[pd.DataFrame]:
+    def handleInputRows(self, key, rows, timerValues) -> Iterator[pd.DataFrame]:
         with self.assertRaisesRegex(PySparkRuntimeError, "Error checking value state exists"):
             self.temp_state.exists()
         new_violations = 0
@@ -1674,7 +1674,7 @@ class StatefulProcessorChainingOps(StatefulProcessor):
     def init(self, handle: StatefulProcessorHandle) -> None:
         pass
 
-    def handleInputRows(self, key, rows, timer_values) -> Iterator[pd.DataFrame]:
+    def handleInputRows(self, key, rows, timerValues) -> Iterator[pd.DataFrame]:
         for pdf in rows:
             timestamp_list = pdf["eventTime"].tolist()
         yield pd.DataFrame({"id": key, "outputTimestamp": timestamp_list[0]})
@@ -1704,7 +1704,7 @@ class TTLStatefulProcessor(StatefulProcessor):
             "ttl-map-state", user_key_schema, state_schema, 10000
         )
 
-    def handleInputRows(self, key, rows, timer_values) -> Iterator[pd.DataFrame]:
+    def handleInputRows(self, key, rows, timerValues) -> Iterator[pd.DataFrame]:
         count = 0
         ttl_count = 0
         ttl_list_state_count = 0
@@ -1719,7 +1719,7 @@ class TTLStatefulProcessor(StatefulProcessor):
             for s in iter:
                 ttl_list_state_count += s[0]
         if self.ttl_map_state.exists():
-            ttl_map_state_count = self.ttl_map_state.get_value(key)[0]
+            ttl_map_state_count = self.ttl_map_state.getValue(key)[0]
         for pdf in rows:
             pdf_count = pdf.count().get("temperature")
             count += pdf_count
@@ -1732,7 +1732,7 @@ class TTLStatefulProcessor(StatefulProcessor):
         if not (ttl_count == 2 and id == "0"):
             self.ttl_count_state.update((ttl_count,))
             self.ttl_list_state.put([(ttl_list_state_count,), (ttl_list_state_count,)])
-            self.ttl_map_state.update_value(key, (ttl_map_state_count,))
+            self.ttl_map_state.updateValue(key, (ttl_map_state_count,))
         yield pd.DataFrame(
             {
                 "id": [
@@ -1754,7 +1754,7 @@ class InvalidSimpleStatefulProcessor(StatefulProcessor):
         state_schema = StructType([StructField("value", IntegerType(), True)])
         self.num_violations_state = handle.getValueState("numViolations", state_schema)
 
-    def handleInputRows(self, key, rows, timer_values) -> Iterator[pd.DataFrame]:
+    def handleInputRows(self, key, rows, timerValues) -> Iterator[pd.DataFrame]:
         count = 0
         exists = self.num_violations_state.exists()
         assert not exists
@@ -1778,16 +1778,16 @@ class ListStateProcessor(StatefulProcessor):
         self.list_state1 = handle.getListState("listState1", state_schema)
         self.list_state2 = handle.getListState("listState2", state_schema)
 
-    def handleInputRows(self, key, rows, timer_values) -> Iterator[pd.DataFrame]:
+    def handleInputRows(self, key, rows, timerValues) -> Iterator[pd.DataFrame]:
         count = 0
         for pdf in rows:
             list_state_rows = [(120,), (20,)]
             self.list_state1.put(list_state_rows)
             self.list_state2.put(list_state_rows)
-            self.list_state1.append_value((111,))
-            self.list_state2.append_value((222,))
-            self.list_state1.append_list(list_state_rows)
-            self.list_state2.append_list(list_state_rows)
+            self.list_state1.appendValue((111,))
+            self.list_state2.appendValue((222,))
+            self.list_state1.appendList(list_state_rows)
+            self.list_state2.appendList(list_state_rows)
             pdf_count = pdf.count()
             count += pdf_count.get("temperature")
         iter1 = self.list_state1.get()
@@ -1832,7 +1832,7 @@ class MapStateProcessor(StatefulProcessor):
         # Test string type schemas
         self.map_state = handle.getMapState("mapState", "name string", "count int")
 
-    def handleInputRows(self, key, rows, timer_values) -> Iterator[pd.DataFrame]:
+    def handleInputRows(self, key, rows, timerValues) -> Iterator[pd.DataFrame]:
         count = 0
         key1 = ("key1",)
         key2 = ("key2",)
@@ -1842,12 +1842,12 @@ class MapStateProcessor(StatefulProcessor):
         value1 = count
         value2 = count
         if self.map_state.exists():
-            if self.map_state.contains_key(key1):
-                value1 += self.map_state.get_value(key1)[0]
-            if self.map_state.contains_key(key2):
-                value2 += self.map_state.get_value(key2)[0]
-        self.map_state.update_value(key1, (value1,))
-        self.map_state.update_value(key2, (value2,))
+            if self.map_state.containsKey(key1):
+                value1 += self.map_state.getValue(key1)[0]
+            if self.map_state.containsKey(key2):
+                value2 += self.map_state.getValue(key2)[0]
+        self.map_state.updateValue(key1, (value1,))
+        self.map_state.updateValue(key2, (value2,))
         key_iter = self.map_state.keys()
         assert next(key_iter)[0] == "key1"
         assert next(key_iter)[0] == "key2"
@@ -1857,8 +1857,8 @@ class MapStateProcessor(StatefulProcessor):
         map_iter = self.map_state.iterator()
         assert next(map_iter)[0] == key1
         assert next(map_iter)[1] == (value2,)
-        self.map_state.remove_key(key1)
-        assert not self.map_state.contains_key(key1)
+        self.map_state.removeKey(key1)
+        assert not self.map_state.containsKey(key1)
         yield pd.DataFrame({"id": key, "countAsString": str(count)})
 
     def close(self) -> None:
@@ -1884,7 +1884,7 @@ class BasicProcessor(StatefulProcessor):
     def init(self, handle):
         self.state = handle.getValueState("state", self.state_schema)
 
-    def handleInputRows(self, key, rows, timer_values) -> Iterator[pd.DataFrame]:
+    def handleInputRows(self, key, rows, timerValues) -> Iterator[pd.DataFrame]:
         for pdf in rows:
             pass
         id_val = int(key[0])
@@ -1910,7 +1910,7 @@ class AddFieldsProcessor(StatefulProcessor):
     def init(self, handle):
         self.state = handle.getValueState("state", self.state_schema)
 
-    def handleInputRows(self, key, rows, timer_values) -> Iterator[pd.DataFrame]:
+    def handleInputRows(self, key, rows, timerValues) -> Iterator[pd.DataFrame]:
         for pdf in rows:
             pass
         id_val = int(key[0])
@@ -1958,7 +1958,7 @@ class RemoveFieldsProcessor(StatefulProcessor):
     def init(self, handle):
         self.state = handle.getValueState("state", self.state_schema)
 
-    def handleInputRows(self, key, rows, timer_values) -> Iterator[pd.DataFrame]:
+    def handleInputRows(self, key, rows, timerValues) -> Iterator[pd.DataFrame]:
         for pdf in rows:
             pass
         id_val = int(key[0])
@@ -1986,7 +1986,7 @@ class ReorderedFieldsProcessor(StatefulProcessor):
     def init(self, handle):
         self.state = handle.getValueState("state", self.state_schema)
 
-    def handleInputRows(self, key, rows, timer_values) -> Iterator[pd.DataFrame]:
+    def handleInputRows(self, key, rows, timerValues) -> Iterator[pd.DataFrame]:
         for pdf in rows:
             pass
         id_val = int(key[0])
@@ -2035,7 +2035,7 @@ class UpcastProcessor(StatefulProcessor):
     def init(self, handle):
         self.state = handle.getValueState("state", self.state_schema)
 
-    def handleInputRows(self, key, rows, timer_values) -> Iterator[pd.DataFrame]:
+    def handleInputRows(self, key, rows, timerValues) -> Iterator[pd.DataFrame]:
         for pdf in rows:
             pass
         id_val = int(key[0])


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Unify naming convention for stateful processor APIs.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Following best practice, make TransformWithStateInPandas naming convention consistent across APIs.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing unit test.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.