### PR TITLE
[SPARK-50973][SQL][AVRO] Cleanup deprecated api usage related to `avro.Schema#toString(boolean)`

### DIFF
--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -22,7 +22,9 @@ import java.net.URI
 import java.nio.file.{Files, Paths, StandardCopyOption}
 import java.sql.{Date, Timestamp}
 import java.util.UUID
+
 import scala.jdk.CollectionConverters._
+
 import org.apache.avro.{AvroTypeException, Schema, SchemaBuilder, SchemaFormatter}
 import org.apache.avro.Schema.{Field, Type}
 import org.apache.avro.Schema.Type._
@@ -30,6 +32,7 @@ import org.apache.avro.file.{DataFileReader, DataFileWriter}
 import org.apache.avro.generic.{GenericData, GenericDatumReader, GenericDatumWriter, GenericRecord}
 import org.apache.avro.generic.GenericData.{EnumSymbol, Fixed}
 import org.apache.commons.io.FileUtils
+
 import org.apache.spark.{SPARK_VERSION_SHORT, SparkConf, SparkException, SparkUpgradeException}
 import org.apache.spark.TestUtils.assertExceptionMsg
 import org.apache.spark.sql._
@@ -38,7 +41,7 @@ import org.apache.spark.sql.avro.AvroCompressionCodec._
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.logical.Filter
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils
-import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{LA, UTC, withDefaultTimeZone}
+import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, LA, UTC}
 import org.apache.spark.sql.execution.{FormattedMode, SparkPlan}
 import org.apache.spark.sql.execution.datasources.{CommonFileDataSourceSuite, DataSource, FilePartition}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -97,7 +97,7 @@ abstract class AvroSuite
           .head
       }
     }, new GenericDatumReader[Any]()).getSchema
-    SchemaFormatter.getInstance("json/inline").format(schema)
+    SchemaFormatter.getInstance(AvroUtils.JSON_INLINE_FORMAT).format(schema)
   }
 
   // Check whether an Avro schema of union type is converted to SQL in an expected way, when the

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -97,7 +97,7 @@ abstract class AvroSuite
           .head
       }
     }, new GenericDatumReader[Any]()).getSchema
-    SchemaFormatter.getInstance(AvroUtils.JSON_INLINE_FORMAT).format(schema)
+    SchemaFormatter.format(AvroUtils.JSON_INLINE_FORMAT, schema)
   }
 
   // Check whether an Avro schema of union type is converted to SQL in an expected way, when the

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
@@ -21,7 +21,7 @@ import java.util.Locale
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.avro.Schema
+import org.apache.avro.{Schema, SchemaFormatter}
 import org.apache.avro.file.{DataFileReader, FileReader}
 import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
 import org.apache.avro.mapred.{AvroOutputFormat, FsInput}
