### PR TITLE
[SPARK-51046][SQL][TEST] Reduce `numCols` in `withFilter()` to prevent `SubExprEliminationBenchmark` from failing due to a Codegen error

### DIFF
--- a/sql/core/benchmarks/SubExprEliminationBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/SubExprEliminationBenchmark-jdk21-results.txt
@@ -3,23 +3,23 @@ Benchmark for performance of subexpression elimination
 ================================================================================================
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 from_json as subExpr in Project:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-subExprElimination false, codegen: true            6313           6431         120          0.0    63134831.3       1.0X
-subExprElimination false, codegen: false           6093           6348         288          0.0    60930747.6       1.0X
-subExprElimination true, codegen: true             1387           1425          33          0.0    13872525.5       4.6X
-subExprElimination true, codegen: false            1218           1332          99          0.0    12182992.7       5.2X
+subExprElimination false, codegen: true            6431           6648         259          0.0    64312623.3       1.0X
+subExprElimination false, codegen: false           6236           6315          74          0.0    62364653.0       1.0X
+subExprElimination true, codegen: true             1237           1359         114          0.0    12365648.3       5.2X
+subExprElimination true, codegen: false            1217           1295          68          0.0    12170008.6       5.3X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 from_json as subExpr in Filter:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-subExprElimination false, codegen: true            6610           6705          85          0.0    66104698.4       1.0X
-subExprElimination false, codegen: false           6647           6730          76          0.0    66469463.5       1.0X
-subExprElimination true, codegen: true             2077           2126          43          0.0    20769220.1       3.2X
-subExprElimination true, codegen: false            1949           2000          64          0.0    19489004.0       3.4X
+subExprElimination false, codegen: true            3141           3207          69          0.0    31407804.8       1.0X
+subExprElimination false, codegen: false           2196           2231          30          0.0    21962409.0       1.4X
+subExprElimination true, codegen: true             2924           2989          78          0.0    29239465.3       1.1X
+subExprElimination true, codegen: false             627            655          41          0.0     6267700.0       5.0X
 
 

--- a/sql/core/benchmarks/SubExprEliminationBenchmark-results.txt
+++ b/sql/core/benchmarks/SubExprEliminationBenchmark-results.txt
@@ -3,23 +3,23 @@ Benchmark for performance of subexpression elimination
 ================================================================================================
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 from_json as subExpr in Project:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-subExprElimination false, codegen: true            6438           6551          98          0.0    64378783.5       1.0X
-subExprElimination false, codegen: false           6216           6320         175          0.0    62161826.1       1.0X
-subExprElimination true, codegen: true             1480           1518          39          0.0    14799890.8       4.3X
-subExprElimination true, codegen: false            1321           1429          94          0.0    13212919.6       4.9X
+subExprElimination false, codegen: true            6398           6601         177          0.0    63980070.0       1.0X
+subExprElimination false, codegen: false           6018           6137         123          0.0    60178371.6       1.1X
+subExprElimination true, codegen: true             1288           1352          78          0.0    12883220.0       5.0X
+subExprElimination true, codegen: false            1299           1340          66          0.0    12989399.4       4.9X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 from_json as subExpr in Filter:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-subExprElimination false, codegen: true            7107           7310         207          0.0    71066752.8       1.0X
-subExprElimination false, codegen: false           6738           6781          41          0.0    67375897.0       1.1X
-subExprElimination true, codegen: true             2052           2110          51          0.0    20519152.3       3.5X
-subExprElimination true, codegen: false            2053           2079          33          0.0    20526629.8       3.5X
+subExprElimination false, codegen: true            2474           2512          44          0.0    24744107.3       1.0X
+subExprElimination false, codegen: false           2231           2246          20          0.0    22306061.2       1.1X
+subExprElimination true, codegen: true             2408           2509         100          0.0    24084091.2       1.0X
+subExprElimination true, codegen: false             642            683          41          0.0     6421785.4       3.9X
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SubExprEliminationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SubExprEliminationBenchmark.scala
@@ -82,7 +82,7 @@ object SubExprEliminationBenchmark extends SqlBasedBenchmark {
 
     withTempPath { path =>
       prepareDataInfo(benchmark)
-      val numCols = 500
+      val numCols = 300
       val schema = writeWideRow(path.getAbsolutePath, rowsNum, numCols)
 
       val jsonValue = from_json($"value", schema)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR aims to reduce `numCols` in `withFilter()` to prevent `SubExprEliminationBenchmark` from failing due to a Codegen error.

I did some debug investigation and found that in the current master branch, the codegen code has a huge `processNext` method, but in branch-3.5, it is split into many small methods. Because the logic of codegen is different, the previous benchmark cannot run normally.

master branch:
```
protected void processNext() throws java.io.IOException {

	while ( inputadapter_input_0.hasNext()) {
                 ...
        }
}
```
3.5 branch:
```
        public boolean eval(InternalRow i) {
		boolean value_2997 = Or_498(i);
		return !globalIsNull_498 && value_2997;
	}
        private boolean Or_498(InternalRow i) {
                ...
        }
        ...
        private boolean Or_xxxx(InternalRow i) {
               ...
        }    
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
If we run `SubExprEliminationBenchmark`:
```
build/sbt "sql/Test/runMain org.apache.spark.sql.execution.SubExprEliminationBenchmark"
```
It fails at `CodeGenerator`, details:
> [info] Running benchmark: from_json as subExpr in Filter
[info]   Running case: subExprElimination false, codegen: true
[info] 00:08:31.509 ERROR org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator: Failed to compile the generated Java code.
[info] org.codehaus.commons.compiler.InternalCompilerException: Compiling "GeneratedClass" in File 'generated.java', Line 1, Column 1: File 'generated.java', Line 24, Column 16: Compiling "processNext()"

The root cause is:
> [error] Caused by: org.codehaus.commons.compiler.InternalCompilerException: Code grows beyond 64 KB
[error]         at org.codehaus.janino.CodeContext.makeSpace(CodeContext.java:699)
[error]         at org.codehaus.janino.CodeContext.write(CodeContext.java:558)
[error]         at org.codehaus.janino.UnitCompiler.write(UnitCompiler.java:13079)
[error]         at org.codehaus.janino.UnitCompiler.store(UnitCompiler.java:12752)
[error]         at org.codehaus.janino.UnitCompiler.store(UnitCompiler.java:12730)
[error]         at org.codehaus.janino.UnitCompiler.compile2(UnitCompiler.java:2742)
[error]         ... 164 more

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, just fix a test benchmark failure.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Run benchmark tests manually.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.