### PR TITLE
[SPARK-51072][CORE] CallerContext to set Hadoop cloud audit context

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1013,8 +1013,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
       Some(2),
       Some(3),
       Some(4),
-      Some(5),
-    ).setCurrentContext()
+      Some(5)).setCurrentContext()
     val expected = s"SPARK_test_app_attempt_JId_1_SId_2_3_TId_4_5_upstream"
     assert(expected === HadoopCallerContext.getCurrent.toString)
     assert(expected === currentAuditContext.get("spark"))

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -37,6 +37,7 @@ import org.apache.commons.lang3.SystemUtils
 import org.apache.commons.math3.stat.inference.ChiSquareTest
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.audit.CommonAuditContext.currentAuditContext
 import org.apache.hadoop.ipc.{CallerContext => HadoopCallerContext}
 import org.apache.logging.log4j.Level
 
@@ -1003,9 +1004,20 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
   }
 
   test("Set Spark CallerContext") {
-    val context = "test"
-    new CallerContext(context).setCurrentContext()
-    assert(s"SPARK_$context" === HadoopCallerContext.getCurrent.toString)
+    currentAuditContext.reset
+    new CallerContext("test",
+      Some("upstream"),
+      Some("app"),
+      Some("attempt"),
+      Some(1),
+      Some(2),
+      Some(3),
+      Some(4),
+      Some(5),
+    ).setCurrentContext()
+    val expected = s"SPARK_test_app_attempt_JId_1_SId_2_3_TId_4_5_upstream"
+    assert(expected === HadoopCallerContext.getCurrent.toString)
+    assert(expected === currentAuditContext.get("spark"))
   }
 
   test("encodeFileNameToURIRawPath") {


### PR DESCRIPTION


### What changes were proposed in this pull request?

When enabled, cloud store client audit context is set to the
same context string as the Hadoop IPC context.


### Why are the changes needed?

CallerContext adds information about the spark task to hadoop IPC context and then to HDFS, YARN and HBase server logs.

It is also possible to update the cloud storage "audit context".
Storage clients can attach the audit information to requests to be stored in the service's own logs, where it can be retrieved, parsed and used for analysis.

It is currently supported by the S3A connector, which adds the information to a synthetic referrer header, which is then stored in the S3 Server logs. (Not cloudtrail, sadly).

See [S3A Auditing](https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/auditing.html)

### Does this PR introduce _any_ user-facing change?
 
If enabled, it adds extra entries in cloud storage server logs through cloud
storage clients which support it.


### How was this patch tested?

Expanded existing test `"Set Spark CallerContext"` to verify
full setting of passed down parameters to caller and audit contexts.
This required extracting the functional code of `CallerContext.setCurrentContext`
into a `@VisibleForTesting private[util]` method `setCurrentContext(Boolean)`

Without this, the test suite only ran if the process had been launched
with the configuration option `"hadoop.caller.context.enabled` being set
to true -this is not the default, so the existing test suite code
was probably never executed.


### Was this patch authored or co-authored using generative AI tooling?

No
