### PR TITLE
[SPARK-51088][SQL] Update comments for the `ResolveFunctions` rule

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2011,6 +2011,8 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
    * Replaces [[UnresolvedFunction]]s with concrete [[Expression]]s.
    * Replaces [[UnresolvedGenerator]]s with concrete [[Expression]]s.
    * Replaces [[UnresolvedTableValuedFunction]]s with concrete [[LogicalPlan]]s.
+   * Replaces [[UnresolvedTVFAliases]]s with concrete [[LogicalPlan]]s.
+   * Replaces [[UnresolvedPolymorphicPythonUDTF]]s with concrete [[Expression]]s.
    */
   object ResolveFunctions extends Rule[LogicalPlan] {
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsUpWithPruning(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR only update the comments for `ResolveFunctions` rule. 

### Why are the changes needed?
After [SPARK-41595](https://issues.apache.org/jira/browse/SPARK-41595), [SPARK-44380](https://issues.apache.org/jira/browse/SPARK-44380), the ‘ResolveFunctions’ rule supports handling more cases, and we need to update the comments.

### How was this patch tested?
Only update comments.

### Was this patch authored or co-authored using generative AI tooling?
No.
