### PR TITLE
[SPARK-51119][SQL][FOLLOW-UP] Readers on executors resolving EXISTS_DEFAULT should not call catalogs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -268,6 +268,9 @@ object Literal {
       s"but class ${Utils.getSimpleName(value.getClass)} found.")
   }
 
+  /**
+   * Inverse of [[Literal.sql]]
+   */
   def fromSQL(sql: String): Expression = {
     CatalystSqlParser.parseExpression(sql).transformUp {
       case u: UnresolvedFunction =>
@@ -278,10 +281,6 @@ object Literal {
         assert(u.orderingWithinGroup.isEmpty)
         assert(!u.isInternal)
         FunctionRegistry.builtin.lookupFunction(FunctionIdentifier(u.nameParts.head), u.arguments)
-    } match {
-      case c: Cast if c.needsTimeZone =>
-        c.withTimeZone(SQLConf.get.sessionLocalTimeZone)
-      case e: Expression => e
     }
   }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?
 Code cleanup for https://github.com/apache/spark/pull/49840/.  Literal#fromSQL should be the inverse of Literal#sql.  The cast handling is an artifact of the calling ResolveDefaultColumns object that adds the cast when making EXISTS_DEFAULT, so its handling is moved to ResolveDefaultColumns as well.

### Why are the changes needed?
Code cleanup

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests


### Was this patch authored or co-authored using generative AI tooling?
No
