### PR TITLE
[SPARK-51060][ML][PYTHON][CONNECT][FOLLOW-UP] Fix the `uid` of `Bucketizer` fitted by `QuantileDiscretizer`

### DIFF
--- a/python/pyspark/ml/tests/test_feature.py
+++ b/python/pyspark/ml/tests/test_feature.py
@@ -998,7 +998,7 @@ class FeatureTestsMixin:
         bucketizer = qds.fit(df)
         self.assertIsInstance(bucketizer, Bucketizer)
         # Bucketizer doesn't inherit uid from QuantileDiscretizer
-        # self.assertEqual(qds.uid, bucketizer.uid)
+        self.assertNotEqual(qds.uid, bucketizer.uid)
 
         # check model coefficients
         self.assertEqual(bucketizer.getSplits(), [float("-inf"), 0.4, float("inf")])
@@ -1046,7 +1046,7 @@ class FeatureTestsMixin:
         bucketizer = qds.fit(df)
         self.assertIsInstance(bucketizer, Bucketizer)
         # Bucketizer doesn't inherit uid from QuantileDiscretizer
-        # self.assertEqual(qds.uid, bucketizer.uid)
+        self.assertNotEqual(qds.uid, bucketizer.uid)
 
         # check model coefficients
         self.assertEqual(

--- a/python/pyspark/ml/tests/test_feature.py
+++ b/python/pyspark/ml/tests/test_feature.py
@@ -999,6 +999,8 @@ class FeatureTestsMixin:
         self.assertIsInstance(bucketizer, Bucketizer)
         # Bucketizer doesn't inherit uid from QuantileDiscretizer
         self.assertNotEqual(qds.uid, bucketizer.uid)
+        self.assertTrue(qds.uid.startswith("QuantileDiscretizer"))
+        self.assertTrue(bucketizer.uid.startswith("Bucketizer"))
 
         # check model coefficients
         self.assertEqual(bucketizer.getSplits(), [float("-inf"), 0.4, float("inf")])
@@ -1047,6 +1049,8 @@ class FeatureTestsMixin:
         self.assertIsInstance(bucketizer, Bucketizer)
         # Bucketizer doesn't inherit uid from QuantileDiscretizer
         self.assertNotEqual(qds.uid, bucketizer.uid)
+        self.assertTrue(qds.uid.startswith("QuantileDiscretizer"))
+        self.assertTrue(bucketizer.uid.startswith("Bucketizer"))
 
         # check model coefficients
         self.assertEqual(

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -136,7 +136,8 @@ def try_remote_fit(f: FuncT) -> FuncT:
             model_info = deserialize(properties)
             client.add_ml_cache(model_info.obj_ref.id)
             model = self._create_model(model_info.obj_ref.id)
-            model._resetUid(self.uid)
+            if model.__class__.__name__ not in ["Bucketizer"]:
+                model._resetUid(self.uid)
             return self._copyValues(model)
         else:
             return f(self, dataset)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix the `uid` of `Bucketizer` fitted by `QuantileDiscretizer`


### Why are the changes needed?
On connect, the `Bucketizer` fitted by `QuantileDiscretizer` has the same `uid` as `QuantileDiscretizer`.
This is not consistent with pyspark classic.

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
added tests


### Was this patch authored or co-authored using generative AI tooling?
no