### PR TITLE
[SPARK-51152][PYTHON][SQL][DOCS] Add usage examples for the get_json_object function

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -20147,8 +20147,8 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
     |  2|value12|value13|
     +---+-------+-------+
 
-    >>> extracted3 = get_json_object(df.jarray, '$[*].f1').alias("c0")
-    >>> extracted4 = get_json_object(df.jarray, '$[*].f2').alias("c1")
+    >>> extracted3 = sf.get_json_object(df.jarray, '$[*].f1').alias("c0")
+    >>> extracted4 = sf.get_json_object(df.jarray, '$[*].f2').alias("c1")
     >>> df.select(df.key, extracted3, extracted4).show()
     +---+-------------------+---------+
     |key|                 c0|       c1|

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -20115,11 +20115,23 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
 
     Examples
     --------
+    Example1: Get json object from json object
+
     >>> data = [("1", '''{"f1": "value1", "f2": "value2"}'''), ("2", '''{"f1": "value12"}''')]
     >>> df = spark.createDataFrame(data, ("key", "jstring"))
     >>> df.select(df.key, get_json_object(df.jstring, '$.f1').alias("c0"), \\
     ...                   get_json_object(df.jstring, '$.f2').alias("c1") ).collect()
     [Row(key='1', c0='value1', c1='value2'), Row(key='2', c0='value12', c1=None)]
+
+    Example2: Get json object from json array object
+    data = [("1", '''[{"f1": "value1", "f2": "value2"},{"f1": "value3", "f2": "value4"}]'''), ("2", '''[{"f1": "value12"},{"f1": "value13"}]''')]
+    df = spark.createDataFrame(data, ("key", "jarray"))
+    df.select(df.key, get_json_object(df.jarray, '$[0].f1').alias("c0"), \\
+    ...                   get_json_object(df.jarray, '$[0].f2').alias("c1") ).collect()
+    [Row(key='1', c0='value1', c1='value2'), Row(key='2', c0='value12', c1=None)]
+    df.select(df.key, get_json_object(df.jarray, '$[*].f1').alias("c0"), \\
+    ...                   get_json_object(df.jarray, '$[*].f2').alias("c1") ).collect()
+    [Row(key='1', c0='["value1","value3"]', c1='["value2","value4"]'), Row(key='2', c0='["value12","value13"]', c1=None)]
     """
     from pyspark.sql.classic.column import _to_java_column
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -20124,13 +20124,15 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
     [Row(key='1', c0='value1', c1='value2'), Row(key='2', c0='value12', c1=None)]
 
     Example 2: Extracts a json object from json array
-    data = [("1", '''[{"f1": "value1", "f2": "value2"},{"f1": "value3", "f2": "value4"}]'''), \\
+
+    >>> data = [("1", '''[{"f1": "value1", "f2": "value2"},{"f1": "value3", "f2": "value4"}]'''), \\
     ...                   ("2", '''[{"f1": "value12"},{"f1": "value13"}]''')]
-    df = spark.createDataFrame(data, ("key", "jarray"))
-    df.select(df.key, get_json_object(df.jarray, '$[0].f1').alias("c0"), \\
+    >>> df = spark.createDataFrame(data, ("key", "jarray"))
+    >>> df.select(df.key, get_json_object(df.jarray, '$[0].f1').alias("c0"), \\
     ...                   get_json_object(df.jarray, '$[0].f2').alias("c1") ).collect()
     [Row(key='1', c0='value1', c1='value2'), Row(key='2', c0='value12', c1=None)]
-    df.select(df.key, get_json_object(df.jarray, '$[*].f1').alias("c0"), \\
+
+    >>> df.select(df.key, get_json_object(df.jarray, '$[*].f1').alias("c0"), \\
     ...                   get_json_object(df.jarray, '$[*].f2').alias("c1") ).collect()
     [Row(key='1', c0='["value1","value3"]', c1='["value2","value4"]'), \\
     ...                   Row(key='2', c0='["value12","value13"]', c1=None)]

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -20125,16 +20125,16 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
 
     Example 2: Extracts a json object from json array
 
-    >>> data = [("1", '''[{"f1": "value1", "f2": "value2"},{"f1": "value3", "f2": "value4"}]'''), \\
-    ...                   ("2", '''[{"f1": "value12"}]''')]
+    >>> data = [("1", '''[{"f1": "value1"},{"f1": "value2"}]'''), \\
+    ...                   ("2", '''[{"f1": "value12"},{"f2": "value13"}]''')]
     >>> df = spark.createDataFrame(data, ("key", "jarray"))
     >>> df.select(df.key, get_json_object(df.jarray, '$[0].f1').alias("c0"), \\
-    ...                   get_json_object(df.jarray, '$[0].f2').alias("c1") ).collect()
-    [Row(key='1', c0='value1', c1='value2'), Row(key='2', c0='value12', c1=None)]
+    ...                   get_json_object(df.jarray, '$[1].f2').alias("c1") ).collect()
+    [Row(key='1', c0='value1', c1=None), Row(key='2', c0='value12', c1='value13')]
 
     >>> df.select(df.key, get_json_object(df.jarray, '$[*].f1').alias("c0"), \\
     ...                   get_json_object(df.jarray, '$[*].f2').alias("c1") ).collect()
-    [Row(key='1', c0='["value1","value3"]', c1='["value2","value4"]'), Row(key='2', c0='"value12"', c1=None)]
+    [Row(key='1', c0='["value1","value2"]', c1=None), Row(key='2', c0='"value12"', c1='"value13"')]
     """
     from pyspark.sql.classic.column import _to_java_column
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -20115,26 +20115,47 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
 
     Examples
     --------
