### PR TITLE
[SPARK-51093][SQL][TESTS] Fix minor endianness issues in tests.

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilderSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.catalyst.util
 
-import java.nio.ByteOrder.{nativeOrder, BIG_ENDIAN}
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.SparkRuntimeException
 import org.apache.spark.sql.catalyst.InternalRow
@@ -145,15 +143,12 @@ class ArrayBasedMapBuilderSuite extends SparkFunSuite with SQLHelper {
     val builder = new ArrayBasedMapBuilder(new StructType().add("i", "int"), IntegerType)
     builder.put(InternalRow(1), 1)
     builder.put(InternalRow(2), 2)
-    // The UnsafeRow.toString() method output is based on the underlying bytes and is
-    // endian dependent.
-    val keyAsString = if (nativeOrder().equals(BIG_ENDIAN)) "[0,100000000]" else "[0,1]"
     // By default duplicated map key fails the query.
     checkError(
       exception = intercept[SparkRuntimeException](builder.put(unsafeRow, 3)),
       condition = "DUPLICATED_MAP_KEY",
       parameters = Map(
-        "key" -> keyAsString,
+        "key" -> unsafeRow.toString(),
         "mapKeyDedupPolicy" -> "\"spark.sql.mapKeyDedupPolicy\"")
     )
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
@@ -70,7 +70,7 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   private val tableNameAsString = "testcat." + ident.toString
   private val emptyProps = Collections.emptyMap[String, String]
   private val columns = Array(
-    Column.create("id", IntegerType),
+    Column.create("id", LongType),
     Column.create("data", StringType),
     Column.create("day", DateType))
 
@@ -1122,7 +1122,7 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
         Seq.empty
       ),
       catalyst.expressions.SortOrder(
-        ApplyFunctionExpression(BucketFunction, Seq(Literal(10), Cast(attr("id"), LongType))),
+        ApplyFunctionExpression(BucketFunction, Seq(Literal(10), attr("id"))),
         catalyst.expressions.Descending,
         catalyst.expressions.NullsFirst,
         Seq.empty


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix minor endianness issues in the following tests.

ArrayBasedMapBuilderSuite: The output of the UnsafeRow.toString() is based on the underlying bytes and is endian dependent. Add an expected value for big endian platforms. Add an expected value for big endian platforms.

WriteDistributionAndOrderingSuite: Casting the id of type Int to Long doesn't work on big endian platforms because the BucketFunction calls UnsafeRow.getLong() for that column. That happens to work on little endian since an int field is stored in the first 4 bytes of the 8 byte field so positive ints are layed out the same as positive longs ie. little endian order. On big endian, the layout of UnsafeRow int fields does not happen to match the layout of long fields for the same number. Change the type of the id column to Long so that it matches what BucketFunction expects. Change the type of the id column to Long so that it matches what BucketFunction expects.

### Why are the changes needed?
Allow tests to pass on big endian platforms


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Ran existing tests on amd64 (little endian) and s390x (big endian)


### Was this patch authored or co-authored using generative AI tooling?
No
