### PR TITLE
[SPARK-51246][SQL] Make InTypeCoercion produce resolved Casts

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionHelper.scala
@@ -273,11 +273,13 @@ abstract class TypeCoercionHelper {
         // IN subquery expression.
         if (commonTypes.length == lhs.length) {
           val castedRhs = rhs.zip(commonTypes).map {
-            case (e, dt) if e.dataType != dt => Alias(Cast(e, dt), e.name)()
+            case (e, dt) if e.dataType != dt =>
+              Alias(Cast(e, dt).withTimeZone(conf.sessionLocalTimeZone), e.name)()
             case (e, _) => e
           }
           val newLhs = lhs.zip(commonTypes).map {
-            case (e, dt) if e.dataType != dt => Cast(e, dt)
+            case (e, dt) if e.dataType != dt =>
+              Cast(e, dt).withTimeZone(conf.sessionLocalTimeZone)
             case (e, _) => e
           }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make `InTypeCoercion` produce resolved `Cast`s.

### Why are the changes needed?

This is important to avoid recursing down the tree in the single-pass Analyzer.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.