### PR TITLE
[SPARK-51138][PYTHON][CONNECT][TESTS] Skip pyspark.sql.tests.connect.test_parity_frame_plot_plotly.FramePlotPlotlyParityTests.test_area_plot

### DIFF
--- a/python/pyspark/pandas/tests/connect/plot/test_parity_frame_plot_plotly.py
+++ b/python/pyspark/pandas/tests/connect/plot/test_parity_frame_plot_plotly.py
@@ -24,7 +24,9 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils, TestUtils
 class DataFramePlotPlotlyParityTests(
     DataFramePlotPlotlyTestsMixin, PandasOnSparkTestUtils, TestUtils, ReusedConnectTestCase
 ):
-    pass
+    @unittest.skip("SPARK-51137: Should be reenabled")
+    def test_area_plot(self):
+        self.test_area_plot()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip pyspark.sql.tests.connect.test_parity_frame_plot_plotly.FramePlotPlotlyParityTests.test_area_plot.

The failure happens in https://github.com/apache/spark/actions/runs/13228738315/job/36922950044 build

### Why are the changes needed?

One failure here stops the Python build so it can't test others. Filed a JIRA to reenable https://issues.apache.org/jira/browse/SPARK-51137

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Will monitor the build.

### Was this patch authored or co-authored using generative AI tooling?
No.
