### PR TITLE
[SPARK-50265][CONNECT] Support spark.udf.registerJavaUdf in Connect

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/UserDefinedFunctionE2ETestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/UserDefinedFunctionE2ETestSuite.scala
@@ -436,7 +436,8 @@ class UserDefinedFunctionE2ETestSuite extends QueryTest with RemoteSparkSession 
 
   test("registerJavaUdf") {
     spark.udf.registerJava("sconcat", classOf[StringConcat].getName, StringType)
-    val ds = spark.range(2)
+    val ds = spark
+      .range(2)
       .select(call_function("sconcat", col("id").cast("string"), (col("id") + 1).cast("string")))
       .as(StringEncoder)
     checkDataset(ds, "01", "12")

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/UserDefinedFunctionE2ETestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/UserDefinedFunctionE2ETestSuite.scala
@@ -25,11 +25,11 @@ import scala.jdk.CollectionConverters._
 import org.apache.spark.api.java.function._
 import org.apache.spark.sql.{AnalysisException, Encoder, Encoders, Row}
 import org.apache.spark.sql.api.java.UDF2
-import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.{PrimitiveIntEncoder, PrimitiveLongEncoder}
+import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.{PrimitiveIntEncoder, PrimitiveLongEncoder, StringEncoder}
 import org.apache.spark.sql.connect.test.{QueryTest, RemoteSparkSession}
 import org.apache.spark.sql.expressions.Aggregator
-import org.apache.spark.sql.functions.{col, struct, udaf, udf}
-import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.functions.{call_function, col, struct, udaf, udf}
+import org.apache.spark.sql.types.{IntegerType, StringType}
 
 /**
  * All tests in this class requires client UDF defined in this test class synced with the server.
@@ -433,6 +433,14 @@ class UserDefinedFunctionE2ETestSuite extends QueryTest with RemoteSparkSession 
     assert(ds.select(RowAggregator.toColumn).head() == 405)
     assert(ds.agg(RowAggregator.toColumn).head().getLong(0) == 405)
   }
+
+  test("registerJavaUdf") {
+    spark.udf.registerJava("sconcat", classOf[StringConcat].getName, StringType)
+    val ds = spark.range(2)
+      .select(call_function("sconcat", col("id").cast("string"), (col("id") + 1).cast("string")))
+      .as(StringEncoder)
+    checkDataset(ds, "01", "12")
+  }
 }
 
 case class UdafTestInput(id: Long, extra: Long)
@@ -489,4 +497,8 @@ object RowAggregator extends Aggregator[Row, (Long, Long), Long] {
   override def bufferEncoder: Encoder[(Long, Long)] =
     Encoders.tuple(Encoders.scalaLong, Encoders.scalaLong)
   override def outputEncoder: Encoder[Long] = Encoders.scalaLong
+}
+
+class StringConcat extends UDF2[String, String, String] {
+  override def call(t1: String, t2: String): String = t1 + t2
 }

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/UDFRegistration.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/UDFRegistration.scala
@@ -17,7 +17,9 @@
 
 package org.apache.spark.sql.connect
 
+import org.apache.spark.connect.proto
 import org.apache.spark.sql
+import org.apache.spark.sql.connect.common.DataTypeProtoConverter
 import org.apache.spark.sql.expressions.{UserDefinedAggregateFunction, UserDefinedFunction}
 import org.apache.spark.sql.types.DataType
 
@@ -42,8 +44,12 @@ class UDFRegistration(session: SparkSession) extends sql.UDFRegistration {
   }
 
   override def registerJava(name: String, className: String, returnDataType: DataType): Unit = {
-    throw new UnsupportedOperationException(
-      "registerJava is currently not supported in Spark Connect.")
+    val builder = proto.CommonInlineUserDefinedFunction.newBuilder().setFunctionName(name)
+    builder.getJavaUdfBuilder
+      .setClassName(className)
+      .setOutputType(DataTypeProtoConverter.toConnectProtoType(returnDataType))
+      .setAggregate(false)
+    session.registerUdf(builder.build())
   }
 
   /** @inheritdoc */


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds support for `UDFRegistration.registerJavaUdf(..)` to the Connect Scala Client.

### Why are the changes needed?
This increase compatibility between the Classic and Connect implementations.

### Does this PR introduce _any_ user-facing change?
Yes. It enables Scala client users to use `UDFRegistration.registerJavaUdf(..)`.

### How was this patch tested?
I have added a Unit tests to the `UserDefinedFunctionE2ETestSuite`.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
