### PR TITLE
[SPARK-50393][PYTHON][CONNECT] Introduce common TableArg for Spark Classic and Spark Connect

### DIFF
--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1798,7 +1798,9 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             return DataFrame(self._jdf.transpose(), self.sparkSession)
 
     def asTable(self) -> TableArg:
-        return TableArg(self._jdf.asTable())
+        from pyspark.sql.classic.table_arg import TableArg as ClassicTableArg
+
+        return ClassicTableArg(self._jdf.asTable())
 
     def scalar(self) -> Column:
         return Column(self._jdf.scalar())

--- a/python/pyspark/sql/classic/table_arg.py
+++ b/python/pyspark/sql/classic/table_arg.py
@@ -17,6 +17,7 @@
 
 from typing import TYPE_CHECKING
 
+from pyspark.sql.classic.column import _to_java_column, _to_seq
 from pyspark.sql.table_arg import TableArg as ParentTableArg
 from pyspark.sql.utils import get_active_spark_context
 
@@ -31,8 +32,6 @@ class TableArg(ParentTableArg):
         self._j_table_arg = j_table_arg
 
     def partitionBy(self, *cols: "ColumnOrName") -> "TableArg":
-        from pyspark.sql.classic.column import _to_java_column, _to_seq
-
         sc = get_active_spark_context()
         if len(cols) == 1 and isinstance(cols[0], list):
             cols = cols[0]
@@ -41,8 +40,6 @@ class TableArg(ParentTableArg):
         return TableArg(new_j_table_arg)
 
     def orderBy(self, *cols: "ColumnOrName") -> "TableArg":
-        from pyspark.sql.classic.column import _to_java_column, _to_seq
-
         sc = get_active_spark_context()
         if len(cols) == 1 and isinstance(cols[0], list):
             cols = cols[0]

--- a/python/pyspark/sql/classic/table_arg.py
+++ b/python/pyspark/sql/classic/table_arg.py
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import TYPE_CHECKING
+
+from pyspark.sql.table_arg import TableArg as ParentTableArg
+from pyspark.sql.utils import get_active_spark_context
+
+
+if TYPE_CHECKING:
+    from py4j.java_gateway import JavaObject
+    from pyspark.sql._typing import ColumnOrName
+
+
+class TableArg(ParentTableArg):
+    def __init__(self, j_table_arg: "JavaObject"):
+        self._j_table_arg = j_table_arg
+
+    def partitionBy(self, *cols: "ColumnOrName") -> "TableArg":
+        from pyspark.sql.classic.column import _to_java_column, _to_seq
+
+        sc = get_active_spark_context()
+        if len(cols) == 1 and isinstance(cols[0], list):
+            cols = cols[0]
+        j_cols = _to_seq(sc, cols, _to_java_column)
+        new_j_table_arg = self._j_table_arg.partitionBy(j_cols)
+        return TableArg(new_j_table_arg)
+
+    def orderBy(self, *cols: "ColumnOrName") -> "TableArg":
+        from pyspark.sql.classic.column import _to_java_column, _to_seq
+
+        sc = get_active_spark_context()
+        if len(cols) == 1 and isinstance(cols[0], list):
+            cols = cols[0]
+        j_cols = _to_seq(sc, cols, _to_java_column)
+        new_j_table_arg = self._j_table_arg.orderBy(j_cols)
+        return TableArg(new_j_table_arg)
+
+    def withSinglePartition(self) -> "TableArg":
+        new_j_table_arg = self._j_table_arg.withSinglePartition()
+        return TableArg(new_j_table_arg)

