### PR TITLE
[SPARK-51041][BUILD] Add `hive-llap-client` and `hive-llap-common` as test dependency of `hive-thriftserver`

### DIFF
--- a/sql/hive-thriftserver/pom.xml
+++ b/sql/hive-thriftserver/pom.xml
@@ -149,6 +149,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>${hive.group}</groupId>
+      <artifactId>hive-llap-common</artifactId>
+      <scope>${hive.llap.scope}</scope>
+    </dependency>
+    <dependency>
+      <groupId>${hive.group}</groupId>
+      <artifactId>hive-llap-client</artifactId>
+      <scope>${hive.llap.scope}</scope>
+    </dependency>
+    <dependency>
       <groupId>net.sf.jpam</groupId>
       <artifactId>jpam</artifactId>
       <exclusions>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to add `hive-llap-client` and `hive-llap-common` as test dependency of `hive-thriftserver`

### Why are the changes needed?
Fix  maven test of  `hive-thriftserver`.  Due to the lack of these test dependencies, testing `hive-thriftserver` using Maven will  hang.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Manually check: After adding the test dependencies, when testing the `hive-thriftserver` module using Maven, `HiveThriftBinaryServerSuite` will no longer hang.

```
build/mvn -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pjvm-profiler -Pspark-ganglia-lgpl -Pkinesis-asl clean install
build/mvn -pl sql/hive-thriftserver -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pjvm-profiler -Pspark-ganglia-lgpl -Pkinesis-asl clean install -fae
```

### Was this patch authored or co-authored using generative AI tooling?
No
