### PR TITLE
[SPARK-51177][PYTHON][CONNECT] Add `InvalidCommandInput` to Spark Connect Python client

### DIFF
--- a/python/pyspark/errors/exceptions/connect.py
+++ b/python/pyspark/errors/exceptions/connect.py
@@ -301,6 +301,12 @@ class InvalidPlanInput(SparkConnectGrpcException):
     """
 
 
+class InvalidCommandInput(SparkConnectGrpcException):
+    """
+    Error thrown when a connect command is not valid.
+    """
+
+
 # Update EXCEPTION_CLASS_MAPPING here when adding a new exception
 EXCEPTION_CLASS_MAPPING = {
     "org.apache.spark.sql.catalyst.parser.ParseException": ParseException,
@@ -319,6 +325,7 @@ EXCEPTION_CLASS_MAPPING = {
     "org.apache.spark.SparkNoSuchElementException": SparkNoSuchElementException,
     "org.apache.spark.SparkException": SparkException,
     "org.apache.spark.sql.connect.common.InvalidPlanInput": InvalidPlanInput,
+    "org.apache.spark.sql.connect.common.InvalidCommandInput": InvalidCommandInput,
 }
 
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR proposes to add `InvalidCommandInput` to Spark Connect Python client.

### Why are the changes needed?

To keep the consistency with Spark Connect Scala client. We should capture the `SparkConnectGrpcException` more generally across all clients.

### Does this PR introduce _any_ user-facing change?

No API changes, but the user-facing error message would keep consistency with Spark Connect Scala client.

### How was this patch tested?

The existing CI should pass

### Was this patch authored or co-authored using generative AI tooling?

No.
