### PR TITLE
[SPARK-48353][SQL][FOLLOWUP] Enable ANSI for SQL Scripting execution suites

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
@@ -50,7 +50,9 @@ class SqlScriptingE2eSuite extends QueryTest with SharedSparkSession {
 
   // Tests setup
   override protected def sparkConf: SparkConf = {
-    super.sparkConf.set(SQLConf.SQL_SCRIPTING_ENABLED.key, "true")
+    super.sparkConf
+      .set(SQLConf.ANSI_ENABLED.key, "true")
+      .set(SQLConf.SQL_SCRIPTING_ENABLED.key, "true")
   }
 
   // Tests

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -38,7 +38,9 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
 
   // Tests setup
   override protected def sparkConf: SparkConf = {
-    super.sparkConf.set(SQLConf.SQL_SCRIPTING_ENABLED.key, "true")
+    super.sparkConf
+      .set(SQLConf.ANSI_ENABLED.key, "true")
+      .set(SQLConf.SQL_SCRIPTING_ENABLED.key, "true")
   }
 
   // Helpers


### PR DESCRIPTION
### What changes were proposed in this pull request?
Keep ANSI enabled for SQL Scripting execution suites to enable proper testing of exception handling.

### Why are the changes needed?
13 new tests in `SqlScriptingExecutionSuite` and `SqlScriptingE2eSuite` introduced in https://github.com/apache/spark/pull/49427 will fail to execute in non-ANSI mode and the NON-ANSI daily test failed:
![image](https://github.com/user-attachments/assets/78a0b6fd-1b98-4b85-80e5-688e4b447cae)

If ANSI is off, code that should trigger exception fails silently (zero division does not throw). We want to keep ANSI behavior so that we can test exception handling properly. 


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
