### PR TITLE
[SPARK-51154][BUILD][TESTS] Remove unused `jopt` test dependency

### DIFF
--- a/connector/kafka-0-10-sql/pom.xml
+++ b/connector/kafka-0-10-sql/pom.xml
@@ -131,12 +131,6 @@
       <artifactId>zookeeper</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>net.sf.jopt-simple</groupId>
-      <artifactId>jopt-simple</artifactId>
-      <version>3.2</version>
-      <scope>test</scope>
-    </dependency>
      <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>

--- a/connector/kafka-0-10/pom.xml
+++ b/connector/kafka-0-10/pom.xml
@@ -104,12 +104,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>net.sf.jopt-simple</groupId>
-      <artifactId>jopt-simple</artifactId>
-      <version>3.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
### What changes were proposed in this pull request?

The Kafka connector declares a dependecy on the jopt library. This library is not actually used in the code, so we can remove it.

### Why are the changes needed?

We have no apparent need for this dependency. The version we are including is 15 years old with numerous unresolved bugs.

### Does this PR introduce _any_ user-facing change?

No. This change only impacts tests.

### How was this patch tested?

Run all Kafka tests.

```
build/mvn -pl connector/kafka-0-10,connector/kafka-0-10-sql test
```

### Was this patch authored or co-authored using generative AI tooling?

No.