-    Example 1: Extracts a json object from json string
+    Example 1: Extract a json object from json string
 
+    >>> import pyspark.sql.functions as sf
     >>> data = [("1", '''{"f1": "value1", "f2": "value2"}'''), ("2", '''{"f1": "value12"}''')]
     >>> df = spark.createDataFrame(data, ("key", "jstring"))
-    >>> df.select(df.key, get_json_object(df.jstring, '$.f1').alias("c0"), \\
-    ...                   get_json_object(df.jstring, '$.f2').alias("c1") ).collect()
-    [Row(key='1', c0='value1', c1='value2'), Row(key='2', c0='value12', c1=None)]
+    >>> extracted1 = sf.get_json_object(df.jstring, '$.f1').alias("c0")
+    >>> extracted2 = get_json_object(df.jstring, '$.f2').alias("c1")
+    >>> df.select(df.key, extracted1, extracted2).show()
+    +---+-------+------+
+    |key|     c0|    c1|
+    +---+-------+------+
+    |  1| value1|value2|
+    |  2|value12|  null|
+    +---+-------+------+
 
-    Example 2: Extracts a json object from json array
+    Example 2: Extract a json object from json array
 
-    >>> data = [("1", '''[{"f1": "value1"},{"f1": "value2"}]'''), \\
-    ...                   ("2", '''[{"f1": "value12"},{"f2": "value13"}]''')]
+    >>> import pyspark.sql.functions as sf
+    >>> jarray1 = '''[{"f1": "value1"},{"f1": "value2"}]'''
+    >>> jarray2 = '''[{"f1": "value12"},{"f2": "value13"}]'''
+    >>> data = [("1", jarray1), ("2", jarray2)]
     >>> df = spark.createDataFrame(data, ("key", "jarray"))
-    >>> df.select(df.key, get_json_object(df.jarray, '$[0].f1').alias("c0"), \\
-    ...                   get_json_object(df.jarray, '$[1].f2').alias("c1") ).collect()
-    [Row(key='1', c0='value1', c1=None), Row(key='2', c0='value12', c1='value13')]
+    >>> extracted1 = get_json_object(df.jarray, '$[0].f1').alias("c0")
+    >>> extracted2 = get_json_object(df.jarray, '$[1].f2').alias("c1")
+    >>> df.select(df.key, extracted1, extracted2).show()
+    +---+-------+-------+
+    |key|     c0|     c1|
+    +---+-------+-------+
+    |  1| value1|   null|
+    |  2|value12|value13|
+    +---+-------+-------+
 
