### PR TITLE
[SPARK-51608][PYTHON] Log exception on Python runner termination

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -274,7 +274,7 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
           worker.stop()
         } catch {
           case e: Exception =>
-            logWarning("Failed to stop worker", e)
+            logWarning(log"Failed to stop worker", e)
         }
       }
     }

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -274,7 +274,7 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
           worker.stop()
         } catch {
           case e: Exception =>
-            logWarning("Failed to stop worker")
+            logWarning("Failed to stop worker", e)
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
There are situations, when python worker may throw exceptions that are not covered by any other kind of logging (for example custom implementation/unexpected throw from existing code)

In these situations it is hard to debug which exactly issue happened, as there is no stack trace in logs and no actual message from exception.

To address this issue exception is added for the logging call (rare exception situation while stopping python worker)

### Why are the changes needed?
To effectively debug rare situations with worker termination.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
no need

### Was this patch authored or co-authored using generative AI tooling?
no