### PR TITLE
[SPARK-51148][BUILD] Upgrade `zstd-jni` to 1.5.6-10

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -284,4 +284,4 @@ xz/1.10//xz-1.10.jar
 zjsonpatch/7.0.1//zjsonpatch-7.0.1.jar
 zookeeper-jute/3.9.3//zookeeper-jute-3.9.3.jar
 zookeeper/3.9.3//zookeeper-3.9.3.jar
-zstd-jni/1.5.6-9//zstd-jni-1.5.6-9.jar
+zstd-jni/1.5.6-10//zstd-jni-1.5.6-10.jar

--- a/pom.xml
+++ b/pom.xml
@@ -841,7 +841,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.6-9</version>
+        <version>1.5.6-10</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `zstd-jni` to 1.5.6-10 for Apache Spark 4.1.0.

### Why are the changes needed?

To bring a new improvement,
- https://github.com/luben/zstd-jni/pull/347

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.