-    >>> df.select(df.key, get_json_object(df.jarray, '$[*].f1').alias("c0"), \\
-    ...                   get_json_object(df.jarray, '$[*].f2').alias("c1") ).collect()
-    [Row(key='1', c0='["value1","value2"]', c1=None), Row(key='2', c0='"value12"', c1='"value13"')]
+    >>> extracted3 = get_json_object(df.jarray, '$[*].f1').alias("c0")
+    >>> extracted4 = get_json_object(df.jarray, '$[*].f2').alias("c1")
+    >>> df.select(df.key, extracted3, extracted4).show()
+    +---+-------------------+---------+
+    |key|                 c0|       c1|
+    +---+-------------------+---------+
+    |  1|["value1","value2"]|     null|
+    |  2|          "value12"|"value13"|
+    +---+-------------------+---------+
     """
     from pyspark.sql.classic.column import _to_java_column
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -20124,6 +20124,7 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
     [Row(key='1', c0='value1', c1='value2'), Row(key='2', c0='value12', c1=None)]
 
     Example2: Get json object from json array object
+
     data = [("1", '''[{"f1": "value1", "f2": "value2"},{"f1": "value3", "f2": "value4"}]'''), ("2", '''[{"f1": "value12"},{"f1": "value13"}]''')]
     df = spark.createDataFrame(data, ("key", "jarray"))
     df.select(df.key, get_json_object(df.jarray, '$[0].f1').alias("c0"), \\

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -20115,7 +20115,7 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
 
     Examples
     --------
-    Example1: Get json object from json object
+    Example 1: Extracts a json object from json string
 
     >>> data = [("1", '''{"f1": "value1", "f2": "value2"}'''), ("2", '''{"f1": "value12"}''')]
     >>> df = spark.createDataFrame(data, ("key", "jstring"))
@@ -20123,15 +20123,17 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
     ...                   get_json_object(df.jstring, '$.f2').alias("c1") ).collect()
     [Row(key='1', c0='value1', c1='value2'), Row(key='2', c0='value12', c1=None)]
 
-    Example2: Get json object from json array object
-    data = [("1", '''[{"f1": "value1", "f2": "value2"},{"f1": "value3", "f2": "value4"}]'''), ("2", '''[{"f1": "value12"},{"f1": "value13"}]''')]
+    Example 2: Extracts a json object from json array
+    data = [("1", '''[{"f1": "value1", "f2": "value2"},{"f1": "value3", "f2": "value4"}]'''), \\
+    ...                   ("2", '''[{"f1": "value12"},{"f1": "value13"}]''')]
     df = spark.createDataFrame(data, ("key", "jarray"))
     df.select(df.key, get_json_object(df.jarray, '$[0].f1').alias("c0"), \\
     ...                   get_json_object(df.jarray, '$[0].f2').alias("c1") ).collect()
     [Row(key='1', c0='value1', c1='value2'), Row(key='2', c0='value12', c1=None)]
     df.select(df.key, get_json_object(df.jarray, '$[*].f1').alias("c0"), \\
     ...                   get_json_object(df.jarray, '$[*].f2').alias("c1") ).collect()
-    [Row(key='1', c0='["value1","value3"]', c1='["value2","value4"]'), Row(key='2', c0='["value12","value13"]', c1=None)]
+    [Row(key='1', c0='["value1","value3"]', c1='["value2","value4"]'), \\
+    ...                   Row(key='2', c0='["value12","value13"]', c1=None)]
     """
     from pyspark.sql.classic.column import _to_java_column
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -20117,12 +20117,12 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
     --------
     Example 1: Extract a json object from json string
 
