### PR TITLE
[SPARK-51085][SQL] Restore SQLContext Companion

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -980,7 +980,6 @@ abstract class SQLContext private[sql] (val sparkSession: SparkSession)
  */
 private[sql] trait SQLContextCompanion {
   private[sql] type SQLContextImpl <: SQLContext
-  private[sql] type SparkContextImpl <: SparkContext
 
   /**
    * Get the singleton SQLContext if it exists or create a new one using the given SparkContext.
@@ -994,7 +993,7 @@ private[sql] trait SQLContextCompanion {
    * @since 1.5.0
    */
   @deprecated("Use SparkSession.builder instead", "2.0.0")
-  def getOrCreate(sparkContext: SparkContextImpl): SQLContextImpl
+  def getOrCreate(sparkContext: SparkContext): SQLContextImpl
 
   /**
    * Changes the SQLContext that will be returned in this thread and its children when
@@ -1017,5 +1016,15 @@ private[sql] trait SQLContextCompanion {
   @deprecated("Use SparkSession.clearActiveSession instead", "2.0.0")
   def clearActive(): Unit = {
     SparkSession.clearActiveSession()
+  }
+}
+
+object SQLContext extends SQLContextCompanion {
+  private[sql] type SQLContextImpl = SQLContext
+
+  /** @inheritdoc */
+  @deprecated("Use SparkSession.builder instead", "2.0.0")
+  def getOrCreate(sparkContext: SparkContext): SQLContext = {
+    SparkSession.builder().sparkContext(sparkContext).getOrCreate().sqlContext
   }
 }

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/SparkSessionBuilderImplementationBindingSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/SparkSessionBuilderImplementationBindingSuite.scala
@@ -16,8 +16,7 @@
  */
 package org.apache.spark.sql.connect
 
-import org.apache.spark.sql
-import org.apache.spark.sql.SparkSessionBuilder
+import org.apache.spark.{sql, SparkContext}
 import org.apache.spark.sql.connect.test.{ConnectFunSuite, RemoteSparkSession}
 
 /**
@@ -27,8 +26,11 @@ class SparkSessionBuilderImplementationBindingSuite
     extends ConnectFunSuite
     with sql.SparkSessionBuilderImplementationBindingSuite
     with RemoteSparkSession {
-  override protected def configure(builder: SparkSessionBuilder): builder.type = {
+  override def beforeAll(): Unit = {
     // We need to set this configuration because the port used by the server is random.
-    builder.remote(s"sc://localhost:$serverPort")
+    System.setProperty("spark.remote", s"sc://localhost:$serverPort")
+    super.beforeAll()
   }
+
+  override protected def sparkContext: SparkContext = null
 }

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SQLContext.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SQLContext.scala
@@ -305,29 +305,13 @@ class SQLContext private[sql] (override val sparkSession: SparkSession)
     super.jdbc(url, table, theParts)
   }
 }
+
 object SQLContext extends sql.SQLContextCompanion {
 
   override private[sql] type SQLContextImpl = SQLContext
-  override private[sql] type SparkContextImpl = SparkContext
 
-  /**
-   * Get the singleton SQLContext if it exists or create a new one.
-   *
-   * This function can be used to create a singleton SQLContext object that can be shared across
-   * the JVM.
-   *
-   * If there is an active SQLContext for current thread, it will be returned instead of the
-   * global one.
-   *
-   * @param sparkContext
-   *   The SparkContext. This parameter is not used in Spark Connect.
-   *
-   * @since 4.0.0
-   */
+  /** @inheritdoc */
   def getOrCreate(sparkContext: SparkContext): SQLContext = {
     SparkSession.builder().getOrCreate().sqlContext
   }
-
-  /** @inheritdoc */
-  override def setActive(sqlContext: SQLContext): Unit = super.setActive(sqlContext)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/SQLContext.scala
@@ -378,17 +378,12 @@ class SQLContext private[sql] (override val sparkSession: SparkSession)
 }
 
 object SQLContext extends sql.SQLContextCompanion {
-
   override private[sql] type SQLContextImpl = SQLContext
-  override private[sql] type SparkContextImpl = SparkContext
 
   /** @inheritdoc */
   def getOrCreate(sparkContext: SparkContext): SQLContext = {
     newSparkSessionBuilder().sparkContext(sparkContext).getOrCreate().sqlContext
   }
-
-  /** @inheritdoc */
-  override def setActive(sqlContext: SQLContext): Unit = super.setActive(sqlContext)
 
   /**
    * Converts an iterator of Java Beans to InternalRow using the provided bean info & schema. This


### PR DESCRIPTION
### What changes were proposed in this pull request?
The companion object for SQLContext was accidentally dropped when we swapped the interface and the implementation. This PR restores the companion.

### Why are the changes needed?
The SQLContext Companion is part of the 

### Does this PR introduce _any_ user-facing change?
No. Well it mitigates a potentially user facing change.

### How was this patch tested?
I added a test to `SparkSessionBuilderImplementationBindingSuite`.

### Was this patch authored or co-authored using generative AI tooling?
No.