### PR TITLE
[SPARK-51109][SQL] CTE in subquery expression as grouping column

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/MergeScalarSubqueriesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/MergeScalarSubqueriesSuite.scala
@@ -346,11 +346,7 @@ class MergeScalarSubqueriesSuite extends PlanTest {
       subquery2)
 
     val mergedSubquery = testRelation.as("t1")
-      .select(Symbol("a"), Symbol("b"), Symbol("c"))
-      .join(
-        testRelation.as("t2").select(Symbol("a"), Symbol("b"), Symbol("c")),
-        Inner,
-        Some($"t1.b" === $"t2.b"))
+      .join(testRelation.as("t2"), Inner, Some($"t1.b" === $"t2.b"))
       .select($"t1.a", $"t2.c")
       .select(CreateNamedStruct(Seq(
         Literal("a"), Symbol("a"),
@@ -387,11 +383,7 @@ class MergeScalarSubqueriesSuite extends PlanTest {
       subquery2)
 
     val mergedSubquery = testRelation.as("t1")
-      .select(Symbol("a"), Symbol("b"), Symbol("c"))
-      .join(
-        testRelation.as("t2").select(Symbol("a"), Symbol("b"), Symbol("c")),
-        Inner,
-        Some($"t1.b" < $"t2.b" && $"t1.a" === $"t2.c"))
+      .join(testRelation.as("t2"), Inner, Some($"t1.b" < $"t2.b" && $"t1.a" === $"t2.c"))
       .select($"t1.a", $"t2.c")
       .select(CreateNamedStruct(Seq(
         Literal("a"), Symbol("a"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/CTEInlineSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CTEInlineSuite.scala
@@ -333,14 +333,14 @@ abstract class CTEInlineSuiteBase
 
   test("CTE Predicate push-down and column pruning - combined predicate") {
     withTempView("t") {
-      Seq((0, 1, 2), (1, 2, 3)).toDF("c1", "c2", "c3").createOrReplaceTempView("t")
+      Seq((0, 1, 2, 3), (1, 2, 3, 4)).toDF("c1", "c2", "c3", "c4").createOrReplaceTempView("t")
       val df = sql(
         s"""with
            |v as (
-           |  select c1, c2, c3, rand() c4 from t
+           |  select c1, c2, c3, c4, rand() c5 from t
            |),
            |vv as (
-           |  select v1.c1, v1.c2, rand() c5 from v v1, v v2
+           |  select v1.c1, v1.c2, rand() c6 from v v1, v v2
            |  where v1.c1 > 0 and v2.c3 < 5 and v1.c2 = v2.c2
            |)
            |select vv1.c1, vv1.c2, vv2.c1, vv2.c2 from vv vv1, vv vv2

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenamePartitionSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenamePartitionSuiteBase.scala
@@ -220,25 +220,26 @@ trait AlterTableRenamePartitionSuiteBase extends QueryTest with DDLCommandTestUt
       checkCachedRelation(t, Seq(Row(0, 0), Row(1, 1)))
 
       withView("v0") {
-        sql(s"CREATE VIEW v0 AS SELECT * FROM $t")
+        // Add a dummy column so that this view is semantically different from raw table scan.
+        sql(s"CREATE VIEW v0 AS SELECT *, 'a' FROM $t")
         cacheRelation("v0")
         sql(s"ALTER TABLE $t PARTITION (part=0) RENAME TO PARTITION (part=2)")
-        checkCachedRelation("v0", Seq(Row(0, 2), Row(1, 1)))
+        checkCachedRelation("v0", Seq(Row(0, 2, "a"), Row(1, 1, "a")))
       }
 
       withTempView("v1") {
-        sql(s"CREATE TEMP VIEW v1 AS SELECT * FROM $t")
+        sql(s"CREATE TEMP VIEW v1 AS SELECT *, 'a' FROM $t")
         cacheRelation("v1")
         sql(s"ALTER TABLE $t PARTITION (part=1) RENAME TO PARTITION (part=3)")
-        checkCachedRelation("v1", Seq(Row(0, 2), Row(1, 3)))
+        checkCachedRelation("v1", Seq(Row(0, 2, "a"), Row(1, 3, "a")))
       }
 
       val v2 = s"${spark.sharedState.globalTempDB}.v2"
       withGlobalTempView("v2") {
-        sql(s"CREATE GLOBAL TEMP VIEW v2 AS SELECT * FROM $t")
+        sql(s"CREATE GLOBAL TEMP VIEW v2 AS SELECT *, 'a' FROM $t")
         cacheRelation(v2)
         sql(s"ALTER TABLE $t PARTITION (part=2) RENAME TO PARTITION (part=4)")
-        checkCachedRelation(v2, Seq(Row(0, 4), Row(1, 3)))
+        checkCachedRelation(v2, Seq(Row(0, 4, "a"), Row(1, 3, "a")))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TruncateTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TruncateTableSuiteBase.scala
@@ -271,26 +271,27 @@ trait TruncateTableSuiteBase extends QueryTest with DDLCommandTestUtils {
         Seq(Row(0, 0, 0), Row(1, 1, 1), Row(1, 2, 3)))
 
       withView("v0") {
-        sql(s"CREATE VIEW v0 AS SELECT * FROM $t")
+        // Add a dummy column so that this view is semantically different from raw table scan.
+        sql(s"CREATE VIEW v0 AS SELECT *, 'a' FROM $t")
         cacheRelation("v0")
         sql(s"TRUNCATE TABLE $t PARTITION (width = 1, length = 2)")
-        checkCachedRelation("v0", Seq(Row(0, 0, 0), Row(1, 1, 1)))
+        checkCachedRelation("v0", Seq(Row(0, 0, 0, "a"), Row(1, 1, 1, "a")))
       }
 
       withTempView("v1") {
-        sql(s"CREATE TEMP VIEW v1 AS SELECT * FROM $t")
+        sql(s"CREATE TEMP VIEW v1 AS SELECT *, 'a' FROM $t")
         cacheRelation("v1")
         sql(s"TRUNCATE TABLE $t PARTITION (width = 1, length = 1)")
-        checkCachedRelation("v1", Seq(Row(0, 0, 0)))
+        checkCachedRelation("v1", Seq(Row(0, 0, 0, "a")))
       }
 
       val v2 = s"${spark.sharedState.globalTempDB}.v2"
       withGlobalTempView("v2") {
         sql(s"INSERT INTO $t PARTITION (width = 10, length = 10) SELECT 10")
-        sql(s"CREATE GLOBAL TEMP VIEW v2 AS SELECT * FROM $t")
+        sql(s"CREATE GLOBAL TEMP VIEW v2 AS SELECT *, 'a' FROM $t")
         cacheRelation(v2)
         sql(s"TRUNCATE TABLE $t PARTITION (width = 10, length = 10)")
-        checkCachedRelation(v2, Seq(Row(0, 0, 0)))
+        checkCachedRelation(v2, Seq(Row(0, 0, 0, "a")))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableAddPartitionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableAddPartitionSuite.scala
@@ -92,25 +92,26 @@ class AlterTableAddPartitionSuite
       checkCachedRelation(t, Seq(Row(0, 0)))
 
       withView("v0") {
-        sql(s"CREATE VIEW v0 AS SELECT * FROM $t")
+        // Add a dummy column so that this view is semantically different from raw table scan.
+        sql(s"CREATE VIEW v0 AS SELECT *, 'a' FROM $t")
         cacheRelation("v0")
         sql(s"ALTER TABLE $t ADD PARTITION (id=0, part=1)")
-        checkCachedRelation("v0", Seq(Row(0, 0), Row(0, 1)))
+        checkCachedRelation("v0", Seq(Row(0, 0, "a"), Row(0, 1, "a")))
       }
 
       withTempView("v1") {
-        sql(s"CREATE TEMP VIEW v1 AS SELECT * FROM $t")
+        sql(s"CREATE TEMP VIEW v1 AS SELECT *, 'a' FROM $t")
         cacheRelation("v1")
         sql(s"ALTER TABLE $t ADD PARTITION (id=1, part=2)")
-        checkCachedRelation("v1", Seq(Row(0, 0), Row(0, 1), Row(1, 2)))
+        checkCachedRelation("v1", Seq(Row(0, 0, "a"), Row(0, 1, "a"), Row(1, 2, "a")))
       }
 
       val v2 = s"${spark.sharedState.globalTempDB}.v2"
       withGlobalTempView(v2) {
-        sql(s"CREATE GLOBAL TEMP VIEW v2 AS SELECT * FROM $t")
+        sql(s"CREATE GLOBAL TEMP VIEW v2 AS SELECT *, 'a' FROM $t")
         cacheRelation(v2)
         sql(s"ALTER TABLE $t ADD PARTITION (id=2, part=3)")
-        checkCachedRelation(v2, Seq(Row(0, 0), Row(0, 1), Row(1, 2), Row(2, 3)))
+        checkCachedRelation(v2, Seq(Row(0, 0, "a"), Row(0, 1, "a"), Row(1, 2, "a"), Row(2, 3, "a")))
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a long-standing problem. With the GROUP BY ordinal feature, it's quite easy for users to write a complicated expression as the GROUP BY expression and also put it in the SELECT list. It's usually OK as the complicated expressions in the GROUP BY expression and SELECT list remain the same, but problems may occur with subquery expressions, duplicated relations, and CTE inline. Let's look at this example:
```
CREATE VIEW v AS
WITH r AS (SELECT c1 + c2 AS c FROM t)
SELECT * FROM r;

SELECT (SELECT max(c) FROM v WHERE c > id) FROM range(1) GROUP BY 1;
```

A scalar subquery appears in both the GROUP BY expression and SELECT list. The scalar subquery scans table `t`, and because this scalar subquery appears twice, `DeduplicateRelations` will trigger. This makes the output attributes of CTE def and ref out of sync in the second scalar subquery and `InlineCTE` will add a cosmetic `Project` to adjust the output attr ids. `CheckAnalysis` will inline CTE in the beginning, and this extra cosmetic `Project` in the second scalar subquery makes Spark think it's not semantically equal to the first scalar subquery and fails the query.

The proposal here is to remove cosmetic Projects during plan canonicalization.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
bug fix

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, some queries fail before and work now.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no