### PR TITLE
[SPARK-50126][PYTHON][CONNECT][3.5] PySpark expr() (expression) SQL Function returns None in Spark Connect

### DIFF
--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -448,7 +448,10 @@ class LiteralExpression(Expression):
         return expr
 
     def __repr__(self) -> str:
-        return f"{self._value}"
+        if self._value is None:
+            return "NULL"
+        else:
+            return f"{self._value}"
 
 
 class ColumnReference(Expression):
@@ -525,6 +528,7 @@ class SQLExpression(Expression):
 
     def __init__(self, expr: str) -> None:
         super().__init__()
+        assert isinstance(expr, str)
         self._expr: str = expr
 
     def to_plan(self, session: "SparkConnectClient") -> proto.Expression:
@@ -535,6 +539,9 @@ class SQLExpression(Expression):
 
     def __eq__(self, other: Any) -> bool:
         return other is not None and isinstance(other, SQLExpression) and other._expr == self._expr
+
+    def __repr__(self) -> str:
+        return self._expr
 
 
 class SortOrder(Expression):

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -207,6 +207,13 @@ class ColumnTestsMixin:
 
         self.assertTrue("e" not in result["a2"]["d"] and "f" in result["a2"]["d"])
 
+    def test_expr_str_representation(self):
+        from pyspark.sql import functions as sf
+
+        expression = sf.expr("foo")
+        when_cond = sf.when(expression, sf.lit(None))
+        self.assertEqual(str(when_cond), "Column<'CASE WHEN foo THEN NULL END'>")
+
 
 class ColumnTests(ColumnTestsMixin, ReusedSQLTestCase):
     pass


### PR DESCRIPTION
Cherry-pick https://github.com/apache/spark/pull/46583 to branch-3.5
Original JIRA: SPARK-48276

### What changes were proposed in this pull request?
Original PR proposed these changes:
- Add the missing `__repr__` method for `SQLExpression`
- Also adjust the output of `lit(None): None -> NULL` to be more consistent with the Spark Classic

I had to make very minor modifications to fix unclean cherry-pick:
- The UT added in the original PR needed an import.


### Why are the changes needed?
- In Spark 3.5, when PySpark is launched with a remote `Spark Connect` configuration, calls to `pyspark.sql.functions.expr` incorrectly return `Column<None>` instead of the expected expression. This change addresses the issue to ensure proper expression resolution in Spark Connect mode.
- As per original PR: [Bug fix] All expressions should implement the `__repr__` method.


### Does this PR introduce _any_ user-facing change?
Yes, this PR ensures that `pyspark.sql.functions.expr` correctly resolves expressions in Spark Connect mode. Previously, it returned `Column<None>`, but now it behaves correctly.


### How was this patch tested?
Manually tested. Also original PR added a UT.


### Was this patch authored or co-authored using generative AI tooling?
No.
