### PR TITLE
[SPARK-51208][SQL] `ColumnDefinition.toV1Column` should preserve `EXISTS_DEFAULT` resolution

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ColumnDefinition.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ColumnDefinition.scala
@@ -75,7 +75,7 @@ case class ColumnDefinition(
       // For v1 CREATE TABLE command, we will resolve and execute the default value expression later
       // in the rule `DataSourceAnalysis`. We just need to put the default value SQL string here.
       metadataBuilder.putString(CURRENT_DEFAULT_COLUMN_METADATA_KEY, default.originalSQL)
-      metadataBuilder.putString(EXISTS_DEFAULT_COLUMN_METADATA_KEY, default.originalSQL)
+      metadataBuilder.putString(EXISTS_DEFAULT_COLUMN_METADATA_KEY, default.child.sql)
     }
     generationExpression.foreach { generationExpr =>
       metadataBuilder.putString(GeneratedColumn.GENERATION_EXPRESSION_METADATA_KEY, generationExpr)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
@@ -22,10 +22,12 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.spark.{SparkException, SparkFunSuite, SparkIllegalArgumentException}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.{caseInsensitiveResolution, caseSensitiveResolution}
+import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.SQLHelper
+import org.apache.spark.sql.catalyst.plans.logical.{ColumnDefinition, DefaultValueExpression}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns
+import org.apache.spark.sql.catalyst.util.{ResolveDefaultColumns, ResolveDefaultColumnsUtils}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DayTimeIntervalType => DT}
 import org.apache.spark.sql.types.{YearMonthIntervalType => YM}
@@ -797,5 +799,36 @@ class StructTypeSuite extends SparkFunSuite with SQLHelper {
 
     assert(
       mapper.readTree(mapWithNestedArray.json) == mapper.readTree(expectedJson))
+  }
+
+  test("SPARK-51208: ColumnDefinition.toV1Column should preserve EXISTS_DEFAULT resolution") {
+
+    def validateConvertedDefaults(
+      colName: String,
+      dataType: DataType,
+      defaultSQL: String,
+      expectedExists: String): Unit = {
+      val existsDefault = ResolveDefaultColumns.analyze(colName, dataType, defaultSQL, "")
+      val col =
+        ColumnDefinition(colName, dataType, true, None,
+          Some(DefaultValueExpression(existsDefault, defaultSQL)))
+
+      val structField = col.toV1Column
+      assert(
+        structField.metadata.getString(
+          ResolveDefaultColumnsUtils.CURRENT_DEFAULT_COLUMN_METADATA_KEY) ==
+          defaultSQL)
+      val existsSQL = structField.metadata.getString(
+          ResolveDefaultColumnsUtils.EXISTS_DEFAULT_COLUMN_METADATA_KEY)
+      assert(existsSQL == expectedExists)
+      assert(Literal.fromSQL(existsSQL).resolved)
+    }
+
+    validateConvertedDefaults("c1", StringType, "current_catalog()", "'spark_catalog'")
+    validateConvertedDefaults("c2", VariantType, "parse_json('1')", "PARSE_JSON('1')")
+    validateConvertedDefaults("c3", VariantType, "parse_json('{\"k\": \"v\"}')",
+      "PARSE_JSON('{\"k\":\"v\"}')")
+    validateConvertedDefaults("c4", VariantType, "parse_json(null)", "CAST(NULL AS VARIANT)")
+
   }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fix ColumnDefintiion.toV1Column to preserve EXISTS_DEFAULT if it is already on the original column


### Why are the changes needed?
Some external catalogs use toV1Column and fromV1Column.  However, we noticed that toV1Column will un-resolve some already-resolved EXISTS default values.

Long Description: When user creates a column with default value, Spark will resolve the user-provided CURRENT_DEFAULT sql, to make an EXISTS_DEFAULT value.  That is done to save the values at that time, for example to resolve current_database(), current_user() functions.  Existing data will get those values. 

The typical workflow is:

```
val existsSQL = ResolveDefaultColumns.analyze(col, type, defaultSQL)
// save both existsSQL and defaultSQL to column metadata
 ```

But this code sets existsDefault metadata back to the original defaultSQL.

Consuming code will get corrupted un-resolved expressions in EXISTS_DEFAULT, like current_user().  This means that later when these columns are read, these may need to be resolved again, potentially leading to data that changes value.   

 

While Spark code base currently does not have such catalogs, there are some extneral catalogs out there that are hitting this issue. 

### Does this PR introduce _any_ user-facing change?
Behavior should be fixed for consumers of the API


### How was this patch tested?
Add unit test