### PR TITLE
Revert "[SPARK-51140][ML][4.0] Sort the params before saving"

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
@@ -486,8 +486,8 @@ private[ml] object DefaultParamsWriter {
       paramMap: Option[JValue]): String = {
     val uid = instance.uid
     val cls = instance.getClass.getName
-    val params = instance.paramMap.toSeq.sortBy(_.param.name)
-    val defaultParams = instance.defaultParamMap.toSeq.sortBy(_.param.name)
+    val params = instance.paramMap.toSeq
+    val defaultParams = instance.defaultParamMap.toSeq
     val jsonParams = paramMap.getOrElse(render(params.map { case ParamPair(p, v) =>
       p.name -> parse(p.jsonEncode(v))
     }.toList))


### PR DESCRIPTION
This reverts commit fab541d43395a61c1b295aa46717d183bf4236ff.

It is just an improvement, no need to backported in 4.0