### PR TITLE
[SPARK-51235][K8S][DOCS] Update `YuniKorn` docs with `1.6.1`

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1988,10 +1988,10 @@ Install Apache YuniKorn:
 ```bash
 helm repo add yunikorn https://apache.github.io/yunikorn-release
 helm repo update
-helm install yunikorn yunikorn/yunikorn --namespace yunikorn --version 1.6.0 --create-namespace --set embedAdmissionController=false
+helm install yunikorn yunikorn/yunikorn --namespace yunikorn --version 1.6.1 --create-namespace --set embedAdmissionController=false
 ```
 
-The above steps will install YuniKorn v1.6.0 on an existing Kubernetes cluster.
+The above steps will install YuniKorn v1.6.1 on an existing Kubernetes cluster.
 
 ##### Get started
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `YuniKorn` docs with v1.6.1 for Apache Spark 4.0.0.

### Why are the changes needed?

Apache YuniKorn v1.6.1 was released on 2025-01-24 with 12 [JIRAs](https://issues.apache.org/jira/issues/?filter=12353775#) issues.

  - https://yunikorn.apache.org/release-announce/1.6.1/

I installed YuniKorn v1.6.1 on K8s 1.31 and tested manually.

**K8s v1.31**
```
$ kubectl version
Client Version: v1.32.2
Kustomize Version: v5.5.0
Server Version: v1.31.4
```

**YuniKorn v1.6.1**
```
$ helm list -n yunikorn
NAME    	NAMESPACE	REVISION	UPDATED                             	STATUS  	CHART         	APP VERSION
yunikorn	yunikorn 	1       	2025-02-16 19:13:40.251713 -0800 PST	deployed	yunikorn-1.6.1
```

```
$ build/sbt -Pkubernetes -Pkubernetes-integration-tests -Dspark.kubernetes.test.deployMode=docker-desktop "kubernetes-integration-tests/testOnly *.YuniKornSuite" -Dtest.exclude.tags=minikube,local,decom,r -Dtest.default.exclude.tags=
...
[info] YuniKornSuite:
...
[info] Run completed in 7 minutes, 16 seconds.
[info] Total number of tests run: 27
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 27, failed 0, canceled 2, ignored 2, pending 0
[info] All tests passed.
[success] Total time: 453 s (07:33), completed Feb 16, 2025, 7:28:52 PM
```

```
Events:
  Type    Reason             Age   From      Message
  ----    ------             ----  ----      -------
  Normal  Scheduling         9s    yunikorn  spark-3261ae21f56f4250980e111d24e45d53/spark-test-app-e9c45e585ed54a55a526084f74437975-driver is queued and waiting for allocation
  Normal  Scheduled          9s    yunikorn  Successfully assigned spark-3261ae21f56f4250980e111d24e45d53/spark-test-app-e9c45e585ed54a55a526084f74437975-driver to node docker-desktop
  Normal  PodBindSuccessful  9s    yunikorn  Pod spark-3261ae21f56f4250980e111d24e45d53/spark-test-app-e9c45e585ed54a55a526084f74437975-driver is successfully bound to node docker-desktop
  Normal  Pulled             9s    kubelet   Container image "docker.io/kubespark/spark:dev" already present on machine
  Normal  Created            9s    kubelet   Created container spark-kubernetes-driver
  Normal  Started            9s    kubelet   Started container spark-kubernetes-driver
```