### PR TITLE
[SPARK-50541][SQL][FOLLOW-UP] Describe As JSON test case for non-existent table

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
@@ -79,6 +79,31 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
     }
   }
 
+  test("describe a non-existent table") {
+    val tbl = "undefined"
+    val statements = Seq(
+      s"DESCRIBE $tbl",
+      s"DESCRIBE EXTENDED $tbl",
+      s"DESCRIBE FORMATTED $tbl",
+      s"DESCRIBE EXTENDED $tbl AS JSON",
+      s"DESCRIBE FORMATTED $tbl AS JSON"
+    )
+
+    statements.foreach { sqlStatement =>
+      val startPos = sqlStatement.indexOf(tbl)
+      val error = intercept[AnalysisException] {
+        spark.sql(sqlStatement)
+      }
+
+      checkError(
+        exception = error,
+        condition = "TABLE_OR_VIEW_NOT_FOUND",
+        parameters = Map("relationName" -> s"`$tbl`"),
+        context = ExpectedContext(tbl, startPos, startPos + tbl.length - 1)
+      )
+    }
+  }
+
   test("describe a column in case insensitivity") {
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
       withNamespaceAndTable("ns", "tbl") { tbl =>
@@ -460,21 +485,6 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
         exception = error,
         condition = "UNSUPPORTED_FEATURE.DESC_TABLE_COLUMN_JSON")
     }
-  }
-
-  test("DESCRIBE AS JSON for non-existent table throws in checkAnalysis") {
-    val tbl = "undefined"
-    val sqlStatement = s"DESCRIBE FORMATTED $tbl AS JSON"
-    val startPos = sqlStatement.indexOf(tbl)
-    val error = intercept[AnalysisException] {
-      spark.sql(s"DESCRIBE FORMATTED $tbl AS JSON")
-    }
-
-    checkError(
-      exception = error,
-      condition = "TABLE_OR_VIEW_NOT_FOUND",
-      parameters = Map("relationName" -> s"`$tbl`"),
-      context = ExpectedContext(tbl, startPos, startPos + tbl.length - 1))
   }
 
   test("DESCRIBE AS JSON complex types") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
@@ -462,6 +462,21 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
     }
   }
 
+  test("DESCRIBE AS JSON for non-existent table throws in checkAnalysis") {
+    val tbl = "undefined"
+    val sqlStatement = s"DESCRIBE FORMATTED $tbl AS JSON"
+    val startPos = sqlStatement.indexOf(tbl)
+    val error = intercept[AnalysisException] {
+      spark.sql(s"DESCRIBE FORMATTED $tbl AS JSON")
+    }
+
+    checkError(
+      exception = error,
+      condition = "TABLE_OR_VIEW_NOT_FOUND",
+      parameters = Map("relationName" -> s"`$tbl`"),
+      context = ExpectedContext(tbl, startPos, startPos + tbl.length - 1))
+  }
+
   test("DESCRIBE AS JSON complex types") {
     withNamespaceAndTable("ns", "table") { t =>
       val tableCreationStr =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Test that `Describe As JSON` for non-existent table throws in checkAnalysis part of execution


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Improve test coverage of `describe as json`

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added test case in `DescribeTableSuite.scala`


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
