### PR TITLE
[SPARK-51049][CORE] Increase S3A Vector IO threshold for range merge

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -423,6 +423,10 @@ class SparkContext(config: SparkConf) extends Logging {
     if (!_conf.contains("spark.app.name")) {
       throw new SparkException("An application name must be set in your configuration")
     }
+    // HADOOP-19229 Vector IO on cloud storage: increase threshold for range merging
+    // We can remove this after Apache Hadoop 3.4.2 releases
+    conf.setIfMissing("spark.hadoop.fs.s3a.vectored.read.min.seek.size", "128K")
+    conf.setIfMissing("spark.hadoop.fs.s3a.vectored.read.max.merged.size", "2M")
     // This should be set as early as possible.
     SparkContext.fillMissingMagicCommitterConfsIfNeeded(_conf)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to increase S3A Vector IO threshold for range merge.

### Why are the changes needed?

Apache Spark 4.0.0 supported Hadoop Vectored IO via ORC and Parquet.

As a part of [HADOOP-18855 VectorIO API tuning/stabilization](https://issues.apache.org/jira/browse/HADOOP-18855), Apache Hadoop 3.4.2 will have new threshold default values. We had better follow these update in advance until Apache Hadoop 3.4.2 is released.

- https://github.com/apache/hadoop/pull/7281

### Does this PR introduce _any_ user-facing change?

No, Hadoop Vectored IO features are new in Apache Spark 4.0.0 .

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.