### PR TITLE
[SPARK-51165][CORE] Enable `spark.master.rest.enabled` by default

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1973,7 +1973,7 @@ package object config {
   private[spark] val MASTER_REST_SERVER_ENABLED = ConfigBuilder("spark.master.rest.enabled")
     .version("1.3.0")
     .booleanConf
-    .createWithDefault(false)
+    .createWithDefault(true)
 
   private[spark] val MASTER_REST_SERVER_HOST = ConfigBuilder("spark.master.rest.host")
     .doc("Specifies the host of the Master REST API endpoint")

--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -22,6 +22,10 @@ license: |
 * Table of contents
 {:toc}
 
+## Upgrading from Core 4.0 to 4.1
+
+- Since Spark 4.1, Spark Master deamon provides REST API by default. To restore the behavior before Spark 4.1, you can set `spark.master.rest.enabled` to `false`.
+
 ## Upgrading from Core 3.5 to 4.0
 
 - Since Spark 4.0, Spark migrated all its internal reference of servlet API from `javax` to `jakarta` 

--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -237,7 +237,7 @@ SPARK_MASTER_OPTS supports the following system properties:
 </tr>
 <tr>
   <td><code>spark.master.rest.enabled</code></td>
-  <td><code>false</code></td>
+  <td><code>true</code></td>
   <td>
     Whether to use the Master REST API endpoint or not.
   </td>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `spark.master.rest.enabled` by default for Apache Spark 4.1.0.

### Why are the changes needed?

Apache Spark is ready to enable this feature by default.
- Since Apache Spark 1.3.0, `spark.master.rest.enabled` has been used stably.
- Since Apache Spark 4.0.0, `spark.master.rest.filters` provides a way to serve it securely.
  - #47595

### Does this PR introduce _any_ user-facing change?

Yes, the migration guide is updated.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.