### PR TITLE
[SPARK-51209][CORE][FOLLOWUP] Use `user.name` system property first as a fallback

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2439,7 +2439,8 @@ private[spark] object Utils
 
   /**
    * Returns the current user name. This is the currently logged in user, unless that's been
-   * overridden by the `SPARK_USER` environment variable. In case of exceptions, returns 'spark'.
+   * overridden by the `SPARK_USER` environment variable. In case of exceptions, returns the value
+   * of System.getProperty("user.name", "spark").
    */
   def getCurrentUserName(): String = {
     try {
@@ -2448,7 +2449,7 @@ private[spark] object Utils
     } catch {
       // JEP 486: Permanently Disable the Security Manager
       case e: UnsupportedOperationException if e.getMessage().contains("getSubject") =>
-        "spark"
+        System.getProperty("user.name", "spark")
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2440,7 +2440,7 @@ private[spark] object Utils
   /**
    * Returns the current user name. This is the currently logged in user, unless that's been
    * overridden by the `SPARK_USER` environment variable. In case of exceptions, returns the value
-   * of System.getProperty("user.name", "spark").
+   * of System.getProperty("user.name", "<unknown>").
    */
   def getCurrentUserName(): String = {
     try {
@@ -2449,7 +2449,7 @@ private[spark] object Utils
     } catch {
       // JEP 486: Permanently Disable the Security Manager
       case e: UnsupportedOperationException if e.getMessage().contains("getSubject") =>
-        System.getProperty("user.name", "spark")
+        System.getProperty("user.name", "<unknown>")
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2440,7 +2440,7 @@ private[spark] object Utils
   /**
    * Returns the current user name. This is the currently logged in user, unless that's been
    * overridden by the `SPARK_USER` environment variable. In case of exceptions, returns the value
-   * of System.getProperty("user.name", "<unknown>").
+   * of {@code System.getProperty("user.name", "<unknown>")}.
    */
   def getCurrentUserName(): String = {
     try {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #49943 to use `user.name` system property first as a fallback.

### Why are the changes needed?

JVM `user.name` is a more reasonable default value.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.