### PR TITLE
[SPARK-50971][CORE] Combine the two retrievals of `taskDescription` in `CoarseGrainedExecutorBackend#statusUpdate`

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -265,8 +265,9 @@ private[spark] class CoarseGrainedExecutorBackend(
   }
 
   override def statusUpdate(taskId: Long, state: TaskState, data: ByteBuffer): Unit = {
-    val resources = executor.runningTasks.get(taskId).taskDescription.resources
-    val cpus = executor.runningTasks.get(taskId).taskDescription.cpus
+    val taskDescription = executor.runningTasks.get(taskId).taskDescription
+    val resources = taskDescription.resources
+    val cpus = taskDescription.cpus
     val msg = StatusUpdate(executorId, taskId, state, data, cpus, resources)
     if (TaskState.isFinished(state)) {
       lastTaskFinishTime.set(System.nanoTime())


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR reduces the two retrievals of `taskDescription` in `CoarseGrainedExecutorBackend#statusUpdate` to one.

### Why are the changes needed?
Combine the two retrievals of `taskDescription` in `CoarseGrainedExecutorBackend#statusUpdate`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Acitions


### Was this patch authored or co-authored using generative AI tooling?
No