### PR TITLE
[SPARK-51242][CONENCT][PYTHON] Improve Column performance when DQC is disabled 

### DIFF
--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -267,7 +267,8 @@ def _with_origin(func: FuncT) -> FuncT:
                     set_current_origin(None, None)
             else:
                 spark = SparkSession.getActiveSession()
-                assert spark is not None
+                if spark is None:
+                    return func(*args, **kwargs)
                 assert spark._jvm is not None
                 jvm_pyspark_origin = getattr(
                     spark._jvm, "org.apache.spark.sql.catalyst.trees.PySparkCurrentOrigin"

--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -255,9 +255,7 @@ def _with_origin(func: FuncT) -> FuncT:
         from pyspark.sql import SparkSession
         from pyspark.sql.utils import is_remote
 
-        spark = SparkSession.getActiveSession()
-
-        if spark is not None and hasattr(func, "__name__") and is_debugging_enabled():
+        if hasattr(func, "__name__") and is_debugging_enabled():
             if is_remote():
                 # Getting the configuration requires RPC call. Uses the default value for now.
                 depth = 1
@@ -268,6 +266,8 @@ def _with_origin(func: FuncT) -> FuncT:
                 finally:
                     set_current_origin(None, None)
             else:
+                spark = SparkSession.getActiveSession()
+                assert spark is not None
                 assert spark._jvm is not None
                 jvm_pyspark_origin = getattr(
                     spark._jvm, "org.apache.spark.sql.catalyst.trees.PySparkCurrentOrigin"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to  improve Column performance when DQC(DataFrameQueryContext) is disabled by delaying to call `getActiveSession` which is pretty expensive.

### Why are the changes needed?

To improve the performance of Column operations.

### Does this PR introduce _any_ user-facing change?

No, API changes but only improves the performance

### How was this patch tested?

Manually tested, and also the existing CI should pass.

```python
>>> spark.conf.get("spark.python.sql.dataFrameDebugging.enabled")
'false'
```


**Before fix**
```python
>>> import time
>>> import pyspark.sql.functions as F
>>>
>>> c = F.col("name")
>>> start = time.time()
>>> for i in range(10000):
...   _ = c.alias("a")
...
>>> print(time.time() - start)
2.061354875564575
```

**After fix**
```python
>>> import time
>>> import pyspark.sql.functions as F
>>>
>>> c = F.col("name")
>>> start = time.time()
>>> for i in range(10000):
...   _ = c.alias("a")
...
>>> print(time.time() - start)
0.8050589561462402
```


And there is no difference when the flag is on:


```python
>>> spark.conf.get("spark.python.sql.dataFrameDebugging.enabled")
'true'
```

**Before fix**
```python
>>> import time
>>> import pyspark.sql.functions as F
>>>
>>> c = F.col("name")
>>> start = time.time()
>>> for i in range(10000):
...   _ = c.alias("a")
...
>>> print(time.time() - start)
3.755108118057251
```

**After fix**
```python
>>> import time
>>> import pyspark.sql.functions as F
>>>
>>> c = F.col("name")
>>> start = time.time()
>>> for i in range(10000):
...   _ = c.alias("a")
...
>>> print(time.time() - start)
3.6577670574188232
```


### Was this patch authored or co-authored using generative AI tooling?

No.