### PR TITLE
[WIP][SPARK-51040][SQL] Enforce determinism when assigning implicit aliases to collation types

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -95,6 +95,9 @@ package object util extends Logging {
   // generated column names don't contain back-ticks or double-quotes.
   def usePrettyExpression(e: Expression): Expression = e transform {
     case a: Attribute => new PrettyAttribute(a)
+    case Literal(s: UTF8String, collationStringType: StringType)
+        if collationStringType.collationId != 0 =>
+      PrettyAttribute(s.toString, StringType)
     case Literal(s: UTF8String, StringType) => PrettyAttribute(s.toString, StringType)
     case Literal(v, t: NumericType) if v != null => PrettyAttribute(v.toString, t)
     case Literal(null, dataType) => PrettyAttribute("NULL", dataType)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/collations.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/collations.sql.out
@@ -442,77 +442,77 @@ Project [array_except(array(collate(aaa, utf8_lcase)), array(collate(AAA, utf8_l
 -- !query
 select 'a' collate unicode < 'A'
 -- !query analysis
-Project [(collate(a, unicode) < A) AS (collate(a, unicode) < 'A' collate UNICODE)#x]
+Project [(collate(a, unicode) < A) AS (collate(a, unicode) < A)#x]
 +- OneRowRelation
 
 
 -- !query
 select 'a' collate unicode_ci = 'A'
 -- !query analysis
-Project [(collate(a, unicode_ci) = A) AS (collate(a, unicode_ci) = 'A' collate UNICODE_CI)#x]
+Project [(collate(a, unicode_ci) = A) AS (collate(a, unicode_ci) = A)#x]
 +- OneRowRelation
 
 
 -- !query
 select 'a' collate unicode_ai = 'å'
 -- !query analysis
-Project [(collate(a, unicode_ai) = å) AS (collate(a, unicode_ai) = 'å' collate UNICODE_AI)#x]
+Project [(collate(a, unicode_ai) = å) AS (collate(a, unicode_ai) = å)#x]
 +- OneRowRelation
 
 
 -- !query
 select 'a' collate unicode_ci_ai = 'Å'
 -- !query analysis
-Project [(collate(a, unicode_ci_ai) = Å) AS (collate(a, unicode_ci_ai) = 'Å' collate UNICODE_CI_AI)#x]
+Project [(collate(a, unicode_ci_ai) = Å) AS (collate(a, unicode_ci_ai) = Å)#x]
 +- OneRowRelation
 
 
 -- !query
 select 'a' collate en < 'A'
 -- !query analysis
-Project [(collate(a, en) < A) AS (collate(a, en) < 'A' collate en)#x]
+Project [(collate(a, en) < A) AS (collate(a, en) < A)#x]
 +- OneRowRelation
 
 
 -- !query
 select 'a' collate en_ci = 'A'
 -- !query analysis
-Project [(collate(a, en_ci) = A) AS (collate(a, en_ci) = 'A' collate en_CI)#x]
+Project [(collate(a, en_ci) = A) AS (collate(a, en_ci) = A)#x]
 +- OneRowRelation
 
 
 -- !query
 select 'a' collate en_ai = 'å'
 -- !query analysis
-Project [(collate(a, en_ai) = å) AS (collate(a, en_ai) = 'å' collate en_AI)#x]
+Project [(collate(a, en_ai) = å) AS (collate(a, en_ai) = å)#x]
 +- OneRowRelation
 
 
 -- !query
 select 'a' collate en_ci_ai = 'Å'
 -- !query analysis
-Project [(collate(a, en_ci_ai) = Å) AS (collate(a, en_ci_ai) = 'Å' collate en_CI_AI)#x]
+Project [(collate(a, en_ci_ai) = Å) AS (collate(a, en_ci_ai) = Å)#x]
 +- OneRowRelation
 
 
 -- !query
 select 'Kypper' collate sv < 'Köpfe'
 -- !query analysis
-Project [(collate(Kypper, sv) < Köpfe) AS (collate(Kypper, sv) < 'Köpfe' collate sv)#x]
+Project [(collate(Kypper, sv) < Köpfe) AS (collate(Kypper, sv) < Köpfe)#x]
 +- OneRowRelation
 
 
 -- !query
 select 'Kypper' collate de > 'Köpfe'
 -- !query analysis
-Project [(collate(Kypper, de) > Köpfe) AS (collate(Kypper, de) > 'Köpfe' collate de)#x]
+Project [(collate(Kypper, de) > Köpfe) AS (collate(Kypper, de) > Köpfe)#x]
 +- OneRowRelation
 
 
 -- !query
 select 'I' collate tr_ci = 'ı'
 -- !query analysis
-Project [(collate(I, tr_ci) = ı) AS (collate(I, tr_ci) = 'ı' collate tr_CI)#x]
+Project [(collate(I, tr_ci) = ı) AS (collate(I, tr_ci) = ı)#x]
 +- OneRowRelation
 
 
@@ -919,7 +919,7 @@ Project [elt(1, collate(utf8_binary#x, utf8_binary), cast(utf8_lcase#x as string
 -- !query
 select elt(1, utf8_binary, 'word'), elt(1, utf8_lcase, 'word') from t5
 -- !query analysis
-Project [elt(1, utf8_binary#x, word, true) AS elt(1, utf8_binary, word)#x, elt(1, utf8_lcase#x, word, true) AS elt(1, utf8_lcase, 'word' collate UTF8_LCASE)#x]
+Project [elt(1, utf8_binary#x, word, true) AS elt(1, utf8_binary, word)#x, elt(1, utf8_lcase#x, word, true) AS elt(1, utf8_lcase, word)#x]
 +- SubqueryAlias spark_catalog.default.t5
    +- Relation spark_catalog.default.t5[s#x,utf8_binary#x,utf8_lcase#x] parquet
 
@@ -1684,7 +1684,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "inputType" : "\"STRING COLLATE UNICODE_AI\"",
     "paramIndex" : "first",
     "requiredType" : "\"STRING\"",
-    "sqlExpr" : "\"replace(collate(utf8_binary, unicode_ai), collate(utf8_lcase, unicode_ai), 'abc' collate UNICODE_AI)\""
+    "sqlExpr" : "\"replace(collate(utf8_binary, unicode_ai), collate(utf8_lcase, unicode_ai), abc)\""
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2073,7 +2073,7 @@ Project [overlay(collate(utf8_binary#x, utf8_lcase), collate(utf8_lcase#x, utf8_
 -- !query
 select overlay(utf8_binary, 'a', 2), overlay(utf8_lcase, 'a', 2) from t5
 -- !query analysis
-Project [overlay(utf8_binary#x, a, 2, -1) AS overlay(utf8_binary, a, 2, -1)#x, overlay(utf8_lcase#x, a, 2, -1) AS overlay(utf8_lcase, 'a' collate UTF8_LCASE, 2, -1)#x]
+Project [overlay(utf8_binary#x, a, 2, -1) AS overlay(utf8_binary, a, 2, -1)#x, overlay(utf8_lcase#x, a, 2, -1) AS overlay(utf8_lcase, a, 2, -1)#x]
 +- SubqueryAlias spark_catalog.default.t5
    +- Relation spark_catalog.default.t5[s#x,utf8_binary#x,utf8_lcase#x] parquet
 

--- a/sql/core/src/test/resources/sql-tests/results/collations.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/collations.sql.out
@@ -479,7 +479,7 @@ struct<array_except(array(collate(aaa, utf8_lcase)), array(collate(AAA, utf8_lca
 -- !query
 select 'a' collate unicode < 'A'
 -- !query schema
-struct<(collate(a, unicode) < 'A' collate UNICODE):boolean>
+struct<(collate(a, unicode) < A):boolean>
 -- !query output
 true
 
@@ -487,7 +487,7 @@ true
 -- !query
 select 'a' collate unicode_ci = 'A'
 -- !query schema
-struct<(collate(a, unicode_ci) = 'A' collate UNICODE_CI):boolean>
+struct<(collate(a, unicode_ci) = A):boolean>
 -- !query output
 true
 
@@ -495,7 +495,7 @@ true
 -- !query
 select 'a' collate unicode_ai = 'å'
 -- !query schema
-struct<(collate(a, unicode_ai) = 'å' collate UNICODE_AI):boolean>
+struct<(collate(a, unicode_ai) = å):boolean>
 -- !query output
 true
 
@@ -503,7 +503,7 @@ true
 -- !query
 select 'a' collate unicode_ci_ai = 'Å'
 -- !query schema
-struct<(collate(a, unicode_ci_ai) = 'Å' collate UNICODE_CI_AI):boolean>
+struct<(collate(a, unicode_ci_ai) = Å):boolean>
 -- !query output
 true
 
@@ -511,7 +511,7 @@ true
 -- !query
 select 'a' collate en < 'A'
 -- !query schema
-struct<(collate(a, en) < 'A' collate en):boolean>
+struct<(collate(a, en) < A):boolean>
 -- !query output
 true
 
@@ -519,7 +519,7 @@ true
 -- !query
 select 'a' collate en_ci = 'A'
 -- !query schema
-struct<(collate(a, en_ci) = 'A' collate en_CI):boolean>
+struct<(collate(a, en_ci) = A):boolean>
 -- !query output
 true
 
@@ -527,7 +527,7 @@ true
 -- !query
 select 'a' collate en_ai = 'å'
 -- !query schema
-struct<(collate(a, en_ai) = 'å' collate en_AI):boolean>
+struct<(collate(a, en_ai) = å):boolean>
 -- !query output
 true
 
@@ -535,7 +535,7 @@ true
 -- !query
 select 'a' collate en_ci_ai = 'Å'
 -- !query schema
-struct<(collate(a, en_ci_ai) = 'Å' collate en_CI_AI):boolean>
+struct<(collate(a, en_ci_ai) = Å):boolean>
 -- !query output
 true
 
@@ -543,7 +543,7 @@ true
 -- !query
 select 'Kypper' collate sv < 'Köpfe'
 -- !query schema
-struct<(collate(Kypper, sv) < 'Köpfe' collate sv):boolean>
+struct<(collate(Kypper, sv) < Köpfe):boolean>
 -- !query output
 true
 
@@ -551,7 +551,7 @@ true
 -- !query
 select 'Kypper' collate de > 'Köpfe'
 -- !query schema
-struct<(collate(Kypper, de) > 'Köpfe' collate de):boolean>
+struct<(collate(Kypper, de) > Köpfe):boolean>
 -- !query output
 true
 
@@ -559,7 +559,7 @@ true
 -- !query
 select 'I' collate tr_ci = 'ı'
 -- !query schema
-struct<(collate(I, tr_ci) = 'ı' collate tr_CI):boolean>
+struct<(collate(I, tr_ci) = ı):boolean>
 -- !query output
 true
 
@@ -1120,7 +1120,7 @@ kitten
 -- !query
 select elt(1, utf8_binary, 'word'), elt(1, utf8_lcase, 'word') from t5
 -- !query schema
-struct<elt(1, utf8_binary, word):string,elt(1, utf8_lcase, 'word' collate UTF8_LCASE):string collate UTF8_LCASE>
+struct<elt(1, utf8_binary, word):string,elt(1, utf8_lcase, word):string collate UTF8_LCASE>
 -- !query output
 Hello, world! Nice day.	Hello, world! Nice day.
 Something else. Nothing here.	Something else. Nothing here.
@@ -2549,7 +2549,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "inputType" : "\"STRING COLLATE UNICODE_AI\"",
     "paramIndex" : "first",
     "requiredType" : "\"STRING\"",
-    "sqlExpr" : "\"replace(collate(utf8_binary, unicode_ai), collate(utf8_lcase, unicode_ai), 'abc' collate UNICODE_AI)\""
+    "sqlExpr" : "\"replace(collate(utf8_binary, unicode_ai), collate(utf8_lcase, unicode_ai), abc)\""
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -3413,7 +3413,7 @@ ksitTing
 -- !query
 select overlay(utf8_binary, 'a', 2), overlay(utf8_lcase, 'a', 2) from t5
 -- !query schema
-struct<overlay(utf8_binary, a, 2, -1):string,overlay(utf8_lcase, 'a' collate UTF8_LCASE, 2, -1):string collate UTF8_LCASE>
+struct<overlay(utf8_binary, a, 2, -1):string,overlay(utf8_lcase, a, 2, -1):string collate UTF8_LCASE>
 -- !query output
 Hallo, world! Nice day.	Hallo, world! Nice day.
 Saark	SaL

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLExpressionsSuite.scala
@@ -1209,10 +1209,9 @@ class CollationSQLExpressionsSuite
           condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
           sqlState = Some("42K09"),
           parameters = Map(
-            "sqlExpr" -> ("\"str_to_map('a:1,b:2,c:3' collate " + s"${t.collation}, " +
-              "'?' collate " + s"${t.collation}, '?' collate ${t.collation})" + "\""),
+            "sqlExpr" -> "\"str_to_map(a:1,b:2,c:3, ?, ?)\"",
             "paramIndex" -> "first",
-            "inputSql" -> ("\"'a:1,b:2,c:3' collate " + s"${t.collation}" + "\""),
+            "inputSql" -> "\"a:1,b:2,c:3\"",
             "inputType" -> ("\"STRING COLLATE " + s"${t.collation}" + "\""),
             "requiredType" -> "\"STRING\""),
           context = ExpectedContext(

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLRegexpSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLRegexpSuite.scala
@@ -451,8 +451,7 @@ class CollationSQLRegexpSuite
         condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
         parameters = Map(
           "sqlExpr" ->
-            ("\"regexp_replace(collate(ABCDE, UNICODE_CI), '.c.' collate UNICODE_CI," +
-              " 'FFF' collate UNICODE_CI, 1)\""),
+            ("\"regexp_replace(collate(ABCDE, UNICODE_CI), .c., FFF, 1)\""),
           "paramIndex" -> "first",
           "inputSql" -> "\"collate(ABCDE, UNICODE_CI)\"",
           "inputType" -> "\"STRING COLLATE UNICODE_CI\"",

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
@@ -142,9 +142,9 @@ class CollationStringExpressionsSuite
         condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
         sqlState = Some("42K09"),
         parameters = Map(
-          "sqlExpr" -> "\"split_part('1a2' collate UNICODE_AI, 'a' collate UNICODE_AI, 2)\"",
+          "sqlExpr" -> "\"split_part(1a2, a, 2)\"",
           "paramIndex" -> "first",
-          "inputSql" -> "\"'1a2' collate UNICODE_AI\"",
+          "inputSql" -> "\"1a2\"",
           "inputType" -> "\"STRING COLLATE UNICODE_AI\"",
           "requiredType" -> "\"STRING\""),
         context = ExpectedContext(fragment = "split_part('1a2', 'a', 2)", start = 7, stop = 31)
@@ -238,9 +238,9 @@ class CollationStringExpressionsSuite
         condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
         sqlState = Some("42K09"),
         parameters = Map(
-          "sqlExpr" -> "\"contains('abcde' collate UNICODE_AI, 'A' collate UNICODE_AI)\"",
+          "sqlExpr" -> "\"contains(abcde, A)\"",
           "paramIndex" -> "first",
-          "inputSql" -> "\"'abcde' collate UNICODE_AI\"",
+          "inputSql" -> "\"abcde\"",
           "inputType" -> "\"STRING COLLATE UNICODE_AI\"",
           "requiredType" -> "\"STRING\""),
         context = ExpectedContext(fragment = "contains('abcde', 'A')", start = 7, stop = 28)
@@ -295,10 +295,9 @@ class CollationStringExpressionsSuite
         condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
         sqlState = Some("42K09"),
         parameters = Map(
-          "sqlExpr" -> ("\"substring_index('abacde' collate UNICODE_AI, " +
-            "'a' collate UNICODE_AI, 2)\""),
+          "sqlExpr" -> ("\"substring_index(abacde, a, 2)\""),
           "paramIndex" -> "first",
-          "inputSql" -> "\"'abacde' collate UNICODE_AI\"",
+          "inputSql" -> "\"abacde\"",
           "inputType" -> "\"STRING COLLATE UNICODE_AI\"",
           "requiredType" -> "\"STRING\""),
         context = ExpectedContext(
@@ -347,9 +346,9 @@ class CollationStringExpressionsSuite
         condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
         sqlState = Some("42K09"),
         parameters = Map(
-          "sqlExpr" -> "\"instr('a' collate UNICODE_AI, 'abcde' collate UNICODE_AI)\"",
+          "sqlExpr" -> "\"instr(a, abcde)\"",
           "paramIndex" -> "first",
-          "inputSql" -> "\"'a' collate UNICODE_AI\"",
+          "inputSql" -> "\"a\"",
           "inputType" -> "\"STRING COLLATE UNICODE_AI\"",
           "requiredType" -> "\"STRING\""),
         context = ExpectedContext(fragment = "instr('a', 'abcde')", start = 7, stop = 25)
@@ -426,9 +425,9 @@ class CollationStringExpressionsSuite
         condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
         sqlState = Some("42K09"),
         parameters = Map(
-          "sqlExpr" -> "\"startswith('abcde' collate UNICODE_AI, 'A' collate UNICODE_AI)\"",
+          "sqlExpr" -> "\"startswith(abcde, A)\"",
           "paramIndex" -> "first",
-          "inputSql" -> "\"'abcde' collate UNICODE_AI\"",
+          "inputSql" -> "\"abcde\"",
           "inputType" -> "\"STRING COLLATE UNICODE_AI\"",
           "requiredType" -> "\"STRING\""),
         context = ExpectedContext(fragment = "startswith('abcde', 'A')", start = 7, stop = 30)
@@ -481,10 +480,9 @@ class CollationStringExpressionsSuite
         condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
         sqlState = Some("42K09"),
         parameters = Map(
-          "sqlExpr" -> ("\"translate('ABC' collate UNICODE_AI, 'AB' collate UNICODE_AI, " +
-            "'12' collate UNICODE_AI)\""),
+          "sqlExpr" -> "\"translate(ABC, AB, 12)\"",
           "paramIndex" -> "first",
-          "inputSql" -> "\"'ABC' collate UNICODE_AI\"",
+          "inputSql" -> "\"ABC\"",
           "inputType" -> "\"STRING COLLATE UNICODE_AI\"",
           "requiredType" -> "\"STRING\""),
         context = ExpectedContext(fragment = "translate('ABC', 'AB', '12')", start = 7, stop = 34)
@@ -538,10 +536,9 @@ class CollationStringExpressionsSuite
         condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
         sqlState = Some("42K09"),
         parameters = Map(
-          "sqlExpr" -> ("\"replace('abcde' collate UNICODE_AI, 'A' collate UNICODE_AI, " +
-            "'B' collate UNICODE_AI)\""),
+          "sqlExpr" -> "\"replace(abcde, A, B)\"",
           "paramIndex" -> "first",
-          "inputSql" -> "\"'abcde' collate UNICODE_AI\"",
+          "inputSql" -> "\"abcde\"",
           "inputType" -> "\"STRING COLLATE UNICODE_AI\"",
           "requiredType" -> "\"STRING\""),
         context = ExpectedContext(fragment = "replace('abcde', 'A', 'B')", start = 7, stop = 32)
@@ -591,9 +588,9 @@ class CollationStringExpressionsSuite
           condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
           sqlState = Some("42K09"),
           parameters = Map(
-            "sqlExpr" -> "\"endswith('abcde' collate UNICODE_AI, 'A' collate UNICODE_AI)\"",
+            "sqlExpr" -> "\"endswith(abcde, A)\"",
             "paramIndex" -> "first",
-            "inputSql" -> "\"'abcde' collate UNICODE_AI\"",
+            "inputSql" -> "\"abcde\"",
             "inputType" -> "\"STRING COLLATE UNICODE_AI\"",
             "requiredType" -> "\"STRING\""),
           context = ExpectedContext(fragment = "endswith('abcde', 'A')", start = 7, stop = 28)
@@ -1530,9 +1527,9 @@ class CollationStringExpressionsSuite
         condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
         sqlState = Some("42K09"),
         parameters = Map(
-          "sqlExpr" -> "\"locate('aa' collate UNICODE_AI, 'Aaads' collate UNICODE_AI, 0)\"",
+          "sqlExpr" -> "\"locate(aa, Aaads, 0)\"",
           "paramIndex" -> "first",
-          "inputSql" -> "\"'aa' collate UNICODE_AI\"",
+          "inputSql" -> "\"aa\"",
           "inputType" -> "\"STRING COLLATE UNICODE_AI\"",
           "requiredType" -> "\"STRING\""),
         context = ExpectedContext(fragment = "locate('aa', 'Aaads', 0)", start = 7, stop = 30)
@@ -1590,9 +1587,9 @@ class CollationStringExpressionsSuite
         condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
         sqlState = Some("42K09"),
         parameters = Map(
-          "sqlExpr" -> "\"TRIM(LEADING 'x' collate UNICODE_AI FROM 'xxasdxx' collate UNICODE_AI)\"",
+          "sqlExpr" -> "\"TRIM(LEADING x FROM xxasdxx)\"",
           "paramIndex" -> "first",
-          "inputSql" -> "\"'xxasdxx' collate UNICODE_AI\"",
+          "inputSql" -> "\"xxasdxx\"",
           "inputType" -> "\"STRING COLLATE UNICODE_AI\"",
           "requiredType" -> "\"STRING\""),
         context = ExpectedContext(fragment = "ltrim('x', 'xxasdxx')", start = 7, stop = 27)
@@ -1652,10 +1649,9 @@ class CollationStringExpressionsSuite
         condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
         sqlState = Some("42K09"),
         parameters = Map(
-          "sqlExpr" -> ("\"TRIM(TRAILING 'x' collate UNICODE_AI FROM 'xxasdxx'" +
-            " collate UNICODE_AI)\""),
+          "sqlExpr" -> "\"TRIM(TRAILING x FROM xxasdxx)\"",
           "paramIndex" -> "first",
-          "inputSql" -> "\"'xxasdxx' collate UNICODE_AI\"",
+          "inputSql" -> "\"xxasdxx\"",
           "inputType" -> "\"STRING COLLATE UNICODE_AI\"",
           "requiredType" -> "\"STRING\""),
         context = ExpectedContext(fragment = "rtrim('x', 'xxasdxx')", start = 7, stop = 27)
@@ -1716,9 +1712,9 @@ class CollationStringExpressionsSuite
         condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
         sqlState = Some("42K09"),
         parameters = Map(
-          "sqlExpr" -> "\"TRIM(BOTH 'x' collate UNICODE_AI FROM 'xxasdxx' collate UNICODE_AI)\"",
+          "sqlExpr" -> "\"TRIM(BOTH x FROM xxasdxx)\"",
           "paramIndex" -> "first",
-          "inputSql" -> "\"'xxasdxx' collate UNICODE_AI\"",
+          "inputSql" -> "\"xxasdxx\"",
           "inputType" -> "\"STRING COLLATE UNICODE_AI\"",
           "requiredType" -> "\"STRING\""),
         context = ExpectedContext(fragment = "trim('x', 'xxasdxx')", start = 7, stop = 26)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR proposes a change that enforces determinism when assigning implicit aliases to collation types.

### Why are the changes needed?
With the current implementation, `Alias` can be computed both before and after type coercion rule. This will cause non-deterministic behavior when assigning implicit aliases to objects that are (or will be) type coerced to collation type. 

Given a query like:
 ```select concat_ws(' ' collate utf8_lcase, utf8_binary, 'SQL' collate utf8_lcase) from t5```
will produce output schema:
```concat_ws(collate( , utf8_lcase), utf8_binary, collate(SQL, utf8_lcase))```

On the other hand, query like:
```select 'a' collate unicode < 'A'```
will produce output schema:
```(collate(a, unicode) < 'A' collate UNICODE)```

This PR will remove `collate` from alias, making it deterministic in all cases.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Yes. Output schema will be changed in certain cases, as mentioned above.
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Modified existing tests.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
