### PR TITLE
[SPARK-51070][SQL] Use `scala.collection.Set` instead of Set in ValidateExternalType

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -2064,7 +2064,7 @@ case class ValidateExternalType(child: Expression, expected: DataType, externalD
       (value: Any) => {
         value.getClass.isArray ||
           value.isInstanceOf[scala.collection.Seq[_]] ||
-          value.isInstanceOf[Set[_]] ||
+          value.isInstanceOf[scala.collection.Set[_]] ||
           value.isInstanceOf[java.util.List[_]]
       }
     case _: DateType =>
@@ -2106,7 +2106,7 @@ case class ValidateExternalType(child: Expression, expected: DataType, externalD
       case _: ArrayType =>
         val check = genCheckTypes(Seq(
           classOf[scala.collection.Seq[_]],
-          classOf[Set[_]],
+          classOf[scala.collection.Set[_]],
           classOf[java.util.List[_]]))
         s"$obj.getClass().isArray() || $check"
       case _: DateType =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -21,6 +21,7 @@ import java.math.BigInteger
 import java.sql.{Date, Timestamp}
 import java.util.Arrays
 
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.classTag
 import scala.reflect.runtime.universe.TypeTag
@@ -427,6 +428,10 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
     "SPARK-40385 class with only a companion object constructor")
 
   encodeDecodeTest(Array(Set(1, 2), Set(2, 3)), "array of sets")
+
+  encodeDecodeTest(Array(mutable.Set(1, 2)), "SPARK-51070: array of mutable set")
+  encodeDecodeTest(Seq(mutable.Set(1, 2)), "SPARK-51070: seq of mutable set")
+  encodeDecodeTest(Map(0 -> mutable.Set(1, 2)), "SPARK-51070: map of mutable set")
 
   productTest(("UDT", new ExamplePoint(0.1, 0.2)))
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Although this is a rare situation, the following error occurs when trying to create a `Dataset` from `Seq[mutable.Set]`:

```scala
scala> val set: collection.Set[Int] = mutable.Set(1, 2)
set: scala.collection.Set[Int] = Set(1, 2)

scala> Seq(Seq(set)).toDS()
org.apache.spark.SparkRuntimeException: Error while encoding: java.lang.RuntimeException: scala.collection.mutable.HashSet is not a valid external type for schema of array<int>
mapobjects(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), mapobjects(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -2), assertnotnull(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -2), IntegerType, IntegerType)), validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), ArrayType(IntegerType,false), ObjectType(interface scala.collection.Set)).toSeq, None), input[0, scala.collection.Seq, true], None) AS value#16.
  at org.apache.spark.sql.errors.QueryExecutionErrors$.expressionEncodingError(QueryExecutionErrors.scala:1561)
  at org.apache.spark.sql.catalyst.encoders.ExpressionEncoder$Serializer.apply(ExpressionEncoder.scala:210)
  at org.apache.spark.sql.SparkSession.$anonfun$createDataset$1(SparkSession.scala:483)
  at scala.collection.immutable.List.map(List.scala:293)
  at org.apache.spark.sql.SparkSession.createDataset(SparkSession.scala:483)
  at org.apache.spark.sql.SQLContext.createDataset(SQLContext.scala:354)
  at org.apache.spark.sql.SQLImplicits.localSeqToDatasetHolder(SQLImplicits.scala:244)
  ... 51 elided
Caused by: java.lang.RuntimeException: scala.collection.mutable.HashSet is not a valid external type for schema of array<int>
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.Invoke_0$(Unknown Source)
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.MapObjects_0$(Unknown Source)
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.MapObjects_1$(Unknown Source)
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.apply(Unknown Source)
  at org.apache.spark.sql.catalyst.encoders.ExpressionEncoder$Serializer.apply(ExpressionEncoder.scala:207)
  ... 56 more
```

According to the codegen result, it seems that `scala.collection.immutable.Set` was used for validation.

```java
/* 092 */   private scala.collection.Seq Invoke_0(InternalRow i) {
/* 093 */     scala.collection.Set value_4 = null;
/* 094 */     if (!isNull_MapObject_lambda_variable_4) {
/* 095 */       if (value_MapObject_lambda_variable_4.getClass().isArray() || value_MapObject_lambda_variable_4 instanceof scala.collection.Seq || value_MapObject_lambda_variable_4 instanceof scala.collection.immutable.Set || value_MapObject_lambda_variable_4 instanceof java.util.List) {
/* 096 */         value_4 = (scala.collection.Set) value_MapObject_lambda_variable_4;
/* 097 */       } else {
/* 098 */         throw new RuntimeException(value_MapObject_lambda_variable_4.getClass().getName() + ((java.lang.String) references[0] /* errMsg */));
/* 099 */       }
/* 100 */     }
```

This issue is caused by `ValidateExternalType` and occurs on creating `Dataset` from `Array`/`Seq`/`Map` containing `mutable.Set`:

1. When constructing `AgnosticEncoder`, `scala.collection.Set` is converted into `IterableEncoder`.
2. When creating a serializer for `ExpressionEncoder`, the following elements are wrapped with `ValidateExternalType` by `SerializerBuildHelper.validateAndSerializeElement`:
   - Element type of ArrayEncoder
   - Element type of IterableEncoder
   - Key type of MapEncoder
   - Value type of MapEncoder
3. `ValidateExternalType` attempts to validate using `Set`, which is equivalent to `scala.collection.immutable.Set` (regardness of Scala 2.12 / 2.13).

```scala
scala> :paste
// Entering paste mode (ctrl-D to finish)

import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
import org.apache.spark.sql.catalyst.expressions.codegen._
import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeRow}

import scala.collection.mutable
import scala.reflect.runtime.universe.TypeTag

def test[T: TypeTag](value: T): UnsafeRow = {
  val encoder = ExpressionEncoder[T]
  val projection = GenerateUnsafeProjection.generate(encoder.serializer, subexpressionEliminationEnabled = true)
  val inputRow = new GenericInternalRow(1)
  inputRow(0) = value
  projection(inputRow)
}

val set: collection.Set[Int] = mutable.Set(1, 2)

// Exiting paste mode, now interpreting.

import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
import org.apache.spark.sql.catalyst.expressions.codegen._
import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeRow}
import scala.collection.mutable
import scala.reflect.runtime.universe.TypeTag
test: [T](value: T)(implicit evidence$1: reflect.runtime.universe.TypeTag[T])org.apache.spark.sql.catalyst.expressions.UnsafeRow
set: scala.collection.Set[Int] = Set(1, 2)

scala> test(set)
res0: org.apache.spark.sql.catalyst.expressions.UnsafeRow = [0,1000000018,2,0,200000001]

scala> test(Array(set))
java.lang.RuntimeException: scala.collection.mutable.HashSet is not a valid external type for schema of array<int>
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.Invoke_0$(Unknown Source)
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.MapObjects_0$(Unknown Source)
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.MapObjects_1$(Unknown Source)
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.apply(Unknown Source)
  at test(<pastie>:43)
  ... 51 elided

scala> test(Seq(set))
java.lang.RuntimeException: scala.collection.mutable.HashSet is not a valid external type for schema of array<int>
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.Invoke_0$(Unknown Source)
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.MapObjects_0$(Unknown Source)
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.MapObjects_1$(Unknown Source)
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.apply(Unknown Source)
  at test(<pastie>:43)
  ... 51 elided

scala> test(Map(set -> 1))
java.lang.RuntimeException: scala.collection.mutable.HashSet is not a valid external type for schema of array<int>
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.Invoke_0$(Unknown Source)
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.MapObjects_0$(Unknown Source)
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.ExternalMapToCatalyst_0$(Unknown Source)
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.apply(Unknown Source)
  at test(<pastie>:43)
  ... 51 elided

scala> test(Map(1 -> set))
java.lang.RuntimeException: scala.collection.mutable.HashSet is not a valid external type for schema of array<int>
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.Invoke_0$(Unknown Source)
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.MapObjects_0$(Unknown Source)
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.ExternalMapToCatalyst_0$(Unknown Source)
  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.apply(Unknown Source)
  at test(<pastie>:43)
  ... 51 elided
```


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes (bug fix)

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
