### PR TITLE
[SPARK-42746][SQL][FOLLOWUP] Improve the golden files by print the hex string of binary

### DIFF
--- a/sql/core/src/test/resources/sql-tests/inputs/listagg.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/listagg.sql
@@ -1,3 +1,5 @@
+--SET spark.sql.binaryOutputStyle=HEX
+
 -- Create temporary views
 CREATE TEMP VIEW df AS
 SELECT * FROM (VALUES ('a', 'b'), ('a', 'c'), ('b', 'c'), ('b', 'd'), (NULL, NULL)) AS t(a, b);

--- a/sql/core/src/test/resources/sql-tests/results/listagg.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/listagg.sql.out
@@ -154,7 +154,7 @@ SELECT listagg(c1) FROM (VALUES (X'DEAD'), (X'BEEF')) AS t(c1)
 -- !query schema
 struct<listagg(c1, NULL):binary>
 -- !query output
-ޭ��
+DEADBEEF
 
 
 -- !query
@@ -162,7 +162,7 @@ SELECT listagg(c1, NULL) FROM (VALUES (X'DEAD'), (X'BEEF')) AS t(c1)
 -- !query schema
 struct<listagg(c1, NULL):binary>
 -- !query output
-ޭ��
+DEADBEEF
 
 
 -- !query
@@ -170,7 +170,7 @@ SELECT listagg(c1, X'42') FROM (VALUES (X'DEAD'), (X'BEEF')) AS t(c1)
 -- !query schema
 struct<listagg(c1, X'42'):binary>
 -- !query output
-ޭB��
+DEAD42BEEF
 
 
 -- !query


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to improve the golden files by print the hex string of binary


### Why are the changes needed?
Based on the discussion at https://github.com/apache/spark/pull/48748/files#r1852083414.
We should make the output of golden tests more clear.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
GA


### Was this patch authored or co-authored using generative AI tooling?
'No'.