### PR TITLE
[SPARK-51157][SQL][3.5] Add missing @VarArgs Scala annotation for Scala function APIs

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -146,6 +146,7 @@ object functions {
    * @group normal_funcs
    * @since 3.5.0
    */
+  @scala.annotation.varargs
   def named_struct(cols: Column*): Column = Column.fn("named_struct", cols: _*)
 
   //////////////////////////////////////////////////////////////////////////////////////////////
@@ -591,6 +592,7 @@ object functions {
    * @group agg_funcs
    * @since 3.4.0
    */
+  @scala.annotation.varargs
   def grouping_id(cols: Column*): Column = Column.fn("grouping_id", cols: _*)
 
   /**
@@ -606,6 +608,7 @@ object functions {
    * @group agg_funcs
    * @since 3.4.0
    */
+  @scala.annotation.varargs
   def grouping_id(colName: String, colNames: String*): Column =
     grouping_id((Seq(colName) ++ colNames).map(n => Column(n)): _*)
 
@@ -3611,6 +3614,7 @@ object functions {
    * @group misc_funcs
    * @since 3.5.0
    */
+  @scala.annotation.varargs
   def reflect(cols: Column*): Column = Column.fn("reflect", cols: _*)
 
   /**
@@ -3619,6 +3623,7 @@ object functions {
    * @group misc_funcs
    * @since 3.5.0
    */
+  @scala.annotation.varargs
   def java_method(cols: Column*): Column = Column.fn("java_method", cols: _*)
 
   /**
@@ -3645,6 +3650,7 @@ object functions {
    * @group misc_funcs
    * @since 3.5.0
    */
+  @scala.annotation.varargs
   def stack(cols: Column*): Column = Column.fn("stack", cols: _*)
 
   /**
@@ -4419,6 +4425,7 @@ object functions {
    * @group string_funcs
    * @since 3.5.0
    */
+  @scala.annotation.varargs
   def printf(format: Column, arguments: Column*): Column =
     Column.fn("printf", (format +: arguments): _*)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -623,6 +623,7 @@ object functions {
    * @group agg_funcs
    * @since 2.0.0
    */
+  @scala.annotation.varargs
   def grouping_id(cols: Column*): Column = Column(GroupingID(cols.map(_.expr)))
 
   /**
@@ -637,6 +638,7 @@ object functions {
    * @group agg_funcs
    * @since 2.0.0
    */
+  @scala.annotation.varargs
   def grouping_id(colName: String, colNames: String*): Column = {
     grouping_id((Seq(colName) ++ colNames).map(n => Column(n)) : _*)
   }
@@ -1676,6 +1678,7 @@ object functions {
    * @group normal_funcs
    * @since 3.5.0
    */
+  @scala.annotation.varargs
   def named_struct(cols: Column*): Column = withExpr { CreateNamedStruct(cols.map(_.expr)) }
 
   /**
@@ -3661,6 +3664,7 @@ object functions {
    * @group misc_funcs
    * @since 3.5.0
    */
+  @scala.annotation.varargs
   def reflect(cols: Column*): Column = withExpr {
     CallMethodViaReflection(cols.map(_.expr))
   }
@@ -3671,6 +3675,7 @@ object functions {
    * @group misc_funcs
    * @since 3.5.0
    */
+  @scala.annotation.varargs
   def java_method(cols: Column*): Column =
     call_function("java_method", cols: _*)
 
@@ -3702,6 +3707,7 @@ object functions {
    * @group misc_funcs
    * @since 3.5.0
    */
+  @scala.annotation.varargs
   def stack(cols: Column*): Column = withExpr {
     Stack(cols.map(_.expr))
   }
@@ -4547,6 +4553,7 @@ object functions {
    * @group string_funcs
    * @since 3.5.0
    */
+  @scala.annotation.varargs
   def printf(format: Column, arguments: Column*): Column =
     call_function("printf", (format +: arguments): _*)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds missing `@varargs` Scala annotation for Scala function APIs


### Why are the changes needed?

To instruct the compiler to generate java varargs-style forwarder methods for interop


### Does this PR introduce _any_ user-facing change?

No, do not change the current behavior.


### How was this patch tested?

w/o `@varargs`:
![image](https://github.com/user-attachments/assets/6c9b212f-6db5-429e-80cb-c48bb213ee9d)



### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->no
