### PR TITLE
[SPARK-51226][BUILD] Upgrade `extra-enforcer-rules` to support Java 24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2645,7 +2645,7 @@
             <dependency>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>extra-enforcer-rules</artifactId>
-              <version>1.8.0</version>
+              <version>1.9.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `extra-enforcer-rules` to support Java 24.

### Why are the changes needed?

- https://github.com/mojohaus/extra-enforcer-rules/releases/tag/1.9.0
  - https://github.com/mojohaus/extra-enforcer-rules/pull/308

### Does this PR introduce _any_ user-facing change?

No, this is a build plugin.

**BEFORE**
```
[INFO] --- enforcer:3.4.1:enforce (enforce-versions) @ spark-parent_2.13 ---
[INFO] Rule 0: org.apache.maven.enforcer.rules.version.RequireMavenVersion passed
[INFO] Rule 1: org.apache.maven.enforcer.rules.version.RequireJavaVersion passed
[INFO] Rule 2: org.apache.maven.enforcer.rules.dependency.BannedDependencies passed
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/JdkClassReader.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/JdkClassReader$PushbackIterator.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/AsmWrappedAttribute$AsmModuleHashesAttribute.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/AsmWrappedAttribute.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/AsmWrappedAttribute$AsmModuleResolutionAttribute.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/AsmWrappedAttribute$AsmCompilationIdAttribute.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/AsmAttribute$DelegatingClassReader.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/AsmWrappedAttribute$AsmSourceIdAttribute.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/JdkClassWriter$WritingFieldVisitor.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/AsmAttribute$1.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/AsmAttribute.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/JdkClassReader$MergedLocalVariableValue.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/AsmWrappedAttribute$AsmCharacterRangeTableAttribute.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/JdkClassReader$MergedLocalVariableKey.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/JdkClassWriter$WritingMethodVisitor.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/JdkClassWriter.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/JdkClassReader$AnnotationVisitorSource.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/AsmAttribute$DelegatingClassWriter.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/JdkClassReader$AttributeFunction.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/JdkClassWriter$WritingModuleVisitor.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/JdkClassWriter$WritingAnnotationVisitor.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/JdkClassWriter$1.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/JdkClassReader$1.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/AsmWrappedAttribute$AsmUnknownAttribute.class: got null class-file-version
[WARNING] Unknown bytecodeVersion for net.bytebuddy:byte-buddy:jar:1.17.0:test : META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/JdkClassReader$TypeAnnotationVisitorSource.class: got null class-file-version
[INFO] Rule 3: org.codehaus.mojo.extraenforcer.dependencies.EnforceBytecodeVersion passed
```

**AFTER**
```
[INFO] --- enforcer:3.4.1:enforce (enforce-versions) @ spark-parent_2.13 ---
[INFO] Rule 0: org.apache.maven.enforcer.rules.version.RequireMavenVersion passed
[INFO] Rule 1: org.apache.maven.enforcer.rules.version.RequireJavaVersion passed
[INFO] Rule 2: org.apache.maven.enforcer.rules.dependency.BannedDependencies passed
[INFO] Rule 3: org.codehaus.mojo.extraenforcer.dependencies.EnforceBytecodeVersion passed
```

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.