### PR TITLE
[SPARK-51146][SQL][FOLLOWUP] Respect system env `SPARK_CONNECT_MODE` in places that access the api mode config

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -151,7 +151,7 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
       OptionParser parser = new OptionParser(true);
       parser.parse(submitArgs);
       this.isSpecialCommand = parser.isSpecialCommand;
-      boolean connectByDefault = "1".equals(System.getenv("SPARK_CONNECT_MODE"))
+      boolean connectByDefault = "1".equals(System.getenv("SPARK_CONNECT_MODE"));
       String defaultApiMode = connectByDefault ? "connect" : "classic";
       String apiMode = conf.getOrDefault(SparkLauncher.SPARK_API_MODE, defaultApiMode);
       if (conf.containsKey("spark.remote") || "connect".equalsIgnoreCase(apiMode)) {

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -391,6 +391,7 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
       env.put("SPARK_CONNECT_MODE_ENABLED", "1");
     } else if (isRemote) {
       // If `removeStr` is not specified but isRemote is true, it means the api mode is connect.
+      env.put("SPARK_REMOTE", masterStr);
       env.put("SPARK_CONNECT_MODE_ENABLED", "1");
     }
 

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -151,6 +151,11 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
       OptionParser parser = new OptionParser(true);
       parser.parse(submitArgs);
       this.isSpecialCommand = parser.isSpecialCommand;
