### PR TITLE
[SPARK-51100][ML][PYTHON][CONNECT] Replace transformer wrappers with helper model attribute relations

### DIFF
--- a/mllib/src/main/resources/META-INF/services/org.apache.spark.ml.Transformer
+++ b/mllib/src/main/resources/META-INF/services/org.apache.spark.ml.Transformer
@@ -18,9 +18,6 @@
 # Spark Connect ML uses ServiceLoader to find out the supported Spark Ml non-model transformer.
 # So register the supported transformer here if you're trying to add a new one.
 
-########### Helper Model
-org.apache.spark.ml.util.ConnectHelper
-
 ########### Transformers
 org.apache.spark.ml.feature.DCT
 org.apache.spark.ml.feature.NGram
@@ -68,19 +65,12 @@ org.apache.spark.ml.clustering.BisectingKMeansModel
 org.apache.spark.ml.clustering.GaussianMixtureModel
 org.apache.spark.ml.clustering.DistributedLDAModel
 org.apache.spark.ml.clustering.LocalLDAModel
-org.apache.spark.ml.clustering.PowerIterationClusteringWrapper
 
 # recommendation
 org.apache.spark.ml.recommendation.ALSModel
 
 # fpm
 org.apache.spark.ml.fpm.FPGrowthModel
-org.apache.spark.ml.fpm.PrefixSpanWrapper
-
-# stat
-org.apache.spark.ml.stat.ChiSquareTestWrapper
-org.apache.spark.ml.stat.CorrelationWrapper
-org.apache.spark.ml.stat.KolmogorovSmirnovTestWrapper
 
 # feature
 org.apache.spark.ml.feature.RFormulaModel

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/PowerIterationClustering.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/PowerIterationClustering.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.ml.clustering
 
 import org.apache.spark.annotation.Since
-import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
 import org.apache.spark.ml.util._
