### PR TITLE
[SPARK-51048][CORE] Support stop java spark context with exit code

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -552,6 +552,11 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
     sc.stop()
   }
 
+  /** Shut down the SparkContext with exit code. */
+  def stop(exitCode: Int): Unit = {
+    sc.stop(exitCode)
+  }
+
   override def close(): Unit = stop()
 
   /**

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -547,13 +547,13 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
    */
   def broadcast[T](value: T): Broadcast[T] = sc.broadcast(value)(fakeClassTag)
 
-  /** Shut down the JavaSparkContext. */
+  /** Shut down the SparkContext. */
   def stop(): Unit = {
     sc.stop()
   }
 
   /**
-   * Shut down the `JavaSparkContext` with given exit code that will be passed to scheduler backend.
+   * Shut down the `SparkContext` with given exit code that will be passed to scheduler backend.
    *
    * @param exitCode Specified exit code that will be passed to scheduler backend in client mode.
    */

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -555,7 +555,7 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
   /**
    * Shut down the `JavaSparkContext` with given exit code that will be passed to scheduler backend.
    *
-   * @param exitCode Specified exit code that will passed to scheduler backend in client mode.
+   * @param exitCode Specified exit code that will be passed to scheduler backend in client mode.
    */
   def stop(exitCode: Int): Unit = {
     sc.stop(exitCode)

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -547,12 +547,16 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
    */
   def broadcast[T](value: T): Broadcast[T] = sc.broadcast(value)(fakeClassTag)
 
-  /** Shut down the SparkContext. */
+  /** Shut down the JavaSparkContext. */
   def stop(): Unit = {
     sc.stop()
   }
 
-  /** Shut down the SparkContext with exit code. */
+  /**
+   * Shut down the `JavaSparkContext` with given exit code that will be passed to scheduler backend.
+   *
+   * @param exitCode Specified exit code that will passed to scheduler backend in client mode.
+   */
   def stop(exitCode: Int): Unit = {
     sc.stop(exitCode)
   }

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -553,9 +553,15 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
   }
 
   /**
-   * Shut down the `SparkContext` with given exit code that will be passed to scheduler backend.
+   * Shut down the SparkContext with exit code that will passed to scheduler backend.
+   * In client mode, client side may call `SparkContext.stop()` to clean up but exit with
+   * code not equal to 0. This behavior cause resource scheduler such as `ApplicationMaster`
+   * exit with success status but client side exited with failed status. Spark can call
+   * this method to stop SparkContext and pass client side correct exit code to scheduler backend.
+   * Then scheduler backend should send the exit code to corresponding resource scheduler
+   * to keep consistent.
    *
-   * @param exitCode Specified exit code that will be passed to scheduler backend in client mode.
+   * @param exitCode Specified exit code that will passed to scheduler backend in client mode.
    */
   def stop(exitCode: Int): Unit = {
     sc.stop(exitCode)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Considering there is support to stop spark context with required exit code, This PR aims to use the same to add it to java spark context as well.


### Why are the changes needed?

Currently to use `stop(exitCode)` method for  JavaSparkContext, user has to call `javaSparkContextsparkContext.stop(exitCode)`.
Post this PR user can directly do `javaSparkContextsparkContext.stop(exitCode)` to invoke same.


### Does this PR introduce _any_ user-facing change?

No, it introduces an extra method in JavaSparkContext class


### How was this patch tested?

This was tested in internal/production k8 cluster


### Was this patch authored or co-authored using generative AI tooling?
No
