### PR TITLE
[SPARK-51173][TESTS] Add `configName` Scalastyle rule

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -477,4 +477,9 @@ This file is divided into 3 sections:
     <parameters><parameter name="regex">new URL\(</parameter></parameters>
     <customMessage>Use URI.toURL or URL.of instead of URL constructors.</customMessage>
   </check>
+
+  <check customId="configName" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">buildConf\("spark.databricks.</parameter></parameters>
+    <customMessage>Use Apache Spark config namespace.</customMessage>
+  </check>
 </scalastyle>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `configName` Scalastyle rule to prevent invalid config names.

### Why are the changes needed?

To prevent repetitive mistake pattern
- #45649
- #48149
- #49121

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Currently, this PR will fail at Scalastyle test because the `master` branch is broken. We can merge this after the following PR.
- #49897

### Was this patch authored or co-authored using generative AI tooling?

No.