### PR TITLE
[SPARK-51080][ML][PYTHON][CONNECT] Fix save/load for `PowerIterationClustering`

### DIFF
--- a/mllib/src/main/resources/META-INF/services/org.apache.spark.ml.Transformer
+++ b/mllib/src/main/resources/META-INF/services/org.apache.spark.ml.Transformer
@@ -65,6 +65,7 @@ org.apache.spark.ml.clustering.BisectingKMeansModel
 org.apache.spark.ml.clustering.GaussianMixtureModel
 org.apache.spark.ml.clustering.DistributedLDAModel
 org.apache.spark.ml.clustering.LocalLDAModel
+org.apache.spark.ml.clustering.PowerIterationClusteringWrapper
 
 # recommendation
 org.apache.spark.ml.recommendation.ALSModel

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/PowerIterationClustering.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/PowerIterationClustering.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.ml.clustering
 
 import org.apache.spark.annotation.Since
+import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
 import org.apache.spark.ml.util._
@@ -190,4 +191,33 @@ object PowerIterationClustering extends DefaultParamsReadable[PowerIterationClus
 
   @Since("2.4.0")
   override def load(path: String): PowerIterationClustering = super.load(path)
+}
+
+private[spark] class PowerIterationClusteringWrapper(override val uid: String)
+  extends Transformer with PowerIterationClusteringParams with DefaultParamsWritable {
+
+  def this() = this(Identifiable.randomUID("PowerIterationClusteringWrapper"))
+
+  override def transform(dataset: Dataset[_]): DataFrame =
+    throw new UnsupportedOperationException("transform not supported")
+
+  override def transformSchema(schema: StructType): StructType =
+    throw new UnsupportedOperationException("transformSchema not supported")
+
+  override def copy(extra: ParamMap): PowerIterationClusteringWrapper = defaultCopy(extra)
+
+  override def write: MLWriter = new MLWriter {
+    override protected def saveImpl(path: String): Unit = {
+      new PowerIterationClustering(uid).copy(paramMap).save(path)
+    }
+  }
+}
+
+private[spark] object PowerIterationClusteringWrapper
+  extends DefaultParamsReadable[PowerIterationClusteringWrapper] {
+
+  override def load(path: String): PowerIterationClusteringWrapper = {
+    val pic = PowerIterationClustering.load(path)
+    new PowerIterationClusteringWrapper(pic.uid).copy(pic.paramMap)
+  }
 }

--- a/python/pyspark/ml/connect/readwrite.py
+++ b/python/pyspark/ml/connect/readwrite.py
@@ -262,10 +262,6 @@ class RemoteMLReader(MLReader[RL]):
                 clazz.__module__.replace("pyspark", "org.apache.spark") + "." + clazz.__name__
             )
 
