### PR TITLE
[SPARK-51021][CORE] Add log throttler

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -549,6 +549,7 @@ private[spark] object LogKeys {
   case object NUM_ROWS extends LogKey
   case object NUM_RULE_OF_RUNS extends LogKey
   case object NUM_SEQUENCES extends LogKey
+  case object NUM_SKIPPED extends LogKey
   case object NUM_SLOTS extends LogKey
   case object NUM_SPILLS extends LogKey
   case object NUM_SPILL_WRITERS extends LogKey

--- a/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -595,7 +595,7 @@ class LogThrottler(
   def throttledWithSkippedLogMessage(thunk: MessageWithContext => Unit): Unit = {
     this.throttled { numSkipped =>
       val skippedStr = if (numSkipped != 0L) {
-        log" [${MDC(LogKeys.NUM_SKIPPED, numSkipped)} similar messages were skipped.]"
+        log"[${MDC(LogKeys.NUM_SKIPPED, numSkipped)} similar messages were skipped.]"
       } else {
         log""
       }
@@ -617,11 +617,13 @@ class LogThrottler(
         remainingTokens += 1
         nextRecovery += tokenRecoveryInterval
       }
+
+      val currentTime = DeadlineWithTimeSource.now(timeSource)
       if (remainingTokens == bucketSize &&
-        (DeadlineWithTimeSource.now(timeSource) - nextRecovery) > tokenRecoveryInterval) {
+        (currentTime - nextRecovery) > tokenRecoveryInterval) {
         // Reset the recovery time, so we don't accumulate infinite recovery while nothing is
         // going on.
-        nextRecovery = DeadlineWithTimeSource.now(timeSource) + tokenRecoveryInterval
+        nextRecovery = currentTime + tokenRecoveryInterval
       }
     } catch {
       case _: IllegalArgumentException =>

--- a/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.internal
 
+import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
 import org.apache.logging.log4j.{CloseableThreadContext, Level, LogManager}
@@ -27,6 +28,7 @@ import org.apache.logging.log4j.core.filter.AbstractFilter
 import org.slf4j.{Logger, LoggerFactory}
 
 import org.apache.spark.internal.Logging.SparkShellLoggingFilter
+import org.apache.spark.internal.LogKeys
 import org.apache.spark.util.SparkClassUtils
 
 /**
@@ -530,4 +532,157 @@ private[spark] object Logging {
 
     override def isStopped: Boolean = status == LifeCycle.State.STOPPED
   }
+}
+
+/**
+ * A thread-safe token bucket-based throttler implementation with nanosecond accuracy.
+ *
+ * Each instance must be shared across all scopes it should throttle.
+ * For global throttling that means either by extending this class in an `object` or
+ * by creating the instance as a field of an `object`.
+ *
+ * @param bucketSize This corresponds to the largest possible burst without throttling,
+ *                   in number of executions.
+ * @param tokenRecoveryInterval Time between two tokens being added back to the bucket.
+ *                              This is reciprocal of the long-term average unthrottled rate.
+ *
+ * Example: With a bucket size of 100 and a recovery interval of 1s, we could log up to 100 events
+ * in under a second without throttling, but at that point the bucket is exhausted and we only
+ * regain the ability to log more events at 1 event per second. If we log less than 1 event/s
+ * the bucket will slowly refill until it's back at 100.
+ * Either way, we can always log at least 1 event/s.
+ */
+class LogThrottler(
+    val bucketSize: Int = 100,
+    val tokenRecoveryInterval: FiniteDuration = 1.second,
+    val timeSource: NanoTimeTimeSource = SystemNanoTimeSource) extends Logging {
+
+  private var remainingTokens = bucketSize
+  private var nextRecovery: DeadlineWithTimeSource =
+    DeadlineWithTimeSource.now(timeSource) + tokenRecoveryInterval
+  private var numSkipped: Long = 0
+
+  /**
+   * Run `thunk` as long as there are tokens remaining in the bucket,
+   * otherwise skip and remember number of skips.
+   *
+   * The argument to `thunk` is how many previous invocations have been skipped since the last time
+   * an invocation actually ran.
+   *
+   * Note: This method is `synchronized`, so it is concurrency safe.
+   * However, that also means no heavy-lifting should be done as part of this
+   * if the throttler is shared between concurrent threads.
+   * This also means that the synchronized block of the `thunk` that *does* execute will still
+   * hold up concurrent `thunk`s that will actually get rejected once they hold the lock.
+   * This is fine at low concurrency/low recovery rates. But if we need this to be more efficient at
+   * some point, we will need to decouple the check from the `thunk` execution.
+   */
+  def throttled(thunk: Long => Unit): Unit = this.synchronized {
+    tryRecoverTokens()
+    if (remainingTokens > 0) {
+      thunk(numSkipped)
+      numSkipped = 0
+      remainingTokens -= 1
+    } else {
+      numSkipped += 1L
+    }
+  }
+
+  /**
+   * Same as [[throttled]] but turns the number of skipped invocations into a logging message
+   * that can be appended to item being logged in `thunk`.
+   */
+  def throttledWithSkippedLogMessage(thunk: MessageWithContext => Unit): Unit = {
+    this.throttled { numSkipped =>
+      val skippedStr = if (numSkipped != 0L) {
+        log" [${MDC(LogKeys.NUM_SKIPPED, numSkipped)} similar messages were skipped.]"
+      } else {
+        log""
+      }
+      thunk(skippedStr)
+    }
+  }
+
+  /**
+   * Try to recover tokens, if the rate allows.
+   *
+   * Only call from within a `this.synchronized` block!
+   */
+  private[spark] def tryRecoverTokens(): Unit = {
+    try {
+      // Doing it one-by-one is a bit inefficient for long periods, but it's easy to avoid jumps
+      // and rounding errors this way. The inefficiency shouldn't matter as long as the bucketSize
+      // isn't huge.
+      while (remainingTokens < bucketSize && nextRecovery.isOverdue()) {
+        remainingTokens += 1
+        nextRecovery += tokenRecoveryInterval
+      }
+      if (remainingTokens == bucketSize &&
+        (DeadlineWithTimeSource.now(timeSource) - nextRecovery) > tokenRecoveryInterval) {
+        // Reset the recovery time, so we don't accumulate infinite recovery while nothing is
+        // going on.
+        nextRecovery = DeadlineWithTimeSource.now(timeSource) + tokenRecoveryInterval
+      }
+    } catch {
+      case _: IllegalArgumentException =>
+        // Adding FiniteDuration throws IllegalArgumentException instead of wrapping on overflow.
+        // Given that this happens every ~300 years, we can afford some non-linearity here,
+        // rather than taking the effort to properly work around that.
+        nextRecovery = DeadlineWithTimeSource(Duration(-Long.MaxValue, NANOSECONDS), timeSource)
+    }
+  }
+
+  /**
+   * Resets throttler state to initial state.
+   * Visible for testing.
+   */
+  def reset(): Unit = this.synchronized {
+    remainingTokens = bucketSize
+    nextRecovery = DeadlineWithTimeSource.now(timeSource) + tokenRecoveryInterval
+    numSkipped = 0
+  }
+}
+
+/**
+ * This is essentially the same as Scala's [[Deadline]],
+ * just with a custom source of nanoTime so it can actually be tested properly.
+ */
+case class DeadlineWithTimeSource(
+    time: FiniteDuration,
+    timeSource: NanoTimeTimeSource = SystemNanoTimeSource) {
+  // Only implemented the methods LogThrottler actually needs for now.
+
+  /**
+   * Return a deadline advanced (i.e., moved into the future) by the given duration.
+   */
+  def +(other: FiniteDuration): DeadlineWithTimeSource = copy(time = time + other)
+
+  /**
+   * Calculate time difference between this and the other deadline, where the result is directed
+   * (i.e., may be negative).
+   */
+  def -(other: DeadlineWithTimeSource): FiniteDuration = time - other.time
+
+  /**
+   * Determine whether the deadline lies in the past at the point where this method is called.
+   */
+  def isOverdue(): Boolean = (time.toNanos - timeSource.nanoTime()) <= 0
+}
+
+object DeadlineWithTimeSource {
+  /**
+   * Construct a deadline due exactly at the point where this method is called. Useful for then
+   * advancing it to obtain a future deadline, or for sampling the current time exactly once and
+   * then comparing it to multiple deadlines (using subtraction).
+   */
+  def now(timeSource: NanoTimeTimeSource = SystemNanoTimeSource): DeadlineWithTimeSource =
+    DeadlineWithTimeSource(Duration(timeSource.nanoTime(), NANOSECONDS), timeSource)
+}
+
+/** Generalisation of [[System.nanoTime()]]. */
+private[spark] trait NanoTimeTimeSource {
+  def nanoTime(): Long
+}
+private[spark] object SystemNanoTimeSource extends NanoTimeTimeSource {
+  override def nanoTime(): Long = System.nanoTime()
 }

--- a/common/utils/src/test/scala/org/apache/spark/util/LogThrottlingSuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/LogThrottlingSuite.scala
@@ -21,7 +21,7 @@ import scala.concurrent.duration._
 
 import org.apache.spark.internal.{DeadlineWithTimeSource, LogThrottler, NanoTimeTimeSource}
 
-import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
 
 class LogThrottlingSuite extends AnyFunSuite {
 

--- a/common/utils/src/test/scala/org/apache/spark/util/LogThrottlingSuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/LogThrottlingSuite.scala
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+import scala.concurrent.duration._
+
+import org.apache.spark.internal.{DeadlineWithTimeSource, LogThrottler, NanoTimeTimeSource}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class LogThrottlingSuite extends AnyFunSuite {
+
+  // Make sure that the helper works right.
+  test("time control") {
+    val nanoTimeControl = new MockedNanoTime
+    assert(nanoTimeControl.nanoTime() === 0L)
+    assert(nanoTimeControl.nanoTime() === 0L)
+
+    nanoTimeControl.advance(112L.nanos)
+    assert(nanoTimeControl.nanoTime() === 112L)
+    assert(nanoTimeControl.nanoTime() === 112L)
+  }
+
+  test("deadline with time control") {
+    val nanoTimeControl = new MockedNanoTime
+    assert(DeadlineWithTimeSource.now(nanoTimeControl).isOverdue())
+    val deadline = DeadlineWithTimeSource.now(nanoTimeControl) + 5.nanos
+    assert(!deadline.isOverdue())
+    nanoTimeControl.advance(5.nanos)
+    assert(deadline.isOverdue())
+    nanoTimeControl.advance(5.nanos)
+    assert(deadline.isOverdue())
+    // Check addition.
+    assert(deadline + 0.nanos === deadline)
+    val increasedDeadline = deadline + 10.nanos
+    assert(!increasedDeadline.isOverdue())
+    nanoTimeControl.advance(5.nanos)
+    assert(increasedDeadline.isOverdue())
+    // Ensure that wrapping keeps throwing this exact exception, since we rely on it in
+    // LogThrottler.tryRecoverTokens
+    assertThrows[IllegalArgumentException] {
+      deadline + Long.MaxValue.nanos
+    }
+    // Check difference and ordering.
+    assert(deadline - deadline === 0.nanos)
+    assert(increasedDeadline - deadline === 10.nanos)
+    assert(increasedDeadline - deadline > 9.nanos)
+    assert(increasedDeadline - deadline < 11.nanos)
+    assert(deadline - increasedDeadline === -10.nanos)
+    assert(deadline - increasedDeadline < -9.nanos)
+    assert(deadline - increasedDeadline > -11.nanos)
+  }
+
+  test("unthrottled, no burst") {
+    val nanotTimeControl = new MockedNanoTime
+    val throttler = new LogThrottler(
+      bucketSize = 1,
+      tokenRecoveryInterval = 5.nanos,
+      timeSource = nanotTimeControl)
+    val numInvocations = 100
+    var timesExecuted = 0
+    for (i <- 0 until numInvocations) {
+      throttler.throttled { skipped =>
+        assert(skipped === 0L)
+        timesExecuted += 1
+      }
+      nanotTimeControl.advance(5.nanos)
+    }
+    assert(timesExecuted === numInvocations)
+  }
+
+  test("unthrottled, burst") {
+    val nanotTimeControl = new MockedNanoTime
+    val throttler = new LogThrottler(
+      bucketSize = 100,
+      tokenRecoveryInterval = 1000000.nanos, // Just to make it obvious that it's a large number.
+      timeSource = nanotTimeControl)
+    val numInvocations = 100
+    var timesExecuted = 0
+    for (_ <- 0 until numInvocations) {
+      throttler.throttled { skipped =>
+        assert(skipped === 0L)
+        timesExecuted += 1
+      }
+      nanotTimeControl.advance(5.nanos)
+    }
+    assert(timesExecuted === numInvocations)
+  }
+
+  test("throttled, no burst") {
+    val nanoTimeControl = new MockedNanoTime
+    val throttler = new LogThrottler(
+      bucketSize = 1,
+      tokenRecoveryInterval = 5.nanos,
+      timeSource = nanoTimeControl)
+    val numInvocations = 100
+    var timesExecuted = 0
+    for (i <- 0 until numInvocations) {
+      throttler.throttled { skipped =>
+        if (timesExecuted == 0) {
+          assert(skipped === 0L)
+        } else {
+          assert(skipped === 4L)
+        }
+        timesExecuted += 1
+      }
+      nanoTimeControl.advance(1.nanos)
+    }
+    assert(timesExecuted === numInvocations / 5)
+  }
+
+  test("throttled, single burst") {
+    val nanoTimeControl = new MockedNanoTime
+    val throttler = new LogThrottler(
+      bucketSize = 5,
+      tokenRecoveryInterval = 10.nanos,
+      timeSource = nanoTimeControl)
+    val numInvocations = 100
+    var timesExecuted = 0
+    for (i <- 0 until numInvocations) {
+      throttler.throttled { skipped =>
+        if (i < 5) {
+          // First burst
+          assert(skipped === 0L)
+        } else if (i == 10) {
+          // First token recovery
+          assert(skipped === 5L)
+        } else {
+          // All other token recoveries
+          assert(skipped === 9L)
+        }
+        timesExecuted += 1
+      }
+      nanoTimeControl.advance(1.nano)
+    }
+    // A burst of 5 and then 1 every 10ns/invocations.
+    assert(timesExecuted === 5 + (numInvocations - 10) / 10)
+  }
+
+  test("throttled, bursty") {
+    val nanoTimeControl = new MockedNanoTime
+    val throttler = new LogThrottler(
+      bucketSize = 5,
+      tokenRecoveryInterval = 10.nanos,
+      timeSource = nanoTimeControl)
+    val numBursts = 10
+    val numInvocationsPerBurst = 10
+    var timesExecuted = 0
+    for (burst <- 0 until numBursts) {
+      for (i <- 0 until numInvocationsPerBurst) {
+        throttler.throttled { skipped =>
+          if (i == 0 && burst != 0) {
+            // first after recovery
+            assert(skipped === 5L)
+          } else {
+            // either first burst, or post-recovery on every other burst.
+            assert(skipped === 0L)
+          }
+          timesExecuted += 1
+        }
+        nanoTimeControl.advance(1.nano)
+      }
+      nanoTimeControl.advance(100.nanos)
+    }
+    // Bursts of 5.
+    assert(timesExecuted === 5 * numBursts)
+  }
+
+  test("wraparound") {
+    val nanoTimeControl = new MockedNanoTime
+    val throttler = new LogThrottler(
+      bucketSize = 1,
+      tokenRecoveryInterval = 100.nanos,
+      timeSource = nanoTimeControl)
+    def executeThrottled(expectedSkipped: Long = 0L): Boolean = {
+      var executed = false
+      throttler.throttled { skipped =>
+        assert(skipped === expectedSkipped)
+        executed = true
+      }
+      executed
+    }
+    assert(executeThrottled())
+    assert(!executeThrottled())
+
+    // Move to 2 ns before wrapping.
+    nanoTimeControl.advance((Long.MaxValue - 1L).nanos)
+    assert(executeThrottled(expectedSkipped = 1L))
+    assert(!executeThrottled())
+
+    nanoTimeControl.advance(1.nano)
+    assert(!executeThrottled())
+
+    // Wrapping
+    nanoTimeControl.advance(1.nano)
+    assert(!executeThrottled())
+
+    // Recover
+    nanoTimeControl.advance(100.nanos)
+    assert(executeThrottled(expectedSkipped = 3L))
+  }
+}
+
+/**
+ * Use a mocked object to replace calls to `System.nanoTime()` with a custom value that can be
+ * controlled by calling `advance(nanos)` on an instance of this class.
+ */
+class MockedNanoTime extends NanoTimeTimeSource {
+  private var currentTimeNs: Long = 0L
+
+  override def nanoTime(): Long = currentTimeNs
+
+  def advance(time: FiniteDuration): Unit = {
+    currentTimeNs += time.toNanos
+  }
+}

--- a/common/utils/src/test/scala/org/apache/spark/util/LogThrottlingSuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/LogThrottlingSuite.scala
@@ -19,11 +19,14 @@ package org.apache.spark.util
 
 import scala.concurrent.duration._
 
-import org.apache.spark.internal.{DeadlineWithTimeSource, LogThrottler, NanoTimeTimeSource}
-
 import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
 
-class LogThrottlingSuite extends AnyFunSuite {
+import org.apache.spark.internal.{DeadlineWithTimeSource, Logging, LogThrottler, NanoTimeTimeSource}
+
+
+class LogThrottlingSuite
+  extends AnyFunSuite  // scalastyle:ignore funsuite
+  with Logging {
 
   // Make sure that the helper works right.
   test("time control") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add a token bucket based throttler implementation that can be used to throttle log messages that are suspected of potential log flooding issues.

Usage:

```
  val logThrottler = new LogThrottler(bucketSize = 100, tokenRecoveryInterval = 1.second, timeSource = SystemNanoTimeSource)

  logThrottler.throttled { numSkippedEvents =>
    recordProductEvent(...)
  }
```

or

```
  logThrottler.throttledWithSkippedLogMessage { skippedStr =>
     recordProductEvent(...)
  }
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To throttle log messages that are suspected of potential log flooding issues.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New test suite: `LogThrottlingSuite`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
