### PR TITLE
[SPARK-50975][ML][PYTHON][CONNECT] Support `CountVectorizerModel.from_vocabulary` on connect

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/util/ConnectHelper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/ConnectHelper.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.ml.util
 
 import org.apache.spark.ml.Model
-import org.apache.spark.ml.feature.StringIndexerModel
+import org.apache.spark.ml.feature.{CountVectorizerModel, StringIndexerModel}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.types.StructType
@@ -33,6 +33,11 @@ private[spark] class ConnectHelper(override val uid: String) extends Model[Conne
   def stringIndexerModelFromLabelsArray(
       uid: String, labelsArray: Array[Array[String]]): StringIndexerModel = {
     new StringIndexerModel(uid, labelsArray)
+  }
+
+  def countVectorizerModelFromVocabulary(
+      uid: String, vocabulary: Array[String]): CountVectorizerModel = {
+    new CountVectorizerModel(uid, vocabulary)
   }
 
   override def copy(extra: ParamMap): ConnectHelper = defaultCopy(extra)

--- a/python/pyspark/ml/tests/connect/test_parity_feature.py
+++ b/python/pyspark/ml/tests/connect/test_parity_feature.py
@@ -23,8 +23,8 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 class FeatureParityTests(FeatureTestsMixin, ReusedConnectTestCase):
     @unittest.skip("Need to support.")
-    def test_count_vectorizer_from_vocab(self):
-        super().test_count_vectorizer_from_vocab()
+    def test_string_indexer_from_labels(self):
+        super().test_string_indexer_from_labels()
 
     @unittest.skip("Need to support.")
     def test_stop_words_lengague_selection(self):

--- a/python/pyspark/ml/tests/connect/test_parity_feature.py
+++ b/python/pyspark/ml/tests/connect/test_parity_feature.py
@@ -23,10 +23,6 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 class FeatureParityTests(FeatureTestsMixin, ReusedConnectTestCase):
     @unittest.skip("Need to support.")
-    def test_string_indexer_from_labels(self):
-        super().test_string_indexer_from_labels()
-
-    @unittest.skip("Need to support.")
     def test_stop_words_lengague_selection(self):
         super().test_stop_words_lengague_selection()
 

--- a/python/pyspark/ml/tests/test_feature.py
+++ b/python/pyspark/ml/tests/test_feature.py
@@ -83,7 +83,6 @@ from pyspark.ml.feature import (
 )
 from pyspark.ml.linalg import DenseVector, SparseVector, Vectors
 from pyspark.sql import Row
-from pyspark.testing.utils import QuietTest
 from pyspark.testing.mlutils import SparkSessionTestCase
 
 
@@ -1357,9 +1356,8 @@ class FeatureTestsMixin:
             self.assertEqual(feature, expected)
 
         # Test an empty vocabulary
-        with QuietTest(self.sc):
-            with self.assertRaisesRegex(Exception, "vocabSize.*invalid.*0"):
-                CountVectorizerModel.from_vocabulary([], inputCol="words")
+        with self.assertRaisesRegex(Exception, "Vocabulary list cannot be empty"):
+            CountVectorizerModel.from_vocabulary([], inputCol="words")
 
         # Test model with default settings can transform
         model_default = CountVectorizerModel.from_vocabulary(["a", "b", "c"], inputCol="words")

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -655,7 +655,10 @@ private[ml] object MLUtils {
     // Utils
     (
       classOf[ConnectHelper],
-      Set("stringIndexerModelFromLabels", "stringIndexerModelFromLabelsArray")))
+      Set(
+        "stringIndexerModelFromLabels",
+        "stringIndexerModelFromLabelsArray",
+        "countVectorizerModelFromVocabulary")))
 
   private def validate(obj: Any, method: String): Unit = {
     assert(obj != null)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Support `CountVectorizerModel.from_vocabulary` on connect


### Why are the changes needed?
For feature parity

### Does this PR introduce _any_ user-facing change?
yes, new API supported

### How was this patch tested?
enabled parity test


### Was this patch authored or co-authored using generative AI tooling?
no