-            print()
-            print(java_qualified_class_name)
-            print()
-
             command = pb2.Command()
             command.ml_command.read.CopyFrom(
                 pb2.MlCommand.Read(

--- a/python/pyspark/ml/connect/readwrite.py
+++ b/python/pyspark/ml/connect/readwrite.py
@@ -96,6 +96,7 @@ class RemoteMLWriter(MLWriter):
         from pyspark.ml.pipeline import Pipeline, PipelineModel
         from pyspark.ml.tuning import CrossValidator, TrainValidationSplit
         from pyspark.ml.classification import OneVsRest, OneVsRestModel
+        from pyspark.ml.clustering import PowerIterationClustering
 
         # Spark Connect ML is built on scala Spark.ML, that means we're only
         # supporting JavaModel or JavaEstimator or JavaEvaluator
@@ -188,6 +189,21 @@ class RemoteMLWriter(MLWriter):
             ovrm_writer = OneVsRestModelWriter(instance)
             ovrm_writer.session(session)  # type: ignore[arg-type]
             ovrm_writer.save(path)
+
+        elif isinstance(instance, PowerIterationClustering):
+            transformer = JavaTransformer(
+                "org.apache.spark.ml.clustering.PowerIterationClusteringWrapper"
+            )
+            transformer._resetUid(instance.uid)
+            transformer._paramMap = instance._paramMap
+            RemoteMLWriter.saveInstance(
+                transformer,  # type: ignore[arg-type]
+                path,
+                session,
+                shouldOverwrite,
+                optionMap,
+            )
+
         else:
             raise NotImplementedError(f"Unsupported write for {instance.__class__}")
 
@@ -224,6 +240,7 @@ class RemoteMLReader(MLReader[RL]):
         from pyspark.ml.pipeline import Pipeline, PipelineModel
         from pyspark.ml.tuning import CrossValidator, TrainValidationSplit
         from pyspark.ml.classification import OneVsRest, OneVsRestModel
+        from pyspark.ml.clustering import PowerIterationClustering
 
         if (
             issubclass(clazz, JavaModel)
@@ -244,6 +261,10 @@ class RemoteMLReader(MLReader[RL]):
             java_qualified_class_name = (
                 clazz.__module__.replace("pyspark", "org.apache.spark") + "." + clazz.__name__
             )
+
+            print()
+            print(java_qualified_class_name)
+            print()
 
             command = pb2.Command()
             command.ml_command.read.CopyFrom(
@@ -331,6 +352,29 @@ class RemoteMLReader(MLReader[RL]):
             ovrm_reader = OneVsRestModelReader(OneVsRestModel)
             ovrm_reader.session(session)
             return ovrm_reader.load(path)
+
+        elif issubclass(clazz, PowerIterationClustering):
+            java_qualified_class_name = (
+                "org.apache.spark.ml.clustering.PowerIterationClusteringWrapper"
+            )
+
+            command = pb2.Command()
+            command.ml_command.read.CopyFrom(
+                pb2.MlCommand.Read(
+                    operator=pb2.MlOperator(
+                        name=java_qualified_class_name, type=pb2.MlOperator.TRANSFORMER
+                    ),
+                    path=path,
+                )
+            )
+            (_, properties, _) = session.client.execute_command(command)
+            result = deserialize(properties)
+
+            instance = PowerIterationClustering()
+            instance._resetUid(result.uid)
+            params = {k: deserialize_param(v) for k, v in result.params.params.items()}
+            instance._set(**params)
+            return instance  # type: ignore[return-value]
 
         else:
             raise RuntimeError(f"Unsupported read for {clazz}")

--- a/python/pyspark/ml/tests/test_clustering.py
+++ b/python/pyspark/ml/tests/test_clustering.py
@@ -462,7 +462,6 @@ class ClusteringTestsMixin:
             model2 = DistributedLDAModel.load(d)
             self.assertEqual(str(model), str(model2))
 
-    # TODO(SPARK-51080): Fix save/load for PowerIterationClustering
     def test_power_iteration_clustering(self):
         spark = self.spark
 
@@ -495,6 +494,16 @@ class ClusteringTestsMixin:
         assignments = pic.assignClusters(df)
         self.assertEqual(assignments.columns, ["id", "cluster"])
         self.assertEqual(assignments.count(), 6)
+
+        # save & load
+        with tempfile.TemporaryDirectory(prefix="power_iteration_clustering") as d:
+            pic.write().overwrite().save(d)
+            pic2 = PowerIterationClustering.load(d)
+            self.assertEqual(str(pic), str(pic2))
+            self.assertEqual(pic.uid, pic2.uid)
+            self.assertEqual(pic.getK(), pic2.getK())
+            self.assertEqual(pic.getMaxIter(), pic2.getMaxIter())
+            self.assertEqual(pic.getWeightCol(), pic2.getWeightCol())
 
 
 class ClusteringTests(ClusteringTestsMixin, unittest.TestCase):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix save/load for `PowerIterationClustering`


### Why are the changes needed?
for feature parity


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
new test

### Was this patch authored or co-authored using generative AI tooling?
no
