### PR TITLE
[SPARK-51205][BUILD][TESTS] Upgrade `bytebuddy` to 1.17.0 to support Java 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1199,13 +1199,13 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.14.17</version>
+        <version>1.17.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.14.17</version>
+        <version>1.17.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `bytebuddy` to 1.17.0 as a part of Java 25 preparation.

### Why are the changes needed?

**Release Note**
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.0

**Support Matrix of ByteBuddy**
| ByteBuddy Version | Java Version |
| - | - |
| 1.17.0 | 25+ |
| 1.15.4 | 24 |
| 1.14.12 | 23 |
| 1.14.8 | 22 |
| 1.14.3 | 21 |
| 1.12.18 | 20 |
| 1.12.9 | 19 |
| 1.11.6 | 18 |
| 1.10.19 | 17 |

### Does this PR introduce _any_ user-facing change?

No, this is a test dependency upgrade.

### How was this patch tested?

Pass the CIs with the existing Java 17/21.

### Was this patch authored or co-authored using generative AI tooling?

No.