### PR TITLE
[MINOR][DOCS] Fix incorrect description of constraint on spark.sql.adaptive.coalescePartitions.minPartitionSize

### DIFF
--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -286,7 +286,7 @@ This feature coalesces the post shuffle partitions based on the map output stati
      <td><code>spark.sql.adaptive.coalescePartitions.minPartitionSize</code></td>
      <td>1MB</td>
      <td>
-       The minimum size of shuffle partitions after coalescing. Its value can be at most 20% of <code>spark.sql.adaptive.advisoryPartitionSizeInBytes</code>. This is useful when the target size is ignored during partition coalescing, which is the default case.
+       The minimum size of shuffle partitions after coalescing. This is useful when the target size is ignored during partition coalescing, which is the default case.
      </td>
      <td>3.2.0</td>
    </tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR addresses a minor problem in the SQL performance guide's description of the `spark.sql.adaptive.coalescePartitions.minPartitionSize` configuration.

Currently, the guide says:

> The minimum size of shuffle partitions after coalescing. Its value can be at most 20% of `spark.sql.adaptive.advisoryPartitionSizeInBytes`. This is useful when the target size is ignored during partition coalescing, which is the default case.

but the second sentence is not true because the 20% limitation was removed in https://github.com/apache/spark/pull/33655#discussion_r683582184 (SPARK-36430), which shipped in 3.2.0. That PR updated the in-code description but not the guide on the web.

### Why are the changes needed?

Incorrect doc is misleading.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

n/a

### Was this patch authored or co-authored using generative AI tooling?

No.