### PR TITLE
[SPARK-50945][ML][PYTHON][CONNECT] Support Summarizer and SummaryBuilder on Connect

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/sql/ml/InternalFunctionRegistration.scala
+++ b/mllib/src/main/scala/org/apache/spark/sql/ml/InternalFunctionRegistration.scala
@@ -99,7 +99,7 @@ object InternalFunctionRegistration {
   }
 
   FunctionRegistry
-    .registerInternalExpression[SummaryBuilderImpl.MetricsAggregate]("ml_aggregate_metrics")
+    .registerInternalExpression[SummaryBuilderImpl.MetricsAggregate]("aggregate_metrics")
 }
 
 class InternalFunctionRegistration extends SparkSessionExtensionsProvider {

--- a/mllib/src/main/scala/org/apache/spark/sql/ml/InternalFunctionRegistration.scala
+++ b/mllib/src/main/scala/org/apache/spark/sql/ml/InternalFunctionRegistration.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.ml
 
 import org.apache.spark.ml.linalg.{SparseVector, Vector, Vectors}
+import org.apache.spark.ml.stat._
 import org.apache.spark.mllib.linalg.{SparseVector => OldSparseVector, Vector => OldVector}
 import org.apache.spark.sql.{SparkSessionExtensions, SparkSessionExtensionsProvider}
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
@@ -96,6 +97,9 @@ object InternalFunctionRegistration {
     case exprs =>
       throw QueryCompilationErrors.wrongNumArgsError("array_to_vector", "1", exprs.size)
   }
+
+  FunctionRegistry
+    .registerInternalExpression[SummaryBuilderImpl.MetricsAggregate]("ml_aggregate_metrics")
 }
 
 class InternalFunctionRegistration extends SparkSessionExtensionsProvider {

--- a/python/pyspark/ml/stat.py
+++ b/python/pyspark/ml/stat.py
@@ -416,6 +416,17 @@ class Summarizer:
     @staticmethod
     def _get_single_metric(col: Column, weightCol: Optional[Column], metric: str) -> Column:
         col, weightCol = Summarizer._check_param(col, weightCol)
+
+        if is_remote():
+            # The alias name maybe different from the one in Spark Classic,
+            # because we cannot get the same string representation of the Column object.
+            return (
+                Summarizer.metrics(metric)
+                .summary(col, weightCol)
+                .getField(metric)
+                .alias(f"{metric}({col._expr})")
+            )
+
         return Column(
             JavaWrapper._new_java_obj(
                 "org.apache.spark.ml.stat.Summarizer." + metric, col._jc, weightCol._jc
@@ -457,6 +468,12 @@ class Summarizer:
         -------
         :py:class:`pyspark.ml.stat.SummaryBuilder`
         """
+        if is_remote():
+            builder = SummaryBuilder(None)
+            builder._metrics = [m for m in metrics]  # type: ignore[attr-defined]
+            builder._java_obj = None
+            return builder
+
         from pyspark.core.context import SparkContext
         from pyspark.sql.classic.column import _to_seq
 
@@ -481,7 +498,8 @@ class SummaryBuilder(JavaWrapper):
     """
 
     def __init__(self, jSummaryBuilder: "JavaObject"):
-        super(SummaryBuilder, self).__init__(jSummaryBuilder)
+        if not is_remote():
+            super(SummaryBuilder, self).__init__(jSummaryBuilder)
 
     def summary(self, featuresCol: Column, weightCol: Optional[Column] = None) -> Column:
         """
@@ -503,6 +521,16 @@ class SummaryBuilder(JavaWrapper):
             an aggregate column that contains the statistics. The exact content of this
             structure is determined during the creation of the builder.
         """
+        if is_remote():
+            from pyspark.sql.connect.functions import builtin as F
+
+            return F._invoke_function(
+                "ml_aggregate_metrics",
+                F.array([F.lit(m) for m in self._metrics]),  # type: ignore[attr-defined]
+                featuresCol,
+                weightCol if weightCol is not None else F.lit(1.0),
+            )
+
         featuresCol, weightCol = Summarizer._check_param(featuresCol, weightCol)
         assert self._java_obj is not None
 

--- a/python/pyspark/ml/stat.py
+++ b/python/pyspark/ml/stat.py
@@ -525,7 +525,7 @@ class SummaryBuilder(JavaWrapper):
             from pyspark.sql.connect.functions import builtin as F
 
             return F._invoke_function(
-                "ml_aggregate_metrics",
+                "aggregate_metrics",
                 F.array([F.lit(m) for m in self._metrics]),  # type: ignore[attr-defined]
                 featuresCol,
                 weightCol if weightCol is not None else F.lit(1.0),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -905,7 +905,7 @@ object FunctionRegistry {
   /** Registry for internal functions used by Connect and the Column API. */
   private[sql] val internal: SimpleFunctionRegistry = new SimpleFunctionRegistry
 
-  private def registerInternalExpression[T <: Expression : ClassTag](
+  private[spark] def registerInternalExpression[T <: Expression : ClassTag](
       name: String,
       setAlias: Boolean = false): Unit = {
     val (info, builder) = FunctionRegistryBase.build[T](name, None)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support Summarizer and SummaryBuilder on Connect


### Why are the changes needed?
For feature parity

### Does this PR introduce _any_ user-facing change?
yes, new feature supported

```
In [2]:         data = [
   ...:             [Vectors.dense([1, 0, 0, -2]), 1.0],
   ...:             [Vectors.dense([4, 5, 0, 3]), 2.0],
   ...:             [Vectors.dense([6, 7, 0, 8]), 1.0],
   ...:             [Vectors.dense([9, 0, 0, 1]), 1.0],
   ...:         ]
   ...:         df = spark.createDataFrame(data, ["features", "weight"])
   ...:
   ...:         summarizer = Summarizer.metrics("mean", "count")

In [3]: df.select(summarizer.summary(df.features)).show(truncate=False)
+--------------------------------+
|aggregate_metrics(features, 1.0)|
+--------------------------------+
|{[5.0,3.0,0.0,2.5], 4}          |
+--------------------------------+
```


### How was this patch tested?
new tests


### Was this patch authored or co-authored using generative AI tooling?
no