### PR TITLE
[SPARK-51053][SQL] Update `CookieSigner` to use `SHA-512`

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/CookieSigner.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/CookieSigner.java
@@ -32,7 +32,7 @@ import org.apache.spark.internal.SparkLoggerFactory;
  */
 public class CookieSigner {
   private static final String SIGNATURE = "&s=";
-  private static final String SHA_STRING = "SHA-256";
+  private static final String SHA_STRING = "SHA-512";
   private byte[] secretBytes;
   private static final SparkLogger LOG = SparkLoggerFactory.getLogger(CookieSigner.class);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `CookieSigner` to use `SHA-512` instead of `SHA-256` since Apache Spark 4.0.0.

### Why are the changes needed?

This is aligned with the upstream change, [HIVE-24287](https://issues.apache.org/jira/browse/HIVE-24287).
- https://github.com/apache/hive/pull/1589

### Does this PR introduce _any_ user-facing change?

Only the signature of message is changed. There is no user-facing behavior change.

```
$ jshell
|  Welcome to JShell -- Version 21.0.6
|  For an introduction type: /help intro

jshell> java.security.MessageDigest.getInstance("SHA-256")
$1 ==> SHA-256 Message Digest from AppleBundledACCP, <initialized>

jshell> java.security.MessageDigest.getInstance("SHA-512")
$2 ==> SHA-512 Message Digest from AppleBundledACCP, <initialized>
```

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.