### PR TITLE
[SPARK-51131][SQL] Throw exception when SQL Script is found inside EXECUTE IMMEDIATE command

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4629,6 +4629,12 @@
     ],
     "sqlState" : "42K0I"
   },
+  "SQL_SCRIPT_IN_EXECUTE_IMMEDIATE" : {
+    "message" : [
+      "SQL Scripts in EXECUTE IMMEDIATE commands are not allowed. Please ensure that the SQL query provided (<sqlString>) is not SQL Script."
+    ],
+    "sqlState" : "07501"
+  },
   "STAR_GROUP_BY_POS" : {
     "message" : [
       "Star (*) is not allowed in a select list when GROUP BY an ordinal position is used."
@@ -5802,12 +5808,6 @@
         "message" : [
           "Positional parameters are not supported with SQL Scripting."
         ]
-      },
-      "SQL_SCRIPT_IN_EXECUTE_IMMEDIATE" : {
-        "message" : [
-          "SQL Scripts in EXECUTE IMMEDIATE commands are not allowed. Please ensure that the SQL query provided (<sqlString>) is not SQL Script."
-        ],
-        "sqlState" : "07501"
       },
       "STATE_STORE_MULTIPLE_COLUMN_FAMILIES" : {
         "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4631,7 +4631,7 @@
   },
   "SQL_SCRIPT_IN_EXECUTE_IMMEDIATE" : {
     "message" : [
-      "SQL Scripts in EXECUTE IMMEDIATE commands are not allowed. Please ensure that the SQL query provided (<sqlString>) is not SQL Script."
+      "SQL Scripts in EXECUTE IMMEDIATE commands are not allowed. Please ensure that the SQL query provided (<sqlString>) is not SQL Script. Make sure the sql_string is a well-formed SQL statement and does not contain BEGIN and END."
     ],
     "sqlState" : "07501"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5803,6 +5803,12 @@
           "Positional parameters are not supported with SQL Scripting."
         ]
       },
+      "SQL_SCRIPT_IN_EXECUTE_IMMEDIATE" : {
+        "message" : [
+          "SQL Scripts in EXECUTE IMMEDIATE commands are not allowed. Please ensure that the SQL query provided (<sqlString>) is not SQL Script."
+        ],
+        "sqlState" : "07501"
+      },
       "STATE_STORE_MULTIPLE_COLUMN_FAMILIES" : {
         "message" : [
           "Creating multiple column families with <stateStoreProvider> is not supported."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/executeImmediate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/executeImmediate.scala
@@ -21,7 +21,7 @@ import scala.util.{Either, Left, Right}
 
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, VariableReference}
 import org.apache.spark.sql.catalyst.parser.ParseException
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SetVariable}
+import org.apache.spark.sql.catalyst.plans.logical.{CompoundBody, LogicalPlan, SetVariable}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.{EXECUTE_IMMEDIATE, TreePattern}
 import org.apache.spark.sql.connector.catalog.CatalogManager
@@ -177,6 +177,10 @@ class SubstituteExecuteImmediate(val catalogManager: CatalogManager)
       }
     } else {
       catalogManager.v1SessionCatalog.parser.parsePlan(queryString)
+    }
+
+    if (plan.isInstanceOf[CompoundBody]) {
+      throw QueryCompilationErrors.sqlScriptInExecuteImmediate(queryString)
     }
 
     // do not allow nested execute immediate

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -4103,6 +4103,12 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("sqlString" -> toSQLStmt(queryString)))
   }
 
+  def sqlScriptInExecuteImmediate(sqlScriptString: String): Throwable = {
+    throw new AnalysisException(
+      errorClass = "SQL_SCRIPT_IN_EXECUTE_IMMEDIATE",
+      messageParameters = Map("sqlString" -> toSQLStmt(sqlScriptString)))
+  }
+
   def dataSourceTableSchemaMismatchError(
       dsSchema: StructType, expectedSchema: StructType): Throwable = {
     new AnalysisException(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -917,6 +917,22 @@ class AnalysisErrorSuite extends AnalysisTest with DataTypeErrorsBase {
       ))
   }
 
