### PR TITLE
[WIP][DO-NOT-MERGE][SPARK-51211][SS] Rename the option of readChangeFeed to readChangeLog in state store reader

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4760,7 +4760,7 @@
   "STATE_STORE_PROVIDER_DOES_NOT_SUPPORT_FINE_GRAINED_STATE_REPLAY" : {
     "message" : [
       "The given State Store Provider <inputClass> does not extend org.apache.spark.sql.execution.streaming.state.SupportsFineGrainedReplay.",
-      "Therefore, it does not support option snapshotStartBatchId or readChangeFeed in state data source."
+      "Therefore, it does not support option snapshotStartBatchId or readChangeLog in state data source."
     ],
     "sqlState" : "42K06"
   },

--- a/docs/streaming/structured-streaming-state-data-source.md
+++ b/docs/streaming/structured-streaming-state-data-source.md
@@ -157,7 +157,7 @@ The following configurations are optional:
   <td>If specified, only this specific partition will be read. Note that partition ID starts with 0. This option must be used together with 'snapshotStartBatchId'.</td>
 </tr>
 <tr>
-  <td>readChangeFeed</td>
+  <td>readChangeLog</td>
   <td>boolean</td>
   <td>false</td>
   <td>If set to true, will read the change of state over microbatches. The output table schema will also differ. Details can be found in section <a href="#reading-state-changes-over-microbatches">"Reading state changes over microbatches"</a>. Option 'changeStartBatchId' must be specified with this option. Option 'batchId', 'joinSide', 'snapshotStartBatchId' and 'snapshotPartitionId' cannot be used together with this option.</td>
@@ -166,13 +166,13 @@ The following configurations are optional:
   <td>changeStartBatchId</td>
   <td>numeric value</td>
   <td></td>
-  <td>Represents the first batch to read in the read change feed mode. This option requires 'readChangeFeed' to be set to true.</td>
+  <td>Represents the first batch to read in the read change feed mode. This option requires 'readChangeLog' to be set to true.</td>
 </tr>
 <tr>
   <td>changeEndBatchId</td>
   <td>numeric value</td>
   <td>latest commited batchId</td>
-  <td>Represents the last batch to read in the read change feed mode. This option requires 'readChangeFeed' to be set to true.</td>
+  <td>Represents the last batch to read in the read change feed mode. This option requires 'readChangeLog' to be set to true.</td>
 </tr>
 </table>
 
@@ -187,7 +187,7 @@ To enable the functionality to read the internal state store instance directly, 
 
 ### Reading state changes over microbatches
 
-If we want to understand the change of state store over microbatches instead of the whole state store at a particular microbatch, 'readChangeFeed' is the option to use.
+If we want to understand the change of state store over microbatches instead of the whole state store at a particular microbatch, 'readChangeLog' is the option to use.
 For example, this is the code to read the change of state from batch 2 to the latest committed batch.
 
 <div class="codetabs">
@@ -198,7 +198,7 @@ For example, this is the code to read the change of state from batch 2 to the la
 df = spark \
 .read \
 .format("statestore") \
-.option("readChangeFeed", true) \
+.option("readChangeLog", true) \
 .option("changeStartBatchId", 2) \
 .load("<checkpointLocation>")
 
@@ -211,7 +211,7 @@ df = spark \
 val df = spark
 .read
 .format("statestore")
-.option("readChangeFeed", true)
+.option("readChangeLog", true)
 .option("changeStartBatchId", 2)
 .load("<checkpointLocation>")
 
@@ -224,7 +224,7 @@ val df = spark
 Dataset<Row> df = spark
 .read()
 .format("statestore")
-.option("readChangeFeed", true)
+.option("readChangeLog", true)
 .option("changeStartBatchId", 2)
 .load("<checkpointLocation>");
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
@@ -1184,12 +1184,12 @@ class TransformWithStateInPandasTestsMixin:
                         assert state_var["stateName"] == "$procTimers_keyToTimestamp"
                         assert state_var["stateVariableType"] == "TimerState"
 
