### PR TITLE
[SPARK-51201][SQL] Make Partitioning Hints support byte and short values

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6640,7 +6640,7 @@
   },
   "_LEGACY_ERROR_TEMP_1047" : {
     "message" : [
-      "<hintName> Hint parameter should include columns, but <invalidParams> found."
+      "<hintName> Hint parameters should include an optional integral partitionNum and columns, but <invalidParams> can not be recognized as either partitionNum or columns."
     ]
   },
   "_LEGACY_ERROR_TEMP_1048" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6640,7 +6640,7 @@
   },
   "_LEGACY_ERROR_TEMP_1047" : {
     "message" : [
-      "<hintName> Hint parameters should include an optional integral partitionNum and columns, but <invalidParams> can not be recognized as either partitionNum or columns."
+      "<hintName> Hint parameters should include an optional integral partitionNum and/or columns, but <invalidParams> can not be recognized as either partitionNum or columns."
     ]
   },
   "_LEGACY_ERROR_TEMP_1048" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -184,6 +184,7 @@ object ResolveHints {
         case _ => (None, hint.parameters)
       }
     }
+
     private def validateParameters(hint: String, parms: Seq[Any]): Unit = {
       val invalidParams = parms.filter(!_.isInstanceOf[UnresolvedAttribute])
       if (invalidParams.nonEmpty) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -335,6 +335,26 @@ object IntegerLiteral {
 }
 
 /**
+ * Extractor for retrieving Short literals.
+ */
+object ShortLiteral {
+  def unapply(a: Any): Option[Short] = a match {
+    case Literal(a: Short, ShortType) => Some(a)
+    case _ => None
+  }
+}
+
+/**
+ * Extractor for retrieving Byte literals.
+ */
+object ByteLiteral {
+  def unapply(a: Any): Option[Byte] = a match {
+    case Literal(a: Byte, ByteType) => Some(a)
+    case _ => None
+  }
+}
+
+/**
  * Extractor for retrieving Long literals.
  */
 object LongLiteral {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
@@ -139,11 +139,17 @@ class ResolveHintsSuite extends AnalysisTest {
       UnresolvedHint("coalesce", Seq(Literal(20)), table("TaBlE")),
       Repartition(numPartitions = 20, shuffle = false, child = testRelation))
     checkAnalysisWithoutViewWrapper(
+      UnresolvedHint("coalesce", Seq(Literal(20.toByte)), table("TaBlE")),
+      Repartition(numPartitions = 20, shuffle = false, child = testRelation))
+    checkAnalysisWithoutViewWrapper(
       UnresolvedHint("REPARTITION", Seq(Literal(100)), table("TaBlE")),
       Repartition(numPartitions = 100, shuffle = true, child = testRelation))
     checkAnalysisWithoutViewWrapper(
       UnresolvedHint("RePARTITion", Seq(Literal(200)), table("TaBlE")),
       Repartition(numPartitions = 200, shuffle = true, child = testRelation))
+    checkAnalysisWithoutViewWrapper(
+      UnresolvedHint("REPARTITION", Seq(Literal(100.toShort)), table("TaBlE")),
+      Repartition(numPartitions = 100, shuffle = true, child = testRelation))
 
     val errMsg = "COALESCE Hint expects a partition number as a parameter"
 
@@ -194,7 +200,8 @@ class ResolveHintsSuite extends AnalysisTest {
         Seq(SortOrder(AttributeReference("a", IntegerType)(), Ascending)),
         testRelation, None))
 
-    val errMsg2 = "REPARTITION Hint parameter should include columns, but"
+    val errMsg2 = "REPARTITION Hint parameters should include an optional integral partitionNum " +
+      "and/or columns, but"
 
     assertAnalysisError(
       UnresolvedHint("REPARTITION", Seq(Literal(true)), table("TaBlE")),
@@ -206,8 +213,8 @@ class ResolveHintsSuite extends AnalysisTest {
         table("TaBlE")),
       Seq(errMsg2))
 
-    val errMsg3 = "REPARTITION_BY_RANGE Hint parameter should include columns, but"
-
+    val errMsg3 = "REPARTITION_BY_RANGE Hint parameters should include an optional " +
+      "integral partitionNum and/or columns, but"
     assertAnalysisError(
       UnresolvedHint("REPARTITION_BY_RANGE",
         Seq(Literal(1.0), AttributeReference("a", IntegerType)()),
@@ -339,13 +346,15 @@ class ResolveHintsSuite extends AnalysisTest {
         testRelation)
     }
 
+    val msg = "REBALANCE Hint parameters should include an optional integral partitionNum " +
+      "and/or columns, but 1 can not be recognized as either partitionNum or columns."
     assertAnalysisError(
       UnresolvedHint("REBALANCE", Seq(Literal(1), Literal(1)), table("TaBlE")),
-      Seq("Hint parameter should include columns"))
+      Seq(msg))
 
     assertAnalysisError(
       UnresolvedHint("REBALANCE", Seq(1, Literal(1)), table("TaBlE")),
-      Seq("Hint parameter should include columns"))
+      Seq(msg))
   }
 
   test("SPARK-38410: Support specify initial partition number for rebalance") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

The `Dataset.hint` method takes `Any*` as parameters for both the partition number and other columns, and the `Partitioning Hints` resolution process treats anything that CAN NOT be resolved to a partition number as a column candidate. For example, cases like below will report an ambagious error message for users.

```scala
val n: Short = 123
spark.range(10000).hint("rebalance", n).show
```

```
REBALANCE Hint parameter should include columns, but 123 found.
```

This PR makes Partitioning Hints resolution accept byte and short values and improves the debugging error message.

### Why are the changes needed?

- A byte or short value can possibly exist in a user's spark pipeline and takes as a partition number, w/ this PR, runtime errors can be reduced
- improve error message for debugging
- For developers that build Spark Connect clients in other languages, there are some cases in which they can not handle or distinguish integrals. It's good for the server side to handle these valid cases.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, `Dataset.hint("coalesce", 3.toByte)` and `/*+ COALESCE(3S) */` now are valid

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no