### PR TITLE
[SPARK-51017][INFRA] Add Daily PyPy3.10 GitHub Action Job for `branch-4.0`

### DIFF
--- a/.github/workflows/build_branch40_python_pypy3.10.yml
+++ b/.github/workflows/build_branch40_python_pypy3.10.yml
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Build / Python-only (branch-4.0, PyPy 3.10)"
+
+on:
+  schedule:
+    - cron: '0 16 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-build:
+    permissions:
+      packages: write
+    name: Run
+    uses: ./.github/workflows/build_and_test.yml
+    if: github.repository == 'apache/spark'
+    with:
+      java: 17
+      branch: branch-4.0
+      hadoop: hadoop3
+      envs: >-
+        {
+          "PYSPARK_IMAGE_TO_TEST": "pypy-310",
+          "PYTHON_TO_TEST": "pypy3"
+        }
+      jobs: >-
+        {
+          "pyspark": "true",
+          "pyspark-pandas": "true"
+        }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add Daily PyPy3.10 GitHub Action Job for `branch-4.0`

### Why are the changes needed?

Currently, PyPy3.10 is broken in `master` branch. Like `master` branch, we need to check the PyPy support for Apache Spark 4.0.0.

https://github.com/apache/spark/actions/workflows/build_python_pypy3.10.yml

<img width="752" alt="Screenshot 2025-01-27 at 20 56 06" src="https://github.com/user-attachments/assets/0ef0b21f-ef2d-47b0-85fa-8fce6042c420" />

### Does this PR introduce _any_ user-facing change?

No, this is a test infra change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.