### PR TITLE
[SPARK-50994][CORE] Perform RDD conversion under tracked execution

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
@@ -1471,8 +1471,8 @@ class Dataset[T] private[sql](
 
   /** @inheritdoc */
   def foreachPartition(f: Iterator[T] => Unit): Unit = withNewRDDExecutionId("foreachPartition") {
-      materializedRdd.foreachPartition(f)
-    }
+    materializedRdd.foreachPartition(f)
+  }
 
   /** @inheritdoc */
   def tail(n: Int): Array[T] = withAction(

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
@@ -955,7 +955,7 @@ class Dataset[T] private[sql](
 
   /** @inheritdoc */
   def reduce(func: (T, T) => T): T = withNewRDDExecutionId("reduce") {
-    rdd.reduce(func)
+    materializedRdd.reduce(func)
   }
 
   /** @inheritdoc */
@@ -1471,8 +1471,8 @@ class Dataset[T] private[sql](
 
   /** @inheritdoc */
   def foreachPartition(f: Iterator[T] => Unit): Unit = withNewRDDExecutionId("foreachPartition") {
-    rdd.foreachPartition(f)
-  }
+      materializedRdd.foreachPartition(f)
+    }
 
   /** @inheritdoc */
   def tail(n: Int): Array[T] = withAction(
@@ -1573,13 +1573,17 @@ class Dataset[T] private[sql](
     sparkSession.sessionState.executePlan(deserialized)
   }
 
+  private lazy val materializedRdd: RDD[T] = {
+    val objectType = exprEnc.deserializer.dataType
+    rddQueryExecution.toRdd.mapPartitions { rows =>
+      rows.map(_.get(0, objectType).asInstanceOf[T])
+    }
+  }
+
   /** @inheritdoc */
   lazy val rdd: RDD[T] = {
     withNewRDDExecutionId("rdd") {
-      val objectType = exprEnc.deserializer.dataType
-      rddQueryExecution.toRdd.mapPartitions { rows =>
-        rows.map(_.get(0, objectType).asInstanceOf[T])
-      }
+      materializedRdd
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
@@ -1575,9 +1575,11 @@ class Dataset[T] private[sql](
 
   /** @inheritdoc */
   lazy val rdd: RDD[T] = {
-    val objectType = exprEnc.deserializer.dataType
-    rddQueryExecution.toRdd.mapPartitions { rows =>
-      rows.map(_.get(0, objectType).asInstanceOf[T])
+    withNewRDDExecutionId("rdd") {
+      val objectType = exprEnc.deserializer.dataType
+      rddQueryExecution.toRdd.mapPartitions { rows =>
+        rows.map(_.get(0, objectType).asInstanceOf[T])
+      }
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2704,7 +2704,7 @@ class SQLQuerySuite extends SQLQuerySuiteBase with DisableAdaptiveExecutionSuite
                     checkAnswer(sql(s"SELECT id FROM $targetTable"),
                       Row(1) :: Row(2) :: Row(3) :: Nil)
                     spark.sparkContext.listenerBus.waitUntilEmpty()
-                    assert(commands.size == 3)
+                    assert(commands.size == 4)
                     assert(commands.head.nodeName == "Execute CreateHiveTableAsSelectCommand")
 
                     val v1WriteCommand = commands(1)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
- A new lazy variable `materializedRdd` is introduced which actualyl holds RDD after it is created (by executing plan). 
- `Dataset#rdd` is wrapped within `withNewRDDExecutionId`, which takes care of important setup tasks, like updating Spark properties in `SparkContext`'s thread-locals, before executing the `SparkPlan` to fetch data
- `Dataset#rdd` acts like any other RDD operations like `reduce` or `foreachPartition` and operates on `materializedRdd` with new execution id (and initialising it if not done yet)


### Why are the changes needed?
When `Dataset` is converted into `RDD`, It executes `SpakPlan` without any execution context. This leads to:
1. No tracking is available on Spark UI for stages which are necessary to build the `RDD`.
2. Spark properties which are local to thread may not be set in the `RDD` execution context. This leads to these properties not being sent with `TaskContext` but some operations like reading parquet files depend on these properties (eg, case-sesitivity).

Test scenario:
```java
test("SPARK-50994: RDD conversion is performed with execution context") {
    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
      withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
        withTempDir(dir => {
          val dummyDF = Seq((1, 1.0), (2, 2.0), (3, 3.0), (1, 1.0)).toDF("a", "A")
          dummyDF.write.format("parquet").mode("overwrite").save(dir.getCanonicalPath)

          val df = spark.read.parquet(dir.getCanonicalPath)
          val encoder = ExpressionEncoder(df.schema)
          val deduplicated = df.dropDuplicates(Array("a"))
          val df2 = deduplicated.flatMap(row => Seq(row))(encoder).rdd

          val output = spark.createDataFrame(df2, df.schema)
          checkAnswer(output, Seq(Row(1, 1.0), Row(2, 2.0), Row(3, 3.0)))
        })
      }
    }
  }
```
In the above scenario,
- Call to `.rdd` triggers execution which performs shuffle after reading parquet
- However, while reading parquet file `spark.sql.caseSensitive` is not set (even though it is passed during session creation) which is referred into `SQLConf` by `parquet-mr` reader
- This leads to unexpected and wrong result of `dropDuplicates` as it would drop duplicates by either `a` or 'A'. Expectation is to drop duplicates by column `a`
- This behaviour is not applicable to vectorized parquet reader because it reads case-sensitivity flag from `hadoopContext` hence is disabled.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing testcases & new test case added for specific scenario


### Was this patch authored or co-authored using generative AI tooling?
No
