### PR TITLE
[SPARK-42746][SQL][FOLLOWUP] Change the delimiter parameter of listagg scala functions from Column to String

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -1927,9 +1927,7 @@ def listagg(col: "ColumnOrName", delimiter: Optional[Union[str, bytes]] = None) 
 
 
 @_try_remote_functions
-def listagg_distinct(
-    col: "ColumnOrName", delimiter: Optional[Union[str, bytes]] = None
-) -> Column:
+def listagg_distinct(col: "ColumnOrName", delimiter: Optional[Union[str, bytes]] = None) -> Column:
     """
     Aggregate function: returns the concatenation of distinct non-null input values,
     separated by the delimiter.
@@ -2004,9 +2002,7 @@ def listagg_distinct(
 
 
 @_try_remote_functions
-def string_agg(
-    col: "ColumnOrName", delimiter: Optional[Union[str, bytes]] = None
-) -> Column:
+def string_agg(col: "ColumnOrName", delimiter: Optional[Union[str, bytes]] = None) -> Column:
     """
     Aggregate function: returns the concatenation of non-null input values,
     separated by the delimiter.

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -1853,7 +1853,7 @@ def sum_distinct(col: "ColumnOrName") -> Column:
 
 
 @_try_remote_functions
-def listagg(col: "ColumnOrName", delimiter: Optional[Union[Column, str, bytes]] = None) -> Column:
+def listagg(col: "ColumnOrName", delimiter: Optional[Union[str, bytes]] = None) -> Column:
     """
     Aggregate function: returns the concatenation of non-null input values,
     separated by the delimiter.
@@ -1864,7 +1864,7 @@ def listagg(col: "ColumnOrName", delimiter: Optional[Union[Column, str, bytes]] 
     ----------
     col : :class:`~pyspark.sql.Column` or column name
         target column to compute on.
-    delimiter : :class:`~pyspark.sql.Column`, literal string or bytes, optional
+    delimiter : literal string or bytes, optional
         the delimiter to separate the values. The default value is None.
 
     Returns
@@ -1923,12 +1923,12 @@ def listagg(col: "ColumnOrName", delimiter: Optional[Union[Column, str, bytes]] 
     if delimiter is None:
         return _invoke_function_over_columns("listagg", col)
     else:
-        return _invoke_function_over_columns("listagg", col, lit(delimiter))
+        return _invoke_function("listagg", col, delimiter)
 
 
 @_try_remote_functions
 def listagg_distinct(
-    col: "ColumnOrName", delimiter: Optional[Union[Column, str, bytes]] = None
+    col: "ColumnOrName", delimiter: Optional[Union[str, bytes]] = None
 ) -> Column:
     """
     Aggregate function: returns the concatenation of distinct non-null input values,
