### PR TITLE
[SPARK-51087][PYTHON][CONNECT] Raise a warning when memory-profiler is not installed for memory profiling

### DIFF
--- a/python/pyspark/sql/profiler.py
+++ b/python/pyspark/sql/profiler.py
@@ -20,6 +20,7 @@ import os
 import pstats
 from threading import RLock
 from typing import Any, Callable, Dict, Literal, Optional, Tuple, Union, TYPE_CHECKING, overload
+import warnings
 
 from pyspark.accumulators import (
     Accumulator,
@@ -28,7 +29,13 @@ from pyspark.accumulators import (
     _accumulatorRegistry,
 )
 from pyspark.errors import PySparkValueError
-from pyspark.profiler import CodeMapDict, MemoryProfiler, MemUsageParam, PStatsParam
+from pyspark.profiler import (
+    CodeMapDict,
+    MemoryProfiler,
+    MemUsageParam,
+    PStatsParam,
+    has_memory_profiler,
+)
 
 if TYPE_CHECKING:
     from pyspark.sql._typing import ProfileResults
@@ -130,6 +137,12 @@ class ProfilerCollector(ABC):
         with self._lock:
             code_map = self._memory_profile_results
 
+        if not has_memory_profiler and not code_map:
+            warnings.warn(
+                "Install the 'memory_profiler' library in the cluster to enable memory profiling",
+                UserWarning,
+            )
+
         def show(id: int) -> None:
             cm = code_map.get(id)
             if cm is not None:
@@ -207,6 +220,12 @@ class ProfilerCollector(ABC):
         """
         with self._lock:
             code_map = self._memory_profile_results
+
+        if not has_memory_profiler and not code_map:
+            warnings.warn(
+                "Install the 'memory_profiler' library in the cluster to enable memory profiling",
+                UserWarning,
+            )
 
         def dump(id: int) -> None:
             cm = code_map.get(id)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Raise a warning when memory-profiler is not installed for memory profiling.

### Why are the changes needed?
Better usability of PySpark UDF memory profiling.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing and manual tests as shown below:
```py
>>> import memory_profiler  # when memory-profiler is not installed
Traceback (most recent call last):
...
ModuleNotFoundError: No module named 'memory_profiler'

>>> from pyspark.sql.functions import pandas_udf
>>> 
>>> df = spark.range(10)
>>> @pandas_udf("long")
... def add1(x):
...   return x + 1
... 
>>> added = df.select(add1("id"))
>>> 
>>> spark.conf.set("spark.sql.pyspark.udf.profiler", "memory")
>>> added.show()
+--------+                                                                      
|add1(id)|
+--------+
|       1|
|       2|
|       3|
|       4|
|       5|
|       6|
|       7|
|       8|
|       9|
|      10|
+--------+
>>> spark.profile.show(type="memory")
/Users/xinrong.meng/spark/python/pyspark/sql/profiler.py:141: UserWarning: Install the 'memory_profiler' library in the cluster to enable memory profiling
...
>>> spark.profile.dump(path='...', type="memory")
/Users/xinrong.meng/spark/python/pyspark/sql/profiler.py:225: UserWarning: Install the 'memory_profiler' library in the cluster to enable memory profiling
...
```

### Was this patch authored or co-authored using generative AI tooling?
No.