### PR TITLE
[SPARK-51178][CONNECT][PYTHON] Raise proper PySpark error instead of `SparkConnectGrpcException`

### DIFF
--- a/python/docs/source/reference/pyspark.errors.rst
+++ b/python/docs/source/reference/pyspark.errors.rst
@@ -60,6 +60,7 @@ Classes
     TempTableAlreadyExistsException
     UnknownException
     UnsupportedOperationException
+    PickleException
 
 
 Methods

--- a/python/pyspark/errors/__init__.py
+++ b/python/pyspark/errors/__init__.py
@@ -51,6 +51,7 @@ from pyspark.errors.exceptions.base import (  # noqa: F401
     QueryContext,
     QueryContextType,
     StreamingPythonRunnerInitializationException,
+    PickleException,
 )
 
 
@@ -87,4 +88,5 @@ __all__ = [
     "QueryContext",
     "QueryContextType",
     "StreamingPythonRunnerInitializationException",
+    "PickleException",
 ]

--- a/python/pyspark/errors/exceptions/base.py
+++ b/python/pyspark/errors/exceptions/base.py
@@ -363,6 +363,14 @@ class PySparkImportError(PySparkException, ImportError):
     """
 
 
+class PickleException(PySparkException):
+    """
+    Represents an exception which is failed while pickling from server side
+    such as `net.razorvine.pickle.PickleException`. This is different from `PySparkPicklingError`
+    which represents an exception failed from Python built-in `pickle.PicklingError`.
+    """
+
+
 class QueryContextType(Enum):
     """
     The type of :class:`QueryContext`.

--- a/python/pyspark/sql/tests/connect/test_parity_udtf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udtf.py
@@ -27,7 +27,7 @@ if should_test_connect:
     sql.udtf.UserDefinedTableFunction = UserDefinedTableFunction
     from pyspark.sql.connect.functions import lit, udtf
     from pyspark.errors.exceptions.connect import (
-        SparkConnectGrpcException,
+        PickleException,
         PythonException,
         InvalidPlanInput,
     )
@@ -46,10 +46,8 @@ class UDTFParityTests(BaseUDTFTestsMixin, ReusedConnectTestCase):
         finally:
             super(UDTFParityTests, cls).tearDownClass()
 
-    # TODO: use PySpark error classes instead of SparkConnectGrpcException
-
     def test_struct_output_type_casting_row(self):
-        self.check_struct_output_type_casting_row(SparkConnectGrpcException)
+        self.check_struct_output_type_casting_row(PickleException)
 
     def test_udtf_with_invalid_return_type(self):
         @udtf(returnType="int")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR propose to raise proper PySpark error instead of `SparkConnectGrpcException`.

This PR also introduces new PySpark error `PickleException` to cover the errors that represents an exception which is failed while pickling from server side

### Why are the changes needed?

To raise proper exception instead of `SparkConnectGrpcException`

### Does this PR introduce _any_ user-facing change?

No API changes, but the user-facing error improvement.

### How was this patch tested?

Updated the existing UT

### Was this patch authored or co-authored using generative AI tooling?

No