### PR TITLE
[SPARK-51064][SQL] Enable `spark.sql.sources.v2.bucketing.enabled` by default

### DIFF
--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -441,7 +441,7 @@ The following SQL properties enable Storage Partition Join in different join que
     <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>
     <tr>
       <td><code>spark.sql.sources.v2.bucketing.enabled</code></td>
-      <td>false</td>
+      <td>true</td>
       <td>
         When true, try to eliminate shuffle by using the partitioning reported by a compatible V2 data source.
       </td>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1729,7 +1729,7 @@ object SQLConf {
         "avoid shuffle if necessary.")
       .version("3.3.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val V2_BUCKETING_PUSH_PART_VALUES_ENABLED =
     buildConf("spark.sql.sources.v2.bucketing.pushPartValues.enabled")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -1217,7 +1217,8 @@ abstract class DynamicPartitionPruningSuiteBase
   test("SPARK-32509: Unused Dynamic Pruning filter shouldn't affect " +
     "canonicalization and exchange reuse") {
     withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "true") {
-      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+          SQLConf.V2_BUCKETING_ENABLED.key -> "false") {
         val df = sql(
           """ WITH view1 as (
             |   SELECT f.store_id FROM fact_stats f WHERE f.units_sold = 70


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `spark.sql.sources.v2.bucketing.enabled` by default for Apache Spark 4.1.0.

### Why are the changes needed?

We have been using `spark.sql.sources.v2.bucketing.enabled` since Apache Spark 3.3.0 stably to improve Spark performance on V2 data source. Although Apache Spark enables this configuration, Spark checks if all `InputPartition`s have `HasPartitionKey` or not still.

https://github.com/apache/spark/blob/8fc6a200eb533369c7c073e2abe585848a7168c3/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala#L140-L142

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.