### PR TITLE
[SPARK-51033][CORE][TESTS] Fix `CryptoStreamUtilsSuite` to use `sameElements` for array comparison

### DIFF
--- a/core/src/test/scala/org/apache/spark/security/CryptoStreamUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/security/CryptoStreamUtilsSuite.scala
@@ -112,7 +112,7 @@ class CryptoStreamUtilsSuite extends SparkFunSuite {
           bytes.toByteArray()
         }.collect()(0)
 
-      assert(content != encrypted)
+      assert(!content.getBytes(UTF_8).sameElements(encrypted))
 
       val in = CryptoStreamUtils.createCryptoInputStream(new ByteArrayInputStream(encrypted),
         sc.conf, SparkEnv.get.securityManager.getIOEncryptionKey().get)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `CryptoStreamUtilsSuite` to use `sameElements` for array comparison.

### Why are the changes needed?

Since the existing assertion is invalid due to `String != Array[Byte]` comparison, it causes a compilation error from Scala 2.13.16.

https://github.com/apache/spark/blob/6bbfa2dad8c70b94ca52eb7cddde5ec68efbe0b1/core/src/test/scala/org/apache/spark/security/CryptoStreamUtilsSuite.scala#L115

- #49478 

### Does this PR introduce _any_ user-facing change?

No, this is a test-only fix.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.