### PR TITLE
[SPARK-51231][BUILD] Add `--enable-native-access=ALL-UNNAMED` to `.mvn/jvm.config` and `jvmArgs` to suppress Maven warnings

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--enable-native-access=ALL-UNNAMED

--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -7,6 +7,7 @@ cache
 .generated-mima-class-excludes
 .generated-mima-member-excludes
 .rat-excludes
+.mvn/jvm.config
 .*md
 .java-version
 derby.log

--- a/pom.xml
+++ b/pom.xml
@@ -2762,6 +2762,7 @@
               <jvmArg>-Xmx4g</jvmArg>
               <jvmArg>-XX:MaxMetaspaceSize=2g</jvmArg>
               <jvmArg>-XX:ReservedCodeCacheSize=${CodeCacheSize}</jvmArg>
+              <jvmArg>--enable-native-access=ALL-UNNAMED</jvmArg>
             </jvmArgs>
             <javacArgs>
               <javacArg>--release</javacArg>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `.mvn/jvm.config` with `--enable-native-access=ALL-UNNAMED` and `jvmArgs` to suppress excessive Maven warnings during building.

### Why are the changes needed?

**Java 25-EA**
```
$ java -version
openjdk version "25-ea" 2025-09-16
OpenJDK Runtime Environment (build 25-ea+10-1084)
OpenJDK 64-Bit Server VM (build 25-ea+10-1084, mixed mode, sharing)
```

**BEFORE**
```
$ build/mvn clean 2>&1 | grep enable-native-access
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
```

**AFTER**
```
$ build/mvn clean 2>&1 | grep enable-native-access
$
```

Note that this PR didn't add this to `MAVEN_OPTS` of `build/mvn` because it doesn't remove all warnings and IDEs also handles `.mvn/jvm.config` better.

```
$ git diff
diff --git a/build/mvn b/build/mvn
index fef589fc034..9481ff2330f 100755
--- a/build/mvn
+++ b/build/mvn
@@ -156,7 +156,7 @@ install_mvn
 cd "${_CALLING_DIR}"

 # Set any `mvn` options if not already present
-export MAVEN_OPTS=${MAVEN_OPTS:-"$_COMPILE_JVM_OPTS"}
+export MAVEN_OPTS=${MAVEN_OPTS:-"$_COMPILE_JVM_OPTS --enable-native-access=ALL-UNNAMED"}

$ build/mvn clean 2>&1 | grep enable-native-access
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
```

### Does this PR introduce _any_ user-facing change?

No, this is a removal of excessive build warning.

### How was this patch tested?

After CI passes, manual testing the following simply as a quick test.

```
$ build/mvn clean 2>&1 | grep enable-native-access
```

### Was this patch authored or co-authored using generative AI tooling?

No.