### PR TITLE
[SPARK-51184][CORE] Remove `TaskState.LOST` logic from `TaskSchedulerImpl`

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -786,30 +786,13 @@ private[spark] class TaskSchedulerImpl(
       try {
         Option(taskIdToTaskSetManager.get(tid)) match {
           case Some(taskSet) =>
-            if (state == TaskState.LOST) {
-              // TaskState.LOST is only used by the deprecated Mesos fine-grained scheduling mode,
-              // where each executor corresponds to a single task, so mark the executor as failed.
-              val execId = taskIdToExecutorId.getOrElse(tid, {
-                val errorMsg =
-                  "taskIdToTaskSetManager.contains(tid) <=> taskIdToExecutorId.contains(tid)"
-                taskSet.abort(errorMsg)
-                throw new SparkException(
-                  "taskIdToTaskSetManager.contains(tid) <=> taskIdToExecutorId.contains(tid)")
-              })
-              if (executorIdToRunningTaskIds.contains(execId)) {
-                reason = Some(
-                  ExecutorProcessLost(
-                    s"Task $tid was lost, so marking the executor as lost as well."))
-                removeExecutor(execId, reason.get)
-                failedExecutor = Some(execId)
-              }
-            }
+            assert(state != TaskState.LOST)
             if (TaskState.isFinished(state)) {
               cleanupTaskState(tid)
               taskSet.removeRunningTask(tid)
               if (state == TaskState.FINISHED) {
                 taskResultGetter.enqueueSuccessfulTask(taskSet, tid, serializedData)
-              } else if (Set(TaskState.FAILED, TaskState.KILLED, TaskState.LOST).contains(state)) {
+              } else if (Set(TaskState.FAILED, TaskState.KILLED).contains(state)) {
                 taskResultGetter.enqueueFailedTask(taskSet, tid, state, serializedData)
               }
             }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `TaskState.LOST` logic from `TaskSchedulerImpl` from Apache Spark 4.1.0.

https://github.com/apache/spark/blob/6440bdec8af64f0d6b55d53eacb2591eaf8eb859/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala#L789-L790

### Why are the changes needed?

Since Apache Spark 4.0.0, `Apache Mesos` code is removed completely. Since `TaskState.LOST` is no longer used, we had better clean up this unused code to simplify the logic.

- #43135

Please note that this PR didn't aim to remove `LOST` enum value from `TaskState` because it's exposed like the following although it's `private[spark]`.
- https://spark.apache.org/docs/4.0.0-preview2/api/java/org/apache/spark/TaskState.html

![Screenshot 2025-02-12 at 13 11 03](https://github.com/user-attachments/assets/d47af16e-f7c8-44e8-8e62-b77b6f0e9eb4)

### Does this PR introduce _any_ user-facing change?

No, behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.