### PR TITLE
[SPARK-43131][SQL][WIP] Add labels to identify UDFs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -1351,6 +1351,7 @@ trait ComplexTypeMergingExpression extends Expression {
  */
 trait UserDefinedExpression {
   def name: String
+  def fullName: String = s"$name:UDF"
 }
 
 trait CommutativeExpression extends Expression {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -342,7 +342,7 @@ case class PrettyPythonUDF(
     children: Seq[Expression])
   extends UnevaluableAggregateFunc with NonSQLExpression {
 
-  override def toString: String = s"$name(${children.mkString(", ")})"
+  override def toString: String = s"$name:UDF(${children.mkString(", ")})"
 
   override def sql(isDistinct: Boolean): String = {
     val distinct = if (isDistinct) "DISTINCT " else ""

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
@@ -65,7 +65,7 @@ case class ScalaUDF(
 
   final override val nodePatterns: Seq[TreePattern] = Seq(SCALA_UDF)
 
-  override def toString: String = s"$name(${children.mkString(", ")})"
+  override def toString: String = s"$fullName(${children.mkString(", ")})"
 
   override def name: String = udfName.getOrElse("UDF")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/udaf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/udaf.scala
@@ -473,7 +473,7 @@ case class ScalaUDAF(
   }
 
   override def toString: String = {
-    s"""$nodeName(${children.mkString(",")})"""
+    s"""$fullName(${children.mkString(",")})"""
   }
 
   override def nodeName: String = name
@@ -543,7 +543,7 @@ case class ScalaAggregator[IN, BUF, OUT](
     bufferDeserializer(bufferRow)
   }
 
-  override def toString: String = s"""${nodeName}(${children.mkString(",")})"""
+  override def toString: String = s"""${fullName}(${children.mkString(",")})"""
 
   override def nodeName: String = name
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
@@ -123,7 +123,7 @@ class PythonUDFSuite extends QueryTest with SharedSparkSession {
         spark.range(1).select(transform(array("id"), x => pythonTestUDF(x))).collect()
       },
       condition = "UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_PYTHON_UDF",
-      parameters = Map("funcName" -> "\"pyUDF(namedlambdavariable())\""),
+      parameters = Map("funcName" -> "\"pyUDF:UDF(namedlambdavariable())\""),
       context = ExpectedContext(
         "transform", s".*${this.getClass.getSimpleName}.*"))
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -70,7 +70,7 @@ private[hive] case class HiveSimpleUDF(
   }
 
   override def toString: String = {
-    s"$nodeName#${funcWrapper.functionClassName}(${children.mkString(",")})"
+    s"$nodeName:UDF#${funcWrapper.functionClassName}(${children.mkString(",")})"
   }
 
   override def prettyName: String = name
@@ -150,7 +150,7 @@ private[hive] case class HiveGenericUDF(
   override def prettyName: String = name
 
   override def toString: String = {
-    s"$nodeName#${funcWrapper.functionClassName}(${children.mkString(",")})"
+    s"$nodeName:UDF#${funcWrapper.functionClassName}(${children.mkString(",")})"
   }
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression =
@@ -279,7 +279,7 @@ private[hive] case class HiveGenericUDTF(
   }
 
   override def toString: String = {
-    s"$nodeName#${funcWrapper.functionClassName}(${children.mkString(",")})"
+    s"$nodeName:UDF#${funcWrapper.functionClassName}(${children.mkString(",")})"
   }
 
   override def prettyName: String = name


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein <ahussein@apache.org>

This PR adds a label to the UDFS expression to allow identifying the UDF expressions.

Apache Spark's User-Defined Functions (UDFs) are critical for extending SQL functionality, but tracking their performance historically required manual effort. This PR introduces labels to UDF expressions for improved identification and performance analysis. Here's a structured breakdown:

### What changes were proposed in this pull request?

- The proposed label format: `$name:UDF(${children.mkString(", ")})` Example: `plusOne:UDF(5)` for a UDF named `plusOne` with input `5`
- By looking at the log-history, explain-string used to include a udf label `s"UDF:$name"` at some point https://github.com/apache/spark/commit/9f523d3192c71a728fd8a2a64f52bbc337f2f026 , then it was removed in https://github.com/apache/spark/commit/fe3e34dda68fd54212df1dd01b8acb9a9bc6a0ad


### Why are the changes needed?

- Purpose of UDF Labeling
  - Performance Analysis: Labels allow automated extraction of UDF usage metrics from Spark event logs, enabling cluster performance evaluation and optimization opportunities.
  - Debugging/Observability: Identifies UDFs in query plans and logs (e.g., EXPLAIN output), helping diagnose non-deterministic behavior or bottlenecks.
  - Version/Proprietary Tracking: Distinguishes custom UDFs from built-in functions, especially when using version-specific or proprietary implementations

- Use Cases enbaled
  - Event Log Analysis: Aggregate UDF execution times across jobs to identify slow functions.
  - Query Plan Optimization: Detect redundant UDF calls in Spark SQL plans.
  - Compliance Auditing: Track usage of deprecated or unauthorized UDFs

### WIP Consideration:

Get the community feedback regarding:

- Label Format Preferences:
  - Alternatives like `UDF:$name(...)` vs. `name:UDF(...)`; or
  - To include the type of the UDF: `ScalaUDF`, `HiveUDF`, `PyUDF`..etc.
- Including additional metadata (e.g., determinism flags).
- Impact on Column Names:
  - Ensure labels don’t conflict with existing column aliases.
  - Avoid exposing sensitive UDF logic in production logs

### Does this PR introduce _any_ user-facing change?

Yes, the UDF expression strings appear in a different format:

```scala

    val udf1 = spark.udf.register(udf1Name, (n: Int) => n + 1)
    val udf2 = spark.udf.register(udf2Name, (n: Int) => n * 1)
    val df = sql("SELECT myUdf1(myUdf2(1))")
    df.show()
```

| myUdf1:UDF(myUdf2:UDF(1))|
|--------|
| 2 |


Original it will show up as:

| myUdf1(myUdf2(1))|
|--------|
| 2 |


### How was this patch tested?

Updated the unit tests

### Was this patch authored or co-authored using generative AI tooling?

No.
