### PR TITLE
[SPARK-49642][SQL] Remove the ANSI config suggestion in DATETIME_FIELD_OUT_OF_BOUNDS

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1155,7 +1155,7 @@
   },
   "DATETIME_FIELD_OUT_OF_BOUNDS" : {
     "message" : [
-      "<rangeMessage>. If necessary set <ansiConfig> to \"false\" to bypass this error."
+      "<rangeMessage>. To resolve this, validate your input values and ensure they fall within the acceptable range."
     ],
     "sqlState" : "22023"
   },

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -280,8 +280,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
     new SparkDateTimeException(
       errorClass = "DATETIME_FIELD_OUT_OF_BOUNDS",
       messageParameters = Map(
-        "rangeMessage" -> e.getMessage,
-        "ansiConfig" -> toSQLConf(SQLConf.ANSI_ENABLED.key)),
+        "rangeMessage" -> e.getMessage),
       context = Array.empty,
       summary = "")
   }

--- a/sql/core/src/test/resources/sql-tests/results/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/date.sql.out
@@ -56,7 +56,6 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "DATETIME_FIELD_OUT_OF_BOUNDS",
   "sqlState" : "22023",
   "messageParameters" : {
-    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
     "rangeMessage" : "Invalid value for MonthOfYear (valid values 1 - 12): 13"
   }
 }
@@ -72,7 +71,6 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "DATETIME_FIELD_OUT_OF_BOUNDS",
   "sqlState" : "22023",
   "messageParameters" : {
-    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
     "rangeMessage" : "Invalid value for DayOfMonth (valid values 1 - 28/31): 33"
   }
 }

--- a/sql/core/src/test/resources/sql-tests/results/datetime-legacy.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/datetime-legacy.sql.out
@@ -56,7 +56,6 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "DATETIME_FIELD_OUT_OF_BOUNDS",
   "sqlState" : "22023",
   "messageParameters" : {
-    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
     "rangeMessage" : "Invalid value for MonthOfYear (valid values 1 - 12): 13"
   }
 }
@@ -72,7 +71,6 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "DATETIME_FIELD_OUT_OF_BOUNDS",
   "sqlState" : "22023",
   "messageParameters" : {
-    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
     "rangeMessage" : "Invalid value for DayOfMonth (valid values 1 - 28/31): 33"
   }
 }
@@ -1347,7 +1345,6 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "DATETIME_FIELD_OUT_OF_BOUNDS",
   "sqlState" : "22023",
   "messageParameters" : {
-    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
     "rangeMessage" : "Invalid value for SecondOfMinute (valid values 0 - 59): 61"
   }
 }
@@ -1379,7 +1376,6 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "DATETIME_FIELD_OUT_OF_BOUNDS",
   "sqlState" : "22023",
   "messageParameters" : {
-    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
     "rangeMessage" : "Invalid value for SecondOfMinute (valid values 0 - 59): 99"
   }
 }
@@ -1395,7 +1391,6 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "DATETIME_FIELD_OUT_OF_BOUNDS",
   "sqlState" : "22023",
   "messageParameters" : {
-    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
     "rangeMessage" : "Invalid value for SecondOfMinute (valid values 0 - 59): 999"
   }
 }

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/date.sql.out
@@ -690,7 +690,6 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "DATETIME_FIELD_OUT_OF_BOUNDS",
   "sqlState" : "22023",
   "messageParameters" : {
-    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
     "rangeMessage" : "Invalid date 'FEBRUARY 30'"
   }
 }
@@ -706,7 +705,6 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "DATETIME_FIELD_OUT_OF_BOUNDS",
   "sqlState" : "22023",
   "messageParameters" : {
-    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
     "rangeMessage" : "Invalid value for MonthOfYear (valid values 1 - 12): 13"
   }
 }
@@ -722,7 +720,6 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "DATETIME_FIELD_OUT_OF_BOUNDS",
   "sqlState" : "22023",
   "messageParameters" : {
-    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
     "rangeMessage" : "Invalid value for DayOfMonth (valid values 1 - 28/31): -1"
   }
 }

--- a/sql/core/src/test/resources/sql-tests/results/timestamp.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp.sql.out
@@ -157,7 +157,6 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "DATETIME_FIELD_OUT_OF_BOUNDS",
   "sqlState" : "22023",
   "messageParameters" : {
-    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
     "rangeMessage" : "Invalid value for SecondOfMinute (valid values 0 - 59): 61"
   }
 }
@@ -189,7 +188,6 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "DATETIME_FIELD_OUT_OF_BOUNDS",
   "sqlState" : "22023",
   "messageParameters" : {
-    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
     "rangeMessage" : "Invalid value for SecondOfMinute (valid values 0 - 59): 99"
   }
 }
@@ -205,7 +203,6 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "DATETIME_FIELD_OUT_OF_BOUNDS",
   "sqlState" : "22023",
   "messageParameters" : {
-    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
     "rangeMessage" : "Invalid value for SecondOfMinute (valid values 0 - 59): 999"
   }
 }

--- a/sql/core/src/test/resources/sql-tests/results/timestampNTZ/timestamp-ansi.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestampNTZ/timestamp-ansi.sql.out
@@ -157,7 +157,6 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "DATETIME_FIELD_OUT_OF_BOUNDS",
   "sqlState" : "22023",
   "messageParameters" : {
-    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
     "rangeMessage" : "Invalid value for SecondOfMinute (valid values 0 - 59): 61"
   }
 }
@@ -189,7 +188,6 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "DATETIME_FIELD_OUT_OF_BOUNDS",
   "sqlState" : "22023",
   "messageParameters" : {
-    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
     "rangeMessage" : "Invalid value for SecondOfMinute (valid values 0 - 59): 99"
   }
 }
@@ -205,7 +203,6 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "DATETIME_FIELD_OUT_OF_BOUNDS",
   "sqlState" : "22023",
   "messageParameters" : {
-    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
     "rangeMessage" : "Invalid value for SecondOfMinute (valid values 0 - 59): 999"
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Removal of ANSI turn off suggestion for DATETIME_FIELD_OUT_OF_BOUNDS error message.


### Why are the changes needed?
Now that in Spark 4.0.0 we have moved to ANSI mode on by default, we want to keep suggestions of this kind to the minimum.


### Does this PR introduce _any_ user-facing change?
Yes, error message has changed.


### How was this patch tested?
Existing tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