@@ -191,31 +190,4 @@ object PowerIterationClustering extends DefaultParamsReadable[PowerIterationClus
 
   @Since("2.4.0")
   override def load(path: String): PowerIterationClustering = super.load(path)
-}
-
-private[spark] class PowerIterationClusteringWrapper(override val uid: String)
-  extends Transformer with PowerIterationClusteringParams with DefaultParamsWritable {
-
-  def this() = this(Identifiable.randomUID("PowerIterationClusteringWrapper"))
-
-  override def transform(dataset: Dataset[_]): DataFrame = {
-    val pic = new PowerIterationClustering()
-      .setK($(k))
-      .setInitMode($(initMode))
-      .setMaxIter($(maxIter))
-      .setSrcCol($(srcCol))
-      .setDstCol($(dstCol))
-    get(weightCol) match {
-      case Some(w) if w.nonEmpty => pic.setWeightCol(w)
-      case _ =>
-    }
-    pic.assignClusters(dataset)
-  }
-
-  override def transformSchema(schema: StructType): StructType =
-    new StructType()
-      .add(StructField("id", LongType, nullable = false))
-      .add(StructField("cluster", IntegerType, nullable = false))
-
-  override def copy(extra: ParamMap): PowerIterationClusteringWrapper = defaultCopy(extra)
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/fpm/PrefixSpan.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/fpm/PrefixSpan.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.ml.fpm
 
 import org.apache.spark.annotation.Since
-import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.ml.util.Instrumentation.instrumented
@@ -168,29 +167,4 @@ final class PrefixSpan(@Since("2.4.0") override val uid: String) extends PrefixS
 
   @Since("2.4.0")
   override def copy(extra: ParamMap): PrefixSpan = defaultCopy(extra)
-
-}
-
-private[spark] class PrefixSpanWrapper(override val uid: String)
-  extends Transformer with PrefixSpanParams {
-
-  def this() = this(Identifiable.randomUID("prefixSpanWrapper"))
-
-  override def transformSchema(schema: StructType): StructType = {
-    new StructType()
-      .add("sequence", ArrayType(schema($(sequenceCol)).dataType), nullable = false)
-      .add("freq", LongType, nullable = false)
-  }
-
-  override def transform(dataset: Dataset[_]): DataFrame = {
-    val prefixSpan = new PrefixSpan(uid)
-    prefixSpan
-      .setMinSupport($(minSupport))
-      .setMaxPatternLength($(maxPatternLength))
-      .setMaxLocalProjDBSize($(maxLocalProjDBSize))
-      .setSequenceCol($(sequenceCol))
-      .findFrequentSequentialPatterns(dataset)
-  }
-
-  override def copy(extra: ParamMap): PrefixSpanWrapper = defaultCopy(extra)
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/ChiSquareTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/ChiSquareTest.scala
@@ -18,17 +18,12 @@
 package org.apache.spark.ml.stat
 
 import org.apache.spark.annotation.Since
-import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.linalg.{Vector, Vectors, VectorUDT}
-import org.apache.spark.ml.param._
-import org.apache.spark.ml.param.shared.{HasFeaturesCol, HasLabelCol}
-import org.apache.spark.ml.util.{Identifiable, SchemaUtils}
+import org.apache.spark.ml.util.SchemaUtils
 import org.apache.spark.mllib.linalg.{Vectors => OldVectors}
 import org.apache.spark.mllib.stat.test.{ChiSqTest => OldChiSqTest}
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types._
-
 
 /**
  * Chi-square hypothesis testing for categorical data.
@@ -105,40 +100,3 @@ object ChiSquareTest {
     }
   }
 }
-
-/**
- * [[ChiSquareTest]] is not an Estimator/Transformer and thus needs to be wrapped in a wrapper
- * to be compatible with Spark Connect.
- */
-private[spark] class ChiSquareTestWrapper(override val uid: String)
-  extends Transformer with HasFeaturesCol with HasLabelCol {
-
-  val flatten = new BooleanParam(this, "flatten",
-    "If false, the returned DataFrame contains only a single Row, otherwise, one row per feature.")
-
-  setDefault(flatten -> false)
-
-  def this() = this(Identifiable.randomUID("ChiSquareTestWrapper"))
-
-  override def transformSchema(schema: StructType): StructType = {
-    if ($(flatten)) {
-      new StructType()
-        .add("featureIndex", IntegerType, nullable = false)
-        .add("pValue", DoubleType, nullable = false)
-        .add("degreesOfFreedom", IntegerType, nullable = false)
-        .add("statistic", DoubleType, nullable = false)
-    } else {
-      new StructType()
-        .add("pValues", new VectorUDT, nullable = false)
-        .add("degreesOfFreedom", ArrayType(IntegerType, containsNull = false), nullable = false)
-        .add("statistics", new VectorUDT, nullable = false)
-    }
-  }
-
-  override def transform(dataset: Dataset[_]): DataFrame = {
-    ChiSquareTest.test(dataset.toDF(), $(featuresCol), $(labelCol), $(flatten))
-  }
-
-  override def copy(extra: ParamMap): ChiSquareTestWrapper = defaultCopy(extra)
-}
-

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/Correlation.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/Correlation.scala
@@ -20,11 +20,7 @@ package org.apache.spark.ml.stat
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.annotation.Since
-import org.apache.spark.ml._
 import org.apache.spark.ml.linalg.{SQLDataTypes, Vector}
-import org.apache.spark.ml.param._
-import org.apache.spark.ml.param.shared.HasFeaturesCol
-import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.mllib.linalg.{Vectors => OldVectors}
 import org.apache.spark.mllib.stat.{Statistics => OldStatistics}
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
@@ -85,29 +81,4 @@ object Correlation {
   def corr(dataset: Dataset[_], column: String): DataFrame = {
     corr(dataset, column, "pearson")
   }
-}
-
-/**
- * [[Correlation]] is not an Estimator/Transformer and thus needs to be wrapped in a wrapper
- * to be compatible with Spark Connect.
- */
-private[spark] class CorrelationWrapper(override val uid: String)
-  extends Transformer with HasFeaturesCol {
-
-  val method = new Param[String](this, "method", "The correlation method to use")
-
-  setDefault(method -> "pearson")
-
-  def this() = this(Identifiable.randomUID("CorrelationWrapper"))
-
-  override def transformSchema(schema: StructType): StructType = {
-    val name = s"${$(method)}(${$(featuresCol)})"
-    StructType(Array(StructField(name, SQLDataTypes.MatrixType, nullable = false)))
-  }
-
-  override def transform(dataset: Dataset[_]): DataFrame = {
-    Correlation.corr(dataset, $(featuresCol), $(method))
-  }
-
-  override def copy(extra: ParamMap): CorrelationWrapper = defaultCopy(extra)
 }

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -46,6 +46,7 @@ from pyspark.ml.util import (
     GeneralJavaMLWritable,
     HasTrainingSummary,
     try_remote_attribute_relation,
+    invoke_helper_relation,
 )
 from pyspark.ml.wrapper import JavaEstimator, JavaModel, JavaParams, JavaWrapper
 from pyspark.ml.common import inherit_doc
@@ -2155,16 +2156,16 @@ class PowerIterationClustering(
         assert self._java_obj is not None
 
         if is_remote():
-            from pyspark.ml.wrapper import JavaTransformer
-            from pyspark.ml.connect.serialize import serialize_ml_params
-
-            instance = JavaTransformer()
-            instance._java_obj = "org.apache.spark.ml.clustering.PowerIterationClusteringWrapper"
-            instance._serialized_ml_params = serialize_ml_params(  # type: ignore[attr-defined]
-                self,
-                dataset.sparkSession.client,  # type: ignore[arg-type,operator]
+            return invoke_helper_relation(
+                "powerIterationClusteringAssignClusters",
+                dataset,
+                self.getK(),
+                self.getMaxIter(),
+                self.getInitMode(),
+                self.getSrcCol(),
+                self.getDstCol(),
+                self.getWeightCol() if self.isDefined(self.weightCol) else "",
             )
-            return instance.transform(dataset)
 
         self._transfer_params_to_java()
 

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -4849,7 +4849,7 @@ class StringIndexerModel(
             model._java_obj = helper._call_java(
                 "stringIndexerModelFromLabels",
                 model.uid,
-                (list(labels), ArrayType(StringType(), False)),
+                (list(labels), ArrayType(StringType())),
             )
 
         else:
@@ -4891,7 +4891,7 @@ class StringIndexerModel(
                 model.uid,
                 (
                     [list(labels) for labels in arrayOfLabels],
-                    ArrayType(ArrayType(StringType(), False)),
+                    ArrayType(ArrayType(StringType())),
                 ),
             )
 

--- a/python/pyspark/ml/stat.py
+++ b/python/pyspark/ml/stat.py
@@ -22,9 +22,11 @@ from pyspark import since
 from pyspark.ml.common import _java2py, _py2java
 from pyspark.ml.linalg import Matrix, Vector
 from pyspark.ml.wrapper import JavaWrapper, _jvm
+from pyspark.ml.util import invoke_helper_relation
 from pyspark.sql.column import Column
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.functions import lit
+from pyspark.sql.types import ArrayType, DoubleType
 from pyspark.sql.utils import is_remote
 
 if TYPE_CHECKING:
@@ -104,17 +106,7 @@ class ChiSquareTest:
         4.0
         """
         if is_remote():
-            from pyspark.ml.wrapper import JavaTransformer
-            from pyspark.ml.connect.serialize import serialize_ml_params_values
-
-            instance = JavaTransformer()
-            instance._java_obj = "org.apache.spark.ml.stat.ChiSquareTestWrapper"
-            serialized_ml_params = serialize_ml_params_values(
-                {"featuresCol": featuresCol, "labelCol": labelCol, "flatten": flatten},
-                dataset.sparkSession.client,  # type: ignore[arg-type,operator]
-            )
-            instance._serialized_ml_params = serialized_ml_params  # type: ignore[attr-defined]
-            return instance.transform(dataset)
+            return invoke_helper_relation("chiSquareTest", dataset, featuresCol, labelCol, flatten)
 
         else:
             from pyspark.core.context import SparkContext
@@ -189,17 +181,7 @@ class Correlation:
                      [ 0.4       ,  0.9486... ,         NaN,  1.        ]])
         """
         if is_remote():
-            from pyspark.ml.wrapper import JavaTransformer
-            from pyspark.ml.connect.serialize import serialize_ml_params_values
-
-            instance = JavaTransformer()
-            instance._java_obj = "org.apache.spark.ml.stat.CorrelationWrapper"
-            serialized_ml_params = serialize_ml_params_values(
-                {"featuresCol": column, "method": method},
-                dataset.sparkSession.client,  # type: ignore[arg-type,operator]
-            )
-            instance._serialized_ml_params = serialized_ml_params  # type: ignore[attr-defined]
-            return instance.transform(dataset)
+            return invoke_helper_relation("correlation", dataset, column, method)
 
         else:
             from pyspark.core.context import SparkContext
@@ -273,17 +255,13 @@ class KolmogorovSmirnovTest:
         0.175
         """
         if is_remote():
-            from pyspark.ml.wrapper import JavaTransformer
-            from pyspark.ml.connect.serialize import serialize_ml_params_values
-
-            instance = JavaTransformer()
-            instance._java_obj = "org.apache.spark.ml.stat.KolmogorovSmirnovTestWrapper"
-            serialized_ml_params = serialize_ml_params_values(
-                {"inputCol": sampleCol, "distName": distName, "paramsArray": list(params)},
-                dataset.sparkSession.client,  # type: ignore[arg-type,operator]
+            return invoke_helper_relation(
+                "kolmogorovSmirnovTest",
+                dataset,
+                sampleCol,
+                distName,
+                ([float(p) for p in params], ArrayType(DoubleType())),
             )
-            instance._serialized_ml_params = serialized_ml_params  # type: ignore[attr-defined]
-            return instance.transform(dataset)
 
         else:
             from pyspark.core.context import SparkContext

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -661,7 +661,12 @@ private[ml] object MLUtils {
         "stringIndexerModelFromLabelsArray",
         "countVectorizerModelFromVocabulary",
         "stopWordsRemoverLoadDefaultStopWords",
-        "stopWordsRemoverGetDefaultOrUS")))
+        "stopWordsRemoverGetDefaultOrUS",
+        "chiSquareTest",
+        "correlation",
+        "kolmogorovSmirnovTest",
+        "powerIterationClusteringAssignClusters",
+        "prefixSpanFindFrequentSequentialPatterns")))
 
   private def validate(obj: Any, method: String): Unit = {
     assert(obj != null)

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/Serializer.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/Serializer.scala
@@ -167,6 +167,8 @@ private[ml] object Serializer {
           case proto.Expression.Literal.LiteralTypeCase.ARRAY =>
             val array = literal.getArray
             array.getElementType.getKindCase match {
+              case proto.DataType.KindCase.DOUBLE =>
+                (parseDoubleArray(array), classOf[Array[Double]])
               case proto.DataType.KindCase.STRING =>
                 (parseStringArray(array), classOf[Array[String]])
               case proto.DataType.KindCase.ARRAY =>
@@ -189,6 +191,16 @@ private[ml] object Serializer {
         throw MlUnsupportedException(s"$arg not supported")
       }
     }
+  }
+
+  private def parseDoubleArray(array: proto.Expression.Literal.Array): Array[Double] = {
+    val values = new Array[Double](array.getElementsCount)
+    var i = 0
+    while (i < array.getElementsCount) {
+      values(i) = array.getElements(i).getDouble
+      i += 1
+    }
+    values
   }
 
   private def parseStringArray(array: proto.Expression.Literal.Array): Array[String] = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replace transformer wrappers with helper model attributes


### Why are the changes needed?
to simplify the implementations


### Does this PR introduce _any_ user-facing change?
no, refactoring-only


### How was this patch tested?
existing tests should cover this change


### Was this patch authored or co-authored using generative AI tooling?
no