--- a/python/pyspark/sql/connect/table_arg.py
+++ b/python/pyspark/sql/connect/table_arg.py
@@ -27,7 +27,7 @@ from typing import (
 
 import pyspark.sql.connect.proto as proto
 from pyspark.sql.column import Column
-from pyspark.sql.table_arg import TableArg as CommonTableArg
+from pyspark.sql.table_arg import TableArg as ParentTableArg
 from pyspark.sql.connect.expressions import Expression, SubqueryExpression, SortOrder
 from pyspark.sql.connect.functions import builtin as F
 
@@ -44,7 +44,7 @@ def _to_cols(cols: Tuple[Union["ColumnOrName", Sequence["ColumnOrName"]], ...]) 
     return [F._to_col(c) for c in cast(Iterable["ColumnOrName"], cols)]
 
 
-class TableArg(CommonTableArg):
+class TableArg(ParentTableArg):
     def __init__(self, subquery_expr: SubqueryExpression):
         self._subquery_expr = subquery_expr
 

--- a/python/pyspark/sql/table_arg.py
+++ b/python/pyspark/sql/table_arg.py
@@ -29,20 +29,20 @@ class TableArg(TableValuedFunctionArgument):
     @dispatch_table_arg_method
     def partitionBy(self, *cols: "ColumnOrName") -> "TableArg":
         """
-        Abstract method to partition data by specified columns.
+        Partitions the data based on the specified columns.
         """
         ...
 
     @dispatch_table_arg_method
     def orderBy(self, *cols: "ColumnOrName") -> "TableArg":
         """
-        Abstract method to order data by specified columns.
+        Orders the data within each partition by the specified columns.
         """
         ...
 
     @dispatch_table_arg_method
     def withSinglePartition(self) -> "TableArg":
         """
-        Abstract method to enforce a single partition.
+        Forces the data to be processed in a single partition.
         """
         ...

--- a/python/pyspark/sql/table_arg.py
+++ b/python/pyspark/sql/table_arg.py
@@ -18,38 +18,27 @@
 from typing import TYPE_CHECKING
 
 from pyspark.sql.tvf_argument import TableValuedFunctionArgument
-from pyspark.sql.utils import get_active_spark_context
 
 
 if TYPE_CHECKING:
-    from py4j.java_gateway import JavaObject
     from pyspark.sql._typing import ColumnOrName
 
 
 class TableArg(TableValuedFunctionArgument):
-    def __init__(self, j_table_arg: "JavaObject"):
-        self._j_table_arg = j_table_arg
-
     def partitionBy(self, *cols: "ColumnOrName") -> "TableArg":
-        from pyspark.sql.classic.column import _to_java_column, _to_seq
-
-        sc = get_active_spark_context()
-        if len(cols) == 1 and isinstance(cols[0], list):
-            cols = cols[0]
-        j_cols = _to_seq(sc, cols, _to_java_column)
-        new_j_table_arg = self._j_table_arg.partitionBy(j_cols)
-        return TableArg(new_j_table_arg)
+        """
+        Abstract method to partition data by specified columns.
+        """
+        pass
 
     def orderBy(self, *cols: "ColumnOrName") -> "TableArg":
-        from pyspark.sql.classic.column import _to_java_column, _to_seq
-
-        sc = get_active_spark_context()
-        if len(cols) == 1 and isinstance(cols[0], list):
-            cols = cols[0]
-        j_cols = _to_seq(sc, cols, _to_java_column)
-        new_j_table_arg = self._j_table_arg.orderBy(j_cols)
-        return TableArg(new_j_table_arg)
+        """
+        Abstract method to order data by specified columns.
+        """
+        pass
 
     def withSinglePartition(self) -> "TableArg":
-        new_j_table_arg = self._j_table_arg.withSinglePartition()
-        return TableArg(new_j_table_arg)
+        """
+        Abstract method to enforce a single partition.
+        """
+        pass

--- a/python/pyspark/sql/table_arg.py
+++ b/python/pyspark/sql/table_arg.py
@@ -18,6 +18,7 @@
 from typing import TYPE_CHECKING
 
 from pyspark.sql.tvf_argument import TableValuedFunctionArgument
+from pyspark.sql.utils import dispatch_table_arg_method
 
 
 if TYPE_CHECKING:
@@ -25,20 +26,23 @@ if TYPE_CHECKING:
 
 
 class TableArg(TableValuedFunctionArgument):
+    @dispatch_table_arg_method
     def partitionBy(self, *cols: "ColumnOrName") -> "TableArg":
         """
         Abstract method to partition data by specified columns.
         """
-        pass
+        ...
 
+    @dispatch_table_arg_method
     def orderBy(self, *cols: "ColumnOrName") -> "TableArg":
         """
         Abstract method to order data by specified columns.
         """
-        pass
+        ...
 
+    @dispatch_table_arg_method
     def withSinglePartition(self) -> "TableArg":
         """
         Abstract method to enforce a single partition.
         """
-        pass
+        ...

--- a/python/pyspark/sql/table_arg.py
+++ b/python/pyspark/sql/table_arg.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# mypy: disable-error-code="empty-body"
+
 from typing import TYPE_CHECKING
 
 from pyspark.sql.tvf_argument import TableValuedFunctionArgument

--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -387,7 +387,7 @@ class UserDefinedTableFunction:
         for arg in args:
             if isinstance(arg, TableArg):
                 # If the argument is a TableArg, get the Java TableArg object
-                jargs.append(arg._j_table_arg)
+                jargs.append(arg._j_table_arg)  # type: ignore[attr-defined]
             else:
                 # Otherwise, convert it to a Java column
                 jargs.append(_to_java_column(arg))  # type: ignore[arg-type]
@@ -397,7 +397,7 @@ class UserDefinedTableFunction:
         for key, value in kwargs.items():
             if isinstance(value, TableArg):
                 # If the value is a TableArg, get the Java TableArg object
-                j_arg = value._j_table_arg
+                j_arg = value._j_table_arg  # type: ignore[attr-defined]
             else:
                 # Otherwise, convert it to a Java column
                 j_arg = _to_java_column(value)  # type: ignore[arg-type]

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -434,6 +434,26 @@ def dispatch_window_method(f: FuncT) -> FuncT:
     return cast(FuncT, wrapped)
 
 
+def dispatch_table_arg_method(f: FuncT) -> FuncT:
+    """
+    Dispatches TableArg method calls to either ConnectTableArg or ClassicTableArg
+    based on the execution environment.
+    """
+
+    @functools.wraps(f)
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+        if is_remote() and "PYSPARK_NO_NAMESPACE_SHARE" not in os.environ:
+            from pyspark.sql.connect.table_arg import TableArg as ConnectTableArg
+
+            return getattr(ConnectTableArg, f.__name__)(*args, **kwargs)
+        else:
+            from pyspark.sql.classic.table_arg import TableArg as ClassicTableArg
+
+            return getattr(ClassicTableArg, f.__name__)(*args, **kwargs)
+
+    return cast(FuncT, wrapped)
+
+
 def pyspark_column_op(
     func_name: str, left: "IndexOpsLike", right: Any, fillna: Any = None
 ) -> Union["SeriesOrIndex", None]:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduces a common TableArg in pyspark.sql.table_arg.py, serving as a parent for TableArg implementations in both Spark Classic and Spark Connect.


### Why are the changes needed?
Ensuring both Spark Classic and Spark Connect adhere to a unified interface and typing.
Part of [SPARK-50391](https://issues.apache.org/jira/browse/SPARK-50391).
### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
