### PR TITLE
[SPARK-49531][PYTHON][CONNECT][INFRA][FOLLOW-UP] Match pandas version of Python Connect build with development build

### DIFF
--- a/.github/workflows/build_python_connect.yml
+++ b/.github/workflows/build_python_connect.yml
@@ -72,7 +72,7 @@ jobs:
           python packaging/connect/setup.py sdist
           cd dist
           pip install pyspark*connect-*.tar.gz
-          pip install 'six==1.16.0' 'pandas<=2.2.2' scipy 'plotly>=4.8' 'mlflow>=2.8.1' coverage matplotlib openpyxl 'memory-profiler>=0.61.0' 'scikit-learn>=1.3.2' 'graphviz==0.20.3' torch torchvision torcheval deepspeed unittest-xml-reporting 'plotly>=4.8'
+          pip install 'six==1.16.0' 'pandas==2.2.3' scipy 'plotly>=4.8' 'mlflow>=2.8.1' coverage matplotlib openpyxl 'memory-profiler>=0.61.0' 'scikit-learn>=1.3.2' 'graphviz==0.20.3' torch torchvision torcheval deepspeed unittest-xml-reporting 'plotly>=4.8'
       - name: Run tests
         env:
           SPARK_TESTING: 1


### PR DESCRIPTION
### What changes were proposed in this pull request?

This Pr is a followup of https://github.com/apache/spark/pull/48139 that matches pandas version in Python Connect build

### Why are the changes needed?

To fix https://github.com/apache/spark/actions/runs/13186023784/job/36808188511

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Will monitor the CI 

### Was this patch authored or co-authored using generative AI tooling?

No.