### PR TITLE
[SPARK-50984][SQL][TESTS] Make `ExpressionImplUtilsSuite` robust by matching JDK msgs via regex

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtilsSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.commons.lang3.{JavaVersion, SystemUtils}
-
 import org.apache.spark.{SparkFunSuite, SparkIllegalArgumentException, SparkRuntimeException}
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -287,12 +285,6 @@ class ExpressionImplUtilsSuite extends SparkFunSuite {
     }
   }
 
-  // JDK-8267125 changes tag error message at Java 18
-  val msgTagMismatch = if (SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17)) {
-    "Tag mismatch!"
-  } else {
-    "Tag mismatch"
-  }
   val corruptedCiphertexts = Seq(
     // This is truncated
     TestCase(
@@ -304,8 +296,7 @@ class ExpressionImplUtilsSuite extends SparkFunSuite {
       errorParamsMap = Map(
         "parameter" -> "`expr`, `key`",
         "functionName" -> "`aes_encrypt`/`aes_decrypt`",
-        "detailMessage" ->
-          "Input length must be multiple of 16 when decrypting with padded cipher"
+        "detailMessage" -> "Input length .*"
       )
     ),
     // The ciphertext is corrupted
@@ -318,7 +309,7 @@ class ExpressionImplUtilsSuite extends SparkFunSuite {
       errorParamsMap = Map(
         "parameter" -> "`expr`, `key`",
         "functionName" -> "`aes_encrypt`/`aes_decrypt`",
-        "detailMessage" -> msgTagMismatch
+        "detailMessage" -> "Tag mismatch[!]?"
       )
     ),
     // Valid ciphertext, wrong AAD
@@ -332,7 +323,7 @@ class ExpressionImplUtilsSuite extends SparkFunSuite {
       errorParamsMap = Map(
         "parameter" -> "`expr`, `key`",
         "functionName" -> "`aes_encrypt`/`aes_decrypt`",
-        "detailMessage" -> msgTagMismatch
+        "detailMessage" -> "Tag mismatch[!]?"
       )
     )
   )
@@ -350,7 +341,8 @@ class ExpressionImplUtilsSuite extends SparkFunSuite {
         f(t)
       },
       condition = t.expectedErrorClassOpt.get,
-      parameters = t.errorParamsMap
+      parameters = t.errorParamsMap,
+      matchPVals = true
     )
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `ExpressionImplUtilsSuite` robust and simpler by matching JDK msgs via regex.

### Why are the changes needed?

Historically, the error messages are different across JDK versions.

https://github.com/apache/spark/blob/44966c94b686df72b827307d3c3eadc6804abaf2/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtilsSuite.scala#L290-L295

In JDK 17.0.14, the error messages are different in some distributions. Note that it succeeds with GitHub Action Zulu distribution.
```
 [info] - AesEncrypt Expected Errors *** FAILED *** (8 milliseconds)
...
     [info]   Analysis:
     [info]   JavaCollectionWrappers$JMapWrapper("detailMessage":
"Input length not multiple of 16 bytes" ->
"Input length must be multiple of 16 when decrypting with padded cipher")
```

We had better make it more robust.

### Does this PR introduce _any_ user-facing change?

No. This is a test-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.