### PR TITLE
[SPARK-51222][SQL] Optimize ReplaceCurrentLike

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -142,22 +142,22 @@ object ComputeCurrentTime extends Rule[LogicalPlan] {
 }
 
 /**
- * Replaces the expression of CurrentDatabase with the current database name.
- * Replaces the expression of CurrentCatalog with the current catalog name.
+ * Replaces the expression of CurrentDatabase, CurrentCatalog, and CurrentUser
+ * with the current values.
  */
 case class ReplaceCurrentLike(catalogManager: CatalogManager) extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = {
     import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
-    lazy val currentNamespace = catalogManager.currentNamespace.quoted
-    lazy val currentCatalog = catalogManager.currentCatalog.name()
-    lazy val currentUser = CurrentUserContext.getCurrentUser
 
     plan.transformAllExpressionsWithPruning(_.containsPattern(CURRENT_LIKE)) {
       case CurrentDatabase() =>
+        val currentNamespace = catalogManager.currentNamespace.quoted
         Literal.create(currentNamespace, StringType)
       case CurrentCatalog() =>
+        val currentCatalog = catalogManager.currentCatalog.name()
         Literal.create(currentCatalog, StringType)
       case CurrentUser() =>
+        val currentUser = CurrentUserContext.getCurrentUser
         Literal.create(currentUser, StringType)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -148,9 +148,9 @@ object ComputeCurrentTime extends Rule[LogicalPlan] {
 case class ReplaceCurrentLike(catalogManager: CatalogManager) extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = {
     import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
-    val currentNamespace = catalogManager.currentNamespace.quoted
-    val currentCatalog = catalogManager.currentCatalog.name()
-    val currentUser = CurrentUserContext.getCurrentUser
+    lazy val currentNamespace = catalogManager.currentNamespace.quoted
+    lazy val currentCatalog = catalogManager.currentCatalog.name()
+    lazy val currentUser = CurrentUserContext.getCurrentUser
 
     plan.transformAllExpressionsWithPruning(_.containsPattern(CURRENT_LIKE)) {
       case CurrentDatabase() =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve ReplaceCurrentLike FinishAnalysis rule.  This was found as a result of debugging SPARK-51119.

### Why are the changes needed?
The rule calls the catalog unnecessarily, and this can be done lazily only if it is resolving current_catalog() and current_database() expressions.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing unit test


### Was this patch authored or co-authored using generative AI tooling?
No
