### PR TITLE
[SPARK-50557][CONNECT][SQL] Support RuntimeConfig.contains(..) in Scala SQL Interface

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
@@ -100,6 +100,11 @@ abstract class RuntimeConfig {
   private[sql] def get[T](entry: ConfigEntry[T], default: T): T
 
   /**
+   * Returns whether a particular key is set.
+   */
+  private[sql] def contains(key: String): Boolean
+
+  /**
    * Returns all properties set in this conf.
    *
    * @since 2.0.0

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
@@ -1046,6 +1046,9 @@ class ClientE2ETestSuite
     assert(spark.conf.get(entryWithDefault.key) === "12")
     assert(spark.conf.get(entryWithDefault) === 12)
     assert(spark.conf.get(entryWithDefault, 11) === 12)
+
+    assert(spark.conf.contains(entryWithDefault.key))
+    assert(!spark.conf.contains("nope"))
   }
 
   test("SparkVersion") {

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/RuntimeConfig.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/RuntimeConfig.scala
@@ -87,6 +87,11 @@ class RuntimeConfig private[sql] (client: SparkConnectClient)
   }
 
   /** @inheritdoc */
+  override private[sql] def contains(key: String): Boolean = {
+    get(key, null) != null
+  }
+
+  /** @inheritdoc */
   def getAll: Map[String, String] = {
     val response = executeConfigRequest { builder =>
       builder.getGetAllBuilder


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR restores support for the `contains(..)` method in the `org.apache.spark.sql.RuntimeConfig` interface.

### Why are the changes needed?
This method was used quite a lot in 3rd party libraries. We are adding it back to reduce friction.

### Does this PR introduce _any_ user-facing change?
No, technically this is an internal method :)...

### How was this patch tested?
I added a test for Connect to the `SessionE2ETestSuite`

### Was this patch authored or co-authored using generative AI tooling?
No.