### PR TITLE
[SPARK-50605][CONNECT][FOLLOW-UP] Install dependencies for Yarn tests in Maven build

### DIFF
--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -176,7 +176,7 @@ jobs:
           python-version: '3.11'
           architecture: x64
       - name: Install Python packages (Python 3.11)
-        if: (contains(matrix.modules, 'sql#core')) || contains(matrix.modules, 'connect')
+        if: (contains(matrix.modules, 'sql#core')) || contains(matrix.modules, 'connect') || (contains(matrix.modules, 'resource-managers#yarn')
         run: |
           python3.11 -m pip install 'numpy>=1.20.0' pyarrow pandas scipy unittest-xml-reporting 'grpcio==1.67.0' 'grpcio-status==1.67.0' 'protobuf==5.29.1'
           python3.11 -m pip list


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR installs Python dependencies for yarn module. This is a followup of https://github.com/apache/spark/pull/49107

### Why are the changes needed?

To fix up the build, see also https://github.com/apache/spark/pull/49107#discussion_r1945123620

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Will monitor the build

### Was this patch authored or co-authored using generative AI tooling?

No.
