### PR TITLE
[WIP][SPARK-50983][SQL] Support Nested Correlated Subqueries for Analyzer

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5906,6 +5906,11 @@
           "Correlated scalar subqueries must be aggregated to return at most one row."
         ]
       },
+      "NESTED_CORRELATED_SUBQUERIES_NOT_SUPPORTED" : {
+        "message" : [
+          "Nested correlated subqueries are not supported."
+        ]
+      },
       "NON_CORRELATED_COLUMNS_IN_GROUP_BY" : {
         "message" : [
           "A GROUP BY clause in a scalar correlated subquery cannot contain non-correlated columns: <value>."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2365,7 +2365,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
           val res = resolveSubQuery(e, outer)(Exists(_, _, Seq.empty, exprId))
           val unresolvedOuterReferences = getUnresolvedOuterReferences(res, plan)
           res.withNewUnresolvedOuterAttrs(unresolvedOuterReferences)
-        case InSubquery(values, l @ ListQuery(_, _, exprId, _, _, _))
+        case InSubquery(values, l @ ListQuery(_, _, _, exprId, _, _, _))
             if values.forall(_.resolved) && !l.resolved =>
           val expr = resolveSubQuery(l, outer)((plan, exprs) => {
             ListQuery(plan, exprs, Seq.empty, exprId, plan.output.length)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -359,7 +359,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
       // Please do not insert any other rules in between. See the TODO comments in rule
       // ResolveLateralColumnAliasReference for more details.
       ResolveLateralColumnAliasReference ::
-       ::
+      ResolveExpressionsWithNamePlaceholders ::
       ResolveDeserializer ::
       ResolveNewInstance ::
       ResolveUpCast ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -359,7 +359,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
       // Please do not insert any other rules in between. See the TODO comments in rule
       // ResolveLateralColumnAliasReference for more details.
       ResolveLateralColumnAliasReference ::
-      ResolveExpressionsWithNamePlaceholders ::
+       ::
       ResolveDeserializer ::
       ResolveNewInstance ::
       ResolveUpCast ::
@@ -4109,25 +4109,25 @@ object ResolveExpressionsWithNamePlaceholders extends Rule[LogicalPlan] {
  *    +- Filter exists#245 [min(b#227)#249]
  *       :  +- Project [1 AS 1#247]
  *       :     +- Filter (d#238 < min(outer(b#227)))       <-----
- *       :- SubqueryAlias r
- *       :   - Project [_1#234 AS c#237, _2#235 AS d#238]
- *       :      - LocalRelation [_1#234, _2#235]
+ *       :        +- SubqueryAlias r
+ *       :           +- Project [_1#234 AS c#237, _2#235 AS d#238]
+ *       :              +- LocalRelation [_1#234, _2#235]
  *       +- Aggregate [a#226], [a#226, min(b#227) AS min(b#227)#249]
- *  - SubqueryAlias l
- *     - Project [_1#223 AS a#226, _2#224 AS b#227]
- *        - LocalRelation [_1#223, _2#224]
+ *          +- SubqueryAlias l
+ *             +- Project [_1#223 AS a#226, _2#224 AS b#227]
+ *                +- LocalRelation [_1#223, _2#224]
  * Plan after the rule.
  *    Project [a#226]
  *    +- Filter exists#245 [min(b#227)#249]
  *       :  +- Project [1 AS 1#247]
  *       :     +- Filter (d#238 < outer(min(b#227)#249))   <-----
- *       :- SubqueryAlias r
- *       :   - Project [_1#234 AS c#237, _2#235 AS d#238]
- *       :      - LocalRelation [_1#234, _2#235]
+ *       :        +- SubqueryAlias r
+ *       :           +- Project [_1#234 AS c#237, _2#235 AS d#238]
+ *       :              +- LocalRelation [_1#234, _2#235]
  *       +- Aggregate [a#226], [a#226, min(b#227) AS min(b#227)#249]
- *  - SubqueryAlias l
- *     - Project [_1#223 AS a#226, _2#224 AS b#227]
- *        - LocalRelation [_1#223, _2#224]
+ *          +- SubqueryAlias l
+ *             +- Project [_1#223 AS a#226, _2#224 AS b#227]
+ *                +- LocalRelation [_1#223, _2#224]
  */
 object UpdateOuterReferences extends Rule[LogicalPlan] {
   private def stripAlias(expr: Expression): Expression = expr match { case a: Alias => a.child }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -1395,9 +1395,9 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
     // +- Project [c1#87, c2#88]
     // :  (Aggregate or Window operator)
     // :  +- Filter [outer(c2#77) >= c2#88)]
-    // : - SubqueryAlias t2, `t2`
-    // :  - Project [_1#84 AS c1#87, _2#85 AS c2#88]
-    // :     - LocalRelation [_1#84, _2#85]
+    // :     +- SubqueryAlias t2, `t2`
+    // :        +- Project [_1#84 AS c1#87, _2#85 AS c2#88]
+    // :           +- LocalRelation [_1#84, _2#85]
     // +- SubqueryAlias t1, `t1`
     // +- Project [_1#73 AS c1#76, _2#74 AS c2#77]
     // +- LocalRelation [_1#73, _2#74]
@@ -1414,7 +1414,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
     // Original subquery plan:
     //   Aggregate [count(1)]
     //   +- Filter ((a + b) = outer(c))
-    //- LocalRelation [a, b]
+    //      +- LocalRelation [a, b]
     //
     // Plan after pulling up correlated predicates:
     //   Aggregate [a, b] [count(1), a, b]
@@ -1424,8 +1424,8 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
     //   Project [c1, count(1)]
     //   +- Join LeftOuter ((a + b) = c)
     //      :- LocalRelation [c]
-    //- Aggregate [a, b] [count(1), a, b]
-    //   - LocalRelation [a, b]
+    //      +- Aggregate [a, b] [count(1), a, b]
+    //         +- LocalRelation [a, b]
     //
     // The right hand side of the join transformed from the subquery will output
     //   count(1) | a | b

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SQLFunction.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SQLFunction.scala
@@ -85,7 +85,8 @@ case class SQLFunction(
       case (None, Some(Project(expr :: Nil, _: OneRowRelation)))
         if !isTableFunc =>
         (Some(expr), None)
-      case (Some(ScalarSubquery(Project(expr :: Nil, _: OneRowRelation), _, _, _, _, _, _)), None)
+      case (Some(ScalarSubquery(
+          Project(expr :: Nil, _: OneRowRelation), _, _, _, _, _, _, _)), None)
         if !isTableFunc =>
         (Some(expr), None)
       case (_, _) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCo
 import org.apache.spark.sql.catalyst.plans.logical.{HintInfo, LogicalPlan}
 import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.trees.UnaryLike
-import org.apache.spark.sql.errors.QueryExecutionErrors
 
 trait DynamicPruning extends Predicate
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
@@ -89,7 +89,7 @@ case class FunctionTableSubqueryArgumentExpression(
       unresolvedOuterAttrs: Seq[Expression]
   ): FunctionTableSubqueryArgumentExpression = {
     if (!unresolvedOuterAttrs.forall(outerAttrs.contains(_))) {
-      // throw
+      // TODO(avery): create suitable error subclass to throw
     }
     copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -424,7 +424,7 @@ case class ScalarSubquery(
       unresolvedOuterAttrs: Seq[Expression]
   ): ScalarSubquery = {
     if (!unresolvedOuterAttrs.forall(outerAttrs.contains(_))) {
-      // throw
+      // TODO(avery): create suitable error subclass to throw
     }
     copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
   }
@@ -489,7 +489,7 @@ case class LateralSubquery(
       unresolvedOuterAttrs: Seq[Expression]
   ): LateralSubquery = {
     if (!unresolvedOuterAttrs.forall(outerAttrs.contains(_))) {
-      // throw
+      // TODO(avery): create suitable error subclass to throw
     }
     copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
   }
@@ -560,7 +560,7 @@ case class ListQuery(
       unresolvedOuterAttrs: Seq[Expression]
   ): ListQuery = {
     if (!unresolvedOuterAttrs.forall(outerAttrs.contains(_))) {
-      // throw
+      // TODO(avery): create suitable error subclass to throw
     }
     copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
   }
@@ -628,7 +628,7 @@ case class Exists(
             unresolvedOuterAttrs: Seq[Expression]
   ): Exists = {
     if (!unresolvedOuterAttrs.forall(outerAttrs.contains(_))) {
-      // throw
+      // TODO(avery): create suitable error subclass to throw
     }
     copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -67,6 +67,8 @@ abstract class PlanExpression[T <: QueryPlan[_]] extends Expression {
  *
  * @param plan: the subquery plan
  * @param outerAttrs: the outer references in the subquery plan
+ * @param unresolvedOuterAttrs: the outer references in the subquery plan
+ * but can't be resolved by its immediate parent plan
  * @param exprId: ID of the expression
  * @param joinCond: the join conditions with the outer query. It contains both inner and outer
  *                  query references.
@@ -76,18 +78,22 @@ abstract class PlanExpression[T <: QueryPlan[_]] extends Expression {
 abstract class SubqueryExpression(
     plan: LogicalPlan,
     outerAttrs: Seq[Expression],
+    unresolvedOuterAttrs: Seq[Expression],
     exprId: ExprId,
     joinCond: Seq[Expression],
     hint: Option[HintInfo]) extends PlanExpression[LogicalPlan] {
   override lazy val resolved: Boolean = childrenResolved && plan.resolved
   override lazy val references: AttributeSet =
-    AttributeSet.fromAttributeSets(outerAttrs.map(_.references))
+    AttributeSet.fromAttributeSets(outerAttrs.map(_.references)) --
+      AttributeSet.fromAttributeSets(unresolvedOuterAttrs.map(_.references))
   override def children: Seq[Expression] = outerAttrs ++ joinCond
   override def withNewPlan(plan: LogicalPlan): SubqueryExpression
   def withNewOuterAttrs(outerAttrs: Seq[Expression]): SubqueryExpression
   def isCorrelated: Boolean = outerAttrs.nonEmpty
   def hint: Option[HintInfo]
   def withNewHint(hint: Option[HintInfo]): SubqueryExpression
+  def withNewUnresolvedOuterAttrs(unresolvedOuterAttrs: Seq[Expression]): SubqueryExpression
+  def getUnresolvedOuterAttrs: Seq[Expression] = unresolvedOuterAttrs
 }
 
 object SubqueryExpression {
@@ -395,12 +401,14 @@ object SubExprUtils extends PredicateHelper {
 case class ScalarSubquery(
     plan: LogicalPlan,
     outerAttrs: Seq[Expression] = Seq.empty,
+    unresolvedOuterAttrs: Seq[Expression] = Seq.empty,
     exprId: ExprId = NamedExpression.newExprId,
     joinCond: Seq[Expression] = Seq.empty,
     hint: Option[HintInfo] = None,
     mayHaveCountBug: Option[Boolean] = None,
     needSingleJoin: Option[Boolean] = None)
-  extends SubqueryExpression(plan, outerAttrs, exprId, joinCond, hint) with Unevaluable {
+  extends SubqueryExpression(
+    plan, outerAttrs, unresolvedOuterAttrs, exprId, joinCond, hint) with Unevaluable {
   override def dataType: DataType = {
     if (!plan.schema.fields.nonEmpty) {
       throw QueryCompilationErrors.subqueryReturnMoreThanOneColumn(plan.schema.fields.length,
@@ -412,12 +420,21 @@ case class ScalarSubquery(
   override def withNewPlan(plan: LogicalPlan): ScalarSubquery = copy(plan = plan)
   override def withNewOuterAttrs(outerAttrs: Seq[Expression]): ScalarSubquery = copy(
     outerAttrs = outerAttrs)
+  override def withNewUnresolvedOuterAttrs(
+      unresolvedOuterAttrs: Seq[Expression]
+  ): ScalarSubquery = {
+    if (!unresolvedOuterAttrs.forall(outerAttrs.contains(_))) {
+      // throw
+    }
+    copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
+  }
   override def withNewHint(hint: Option[HintInfo]): ScalarSubquery = copy(hint = hint)
   override def toString: String = s"scalar-subquery#${exprId.id} $conditionString"
   override lazy val canonicalized: Expression = {
     ScalarSubquery(
       plan.canonicalized,
       outerAttrs.map(_.canonicalized),
+      unresolvedOuterAttrs.map(_.canonicalized),
       ExprId(0),
       joinCond.map(_.canonicalized))
   }
@@ -457,21 +474,32 @@ case class UnresolvedScalarSubqueryPlanId(planId: Long)
 case class LateralSubquery(
     plan: LogicalPlan,
     outerAttrs: Seq[Expression] = Seq.empty,
+    unresolvedOuterAttrs: Seq[Expression] = Seq.empty,
     exprId: ExprId = NamedExpression.newExprId,
     joinCond: Seq[Expression] = Seq.empty,
     hint: Option[HintInfo] = None)
-  extends SubqueryExpression(plan, outerAttrs, exprId, joinCond, hint) with Unevaluable {
+  extends SubqueryExpression(
+    plan, outerAttrs, unresolvedOuterAttrs, exprId, joinCond, hint) with Unevaluable {
   override def dataType: DataType = plan.output.toStructType
   override def nullable: Boolean = true
   override def withNewPlan(plan: LogicalPlan): LateralSubquery = copy(plan = plan)
   override def withNewOuterAttrs(outerAttrs: Seq[Expression]): LateralSubquery = copy(
     outerAttrs = outerAttrs)
+  override def withNewUnresolvedOuterAttrs(
+      unresolvedOuterAttrs: Seq[Expression]
+  ): LateralSubquery = {
+    if (!unresolvedOuterAttrs.forall(outerAttrs.contains(_))) {
+      // throw
+    }
+    copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
+  }
   override def withNewHint(hint: Option[HintInfo]): LateralSubquery = copy(hint = hint)
   override def toString: String = s"lateral-subquery#${exprId.id} $conditionString"
   override lazy val canonicalized: Expression = {
     LateralSubquery(
       plan.canonicalized,
       outerAttrs.map(_.canonicalized),
+      unresolvedOuterAttrs.map(_.canonicalized),
       ExprId(0),
       joinCond.map(_.canonicalized))
   }
@@ -500,13 +528,15 @@ case class LateralSubquery(
 case class ListQuery(
     plan: LogicalPlan,
     outerAttrs: Seq[Expression] = Seq.empty,
+    unresolvedOuterAttrs: Seq[Expression] = Seq.empty,
     exprId: ExprId = NamedExpression.newExprId,
     // The plan of list query may have more columns after de-correlation, and we need to track the
     // number of the columns of the original plan, to report the data type properly.
     numCols: Int = -1,
     joinCond: Seq[Expression] = Seq.empty,
     hint: Option[HintInfo] = None)
-  extends SubqueryExpression(plan, outerAttrs, exprId, joinCond, hint) with Unevaluable {
+  extends SubqueryExpression(
+    plan, outerAttrs, unresolvedOuterAttrs, exprId, joinCond, hint) with Unevaluable {
   def childOutputs: Seq[Attribute] = plan.output.take(numCols)
   override def dataType: DataType = if (numCols > 1) {
     childOutputs.toStructType
@@ -526,12 +556,21 @@ case class ListQuery(
   override def withNewPlan(plan: LogicalPlan): ListQuery = copy(plan = plan)
   override def withNewOuterAttrs(outerAttrs: Seq[Expression]): ListQuery = copy(
     outerAttrs = outerAttrs)
+  override def withNewUnresolvedOuterAttrs(
+      unresolvedOuterAttrs: Seq[Expression]
+  ): ListQuery = {
+    if (!unresolvedOuterAttrs.forall(outerAttrs.contains(_))) {
+      // throw
+    }
+    copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
+  }
   override def withNewHint(hint: Option[HintInfo]): ListQuery = copy(hint = hint)
   override def toString: String = s"list#${exprId.id} $conditionString"
   override lazy val canonicalized: Expression = {
     ListQuery(
       plan.canonicalized,
       outerAttrs.map(_.canonicalized),
+      unresolvedOuterAttrs.map(_.canonicalized),
       ExprId(0),
       numCols,
       joinCond.map(_.canonicalized))
@@ -574,22 +613,32 @@ case class ListQuery(
 case class Exists(
     plan: LogicalPlan,
     outerAttrs: Seq[Expression] = Seq.empty,
+    unresolvedOuterAttrs: Seq[Expression] = Seq.empty,
     exprId: ExprId = NamedExpression.newExprId,
     joinCond: Seq[Expression] = Seq.empty,
     hint: Option[HintInfo] = None)
-  extends SubqueryExpression(plan, outerAttrs, exprId, joinCond, hint)
+  extends SubqueryExpression(plan, outerAttrs, unresolvedOuterAttrs, exprId, joinCond, hint)
   with Predicate
   with Unevaluable {
   override def nullable: Boolean = false
   override def withNewPlan(plan: LogicalPlan): Exists = copy(plan = plan)
   override def withNewOuterAttrs(outerAttrs: Seq[Expression]): Exists = copy(
     outerAttrs = outerAttrs)
+  override def withNewUnresolvedOuterAttrs(
+            unresolvedOuterAttrs: Seq[Expression]
+  ): Exists = {
+    if (!unresolvedOuterAttrs.forall(outerAttrs.contains(_))) {
+      // throw
+    }
+    copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
+  }
   override def withNewHint(hint: Option[HintInfo]): Exists = copy(hint = hint)
   override def toString: String = s"exists#${exprId.id} $conditionString"
   override lazy val canonicalized: Expression = {
     Exists(
       plan.canonicalized,
       outerAttrs.map(_.canonicalized),
+      unresolvedOuterAttrs.map(_.canonicalized),
       ExprId(0),
       joinCond.map(_.canonicalized))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -94,6 +94,7 @@ abstract class SubqueryExpression(
   def withNewHint(hint: Option[HintInfo]): SubqueryExpression
   def withNewUnresolvedOuterAttrs(unresolvedOuterAttrs: Seq[Expression]): SubqueryExpression
   def getUnresolvedOuterAttrs: Seq[Expression] = unresolvedOuterAttrs
+  def getOuterAttrs: Seq[Expression] = outerAttrs
 }
 
 object SubqueryExpression {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -364,7 +364,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
       case d: DynamicPruningSubquery => d
       case s @ ScalarSubquery(
         PhysicalOperation(projections, predicates, a @ Aggregate(group, _, child, _)),
-        _, _, _, _, mayHaveCountBug, _)
+        _, _, _, _, _, mayHaveCountBug, _)
         if conf.getConf(SQLConf.DECORRELATE_SUBQUERY_PREVENT_CONSTANT_FOLDING_FOR_COUNT_BUG) &&
           mayHaveCountBug.nonEmpty && mayHaveCountBug.get =>
         // This is a subquery with an aggregate that may suffer from a COUNT bug.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -90,7 +90,7 @@ object ConstantFolding extends Rule[LogicalPlan] {
       }
 
     // Don't replace ScalarSubquery if its plan is an aggregate that may suffer from a COUNT bug.
-    case s @ ScalarSubquery(_, _, _, _, _, mayHaveCountBug, _)
+    case s @ ScalarSubquery(_, _, _, _, _, _, mayHaveCountBug, _)
       if conf.getConf(SQLConf.DECORRELATE_SUBQUERY_PREVENT_CONSTANT_FOLDING_FOR_COUNT_BUG) &&
         mayHaveCountBug.nonEmpty && mayHaveCountBug.get =>
       s
@@ -891,7 +891,7 @@ object NullPropagation extends Rule[LogicalPlan] {
       case InSubquery(Seq(Literal(null, _)), _)
         if SQLConf.get.legacyNullInEmptyBehavior =>
         Literal.create(null, BooleanType)
-      case InSubquery(Seq(Literal(null, _)), ListQuery(sub, _, _, _, conditions, _))
+      case InSubquery(Seq(Literal(null, _)), ListQuery(sub, _, _, _, _, conditions, _))
         if !SQLConf.get.legacyNullInEmptyBehavior
         && conditions.isEmpty =>
         If(Exists(sub), Literal(null, BooleanType), FalseLiteral)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4013,7 +4013,7 @@ object SQLConf {
     buildConf("spark.sql.optimizer.supportNestedCorrelatedSubqueries.enabled")
       .internal()
       .doc("If enabled, support nested correlated subqueries")
-      .version("4.0.0")
+      .version("4.1.0")
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4009,6 +4009,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val SUPPORT_NESTED_CORRELATED_SUBQUERIES =
+    buildConf("spark.sql.optimizer.supportNestedCorrelatedSubqueries.enabled")
+      .internal()
+      .doc("If enabled, support nested correlated subqueries")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val PULL_OUT_NESTED_DATA_OUTER_REF_EXPRESSIONS_ENABLED =
     buildConf("spark.sql.optimizer.pullOutNestedDataOuterRefExpressions.enabled")
       .internal()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveSubqueries.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveSubqueries.scala
@@ -30,11 +30,11 @@ case class PlanAdaptiveSubqueries(
   def apply(plan: SparkPlan): SparkPlan = {
     plan.transformAllExpressionsWithPruning(
       _.containsAnyPattern(SCALAR_SUBQUERY, IN_SUBQUERY, DYNAMIC_PRUNING_SUBQUERY)) {
-      case expressions.ScalarSubquery(_, _, exprId, _, _, _, _) =>
+      case expressions.ScalarSubquery(_, _, _, exprId, _, _, _, _) =>
         val subquery = SubqueryExec.createForScalarSubquery(
           s"subquery#${exprId.id}", subqueryMap(exprId.id))
         execution.ScalarSubquery(subquery, exprId)
-      case expressions.InSubquery(values, ListQuery(_, _, exprId, _, _, _)) =>
+      case expressions.InSubquery(values, ListQuery(_, _, _, exprId, _, _, _)) =>
         val expr = if (values.length == 1) {
           values.head
         } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
@@ -187,7 +187,7 @@ case class PlanSubqueries(sparkSession: SparkSession) extends Rule[SparkPlan] {
           SubqueryExec.createForScalarSubquery(
             s"scalar-subquery#${subquery.exprId.id}", executedPlan),
           subquery.exprId)
-      case expressions.InSubquery(values, ListQuery(query, _, exprId, _, _, _)) =>
+      case expressions.InSubquery(values, ListQuery(query, _, _, exprId, _, _, _)) =>
         val expr = if (values.length == 1) {
           values.head
         } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -1008,7 +1008,7 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
           query match {
             case ListQuery(Project(projects, SubqueryAlias(AliasIdentifier("s", Seq()),
                 UnresolvedSubqueryColumnAliases(outputColumnNames, Project(_, _: OneRowRelation)))),
-                _, _, _, _, _) =>
+                _, _, _, _, _, _) =>
               assert(projects.size == 1 && projects.head.name == "s.name")
               assert(outputColumnNames.size == 1 && outputColumnNames.head == "name")
             case o => fail("Unexpected subquery: \n" + o.treeString)
@@ -1089,7 +1089,7 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
           query match {
             case ListQuery(Project(projects, SubqueryAlias(AliasIdentifier("s", Seq()),
                 UnresolvedSubqueryColumnAliases(outputColumnNames, Project(_, _: OneRowRelation)))),
-                _, _, _, _, _) =>
+                _, _, _, _, _, _) =>
               assert(projects.size == 1 && projects.head.name == "s.name")
               assert(outputColumnNames.size == 1 && outputColumnNames.head == "name")
             case o => fail("Unexpected subquery: \n" + o.treeString)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

1. Analyzer is using same outer plan context to resolve subquery if there is outer plan context defined, otherwise it uses the outer plan provided by the function as context.

2. Add unresolvedOuterAttrs argument for SubqueryExpression to record outerAttrs cannot be resolved in the immediate parent query but might be resolved in other ancestor queries.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Support Nested Correlated Subqueries for Analyzer needed for decorrelating nested correlated subqueries.
 
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, add a user-facing config to enable analyzer to support nested correlated subqueries.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
WIP

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No