### PR TITLE
[SPARK-51251][SQL] Add DataType class for timestamp with nanoseconds

### DIFF
--- a/sql/api/src/main/java/org/apache/spark/sql/types/DataTypes.java
+++ b/sql/api/src/main/java/org/apache/spark/sql/types/DataTypes.java
@@ -58,6 +58,15 @@ public class DataTypes {
    * Gets the TimestampNTZType object.
    */
   public static final DataType TimestampNTZType = TimestampNTZType$.MODULE$;
+  /**
+   * Gets the TimestampNsType object.
+   */
+  public static final DataType TimestampNsType = TimestampNsType$.MODULE$;
+
+  /**
+   * Gets the TimestampNsNTZType object.
+   */
+  public static final DataType TimestampNsNTZType = TimestampNsNTZType$.MODULE$;
 
   /**
    * Gets the CalendarIntervalType object.

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/TimestampNsNTZType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/TimestampNsNTZType.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types
+
+import org.apache.spark.annotation.Unstable
+
+/**
+ * The timestamp_ns without time zone type represents a local time in nanosecond precision, which is
+ * independent of time zone. Its valid range is [0001-01-01T00:00:00.000000000,
+ * 9999-12-31T23:59:59.999999999]. To represent an absolute point in time, use `TimestampNsType`
+ * instead.
+ *
+ * Please use the singleton `DataTypes.TimestampNsNTZType` to refer the type.
+ *
+ */
+@Unstable
+class TimestampNsNTZType private () extends DatetimeType {
+
+  /**
+   * The default size of a value of the TimestampNsNTZType is 8 bytes.
+   */
+  override def defaultSize: Int = 10
+
+  override def typeName: String = "timestamp_ns_ntz"
+
+  private[spark] override def asNullable: TimestampNsNTZType = this
+}
+
+@Unstable
+case object TimestampNsNTZType extends TimestampNsNTZType

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/TimestampNsType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/TimestampNsType.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types
+
+import org.apache.spark.annotation.Unstable
+
+/**
+ * The timestamp_ns type represents a time instant in nanosecond precision. Valid range is
+ * [0001-01-01T00:00:00.000000000Z, 9999-12-31T23:59:59.999999999Z] where the left/right-bound is a
+ * date and time of the proleptic Gregorian calendar in UTC+00:00.
+ *
+ * Please use the singleton `DataTypes.TimestampNsType` to refer the type.
+ */
+
+@Unstable
+class TimestampNsType private () extends DatetimeType {
+  override def defaultSize: Int = 10
+
+  override def typeName: String = "timestamp_ns"
+
+  private[spark] override def asNullable: TimestampType = this
+}
+
+@UnStable
+case object TimestampNsType extends TimestampNsType

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -365,6 +365,8 @@ class DataTypeSuite extends SparkFunSuite {
   checkDefaultSize(DateType, 4)
   checkDefaultSize(TimestampType, 8)
   checkDefaultSize(TimestampNTZType, 8)
+  checkDefaultSize(TimestampNsType, 10)
+  checkDefaultSize(TimestampNsNTZType, 10)
   checkDefaultSize(StringType, 20)
   checkDefaultSize(CharType(20), 20)
   checkDefaultSize(VarcharType(20), 20)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add two datatype:
1. TimestampNs: Timestamp with nanoseconds
2. TimestampNsNTZ: Timestamp with nanoseconds without timezone



### Why are the changes needed?
Source from https://issues.apache.org/jira/browse/SPARK-50532 description:
Iceberg Table V3 will release support for nano second timestamp，spark core/sql only support to micro second for now. Ideally should keep aline with iceberg`s timestamp percision, because  nano second make big difference in quants trading scenorio.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
Unit Test


### Was this patch authored or co-authored using generative AI tooling?
No