### PR TITLE
[SPARK-50958][ML][PYTHON][CONNECT] Support `Word2VecModel.findSynonymsArray` on connect

### DIFF
--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -6476,11 +6476,10 @@ class Word2VecModel(JavaModel, _Word2VecParams, JavaMLReadable["Word2VecModel"],
         Returns an array with two fields word and similarity (which
         gives the cosine similarity).
         """
-        if not isinstance(word, str):
-            word = _convert_to_vector(word)
-        assert self._java_obj is not None
-        tuples = self._java_obj.findSynonymsArray(word, num)
-        return list(map(lambda st: (st._1(), st._2()), list(tuples)))
+        res = []
+        for row in self.findSynonyms(word, num).collect():
+            res.append((str(row.word), float(row.similarity)))
+        return res
 
 
 class _PCAParams(HasInputCol, HasOutputCol):

--- a/python/pyspark/ml/tests/test_feature.py
+++ b/python/pyspark/ml/tests/test_feature.py
@@ -678,13 +678,12 @@ class FeatureTestsMixin:
         self.assertEqual(synonyms.columns, ["word", "similarity"])
         self.assertEqual(synonyms.count(), 2)
 
-        # TODO(SPARK-50958): Support Word2VecModel.findSynonymsArray
-        # synonyms = model.findSynonymsArray("a", 2)
-        # self.assertEqual(len(synonyms), 2)
-        # self.assertEqual(synonyms[0][0], "b")
-        # self.assertTrue(np.allclose(synonyms[0][1], -0.024012837558984756, atol=1e-4))
-        # self.assertEqual(synonyms[1][0], "c")
-        # self.assertTrue(np.allclose(synonyms[1][1], -0.19355154037475586, atol=1e-4))
+        synonyms = model.findSynonymsArray("a", 2)
+        self.assertEqual(len(synonyms), 2)
+        self.assertEqual(synonyms[0][0], "b")
+        self.assertTrue(np.allclose(synonyms[0][1], -0.024012837558984756, atol=1e-4))
+        self.assertEqual(synonyms[1][0], "c")
+        self.assertTrue(np.allclose(synonyms[1][1], -0.19355154037475586, atol=1e-4))
 
         output = model.transform(df)
         self.assertEqual(output.columns, ["sentence", "model"])

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -645,7 +645,7 @@ private[ml] object MLUtils {
     (classOf[UnivariateFeatureSelectorModel], Set("selectedFeatures")),
     (classOf[VarianceThresholdSelectorModel], Set("selectedFeatures")),
     (classOf[PCAModel], Set("pc", "explainedVariance")),
-    (classOf[Word2VecModel], Set("getVectors", "findSynonyms", "findSynonymsArray")),
+    (classOf[Word2VecModel], Set("getVectors", "findSynonyms")),
     (classOf[CountVectorizerModel], Set("vocabulary")),
     (classOf[OneHotEncoderModel], Set("categorySizes")),
     (classOf[StringIndexerModel], Set("labels", "labelsArray")),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix `Word2VecModel.findSynonymsArray` on connect


### Why are the changes needed?
for parity


### Does this PR introduce _any_ user-facing change?
yes, new API supported on connect


### How was this patch tested?
added tests

### Was this patch authored or co-authored using generative AI tooling?
no
