### PR TITLE
[SPARK-51009][INFRA] Add Daily Maven Java 21 CI for `branch-4.0`

### DIFF
--- a/.github/workflows/build_branch40_maven_java21.yml
+++ b/.github/workflows/build_branch40_maven_java21.yml
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Build / Maven (branch-4.0, Scala 2.13, Hadoop 3, JDK 21)"
+
+on:
+  schedule:
+    - cron: '0 14 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-build:
+    permissions:
+      packages: write
+    name: Run
+    uses: ./.github/workflows/maven_test.yml
+    if: github.repository == 'apache/spark'
+    with:
+      branch: branch-4.0
+      java: 21


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a daily `Maven Java 21` CI for `branch-4.0`.

### Why are the changes needed?

Like `master` branch, this PR will provide a test coverage for `Apache Maven` build and test capability additionally.
- https://github.com/apache/spark/actions/workflows/build_maven_java21.yml

### Does this PR introduce _any_ user-facing change?

No, this is a test infra change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.