### PR TITLE
[SPARK-51112][CONNECT] Avoid using pyarrow's `to_pandas` on an empty table

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -933,37 +933,36 @@ class SparkConnectClient(object):
         schema = schema or from_arrow_schema(table.schema, prefer_timestamp_ntz=True)
         assert schema is not None and isinstance(schema, StructType)
 
-        # Rename columns to avoid duplicated column names.
-        renamed_table = table.rename_columns([f"col_{i}" for i in range(table.num_columns)])
-
-        pandas_options = {}
-        if self_destruct:
-            # Configure PyArrow to use as little memory as possible:
-            # self_destruct - free columns as they are converted
-            # split_blocks - create a separate Pandas block for each column
-            # use_threads - convert one column at a time
-            pandas_options.update(
-                {
-                    "self_destruct": True,
-                    "split_blocks": True,
-                    "use_threads": False,
-                }
-            )
-        if LooseVersion(pa.__version__) >= LooseVersion("13.0.0"):
-            # A legacy option to coerce date32, date64, duration, and timestamp
-            # time units to nanoseconds when converting to pandas.
-            # This option can only be added since 13.0.0.
-            pandas_options.update(
-                {
-                    "coerce_temporal_nanoseconds": True,
-                }
-            )
         # SPARK-51112: If the table is empty, we avoid using pyarrow to_pandas to create the
         # DataFrame, as it may fail with a segmentation fault. Instead, we create an empty pandas
         # DataFrame manually with the correct schema.
         if table.num_rows == 0:
-            pdf = pd.DataFrame(columns=[field.name for field in schema.fields])
+            pdf = pd.DataFrame(columns=schema.names)
         else:
+            # Rename columns to avoid duplicated column names.
+            renamed_table = table.rename_columns([f"col_{i}" for i in range(table.num_columns)])
+            pandas_options = {}
+            if self_destruct:
+                # Configure PyArrow to use as little memory as possible:
+                # self_destruct - free columns as they are converted
+                # split_blocks - create a separate Pandas block for each column
+                # use_threads - convert one column at a time
+                pandas_options.update(
+                    {
+                        "self_destruct": True,
+                        "split_blocks": True,
+                        "use_threads": False,
+                    }
+                )
+            if LooseVersion(pa.__version__) >= LooseVersion("13.0.0"):
+                # A legacy option to coerce date32, date64, duration, and timestamp
+                # time units to nanoseconds when converting to pandas.
+                # This option can only be added since 13.0.0.
+                pandas_options.update(
+                    {
+                        "coerce_temporal_nanoseconds": True,
+                    }
+                )
             pdf = renamed_table.to_pandas(**pandas_options)
             pdf.columns = schema.names
 

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -941,6 +941,7 @@ class SparkConnectClient(object):
         else:
             # Rename columns to avoid duplicated column names.
             renamed_table = table.rename_columns([f"col_{i}" for i in range(table.num_columns)])
+
             pandas_options = {}
             if self_destruct:
                 # Configure PyArrow to use as little memory as possible:

--- a/python/pyspark/sql/tests/connect/test_connect_creation.py
+++ b/python/pyspark/sql/tests/connect/test_connect_creation.py
@@ -706,6 +706,28 @@ class SparkConnectCreationTests(SparkConnectSQLTestCase):
 
             self.assertEqual(cdf.schema, sdf.schema)
 
+    def test_empty_df_with_nested_array_columns_conversion_to_pandas_df(self):
+        # SPARK-51112: Segfault must not occur when converting empty DataFrame with nested array
+        # columns to pandas DataFrame.
+        df = self.connect.createDataFrame(
+            data = [],
+            schema=StructType(
+                [
+                    StructField(
+                        name='b_int',
+                        dataType=IntegerType(),
+                        nullable=False,
+                    ),
+                    StructField(
+                        name='b',
+                        dataType=ArrayType(ArrayType(StringType(), True), True),
+                        nullable=True,
+                    ),
+                ]
+            )
+        )
+        df.toPandas()
+
 
 if __name__ == "__main__":
     from pyspark.sql.tests.connect.test_connect_creation import *  # noqa: F401

