### PR TITLE
[SPARK-51190][ML][PYTHON][CONNECT] Fix TreeEnsembleModel.treeWeights

### DIFF
--- a/python/pyspark/ml/tree.py
+++ b/python/pyspark/ml/tree.py
@@ -234,7 +234,7 @@ class _TreeEnsembleModel(JavaPredictionModel[T]):
     @since("1.5.0")
     def treeWeights(self) -> List[float]:
         """Return the weights for each tree"""
-        return list(self._call_java("javaTreeWeights"))
+        return list(self._call_java("treeWeights"))
 
     @property
     @since("2.0.0")

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -512,7 +512,6 @@ private[ml] object MLUtils {
         "predictLeaf",
         "trees",
         "treeWeights",
-        "javaTreeWeights",
         "getNumTrees",
         "totalNumNodes",
         "toDebugString")),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix TreeEnsembleModel.treeWeights


### Why are the changes needed?
the pyspark classic used `javaTreeWeights` to 
https://github.com/apache/spark/blob/ba18f502efbf4788410df65ab4a4edea8c2ec2db/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala#L138-L141

actually, I test that the `def treeWeights: Array[Double]` works now, change it to `treeWeights` to narrow the allow list


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
existing tests


### Was this patch authored or co-authored using generative AI tooling?
no
