### PR TITLE
[SPARK-51164][CORE][TESTS] Fix `CallerContext` test by enabling `hadoop.caller.context.enabled`

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1005,9 +1005,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
   test("Set Spark CallerContext") {
     val context = "test"
     new CallerContext(context).setCurrentContext()
-    if (CallerContext.callerContextEnabled) {
-      assert(s"SPARK_$context" === HadoopCallerContext.getCurrent.toString)
-    }
+    assert(s"SPARK_$context" === HadoopCallerContext.getCurrent.toString)
   }
 
   test("encodeFileNameToURIRawPath") {

--- a/pom.xml
+++ b/pom.xml
@@ -2821,6 +2821,7 @@
               <spark.ui.enabled>false</spark.ui.enabled>
               <spark.ui.showConsoleProgress>false</spark.ui.showConsoleProgress>
               <spark.unsafe.exceptionOnMemoryLeak>true</spark.unsafe.exceptionOnMemoryLeak>
+              <spark.hadoop.hadoop.caller.context.enabled>true</spark.hadoop.hadoop.caller.context.enabled>
               <spark.memory.debugFill>true</spark.memory.debugFill>
               <!-- Needed by sql/hive tests. -->
               <test.src.tables>src</test.src.tables>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1609,6 +1609,7 @@ object TestSettings {
     (Test / javaOptions) += "-Dspark.ui.enabled=false",
     (Test / javaOptions) += "-Dspark.ui.showConsoleProgress=false",
     (Test / javaOptions) += "-Dspark.unsafe.exceptionOnMemoryLeak=true",
+    (Test / javaOptions) += "-Dspark.hadoop.hadoop.caller.context.enabled=true",
     (Test / javaOptions) += "-Dhive.conf.validation=false",
     (Test / javaOptions) += "-Dsun.io.serialization.extendedDebugInfo=false",
     (Test / javaOptions) += "-Dderby.system.durability=test",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `CallerContext` test by enabling `hadoop.caller.context.enabled` during tests.

### Why are the changes needed?

This test case was disabled since Apache Spark 2.1.0 because `CallerContext` was supported since Apache Hadoop 2.8+.
- #15377

We need to recover `CallerContext` test coverage.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.