### PR TITLE
[SPARK-51198][CORE][DOCS] Revise `defaultMinPartitions` function description

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2877,7 +2877,10 @@ class SparkContext(config: SparkConf) extends Logging {
   /**
    * Default min number of partitions for Hadoop RDDs when not given by user
    * Notice that we use math.min so the "defaultMinPartitions" cannot be higher than 2.
-   * The reasons for this are discussed in https://github.com/mesos/spark/pull/718
+   * For large files, the Hadoop InputFormat library always creates more partitions even though
+   * defaultMinPartitions is 2. For small files, it can be good to process small files quickly.
+   * However, usually when Spark joins a small table with a big one, we'll still spend most of
+   * time on the map part of the big one anyway.
    */
   def defaultMinPartitions: Int = math.min(defaultParallelism, 2)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to revise the function description of `SparkContext.defaultMinPartitions`.

### Why are the changes needed?

The repository, `https://github.com/mesos/spark`, was archived 11 years ago.

We had better embed the description instead of pointing to the ancient repository. It's hard to figure out the real reasons from a series of comments.

https://github.com/apache/spark/blob/0a102327d52712f3947cb90da671ffb18be62626/core/src/main/scala/org/apache/spark/SparkContext.scala#L2880

### Does this PR introduce _any_ user-facing change?

No. This is a change of comment.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.