### PR TITLE
[SPARK-51227][PYTHON][CONNECT] Fix PySpark Connect `_minimum_grpc_version` to 1.67.0

### DIFF
--- a/python/packaging/connect/setup.py
+++ b/python/packaging/connect/setup.py
@@ -133,7 +133,7 @@ try:
     _minimum_pandas_version = "2.0.0"
     _minimum_numpy_version = "1.21"
     _minimum_pyarrow_version = "11.0.0"
-    _minimum_grpc_version = "1.59.3"
+    _minimum_grpc_version = "1.67.0"
     _minimum_googleapis_common_protos_version = "1.56.4"
 
     with open("README.md") as f:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix PySpark Connect `_minimum_grpc_version` from 1.59.3 to 1.67.0 correctly.

https://github.com/apache/spark/blob/c36916f7a112dc6c6505c12d68c3f63c5aa31db2/python/docs/source/getting_started/install.rst?plain=1#L211

https://github.com/apache/spark/blob/c36916f7a112dc6c6505c12d68c3f63c5aa31db2/dev/spark-test-image/python-minimum/Dockerfile#L76

### Why are the changes needed?

It seems that we missed to this at
- #44929
- #48524

### Does this PR introduce _any_ user-facing change?

This will make it sure that PySpark Connect installation meets the minimum requirement correctly.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.