### PR TITLE
[SPARK-51225][BUILD] Upgrade several Maven plugins to the latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <java.version>17</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <maven.version>3.9.9</maven.version>
-    <exec-maven-plugin.version>3.2.0</exec-maven-plugin.version>
+    <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.7.1</asm.version>
     <slf4j.version>2.0.16</slf4j.version>
@@ -174,7 +174,7 @@
     <scalatest-maven-plugin.version>2.2.0</scalatest-maven-plugin.version>
     <scala-maven-plugin.version>4.9.2</scala-maven-plugin.version>
     <maven.scaladoc.skip>false</maven.scaladoc.skip>
-    <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>
+    <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <scalafmt.validateOnly>true</scalafmt.validateOnly>
@@ -2591,7 +2591,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>3.5.0</version>
           <executions>
             <execution>
               <id>enforce-versions</id>
@@ -2652,7 +2652,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.0</version>
           <executions>
             <execution>
               <id>module-timestamp-property</id>
@@ -2788,7 +2788,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.2.5</version>
+          <version>3.5.2</version>
           <!-- Note config is repeated in scalatest config -->
           <configuration>
             <includes>
@@ -2924,7 +2924,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.3.2</version>
+          <version>3.4.0</version>
           <configuration>
             <filesets>
               <fileset>
@@ -2951,7 +2951,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.6.3</version>
+          <version>3.11.2</version>
           <configuration>
             <additionalJOptions>
               <additionalJOption>-Xdoclint:all</additionalJOption>
@@ -3007,7 +3007,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.5.2</version>
+          <version>3.6.0</version>
           <dependencies>
             <dependency>
               <groupId>org.ow2.asm</groupId>
@@ -3037,7 +3037,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.6.1</version>
+          <version>3.8.1</version>
           <executions>
             <execution>
               <id>default-cli</id>
@@ -3178,7 +3178,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.6.0</version>
         <configuration>
           <failOnViolation>false</failOnViolation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
@@ -3296,7 +3296,7 @@
       <plugin>
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
-        <version>2.8.0</version>
+        <version>2.9.1</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade several maven plugins to the latest versions for Apache Spark 4.1.0.

### Why are the changes needed?

To bring the latest bug fixes and prepare for Apache Maven 4.0.0.
- `versions-maven-plugin` from 2.16.2 to 2.18.0
- `build-helper-maven-plugin` from 3.5.0 to 3.6.0
- `cyclonedx-maven-plugin` from 2.8.0 to 2.9.1
- `exec-maven-plugin` from 3.2.0 to 3.5.0
- `maven-enforcer-plugin` from 3.4.1 to 3.5.0
- `maven-surefire-plugin` from 3.2.5 to 3.5.2
- `maven-clean-plugin` from 3.3.2 to 3.4.0
- `maven-javadoc-plugin` from 3.6.3 to 3.11.2
- `maven-shade-plugin` from 3.5.2 to 3.6.0
- `maven-dependency-plugin` from 3.6.1 to 3.8.1
- `maven-checkstyle-plugin` from 3.3.1 to 3.6.0

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.