### PR TITLE
[SPARK-51208][SQL][FOLLOW-UP] ColumnDefinition.toV1Column should preserve EXISTS_DEFAULT resolution

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ColumnDefinition.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ColumnDefinition.scala
@@ -75,7 +75,11 @@ case class ColumnDefinition(
       // For v1 CREATE TABLE command, we will resolve and execute the default value expression later
       // in the rule `DataSourceAnalysis`. We just need to put the default value SQL string here.
       metadataBuilder.putString(CURRENT_DEFAULT_COLUMN_METADATA_KEY, default.originalSQL)
-      metadataBuilder.putString(EXISTS_DEFAULT_COLUMN_METADATA_KEY, default.child.sql)
+      val existsSQL = default.child match {
+        case l: Literal => l.sql
+        case _ => default.originalSQL
+      }
+      metadataBuilder.putString(EXISTS_DEFAULT_COLUMN_METADATA_KEY, existsSQL)
     }
     generationExpression.foreach { generationExpr =>
       metadataBuilder.putString(GeneratedColumn.GENERATION_EXPRESSION_METADATA_KEY, generationExpr)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
@@ -804,10 +804,10 @@ class StructTypeSuite extends SparkFunSuite with SQLHelper {
   test("SPARK-51208: ColumnDefinition.toV1Column should preserve EXISTS_DEFAULT resolution") {
 
     def validateConvertedDefaults(
-      colName: String,
-      dataType: DataType,
-      defaultSQL: String,
-      expectedExists: String): Unit = {
+        colName: String,
+        dataType: DataType,
+        defaultSQL: String,
+        expectedExists: String): Unit = {
       val existsDefault = ResolveDefaultColumns.analyze(colName, dataType, defaultSQL, "")
       val col =
         ColumnDefinition(colName, dataType, true, None,
@@ -829,6 +829,6 @@ class StructTypeSuite extends SparkFunSuite with SQLHelper {
     validateConvertedDefaults("c3", VariantType, "parse_json('{\"k\": \"v\"}')",
       "PARSE_JSON('{\"k\":\"v\"}')")
     validateConvertedDefaults("c4", VariantType, "parse_json(null)", "CAST(NULL AS VARIANT)")
-
+    validateConvertedDefaults("c5", IntegerType, "1 + 1", "2")
   }
 }


### PR DESCRIPTION
Small follow up for: https://github.com/apache/spark/pull/49942


### What changes were proposed in this pull request?
Restrict the logic of https://github.com/apache/spark/pull/49942 to only resolved and folded existsDefaults.

### Why are the changes needed?
Previous part of PR may have unexpected behavior if expression is not resolved/folded.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing unit test


### Was this patch authored or co-authored using generative AI tooling?
No
