### PR TITLE
[SPARK-51271][PYTHON] Add filter pushdown API to Python Data Sources

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -189,9 +189,19 @@
       "Remote client cannot create a SparkContext. Create SparkSession instead."
     ]
   },
+  "DATA_SOURCE_EXTRANEOUS_FILTERS": {
+    "message": [
+      "<type>.pushFilters() returned filters that are not part of the input. Make sure that each returned filter is one of the input filters by reference."
+    ]
+  },
   "DATA_SOURCE_INVALID_RETURN_TYPE": {
     "message": [
       "Unsupported return type ('<type>') from Python data source '<name>'. Expected types: <supported_types>."
+    ]
+  },
+  "DATA_SOURCE_PUSHDOWN_DISABLED": {
+    "message": [
+      "<type> implements pushFilters() but filter pushdown is disabled because configuration '<conf>' is false. Set it to true to enable filter pushdown."
     ]
   },
   "DATA_SOURCE_RETURN_SCHEMA_MISMATCH": {
@@ -202,6 +212,11 @@
   "DATA_SOURCE_TYPE_MISMATCH": {
     "message": [
       "Expected <expected>, but got <actual>."
+    ]
+  },
+  "DATA_SOURCE_UNSUPPORTED_FILTER": {
+    "message": [
+      "Unexpected filter <name>."
     ]
   },
   "DIFFERENT_PANDAS_DATAFRAME": {

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -18,12 +18,14 @@ import os
 import platform
 import tempfile
 import unittest
-from typing import Callable, Union
+from typing import Callable, Iterable, List, Union
 
 from pyspark.errors import PythonException, AnalysisException
 from pyspark.sql.datasource import (
     DataSource,
     DataSourceReader,
+    EqualTo,
+    Filter,
     InputPartition,
     DataSourceWriter,
     DataSourceArrowWriter,
@@ -31,6 +33,7 @@ from pyspark.sql.datasource import (
     CaseInsensitiveDict,
 )
 from pyspark.sql.functions import spark_partition_id
+from pyspark.sql.session import SparkSession
 from pyspark.sql.types import Row, StructType
 from pyspark.testing.sqlutils import (
     have_pyarrow,
@@ -42,6 +45,8 @@ from pyspark.testing.sqlutils import ReusedSQLTestCase, SPARK_HOME
 
 @unittest.skipIf(not have_pyarrow, pyarrow_requirement_message)
 class BasePythonDataSourceTestsMixin:
+    spark: SparkSession
+
     def test_basic_data_source_class(self):
         class MyDataSource(DataSource):
             ...
@@ -245,6 +250,161 @@ class BasePythonDataSourceTestsMixin:
         df = self.spark.read.format("memory").option("num_partitions", 2).load()
         assertDataFrameEqual(df, [Row(x=0, y="0"), Row(x=1, y="1")])
         self.assertEqual(df.select(spark_partition_id()).distinct().count(), 2)
+
+    def test_filter_pushdown(self):
+        class TestDataSourceReader(DataSourceReader):
+            def __init__(self):
+                self.has_filter = False
+
+            def pushFilters(self, filters: List[Filter]) -> Iterable[Filter]:
+                assert set(filters) == {
+                    EqualTo(("x",), 1),
+                    EqualTo(("y",), 2),
+                }, filters
+                self.has_filter = True
+                # pretend we support x = 1 filter but in fact we don't
+                # so we only return y = 2 filter
+                yield filters[filters.index(EqualTo(("y",), 2))]
+
+            def partitions(self):
+                assert self.has_filter
+                return super().partitions()
+
+            def read(self, partition):
+                assert self.has_filter
+                yield [1, 1]
+                yield [1, 2]
+                yield [2, 2]
+
+        class TestDataSource(DataSource):
+            @classmethod
+            def name(cls):
+                return "test"
+
+            def schema(self):
+                return "x int, y int"
+
+            def reader(self, schema) -> "DataSourceReader":
+                return TestDataSourceReader()
+
+        with self.sql_conf({"spark.sql.python.filterPushdown.enabled": True}):
+            self.spark.dataSource.register(TestDataSource)
+            df = self.spark.read.format("test").load().filter("x = 1 and y = 2")
+            # only the y = 2 filter is applied post scan
+            assertDataFrameEqual(df, [Row(x=1, y=2), Row(x=2, y=2)])
+
+    def test_extraneous_filter(self):
+        class TestDataSourceReader(DataSourceReader):
+            def pushFilters(self, filters: List[Filter]) -> Iterable[Filter]:
+                yield EqualTo(("x",), 1)
+
+            def partitions(self):
+                assert False
+
+            def read(self, partition):
+                assert False
+
+        class TestDataSource(DataSource):
+            @classmethod
+            def name(cls):
+                return "test"
+
+            def schema(self):
+                return "x int"
+
+            def reader(self, schema) -> "DataSourceReader":
+                return TestDataSourceReader()
+
+        with self.sql_conf({"spark.sql.python.filterPushdown.enabled": True}):
+            self.spark.dataSource.register(TestDataSource)
+            with self.assertRaisesRegex(Exception, "DATA_SOURCE_EXTRANEOUS_FILTERS"):
+                self.spark.read.format("test").load().filter("x = 1").show()
+
+    def test_filter_pushdown_error(self):
+        error_str = "dummy error"
+
+        class TestDataSourceReader(DataSourceReader):
+            def pushFilters(self, filters: List[Filter]) -> Iterable[Filter]:
+                raise Exception(error_str)
+
+            def read(self, partition):
+                yield [1]
+
+        class TestDataSource(DataSource):
+            def schema(self):
+                return "x int"
+
+            def reader(self, schema) -> "DataSourceReader":
+                return TestDataSourceReader()
+
+        with self.sql_conf({"spark.sql.python.filterPushdown.enabled": True}):
+            self.spark.dataSource.register(TestDataSource)
+            df = self.spark.read.format("TestDataSource").load().filter("x = 1 or x is null")
+            assertDataFrameEqual(df, [Row(x=1)])  # works when not pushing down filters
+            with self.assertRaisesRegex(Exception, error_str):
+                df.filter("x = 1").explain()
+
+    def test_filter_pushdown_disabled(self):
+        class TestDataSourceReader(DataSourceReader):
+            def pushFilters(self, filters: List[Filter]) -> Iterable[Filter]:
+                assert False
+
+            def read(self, partition):
+                assert False
+
+        class TestDataSource(DataSource):
+            def reader(self, schema) -> "DataSourceReader":
+                return TestDataSourceReader()
+
+        with self.sql_conf({"spark.sql.python.filterPushdown.enabled": False}):
+            self.spark.dataSource.register(TestDataSource)
+            df = self.spark.read.format("TestDataSource").schema("x int").load()
+            with self.assertRaisesRegex(Exception, "DATA_SOURCE_PUSHDOWN_DISABLED"):
+                df.show()
+
+    def _check_filters(self, sql_type, sql_filter, python_filters):
+        """
+        Parameters
+        ----------
+        sql_type: str
+            The SQL type of the column x.
+        sql_filter: str
+            A SQL filter using the column x.
+        python_filters: List[Filter]
+            The expected python filters to be pushed down.
+        """
+
+        class TestDataSourceReader(DataSourceReader):
+            def pushFilters(self, filters: List[Filter]) -> Iterable[Filter]:
+                expected = python_filters
+                assert filters == expected, (filters, expected)
+                return filters
+
+            def read(self, partition):
+                yield from []
+
+        class TestDataSource(DataSource):
+            def schema(self):
+                return f"x {sql_type}"
+
+            def reader(self, schema) -> "DataSourceReader":
+                return TestDataSourceReader()
+
+        with self.sql_conf({"spark.sql.python.filterPushdown.enabled": True}):
+            self.spark.dataSource.register(TestDataSource)
+            df = self.spark.read.format("TestDataSource").load().filter(sql_filter)
+            df.count()
+
+    def test_unsupported_filter(self):
+        self._check_filters(
+            "struct<a:int, b:int, c:int>", "x.a = 1 and x.b = x.c", [EqualTo(("x", "a"), 1)]
+        )
+        self._check_filters("int", "x <> 0", [])
+        self._check_filters("int", "x = 1 or x > 2", [])
+        self._check_filters("int", "(0 < x and x < 1) or x = 2", [])
+        self._check_filters("int", "x % 5 = 1", [])
+        self._check_filters("boolean", "not x", [])
+        self._check_filters("array<int>", "x[0] = 1", [])
 
     def _get_test_json_data_source(self):
         import json

--- a/python/pyspark/sql/worker/data_source_pushdown_filters.py
+++ b/python/pyspark/sql/worker/data_source_pushdown_filters.py
@@ -1,0 +1,206 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import faulthandler
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import IO, List
+
+from pyspark.accumulators import _accumulatorRegistry
+from pyspark.errors import PySparkAssertionError, PySparkValueError
+from pyspark.serializers import SpecialLengths, UTF8Deserializer, read_int, write_int
+from pyspark.sql.datasource import DataSource, DataSourceReader, EqualTo, Filter
+from pyspark.sql.types import StructType, _parse_datatype_json_string
+from pyspark.util import handle_worker_exception, local_connect_and_auth
+from pyspark.worker_util import (
+    check_python_version,
+    pickleSer,
+    read_command,
+    send_accumulator_updates,
+    setup_broadcasts,
+    setup_memory_limits,
+    setup_spark_files,
+)
+
+utf8_deserializer = UTF8Deserializer()
+
+
+@dataclass(frozen=True)
+class FilterRef:
+    filter: Filter = field(compare=False)
+    id: int = field(init=False)  # only id is used for comparison
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "id", id(self.filter))
+
+
+def main(infile: IO, outfile: IO) -> None:
+    """
+    Main method for planning a data source read with filter pushdown.
+
+    This process is invoked from the `UserDefinedPythonDataSourceReadRunner.runInPython`
+    method in the optimizer rule `PlanPythonDataSourceScan` in JVM. This process is responsible
+    for creating a `DataSourceReader` object, applying filter pushdown, and sending the
+    information needed back to the JVM.
+
+    The infile and outfile are connected to the JVM via a socket. The JVM sends the following
+    information to this process via the socket:
+    - a `DataSource` instance representing the data source
+    - a `StructType` instance representing the output schema of the data source
+    - a list of filters to be pushed down
+
+    This process then creates a `DataSourceReader` instance by calling the `reader` method
+    on the `DataSource` instance. It applies the filters by calling the `pushFilters` method
+    on the reader and determines which filters are supported. The data source with updated reader
+    is then sent back to the JVM along with the indices of the supported filters.
+    """
+    faulthandler_log_path = os.environ.get("PYTHON_FAULTHANDLER_DIR", None)
+    try:
+        if faulthandler_log_path:
+            faulthandler_log_path = os.path.join(faulthandler_log_path, str(os.getpid()))
+            faulthandler_log_file = open(faulthandler_log_path, "w")
+            faulthandler.enable(file=faulthandler_log_file)
+
+        check_python_version(infile)
+
+        memory_limit_mb = int(os.environ.get("PYSPARK_PLANNER_MEMORY_MB", "-1"))
+        setup_memory_limits(memory_limit_mb)
+
+        setup_spark_files(infile)
+        setup_broadcasts(infile)
+
+        _accumulatorRegistry.clear()
+
+        # ----------------------------------------------------------------------
+        # Start of worker logic
+        # ----------------------------------------------------------------------
+
+        # Receive the data source instance.
+        data_source = read_command(pickleSer, infile)
+        if not isinstance(data_source, DataSource):
+            raise PySparkAssertionError(
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
+                    "expected": "a Python data source instance of type 'DataSource'",
+                    "actual": f"'{type(data_source).__name__}'",
+                },
+            )
+
+        # Receive the data source output schema.
+        schema_json = utf8_deserializer.loads(infile)
+        schema = _parse_datatype_json_string(schema_json)
+        if not isinstance(schema, StructType):
+            raise PySparkAssertionError(
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
+                    "expected": "an output schema of type 'StructType'",
+                    "actual": f"'{type(schema).__name__}'",
+                },
+            )
+
+        # Get the reader.
+        reader = data_source.reader(schema=schema)
+        # Validate the reader.
+        if not isinstance(reader, DataSourceReader):
+            raise PySparkAssertionError(
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
+                    "expected": "an instance of DataSourceReader",
+                    "actual": f"'{type(reader).__name__}'",
+                },
+            )
+
+        # Receive the pushdown filters.
+        num_filters = read_int(infile)
+        filters: List[FilterRef] = []
+        for _ in range(num_filters):
+            name = utf8_deserializer.loads(infile)
+            if name == "EqualTo":
+                num_parts = read_int(infile)
+                column_path = tuple(utf8_deserializer.loads(infile) for _ in range(num_parts))
+                value = read_int(infile)
+                filters.append(FilterRef(EqualTo(column_path, value)))
+            else:
+                raise PySparkAssertionError(
+                    errorClass="DATA_SOURCE_UNSUPPORTED_FILTER",
+                    messageParameters={
+                        "name": name,
+                    },
+                )
+
+        # Push down the filters and get the indices of the unsupported filters.
+        unsupported_filters = set(
+            FilterRef(f) for f in reader.pushFilters([ref.filter for ref in filters])
+        )
+        supported_filter_indices = []
+        for i, filter in enumerate(filters):
+            if filter in unsupported_filters:
+                unsupported_filters.remove(filter)
+            else:
+                supported_filter_indices.append(i)
+
+        # If it returned any filters that are not in the original filters, raise an error.
+        if len(unsupported_filters) > 0:
+            raise PySparkValueError(
+                errorClass="DATA_SOURCE_EXTRANEOUS_FILTERS",
+                messageParameters={
+                    "type": type(reader).__name__,
+                    "input": str(list(filters)),
+                    "extraneous": str(list(unsupported_filters)),
+                },
+            )
+
+        # Monkey patch the data source instance
+        # to return the existing reader with the pushed down filters.
+        data_source.reader = lambda schema: reader  # type: ignore[method-assign]
+        pickleSer._write_with_length(data_source, outfile)
+
+        # Return the supported filter indices.
+        write_int(len(supported_filter_indices), outfile)
+        for index in supported_filter_indices:
+            write_int(index, outfile)
+
+        # ----------------------------------------------------------------------
+        # End of worker logic
+        # ----------------------------------------------------------------------
+    except BaseException as e:
+        handle_worker_exception(e, outfile)
+        sys.exit(-1)
+    finally:
+        if faulthandler_log_path:
+            faulthandler.disable()
+            faulthandler_log_file.close()
+            os.remove(faulthandler_log_path)
+
+    send_accumulator_updates(outfile)
+
+    # check end of stream
+    if read_int(infile) == SpecialLengths.END_OF_STREAM:
+        write_int(SpecialLengths.END_OF_STREAM, outfile)
+    else:
+        # write a different value to tell JVM to not reuse this worker
+        write_int(SpecialLengths.END_OF_DATA_SECTION, outfile)
+        sys.exit(-1)
+
+
+if __name__ == "__main__":
+    # Read information about how to connect back to the JVM from the environment.
+    java_port = int(os.environ["PYTHON_WORKER_FACTORY_PORT"])
+    auth_secret = os.environ["PYTHON_WORKER_FACTORY_SECRET"]
+    (sock_file, _) = local_connect_and_auth(java_port, auth_secret)
+    main(sock_file, sock_file)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4716,6 +4716,13 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val PYTHON_FILTER_PUSHDOWN_ENABLED = buildConf("spark.sql.python.filterPushdown.enabled")
+    .doc("When true, enable filter pushdown to Python datasource, at the cost of running " +
+      "Python worker one additional time during planning.")
+    .version("4.1.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val CSV_FILTER_PUSHDOWN_ENABLED = buildConf("spark.sql.csv.filterPushdown.enabled")
     .doc("When true, enable filter pushdown to CSV datasource.")
     .version("3.0.0")
@@ -6500,6 +6507,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def ignoreDataLocality: Boolean = getConf(SQLConf.IGNORE_DATA_LOCALITY)
 
   def useListFilesFileSystemList: String = getConf(SQLConf.USE_LISTFILES_FILESYSTEM_LIST)
+
+  def pythonFilterPushDown: Boolean = getConf(PYTHON_FILTER_PUSHDOWN_ENABLED)
 
   def csvFilterPushDown: Boolean = getConf(CSV_FILTER_PUSHDOWN_ENABLED)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonDataSourceV2.scala
@@ -52,6 +52,10 @@ class PythonDataSourceV2 extends TableProvider {
     dataSourceInPython
   }
 
+  def setDataSourceInPython(dataSourceInPython: PythonDataSourceCreationResult): Unit = {
+    this.dataSourceInPython = dataSourceInPython
+  }
+
   override def inferSchema(options: CaseInsensitiveStringMap): StructType = {
     getOrCreateDataSourceInPython(shortName, options, None).schema
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonScan.scala
@@ -16,26 +16,43 @@
  */
 package org.apache.spark.sql.execution.datasources.v2.python
 
+import org.apache.commons.lang3.StringUtils
+
 import org.apache.spark.JobArtifactSet
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.metric.CustomMetric
 import org.apache.spark.sql.connector.read._
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream
+import org.apache.spark.sql.internal.connector.SupportsMetadata
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-
+import org.apache.spark.util.Utils
 
 class PythonScan(
-     ds: PythonDataSourceV2,
-     shortName: String,
-     outputSchema: StructType,
-     options: CaseInsensitiveStringMap) extends Scan {
+    ds: PythonDataSourceV2,
+    shortName: String,
+    outputSchema: StructType,
+    options: CaseInsensitiveStringMap,
+    supportedFilters: Array[Filter]
+) extends Scan with SupportsMetadata {
+  private lazy val sparkSession = SparkSession.active
 
   override def toBatch: Batch = new PythonBatch(ds, shortName, outputSchema, options)
 
   override def toMicroBatchStream(checkpointLocation: String): MicroBatchStream =
     new PythonMicroBatchStream(ds, shortName, outputSchema, options)
 
-  override def description: String = "(Python)"
+  override def description: String = {
+    val metadataStr = getMetaData().toSeq.sorted.map {
+      case (key, value) =>
+        val redactedValue =
+          Utils.redact(sparkSession.sessionState.conf.stringRedactionPattern, value)
+        key + ": " + StringUtils.abbreviate(
+          redactedValue, sparkSession.sessionState.conf.maxMetadataStringLength)
+    }.mkString(", ")
+    s"(Python) $metadataStr"
+  }
 
   override def readSchema(): StructType = outputSchema
 
@@ -44,6 +61,13 @@ class PythonScan(
 
   override def columnarSupportMode(): Scan.ColumnarSupportMode =
     Scan.ColumnarSupportMode.UNSUPPORTED
+
+  override def getMetaData(): Map[String, String] = {
+    Map(
+      "PushedFilters" -> supportedFilters.mkString("[", ", ", "]"),
+      "ReadSchema" -> outputSchema.simpleString
+    )
+  }
 }
 
 class PythonBatch(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonScan.scala
@@ -43,16 +43,7 @@ class PythonScan(
   override def toMicroBatchStream(checkpointLocation: String): MicroBatchStream =
     new PythonMicroBatchStream(ds, shortName, outputSchema, options)
 
-  override def description: String = {
-    val metadataStr = getMetaData().toSeq.sorted.map {
-      case (key, value) =>
-        val redactedValue =
-          Utils.redact(sparkSession.sessionState.conf.stringRedactionPattern, value)
-        key + ": " + StringUtils.abbreviate(
-          redactedValue, sparkSession.sessionState.conf.maxMetadataStringLength)
-    }.mkString(", ")
-    s"(Python) $metadataStr"
-  }
+  override def description: String = "(Python)"
 
   override def readSchema(): StructType = outputSchema
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonScan.scala
@@ -16,10 +16,7 @@
  */
 package org.apache.spark.sql.execution.datasources.v2.python
 
-import org.apache.commons.lang3.StringUtils
-
 import org.apache.spark.JobArtifactSet
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.metric.CustomMetric
 import org.apache.spark.sql.connector.read._
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream
@@ -27,7 +24,6 @@ import org.apache.spark.sql.internal.connector.SupportsMetadata
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import org.apache.spark.util.Utils
 
 class PythonScan(
     ds: PythonDataSourceV2,
@@ -36,8 +32,6 @@ class PythonScan(
     options: CaseInsensitiveStringMap,
     supportedFilters: Array[Filter]
 ) extends Scan with SupportsMetadata {
-  private lazy val sparkSession = SparkSession.active
-
   override def toBatch: Batch = new PythonBatch(ds, shortName, outputSchema, options)
 
   override def toMicroBatchStream(checkpointLocation: String): MicroBatchStream =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonScanBuilder.scala
@@ -16,7 +16,9 @@
  */
 package org.apache.spark.sql.execution.datasources.v2.python
 
-import org.apache.spark.sql.connector.read.{Scan, ScanBuilder}
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownFilters}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -25,6 +27,34 @@ class PythonScanBuilder(
     ds: PythonDataSourceV2,
     shortName: String,
     outputSchema: StructType,
-    options: CaseInsensitiveStringMap) extends ScanBuilder {
-  override def build(): Scan = new PythonScan(ds, shortName, outputSchema, options)
+    options: CaseInsensitiveStringMap)
+    extends ScanBuilder
+    with SupportsPushDownFilters {
+  private var supportedFilters: Array[Filter] = Array.empty
+
+  override def build(): Scan =
+    new PythonScan(ds, shortName, outputSchema, options, supportedFilters)
+
+  // Optionally called by DSv2 once to push down filters before the scan is built.
+  override def pushFilters(filters: Array[Filter]): Array[Filter] = {
+    if (!SQLConf.get.pythonFilterPushDown) {
+      return filters
+    }
+
+    val dataSource = ds.getOrCreateDataSourceInPython(shortName, options, Some(outputSchema))
+    val result = ds.source.pushdownFiltersInPython(dataSource, outputSchema, filters)
+
+    // The Data Source instance state changes after pushdown to remember the reader instance
+    // created and the filters pushed down. So pushdownFiltersInPython returns a new pickled
+    // Data Source instance. We need to use that new instance for further operations.
+    ds.setDataSourceInPython(dataSource.copy(dataSource = result.dataSource))
+
+    // Partition the filters into supported and unsupported ones.
+    val isPushed = result.isFilterPushed.zip(filters)
+    supportedFilters = isPushed.collect { case (true, filter) => filter }.toArray
+    val unsupported = isPushed.collect { case (false, filter) => filter }.toArray
+    unsupported
+  }
+
+  override def pushedFilters(): Array[Filter] = supportedFilters
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/UserDefinedPythonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/UserDefinedPythonDataSource.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.python.{ArrowPythonRunner, MapInBatchEvaluatorFactory, PythonPlannerRunner, PythonSQLMetrics}
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{BinaryType, DataType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.ArrayImplicits._
@@ -59,6 +60,26 @@ case class UserDefinedPythonDataSource(dataSourceCls: PythonFunction) {
       shortName,
       userSpecifiedSchema,
       CaseInsensitiveMap(options.asCaseSensitiveMap().asScala.toMap)).runInPython()
+  }
+
+  /**
+   * (Driver-side) Run Python process to push down filters, get the updated
+   * data source instance and the filter pushdown result.
+   */
+  def pushdownFiltersInPython(
+      pythonResult: PythonDataSourceCreationResult,
+      outputSchema: StructType,
+      filters: Array[Filter]): PythonFilterPushdownResult = {
+    val runner = new UserDefinedPythonDataSourceFilterPushdownRunner(
+      createPythonFunction(pythonResult.dataSource),
+      outputSchema,
+      filters
+    )
+    if (runner.isAnyFilterSupported) {
+      runner.runInPython()
+    } else {
+      PythonFilterPushdownResult(pythonResult.dataSource, filters.map(_ => false))
+    }
   }
 
   /**
@@ -300,6 +321,97 @@ private class UserDefinedPythonDataSourceRunner(
   }
 }
 
+/**
+ * @param isFilterPushed A sequence of bools indicating whether each filter is pushed down.
+ */
+case class PythonFilterPushdownResult(
+    dataSource: Array[Byte],
+    isFilterPushed: collection.Seq[Boolean])
+
+/**
+ * Push down filters to a Python data source.
+ *
+ * @param dataSource
+ *   a Python data source instance
+ * @param schema
+ *   output schema of the Python data source
+ * @param filters
+ *   all filters to be pushed down
+ */
+private class UserDefinedPythonDataSourceFilterPushdownRunner(
+    dataSource: PythonFunction,
+    schema: StructType,
+    filters: collection.Seq[Filter])
+    extends PythonPlannerRunner[PythonFilterPushdownResult](dataSource) {
+
+  private case class SerializedFilter(
+      name: String,
+      columnPath: collection.Seq[String],
+      value: Int,
+      index: Int)
+
+  private val serializedFilters = filters.zipWithIndex.flatMap {
+    case (filter, i) =>
+      filter match {
+        case filter @ org.apache.spark.sql.sources.EqualTo(_, value: Int) =>
+          val columnPath = filter.v2references.head
+          Some(SerializedFilter("EqualTo", columnPath, value, i))
+        case _ =>
+          None
+      }
+  }
+
+  // See the logic in `pyspark.sql.worker.data_source_pushdown_filters.py`.
+  override val workerModule = "pyspark.sql.worker.data_source_pushdown_filters"
+
+  def isAnyFilterSupported: Boolean = serializedFilters.nonEmpty
+
+  override protected def writeToPython(dataOut: DataOutputStream, pickler: Pickler): Unit = {
+    // Send Python data source
+    PythonWorkerUtils.writePythonFunction(dataSource, dataOut)
+
+    // Send output schema
+    PythonWorkerUtils.writeUTF(schema.json, dataOut)
+
+    // Send the filters
+    // For now only handle EqualTo filter on int
+    dataOut.writeInt(serializedFilters.length)
+    for (f <- serializedFilters) {
+      PythonWorkerUtils.writeUTF(f.name, dataOut)
+      dataOut.writeInt(f.columnPath.length)
+      for (path <- f.columnPath) {
+        PythonWorkerUtils.writeUTF(path, dataOut)
+      }
+      dataOut.writeInt(f.value)
+    }
+  }
+
+  override protected def receiveFromPython(dataIn: DataInputStream): PythonFilterPushdownResult = {
+    // Receive the picked data source or an exception raised in Python worker.
+    val length = dataIn.readInt()
+    if (length == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
+      val msg = PythonWorkerUtils.readUTF(dataIn)
+      throw QueryCompilationErrors.pythonDataSourceError(action = "plan", tpe = "read", msg = msg)
+    }
+
+    // Receive the pickled data source.
+    val pickledDataSourceInstance: Array[Byte] = PythonWorkerUtils.readBytes(length, dataIn)
+
+    // Receive the pushed filters as a list of indices.
+    val numFiltersPushed = dataIn.readInt()
+    val isFilterPushed = ArrayBuffer.fill(filters.length)(false)
+    for (_ <- 0 until numFiltersPushed) {
+      val i = dataIn.readInt()
+      isFilterPushed(serializedFilters(i).index) = true
+    }
+
+    PythonFilterPushdownResult(
+      dataSource = pickledDataSourceInstance,
+      isFilterPushed = isFilterPushed
+    )
+  }
+}
+
 case class PythonDataSourceReadInfo(
     func: Array[Byte],
     partitions: Seq[Array[Byte]])
@@ -332,6 +444,7 @@ private class UserDefinedPythonDataSourceReadRunner(
 
     // Send configurations
     dataOut.writeInt(SQLConf.get.arrowMaxRecordsPerBatch)
+    dataOut.writeBoolean(SQLConf.get.pythonFilterPushDown)
 
     dataOut.writeBoolean(isStreaming)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -22,13 +22,20 @@ import java.io.{File, FileWriter}
 import org.apache.spark.SparkException
 import org.apache.spark.api.python.PythonUtils
 import org.apache.spark.sql.{AnalysisException, IntegratedUDFTestUtils, QueryTest, Row}
+import org.apache.spark.sql.execution.FilterExec
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.datasources.DataSourceManager
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanRelation}
+import org.apache.spark.sql.execution.datasources.v2.python.PythonScan
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
 
-abstract class PythonDataSourceSuiteBase extends QueryTest with SharedSparkSession {
+abstract class PythonDataSourceSuiteBase
+    extends QueryTest
+    with SharedSparkSession
+    with AdaptiveSparkPlanHelper {
 
   protected val simpleDataSourceReaderScript: String =
     """
@@ -211,6 +218,76 @@ class PythonDataSourceSuite extends PythonDataSourceSuiteBase {
       exception = intercept[AnalysisException](spark.read.format(dataSourceName).load()),
       condition = "INVALID_SCHEMA.NON_STRUCT_TYPE",
       parameters = Map("inputSchema" -> "INT", "dataType" -> "\"INT\""))
+  }
+
+  test("data source reader with filter pushdown") {
+    assume(shouldTestPandasUDFs)
+    val dataSourceScript =
+      s"""
+         |from pyspark.sql.datasource import (
+         |    DataSource,
+         |    DataSourceReader,
+         |    EqualTo,
+         |    InputPartition,
+         |)
+         |
+         |class SimpleDataSourceReader(DataSourceReader):
+         |    def partitions(self):
+         |        return [InputPartition(i) for i in range(2)]
+         |
+         |    def pushFilters(self, filters):
+         |        yield filters[filters.index(EqualTo(("id",), 1))]
+         |
+         |    def read(self, partition):
+         |        yield (0, partition.value)
+         |        yield (1, partition.value)
+         |        yield (2, partition.value)
+         |
+         |class SimpleDataSource(DataSource):
+         |    def schema(self):
+         |        return "id int, partition int"
+         |
+         |    def reader(self, schema):
+         |        return SimpleDataSourceReader()
+         |""".stripMargin
+    val schema = StructType.fromDDL("id INT, partition INT")
+    val dataSource =
+      createUserDefinedPythonDataSource(name = dataSourceName, pythonScript = dataSourceScript)
+    withSQLConf(SQLConf.PYTHON_FILTER_PUSHDOWN_ENABLED.key -> "true") {
+      spark.dataSource.registerPython(dataSourceName, dataSource)
+      val df =
+        spark.read.format(dataSourceName).schema(schema).load().filter("id = 1 and partition = 0")
+      val plan = df.queryExecution.executedPlan
+
+      /**
+       * == Physical Plan ==
+       * *(1) Project [id#261, partition#262]
+       * +- *(1) Filter ((isnotnull(id#261) AND isnotnull(partition#262)) AND (id#261 = 1))
+       *    +- BatchScan SimpleDataSource[id#261, partition#262] (Python)
+       *       PushedFilters: [EqualTo(partition,0)],
+       *       ReadSchema: struct<id:int,partition:int> RuntimeFilters: []
+       */
+      fail(df.queryExecution.explainString(org.apache.spark.sql.execution.ExtendedMode))
+      val filter = collectFirst(df.queryExecution.executedPlan) {
+        case s: FilterExec =>
+          val condition = s.condition.toString
+          assert(!condition.contains("= 0")) // pushed filter is not in FilterExec
+          assert(condition.contains("= 1")) // unsupported filter is in FilterExec
+          s
+      }.getOrElse(
+        fail(s"Filter not found in the plan. Actual plan:\n$plan")
+      )
+
+      collectFirst(filter) {
+        case s: BatchScanExec if s.scan.isInstanceOf[PythonScan] =>
+          val p = s.scan.asInstanceOf[PythonScan]
+          assert(p.getMetaData().get("PushedFilters").contains("[EqualTo(partition,0)]"))
+      }.getOrElse(
+        fail(s"PythonScan not found in the plan. Actual plan:\n$plan")
+      )
+
+      checkAnswer(df, Seq(Row(1, 0), Row(1, 1)))
+    }
   }
 
   test("register data source") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -267,7 +267,6 @@ class PythonDataSourceSuite extends PythonDataSourceSuiteBase {
        *       PushedFilters: [EqualTo(partition,0)],
        *       ReadSchema: struct<id:int,partition:int> RuntimeFilters: []
        */
-      fail(df.queryExecution.explainString(org.apache.spark.sql.execution.ExtendedMode))
       val filter = collectFirst(df.queryExecution.executedPlan) {
         case s: FilterExec =>
           val condition = s.condition.toString


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds support for filter pushdown to Python Data Source batch read, with a API similar to `SupportsPushDownFilters` interface. The user can implement `DataSourceReader.pushFilters` to receive filters that may be pushed down, decide which filters to push down, remember them, and return the remaining filters to be applied by Spark.

Note that filter pushdown is only supported for batch read, not for streaming read. This is also the case for the Scala API. Therefore the new API is added to `DataSourceReader` and not to `DataSource` or `DataSourceStreamReader`.

To keep the Python API simple, we will only support V1 filters that have a column, a boolean operator, and a literal value. The filter serialization is a placeholder and will be implemented in a future PR.

```py
class DataSourceReader(ABC):
    ...

    def pushFilters(self, filters: List["Filter"]) -> Iterable["Filter"]:
        """
        Called with the list of filters that can be pushed down to the data source.

        The list of filters should be interpreted as the AND of the elements.

        Filter pushdown allows the data source to handle a subset of filters. This
        can improve performance by reducing the amount of data that needs to be
        processed by Spark.

        This method is called once during query planning. By default, it returns
        all filters, indicating that no filters can be pushed down. Subclasses can
        override this method to implement filter pushdown.

        It's recommended to implement this method only for data sources that natively
        support filtering, such as databases and GraphQL APIs.

        .. versionadded: 4.1.0

        Parameters
        ----------
        filters : list of :class:`Filter`\\s

        Returns
        -------
        iterable of :class:`Filter`\\s
            Filters that still need to be evaluated by Spark post the data source
            scan. This includes unsupported filters and partially pushed filters.
            Every returned filter must be one of the input filters by reference.

        Side effects
        ------------
        This method is allowed to modify `self`. The object must remain picklable.
        Modifications to `self` are visible to the `partitions()` and `read()` methods.

        Examples
        --------
        Example filters and the resulting arguments passed to pushFilters:

        +-------------------------------+---------------------------------------------+
        | Filters                       | Pushdown Arguments                          |
        +-------------------------------+---------------------------------------------+
        | `a = 1 and b = 2`             | `[EqualTo(("a",), 1), EqualTo(("b",), 2)]`  |
        | `a = 1 or b = 2`              | `[]`                                        |
        | `a = 1 or (b = 2 and c = 3)`  | `[]`                                        |
        | `a = 1 and (b = 2 or c = 3)`  | `[EqualTo(("a",), 1)]`                      |
        +-------------------------------+---------------------------------------------+

        Implement pushFilters to support EqualTo filters only:

        >>> def pushFilters(self, filters):
        ...     for filter in filters:
        ...         if isinstance(filter, EqualTo):
        ...             # Save supported filter for handling in partitions() and read()
        ...             self.filters.append(filter)
        ...         else:
        ...             # Unsupported filter
        ...             yield filter
        """
        return filters
```

#### Roadmap
- (this PR) Add filter pushdown API
- Implement filter serialization and more filter types
- Add column pruning API

#### Suggested reivew order (from high level to details)
1. `datasource.py`: add filter pushdown to Python Data Source API
2. `test_python_datasource.py`: tests for filter pushdown
3. `PythonScanBuilder.scala`: implement filter pushdown API in Scala
4. `UserDefinedPythonDataSource.scala`, `data_source_pushdown_filters.py`: communication between Python and Scala and filter pushdown logic
   - Note that the current filter serialization is a placeholder. An upcoming PR will implement the actual serialization.

#### Changes to interactions between Python and Scala
Original sequence:
```mermaid
sequenceDiagram
    # autonumber
    participant S as Data Sources API
    participant D as PythonDataSourceV2
    participant P as Python Worker
    participant U as User Implementation

    S ->> D: PythonDataSourceV2.inferSchema(options)
    
    D ->+ P: create_data_source.py
    D -->> P: pickled DS class, name,<br/>schema, options
    P ->+ U: unpickle DS class
    P ->> U: DataSource(options)
    U -->> P: DS instance
    U ->- P: pickle DS instance
    P -->>- D: pickled DS, schema

    D -->> S: schema
    S ->> D: PythonDataSourceV2.getTable(...)
    D -->> S: PythonTable
    S ->> D: PythonTable.newScanBuilder(options)
    D -->> S: PythonScanBuilder
    S ->> D: PythonScanBuilder.build()
    D -->> S: PythonScan
    S ->> D: PythonScan.toBatch()
    D -->> S: PythonBatch
    S ->> D: PythonBatch.planInputPartitions()

    D ->+ P: plan_data_source_read.py
    D -->> P: pickled DS, schema, ...
    P ->+ U: unpickle DS
    P ->> U: DS.reader(schema)
    U -->> P: reader
    P ->> U: reader.partitions()
    U -->> P: partitions
    U ->- P: pickle reader
    P -->>- D: pickled read,<br/>pickled partitions

    D -->> S: partitions
```

Updated sequence (new interactions are highlighted in yellow):
```mermaid
sequenceDiagram
    # autonumber
    participant S as Data Sources API
    participant D as PythonDataSourceV2
    participant P as Python Worker
    participant U as User Implementation

    S ->> D: PythonDataSourceV2.inferSchema(options)
    
    D ->+ P: create_data_source.py
    D -->> P: pickled DS class, name,<br/>schema, options
    P ->+ U: unpickle DS class
    P ->> U: DataSource(options)
    U -->> P: DS instance
    U ->- P: pickle DS instance
    P -->>- D: pickled DS, schema

    D -->> S: schema
    S ->> D: PythonDataSourceV2.getTable(...)
    D -->> S: PythonTable
    S ->> D: PythonTable.newScanBuilder(options)
    D -->> S: PythonScanBuilder

    rect rgb(255, 252, 238)
    S ->> D: PythonScanBuilder.pushFilters(filters)

    note right of D: Pushdown filters
    note right of D: Only simple filters are serialized<br/> and passed to Python
    note right of D: Other more complex filters are<br/> directly marked as unsupported
    D ->+ P: data_source_pushdown_filters.py
    D -->> P: pickled DS, filters, schema
    P ->+ U: unpickle DS
    P ->> U: DS.reader(schema)
    U -->> P: DataSourceReader
    P ->> U: reader.push_filters(filters)
    U -->> P: unsupported filters
    U ->- P: pickle DS with <br/>monkey patched reader()
    P -->>- D: pickled DS, supported filters

    D -->> S: unsupported filters, supported filters

    S ->> D: PythonScanBuilder.pushedFilters()
    D -->> S: supported filters
    end

    S ->> D: PythonScanBuilder.build()
    D -->> S: PythonScan
    S ->> D: PythonScan.toBatch()
    D -->> S: PythonBatch
    S ->> D: PythonBatch.planInputPartitions()

    D ->+ P: plan_data_source_read.py
    D -->> P: pickled DS, schema, ...
    P ->+ U: unpickle DS
    P ->> U: DS.reader(schema)
    U -->> P: DataSourceReader
    P ->> U: reader.partitions()
    U -->> P: partitions
    U ->- P: pickle read function
    P -->>- D: pickled read,<br/>pickled partitions

    D -->> S: partitions
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Filter pushdown allows reducing the amount of data produced by the reader, by filtering rows directly in the data source scan. The reduction in the amount of data can improve query performance. This PR implements filter pushdown for Python Data Sources API using the existing Scala DS filter pushdown API. An upcoming PR will implement the actual filter types and the serialization of filters.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. New API are added. See `datasource.py` for details.

The new API is optional to implement. If not implemented, the reader will behave as before.

The feature is also controlled by the new `spark.sql.python.filterPushdown.enabled` configuration which is disabled by default.
If the conf is enabled, the new code path for filter pushdown is used. Otherwise, the code path is skipped and we throw an exception if the user implements `DataSourceReader.pushFilters()` so that it's not ignored silently.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Tests added to `test_python_datasource.py` to check that:
- pushed filters are not reapplied by Spark
- unsupported filters are applied by Spark
- pushdown happens before partitions
- reader state is preserved after pushdown
- pushdown is not called if no filters are present
- conf is respected
- ...

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
