### PR TITLE
[SPARK-49479][CORE] Cancel the Timer non-daemon thread on stopping the BarrierCoordinator

### DIFF
--- a/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
@@ -77,6 +77,7 @@ private[spark] class BarrierCoordinator(
       states.forEachValue(1, clearStateConsumer)
       states.clear()
       listenerBus.removeListener(listener)
+      timer.cancel()
     } finally {
       super.onStop()
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Cancelling the `Timer` non-daemon thread on stopping the `BarrierCoordinator`


### Why are the changes needed?
In Barrier Execution Mode, Spark driver JVM could hang around after calling spark.stop(). Although the Spark Context was shutdown, the JVM was still running. The reason was that there is a non-daemon timer thread named `BarrierCoordinator barrier epoch increment timer`, which prevented the driver JVM from stopping.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Run the following scripts locally using s./bin/spark-submit. Without this change, the JVM would hang there and not exit. With this change it would exit successfully.
1. [barrier_example.py](https://gist.github.com/jshmchenxi/5d7e7c61e1eedd03cd6d676699059e9b#file-barrier_example-py) 
2. [xgboost-test.py](https://gist.github.com/bcheena/510230e19120eb9ae631dcafa804409f). 


### Was this patch authored or co-authored using generative AI tooling?
No
