### PR TITLE
[SPARK-51127][PYTHON][FOLLOWUP] Update version for the configs

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/Python.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Python.scala
@@ -90,7 +90,7 @@ private[spark] object Python {
     .doc("Whether Spark should terminate the Python worker process when the idle timeout " +
       s"(as defined by $PYTHON_WORKER_IDLE_TIMEOUT_SECONDS_KEY) is reached. If enabled, " +
       "Spark will terminate the Python worker process in addition to logging the status.")
-    .version("4.0.0")
+    .version("4.1.0")
     .booleanConf
     .createWithDefault(false)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3372,7 +3372,7 @@ object SQLConf {
       .doc(
         s"Same as ${Python.PYTHON_WORKER_KILL_ON_IDLE_TIMEOUT.key} for Python execution with " +
           "DataFrame and SQL. It can change during runtime.")
-      .version("4.0.0")
+      .version("4.1.0")
       .fallbackConf(Python.PYTHON_WORKER_KILL_ON_IDLE_TIMEOUT)
 
   val PYSPARK_PLOT_MAX_ROWS =


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #49843.

Updates `version` for the configs `spark.python.worker.killOnIdleTimeout` and `spark.sql.execution.pyspark.udf.killOnIdleTimeout`.

### Why are the changes needed?

The original PR #49843 missed the `4.0.0` period.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing tests should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.
