### PR TITLE
[SPARK-51210][CORE] Add `--enable-native-access=ALL-UNNAMED` to Java options for Java 24+

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/JavaModuleOptions.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/JavaModuleOptions.java
@@ -44,7 +44,8 @@ public class JavaModuleOptions {
       "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED",
       "--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED",
       "-Djdk.reflect.useDirectMethodHandle=false",
-      "-Dio.netty.tryReflectionSetAccessible=true"};
+      "-Dio.netty.tryReflectionSetAccessible=true",
+      "--enable-native-access=ALL-UNNAMED"};
 
     /**
      * Returns the default JVM runtime options used by Spark.

--- a/pom.xml
+++ b/pom.xml
@@ -327,6 +327,7 @@
       --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
       -Djdk.reflect.useDirectMethodHandle=false
       -Dio.netty.tryReflectionSetAccessible=true
+      --enable-native-access=ALL-UNNAMED
     </extraJavaTestArgs>
     <mariadb.java.client.version>2.7.12</mariadb.java.client.version>
     <mysql.connector.version>9.2.0</mysql.connector.version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1642,7 +1642,8 @@ object TestSettings {
         "--add-opens=java.base/sun.security.action=ALL-UNNAMED",
         "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED",
         "-Djdk.reflect.useDirectMethodHandle=false",
-        "-Dio.netty.tryReflectionSetAccessible=true").mkString(" ")
+        "-Dio.netty.tryReflectionSetAccessible=true",
+        "--enable-native-access=ALL-UNNAMED").mkString(" ")
       s"-Xmx$heapSize -Xss4m -XX:MaxMetaspaceSize=$metaspaceSize -XX:ReservedCodeCacheSize=128m -Dfile.encoding=UTF-8 $extraTestJavaArgs"
         .split(" ").toSeq
     },

--- a/sql/connect/bin/spark-connect-scala-client
+++ b/sql/connect/bin/spark-connect-scala-client
@@ -69,6 +69,7 @@ JVM_ARGS="-XX:+IgnoreUnrecognizedVMOptions \
   --add-opens=java.base/sun.util.calendar=ALL-UNNAMED \
   --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED \
   -Djdk.reflect.useDirectMethodHandle=false \
-  -Dio.netty.tryReflectionSetAccessible=true"
+  -Dio.netty.tryReflectionSetAccessible=true \
+  --enable-native-access=ALL-UNNAMED"
 
 exec java $JVM_ARGS -cp "$SCCLASSPATH" org.apache.spark.sql.application.ConnectRepl "$@"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to `--enable-native-access=ALL-UNNAMED` to Java options.

### Why are the changes needed?

To remove restricted method warnings from [JEP 472: Prepare to Restrict the Use of JNI](https://openjdk.org/jeps/472) at Java 24+.

**sbt**
```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by org.scalasbt.ipcsocket.NativeLoader in an unnamed module (file:/Users/dongjoon/.sbt/boot/scala-2.12.18/org.scala-sbt/sbt/1.9.3/ipcsocket-1.6.2.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

**jline**
```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by org.jline.nativ.JLineNativeLoader in an unnamed module (file:/Users/dongjoon/APACHE/spark-merge/assembly/target/scala-2.13/jars/jline-3.27.1-jdk8.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

**netty**
```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by io.netty.util.internal.NativeLibraryUtil in an unnamed module (file:/Users/dongjoon/.m2/repository/io/netty/netty-common/4.1.118.Final/netty-common-4.1.118.Final.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

### Does this PR introduce _any_ user-facing change?

No, this is additional JVM option.

### How was this patch tested?

Manually tests.

### Was this patch authored or co-authored using generative AI tooling?

No.