### PR TITLE
[SPARK-51200][BUILD] Add SparkR deprecation info to `README.md` and `make-distribution.sh` help

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Apache Spark
 
 Spark is a unified analytics engine for large-scale data processing. It provides
-high-level APIs in Scala, Java, Python, and R, and an optimized engine that
+high-level APIs in Scala, Java, Python, and R (Deprecated), and an optimized engine that
 supports general computation graphs for data analysis. It also supports a
 rich set of higher-level tools including Spark SQL for SQL and DataFrames,
 pandas API on Spark for pandas workloads, MLlib for machine learning, GraphX for graph processing,

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -47,6 +47,7 @@ function exit_with_usage {
   cl_options="[--name] [--tgz] [--pip] [--r] [--connect] [--mvn <mvn-command>]"
   echo "make-distribution.sh $cl_options <maven build options>"
   echo "See Spark's \"Building Spark\" doc for correct Maven options."
+  echo "SparkR is deprecated from Apache Spark 4.0.0 and will be removed in a future version."
   echo ""
   exit 1
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `SparkR` deprecation info additionally to the following for developers.
- `README.md`
- `make-distribution.sh` help message

### Why are the changes needed?

`SparkR` is deprecated properly by the following.
- #47842

This PR adds a little more because `README.md` and `make-distribution.sh` are the starting point for downstream Spark distribution developers.

### Does this PR introduce _any_ user-facing change?

No behavior change. Only the documentation and help message of developer script.

### How was this patch tested?

Manual review.

```
$ dev/make-distribution.sh --help 2> /dev/null
make-distribution.sh - tool for making binary distributions of Spark

usage:
make-distribution.sh [--name] [--tgz] [--pip] [--r] [--connect] [--mvn <mvn-command>] <maven build options>
See Spark's "Building Spark" doc for correct Maven options.
SparkR is deprecated from Apache Spark 4.0.0 and will be removed in a future version.
```

### Was this patch authored or co-authored using generative AI tooling?

No