@@ -1940,7 +1940,7 @@ def listagg_distinct(
     ----------
     col : :class:`~pyspark.sql.Column` or column name
         target column to compute on.
-    delimiter : :class:`~pyspark.sql.Column`, literal string or bytes, optional
+    delimiter : literal string or bytes, optional
         the delimiter to separate the values. The default value is None.
 
     Returns
@@ -2000,12 +2000,12 @@ def listagg_distinct(
     if delimiter is None:
         return _invoke_function_over_columns("listagg_distinct", col)
     else:
-        return _invoke_function_over_columns("listagg_distinct", col, lit(delimiter))
+        return _invoke_function("listagg_distinct", col, delimiter)
 
 
 @_try_remote_functions
 def string_agg(
-    col: "ColumnOrName", delimiter: Optional[Union[Column, str, bytes]] = None
+    col: "ColumnOrName", delimiter: Optional[Union[str, bytes]] = None
 ) -> Column:
     """
     Aggregate function: returns the concatenation of non-null input values,
@@ -2019,7 +2019,7 @@ def string_agg(
     ----------
     col : :class:`~pyspark.sql.Column` or column name
         target column to compute on.
-    delimiter : :class:`~pyspark.sql.Column`, literal string or bytes, optional
+    delimiter : literal string or bytes, optional
         the delimiter to separate the values. The default value is None.
 
     Returns
@@ -2078,12 +2078,12 @@ def string_agg(
     if delimiter is None:
         return _invoke_function_over_columns("string_agg", col)
     else:
-        return _invoke_function_over_columns("string_agg", col, lit(delimiter))
+        return _invoke_function("string_agg", col, delimiter)
 
 
 @_try_remote_functions
 def string_agg_distinct(
-    col: "ColumnOrName", delimiter: Optional[Union[Column, str, bytes]] = None
+    col: "ColumnOrName", delimiter: Optional[Union[str, bytes]] = None
 ) -> Column:
     """
     Aggregate function: returns the concatenation of distinct non-null input values,
@@ -2097,7 +2097,7 @@ def string_agg_distinct(
     ----------
     col : :class:`~pyspark.sql.Column` or column name
         target column to compute on.
-    delimiter : :class:`~pyspark.sql.Column`, literal string or bytes, optional
+    delimiter : literal string or bytes, optional
         the delimiter to separate the values. The default value is None.
 
     Returns
@@ -2157,7 +2157,7 @@ def string_agg_distinct(
     if delimiter is None:
         return _invoke_function_over_columns("string_agg_distinct", col)
     else:
-        return _invoke_function_over_columns("string_agg_distinct", col, lit(delimiter))
+        return _invoke_function("string_agg_distinct", col, delimiter)
 
 
 @_try_remote_functions

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1162,7 +1162,7 @@ object functions {
    * @group agg_funcs
    * @since 4.0.0
    */
-  def listagg(e: Column, delimiter: Column): Column = Column.fn("listagg", e, delimiter)
+  def listagg(e: Column, delimiter: String): Column = Column.fn("listagg", e, lit(delimiter))
 
   /**
    * Aggregate function: returns the concatenation of distinct non-null input values.
@@ -1179,8 +1179,8 @@ object functions {
    * @group agg_funcs
    * @since 4.0.0
    */
-  def listagg_distinct(e: Column, delimiter: Column): Column =
-    Column.fn("listagg", isDistinct = true, e, delimiter)
+  def listagg_distinct(e: Column, delimiter: String): Column =
+    Column.fn("listagg", isDistinct = true, e, lit(delimiter))
 
   /**
    * Aggregate function: returns the concatenation of non-null input values. Alias for `listagg`.
@@ -1197,7 +1197,7 @@ object functions {
    * @group agg_funcs
    * @since 4.0.0
    */
-  def string_agg(e: Column, delimiter: Column): Column = Column.fn("string_agg", e, delimiter)
+  def string_agg(e: Column, delimiter: String): Column = Column.fn("string_agg", e, lit(delimiter))
 
   /**
    * Aggregate function: returns the concatenation of distinct non-null input values. Alias for
@@ -1215,8 +1215,8 @@ object functions {
    * @group agg_funcs
    * @since 4.0.0
    */
-  def string_agg_distinct(e: Column, delimiter: Column): Column =
-    Column.fn("string_agg", isDistinct = true, e, delimiter)
+  def string_agg_distinct(e: Column, delimiter: String): Column =
+    Column.fn("string_agg", isDistinct = true, e, lit(delimiter))
 
   /**
    * Aggregate function: alias for `var_samp`.

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1165,6 +1165,15 @@ object functions {
   def listagg(e: Column, delimiter: String): Column = Column.fn("listagg", e, lit(delimiter))
 
   /**
+   * Aggregate function: returns the concatenation of non-null input values, separated by the
+   * delimiter.
+   *
+   * @group agg_funcs
+   * @since 4.0.0
+   */
+  def listagg(e: Column, delimiter: Array[Byte]): Column = Column.fn("listagg", e, lit(delimiter))
+
+  /**
    * Aggregate function: returns the concatenation of distinct non-null input values.
    *
    * @group agg_funcs
@@ -1180,6 +1189,16 @@ object functions {
    * @since 4.0.0
    */
   def listagg_distinct(e: Column, delimiter: String): Column =
+    Column.fn("listagg", isDistinct = true, e, lit(delimiter))
+
+  /**
+   * Aggregate function: returns the concatenation of distinct non-null input values, separated by
+   * the delimiter.
+   *
+   * @group agg_funcs
+   * @since 4.0.0
+   */
+  def listagg_distinct(e: Column, delimiter: Array[Byte]): Column =
     Column.fn("listagg", isDistinct = true, e, lit(delimiter))
 
   /**
@@ -1201,6 +1220,16 @@ object functions {
     Column.fn("string_agg", e, lit(delimiter))
 
   /**
+   * Aggregate function: returns the concatenation of non-null input values, separated by the
+   * delimiter. Alias for `listagg`.
+   *
+   * @group agg_funcs
+   * @since 4.0.0
+   */
+  def string_agg(e: Column, delimiter: Array[Byte]): Column =
+    Column.fn("string_agg", e, lit(delimiter))
+
+  /**
    * Aggregate function: returns the concatenation of distinct non-null input values. Alias for
    * `listagg`.
    *
@@ -1217,6 +1246,16 @@ object functions {
    * @since 4.0.0
    */
   def string_agg_distinct(e: Column, delimiter: String): Column =
+    Column.fn("string_agg", isDistinct = true, e, lit(delimiter))
+
+  /**
+   * Aggregate function: returns the concatenation of distinct non-null input values, separated by
+   * the delimiter. Alias for `listagg`.
+   *
+   * @group agg_funcs
+   * @since 4.0.0
+   */
+  def string_agg_distinct(e: Column, delimiter: Array[Byte]): Column =
     Column.fn("string_agg", isDistinct = true, e, lit(delimiter))
 
   /**

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1197,7 +1197,8 @@ object functions {
    * @group agg_funcs
    * @since 4.0.0
    */
-  def string_agg(e: Column, delimiter: String): Column = Column.fn("string_agg", e, lit(delimiter))
+  def string_agg(e: Column, delimiter: String): Column =
+    Column.fn("string_agg", e, lit(delimiter))
 
   /**
    * Aggregate function: returns the concatenation of distinct non-null input values. Alias for

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -636,7 +636,7 @@ class DataFrameAggregateSuite extends QueryTest
     )
 
     checkAnswer(
-      df.select(listagg($"a", null), listagg($"b", "-")),
+      df.select(listagg($"a", null.asInstanceOf[String]), listagg($"b", "-")),
       Seq(Row("abc", "b-c-d"))
     )
 
@@ -648,7 +648,7 @@ class DataFrameAggregateSuite extends QueryTest
     )
 
     checkAnswer(
-      df2.select(listagg_distinct($"a", null), listagg_distinct($"b", "-")),
+      df2.select(listagg_distinct($"a", ""), listagg_distinct($"b", "-")),
       Seq(Row("ab", "b-d"))
     )
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -635,11 +635,21 @@ class DataFrameAggregateSuite extends QueryTest
       Seq(Row("abc", "bcd"))
     )
 
+    checkAnswer(
+      df.select(listagg($"a", null), listagg($"b", "-")),
+      Seq(Row("abc", "b-c-d"))
+    )
+
     // distinct case
     val df2 = Seq(("a", "b"), ("a", "b"), ("b", "d")).toDF("a", "b")
     checkAnswer(
       df2.select(listagg_distinct($"a"), listagg_distinct($"b")),
       Seq(Row("ab", "bd"))
+    )
+
+    checkAnswer(
+      df2.select(listagg_distinct($"a", null), listagg_distinct($"b", "-")),
+      Seq(Row("ab", "b-d"))
     )
 
     // null case


### PR DESCRIPTION

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR changes the delimiter parameter of listagg scala functions from Column to String


### Why are the changes needed?

Since the delimiter parameter must be a string literal, we can use String here directly to take advantage of the compiler instead of delaying to runtime errors.

### Does this PR introduce _any_ user-facing change?
no, this is a new feature of unreleased 4.0.0

### How was this patch tested?
new ut

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->no
