### PR TITLE
[SPARK-50692][SQL][FOLLOWUP] Add comments for LPAD and RPAD

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GeneralScalarExpression.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GeneralScalarExpression.java
@@ -416,6 +416,18 @@ import org.apache.spark.sql.internal.connector.ExpressionWithToString;
  *    <li>Since version: 3.4.0</li>
  *   </ul>
  *  </li>
+ *  <li>Name: <code>LPAD</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>LPAD(str, len[, pad])</code></li>
+ *    <li>Since version: 4.0.0</li>
+ *   </ul>
+ *  </li>
+ *  <li>Name: <code>RPAD</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>RPAD(str, len[, pad])</code></li>
+ *    <li>Since version: 4.0.0</li>
+ *   </ul>
+ *  </li>
  * </ol>
  * Note: SQL semantic conforms ANSI standard, so some expressions are not supported when ANSI off,
  * including: add, subtract, multiply, divide, remainder, pmod.


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to add comments for `LPAD` and `RPAD`.


### Why are the changes needed?
https://github.com/apache/spark/pull/49325 had added pushdown support for `LPAD` and `RPAD`. But forget the comments.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
