### PR TITLE
[SPARK-51039][BUILD] Fix `hive-llap-common` dependency to use `hive.llap.scope` in root `pom.xml`

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -323,6 +323,7 @@
       <id>hive-provided</id>
       <properties>
         <hive.deps.scope>provided</hive.deps.scope>
+        <hive.llap.scope>provided</hive.llap.scope>
         <hive.jackson.scope>provided</hive.jackson.scope>
       </properties>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -2255,7 +2255,7 @@
         <groupId>${hive.group}</groupId>
         <artifactId>hive-llap-common</artifactId>
         <version>${hive.version}</version>
-        <scope>${hive.deps.scope}</scope>
+        <scope>${hive.llap.scope}</scope>
         <exclusions>
           <exclusion>
             <groupId>${hive.group}</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `hive-llap-common` dependency to use `hive.llap.scope` in root pom for Apache Spark 3.5 and 4.0.

### Why are the changes needed?

Apache Spark has been supposed to use `hive.llap.scope` for `hive-llap-common` dependency and `hive` module do it correctly.
https://github.com/apache/spark/blob/a1b0f256c04e5b632075358d1e2f946e64588da6/sql/hive/pom.xml#L119-L123

Since Apache Spark 3.0.0 (SPARK-27176), the root `pom.xml` file has been using a wrong scope mistakenly. Probably, it's due to `-Phive-provided` support. This causes a confusion to other external systems and the users. We had better fix the root `pom.xml` to use `hive.llap.scope` correctly.
- #23788

### Does this PR introduce _any_ user-facing change?

No, there is no change technically because `hive` module has been using a correct scope.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.
