### PR TITLE
[SPARK-51232][PYTHON][DOCS] Remove PySpark 3.3 and older logic from `binder/postBuild`

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -37,11 +37,7 @@ else
   SPECIFIER="<="
 fi
 
-if [[ ! $VERSION < "3.4.0" ]]; then
-  pip install plotly "pandas<2.0.0" "pyspark[sql,ml,mllib,pandas_on_spark,connect]$SPECIFIER$VERSION"
-else
-  pip install plotly "pandas<2.0.0" "pyspark[sql,ml,mllib,pandas_on_spark]$SPECIFIER$VERSION"
-fi
+pip install plotly "pandas<2.0.0" "pyspark[sql,ml,mllib,pandas_on_spark,connect]$SPECIFIER$VERSION"
 
 # Set 'PYARROW_IGNORE_TIMEZONE' to suppress warnings from PyArrow.
 echo "export PYARROW_IGNORE_TIMEZONE=1" >> ~/.profile


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove PySpark 3.3 and older logic from `binder/postBuild` because they are the end of life already and didn't have `PySpark Connect` module.

### Why are the changes needed?

After simplifying by removing legacy PySpark without `PySpark Connect` module, we are going to add additional logic to handle `PySpark Connect 4.0+` because they are different from `PySpark Connect 3.4 ~ 3.5`.

### Does this PR introduce _any_ user-facing change?

No, this is a kind of documentation via Binder service.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.