--- a/python/pyspark/sql/tests/connect/test_connect_creation.py
+++ b/python/pyspark/sql/tests/connect/test_connect_creation.py
@@ -706,28 +706,6 @@ class SparkConnectCreationTests(SparkConnectSQLTestCase):
 
             self.assertEqual(cdf.schema, sdf.schema)
 
-    def test_empty_df_with_nested_array_columns_conversion_to_pandas_df(self):
-        # SPARK-51112: Segfault must not occur when converting empty DataFrame with nested array
-        # columns to pandas DataFrame.
-        df = self.connect.createDataFrame(
-            data = [],
-            schema=StructType(
-                [
-                    StructField(
-                        name='b_int',
-                        dataType=IntegerType(),
-                        nullable=False,
-                    ),
-                    StructField(
-                        name='b',
-                        dataType=ArrayType(ArrayType(StringType(), True), True),
-                        nullable=True,
-                    ),
-                ]
-            )
-        )
-        df.toPandas()
-
 
 if __name__ == "__main__":
     from pyspark.sql.tests.connect.test_connect_creation import *  # noqa: F401

--- a/python/pyspark/sql/tests/connect/test_parity_collection.py
+++ b/python/pyspark/sql/tests/connect/test_parity_collection.py
@@ -42,6 +42,9 @@ class DataFrameCollectionParityTests(
     def test_to_pandas_from_mixed_dataframe(self):
         self.check_to_pandas_from_mixed_dataframe()
 
+    def test_to_pandas_for_empty_df_with_nested_array_columns(self):
+        self.check_to_pandas_for_empty_df_with_nested_array_columns()
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/sql/tests/test_collection.py
+++ b/python/pyspark/sql/tests/test_collection.py
@@ -291,6 +291,15 @@ class DataFrameCollectionTestsMixin:
         else:
             self.assertEqual(type(pdf["array_struct_col"][0]), list)
 
+    @unittest.skipIf(
+        not have_pandas or not have_pyarrow,
+        pandas_requirement_message or pyarrow_requirement_message,
+    )
+    def test_to_pandas_for_empty_df_with_nested_array_columns(self):
+        for arrow_enabled in [False, True]:
+            with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": arrow_enabled}):
+                self.check_to_pandas_for_empty_df_with_nested_array_columns()
+
     def check_to_pandas_for_empty_df_with_nested_array_columns(self):
         # SPARK-51112: Segfault must not occur when converting empty DataFrame with nested array
         # columns to pandas DataFrame.

--- a/python/pyspark/sql/tests/test_collection.py
+++ b/python/pyspark/sql/tests/test_collection.py
@@ -18,9 +18,11 @@
 import unittest
 
 from pyspark.sql.types import (
+    ArrayType,
     StringType,
     IntegerType,
     StructType,
+    StructField,
     BooleanType,
     DateType,
     TimestampType,

--- a/python/pyspark/sql/tests/test_collection.py
+++ b/python/pyspark/sql/tests/test_collection.py
@@ -305,6 +305,7 @@ class DataFrameCollectionTestsMixin:
         # SPARK-51112: Segfault must not occur when converting empty DataFrame with nested array
         # columns to pandas DataFrame.
         import pandas as pd
+
         df = self.spark.createDataFrame(
             data=[],
             schema=StructType(

--- a/python/pyspark/sql/tests/test_collection.py
+++ b/python/pyspark/sql/tests/test_collection.py
@@ -32,6 +32,7 @@ from pyspark.sql.types import (
 )
 from pyspark.testing.sqlutils import (
     ReusedSQLTestCase,
+    assertDataFrameEqual,
     have_pyarrow,
     have_pandas,
     pandas_requirement_message,
@@ -320,7 +321,8 @@ class DataFrameCollectionTestsMixin:
                 ]
             ),
         )
-        df.toPandas()
+        expected_pdf = pd.DataFrame(columns=["b_int", "b"])
+        assertDataFrameEqual(df.toPandas(), expected_pdf)
 
     def test_to_local_iterator(self):
         df = self.spark.range(8, numPartitions=4)

--- a/python/pyspark/sql/tests/test_collection.py
+++ b/python/pyspark/sql/tests/test_collection.py
@@ -289,6 +289,28 @@ class DataFrameCollectionTestsMixin:
         else:
             self.assertEqual(type(pdf["array_struct_col"][0]), list)
 
+    def check_to_pandas_for_empty_df_with_nested_array_columns(self):
+        # SPARK-51112: Segfault must not occur when converting empty DataFrame with nested array
+        # columns to pandas DataFrame.
+        df = self.spark.createDataFrame(
+            data=[],
+            schema=StructType(
+                [
+                    StructField(
+                        name="b_int",
+                        dataType=IntegerType(),
+                        nullable=False,
+                    ),
+                    StructField(
+                        name="b",
+                        dataType=ArrayType(ArrayType(StringType(), True), True),
+                        nullable=True,
+                    ),
+                ]
+            ),
+        )
+        df.toPandas()
+
     def test_to_local_iterator(self):
         df = self.spark.range(8, numPartitions=4)
         expected = df.collect()

--- a/python/pyspark/sql/tests/test_collection.py
+++ b/python/pyspark/sql/tests/test_collection.py
@@ -32,12 +32,12 @@ from pyspark.sql.types import (
 )
 from pyspark.testing.sqlutils import (
     ReusedSQLTestCase,
-    assertDataFrameEqual,
     have_pyarrow,
     have_pandas,
     pandas_requirement_message,
     pyarrow_requirement_message,
 )
+from pyspark.testing.utils import assertDataFrameEqual
 
 
 class DataFrameCollectionTestsMixin:
@@ -304,6 +304,7 @@ class DataFrameCollectionTestsMixin:
     def check_to_pandas_for_empty_df_with_nested_array_columns(self):
         # SPARK-51112: Segfault must not occur when converting empty DataFrame with nested array
         # columns to pandas DataFrame.
+        import pandas as pd
         df = self.spark.createDataFrame(
             data=[],
             schema=StructType(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When the `pyarrow` table is empty, avoid calling the `to_pandas` method due to potential segfault failures. Instead, an empty pandas dataframe is created manually.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Consider the following code:
```python
from pyspark.sql.types import StructField, ArrayType, StringType, StructType, IntegerType
import faulthandler
faulthandler.enable()
spark = SparkSession.builder \
    .remote("sc://localhost:15002") \
    .getOrCreate()
sp_df = spark.createDataFrame(
    data = [],
    schema=StructType(
        [
            StructField(
                name='b_int',
                dataType=IntegerType(),
                nullable=False,
            ),
            StructField(
                name='b',
                dataType=ArrayType(ArrayType(StringType(), True), True),
                nullable=True,
            ),
        ]
    )
)
print(sp_df)
print('Spark dataframe generated.')
print(sp_df.toPandas())
print('Pandas dataframe generated.') 
```
Executing this may lead to a segfault when the line `sp_df.toPandas()` is run.
Example:
```
Thread 0x00000001f1904f40 (most recent call first):
  File "/Users/venkata.gudesa/spark/test_env/lib/python3.13/site-packages/pyarrow/pandas_compat.py", line 808 in table_to_dataframe
  File "/Users/venkata.gudesa/spark/test_env/lib/python3.13/site-packages/pyspark/sql/connect/client/core.py", line 949 in to_pandas
  File "/Users/venkata.gudesa/spark/test_env/lib/python3.13/site-packages/pyspark/sql/connect/dataframe.py", line 1857 in toPandas
  File "<python-input-3>", line 1 in <module>
  File "/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/code.py", line 92 in runcode
  File "/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/_pyrepl/console.py", line 205 in runsource
  File "/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/code.py", line 313 in push
  File "/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/_pyrepl/simple_interact.py", line 160 in run_multiline_interactive_console
  File "/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/_pyrepl/main.py", line 59 in interactive_console
  File "/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/_pyrepl/__main__.py", line 6 in <module>
  File "<frozen runpy>", line 88 in _run_code
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit test.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.