-    >>> import pyspark.sql.functions as sf
     >>> data = [("1", '''{"f1": "value1", "f2": "value2"}'''), ("2", '''{"f1": "value12"}''')]
     >>> df = spark.createDataFrame(data, ("key", "jstring"))
-    >>> extracted1 = sf.get_json_object(df.jstring, '$.f1').alias("c0")
-    >>> extracted2 = get_json_object(df.jstring, '$.f2').alias("c1")
-    >>> df.select(df.key, extracted1, extracted2).show()
+    >>> df.select(df.key,
+    ...     get_json_object(df.jstring, '$.f1').alias("c0"),
+    ...     get_json_object(df.jstring, '$.f2').alias("c1")
+    ... ).show()
     +---+-------+------+
     |key|     c0|    c1|
     +---+-------+------+
@@ -20132,14 +20132,15 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
 
     Example 2: Extract a json object from json array
 
-    >>> import pyspark.sql.functions as sf
-    >>> jarray1 = '''[{"f1": "value1"},{"f1": "value2"}]'''
-    >>> jarray2 = '''[{"f1": "value12"},{"f2": "value13"}]'''
-    >>> data = [("1", jarray1), ("2", jarray2)]
+    >>> data = [
+    ... ("1", '''[{"f1": "value1"},{"f1": "value2"}]'''),
+    ... ("2", '''[{"f1": "value12"},{"f2": "value13"}]''')
+    ... ]
     >>> df = spark.createDataFrame(data, ("key", "jarray"))
-    >>> extracted1 = get_json_object(df.jarray, '$[0].f1').alias("c0")
-    >>> extracted2 = get_json_object(df.jarray, '$[1].f2').alias("c1")
-    >>> df.select(df.key, extracted1, extracted2).show()
+    >>> df.select(df.key,
+    ...     get_json_object(df.jarray, '$[0].f1').alias("c0"),
+    ...     get_json_object(df.jarray, '$[1].f2').alias("c1")
+    ... ).show()
     +---+-------+-------+
     |key|     c0|     c1|
     +---+-------+-------+
@@ -20147,9 +20148,10 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
     |  2|value12|value13|
     +---+-------+-------+
 
-    >>> extracted3 = get_json_object(df.jarray, '$[*].f1').alias("c0")
-    >>> extracted4 = get_json_object(df.jarray, '$[*].f2').alias("c1")
-    >>> df.select(df.key, extracted3, extracted4).show()
+    >>> df.select(df.key,
+    ...     get_json_object(df.jarray, '$[*].f1').alias("c0"),
+    ...     get_json_object(df.jarray, '$[*].f2').alias("c1")
+    ... ).show()
     +---+-------------------+---------+
     |key|                 c0|       c1|
     +---+-------------------+---------+

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -20127,7 +20127,7 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
     |key|     c0|    c1|
     +---+-------+------+
     |  1| value1|value2|
-    |  2|value12|  null|
+    |  2|value12|  NULL|
     +---+-------+------+
 
     Example 2: Extract a json object from json array
@@ -20143,7 +20143,7 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
     +---+-------+-------+
     |key|     c0|     c1|
     +---+-------+-------+
-    |  1| value1|   null|
+    |  1| value1|   NULL|
     |  2|value12|value13|
     +---+-------+-------+
 
@@ -20153,7 +20153,7 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
     +---+-------------------+---------+
     |key|                 c0|       c1|
     +---+-------------------+---------+
