### PR TITLE
[SPARK-51073][SQL] Remove `Unstable` from `SparkSessionExtensionsProvider` trait

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensionsProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensionsProvider.scala
@@ -17,12 +17,10 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.annotation.{DeveloperApi, Since, Unstable}
+import org.apache.spark.annotation.{DeveloperApi, Since}
 
 // scalastyle:off line.size.limit
 /**
- * :: Unstable ::
- *
  * Base trait for implementations used by [[SparkSessionExtensions]]
  *
  *
@@ -76,7 +74,6 @@ import org.apache.spark.annotation.{DeveloperApi, Since, Unstable}
  * @since 3.2.0
  */
 @DeveloperApi
-@Unstable
 @Since("3.2.0")
 trait SparkSessionExtensionsProvider extends Function1[SparkSessionExtensions, Unit]
 // scalastyle:on line.size.limit


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `Unstable` from `SparkSessionExtensionsProvider` trait from Apache Spark 4.1.0.

https://github.com/apache/spark/blob/400e2b29caf43b443f2e0c42aee92c4d0e3e0eb7/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensionsProvider.scala#L78-L81

### Why are the changes needed?

Since Apache Spark 3.2.0, we provide `SparkSessionExtensionsProvider` trait without any change to allow third-party developers to provide a resource file that contains default extensions.
- #32515

Apache Iceberg has been using this since 0.11.0.
- https://iceberg.apache.org/docs/1.7.1/spark-configuration/#sql-extensions
    > Iceberg 0.11.0 and later add an extension module to Spark to add new SQL commands, like CALL for stored procedures or ALTER TABLE ... WRITE ORDERED BY.

Although `SparkSessionExtensions` is an unstable developer API, `SparkSessionExtensionsProvider` trait itself and ServiceLoader framework is stable and it's unlikely for Apache Spark to change this `trait`.

https://github.com/apache/spark/blob/400e2b29caf43b443f2e0c42aee92c4d0e3e0eb7/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensions.scala#L106-L109

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.