### PR TITLE
[SPARK-51042][SQL][3.5] Read and write the month and days fields of intervals with one call in Unsafe* classes

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeArrayData.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeArrayData.java
@@ -225,8 +225,9 @@ public final class UnsafeArrayData extends ArrayData implements Externalizable, 
     if (isNullAt(ordinal)) return null;
     final long offsetAndSize = getLong(ordinal);
     final int offset = (int) (offsetAndSize >> 32);
-    final int months = Platform.getInt(baseObject, baseOffset + offset);
-    final int days = Platform.getInt(baseObject, baseOffset + offset + 4);
+    final long monthAndDays = Platform.getLong(baseObject, baseOffset + offset);
+    final int months = (int) (0xFFFFFFFFL & monthAndDays);
+    final int days = (int) ((0xFFFFFFFF00000000L & monthAndDays) >> 32);
     final long microseconds = Platform.getLong(baseObject, baseOffset + offset + 8);
     return new CalendarInterval(months, days, microseconds);
   }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
@@ -139,8 +139,9 @@ public abstract class UnsafeWriter {
       BitSetMethods.set(getBuffer(), startingOffset, ordinal);
     } else {
       // Write the months, days and microseconds fields of interval to the variable length portion.
-      Platform.putInt(getBuffer(), cursor(), input.months);
-      Platform.putInt(getBuffer(), cursor() + 4, input.days);
+      long longVal =
+        ((long) input.months & 0xFFFFFFFFL) | (((long) input.days << 32) & 0xFFFFFFFF00000000L);
+      Platform.putLong(getBuffer(), cursor(), longVal);
       Platform.putLong(getBuffer(), cursor() + 8, input.microseconds);
     }
     // we need to reserve the space so that we can update it later.


### PR DESCRIPTION
This is the branch-3.5 backport of https://github.com/apache/spark/pull/49737

### What changes were proposed in this pull request?

Write the month and days fields of intervals with one call to Platform.put/getLong() instead of two calls to Platform.put/getInt().

In commit ac07cea234f4fb687442aafa8b6d411695110a4e there was a performance improvement to reading a writing CalendarIntervals in UnsafeRow. This makes writing intervals consistent with UnsafeRow and has better performance compared to the original code.

This also fixes big endian platforms where the old (two calls to getput) and new methods of reading and writing CalendarIntervals do not order the bytes in the same way. Currently CalendarInterval related tests in Catalyst and SQL are failing on big endian platforms.

There is no effect on little endian platforms (byte order is not affected) except for performance improvement.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?

* Improves performance reading and writing CalendarIntervals in Unsafe* classes
* Fixes big endian platforms where CalendarIntervals are not read or written correctly in Unsafe* classes
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?

No
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?

Existing unit tests on big and little endian platforms
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?

No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
