### PR TITLE
[SPARK-51084][SQL] Assign appropriate error class for `negativeScaleNotAllowedError`

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3923,7 +3923,7 @@
     ],
     "sqlState" : "0A000"
   },
-  "NEGATIVE_SCALE_DISALLOWED": {
+  "NEGATIVE_SCALE_DISALLOWED" : {
     "message" : [
       "Negative scale is not allowed: '<scale>'. Set the config <sqlConf> to \"true\" to allow it."
     ],

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3925,8 +3925,7 @@
   },
   "NEGATIVE_SCALE_DISALLOWED": {
     "message": [
-      "Negative scale is not allowed: '<scale>'.",
-      "Set the config <sqlConf> to 'true' to allow it."
+      "Negative scale is not allowed: '<scale>'. Set the config <sqlConf> to \"true\" to allow it."
     ],
     "sqlState" : "0A000"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3923,6 +3923,12 @@
     ],
     "sqlState" : "0A000"
   },
+  "NEGATIVE_SCALE_DISALLOWED": {
+    "message": [
+      "Negative scale is not allowed: '<scale>'.",
+      "Set the config <sqlConf> to 'true' to allow it."
+    ]
+  },
   "NEGATIVE_VALUES_IN_FREQUENCY_EXPRESSION" : {
     "message" : [
       "Found the negative value in <frequencyExpression>: <negativeValue>, but expected a positive integral value."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3924,7 +3924,7 @@
     "sqlState" : "0A000"
   },
   "NEGATIVE_SCALE_DISALLOWED": {
-    "message": [
+    "message" : [
       "Negative scale is not allowed: '<scale>'. Set the config <sqlConf> to \"true\" to allow it."
     ],
     "sqlState" : "0A000"

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3927,7 +3927,8 @@
     "message": [
       "Negative scale is not allowed: '<scale>'.",
       "Set the config <sqlConf> to 'true' to allow it."
-    ]
+    ],
+    "sqlState" : "0A000"
   },
   "NEGATIVE_VALUES_IN_FREQUENCY_EXPRESSION" : {
     "message" : [

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/DataTypeErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/DataTypeErrors.scala
@@ -126,7 +126,7 @@ private[sql] object DataTypeErrors extends DataTypeErrorsBase {
     val sqlConf = QuotingUtils.toSQLConf("spark.sql.legacy.allowNegativeScaleOfDecimal")
     new AnalysisException(
       errorClass = "NEGATIVE_SCALE_DISALLOWED",
-      messageParameters = Map("scale" -> scale.toString, "sqlConf" -> sqlConf))
+      messageParameters = Map("scale" -> toSQLValue(scale), "sqlConf" -> sqlConf))
   }
 
   def attributeNameSyntaxError(name: String): Throwable = {

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/DataTypeErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/DataTypeErrors.scala
@@ -124,10 +124,9 @@ private[sql] object DataTypeErrors extends DataTypeErrorsBase {
 
   def negativeScaleNotAllowedError(scale: Int): Throwable = {
     val sqlConf = QuotingUtils.toSQLConf("spark.sql.legacy.allowNegativeScaleOfDecimal")
-    SparkException.internalError(
-      s"Negative scale is not allowed: ${scale.toString}." +
-        s" Set the config ${sqlConf}" +
-        " to \"true\" to allow it.")
+    new AnalysisException(
+      errorClass = "NEGATIVE_SCALE_DISALLOWED",
+      messageParameters = Map("scale" -> scale.toString, "sqlConf" -> sqlConf))
   }
 
   def attributeNameSyntaxError(name: String): Throwable = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
@@ -124,15 +124,15 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
     }
   }
 
-  test("SPARK-30252: Negative scale is not allowed by default") {
+  test("SPARK-30252, SPARK-51084: Negative scale is not allowed by default") {
     def checkNegativeScaleDecimal(d: => Decimal): Unit = {
       checkError(
-        exception = intercept[SparkException] (d),
-        condition = "INTERNAL_ERROR",
-        parameters = Map("message" -> ("Negative scale is not allowed: -3. " +
-          "Set the config \"spark.sql.legacy.allowNegativeScaleOfDecimal\" " +
-          "to \"true\" to allow it."))
-      )
+        exception = intercept[AnalysisException](d),
+        condition = "NEGATIVE_SCALE_DISALLOWED",
+        parameters = Map(
+          "scale" -> "-3",
+          "sqlConf" -> "\"spark.sql.legacy.allowNegativeScaleOfDecimal\""
+        ))
     }
     checkNegativeScaleDecimal(Decimal(BigDecimal("98765"), 5, -3))
     checkNegativeScaleDecimal(Decimal(BigDecimal("98765").underlying(), 5, -3))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.types
 import org.scalatest.PrivateMethodTester
 
 import org.apache.spark.{SparkArithmeticException, SparkException, SparkFunSuite, SparkNumberFormatException}
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.Decimal._
@@ -103,6 +104,13 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
         "precision" -> "17",
         "scale" -> "0",
         "config" -> "\"spark.sql.ansi.enabled\""))
+    checkError(
+      exception = intercept[AnalysisException](Decimal(BigDecimal("10"), 2, -5)),
+      condition = "NEGATIVE_SCALE_DISALLOWED",
+      parameters = Map(
+        "scale" -> "-5",
+        "sqlConf" -> "\"spark.sql.legacy.allowNegativeScaleOfDecimal\""
+      ))
   }
 
   test("creating decimals with negative scale under legacy mode") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1007,23 +1007,6 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
     }
   }
 
