### PR TITLE
[SPARK-51025][K8S] Install `libssl-dev` in K8s Dockerfile

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -35,7 +35,7 @@ ARG spark_uid=185
 RUN set -ex && \
     apt-get update && \
     ln -s /lib /lib64 && \
-    apt install -y bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools logrotate && \
+    apt install -y bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools logrotate libssl-dev && \
     mkdir -p /opt/spark && \
     mkdir -p /opt/spark/examples && \
     mkdir -p /opt/spark/work-dir && \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to install `libssl-dev` in K8s Dockerfile.

### Why are the changes needed?

This can be used when we use SSL via the following.
- #49716 

### Does this PR introduce _any_ user-facing change?

No behavior change. This is additional library on Docker images.

### How was this patch tested?

Pass the CIs (including K8s integration test) and manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.