### PR TITLE
[SPARK-51078][SPARK-50963][ML][PYTHON][CONNECT] Fix the py4j call in `StopWordsRemover`

### DIFF
--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -4992,7 +4992,7 @@ class StopWordsRemover(
     Notes
     -----
     - null values from input array are preserved unless adding null to stopWords explicitly.
-    - In Spark Connect Mode, the default value of parameter `locale` is not set.
+    - In Spark Connect Mode, the default value of parameter `locale` and `stopWords` are not set.
 
     Examples
     --------
@@ -5092,10 +5092,10 @@ class StopWordsRemover(
             "org.apache.spark.ml.feature.StopWordsRemover", self.uid
         )
         if isinstance(self._java_obj, str):
-            # Skip setting the default value of 'locale', which needs to invoke a JVM method.
-            # So if users don't explicitly set 'locale', then getLocale fails.
+            # Skip setting the default value of 'locale' and 'stopWords', which
+            # needs to invoke a JVM method.
+            # So if users don't explicitly set 'locale' and/or 'stopWords', then the getters fails.
             self._setDefault(
-                stopWords=StopWordsRemover.loadDefaultStopWords("english"),
                 caseSensitive=False,
             )
         else:

--- a/python/pyspark/ml/tests/connect/test_parity_feature.py
+++ b/python/pyspark/ml/tests/connect/test_parity_feature.py
@@ -30,14 +30,6 @@ class FeatureParityTests(FeatureTestsMixin, ReusedConnectTestCase):
     def test_string_indexer_from_labels(self):
         super().test_string_indexer_from_labels()
 
-    @unittest.skip("Need to support.")
-    def test_stop_words_remover(self):
-        super().test_stop_words_remover()
-
-    @unittest.skip("Need to support.")
-    def test_stop_words_remover_II(self):
-        super().test_stop_words_remover_II()
-
 
 if __name__ == "__main__":
     from pyspark.ml.tests.connect.test_parity_feature import *  # noqa: F401

--- a/python/pyspark/ml/tests/test_feature.py
+++ b/python/pyspark/ml/tests/test_feature.py
@@ -889,8 +889,8 @@ class FeatureTestsMixin:
         self.assertEqual(stopWordRemover.getInputCol(), "input")
         transformedDF = stopWordRemover.transform(dataset)
         self.assertEqual(transformedDF.head().output, ["panda"])
-        self.assertEqual(type(stopWordRemover.getStopWords()), list)
-        self.assertTrue(isinstance(stopWordRemover.getStopWords()[0], str))
+        # self.assertEqual(type(stopWordRemover.getStopWords()), list)
+        # self.assertTrue(isinstance(stopWordRemover.getStopWords()[0], str))
         # Custom
         stopwords = ["panda"]
         stopWordRemover.setStopWords(stopwords)

--- a/python/pyspark/ml/tests/test_feature.py
+++ b/python/pyspark/ml/tests/test_feature.py
@@ -889,8 +889,6 @@ class FeatureTestsMixin:
         self.assertEqual(stopWordRemover.getInputCol(), "input")
         transformedDF = stopWordRemover.transform(dataset)
         self.assertEqual(transformedDF.head().output, ["panda"])
-        # self.assertEqual(type(stopWordRemover.getStopWords()), list)
-        # self.assertTrue(isinstance(stopWordRemover.getStopWords()[0], str))
         # Custom
         stopwords = ["panda"]
         stopWordRemover.setStopWords(stopwords)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix the py4j call in `StopWordsRemover`

### Why are the changes needed?
to enable `StopWordsRemover`


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
reenabled tests


### Was this patch authored or co-authored using generative AI tooling?
no
