### PR TITLE
[SPARK-51181] [SQL] Enforce determinism when pulling out non deterministic expressions from logical plan

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/NondeterministicExpressionCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/NondeterministicExpressionCollection.scala
@@ -17,11 +17,14 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
+import java.util.LinkedHashMap
+
 import org.apache.spark.sql.catalyst.expressions._
 
 object NondeterministicExpressionCollection {
   def getNondeterministicToAttributes(
-      expressions: Seq[Expression]): Map[Expression, NamedExpression] = {
+      expressions: Seq[Expression]): LinkedHashMap[Expression, NamedExpression] = {
+    val nonDeterministicToAttributes = new LinkedHashMap[Expression, NamedExpression]
     expressions
       .filterNot(_.deterministic)
       .flatMap { expr =>
@@ -34,9 +37,9 @@ object NondeterministicExpressionCollection {
             case n: NamedExpression => n
             case _ => Alias(e, "_nondeterministic")()
           }
-          e -> ne
+          nonDeterministicToAttributes.put(e, ne)
         }
       }
-      .toMap
+    nonDeterministicToAttributes
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enforce determinism when pulling out non deterministic expressions from logical plan.

### Why are the changes needed?
This is needed to avoid plan normalization problem when comparing single-pass and fixed point results.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.