@@ -71,7 +71,7 @@ private[sql] object AvroUtils extends Logging {
       case _ => throw new RuntimeException(
         s"""Avro schema cannot be converted to a Spark SQL StructType:
            |
-           |${avroSchema.toString(true)}
+           |${SchemaFormatter.getInstance("json/pretty").format(avroSchema)}
            |""".stripMargin)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
@@ -44,6 +44,10 @@ import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
 private[sql] object AvroUtils extends Logging {
+
+  val JSON_INLINE_FORMAT: String = "json/inline"
+  val JSON_PRETTY_FORMAT: String = "json/pretty"
+
   def inferSchema(
       spark: SparkSession,
       options: Map[String, String],
@@ -71,7 +75,7 @@ private[sql] object AvroUtils extends Logging {
       case _ => throw new RuntimeException(
         s"""Avro schema cannot be converted to a Spark SQL StructType:
            |
-           |${SchemaFormatter.getInstance("json/pretty").format(avroSchema)}
+           |${SchemaFormatter.getInstance(JSON_PRETTY_FORMAT).format(avroSchema)}
            |""".stripMargin)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
@@ -75,7 +75,7 @@ private[sql] object AvroUtils extends Logging {
       case _ => throw new RuntimeException(
         s"""Avro schema cannot be converted to a Spark SQL StructType:
            |
-           |${SchemaFormatter.getInstance(JSON_PRETTY_FORMAT).format(avroSchema)}
+           |${SchemaFormatter.format(JSON_PRETTY_FORMAT, avroSchema)}
            |""".stripMargin)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
@@ -22,7 +22,7 @@ import java.util.Locale
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
-import org.apache.avro.{LogicalTypes, Schema, SchemaBuilder}
+import org.apache.avro.{LogicalTypes, Schema, SchemaBuilder, SchemaFormatter}
 import org.apache.avro.LogicalTypes.{Decimal, _}
 import org.apache.avro.Schema.Type._
 import org.apache.avro.SchemaBuilder.FieldAssembler
@@ -150,8 +150,8 @@ object SchemaConverters extends Logging {
         if (recursiveDepth > 0 && recursiveFieldMaxDepth <= 0) {
           throw new IncompatibleSchemaException(s"""
             |Found recursive reference in Avro schema, which can not be processed by Spark by
-            | default: ${avroSchema.toString(true)}. Try setting the option `recursiveFieldMaxDepth`
-            | to 1 - $RECURSIVE_FIELD_MAX_DEPTH_LIMIT.
+            | default: ${SchemaFormatter.getInstance("json/pretty").format(avroSchema)}.
+            | Try setting the option `recursiveFieldMaxDepth` to 1 - $RECURSIVE_FIELD_MAX_DEPTH_LIMIT.
           """.stripMargin)
         } else if (recursiveDepth > 0 && recursiveDepth >= recursiveFieldMaxDepth) {
           logInfo(

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
@@ -148,10 +148,11 @@ object SchemaConverters extends Logging {
       case RECORD =>
         val recursiveDepth: Int = existingRecordNames.getOrElse(avroSchema.getFullName, 0)
         if (recursiveDepth > 0 && recursiveFieldMaxDepth <= 0) {
+          val formattedAvroSchema = SchemaFormatter.getInstance(AvroUtils.JSON_PRETTY_FORMAT)
+            .format(avroSchema)
           throw new IncompatibleSchemaException(s"""
             |Found recursive reference in Avro schema, which can not be processed by Spark by
-            | default: ${SchemaFormatter.getInstance("json/pretty").format(avroSchema)}.
-            | Try setting the option `recursiveFieldMaxDepth`
+            | default: $formattedAvroSchema. Try setting the option `recursiveFieldMaxDepth`
             | to 1 - $RECURSIVE_FIELD_MAX_DEPTH_LIMIT.
           """.stripMargin)
         } else if (recursiveDepth > 0 && recursiveDepth >= recursiveFieldMaxDepth) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
@@ -151,7 +151,8 @@ object SchemaConverters extends Logging {
           throw new IncompatibleSchemaException(s"""
             |Found recursive reference in Avro schema, which can not be processed by Spark by
             | default: ${SchemaFormatter.getInstance("json/pretty").format(avroSchema)}.
-            | Try setting the option `recursiveFieldMaxDepth` to 1 - $RECURSIVE_FIELD_MAX_DEPTH_LIMIT.
+            | Try setting the option `recursiveFieldMaxDepth`
+            | to 1 - $RECURSIVE_FIELD_MAX_DEPTH_LIMIT.
           """.stripMargin)
         } else if (recursiveDepth > 0 && recursiveDepth >= recursiveFieldMaxDepth) {
           logInfo(

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
@@ -148,8 +148,7 @@ object SchemaConverters extends Logging {
       case RECORD =>
         val recursiveDepth: Int = existingRecordNames.getOrElse(avroSchema.getFullName, 0)
         if (recursiveDepth > 0 && recursiveFieldMaxDepth <= 0) {
-          val formattedAvroSchema = SchemaFormatter.getInstance(AvroUtils.JSON_PRETTY_FORMAT)
-            .format(avroSchema)
+          val formattedAvroSchema = SchemaFormatter.format(AvroUtils.JSON_PRETTY_FORMAT, avroSchema)
           throw new IncompatibleSchemaException(s"""
             |Found recursive reference in Avro schema, which can not be processed by Spark by
             | default: $formattedAvroSchema. Try setting the option `recursiveFieldMaxDepth`

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetAvroCompatibilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetAvroCompatibilitySuite.scala
@@ -23,7 +23,7 @@ import java.util.{List => JList, Map => JMap}
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.avro.Schema
+import org.apache.avro.{Schema, SchemaFormatter}
 import org.apache.avro.generic.IndexedRecord
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.avro.AvroParquetWriter
@@ -40,7 +40,7 @@ class ParquetAvroCompatibilitySuite extends ParquetCompatibilityTest with Shared
     logInfo(
       s"""Writing Avro records with the following Avro schema into Parquet file:
          |
-         |${schema.toString(true)}
+         |${SchemaFormatter.getInstance("json/pretty").format(schema)}
        """.stripMargin)
 
     val writer = AvroParquetWriter.builder[T](new Path(path)).withSchema(schema).build()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetAvroCompatibilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetAvroCompatibilitySuite.scala
@@ -41,7 +41,7 @@ class ParquetAvroCompatibilitySuite extends ParquetCompatibilityTest with Shared
     logInfo(
       s"""Writing Avro records with the following Avro schema into Parquet file:
          |
-         |${SchemaFormatter.getInstance(AvroUtils.JSON_PRETTY_FORMAT).format(schema)}
+         |${SchemaFormatter.format(AvroUtils.JSON_PRETTY_FORMAT, schema)}
        """.stripMargin)
 
     val writer = AvroParquetWriter.builder[T](new Path(path)).withSchema(schema).build()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetAvroCompatibilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetAvroCompatibilitySuite.scala
@@ -30,6 +30,7 @@ import org.apache.parquet.avro.AvroParquetWriter
 import org.apache.parquet.hadoop.ParquetWriter
 
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.avro.AvroUtils
 import org.apache.spark.sql.execution.datasources.parquet.test.avro._
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -40,7 +41,7 @@ class ParquetAvroCompatibilitySuite extends ParquetCompatibilityTest with Shared
     logInfo(
       s"""Writing Avro records with the following Avro schema into Parquet file:
          |
-         |${SchemaFormatter.getInstance("json/pretty").format(schema)}
+         |${SchemaFormatter.getInstance(AvroUtils.JSON_PRETTY_FORMAT).format(schema)}
        """.stripMargin)
 
     val writer = AvroParquetWriter.builder[T](new Path(path)).withSchema(schema).build()


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to use `SchemaFormatter.format(string, Schema)` instead of `avro.Schema#toString(boolean)`, the changes refer to

https://github.com/apache/avro/blob/8c27801dc8d42ccc00997f25c0b8f45f8d4a233e/lang/java/avro/src/main/java/org/apache/avro/Schema.java#L412-L422

![image](https://github.com/user-attachments/assets/ff4477af-dd49-40e6-a2ea-e6636e1e5ece)


### Why are the changes needed?
Cleanup deprecated api usage related to `avro.Schema#toString(boolean)`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No