### PR TITLE
[SPARK-42746][SQL][FOLLOWUP] Correct the comments for SupportsOrderingWithinGroup and Mode

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
@@ -137,21 +137,20 @@ case class Mode(
     if (buffer.isEmpty) {
       return null
     }
-    /*
-      * The Mode class uses special collation awareness logic
-      *  to handle string data types with various collations.
-      *
-      * For string types that don't support binary equality,
-      * we create a new map where the keys are the collation keys of the original strings.
-      *
-      * Keys from the original map are aggregated based on the corresponding collation keys.
-      *  The groupMapReduce method groups the entries by collation key and maps each group
-      *  to a single value (the sum of the counts), and finally reduces the groups to a single map.
-      *
-      * The new map is then used in the rest of the Mode evaluation logic.
-      *
-      * It is expected to work for all simple and complex types with collated fields.
-      */
+
+    // The Mode class uses special collation awareness logic
+    //  to handle string data types with various collations.
+    //
+    // For string types that don't support binary equality,
+    // we create a new map where the keys are the collation keys of the original strings.
+    //
+    // Keys from the original map are aggregated based on the corresponding collation keys.
+    //  The groupMapReduce method groups the entries by collation key and maps each group
+    //  to a single value (the sum of the counts), and finally reduces the groups to a single map.
+    //
+    // The new map is then used in the rest of the Mode evaluation logic.
+    //
+    // It is expected to work for all simple and complex types with collated fields.
     val collationAwareBuffer = getCollationAwareBuffer(child.dataType, buffer)
 
     reverseOpt.map { reverse =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
@@ -139,14 +139,14 @@ case class Mode(
     }
 
     // The Mode class uses special collation awareness logic
-    //  to handle string data types with various collations.
+    // to handle string data types with various collations.
     //
     // For string types that don't support binary equality,
     // we create a new map where the keys are the collation keys of the original strings.
     //
     // Keys from the original map are aggregated based on the corresponding collation keys.
-    //  The groupMapReduce method groups the entries by collation key and maps each group
-    //  to a single value (the sum of the counts), and finally reduces the groups to a single map.
+    // The groupMapReduce method groups the entries by collation key and maps each group
+    // to a single value (the sum of the counts), and finally reduces the groups to a single map.
     //
     // The new map is then used in the rest of the Mode evaluation logic.
     //

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/SupportsOrderingWithinGroup.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/SupportsOrderingWithinGroup.scala
@@ -39,7 +39,7 @@ trait SupportsOrderingWithinGroup { self: AggregateFunction =>
    * Tells Analyzer that DISTINCT is supported.
    * The DISTINCT can conflict with order so some functions can ban it.
    *
-   * @see [[QueryCompilationErrors.functionMissingWithinGroupError]]
+   * @see [[QueryCompilationErrors.distinctWithOrderingFunctionUnsupportedError]]
    */
   def isDistinctSupported: Boolean
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to correct the comments for `SupportsOrderingWithinGroup` and `Mode`.


### Why are the changes needed?
First, some comments added with incorrect style.
Second, replace `QueryCompilationErrors.functionMissingWithinGroupError` with the correct `QueryCompilationErrors.distinctWithOrderingFunctionUnsupportedError`.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
