### PR TITLE
[SPARK-51157][SQL] Add missing @varargs Scala annotation for Scala function APIs

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -631,6 +631,7 @@ object functions {
    * @group agg_funcs
    * @since 2.0.0
    */
+  @scala.annotation.varargs
   def grouping_id(cols: Column*): Column = Column.fn("grouping_id", cols: _*)
 
   /**
@@ -646,6 +647,7 @@ object functions {
    * @group agg_funcs
    * @since 2.0.0
    */
+  @scala.annotation.varargs
   def grouping_id(colName: String, colNames: String*): Column = {
     grouping_id((Seq(colName) ++ colNames).map(n => Column(n)): _*)
   }
@@ -1742,6 +1744,7 @@ object functions {
    * @group struct_funcs
    * @since 3.5.0
    */
+  @scala.annotation.varargs
   def named_struct(cols: Column*): Column = Column.fn("named_struct", cols: _*)
 
   /**
@@ -3784,6 +3787,7 @@ object functions {
    * @group misc_funcs
    * @since 3.5.0
    */
+  @scala.annotation.varargs
   def reflect(cols: Column*): Column = Column.fn("reflect", cols: _*)
 
   /**
@@ -3792,6 +3796,7 @@ object functions {
    * @group misc_funcs
    * @since 3.5.0
    */
+  @scala.annotation.varargs
   def java_method(cols: Column*): Column = Column.fn("java_method", cols: _*)
 
   /**
@@ -3801,6 +3806,7 @@ object functions {
    * @group misc_funcs
    * @since 4.0.0
    */
+  @scala.annotation.varargs
   def try_reflect(cols: Column*): Column = Column.fn("try_reflect", cols: _*)
 
   /**
@@ -3827,6 +3833,7 @@ object functions {
    * @group generator_funcs
    * @since 3.5.0
    */
+  @scala.annotation.varargs
   def stack(cols: Column*): Column = Column.fn("stack", cols: _*)
 
   /**
@@ -4818,6 +4825,7 @@ object functions {
    * @group string_funcs
    * @since 3.5.0
    */
+  @scala.annotation.varargs
   def printf(format: Column, arguments: Column*): Column =
     Column.fn("printf", (format +: arguments): _*)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds missing `@varargs` Scala annotation for Scala function APIs


### Why are the changes needed?

To instruct the compiler to generate java varargs-style forwarder methods for interop


### Does this PR introduce _any_ user-facing change?

No, do not change the current behavior.


### How was this patch tested?

w/o `@varargs`:
![image](https://github.com/user-attachments/assets/6c9b212f-6db5-429e-80cb-c48bb213ee9d)



### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->no
