### PR TITLE
[SPARK-51005][ML][PYTHON][CONNECT] Support VectorIndexer and ElementwiseProduct on Connect

### DIFF
--- a/mllib/src/main/resources/META-INF/services/org.apache.spark.ml.Estimator
+++ b/mllib/src/main/resources/META-INF/services/org.apache.spark.ml.Estimator
@@ -60,6 +60,7 @@ org.apache.spark.ml.feature.ChiSqSelector
 org.apache.spark.ml.feature.UnivariateFeatureSelector
 org.apache.spark.ml.feature.VarianceThresholdSelector
 org.apache.spark.ml.feature.StringIndexer
+org.apache.spark.ml.feature.VectorIndexer
 org.apache.spark.ml.feature.PCA
 org.apache.spark.ml.feature.IDF
 org.apache.spark.ml.feature.Word2Vec

--- a/mllib/src/main/resources/META-INF/services/org.apache.spark.ml.Transformer
+++ b/mllib/src/main/resources/META-INF/services/org.apache.spark.ml.Transformer
@@ -31,6 +31,7 @@ org.apache.spark.ml.feature.RegexTokenizer
 org.apache.spark.ml.feature.SQLTransformer
 org.apache.spark.ml.feature.StopWordsRemover
 org.apache.spark.ml.feature.FeatureHasher
+org.apache.spark.ml.feature.ElementwiseProduct
 org.apache.spark.ml.feature.HashingTF
 
 ########### Model for loading
@@ -77,6 +78,7 @@ org.apache.spark.ml.feature.ChiSqSelectorModel
 org.apache.spark.ml.feature.UnivariateFeatureSelectorModel
 org.apache.spark.ml.feature.VarianceThresholdSelectorModel
 org.apache.spark.ml.feature.StringIndexerModel
+org.apache.spark.ml.feature.VectorIndexerModel
 org.apache.spark.ml.feature.PCAModel
 org.apache.spark.ml.feature.IDFModel
 org.apache.spark.ml.feature.Word2VecModel

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorIndexer.scala
@@ -297,6 +297,8 @@ class VectorIndexerModel private[ml] (
 
   import VectorIndexerModel._
 
+  private[ml] def this() = this(Identifiable.randomUID("vecIdx"), -1, Map.empty)
+
   /** Java-friendly version of [[categoryMaps]] */
   @Since("1.4.0")
   def javaCategoryMaps: JMap[JInt, JMap[JDouble, JInt]] = {

--- a/python/pyspark/ml/tests/test_feature.py
+++ b/python/pyspark/ml/tests/test_feature.py
@@ -31,6 +31,7 @@ from pyspark.ml.feature import (
     OneHotEncoder,
     OneHotEncoderModel,
     FeatureHasher,
+    ElementwiseProduct,
     HashingTF,
     IDF,
     IDFModel,
@@ -60,6 +61,8 @@ from pyspark.ml.feature import (
     StopWordsRemover,
     StringIndexer,
     StringIndexerModel,
+    VectorIndexer,
+    VectorIndexerModel,
     TargetEncoder,
     TargetEncoderModel,
     VectorSizeHint,
@@ -175,6 +178,67 @@ class FeatureTestsMixin:
         self.assertTrue(result[0][0] == "e" and result[1][0] == "f")
         sorted_value = sorted([v for _, v in result])
         self.assertEqual(sorted_value, [0.0, 1.0])
+
+    def test_vector_indexer(self):
+        spark = self.spark
+        df = spark.createDataFrame(
+            [
+                (Vectors.dense([-1.0, 0.0]),),
+                (Vectors.dense([0.0, 1.0]),),
+                (Vectors.dense([0.0, 2.0]),),
+            ],
+            ["a"],
+        )
+
+        indexer = VectorIndexer(maxCategories=2, inputCol="a")
+        indexer.setOutputCol("indexed")
+        self.assertEqual(indexer.getMaxCategories(), 2)
+        self.assertEqual(indexer.getInputCol(), "a")
+        self.assertEqual(indexer.getOutputCol(), "indexed")
+
+        model = indexer.fit(df)
+        self.assertEqual(indexer.uid, model.uid)
+        self.assertEqual(model.numFeatures, 2)
+
+        output = model.transform(df)
+        self.assertEqual(output.columns, ["a", "indexed"])
+        self.assertEqual(output.count(), 3)
+
+        # save & load
+        with tempfile.TemporaryDirectory(prefix="vector_indexer") as d:
+            indexer.write().overwrite().save(d)
+            indexer2 = VectorIndexer.load(d)
+            self.assertEqual(str(indexer), str(indexer2))
+            self.assertEqual(indexer2.getOutputCol(), "indexed")
+
+            model.write().overwrite().save(d)
+            model2 = VectorIndexerModel.load(d)
+            self.assertEqual(str(model), str(model2))
+            self.assertEqual(model2.getOutputCol(), "indexed")
+
+    def test_elementwise_product(self):
+        spark = self.spark
+        df = spark.createDataFrame([(Vectors.dense([2.0, 1.0, 3.0]),)], ["values"])
+
+        ep = ElementwiseProduct()
+        ep.setScalingVec(Vectors.dense([1.0, 2.0, 3.0]))
+        ep.setInputCol("values")
+        ep.setOutputCol("eprod")
+
+        self.assertEqual(ep.getScalingVec(), Vectors.dense([1.0, 2.0, 3.0]))
+        self.assertEqual(ep.getInputCol(), "values")
+        self.assertEqual(ep.getOutputCol(), "eprod")
+
+        output = ep.transform(df)
+        self.assertEqual(output.columns, ["values", "eprod"])
+        self.assertEqual(output.count(), 1)
+
+        # save & load
+        with tempfile.TemporaryDirectory(prefix="elementwise_product") as d:
+            ep.write().overwrite().save(d)
+            ep2 = ElementwiseProduct.load(d)
+            self.assertEqual(str(ep), str(ep2))
+            self.assertEqual(ep2.getOutputCol(), "eprod")
 
     def test_pca(self):
         df = self.spark.createDataFrame(

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -639,6 +639,7 @@ private[ml] object MLUtils {
     (classOf[MaxAbsScalerModel], Set("maxAbs")),
     (classOf[MinMaxScalerModel], Set("originalMax", "originalMin")),
     (classOf[RobustScalerModel], Set("range", "median")),
+    (classOf[VectorIndexerModel], Set("numFeatures")),
     (classOf[ChiSqSelectorModel], Set("selectedFeatures")),
     (classOf[UnivariateFeatureSelectorModel], Set("selectedFeatures")),
     (classOf[VarianceThresholdSelectorModel], Set("selectedFeatures")),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Support VectorIndexer and ElementwiseProduct on Connect


### Why are the changes needed?
For feature parity

### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
new tests


### Was this patch authored or co-authored using generative AI tooling?
no