### PR TITLE
[SPARK-51050][SQL][TESTS] Add group by alias tests to the group-by-alias.sql

### DIFF
--- a/sql/core/src/test/resources/sql-tests/analyzer-results/group-by-alias.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/group-by-alias.sql.out
@@ -13,6 +13,18 @@ AS testData(a, b), false, true, LocalTempView, UNSUPPORTED, true
 
 
 -- !query
+SELECT a from testData GROUP BY A
+-- !query analysis
+Aggregate [A#x], [a#x]
++- SubqueryAlias testdata
+   +- View (`testData`, [a#x, b#x])
+      +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+         +- Project [a#x, b#x]
+            +- SubqueryAlias testData
+               +- LocalRelation [a#x, b#x]
+
+
+-- !query
 SELECT a AS k, COUNT(b) FROM testData GROUP BY k
 -- !query analysis
 Aggregate [a#x], [a#x AS k#x, count(b#x) AS count(b)#xL]
@@ -49,6 +61,233 @@ Aggregate [col1#x], [col1#x AS k#x, sum(col2#x) AS sum(col2)#xL]
                +- Project [a#x, b#x]
                   +- SubqueryAlias testData
                      +- LocalRelation [a#x, b#x]
+
+
+-- !query
+SELECT a as alias FROM testData GROUP BY ALIAS
+-- !query analysis
+Aggregate [a#x], [a#x AS alias#x]
++- SubqueryAlias testdata
+   +- View (`testData`, [a#x, b#x])
+      +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+         +- Project [a#x, b#x]
+            +- SubqueryAlias testData
+               +- LocalRelation [a#x, b#x]
+
+
+-- !query
+SELECT a AS k FROM testData GROUP BY 'k'
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "MISSING_AGGREGATION",
+  "sqlState" : "42803",
+  "messageParameters" : {
+    "expression" : "\"a\"",
+    "expressionAnyValue" : "\"any_value(a)\""
+  }
+}
+
+
+-- !query
+SELECT 1 AS k FROM testData GROUP BY 'k'
+-- !query analysis
+Aggregate [k], [1 AS k#x]
++- SubqueryAlias testdata
+   +- View (`testData`, [a#x, b#x])
+      +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+         +- Project [a#x, b#x]
+            +- SubqueryAlias testData
+               +- LocalRelation [a#x, b#x]
+
+
+-- !query
+SELECT concat_ws(' ', a, b) FROM testData GROUP BY `concat_ws( , a, b)`
+-- !query analysis
+Aggregate [concat_ws( , cast(a#x as string), cast(b#x as string))], [concat_ws( , cast(a#x as string), cast(b#x as string)) AS concat_ws( , a, b)#x]
++- SubqueryAlias testdata
+   +- View (`testData`, [a#x, b#x])
+      +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+         +- Project [a#x, b#x]
+            +- SubqueryAlias testData
+               +- LocalRelation [a#x, b#x]
+
+
+-- !query
+SELECT 1 AS a FROM testData GROUP BY a
+-- !query analysis
+Aggregate [a#x], [1 AS a#x]
++- SubqueryAlias testdata
+   +- View (`testData`, [a#x, b#x])
+      +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+         +- Project [a#x, b#x]
+            +- SubqueryAlias testData
+               +- LocalRelation [a#x, b#x]
+
+
+-- !query
+SELECT 1 AS a FROM testData GROUP BY `a`
+-- !query analysis
+Aggregate [a#x], [1 AS a#x]
++- SubqueryAlias testdata
+   +- View (`testData`, [a#x, b#x])
+      +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+         +- Project [a#x, b#x]
+            +- SubqueryAlias testData
+               +- LocalRelation [a#x, b#x]
+
+
+-- !query
+SELECT 1 GROUP BY `1`
+-- !query analysis
+Aggregate [1], [1 AS 1#x]
++- OneRowRelation
+
+
+-- !query
+SELECT (SELECT a FROM testData) + (SELECT b FROM testData) group by `(scalarsubquery() + scalarsubquery())`
+-- !query analysis
+Aggregate [(scalar-subquery#x [] + scalar-subquery#x [])], [(scalar-subquery#x [] + scalar-subquery#x []) AS (scalarsubquery() + scalarsubquery())#x]
+:  :- Project [a#x]
+:  :  +- SubqueryAlias testdata
+:  :     +- View (`testData`, [a#x, b#x])
+:  :        +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+:  :           +- Project [a#x, b#x]
+:  :              +- SubqueryAlias testData
+:  :                 +- LocalRelation [a#x, b#x]
+:  :- Project [b#x]
+:  :  +- SubqueryAlias testdata
+:  :     +- View (`testData`, [a#x, b#x])
+:  :        +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+:  :           +- Project [a#x, b#x]
+:  :              +- SubqueryAlias testData
+:  :                 +- LocalRelation [a#x, b#x]
+:  :- Project [a#x]
+:  :  +- SubqueryAlias testdata
+:  :     +- View (`testData`, [a#x, b#x])
+:  :        +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+:  :           +- Project [a#x, b#x]
+:  :              +- SubqueryAlias testData
+:  :                 +- LocalRelation [a#x, b#x]
+:  +- Project [b#x]
+:     +- SubqueryAlias testdata
+:        +- View (`testData`, [a#x, b#x])
+:           +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+:              +- Project [a#x, b#x]
+:                 +- SubqueryAlias testData
+:                    +- LocalRelation [a#x, b#x]
++- OneRowRelation
+
+
+-- !query
+SELECT a, count(*) FROM testData GROUP BY (SELECT b FROM testData)
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "MISSING_AGGREGATION",
+  "sqlState" : "42803",
+  "messageParameters" : {
+    "expression" : "\"a\"",
+    "expressionAnyValue" : "\"any_value(a)\""
+  }
+}
+
+
+-- !query
+SELECT a, count(*) FROM testData GROUP BY a, (SELECT b FROM testData)
+-- !query analysis
+Aggregate [a#x, scalar-subquery#x []], [a#x, count(1) AS count(1)#xL]
+:  +- Project [b#x]
+:     +- SubqueryAlias testdata
+:        +- View (`testData`, [a#x, b#x])
+:           +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+:              +- Project [a#x, b#x]
+:                 +- SubqueryAlias testData
+:                    +- LocalRelation [a#x, b#x]
++- SubqueryAlias testdata
+   +- View (`testData`, [a#x, b#x])
+      +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+         +- Project [a#x, b#x]
+            +- SubqueryAlias testData
+               +- LocalRelation [a#x, b#x]
+
+
+-- !query
+SELECT a, count(*) FROM testData GROUP BY a, (SELECT b FROM testData LIMIT 1)
+-- !query analysis
+Aggregate [a#x, scalar-subquery#x []], [a#x, count(1) AS count(1)#xL]
+:  +- GlobalLimit 1
+:     +- LocalLimit 1
+:        +- Project [b#x]
+:           +- SubqueryAlias testdata
+:              +- View (`testData`, [a#x, b#x])
+:                 +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+:                    +- Project [a#x, b#x]
+:                       +- SubqueryAlias testData
+:                          +- LocalRelation [a#x, b#x]
++- SubqueryAlias testdata
+   +- View (`testData`, [a#x, b#x])
+      +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+         +- Project [a#x, b#x]
+            +- SubqueryAlias testData
+               +- LocalRelation [a#x, b#x]
+
+
+-- !query
+SELECT a, count(*) FROM testData GROUP BY a, b IN (SELECT a FROM testData)
+-- !query analysis
+Aggregate [a#x, b#x IN (list#x [])], [a#x, count(1) AS count(1)#xL]
+:  +- Project [a#x]
+:     +- SubqueryAlias testdata
+:        +- View (`testData`, [a#x, b#x])
+:           +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+:              +- Project [a#x, b#x]
+:                 +- SubqueryAlias testData
+:                    +- LocalRelation [a#x, b#x]
++- SubqueryAlias testdata
+   +- View (`testData`, [a#x, b#x])
+      +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+         +- Project [a#x, b#x]
+            +- SubqueryAlias testData
+               +- LocalRelation [a#x, b#x]
+
+
+-- !query
+SELECT a, count(*) FROM testData GROUP BY a, a IN (SELECT b FROM testData)
+-- !query analysis
+Aggregate [a#x, a#x IN (list#x [])], [a#x, count(1) AS count(1)#xL]
+:  +- Project [b#x]
+:     +- SubqueryAlias testdata
+:        +- View (`testData`, [a#x, b#x])
+:           +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+:              +- Project [a#x, b#x]
+:                 +- SubqueryAlias testData
+:                    +- LocalRelation [a#x, b#x]
++- SubqueryAlias testdata
+   +- View (`testData`, [a#x, b#x])
+      +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+         +- Project [a#x, b#x]
+            +- SubqueryAlias testData
+               +- LocalRelation [a#x, b#x]
+
+
+-- !query
+SELECT a, count(*) FROM testData GROUP BY a, EXISTS(SELECT b FROM testData)
+-- !query analysis
+Aggregate [a#x, exists#x []], [a#x, count(1) AS count(1)#xL]
+:  +- Project [b#x]
+:     +- SubqueryAlias testdata
+:        +- View (`testData`, [a#x, b#x])
+:           +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+:              +- Project [a#x, b#x]
+:                 +- SubqueryAlias testData
+:                    +- LocalRelation [a#x, b#x]
++- SubqueryAlias testdata
+   +- View (`testData`, [a#x, b#x])
+      +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+         +- Project [a#x, b#x]
+            +- SubqueryAlias testData
+               +- LocalRelation [a#x, b#x]
 
 
 -- !query
@@ -117,3 +356,56 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "fragment" : "k"
   } ]
 }
+
+
+-- !query
+SELECT 1 GROUP BY `1`
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION",
+  "sqlState" : "42703",
+  "messageParameters" : {
+    "objectName" : "`1`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 19,
+    "stopIndex" : 21,
+    "fragment" : "`1`"
+  } ]
+}
+
+
+-- !query
+SELECT 1 AS col FROM testData GROUP BY `col`
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNRESOLVED_COLUMN.WITH_SUGGESTION",
+  "sqlState" : "42703",
+  "messageParameters" : {
+    "objectName" : "`col`",
+    "proposal" : "`a`, `b`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 40,
+    "stopIndex" : 44,
+    "fragment" : "`col`"
+  } ]
+}
+
+
+-- !query
+SELECT 1 AS a FROM testData GROUP BY `a`
+-- !query analysis
+Aggregate [a#x], [1 AS a#x]
++- SubqueryAlias testdata
+   +- View (`testData`, [a#x, b#x])
+      +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+         +- Project [a#x, b#x]
+            +- SubqueryAlias testData
+               +- LocalRelation [a#x, b#x]

--- a/sql/core/src/test/resources/sql-tests/inputs/group-by-alias.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/group-by-alias.sql
@@ -3,10 +3,39 @@ CREATE OR REPLACE TEMPORARY VIEW testData AS SELECT * FROM VALUES
 (1, 1), (1, 2), (2, 1), (2, 2), (3, 1), (3, 2), (null, 1), (3, null), (null, null)
 AS testData(a, b);
 
+-- GROUP BY alias should work with case insensitive names
+SELECT a from testData GROUP BY A;
+
 -- Aliases in SELECT could be used in GROUP BY
 SELECT a AS k, COUNT(b) FROM testData GROUP BY k;
 SELECT a AS k, COUNT(b) FROM testData GROUP BY k HAVING k > 1;
 SELECT col1 AS k, SUM(col2) FROM testData AS t(col1, col2) GROUP BY k;
+SELECT a as alias FROM testData GROUP BY ALIAS;
+
+-- GROUP BY literal
+SELECT a AS k FROM testData GROUP BY 'k';
+SELECT 1 AS k FROM testData GROUP BY 'k';
+
+-- GROUP BY alias with the function name
+SELECT concat_ws(' ', a, b) FROM testData GROUP BY `concat_ws( , a, b)`;
+
+-- GROUP BY column with name same as an alias used in the project list
+SELECT 1 AS a FROM testData GROUP BY a;
+SELECT 1 AS a FROM testData GROUP BY `a`;
+
+-- GROUP BY implicit alias
+SELECT 1 GROUP BY `1`;
+
+-- GROUP BY alias with the subquery name
+SELECT (SELECT a FROM testData) + (SELECT b FROM testData) group by `(scalarsubquery() + scalarsubquery())`;
+
+-- GROUP BY with expression subqueries
+SELECT a, count(*) FROM testData GROUP BY (SELECT b FROM testData);
+SELECT a, count(*) FROM testData GROUP BY a, (SELECT b FROM testData);
+SELECT a, count(*) FROM testData GROUP BY a, (SELECT b FROM testData LIMIT 1);
+SELECT a, count(*) FROM testData GROUP BY a, b IN (SELECT a FROM testData);
+SELECT a, count(*) FROM testData GROUP BY a, a IN (SELECT b FROM testData);
+SELECT a, count(*) FROM testData GROUP BY a, EXISTS(SELECT b FROM testData);
 
 -- GROUP BY alias with invalid col in SELECT list
 SELECT a AS k, COUNT(non_existing) FROM testData GROUP BY k;
@@ -19,3 +48,8 @@ set spark.sql.groupByAliases=false;
 
 -- Check analysis exceptions
 SELECT a AS k, COUNT(b) FROM testData GROUP BY k;
+SELECT 1 GROUP BY `1`;
+SELECT 1 AS col FROM testData GROUP BY `col`;
+
+-- GROUP BY attribute takes precedence over alias
+SELECT 1 AS a FROM testData GROUP BY `a`;

--- a/sql/core/src/test/resources/sql-tests/results/group-by-alias.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-alias.sql.out
@@ -10,6 +10,17 @@ struct<>
 
 
 -- !query
+SELECT a from testData GROUP BY A
+-- !query schema
+struct<a:int>
+-- !query output
+1
+2
+3
+NULL
+
+
+-- !query
 SELECT a AS k, COUNT(b) FROM testData GROUP BY k
 -- !query schema
 struct<k:int,count(b):bigint>
@@ -38,6 +49,187 @@ struct<k:int,sum(col2):bigint>
 2	3
 3	3
 NULL	1
+
+
+-- !query
+SELECT a as alias FROM testData GROUP BY ALIAS
+-- !query schema
+struct<alias:int>
+-- !query output
+1
+2
+3
+NULL
+
+
+-- !query
+SELECT a AS k FROM testData GROUP BY 'k'
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "MISSING_AGGREGATION",
+  "sqlState" : "42803",
+  "messageParameters" : {
+    "expression" : "\"a\"",
+    "expressionAnyValue" : "\"any_value(a)\""
+  }
+}
+
+
+-- !query
+SELECT 1 AS k FROM testData GROUP BY 'k'
+-- !query schema
+struct<k:int>
+-- !query output
+1
+
+
+-- !query
+SELECT concat_ws(' ', a, b) FROM testData GROUP BY `concat_ws( , a, b)`
+-- !query schema
+struct<concat_ws( , a, b):string>
+-- !query output
+
+1
+1 1
+1 2
+2 1
+2 2
+3
+3 1
+3 2
+
+
+-- !query
+SELECT 1 AS a FROM testData GROUP BY a
+-- !query schema
+struct<a:int>
+-- !query output
+1
+1
+1
+1
+
+
+-- !query
+SELECT 1 AS a FROM testData GROUP BY `a`
+-- !query schema
+struct<a:int>
+-- !query output
+1
+1
+1
+1
+
+
+-- !query
+SELECT 1 GROUP BY `1`
+-- !query schema
+struct<1:int>
+-- !query output
+1
+
+
+-- !query
+SELECT (SELECT a FROM testData) + (SELECT b FROM testData) group by `(scalarsubquery() + scalarsubquery())`
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkException
+{
+  "errorClass" : "SCALAR_SUBQUERY_TOO_MANY_ROWS",
+  "sqlState" : "21000",
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 31,
+    "fragment" : "(SELECT a FROM testData)"
+  } ]
+}
+
+
+-- !query
+SELECT a, count(*) FROM testData GROUP BY (SELECT b FROM testData)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "MISSING_AGGREGATION",
+  "sqlState" : "42803",
+  "messageParameters" : {
+    "expression" : "\"a\"",
+    "expressionAnyValue" : "\"any_value(a)\""
+  }
+}
+
+
+-- !query
+SELECT a, count(*) FROM testData GROUP BY a, (SELECT b FROM testData)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkException
+{
+  "errorClass" : "SCALAR_SUBQUERY_TOO_MANY_ROWS",
+  "sqlState" : "21000",
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 46,
+    "stopIndex" : 69,
+    "fragment" : "(SELECT b FROM testData)"
+  } ]
+}
+
+
+-- !query
+SELECT a, count(*) FROM testData GROUP BY a, (SELECT b FROM testData LIMIT 1)
+-- !query schema
+struct<a:int,count(1):bigint>
+-- !query output
+1	2
+2	2
+3	3
+NULL	2
+
+
+-- !query
+SELECT a, count(*) FROM testData GROUP BY a, b IN (SELECT a FROM testData)
+-- !query schema
+struct<a:int,count(1):bigint>
+-- !query output
+1	2
+2	2
+3	1
+3	2
+NULL	1
+NULL	1
+
+
+-- !query
+SELECT a, count(*) FROM testData GROUP BY a, a IN (SELECT b FROM testData)
+-- !query schema
+struct<a:int,count(1):bigint>
+-- !query output
+1	2
+2	2
+3	3
+NULL	2
+
+
+-- !query
+SELECT a, count(*) FROM testData GROUP BY a, EXISTS(SELECT b FROM testData)
+-- !query schema
+struct<a:int,count(1):bigint>
+-- !query output
+1	2
+2	2
+3	3
+NULL	2
 
 
 -- !query
@@ -114,3 +306,59 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "fragment" : "k"
   } ]
 }
+
+
+-- !query
+SELECT 1 GROUP BY `1`
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION",
+  "sqlState" : "42703",
+  "messageParameters" : {
+    "objectName" : "`1`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 19,
+    "stopIndex" : 21,
+    "fragment" : "`1`"
+  } ]
+}
+
+
+-- !query
+SELECT 1 AS col FROM testData GROUP BY `col`
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNRESOLVED_COLUMN.WITH_SUGGESTION",
+  "sqlState" : "42703",
+  "messageParameters" : {
+    "objectName" : "`col`",
+    "proposal" : "`a`, `b`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 40,
+    "stopIndex" : 44,
+    "fragment" : "`col`"
+  } ]
+}
+
+
+-- !query
+SELECT 1 AS a FROM testData GROUP BY `a`
+-- !query schema
+struct<a:int>
+-- !query output
+1
+1
+1
+1


### PR DESCRIPTION
### What changes were proposed in this pull request?
I propose that we extend group-by-alias.sql with some cases where we `group by` aliases.

### Why are the changes needed?
Extend the testing coverage.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added tests.

### Was this patch authored or co-authored using generative AI tooling?
No.