### PR TITLE
[SPARK-50853][CORE][3.5] Close temp shuffle file writable channel

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/DownloadFileWritableChannel.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/DownloadFileWritableChannel.java
@@ -19,6 +19,7 @@ package org.apache.spark.network.shuffle;
 
 import org.apache.spark.network.buffer.ManagedBuffer;
 
+import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
 
 /**
@@ -26,5 +27,5 @@ import java.nio.channels.WritableByteChannel;
  * after the writer has been closed.  Used with DownloadFile and DownloadFileManager.
  */
 public interface DownloadFileWritableChannel extends WritableByteChannel {
-  ManagedBuffer closeAndRead();
+  ManagedBuffer closeAndRead() throws IOException;
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/SimpleDownloadFile.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/SimpleDownloadFile.java
@@ -69,7 +69,8 @@ public class SimpleDownloadFile implements DownloadFile {
     }
 
     @Override
-    public ManagedBuffer closeAndRead() {
+    public ManagedBuffer closeAndRead() throws IOException {
+      channel.close();
       return new FileSegmentManagedBuffer(transportConf, file, 0, file.length());
     }
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SimpleDownloadFileSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SimpleDownloadFileSuite.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle;
+
+import org.apache.spark.network.util.MapConfigProvider;
+import org.apache.spark.network.util.TransportConf;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Assertions;
+
+public class SimpleDownloadFileSuite {
+  @Test
+  public void testChannelIsClosedAfterCloseAndRead() throws IOException {
+    File tempFile = File.createTempFile("testChannelIsClosed", ".tmp");
+    tempFile.deleteOnExit();
+    TransportConf conf = new TransportConf("test", MapConfigProvider.EMPTY);
+
+    DownloadFile downloadFile = null;
+    try {
+      downloadFile = new SimpleDownloadFile(tempFile, conf);
+      DownloadFileWritableChannel channel = downloadFile.openForWriting();
+      channel.closeAndRead();
+      Assertions.assertFalse(channel.isOpen(), "Channel should be closed after closeAndRead.");
+    } finally {
+      if (downloadFile != null) {
+        downloadFile.delete();
+      }
+    }
+  }
+}

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SimpleDownloadFileSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SimpleDownloadFileSuite.java
@@ -19,12 +19,12 @@ package org.apache.spark.network.shuffle;
 
 import org.apache.spark.network.util.MapConfigProvider;
 import org.apache.spark.network.util.TransportConf;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
-
-import org.junit.jupiter.api.Assertions;
 
 public class SimpleDownloadFileSuite {
   @Test
@@ -38,7 +38,7 @@ public class SimpleDownloadFileSuite {
       downloadFile = new SimpleDownloadFile(tempFile, conf);
       DownloadFileWritableChannel channel = downloadFile.openForWriting();
       channel.closeAndRead();
-      Assertions.assertFalse(channel.isOpen(), "Channel should be closed after closeAndRead.");
+      assertFalse("Channel should be closed after closeAndRead.", channel.isOpen());
     } finally {
       if (downloadFile != null) {
         downloadFile.delete();


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a backport of
- https://github.com/apache/spark/pull/49531

Currently, there are two implementations of DownloadFileWritableChannel (which is used for writing data fetched to disk), SimpleDownloadWritableChannel and EncryptedDownloadWritableChannel. The latter closes the writable channel in its implementation of closeAndRead method while the former does not. As a result, SimpleDownloadWritableChannel channel is never closed and is relying on either the finalizer in FileOutputStream or the phantom cleanable in FileDescriptor to close the file descriptor. The change in this PR is to close the channel in SimpleDownloadWritableChannel closeAndRead method.

### Why are the changes needed?

Should be closing file handles when they are not needed anymore instead of relying on finalizer/cleanables to do it.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing spark tests.

### Was this patch authored or co-authored using generative AI tooling?

No
