### PR TITLE
[SPARK-51170][PYTHON][CONNECT][TESTS] Separate local and local-cluster in pure Python build in master

### DIFF
--- a/.github/workflows/build_python_connect.yml
+++ b/.github/workflows/build_python_connect.yml
@@ -73,7 +73,7 @@ jobs:
           cd dist
           pip install pyspark*connect-*.tar.gz
           pip install 'six==1.16.0' 'pandas==2.2.3' scipy 'plotly<6.0.0' 'mlflow>=2.8.1' coverage matplotlib openpyxl 'memory-profiler>=0.61.0' 'scikit-learn>=1.3.2' 'graphviz==0.20.3' 'torch<2.6.0' torchvision torcheval deepspeed unittest-xml-reporting 'plotly>=4.8'
-      - name: Run tests
+      - name: Run tests (local)
         env:
           SPARK_TESTING: 1
           SPARK_CONNECT_TESTING_REMOTE: sc://localhost
@@ -101,6 +101,11 @@ jobs:
           mv lib.back python/lib
           mv pyspark.back python/pyspark
 
+      - name: Run tests (local-cluster)
+        env:
+          SPARK_TESTING: 1
+          SPARK_CONNECT_TESTING_REMOTE: sc://localhost
+        run: |
           # Start a Spark Connect server for local-cluster
           PYTHONPATH="python/lib/pyspark.zip:python/lib/py4j-0.10.9.9-src.zip:$PYTHONPATH" ./sbin/start-connect-server.sh \
             --master "local-cluster[2, 4, 1024]" \
@@ -112,6 +117,11 @@ jobs:
           mv python/pyspark lib.back
 
           ./python/run-tests --parallelism=1 --python-executables=python3 --testnames "pyspark.resource.tests.test_connect_resources,pyspark.sql.tests.connect.client.test_artifact,pyspark.sql.tests.connect.client.test_artifact_localcluster,pyspark.sql.tests.connect.test_resources"
+
+          # Stop Spark Connect server.
+          ./sbin/stop-connect-server.sh
+          mv lib.back python/lib
+          mv pyspark.back python/pyspark
       - name: Upload test results to report
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR refactors pure Python build in master by separating local and local-cluster test sets.

### Why are the changes needed?

To reduce the potential impact to each other.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Will monitor the build

### Was this patch authored or co-authored using generative AI tooling?

No.