### PR TITLE
[SPARK-50909][PYTHON][FOLLOWUP] Disable segfault tests in pypy

### DIFF
--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 import os
+import platform
 import tempfile
 import unittest
 from typing import Callable, Union
@@ -508,6 +509,9 @@ class BasePythonDataSourceTestsMixin:
         ):
             df.write.format("test").mode("append").saveAsTable("test_table")
 
+    @unittest.skipIf(
+        "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+    )
     def test_data_source_segfault(self):
         import ctypes
 

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 import os
+import platform
 import shutil
 import tempfile
 import unittest
@@ -2761,6 +2762,9 @@ class BaseUDTFTestsMixin:
         res = self.spark.sql("select i, to_json(v['v1']) from test_udtf_struct(8)")
         assertDataFrameEqual(res, [Row(i=n, s=f'{{"a":"{chr(99 + n)}"}}') for n in range(8)])
 
+    @unittest.skipIf(
+        "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+    )
     def test_udtf_segfault(self):
         for enabled, expected in [
             (True, "Segmentation fault"),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Disable segfault tests in `pypy`, same as in `test_udf`.

### Why are the changes needed?

In pypy environment, segfault doesn't happen.

- https://github.com/apache/spark/pull/49592#pullrequestreview-2577075949

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing tests should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.