### PR TITLE
[SPARK-50940][SPARK-50941][ML][PYTHON][CONNECT][FOLLOW-UP]  Directly reuse the CrossValidatorModelWriter and TrainValidationSplitModelWriter

### DIFF
--- a/python/pyspark/ml/connect/readwrite.py
+++ b/python/pyspark/ml/connect/readwrite.py
@@ -138,7 +138,8 @@ class RemoteMLWriter(MLWriter):
             from pyspark.ml.tuning import CrossValidatorModelWriter
 
             RemoteMLWriter.handleOverwrite(path, shouldOverwrite)
-            cvm_writer = CrossValidatorModelWriter(instance, optionMap, session)
+            cvm_writer = CrossValidatorModelWriter(instance)
+            cvm_writer.optionMap = optionMap
             cvm_writer.session(session)  # type: ignore[arg-type]
             cvm_writer.save(path)
         elif isinstance(instance, TrainValidationSplit):
@@ -151,7 +152,8 @@ class RemoteMLWriter(MLWriter):
             from pyspark.ml.tuning import TrainValidationSplitModelWriter
 
             RemoteMLWriter.handleOverwrite(path, shouldOverwrite)
-            tvsm_writer = TrainValidationSplitModelWriter(instance, optionMap, session)
+            tvsm_writer = TrainValidationSplitModelWriter(instance)
+            tvsm_writer.optionMap = optionMap
             tvsm_writer.session(session)  # type: ignore[arg-type]
             tvsm_writer.save(path)
         elif isinstance(instance, OneVsRest):

--- a/python/pyspark/ml/connect/readwrite.py
+++ b/python/pyspark/ml/connect/readwrite.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import cast, Type, TYPE_CHECKING, Union, Dict, Any, Optional
+from typing import cast, Type, TYPE_CHECKING, Union, Dict, Any
 
 import pyspark.sql.connect.proto as pb2
 from pyspark.ml.connect.serialize import serialize_ml_params, deserialize, deserialize_param

--- a/python/pyspark/ml/tests/connect/test_parity_tuning.py
+++ b/python/pyspark/ml/tests/connect/test_parity_tuning.py
@@ -17,31 +17,12 @@
 
 import unittest
 
-from pyspark.ml.classification import LogisticRegression
-from pyspark.ml.connect.readwrite import RemoteCrossValidatorModelWriter
-from pyspark.ml.linalg import Vectors
 from pyspark.ml.tests.test_tuning import TuningTestsMixin
-from pyspark.ml.tuning import CrossValidatorModel
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class TuningParityTests(TuningTestsMixin, ReusedConnectTestCase):
-    def test_remote_cross_validator_model_writer(self):
-        df = self.spark.createDataFrame(
-            [
-                (1.0, 1.0, Vectors.dense(0.0, 5.0)),
-                (0.0, 2.0, Vectors.dense(1.0, 2.0)),
-                (1.0, 3.0, Vectors.dense(2.0, 1.0)),
-                (0.0, 4.0, Vectors.dense(3.0, 3.0)),
-            ],
-            ["label", "weight", "features"],
-        )
-
-        lor = LogisticRegression()
-        lor_model = lor.fit(df)
-        cv_model = CrossValidatorModel(lor_model)
-        writer = RemoteCrossValidatorModelWriter(cv_model, {"a": "b"}, self.spark)
-        self.assertEqual(writer.optionMap["a"], "b")
+    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Directly reuse the CrossValidatorModelWriter and TrainValidationSplitModelWriter


### Why are the changes needed?
to simplify the code, we don't need dedicated writers for connect

### Does this PR introduce _any_ user-facing change?
no, internal changes

### How was this patch tested?
existing tests


### Was this patch authored or co-authored using generative AI tooling?
no