+  test("EXEC IMMEDIATE - SQL Script as sqlString parameter") {
+    withSQLConf(SQLConf.SQL_SCRIPTING_ENABLED.key -> "true") {
+      val execImmediatePlan = ExecuteImmediateQuery(
+        Seq.empty,
+        scala.util.Left("BEGIN SELECT 1; END"),
+        Seq.empty)
+
+      assertAnalysisErrorCondition(
+        inputPlan = execImmediatePlan,
+        expectedErrorCondition = "SQL_SCRIPT_IN_EXECUTE_IMMEDIATE",
+        expectedMessageParameters = Map(
+          "sqlString" -> "BEGIN SELECT 1; END"
+        ))
+    }
+  }
+
   test("SPARK-6452 regression test") {
     // CheckAnalysis should throw AnalysisException when Aggregate contains missing attribute(s)
     // Since we manually construct the logical plan at here and Sum only accept

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -917,22 +917,6 @@ class AnalysisErrorSuite extends AnalysisTest with DataTypeErrorsBase {
       ))
   }
 
-  test("EXEC IMMEDIATE - SQL Script as sqlString parameter") {
-    withSQLConf(SQLConf.SQL_SCRIPTING_ENABLED.key -> "true") {
-      val execImmediatePlan = ExecuteImmediateQuery(
-        Seq.empty,
-        scala.util.Left("BEGIN SELECT 1; END"),
-        Seq.empty)
-
-      assertAnalysisErrorCondition(
-        inputPlan = execImmediatePlan,
-        expectedErrorCondition = "SQL_SCRIPT_IN_EXECUTE_IMMEDIATE",
-        expectedMessageParameters = Map(
-          "sqlString" -> "BEGIN SELECT 1; END"
-        ))
-    }
-  }
-
   test("SPARK-6452 regression test") {
     // CheckAnalysis should throw AnalysisException when Aggregate contains missing attribute(s)
     // Since we manually construct the logical plan at here and Sum only accept

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.{QueryTest}
+import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.sql.test.SharedSparkSession
 
 class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
@@ -34,6 +34,18 @@ class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
       checkAnswer(originalQuery, newQuery.collect().toIndexedSeq)
     } finally {
       spark.sql("DROP TEMPORARY VARIABLE IF EXISTS parm;")
+    }
+  }
+
+  test("SQL Scripting not supported inside EXECUTE IMMEDIATE") {
+    withSQLConf("spark.sql.scripting.enabled" -> "true") {
+      val executeImmediateText = "EXECUTE IMMEDIATE 'BEGIN SELECT 1; END'"
+      checkError(
+        exception = intercept[AnalysisException ] {
+          spark.sql(executeImmediateText)
+        },
+        condition = "SQL_SCRIPT_IN_EXECUTE_IMMEDIATE",
+        parameters = Map("sqlString" -> "BEGIN SELECT 1; END"))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
@@ -38,7 +39,7 @@ class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SQL Scripting not supported inside EXECUTE IMMEDIATE") {
-    withSQLConf("spark.sql.scripting.enabled" -> "true") {
+    withSQLConf(SQLConf.SQL_SCRIPTING_ENABLED.key -> "true") {
       val executeImmediateText = "EXECUTE IMMEDIATE 'BEGIN SELECT 1; END'"
       checkError(
         exception = intercept[AnalysisException ] {


### PR DESCRIPTION
### What changes were proposed in this pull request?
An exception is thrown when user tries to use SQL Script as query string in EXECUTE IMMEDIATE.

### Why are the changes needed?
This changes are needed to forbid scripts inside EXECUTE IMMEDIATE to not introduce additional complexity in script execution or leave system in undefined state.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
New test in `ExecuteImmediateEndToEndSuite`.


### Was this patch authored or co-authored using generative AI tooling?
No
