### PR TITLE
[SPARK-51034][SQL] Reformat Describe As JSON statistics dict for parse-ability

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -61,6 +61,10 @@ trait MetadataMapSupport {
     jsonToString(toJsonLinkedHashMap)
   }
 
+  /**
+   * Some fields from JsonLinkedHashMap are reformatted for human readability in `describe table`.
+   * If a field does not require special re-formatting, it is simply handled by `jsonToString`.
+   */
   private def jsonToStringReformat(key: String, jValue: JValue): Option[(String, String)] = {
     val reformattedValue: Option[String] = key match {
       case "Statistics" =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
@@ -273,7 +273,7 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
     }
   }
 
-  test("DESCRIBE AS JSON partition spec") {
+  test("DESCRIBE AS JSON partition spec and statistics") {
     withNamespaceAndTable("ns", "table") { t =>
       val tableCreationStr =
         s"""
@@ -289,6 +289,7 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
            |""".stripMargin
       spark.sql(tableCreationStr)
       spark.sql(s"ALTER TABLE $t ADD PARTITION (region='USA', category='tech')")
+      spark.sql(s"ANALYZE TABLE $t COMPUTE STATISTICS FOR ALL COLUMNS")
 
       val descriptionDf =
         spark.sql(s"DESCRIBE FORMATTED $t PARTITION (region='USA', category='tech') AS JSON")
@@ -324,7 +325,11 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
         },
         partition_provider = Some("Catalog"),
         partition_columns = Some(List("region", "category")),
-        partition_values = Some(Map("region" -> "USA", "category" -> "tech"))
+        partition_values = Some(Map("region" -> "USA", "category" -> "tech")),
+        statistics = Some(Map(
+          "size_in_bytes" -> 0,
+          "num_rows" -> 0
+        ))
       )
 
       assert(parsedOutput.location.isDefined)
@@ -726,6 +731,7 @@ case class DescribeTableJson(
     partition_provider: Option[String] = None,
     partition_columns: Option[List[String]] = Some(Nil),
     partition_values: Option[Map[String, String]] = None,
+    statistics: Option[Map[String, Any]] = None,
     view_text: Option[String] = None,
     view_original_text: Option[String] = None,
     view_schema_mode: Option[String] = None,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
@@ -55,15 +55,6 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
           Row("# col_name", "data_type", "comment"),
           Row("s.id", "int", null),
           Row("s.a", "bigint", null)))
-
-      // example date format: Mon Nov 01 12:00:00 UTC 2021
-      val timeRegex = raw"""^[A-Z][a-z]{2} [A-Z][a-z]{2} [ 0-9][0-9]
-          |[0-9]{2}:[0-9]{2}:[0-9]{2} [A-Z]{3,4}
-          |[0-9]{4}$""".stripMargin.r
-
-      val createdTimeValue = descriptionDf.filter("col_name = 'Created Time'")
-          .collect().head.getString(1)
-      assert(timeRegex.matches(createdTimeValue))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
@@ -55,6 +55,15 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
           Row("# col_name", "data_type", "comment"),
           Row("s.id", "int", null),
           Row("s.a", "bigint", null)))
+
+      // example date format: Mon Nov 01 12:00:00 UTC 2021
+      val timeRegex = raw"""^[A-Z][a-z]{2} [A-Z][a-z]{2} [ 0-9][0-9]
+          |[0-9]{2}:[0-9]{2}:[0-9]{2} [A-Z]{3,4}
+          |[0-9]{4}$""".stripMargin.r
+
+      val createdTimeValue = descriptionDf.filter("col_name = 'Created Time'")
+          .collect().head.getString(1)
+      assert(timeRegex.matches(createdTimeValue))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
@@ -95,6 +95,44 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
     }
   }
 