-  test("SPARK-51084: DecimalType negative scale not allowed") {
-    val exception = intercept[AnalysisException] {
-      Seq.empty[(java.math.BigDecimal, java.math.BigDecimal)]
-        .toDF("d1", "d2")
-        .select($"d1".cast(DecimalType(10, -5)).as("d"))
-        .createOrReplaceTempView("dn")
-    }
-    checkError(
-      exception = exception,
-      condition = "NEGATIVE_SCALE_DISALLOWED",
-      parameters = Map(
-        "scale" -> "-5",
-        "sqlConf" -> "\"spark.sql.legacy.allowNegativeScaleOfDecimal\""
-      )
-    )
-  }
-
   test("Star Expansion - script transform") {
     withTempView("script_trans") {
       assume(TestUtils.testCommandAvailable("/bin/bash"))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1007,6 +1007,23 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
     }
   }
 
+  test("SPARK-51084: DecimalType negative scale not allowed") {
+    val exception = intercept[AnalysisException] {
+      Seq.empty[(java.math.BigDecimal, java.math.BigDecimal)]
+        .toDF("d1", "d2")
+        .select($"d1".cast(DecimalType(10, -5)).as("d"))
+        .createOrReplaceTempView("dn")
+    }
+    checkError(
+      exception = exception,
+      condition = "NEGATIVE_SCALE_DISALLOWED",
+      parameters = Map(
+        "scale" -> "-5",
+        "sqlConf" -> "\"spark.sql.legacy.allowNegativeScaleOfDecimal\""
+      )
+    )
+  }
+
   test("Star Expansion - script transform") {
     withTempView("script_trans") {
       assume(TestUtils.testCommandAvailable("/bin/bash"))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Clarify error message for `negativeScaleNotAllowedError` with user-facing error class


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Raise a more user-friendly error message when users attempt to use a negative precision for DecimalType when the Spark config `spark.sql.legacy.allowNegativeScaleOfDecimal` is not set. Previously an internal error was raised, which is not correct.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, it affects the error class when users attempt to use a negative precision for DecimalType when the Spark config `spark.sql.legacy.allowNegativeScaleOfDecimal` is not set. 


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added test in `DecimalSuite.scala`


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
