### PR TITLE
[SPARK-50864][TESTS] Disable slow tests

### DIFF
--- a/python/pyspark/ml/tests/connect/test_parity_torch_data_loader.py
+++ b/python/pyspark/ml/tests/connect/test_parity_torch_data_loader.py
@@ -19,14 +19,15 @@ import unittest
 
 from pyspark.util import is_remote_only
 from pyspark.sql import SparkSession
-from pyspark.testing.utils import have_torch, torch_requirement_message
 
-if False:  # not is_remote_only():
+if not is_remote_only():
     from pyspark.ml.torch.tests.test_data_loader import TorchDistributorDataLoaderUnitTests
 
-    @unittest.skipIf(
-        not have_torch or is_remote_only(), torch_requirement_message or "Requires JVM access"
-    )
+    # @unittest.skipIf(
+    #     not have_torch or is_remote_only(), torch_requirement_message or "Requires JVM access"
+    # )
+    # TODO(SPARK-50864): Re-enable this test after fixing the slowness
+    @unittest.skip("Disabled due to slowness")
     class TorchDistributorBaselineUnitTestsOnConnect(TorchDistributorDataLoaderUnitTests):
         def setUp(self) -> None:
             self.spark = (

--- a/python/pyspark/ml/tests/connect/test_parity_torch_data_loader.py
+++ b/python/pyspark/ml/tests/connect/test_parity_torch_data_loader.py
@@ -21,7 +21,7 @@ from pyspark.util import is_remote_only
 from pyspark.sql import SparkSession
 from pyspark.testing.utils import have_torch, torch_requirement_message
 
-if not is_remote_only():
+if False:  # not is_remote_only():
     from pyspark.ml.torch.tests.test_data_loader import TorchDistributorDataLoaderUnitTests
 
     @unittest.skipIf(

--- a/python/pyspark/ml/torch/tests/test_data_loader.py
+++ b/python/pyspark/ml/torch/tests/test_data_loader.py
@@ -23,10 +23,11 @@ from pyspark.ml.torch.distributor import (
 )
 from pyspark.sql import SparkSession
 from pyspark.ml.linalg import Vectors
-from pyspark.testing.utils import have_torch, torch_requirement_message
 
 
-@unittest.skipIf(True, torch_requirement_message)
+# @unittest.skipIf(not have_torch, torch_requirement_message)
+# TODO(SPARK-50864): Re-enable this test after fixing the slowness
+@unittest.skip("Disabled due to slowness")
 class TorchDistributorDataLoaderUnitTests(unittest.TestCase):
     def setUp(self) -> None:
         self.spark = (

--- a/python/pyspark/ml/torch/tests/test_data_loader.py
+++ b/python/pyspark/ml/torch/tests/test_data_loader.py
@@ -26,7 +26,7 @@ from pyspark.ml.linalg import Vectors
 from pyspark.testing.utils import have_torch, torch_requirement_message
 
 
-@unittest.skipIf(not have_torch, torch_requirement_message)
+@unittest.skipIf(True, torch_requirement_message)
 class TorchDistributorDataLoaderUnitTests(unittest.TestCase):
     def setUp(self) -> None:
         self.spark = (


### PR DESCRIPTION
### What changes were proposed in this pull request?

Disables slow tests:

- `TorchDistributorDataLoaderUnitTests`
- `TorchDistributorBaselineUnitTestsOnConnect`

### Why are the changes needed?

The tests above are slow or stuck, similar to other disabled tests for [SPARK-50864](https://issues.apache.org/jira/browse/SPARK-50864).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Run on the GHA.

### Was this patch authored or co-authored using generative AI tooling?

No.
