### PR TITLE
[SPARK-50998][K8S][DOCS] Fix `spark.kubernetes.configMap.maxSize` default value in docs

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1493,7 +1493,7 @@ See the [configuration page](configuration.html) for information on Spark config
 </tr>
 <tr>
   <td><code>spark.kubernetes.configMap.maxSize</code></td>
-  <td><code>1572864</code></td>
+  <td><code>1048576</code></td>
   <td>
     Max size limit for a config map.
     This is configurable as per <a href="https://etcd.io/docs/latest/dev-guide/limit/">limit</a> on k8s server end.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to Fix `spark.kubernetes.configMap.maxSize` default value in docs

### Why are the changes needed?

Since Apache Spark 3.3.2, we fixed this value from `1572864` from `1048576` in the validation logic.
- #39884

### Does this PR introduce _any_ user-facing change?

No, this is a doc only update to be consistent with the code.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.