### PR TITLE
[SPARK-51182][SQL] DataFrameWriter should throw dataPathNotSpecifiedError when path is not specified

### DIFF
--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -4000,7 +4000,7 @@ test_that("Call DataFrameWriter.save() API in Java without path and check argume
   # DataFrameWriter.save() without path.
   expect_error(write.df(df, source = "csv"),
                paste("Error in save : org.apache.spark.SparkIllegalArgumentException:",
-                     "Expected exactly one path to be specified"))
+                     "'path' is not specified."))
   expect_error(write.json(df, jsonPath),
               "Error in json : analysis error - \\[PATH_ALREADY_EXISTS\\].*")
   expect_error(write.text(df, jsonPath),

--- a/python/pyspark/sql/tests/test_readwriter.py
+++ b/python/pyspark/sql/tests/test_readwriter.py
@@ -238,6 +238,13 @@ class ReadwriterTestsMixin:
 
                 self.assertEqual(join2.columns, ["id", "value_1", "index", "value_2"])
 
+    # "[SPARK-51182]: DataFrameWriter should throw dataPathNotSpecifiedError when path is not
+    # specified"
+    def test_save(self):
+        writer = self.df.write
+        with self.assertRaisesRegex(Exception, "'path' is not specified."):
+            writer.save()
+
 
 class ReadwriterV2TestsMixin:
     def test_api(self):

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -467,8 +467,10 @@ case class DataSource(
     val allPaths = paths ++ caseInsensitiveOptions.get("path")
     val outputPath = if (allPaths.length == 1) {
       makeQualified(new Path(allPaths.head))
-    } else {
+    } else if (allPaths.length > 1) {
       throw QueryExecutionErrors.multiplePathsSpecifiedError(allPaths)
+    } else {
+      throw QueryExecutionErrors.dataPathNotSpecifiedError()
     }
 
     val caseSensitive = sparkSession.sessionState.conf.caseSensitiveAnalysis

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameReaderWriterSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameReaderWriterSuite.java
@@ -20,14 +20,21 @@ package test.org.apache.spark.sql;
 import java.io.File;
 import java.util.HashMap;
 
+import org.apache.spark.SparkIllegalArgumentException;
+import org.apache.spark.sql.DataFrameWriter;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.test.TestSparkSession;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.util.Utils;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 public class JavaDataFrameReaderWriterSuite {
   private SparkSession spark = new TestSparkSession();
@@ -151,5 +158,17 @@ public class JavaDataFrameReaderWriterSuite {
     spark.read().schema(schema).orc(input, input, input);
     spark.read().schema(schema).orc(new String[]{input, input})
         .write().orc(output);
+  }
+
+  @Test
+  @DisplayName("[SPARK-51182]: DataFrameWriter should throw dataPathNotSpecifiedError when path " +
+      "is not specified")
+  public void testPathNotSpecified() {
+    DataFrameWriter<Long> dataFrameWriter = spark.range(0).write();
+    SparkIllegalArgumentException e = assertThrowsExactly(
+        SparkIllegalArgumentException.class,
+        () -> dataFrameWriter.save(),
+        "Expected save() to throw SparkIllegalArgumentException when path is not specified");
+    assertEquals("'path' is not specified.", e.getMessage());
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -32,7 +32,7 @@ import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 import org.apache.parquet.schema.Type.Repetition
 import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.{SparkContext, TestUtils}
+import org.apache.spark.{SparkContext, SparkIllegalArgumentException, TestUtils}
 import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
 import org.apache.spark.internal.io.HadoopMapReduceCommitProtocol
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
@@ -1466,5 +1466,13 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSparkSession with 
       .replaceFirst("file:/", "har:/")
 
     testRead(spark.read.schema(fileSchema).csv(s"$harPath/test.csv"), data, fileSchema)
+  }
+
+  test("SPARK-51182: DataFrameWriter should throw dataPathNotSpecifiedError when path is not " +
+    "specified") {
+    val dataFrameWriter = spark.range(0).write
+    checkError(
+      exception = intercept[SparkIllegalArgumentException](dataFrameWriter.save()),
+      condition = "_LEGACY_ERROR_TEMP_2047")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change error message from `Expected exactly one path to be specified, but got: .` to `'path' is not specified.` when path is not specified in the call to `DataFrame.write().save(path)` explicitly or using `option(path, ...)`, `parquet(path)` and etc.

### Why are the changes needed?
The error message is more accurate. 

### Does this PR introduce _any_ user-facing change?
Yes, user would get corrected error message when they do not specify path.


### How was this patch tested?
Updated error message in the R test suite.

### Was this patch authored or co-authored using generative AI tooling?
No
