### PR TITLE
[SPARK-51179][SQL] Refactor SupportsOrderingWithinGroup so that centralized check

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -469,11 +469,6 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                 "funcName" -> toSQLExpr(wf),
                 "windowExpr" -> toSQLExpr(w)))
 
-          case agg @ AggregateExpression(listAgg: ListAgg, _, _, _, _)
-            if agg.isDistinct && listAgg.needSaveOrderValue =>
-            throw QueryCompilationErrors.functionAndOrderExpressionMismatchError(
-              listAgg.prettyName, listAgg.child, listAgg.orderExpressions)
-
           case w: WindowExpression =>
             // Only allow window functions with an aggregate expression or an offset window
             // function or a Pandas window UDF.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionResolution.scala
@@ -199,7 +199,7 @@ class FunctionResolution(
         val newAgg = agg match {
           case owg: SupportsOrderingWithinGroup
               if !owg.orderingFilled && u.orderingWithinGroup.nonEmpty =>
-            owg.withOrderingWithinGroup(u.orderingWithinGroup)
+            owg.withOrderingWithinGroup(u.orderingWithinGroup, u)
           case _ =>
             agg
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.expressions.aggregate
 
 import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.analysis.{ExpressionBuilder, UnresolvedWithinGroup}
+import org.apache.spark.sql.catalyst.analysis.{ExpressionBuilder, UnresolvedFunction, UnresolvedWithinGroup}
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Descending, Expression, ExpressionDescription, ImplicitCastInputTypes, SortOrder}
 import org.apache.spark.sql.catalyst.expressions.Cast.toSQLExpr
 import org.apache.spark.sql.catalyst.trees.UnaryLike
@@ -188,7 +188,8 @@ case class Mode(
 
   assert(orderingFilled || (!orderingFilled && reverseOpt.isEmpty))
 
-  override def withOrderingWithinGroup(orderingWithinGroup: Seq[SortOrder]): AggregateFunction = {
+  override def withOrderingWithinGroup(
+      orderingWithinGroup: Seq[SortOrder], u: UnresolvedFunction): AggregateFunction = {
     child match {
       case UnresolvedWithinGroup =>
         if (orderingWithinGroup.length != 1) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/SupportsOrderingWithinGroup.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/SupportsOrderingWithinGroup.scala
@@ -17,13 +17,15 @@
 
 package org.apache.spark.sql.catalyst.expressions.aggregate
 
+import org.apache.spark.sql.catalyst.analysis.UnresolvedFunction
 import org.apache.spark.sql.catalyst.expressions.SortOrder
 
 /**
  * The trait used to set the [[SortOrder]] for supporting functions.
  */
 trait SupportsOrderingWithinGroup { self: AggregateFunction =>
-  def withOrderingWithinGroup(orderingWithinGroup: Seq[SortOrder]): AggregateFunction
+  def withOrderingWithinGroup(
+      orderingWithinGroup: Seq[SortOrder], u: UnresolvedFunction): AggregateFunction
 
   /** Indicator that ordering was set. */
   def orderingFilled: Boolean

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.expressions.aggregate
 import java.util
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.analysis.{ExpressionBuilder, TypeCheckResult, UnresolvedWithinGroup}
+import org.apache.spark.sql.catalyst.analysis.{ExpressionBuilder, TypeCheckResult, UnresolvedFunction, UnresolvedWithinGroup}
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{DataTypeMismatch, TypeCheckSuccess}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.Cast._
@@ -376,7 +376,8 @@ case class PercentileCont(left: Expression, right: Expression, reverse: Boolean 
     percentile.checkInputDataTypes()
   }
 
-  override def withOrderingWithinGroup(orderingWithinGroup: Seq[SortOrder]): AggregateFunction = {
+  override def withOrderingWithinGroup(
+      orderingWithinGroup: Seq[SortOrder], u: UnresolvedFunction): AggregateFunction = {
     if (orderingWithinGroup.length != 1) {
       throw QueryCompilationErrors.wrongNumOrderingsForFunctionError(
         nodeName, 1, orderingWithinGroup.length)
@@ -434,7 +435,8 @@ case class PercentileDisc(
     s"$prettyName($distinct${right.sql}) WITHIN GROUP (ORDER BY ${left.sql}$direction)"
   }
 
-  override def withOrderingWithinGroup(orderingWithinGroup: Seq[SortOrder]): AggregateFunction = {
+  override def withOrderingWithinGroup(
+      orderingWithinGroup: Seq[SortOrder], u: UnresolvedFunction): AggregateFunction = {
     if (orderingWithinGroup.length != 1) {
       throw QueryCompilationErrors.wrongNumOrderingsForFunctionError(
         nodeName, 1, orderingWithinGroup.length)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/listagg-collations.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/listagg-collations.sql.out
@@ -74,7 +74,7 @@ Aggregate [listagg(c1#x, null, collate(c1#x, unicode_rtrim) ASC NULLS FIRST, 0, 
 -- !query
 SELECT listagg(DISTINCT c1 COLLATE utf8_lcase) WITHIN GROUP (ORDER BY c1 COLLATE utf8_binary) FROM (VALUES ('a'), ('b'), ('A'), ('B')) AS t(c1)
 -- !query analysis
-org.apache.spark.sql.catalyst.ExtendedAnalysisException
+org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "INVALID_WITHIN_GROUP_EXPRESSION.MISMATCH_WITH_DISTINCT_INPUT",
   "sqlState" : "42K0K",
@@ -82,5 +82,12 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "funcArg" : "\"collate(c1, utf8_lcase)\"",
     "funcName" : "`listagg`",
     "orderingExpr" : "\"collate(c1, utf8_binary)\""
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 93,
+    "fragment" : "listagg(DISTINCT c1 COLLATE utf8_lcase) WITHIN GROUP (ORDER BY c1 COLLATE utf8_binary)"
+  } ]
 }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/listagg.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/listagg.sql.out
@@ -408,7 +408,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 -- !query
 SELECT listagg(DISTINCT a) WITHIN GROUP (ORDER BY b) FROM df
 -- !query analysis
-org.apache.spark.sql.catalyst.ExtendedAnalysisException
+org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "INVALID_WITHIN_GROUP_EXPRESSION.MISMATCH_WITH_DISTINCT_INPUT",
   "sqlState" : "42K0K",
@@ -416,14 +416,21 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "funcArg" : "\"a\"",
     "funcName" : "`listagg`",
     "orderingExpr" : "\"b\""
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 52,
+    "fragment" : "listagg(DISTINCT a) WITHIN GROUP (ORDER BY b)"
+  } ]
 }
 
 
 -- !query
 SELECT listagg(DISTINCT a) WITHIN GROUP (ORDER BY a, b) FROM df
 -- !query analysis
-org.apache.spark.sql.catalyst.ExtendedAnalysisException
+org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "INVALID_WITHIN_GROUP_EXPRESSION.MISMATCH_WITH_DISTINCT_INPUT",
   "sqlState" : "42K0K",
@@ -431,5 +438,12 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "funcArg" : "\"a\"",
     "funcName" : "`listagg`",
     "orderingExpr" : "\"a\", \"b\""
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 55,
+    "fragment" : "listagg(DISTINCT a) WITHIN GROUP (ORDER BY a, b)"
+  } ]
 }

--- a/sql/core/src/test/resources/sql-tests/results/listagg-collations.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/listagg-collations.sql.out
@@ -70,7 +70,7 @@ SELECT listagg(DISTINCT c1 COLLATE utf8_lcase) WITHIN GROUP (ORDER BY c1 COLLATE
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.ExtendedAnalysisException
+org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "INVALID_WITHIN_GROUP_EXPRESSION.MISMATCH_WITH_DISTINCT_INPUT",
   "sqlState" : "42K0K",
@@ -78,5 +78,12 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "funcArg" : "\"collate(c1, utf8_lcase)\"",
     "funcName" : "`listagg`",
     "orderingExpr" : "\"collate(c1, utf8_binary)\""
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 93,
+    "fragment" : "listagg(DISTINCT c1 COLLATE utf8_lcase) WITHIN GROUP (ORDER BY c1 COLLATE utf8_binary)"
+  } ]
 }

--- a/sql/core/src/test/resources/sql-tests/results/listagg.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/listagg.sql.out
@@ -339,7 +339,7 @@ SELECT listagg(DISTINCT a) WITHIN GROUP (ORDER BY b) FROM df
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.ExtendedAnalysisException
+org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "INVALID_WITHIN_GROUP_EXPRESSION.MISMATCH_WITH_DISTINCT_INPUT",
   "sqlState" : "42K0K",
@@ -347,7 +347,14 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "funcArg" : "\"a\"",
     "funcName" : "`listagg`",
     "orderingExpr" : "\"b\""
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 52,
+    "fragment" : "listagg(DISTINCT a) WITHIN GROUP (ORDER BY b)"
+  } ]
 }
 
 
@@ -356,7 +363,7 @@ SELECT listagg(DISTINCT a) WITHIN GROUP (ORDER BY a, b) FROM df
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.ExtendedAnalysisException
+org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "INVALID_WITHIN_GROUP_EXPRESSION.MISMATCH_WITH_DISTINCT_INPUT",
   "sqlState" : "42K0K",
@@ -364,5 +371,12 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "funcArg" : "\"a\"",
     "funcName" : "`listagg`",
     "orderingExpr" : "\"a\", \"b\""
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 55,
+    "fragment" : "listagg(DISTINCT a) WITHIN GROUP (ORDER BY a, b)"
+  } ]
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to refactor `SupportsOrderingWithinGroup` so that centralized check.


### Why are the changes needed?
Currently, the check in analysis for `ListAgg` scattered in multiple locations.
We should improve it with centralized check.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
GA


### Was this patch authored or co-authored using generative AI tooling?
'No'.
