### PR TITLE
[SPARK-50666][SQL][FOLLOWUP] Revise JDBC hint support and remove a typo in comment

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -249,14 +249,12 @@ class JDBCOptions(
       .map(_.toBoolean)
       .getOrElse(SQLConf.get.timestampType == TimestampNTZType)
 
-  val hint = {
-    parameters.get(JDBC_HINT_STRING).map(value => {
-      require(value.matches("(?s)^/\\*\\+ .* \\*/$"),
-        s"Invalid value `$value` for option `$JDBC_HINT_STRING`." +
-          s" It should start with `/*+ ` and end with ` */`.")
+  val hint = parameters.get(JDBC_HINT_STRING).map(value => {
+    require(value.matches("(?s)^/\\*\\+ .* \\*/$"),
+      s"Invalid value `$value` for option `$JDBC_HINT_STRING`." +
+        s" It should start with `/*+ ` and end with ` */`.")
       s"$value "
     }).getOrElse("")
-  }
 
   override def hashCode: Int = this.parameters.hashCode()
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
@@ -207,7 +207,7 @@ private case class DB2Dialect() extends JdbcDialect with SQLConfHelper with NoLe
       val offsetClause = dialect.getOffsetClause(offset)
 
       options.prepareQuery +
-        s"SELECT $hintClause$columnList FROM ${options.tableOrQuery} $tableSampleClause" +
+        s"SELECT $columnList FROM ${options.tableOrQuery} $tableSampleClause" +
         s" $whereClause $groupByClause $orderByClause $offsetClause $limitClause"
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLQueryBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLQueryBuilder.scala
@@ -69,7 +69,7 @@ class JdbcSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions) {
   protected var tableSampleClause: String = ""
 
   /**
-   * A hint sample clause representing query hints.
+   * A hint clause representing query hints.
    */
   protected val hintClause: String = {
     if (options.hint == "" || dialect.supportsHint) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -249,7 +249,7 @@ private case class MsSqlServerDialect() extends JdbcDialect with NoLegacyJDBCErr
       val limitClause = dialect.getLimitClause(limit)
 
       options.prepareQuery +
-        s"SELECT $hintClause$limitClause $columnList FROM ${options.tableOrQuery}" +
+        s"SELECT $limitClause $columnList FROM ${options.tableOrQuery}" +
         s" $tableSampleClause $whereClause $groupByClause $orderByClause"
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -2222,10 +2222,8 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     val baseParameters = CaseInsensitiveMap(
       Map("dbtable" -> "test", "hint" -> "/*+ INDEX(test idx1) */"))
     // supported
-    Seq(
-      "jdbc:oracle:thin:@//host:port",
-      "jdbc:mysql://host:port",
-      "jdbc:databricks://host:port").foreach { url =>
+    Seq("jdbc:oracle:thin:@", "jdbc:mysql:", "jdbc:databricks:").foreach { prefix =>
+      val url = s"$prefix//host:port"
       val options = new JDBCOptions(baseParameters + ("url" -> url))
       val dialect = JdbcDialects.get(url)
       assert(dialect.getJdbcSQLQueryBuilder(options)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to fix some minor issues related to https://github.com/apache/spark/pull/49564


### Why are the changes needed?
First, simplify some code.
Second, The JDBC dialects doesn't support hint should not override the SQL builder. It's confused.
Third, fix a little incorrect comment.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
