### PR TITLE
[SPARK-51240][BUILD] Upgrade commons-codec to 1.18.0 

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -36,7 +36,7 @@ checker-qual/3.43.0//checker-qual-3.43.0.jar
 chill-java/0.10.0//chill-java-0.10.0.jar
 chill_2.13/0.10.0//chill_2.13-0.10.0.jar
 commons-cli/1.9.0//commons-cli-1.9.0.jar
-commons-codec/1.17.2//commons-codec-1.17.2.jar
+commons-codec/1.18.0//commons-codec-1.18.0.jar
 commons-collections/3.2.2//commons-collections-3.2.2.jar
 commons-collections4/4.4//commons-collections4-4.4.jar
 commons-compiler/3.1.9//commons-compiler-3.1.9.jar

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
     <ws.xmlschema.version>2.3.1</ws.xmlschema.version>
     <snappy.version>1.1.10.7</snappy.version>
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
-    <commons-codec.version>1.17.2</commons-codec.version>
+    <commons-codec.version>1.18.0</commons-codec.version>
     <commons-compress.version>1.27.1</commons-compress.version>
     <commons-io.version>2.18.0</commons-io.version>
     <!-- To support Hive UDF jars built by Hive 2.0.0 ~ 2.3.9 and 3.0.0 ~ 3.1.3. -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `commons-codec` from `1.17.2` to `1.18.0`.

### Why are the changes needed?
The new version adds support for two new APIs:
- `Base32.Builder.setHexDecodeTable(boolean)` and `Base32.Builder.setHexEncodeTable(boolean)`: https://github.com/apache/commons-codec/commit/9fb8ee2a07031b16c8cde31edaaea58bfd5d3739

And the full release notes: https://commons.apache.org/proper/commons-codec/changes.html#a1.18.0

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
