### PR TITLE
[SPARK-51126][PS][DOCS] Optimize the memory usage in kde examples

### DIFF
--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -990,12 +990,12 @@ class PandasOnSparkPlotAccessor(PandasObject):
         .. plotly::
 
             >>> s = ps.Series([1, 2, 2.5, 3, 3.5, 4, 5])
-            >>> s.plot.kde(bw_method=0.3)  # doctest: +SKIP
+            >>> s.plot.kde(bw_method=0.3, ind=100)  # doctest: +SKIP
 
         .. plotly::
 
             >>> s = ps.Series([1, 2, 2.5, 3, 3.5, 4, 5])
-            >>> s.plot.kde(bw_method=3)  # doctest: +SKIP
+            >>> s.plot.kde(bw_method=3, ind=100)  # doctest: +SKIP
 
         The `ind` parameter determines the evaluation points for the
         plot of the estimated KDF:
@@ -1013,7 +1013,7 @@ class PandasOnSparkPlotAccessor(PandasObject):
             ...     'x': [1, 2, 2.5, 3, 3.5, 4, 5],
             ...     'y': [4, 4, 4.5, 5, 5.5, 6, 6],
             ... })
-            >>> df.plot.kde(bw_method=0.3)  # doctest: +SKIP
+            >>> df.plot.kde(bw_method=0.3, ind=100)  # doctest: +SKIP
 
         .. plotly::
 
@@ -1021,7 +1021,7 @@ class PandasOnSparkPlotAccessor(PandasObject):
             ...     'x': [1, 2, 2.5, 3, 3.5, 4, 5],
             ...     'y': [4, 4, 4.5, 5, 5.5, 6, 6],
             ... })
-            >>> df.plot.kde(bw_method=3)  # doctest: +SKIP
+            >>> df.plot.kde(bw_method=3, ind=100)  # doctest: +SKIP
 
         .. plotly::
 

--- a/python/pyspark/sql/plot/core.py
+++ b/python/pyspark/sql/plot/core.py
@@ -415,9 +415,9 @@ class PySparkPlotAccessor:
         >>> data = [(5.1, 3.5, 0), (4.9, 3.0, 0), (7.0, 3.2, 1), (6.4, 3.2, 1), (5.9, 3.0, 2)]
         >>> columns = ["length", "width", "species"]
         >>> df = spark.createDataFrame(data, columns)
-        >>> df.plot.kde(bw_method=0.3)  # doctest: +SKIP
-        >>> df.plot.kde(column=["length", "width"], bw_method=0.3)  # doctest: +SKIP
-        >>> df.plot.kde(column="length", bw_method=0.3)  # doctest: +SKIP
+        >>> df.plot.kde(bw_method=0.3, ind=100)  # doctest: +SKIP
+        >>> df.plot.kde(column=["length", "width"], bw_method=0.3, ind=100)  # doctest: +SKIP
+        >>> df.plot.kde(column="length", bw_method=0.3, ind=100)  # doctest: +SKIP
         """
         return self(kind="kde", column=column, bw_method=bw_method, ind=ind, **kwargs)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Optimize the memory usage in KDE examples, the memory usage for KDE computation should be about 10% X previous value.

### Why are the changes needed?
https://github.com/apache/spark/commit/4b7191d43b4b505faa1e26481311c5e83e6340e5 computes all metrics for all curves together, so only need one pass on the dataset.
however, it increase the memory usage, so fail the dynamic plot generation.


### Does this PR introduce _any_ user-facing change?
yes, minor quality loss

before:
![image](https://github.com/user-attachments/assets/84284a05-6469-45f8-8246-7718e1235aed)


after:
![image](https://github.com/user-attachments/assets/d18ad03d-d4fa-454c-beb4-db12af0c209a)



### How was this patch tested?
manually test, with `bin/pyspark`, the example fails with OOM before

### Was this patch authored or co-authored using generative AI tooling?
no