### PR TITLE
[MINOR][SQL] Remove unused TableSchema constructor

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/TableSchema.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/TableSchema.java
@@ -36,10 +36,6 @@ public class TableSchema {
   public TableSchema() {
   }
 
-  public TableSchema(int numColumns) {
-    // TODO: remove this constructor
-  }
-
   public TableSchema(TTableSchema tTableSchema) {
     for (TColumnDesc tColumnDesc : tTableSchema.getColumns()) {
       columns.add(new ColumnDescriptor(tColumnDesc));


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR removes the unused TableSchema(int numColumns) constructor, which was previously marked with a TODO comment for removal. 

### Why are the changes needed?
The constructor is no longer required and does not serve any functional purpose in the codebase. Eliminating this dead code enhances code maintainability and readability.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests and moreover we don't use this constructor anywhere in the codebase:

```
❯ git grep "new TableSchema"
sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetCatalogsOperation.java:  private static final TableSchema RESULT_SET_SCHEMA = new TableSchema()
sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetColumnsOperation.java:  protected static final TableSchema RESULT_SET_SCHEMA = new TableSchema()
sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetColumnsOperation.java:          TableSchema schema = new TableSchema(metastoreClient.getSchema(dbName,
sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetCrossReferenceOperation.java:  private static final TableSchema RESULT_SET_SCHEMA = new TableSchema()
sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetFunctionsOperation.java:  private static final TableSchema RESULT_SET_SCHEMA = new TableSchema()
sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetPrimaryKeysOperation.java:  private static final TableSchema RESULT_SET_SCHEMA = new TableSchema()
sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetSchemasOperation.java:  private static final TableSchema RESULT_SET_SCHEMA = new TableSchema()
sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetTableTypesOperation.java:  protected static TableSchema RESULT_SET_SCHEMA = new TableSchema()
sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetTablesOperation.java:  private static final TableSchema RESULT_SET_SCHEMA = new TableSchema()
sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetTypeInfoOperation.java:  private static final TableSchema RESULT_SET_SCHEMA = new TableSchema()
sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/OperationManager.java:    TableSchema tableSchema = new TableSchema(getLogSchema());
```


### Was this patch authored or co-authored using generative AI tooling?
No
