### PR TITLE
[SPARK-51015][ML][PYTHON][CONNECT] Support  RFormulaModel.toString on Connect

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -387,6 +387,10 @@ class RFormulaModel private[feature](
     s"RFormulaModel: uid=$uid, resolvedFormula=$resolvedFormula"
   }
 
+  // For ml connect only
+  @Since("4.0.0")
+  private[ml] def resolvedFormulaString: String = resolvedFormula.toString
+
   private def transformLabel(dataset: Dataset[_]): DataFrame = {
     val labelName = resolvedFormula.label
     if (labelName.isEmpty || hasLabelCol(dataset.schema)) {

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -6841,7 +6841,7 @@ class RFormulaModel(JavaModel, _RFormulaParams, JavaMLReadable["RFormulaModel"],
     """
 
     def __str__(self) -> str:
-        resolvedFormula = self._call_java("resolvedFormula")
+        resolvedFormula = self._call_java("resolvedFormulaString")
         return "RFormulaModel(%s) (uid=%s)" % (resolvedFormula, self.uid)
 
 

--- a/python/pyspark/ml/tests/test_feature.py
+++ b/python/pyspark/ml/tests/test_feature.py
@@ -1312,8 +1312,7 @@ class FeatureTestsMixin:
 
             model.write().overwrite().save(d)
             model2 = RFormulaModel.load(d)
-            # TODO: fix str(model)
-            # self.assertEqual(str(model), str(model2))
+            self.assertEqual(str(model), str(model2))
             self.assertEqual(model.getFormula(), model2.getFormula())
 
     def test_string_indexer_handle_invalid(self):

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -648,6 +648,7 @@ private[ml] object MLUtils {
     (classOf[CountVectorizerModel], Set("vocabulary")),
     (classOf[OneHotEncoderModel], Set("categorySizes")),
     (classOf[StringIndexerModel], Set("labels", "labelsArray")),
+    (classOf[RFormulaModel], Set("resolvedFormulaString")),
     (classOf[IDFModel], Set("idf", "docFreq", "numDocs")))
 
   private def validate(obj: Any, method: String): Unit = {


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR adds support toString for RFormulaModel on ml Connect.

### Why are the changes needed?

Feature parity


### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
CI passes


### Was this patch authored or co-authored using generative AI tooling?
No