### PR TITLE
[SPARK-51091][ML][PYTHON][CONNECT] Fix the default params of `StopWordsRemover`

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StopWordsRemover.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StopWordsRemover.scala
@@ -20,7 +20,7 @@ package org.apache.spark.ml.feature
 import java.util.Locale
 
 import org.apache.spark.annotation.Since
-import org.apache.spark.internal.{LogKeys, MDC}
+import org.apache.spark.internal.{Logging, LogKeys, MDC}
 import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared.{HasInputCol, HasInputCols, HasOutputCol, HasOutputCols}
@@ -122,21 +122,6 @@ class StopWordsRemover @Since("1.5.0") (@Since("1.5.0") override val uid: String
   @Since("2.4.0")
   def getLocale: String = $(locale)
 
-  /**
-   * Returns system default locale, or `Locale.US` if the default locale is not in available locales
-   * in JVM.
-   */
-  private val getDefaultOrUS: Locale = {
-    if (Locale.getAvailableLocales.contains(Locale.getDefault)) {
-      Locale.getDefault
-    } else {
-      logWarning(log"Default locale set was [${MDC(LogKeys.LOCALE, Locale.getDefault)}]; " +
-        log"however, it was not found in available locales in JVM, falling back to en_US locale. " +
-        log"Set param `locale` in order to respect another locale.")
-      Locale.US
-    }
-  }
-
   /** Returns the input and output column names corresponding in pair. */
   private[feature] def getInOutCols(): (Array[String], Array[String]) = {
     if (isSet(inputCol)) {
@@ -147,7 +132,7 @@ class StopWordsRemover @Since("1.5.0") (@Since("1.5.0") override val uid: String
   }
 
   setDefault(stopWords -> StopWordsRemover.loadDefaultStopWords("english"),
-    caseSensitive -> false, locale -> getDefaultOrUS.toString)
+    caseSensitive -> false, locale -> StopWordsRemover.getDefaultOrUS.toString)
 
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
@@ -218,7 +203,7 @@ class StopWordsRemover @Since("1.5.0") (@Since("1.5.0") override val uid: String
 }
 
 @Since("1.6.0")
-object StopWordsRemover extends DefaultParamsReadable[StopWordsRemover] {
+object StopWordsRemover extends DefaultParamsReadable[StopWordsRemover] with Logging {
 
   private[feature]
   val supportedLanguages = Set("danish", "dutch", "english", "finnish", "french", "german",
@@ -240,5 +225,16 @@ object StopWordsRemover extends DefaultParamsReadable[StopWordsRemover] {
       s"$language is not in the supported language list: ${supportedLanguages.mkString(", ")}.")
     val is = getClass.getResourceAsStream(s"/org/apache/spark/ml/feature/stopwords/$language.txt")
     scala.io.Source.fromInputStream(is)(scala.io.Codec.UTF8).getLines().toArray
+  }
+
+  private[spark] def getDefaultOrUS: Locale = {
+    if (Locale.getAvailableLocales.contains(Locale.getDefault)) {
+      Locale.getDefault
+    } else {
+      logWarning(log"Default locale set was [${MDC(LogKeys.LOCALE, Locale.getDefault)}]; " +
+        log"however, it was not found in available locales in JVM, falling back to en_US locale. " +
+        log"Set param `locale` in order to respect another locale.")
+      Locale.US
+    }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/util/ConnectHelper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/ConnectHelper.scala
@@ -44,8 +44,8 @@ private[spark] class ConnectHelper(override val uid: String) extends Model[Conne
     StopWordsRemover.loadDefaultStopWords(language)
   }
 
-  def stopWordsRemoverGetLocale: String = {
-    new StopWordsRemover().getLocale
+  def stopWordsRemoverGetDefaultOrUS: String = {
+    StopWordsRemover.getDefaultOrUS.toString
   }
 
   override def copy(extra: ParamMap): ConnectHelper = defaultCopy(extra)

--- a/mllib/src/main/scala/org/apache/spark/ml/util/ConnectHelper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/ConnectHelper.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.ml.util
 
 import org.apache.spark.ml.Model
-import org.apache.spark.ml.feature.{CountVectorizerModel, StringIndexerModel}
+import org.apache.spark.ml.feature._
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.types.StructType
@@ -38,6 +38,14 @@ private[spark] class ConnectHelper(override val uid: String) extends Model[Conne
   def countVectorizerModelFromVocabulary(
       uid: String, vocabulary: Array[String]): CountVectorizerModel = {
     new CountVectorizerModel(uid, vocabulary)
+  }
+
+  def stopWordsRemoverLoadDefaultStopWords(language: String): Array[String] = {
+    StopWordsRemover.loadDefaultStopWords(language)
+  }
+
+  def stopWordsRemoverGetLocale: String = {
+    new StopWordsRemover().getLocale
   }
 
   override def copy(extra: ParamMap): ConnectHelper = defaultCopy(extra)

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -5143,7 +5143,7 @@ class StopWordsRemover(
         )
         if is_remote():
             helper = JavaWrapper(java_obj=ML_CONNECT_HELPER_ID)
-            locale = helper._call_java("stopWordsRemoverGetLocale")
+            locale = helper._call_java("stopWordsRemoverGetDefaultOrUS")
         else:
             locale = self._java_obj.getLocale()
 

--- a/python/pyspark/ml/tests/connect/test_parity_feature.py
+++ b/python/pyspark/ml/tests/connect/test_parity_feature.py
@@ -22,9 +22,7 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class FeatureParityTests(FeatureTestsMixin, ReusedConnectTestCase):
-    @unittest.skip("Need to support.")
-    def test_stop_words_lengague_selection(self):
-        super().test_stop_words_lengague_selection()
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/test_feature.py
+++ b/python/pyspark/ml/tests/test_feature.py
@@ -880,8 +880,9 @@ class FeatureTestsMixin:
             remover2 = StopWordsRemover.load(d)
             self.assertEqual(str(remover), str(remover2))
 
-    def test_stop_words_remover_II(self):
-        dataset = self.spark.createDataFrame([Row(input=["a", "panda"])])
+    def test_stop_words_remover_with_given_words(self):
+        spark = self.spark
+        dataset = spark.createDataFrame([Row(input=["a", "panda"])])
         stopWordRemover = StopWordsRemover(inputCol="input", outputCol="output")
         # Default
         self.assertEqual(stopWordRemover.getInputCol(), "input")
@@ -902,14 +903,29 @@ class FeatureTestsMixin:
         transformedDF = stopWordRemover.transform(dataset)
         self.assertEqual(transformedDF.head().output, [])
 
-    def test_stop_words_language_selection(self):
+    def test_stop_words_remover_with_turkish(self):
+        spark = self.spark
+        dataset = spark.createDataFrame([Row(input=["acaba", "ama", "biri"])])
         stopWordRemover = StopWordsRemover(inputCol="input", outputCol="output")
         stopwords = StopWordsRemover.loadDefaultStopWords("turkish")
-        dataset = self.spark.createDataFrame([Row(input=["acaba", "ama", "biri"])])
         stopWordRemover.setStopWords(stopwords)
         self.assertEqual(stopWordRemover.getStopWords(), stopwords)
         transformedDF = stopWordRemover.transform(dataset)
         self.assertEqual(transformedDF.head().output, [])
+
+    def test_stop_words_remover_default(self):
+        stopWordRemover = StopWordsRemover(inputCol="input", outputCol="output")
+
+        # check the default value of local
+        locale = stopWordRemover.getLocale()
+        self.assertIsInstance(locale, str)
+        self.assertTrue(len(locale) > 0)
+
+        # check the default value of stop words
+        stopwords = stopWordRemover.getStopWords()
+        self.assertIsInstance(stopwords, list)
+        self.assertTrue(len(stopwords) > 0)
+        self.assertTrue(all(isinstance(word, str) for word in stopwords))
 
     def test_binarizer(self):
         b0 = Binarizer()

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -658,7 +658,9 @@ private[ml] object MLUtils {
       Set(
         "stringIndexerModelFromLabels",
         "stringIndexerModelFromLabelsArray",
-        "countVectorizerModelFromVocabulary")))
+        "countVectorizerModelFromVocabulary",
+        "stopWordsRemoverLoadDefaultStopWords",
+        "stopWordsRemoverGetLocale")))
 
   private def validate(obj: Any, method: String): Unit = {
     assert(obj != null)

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -660,7 +660,7 @@ private[ml] object MLUtils {
         "stringIndexerModelFromLabelsArray",
         "countVectorizerModelFromVocabulary",
         "stopWordsRemoverLoadDefaultStopWords",
-        "stopWordsRemoverGetLocale")))
+        "stopWordsRemoverGetDefaultOrUS")))
 
   private def validate(obj: Any, method: String): Unit = {
     assert(obj != null)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix the default params of `StopWordsRemover`


### Why are the changes needed?
for feature parity

### Does this PR introduce _any_ user-facing change?
yes

### How was this patch tested?
added tests


### Was this patch authored or co-authored using generative AI tooling?
no