### PR TITLE
[SPARK-51089][ML][PYTHON][CONNECT] Support `VectorIndexerModel.categoryMaps` on connect

### DIFF
--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -6027,7 +6027,7 @@ class VectorIndexerModel(
         def categoryMapsDF(m: VectorIndexerModel) -> DataFrame:
             return m._call_java("categoryMapsDF")
 
-        res: Dict[int, Tuple[float, int]] = {}
+        res: Dict[int, Dict[float, int]] = {}
         for row in categoryMapsDF(self).collect():
             featureIndex = int(row.featureIndex)
             originalValue = float(row.originalValue)

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -6016,13 +6016,21 @@ class VectorIndexerModel(
 
     @property
     @since("1.4.0")
-    def categoryMaps(self) -> Dict[int, Tuple[float, int]]:
+    def categoryMaps(self) -> Dict[int, Dict[float, int]]:
         """
         Feature value index.  Keys are categorical feature indices (column indices).
         Values are maps from original features values to 0-based category indices.
         If a feature is not in this map, it is treated as continuous.
         """
-        return self._call_java("javaCategoryMaps")
+        res: Dict[int, Tuple[float, int]] = {}
+        for row in self._call_java("categoryMapsDF").collect():
+            featureIndex = row.featureIndex
+            originalValue = row.originalValue
+            categoryIndex = row.categoryIndex
+            if featureIndex not in res:
+                res[featureIndex] = {}
+            res[featureIndex][originalValue] = categoryIndex
+        return res
 
 
 @inherit_doc

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -6029,9 +6029,9 @@ class VectorIndexerModel(
 
         res: Dict[int, Tuple[float, int]] = {}
         for row in categoryMapsDF(self).collect():
-            featureIndex = row.featureIndex
-            originalValue = row.originalValue
-            categoryIndex = row.categoryIndex
+            featureIndex = int(row.featureIndex)
+            originalValue = float(row.originalValue)
+            categoryIndex = int(row.categoryIndex)
             if featureIndex not in res:
                 res[featureIndex] = {}
             res[featureIndex][originalValue] = categoryIndex

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -6022,8 +6022,13 @@ class VectorIndexerModel(
         Values are maps from original features values to 0-based category indices.
         If a feature is not in this map, it is treated as continuous.
         """
+
+        @try_remote_attribute_relation
+        def categoryMapsDF(m: VectorIndexerModel) -> DataFrame:
+            return m._call_java("categoryMapsDF")
+
         res: Dict[int, Tuple[float, int]] = {}
-        for row in self._call_java("categoryMapsDF").collect():
+        for row in categoryMapsDF(self).collect():
             featureIndex = row.featureIndex
             originalValue = row.originalValue
             categoryIndex = row.categoryIndex

--- a/python/pyspark/ml/tests/test_feature.py
+++ b/python/pyspark/ml/tests/test_feature.py
@@ -275,6 +275,9 @@ class FeatureTestsMixin:
         self.assertEqual(indexer.uid, model.uid)
         self.assertEqual(model.numFeatures, 2)
 
+        categoryMaps = model.categoryMaps
+        self.assertEqual(categoryMaps, {0: {0.0: 0, -1.0: 1}}, categoryMaps)
+
         output = model.transform(df)
         self.assertEqual(output.columns, ["a", "indexed"])
         self.assertEqual(output.count(), 3)

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -640,7 +640,7 @@ private[ml] object MLUtils {
     (classOf[MaxAbsScalerModel], Set("maxAbs")),
     (classOf[MinMaxScalerModel], Set("originalMax", "originalMin")),
     (classOf[RobustScalerModel], Set("range", "median")),
-    (classOf[VectorIndexerModel], Set("numFeatures")),
+    (classOf[VectorIndexerModel], Set("numFeatures", "categoryMapsDF")),
     (classOf[ChiSqSelectorModel], Set("selectedFeatures")),
     (classOf[UnivariateFeatureSelectorModel], Set("selectedFeatures")),
     (classOf[VarianceThresholdSelectorModel], Set("selectedFeatures")),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix `VectorIndexerModel.categoryMaps` on connect


### Why are the changes needed?
feature parity


### Does this PR introduce _any_ user-facing change?
yes, new api supported


### How was this patch tested?
added tests


### Was this patch authored or co-authored using generative AI tooling?
no