-    |  1|["value1","value2"]|     null|
+    |  1|["value1","value2"]|     NULL|
     |  2|          "value12"|"value13"|
     +---+-------------------+---------+
     """

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -20137,8 +20137,8 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
     >>> jarray2 = '''[{"f1": "value12"},{"f2": "value13"}]'''
     >>> data = [("1", jarray1), ("2", jarray2)]
     >>> df = spark.createDataFrame(data, ("key", "jarray"))
-    >>> extracted1 = get_json_object(df.jarray, '$[0].f1').alias("c0")
-    >>> extracted2 = get_json_object(df.jarray, '$[1].f2').alias("c1")
+    >>> extracted1 = sf.get_json_object(df.jarray, '$[0].f1').alias("c0")
+    >>> extracted2 = sf.get_json_object(df.jarray, '$[1].f2').alias("c1")
     >>> df.select(df.key, extracted1, extracted2).show()
     +---+-------+-------+
     |key|     c0|     c1|

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -20126,7 +20126,7 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
     Example 2: Extracts a json object from json array
 
     >>> data = [("1", '''[{"f1": "value1", "f2": "value2"},{"f1": "value3", "f2": "value4"}]'''), \\
-    ...                   ("2", '''[{"f1": "value12"},{"f1": "value13"}]''')]
+    ...                   ("2", '''[{"f1": "value12"}]''')]
     >>> df = spark.createDataFrame(data, ("key", "jarray"))
     >>> df.select(df.key, get_json_object(df.jarray, '$[0].f1').alias("c0"), \\
     ...                   get_json_object(df.jarray, '$[0].f2').alias("c1") ).collect()
@@ -20134,8 +20134,7 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
 
     >>> df.select(df.key, get_json_object(df.jarray, '$[*].f1').alias("c0"), \\
     ...                   get_json_object(df.jarray, '$[*].f2').alias("c1") ).collect()
-    [Row(key='1', c0='["value1","value3"]', c1='["value2","value4"]'), \\
-    ...                   Row(key='2', c0='["value12","value13"]', c1=None)]
+    [Row(key='1', c0='["value1","value3"]', c1='["value2","value4"]'), Row(key='2', c0='"value12"', c1=None)]
     """
     from pyspark.sql.classic.column import _to_java_column
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -20121,7 +20121,7 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
     >>> data = [("1", '''{"f1": "value1", "f2": "value2"}'''), ("2", '''{"f1": "value12"}''')]
     >>> df = spark.createDataFrame(data, ("key", "jstring"))
     >>> extracted1 = sf.get_json_object(df.jstring, '$.f1').alias("c0")
-    >>> extracted2 = get_json_object(df.jstring, '$.f2').alias("c1")
+    >>> extracted2 = sf.get_json_object(df.jstring, '$.f2').alias("c1")
     >>> df.select(df.key, extracted1, extracted2).show()
     +---+-------+------+
     |key|     c0|    c1|

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -42,6 +42,8 @@ import org.apache.spark.unsafe.types.UTF8String
     Examples:
       > SELECT _FUNC_('{"a":"b"}', '$.a');
        b
+      > SELECT _FUNC_('[{"a":"b"},{"a":"c"}]', '$[*].a');
+       ["b","c"]
   """,
   group = "json_funcs",
   since = "1.5.0")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -42,6 +42,8 @@ import org.apache.spark.unsafe.types.UTF8String
     Examples:
       > SELECT _FUNC_('{"a":"b"}', '$.a');
        b
+      > SELECT _FUNC_('[{"a":"b"},{"a":"c"}]', '$[0].a');
+       b
       > SELECT _FUNC_('[{"a":"b"},{"a":"c"}]', '$[*].a');
        ["b","c"]
   """,


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to add some usage examples for function `get_json_object`, including: `get_json_object('[{"a":"b"},{"a":"c"}]', '$[0].a')`，`get_json_object('[{"a":"b"},{"a":"c"}]', '$[*].a')`. 

### Why are the changes needed?
When `JSON` is an `array`, some users may not know how to retrieve its data through `get_json_object`. 
Let's add some usage examples.

### Does this PR introduce _any_ user-facing change?
Yes, Spark end-users will learn how to use `get_json_object` to obtain JSON data of type array through examples.

### How was this patch tested?
- Pass GA
- Manually Test.

### Was this patch authored or co-authored using generative AI tooling?

No.