+  test("DESCRIBE TABLE EXTENDED AS JSON of a partitioned table") {
+    withNamespaceAndTable("ns", "table") { tbl =>
+      spark.sql(s"CREATE TABLE $tbl (id bigint, data string) $defaultUsing" +
+        " PARTITIONED BY (id)" +
+        " TBLPROPERTIES ('bar'='baz')" +
+        " COMMENT 'this is a test table'" +
+        " LOCATION 'file:/tmp/testcat/table_name'")
+      val descriptionDf = spark.sql(s"DESCRIBE TABLE EXTENDED $tbl AS JSON")
+      System.out.print(descriptionDf.show(truncate = false))
+//      assert(descriptionDf.schema.map(field => (field.name, field.dataType)) === Seq(
+//        ("col_name", StringType),
+//        ("data_type", StringType),
+//        ("comment", StringType)))
+//      QueryTest.checkAnswer(
+//        descriptionDf,
+//        Seq(
+//          Row("id", "bigint", null),
+//          Row("data", "string", null),
+//          Row("# Partition Information", "", ""),
+//          Row("# col_name", "data_type", "comment"),
+//          Row("id", "bigint", null),
+//          Row("", "", ""),
+//          Row("# Metadata Columns", "", ""),
+//          Row("index", "int", "Metadata column used to conflict with a data column"),
+//          Row("_partition", "string", "Partition key used to store the row"),
+//          Row("", "", ""),
+//          Row("# Detailed Table Information", "", ""),
+//          Row("Name", tbl, ""),
+//          Row("Type", "MANAGED", ""),
+//          Row("Comment", "this is a test table", ""),
+//          Row("Location", "file:/tmp/testcat/table_name", ""),
+//          Row("Provider", "_", ""),
+//          Row(TableCatalog.PROP_OWNER.capitalize, Utils.getCurrentUserName(), ""),
+//          Row("Table Properties", "[bar=baz]", ""),
+//          Row("Statistics", "0 bytes, 0 rows", null)))
+    }
+  }
+
   test("describe a non-existent column") {
     withNamespaceAndTable("ns", "tbl") { tbl =>
       sql(s"""

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
@@ -95,44 +95,6 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
     }
   }
 
-  test("DESCRIBE TABLE EXTENDED AS JSON of a partitioned table") {
-    withNamespaceAndTable("ns", "table") { tbl =>
-      spark.sql(s"CREATE TABLE $tbl (id bigint, data string) $defaultUsing" +
-        " PARTITIONED BY (id)" +
-        " TBLPROPERTIES ('bar'='baz')" +
-        " COMMENT 'this is a test table'" +
-        " LOCATION 'file:/tmp/testcat/table_name'")
-      val descriptionDf = spark.sql(s"DESCRIBE TABLE EXTENDED $tbl AS JSON")
-      System.out.print(descriptionDf.show(truncate = false))
-//      assert(descriptionDf.schema.map(field => (field.name, field.dataType)) === Seq(
-//        ("col_name", StringType),
-//        ("data_type", StringType),
-//        ("comment", StringType)))
-//      QueryTest.checkAnswer(
-//        descriptionDf,
-//        Seq(
-//          Row("id", "bigint", null),
-//          Row("data", "string", null),
-//          Row("# Partition Information", "", ""),
-//          Row("# col_name", "data_type", "comment"),
-//          Row("id", "bigint", null),
-//          Row("", "", ""),
-//          Row("# Metadata Columns", "", ""),
-//          Row("index", "int", "Metadata column used to conflict with a data column"),
-//          Row("_partition", "string", "Partition key used to store the row"),
-//          Row("", "", ""),
-//          Row("# Detailed Table Information", "", ""),
-//          Row("Name", tbl, ""),
-//          Row("Type", "MANAGED", ""),
-//          Row("Comment", "this is a test table", ""),
-//          Row("Location", "file:/tmp/testcat/table_name", ""),
-//          Row("Provider", "_", ""),
-//          Row(TableCatalog.PROP_OWNER.capitalize, Utils.getCurrentUserName(), ""),
-//          Row("Table Properties", "[bar=baz]", ""),
-//          Row("Statistics", "0 bytes, 0 rows", null)))
-    }
-  }
-
   test("describe a non-existent column") {
     withNamespaceAndTable("ns", "tbl") { tbl =>
       sql(s"""


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Reformat `Describe As JSON` statistics table metadata into a dict rather than string for improved parse-ability


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Existing `Describe` formats table statistics into a string `xxx bytes, xxx rows` which is not conducive to parsing. This PR stores the table statistics metadata in raw format and delegates the formatting to the caller of toJsonLinkedHashmap, for improved parsing of the JSON statistics.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, it affects the output of `Describe As JSON`.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added to test suite `DescribeTableSuite`


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