-                # check for state data source and readChangeFeed
+                # check for state data source and readChangeLog
                 value_state_df = (
                     self.spark.read.format("statestore")
                     .option("path", checkpoint_path)
                     .option("stateVarName", "numViolations")
-                    .option("readChangeFeed", True)
+                    .option("readChangeLog", True)
                     .option("changeStartBatchId", 0)
                     .load()
                 ).selectExpr(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSource.scala
@@ -321,17 +321,17 @@ case class ReadChangeLogOptions(
 )
 
 case class StateSourceOptions(
-                               resolvedCpLocation: String,
-                               batchId: Long,
-                               operatorId: Int,
-                               storeName: String,
-                               joinSide: JoinSideValues,
-                               readChangeLog: Boolean,
-                               fromSnapshotOptions: Option[FromSnapshotOptions],
-                               readChangeLogOptions: Option[ReadChangeLogOptions],
-                               stateVarName: Option[String],
-                               readRegisteredTimers: Boolean,
-                               flattenCollectionTypes: Boolean) {
+    resolvedCpLocation: String,
+    batchId: Long,
+    operatorId: Int,
+    storeName: String,
+    joinSide: JoinSideValues,
+    readChangeLog: Boolean,
+    fromSnapshotOptions: Option[FromSnapshotOptions],
+    readChangeLogOptions: Option[ReadChangeLogOptions],
+    stateVarName: Option[String],
+    readRegisteredTimers: Boolean,
+    flattenCollectionTypes: Boolean) {
   def stateCheckpointLocation: Path = new Path(resolvedCpLocation, DIR_NAME_STATE)
 
   override def toString: String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StatePartitionReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StatePartitionReader.scala
@@ -47,7 +47,7 @@ class StatePartitionReaderFactory(
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
     val stateStoreInputPartition = partition.asInstanceOf[StateStoreInputPartition]
-    if (stateStoreInputPartition.sourceOptions.readChangeFeed) {
+    if (stateStoreInputPartition.sourceOptions.readChangeLog) {
       new StateStoreChangeDataPartitionReader(storeConf, hadoopConf,
         stateStoreInputPartition, schema, keyStateEncoderSpec, stateVariableInfoOpt,
         stateStoreColFamilySchemaOpt, stateSchemaProviderOpt)
@@ -210,7 +210,7 @@ class StatePartitionReader(
 }
 
 /**
- * An implementation of [[StatePartitionReaderBase]] for the readChangeFeed mode of State Data
+ * An implementation of [[StatePartitionReaderBase]] for the readChangeLog mode of State Data
  * Source. It reads the change of state over batches of a particular partition.
  */
 class StateStoreChangeDataPartitionReader(
@@ -241,8 +241,8 @@ class StateStoreChangeDataPartitionReader(
 
     provider.asInstanceOf[SupportsFineGrainedReplay]
       .getStateStoreChangeDataReader(
-        partition.sourceOptions.readChangeFeedOptions.get.changeStartBatchId + 1,
-        partition.sourceOptions.readChangeFeedOptions.get.changeEndBatchId + 1,
+        partition.sourceOptions.readChangeLogOptions.get.changeStartBatchId + 1,
+        partition.sourceOptions.readChangeLogOptions.get.changeEndBatchId + 1,
         colFamilyNameOpt)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StateScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StateScanBuilder.scala
@@ -156,7 +156,7 @@ class StateScan(
         desc += s"[snapshotPartitionId=${fromSnapshotOptions.snapshotPartitionId}]"
       case _ =>
     }
-    sourceOptions.readChangeFeedOptions match {
+    sourceOptions.readChangeLogOptions match {
       case Some(fromSnapshotOptions) =>
         desc += s"[changeStartBatchId=${fromSnapshotOptions.changeStartBatchId}"
         desc += s"[changeEndBatchId=${fromSnapshotOptions.changeEndBatchId}"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StateTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StateTable.scala
@@ -72,7 +72,7 @@ class StateTable(
         desc += s"[snapshotPartitionId=${fromSnapshotOptions.snapshotPartitionId}]"
       case _ =>
     }
-    sourceOptions.readChangeFeedOptions match {
+    sourceOptions.readChangeLogOptions match {
       case Some(fromSnapshotOptions) =>
         desc += s"[changeStartBatchId=${fromSnapshotOptions.changeStartBatchId}"
         desc += s"[changeEndBatchId=${fromSnapshotOptions.changeEndBatchId}"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/utils/SchemaUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/utils/SchemaUtil.scala
@@ -53,7 +53,7 @@ object SchemaUtil {
       require(stateStoreColFamilySchemaOpt.isDefined)
       generateSchemaForStateVar(transformWithStateVariableInfoOpt.get,
         stateStoreColFamilySchemaOpt.get, sourceOptions)
-    } else if (sourceOptions.readChangeFeed) {
+    } else if (sourceOptions.readChangeLog) {
       new StructType()
         .add("batch_id", LongType)
         .add("change_type", StringType)
@@ -239,14 +239,14 @@ object SchemaUtil {
 
       stateVarType match {
         case ValueState =>
-          if (sourceOptions.readChangeFeed) {
+          if (sourceOptions.readChangeLog) {
             Seq("batch_id", "change_type", "key", "value", "partition_id")
           } else {
             Seq("key", "value", "partition_id")
           }
 
         case ListState =>
-          if (sourceOptions.readChangeFeed) {
+          if (sourceOptions.readChangeLog) {
             Seq("batch_id", "change_type", "key", "list_element", "partition_id")
           } else if (sourceOptions.flattenCollectionTypes) {
             Seq("key", "list_element", "partition_id")
@@ -255,7 +255,7 @@ object SchemaUtil {
           }
 
         case MapState =>
-          if (sourceOptions.readChangeFeed) {
+          if (sourceOptions.readChangeLog) {
             Seq("batch_id", "change_type", "key", "user_map_key", "user_map_value", "partition_id")
           } else if (sourceOptions.flattenCollectionTypes) {
             Seq("key", "user_map_key", "user_map_value", "partition_id")
@@ -270,7 +270,7 @@ object SchemaUtil {
           throw StateDataSourceErrors
             .internalError(s"Unsupported state variable type $stateVarType")
       }
-    } else if (sourceOptions.readChangeFeed) {
+    } else if (sourceOptions.readChangeLog) {
       Seq("batch_id", "change_type", "key", "value", "partition_id")
     } else {
       Seq("key", "value", "partition_id")
@@ -294,7 +294,7 @@ object SchemaUtil {
 
     stateVarType match {
       case ValueState =>
-        if (stateSourceOptions.readChangeFeed) {
+        if (stateSourceOptions.readChangeLog) {
           new StructType()
             .add("batch_id", LongType)
             .add("change_type", StringType)
@@ -309,7 +309,7 @@ object SchemaUtil {
         }
 
       case ListState =>
-        if (stateSourceOptions.readChangeFeed) {
+        if (stateSourceOptions.readChangeLog) {
           new StructType()
             .add("batch_id", LongType)
             .add("change_type", StringType)
@@ -337,7 +337,7 @@ object SchemaUtil {
           valueType = stateStoreColFamilySchema.valueSchema
         )
 
-        if (stateSourceOptions.readChangeFeed) {
+        if (stateSourceOptions.readChangeLog) {
           new StructType()
             .add("batch_id", LongType)
             .add("change_type", StringType)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -570,7 +570,7 @@ object StateStoreProvider {
 /**
  * This is an optional trait to be implemented by [[StateStoreProvider]]s that can read the change
  * of state store over batches. This is used by State Data Source with additional options like
- * snapshotStartBatchId or readChangeFeed.
+ * snapshotStartBatchId or readChangeLog.
  */
 trait SupportsFineGrainedReplay {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceChangeDataReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceChangeDataReadSuite.scala
@@ -98,7 +98,7 @@ abstract class StateDataSourceChangeDataReaderSuite extends StateDataSourceTestB
     withTempDir { tempDir =>
       val exc = intercept[StateDataSourceInvalidOptionValueIsNegative] {
         spark.read.format("statestore")
-          .option(StateSourceOptions.READ_CHANGE_FEED, value = true)
+          .option(StateSourceOptions.READ_CHANGE_LOG, value = true)
           .option(StateSourceOptions.CHANGE_START_BATCH_ID, -1)
           .option(StateSourceOptions.CHANGE_END_BATCH_ID, 0)
           .load(tempDir.getAbsolutePath)
@@ -111,7 +111,7 @@ abstract class StateDataSourceChangeDataReaderSuite extends StateDataSourceTestB
     withTempDir { tempDir =>
       val exc = intercept[StateDataSourceInvalidOptionValue] {
         spark.read.format("statestore")
-          .option(StateSourceOptions.READ_CHANGE_FEED, value = true)
+          .option(StateSourceOptions.READ_CHANGE_LOG, value = true)
           .option(StateSourceOptions.CHANGE_START_BATCH_ID, 1)
           .option(StateSourceOptions.CHANGE_END_BATCH_ID, 0)
           .load(tempDir.getAbsolutePath)
@@ -120,11 +120,11 @@ abstract class StateDataSourceChangeDataReaderSuite extends StateDataSourceTestB
     }
   }
 
-  test("ERROR: joinSide option is used together with readChangeFeed") {
+  test("ERROR: joinSide option is used together with readChangeLog") {
     withTempDir { tempDir =>
       val exc = intercept[StateDataSourceConflictOptions] {
         spark.read.format("statestore")
-          .option(StateSourceOptions.READ_CHANGE_FEED, value = true)
+          .option(StateSourceOptions.READ_CHANGE_LOG, value = true)
           .option(StateSourceOptions.JOIN_SIDE, "left")
           .option(StateSourceOptions.CHANGE_START_BATCH_ID, 0)
           .option(StateSourceOptions.CHANGE_END_BATCH_ID, 0)
@@ -180,7 +180,7 @@ abstract class StateDataSourceChangeDataReaderSuite extends StateDataSourceTestB
       )
 
       val stateDf = spark.read.format("statestore")
-        .option(StateSourceOptions.READ_CHANGE_FEED, value = true)
+        .option(StateSourceOptions.READ_CHANGE_LOG, value = true)
         .option(StateSourceOptions.CHANGE_START_BATCH_ID, 0)
         .option(StateSourceOptions.CHANGE_END_BATCH_ID, 2)
         .load(tempDir.getAbsolutePath)
@@ -210,7 +210,7 @@ abstract class StateDataSourceChangeDataReaderSuite extends StateDataSourceTestB
       )
 
       val stateDf = spark.read.format("statestore")
-        .option(StateSourceOptions.READ_CHANGE_FEED, value = true)
+        .option(StateSourceOptions.READ_CHANGE_LOG, value = true)
         .option(StateSourceOptions.CHANGE_START_BATCH_ID, 0)
         .option(StateSourceOptions.CHANGE_END_BATCH_ID, 2)
         .load(tempDir.getAbsolutePath)
@@ -249,7 +249,7 @@ abstract class StateDataSourceChangeDataReaderSuite extends StateDataSourceTestB
       )
 
       val stateDf = spark.read.format("statestore")
-        .option(StateSourceOptions.READ_CHANGE_FEED, value = true)
+        .option(StateSourceOptions.READ_CHANGE_LOG, value = true)
         .option(StateSourceOptions.CHANGE_START_BATCH_ID, 0)
         .option(StateSourceOptions.CHANGE_END_BATCH_ID, 2)
         .load(tempDir.getAbsolutePath)
@@ -286,7 +286,7 @@ abstract class StateDataSourceChangeDataReaderSuite extends StateDataSourceTestB
 
       val keyWithIndexToValueDf = spark.read.format("statestore")
         .option(StateSourceOptions.STORE_NAME, "left-keyWithIndexToValue")
-        .option(StateSourceOptions.READ_CHANGE_FEED, value = true)
+        .option(StateSourceOptions.READ_CHANGE_LOG, value = true)
         .option(StateSourceOptions.CHANGE_START_BATCH_ID, 0)
         .option(StateSourceOptions.CHANGE_END_BATCH_ID, 1)
         .load(tempDir.getAbsolutePath)
@@ -303,7 +303,7 @@ abstract class StateDataSourceChangeDataReaderSuite extends StateDataSourceTestB
 
       val keyToNumValuesDf = spark.read.format("statestore")
         .option(StateSourceOptions.STORE_NAME, "left-keyToNumValues")
-        .option(StateSourceOptions.READ_CHANGE_FEED, value = true)
+        .option(StateSourceOptions.READ_CHANGE_LOG, value = true)
         .option(StateSourceOptions.CHANGE_START_BATCH_ID, 0)
         .option(StateSourceOptions.CHANGE_END_BATCH_ID, 1)
         .load(tempDir.getAbsolutePath)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceTransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceTransformWithStateSuite.scala
@@ -220,7 +220,7 @@ class StateDataSourceTransformWithStateSuite extends StateStoreMetricsTest
             .format("statestore")
             .option(StateSourceOptions.PATH, tempDir.getAbsolutePath)
             .option(StateSourceOptions.STATE_VAR_NAME, "valueState")
-            .option(StateSourceOptions.READ_CHANGE_FEED, true)
+            .option(StateSourceOptions.READ_CHANGE_LOG, true)
             .option(StateSourceOptions.CHANGE_START_BATCH_ID, 0)
             .load()
 
@@ -333,7 +333,7 @@ class StateDataSourceTransformWithStateSuite extends StateStoreMetricsTest
           .format("statestore")
           .option(StateSourceOptions.PATH, tempDir.getAbsolutePath)
           .option(StateSourceOptions.STATE_VAR_NAME, "countState")
-          .option(StateSourceOptions.READ_CHANGE_FEED, true)
+          .option(StateSourceOptions.READ_CHANGE_LOG, true)
           .option(StateSourceOptions.CHANGE_START_BATCH_ID, 0)
           .load()
 
@@ -455,7 +455,7 @@ class StateDataSourceTransformWithStateSuite extends StateStoreMetricsTest
           .format("statestore")
           .option(StateSourceOptions.PATH, tempDir.getAbsolutePath)
           .option(StateSourceOptions.STATE_VAR_NAME, "groupsList")
-          .option(StateSourceOptions.READ_CHANGE_FEED, true)
+          .option(StateSourceOptions.READ_CHANGE_LOG, true)
           .option(StateSourceOptions.CHANGE_START_BATCH_ID, 0)
           .load()
 
@@ -595,7 +595,7 @@ class StateDataSourceTransformWithStateSuite extends StateStoreMetricsTest
           .format("statestore")
           .option(StateSourceOptions.PATH, tempDir.getAbsolutePath)
           .option(StateSourceOptions.STATE_VAR_NAME, "groupsListWithTTL")
-          .option(StateSourceOptions.READ_CHANGE_FEED, true)
+          .option(StateSourceOptions.READ_CHANGE_LOG, true)
           .option(StateSourceOptions.CHANGE_START_BATCH_ID, 0)
           .load()
 
@@ -727,7 +727,7 @@ class StateDataSourceTransformWithStateSuite extends StateStoreMetricsTest
           .format("statestore")
           .option(StateSourceOptions.PATH, tempDir.getAbsolutePath)
           .option(StateSourceOptions.STATE_VAR_NAME, "sessionState")
-          .option(StateSourceOptions.READ_CHANGE_FEED, true)
+          .option(StateSourceOptions.READ_CHANGE_LOG, true)
           .option(StateSourceOptions.CHANGE_START_BATCH_ID, 0)
           .load()
 
@@ -890,7 +890,7 @@ class StateDataSourceTransformWithStateSuite extends StateStoreMetricsTest
           .format("statestore")
           .option(StateSourceOptions.PATH, tempDir.getAbsolutePath)
           .option(StateSourceOptions.STATE_VAR_NAME, "mapState")
-          .option(StateSourceOptions.READ_CHANGE_FEED, true)
+          .option(StateSourceOptions.READ_CHANGE_LOG, true)
           .option(StateSourceOptions.CHANGE_START_BATCH_ID, 0)
           .load()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to rename the option of readChangeFeed to readChangeLog in state store reader.

### Why are the changes needed?

We realized that we did marketing of the feature for checkpointing only the update set as "changelog checkpointing". Since this option is dependent on the feature (when users use RocksDB state store provider, they should use changelog checkpointing to use this option), it'd be better to make the option be tightly related.

### Does this PR introduce _any_ user-facing change?

No, it's not released yet.

### How was this patch tested?

Existing UTs.

### Was this patch authored or co-authored using generative AI tooling?

No.