### PR TITLE
[SPARK-50098][PYTHON][CONNECT][FOLLOWUP] Fix PySpark Connect `_minimum_googleapis_common_protos_version` to 1.65.0

### DIFF
--- a/python/packaging/connect/setup.py
+++ b/python/packaging/connect/setup.py
@@ -134,7 +134,7 @@ try:
     _minimum_numpy_version = "1.21"
     _minimum_pyarrow_version = "11.0.0"
     _minimum_grpc_version = "1.59.3"
-    _minimum_googleapis_common_protos_version = "1.56.4"
+    _minimum_googleapis_common_protos_version = "1.65.0"
 
     with open("README.md") as f:
         long_description = f.read()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of 
- #48638

https://github.com/apache/spark/blob/c36916f7a112dc6c6505c12d68c3f63c5aa31db2/python/docs/source/getting_started/install.rst?plain=1#L213

https://github.com/apache/spark/blob/c36916f7a112dc6c6505c12d68c3f63c5aa31db2/dev/spark-test-image/python-minimum/Dockerfile#L76

### Why are the changes needed?

To make it sure that PySpark Connect installation meets the minimum requirement correctly.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.