+      String defaultApiMode = "1".equals(System.getenv("SPARK_CONNECT_MODE")) ? "connect" : "classic";
+      String apiMode = conf.getOrDefault(SparkLauncher.SPARK_API_MODE, defaultApiMode).toLowerCase(Locale.ROOT);
+      if (conf.containsKey("spark.remote") || "connect".equals(apiMode)) {
+        isRemote = true;
+      }
     } else {
       this.isExample = isExample;
       this.isSpecialCommand = true;
@@ -384,12 +389,9 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
     if (remoteStr != null) {
       env.put("SPARK_REMOTE", remoteStr);
       env.put("SPARK_CONNECT_MODE_ENABLED", "1");
-    } else {
-      String defaultApiMode = "1".equals(System.getenv("SPARK_CONNECT_MODE")) ? "connect" : "classic";
-      String apiMode = conf.getOrDefault(SparkLauncher.SPARK_API_MODE, defaultApiMode).toLowerCase(Locale.ROOT);
-      if (apiMode.equals("connect")) {
-        env.put("SPARK_CONNECT_MODE_ENABLED", "1");
-      }
+    } else if (isRemote) {
+      // If `removeStr` is not specified but isRemote is true, it means the api mode is connect.
+      env.put("SPARK_CONNECT_MODE_ENABLED", "1");
     }
 
     if (!isEmpty(pyOpts)) {
@@ -529,11 +531,6 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
           checkArgument(value != null, "Missing argument to %s", CONF);
           String[] setConf = value.split("=", 2);
           checkArgument(setConf.length == 2, "Invalid argument to %s: %s", CONF, value);
-          if (setConf[0].equals("spark.remote") ||
-              (setConf[0].equals(SparkLauncher.SPARK_API_MODE) &&
-                setConf[1].toLowerCase(Locale.ROOT).equals("connect"))) {
-            isRemote = true;
-          }
           conf.put(setConf[0], setConf[1]);
         }
         case CLASS -> {

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -152,8 +152,8 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
       parser.parse(submitArgs);
       this.isSpecialCommand = parser.isSpecialCommand;
       String defaultApiMode = "1".equals(System.getenv("SPARK_CONNECT_MODE")) ? "connect" : "classic";
-      String apiMode = conf.getOrDefault(SparkLauncher.SPARK_API_MODE, defaultApiMode).toLowerCase(Locale.ROOT);
-      if (conf.containsKey("spark.remote") || "connect".equals(apiMode)) {
+      String apiMode = conf.getOrDefault(SparkLauncher.SPARK_API_MODE, defaultApiMode);
+      if (conf.containsKey("spark.remote") || "connect".equalsIgnoreCase(apiMode)) {
         isRemote = true;
       }
     } else {

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -384,11 +384,12 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
     if (remoteStr != null) {
       env.put("SPARK_REMOTE", remoteStr);
       env.put("SPARK_CONNECT_MODE_ENABLED", "1");
-    } else if (conf.getOrDefault(
-        SparkLauncher.SPARK_API_MODE, "classic").toLowerCase(Locale.ROOT).equals("connect") &&
-        masterStr != null) {
-      env.put("SPARK_REMOTE", masterStr);
-      env.put("SPARK_CONNECT_MODE_ENABLED", "1");
+    } else {
+      String defaultApiMode = "1".equals(System.getenv("SPARK_CONNECT_MODE")) ? "connect" : "classic";
+      String apiMode = conf.getOrDefault(SparkLauncher.SPARK_API_MODE, defaultApiMode).toLowerCase(Locale.ROOT);
+      if (apiMode.equals("connect")) {
+        env.put("SPARK_CONNECT_MODE_ENABLED", "1");
+      }
     }
 
     if (!isEmpty(pyOpts)) {

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -151,7 +151,8 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
       OptionParser parser = new OptionParser(true);
       parser.parse(submitArgs);
       this.isSpecialCommand = parser.isSpecialCommand;
-      String defaultApiMode = "1".equals(System.getenv("SPARK_CONNECT_MODE")) ? "connect" : "classic";
+      boolean connectByDefault = "1".equals(System.getenv("SPARK_CONNECT_MODE"))
+      String defaultApiMode = connectByDefault ? "connect" : "classic";
       String apiMode = conf.getOrDefault(SparkLauncher.SPARK_API_MODE, defaultApiMode);
       if (conf.containsKey("spark.remote") || "connect".equalsIgnoreCase(apiMode)) {
         isRemote = true;

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -481,7 +481,7 @@ class SparkSession(SparkConversionMixin):
 
             with self._lock:
                 default_api_mode = "classic"
-                if os.environ["SPARK_CONNECT_MODE"] == "1":
+                if os.environ.get("SPARK_CONNECT_MODE", "") == "1":
                     default_api_mode = "connect"
 
                 is_api_mode_connect = opts.get("spark.api.mode", default_api_mode).lower() == "connect"

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -480,7 +480,11 @@ class SparkSession(SparkConversionMixin):
             from pyspark.core.context import SparkContext
 
             with self._lock:
-                is_api_mode_connect = opts.get("spark.api.mode", "classic").lower() == "connect"
+                default_api_mode = "classic"
+                if os.environ["SPARK_CONNECT_MODE"] == "1":
+                    default_api_mode = "connect"
+
+                is_api_mode_connect = opts.get("spark.api.mode", default_api_mode).lower() == "connect"
 
                 if (
                     "SPARK_CONNECT_MODE_ENABLED" in os.environ

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -484,7 +484,9 @@ class SparkSession(SparkConversionMixin):
                 if os.environ.get("SPARK_CONNECT_MODE", "") == "1":
                     default_api_mode = "connect"
 
-                is_api_mode_connect = opts.get("spark.api.mode", default_api_mode).lower() == "connect"
+                is_api_mode_connect = (
+                    opts.get("spark.api.mode", default_api_mode).lower() == "connect"
+                )
 
                 if (
                     "SPARK_CONNECT_MODE_ENABLED" in os.environ


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a followup of the additional Spark Connect distribution work. Some places that access the api mode config do not use the config framework and do not respect the defined default value. We need to update them manually to get the default value properly by looking at the special system env `SPARK_CONNECT_MODE` set in scripts of the spark connect distribution.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
to make the additional Spark Connect distribution work as expected.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
manually tested locally. The expectation is:
1. if `--remote` is specified, then we pick connect mode no matter what the api mode config is
2. if `--master` is specified, then we pick classic or connect mode depending on the api mode config. If the config is not specified, the default value varies between the default distribution and the Spark connect distribution.
3. if neither `--remote` nor `--master` is specified, it's equal to `--master local[*]`, and then it's the same as rule 2.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no