### PR TITLE
[SPARK-51233][BUILD] Update `pom.xml` to use `https` for `licenses` element

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <licenses>
     <license>
       <name>Apache-2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `pom.xml` to use `https` for `licenses` element like ASF parent `pom.xml` for Apache Spark 4.0.0.

### Why are the changes needed?

ASF parent `pom.xml` file switched to `https` for `licenses` element almost 9 years ago (May 12, 2016)
- [MPOM-116](https://issues.apache.org/jira/browse/MPOM-116) Use https wherever possible
  - https://github.com/apache/maven-apache-parent/commit/6dfc92ab89f6f8e5f8eb4c40707d2e72828fa2f8

Note that the existing link of Apache Spark code was a part of the initial commit during donating Spark to ASF foundation on Sep 1, 2013.
- https://github.com/apache/spark/commit/46eecd110a4017ea0c86cbb1010d0ccd6a5eb2ef

### Does this PR introduce _any_ user-facing change?

No, there is no behavior change. This is only updating a metadata of pom.xml.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.