### PR TITLE
[SPARK-51164][CORE][TESTS][FOLLOWUP] Add hadoop.caller.context.enabled for scalatest-maven-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2869,6 +2869,7 @@
               <derby.system.durability>test</derby.system.durability>
               <java.awt.headless>true</java.awt.headless>
               <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
+              <spark.hadoop.hadoop.caller.context.enabled>true</spark.hadoop.hadoop.caller.context.enabled>
               <spark.test.home>${spark.test.home}</spark.test.home>
               <spark.testing>1</spark.testing>
               <spark.ui.enabled>false</spark.ui.enabled>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Apply previous SPARK-51164 fix to `mvn test` invocations of scalatest-maven-plugin.

### Why are the changes needed?

I found that the previous SPARK-51164 fix was working well for `sbt` test invocations. However, I was seeing `UtilsSuite` fail when invoked through `mvn`. The previous fix applied the `hadoop.caller.context.enabled` configuration to the Java tests run through maven-surefire-plugin. This patch applies the same change for the Scala tests run through scalatest-maven-plugin.

### Does this PR introduce _any_ user-facing change?

No. This change only impacts tests.

### How was this patch tested?

```
build/mvn -o -pl core test -Dtest=none -Dsuites=org.apache.spark.util.UtilsSuite

Run completed in 8 seconds, 900 milliseconds.
Total number of tests run: 61
Suites: completed 1, aborted 0
Tests: succeeded 61, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
```

### Was this patch authored or co-authored using generative AI tooling?

No.
