### PR TITLE
[SPARK-51151][SS] Fix internal and public API naming for `TimeMode.None()` for TransformWithState

### DIFF
--- a/sql/api/src/main/java/org/apache/spark/sql/streaming/TimeMode.java
+++ b/sql/api/src/main/java/org/apache/spark/sql/streaming/TimeMode.java
@@ -19,7 +19,7 @@ package org.apache.spark.sql.streaming;
 
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.catalyst.plans.logical.EventTime$;
-import org.apache.spark.sql.catalyst.plans.logical.NoTime$;
+import org.apache.spark.sql.catalyst.plans.logical.None$;
 import org.apache.spark.sql.catalyst.plans.logical.ProcessingTime$;
 
 /**
@@ -32,7 +32,7 @@ public class TimeMode {
     /**
      * Neither timers nor ttl is supported in this mode.
      */
-    public static final TimeMode None() { return NoTime$.MODULE$; }
+    public static final TimeMode None() { return None$.MODULE$; }
 
     /**
      * Stateful processor that uses query processing time to register timers and

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/TimeMode.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/TimeMode.scala
@@ -22,7 +22,7 @@ import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.sql.streaming.TimeMode
 
 /** TimeMode types used in transformWithState operator */
-case object NoTime extends TimeMode
+case object None extends TimeMode
 
 case object ProcessingTime extends TimeMode
 
@@ -32,7 +32,7 @@ object TimeModes {
   def apply(timeMode: String): TimeMode = {
     timeMode.toLowerCase(Locale.ROOT) match {
       case "none" =>
-        NoTime
+        None
       case "processingtime" =>
         ProcessingTime
       case "eventtime" =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/RelationalGroupedDataset.scala
@@ -554,7 +554,7 @@ class RelationalGroupedDataset protected[sql](
     Dataset.ofRows(df.sparkSession,
       UpdateEventTimeWatermarkColumn(
         UnresolvedAttribute(eventTimeColumnName),
-        None,
+        scala.None,
         transformWithStateDataset.logicalPlan))
   }
 
@@ -606,7 +606,7 @@ private[sql] object RelationalGroupedDataset {
   private def alias(expr: Expression): NamedExpression = expr match {
     case expr: NamedExpression => expr
     case a: AggregateExpression => UnresolvedAlias(a, Some(generateAlias))
-    case _ if !expr.resolved => UnresolvedAlias(expr, None)
+    case _ if !expr.resolved => UnresolvedAlias(expr, scala.None)
     case expr: Expression => Alias(expr, toPrettySQL(expr))()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImplBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImplBase.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution.streaming
 
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.catalyst.plans.logical.NoTime
+import org.apache.spark.sql.catalyst.plans.logical.{None => TimeModeNone}
 import org.apache.spark.sql.execution.streaming.StatefulProcessorHandleState.{INITIALIZED, PRE_INIT, StatefulProcessorHandleState, TIMER_PROCESSED}
 import org.apache.spark.sql.execution.streaming.state.StateStoreErrors
 import org.apache.spark.sql.streaming.{StatefulProcessorHandle, TimeMode}
@@ -34,7 +34,7 @@ abstract class StatefulProcessorHandleImplBase(
   def getHandleState: StatefulProcessorHandleState = currState
 
   def verifyTimerOperations(operationType: String): Unit = {
-    if (timeMode == NoTime) {
+    if (timeMode == TimeModeNone) {
       throw StateStoreErrors.cannotPerformOperationWithInvalidTimeMode(operationType,
         timeMode.toString)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -1495,7 +1495,7 @@ abstract class TransformWithStateSuite extends StateStoreMetricsTest
         )
         val operatorPropsJson = df.select("operatorProperties").collect().head.getString(0)
         val operatorProperties = TransformWithStateOperatorProperties.fromJson(operatorPropsJson)
-        assert(operatorProperties.timeMode == "NoTime")
+        assert(operatorProperties.timeMode == "None")
         assert(operatorProperties.outputMode == "Update")
         assert(operatorProperties.stateVariables.length == 1)
         assert(operatorProperties.stateVariables.head.stateName == "countState")
@@ -1626,7 +1626,7 @@ abstract class TransformWithStateSuite extends StateStoreMetricsTest
               condition = "STATE_STORE_INVALID_CONFIG_AFTER_RESTART",
               parameters = Map(
                 "configName" -> "timeMode",
-                "oldConfig" -> "NoTime",
+                "oldConfig" -> "None",
                 "newConfig" -> "ProcessingTime")
             )
           }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently the naming of `TimeMode.None()` is different with internal case class `case object None extends TimeMode`. This leads to `TimeMode.None().toStr()` returning "NoTime" and in streaming progress metrics, TimeMode.None() is displaying "NoTime" to users. This PR fixes the discrepancies and will use unified name as "None".

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fixing naming discrepancies and avoid confusions from users.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. Only metrics naming changes.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.