### PR TITLE
[SPARK-51078][CONNECT][TESTS][PYTHON] Skip unsupported StopWordsRemover test in Spark Connect

### DIFF
--- a/python/pyspark/ml/tests/connect/test_parity_feature.py
+++ b/python/pyspark/ml/tests/connect/test_parity_feature.py
@@ -30,6 +30,14 @@ class FeatureParityTests(FeatureTestsMixin, ReusedConnectTestCase):
     def test_string_indexer_from_labels(self):
         super().test_string_indexer_from_labels()
 
+    @unittest.skip("Need to support.")
+    def test_stop_words_remover(self):
+        super().test_stop_words_remover()
+
+    @unittest.skip("Need to support.")
+    def test_stop_words_remover_II(self):
+        super().test_stop_words_remover_II()
+
 
 if __name__ == "__main__":
     from pyspark.ml.tests.connect.test_parity_feature import *  # noqa: F401


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip unsupported StopWordsRemover test in Spark Connect, see also https://github.com/apache/spark/pull/49624/files#r1940507357

### Why are the changes needed?

To make the tests pass (https://github.com/apache/spark/actions/runs/13120894941/job/36606320881)

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No