### PR TITLE
[SPARK-51250][K8S] Add Support for K8s PriorityClass Configuration fo…

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -749,6 +749,13 @@ private[spark] object Config extends Logging {
       .checkValue(value => value > 0, "Gracefully shutdown period must be a positive time value")
       .createWithDefaultString("20s")
 
+  val KUBERNETES_PRIORITY_CLASS_NAME =
+    ConfigBuilder("spark.kubernetes.priorityclass.name")
+      .doc("Priority class name of driver and executor pods")
+      .version("4.1.0")
+      .stringConf
+      .createOptional
+
   val KUBERNETES_DRIVER_LABEL_PREFIX = "spark.kubernetes.driver.label."
   val KUBERNETES_DRIVER_ANNOTATION_PREFIX = "spark.kubernetes.driver.annotation."
   val KUBERNETES_DRIVER_SERVICE_LABEL_PREFIX = "spark.kubernetes.driver.service.label."

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/PriorityClassFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/PriorityClassFeatureStep.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s.features
+
+import io.fabric8.kubernetes.api.model.PodBuilder
+
+import org.apache.spark.deploy.k8s.{KubernetesConf, SparkPod}
+import org.apache.spark.deploy.k8s.Config.KUBERNETES_PRIORITY_CLASS_NAME
+
+private[spark] class PriorityClassFeatureStep(conf: KubernetesConf)
+  extends KubernetesFeatureConfigStep {
+
+  private val priorityClassNameConfig = conf.get(KUBERNETES_PRIORITY_CLASS_NAME)
+
+  def configurePod(pod: SparkPod): SparkPod = {
+    priorityClassNameConfig match {
+      case Some(priorityClassName) =>
+        val updatedPod = new PodBuilder(pod.pod)
+          .editSpec()
+          .withPriorityClassName(priorityClassName)
+          .endSpec()
+          .build()
+        SparkPod(updatedPod, pod.container)
+      case None => pod
+    }
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
@@ -83,7 +83,8 @@ class KubernetesDriverBuilder {
       new HadoopConfDriverFeatureStep(conf),
       new KerberosConfDriverFeatureStep(conf),
       new PodTemplateConfigMapStep(conf),
-      new LocalDirsFeatureStep(conf)) ++ userFeatures
+      new LocalDirsFeatureStep(conf),
+      new PriorityClassFeatureStep(conf)) ++ userFeatures
 
     val spec = KubernetesDriverSpec(
       initialPod,

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
@@ -72,7 +72,8 @@ private[spark] class KubernetesExecutorBuilder {
       new EnvSecretsFeatureStep(conf),
       new MountVolumesFeatureStep(conf),
       new HadoopConfExecutorFeatureStep(conf),
-      new LocalDirsFeatureStep(conf)) ++ userFeatures
+      new LocalDirsFeatureStep(conf),
+      new PriorityClassFeatureStep(conf)) ++ userFeatures
 
     val spec = KubernetesExecutorSpec(
       initialPod,

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/PriorityClassFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/PriorityClassFeatureStepSuite.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s.features
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.k8s._
+import org.apache.spark.deploy.k8s.Config._
+
+class PriorityClassFeatureStepSuite extends SparkFunSuite {
+
+  test("Test driver priority class name is set") {
+    val sparkConf = new SparkConf(false).set(KUBERNETES_PRIORITY_CLASS_NAME, "high-criticality-job")
+    val kubernetesDriverConf = KubernetesTestConf.createDriverConf(sparkConf = sparkConf)
+    val priorityClassFeatureStep = new PriorityClassFeatureStep(kubernetesDriverConf)
+    val driverPod = priorityClassFeatureStep.configurePod(SparkPod.initialPod())
+    assert(driverPod.pod.getSpec.getPriorityClassName === "high-criticality-job")
+  }
+
+  test("Test executor priority class name is set") {
+    val sparkConf = new SparkConf(false).set(KUBERNETES_PRIORITY_CLASS_NAME, "high-criticality-job")
+    val kubernetesExecutorConf = KubernetesTestConf.createExecutorConf(sparkConf = sparkConf)
+    val priorityClassFeatureStep = new PriorityClassFeatureStep(kubernetesExecutorConf)
+    val executorPod = priorityClassFeatureStep.configurePod(SparkPod.initialPod())
+    assert(executorPod.pod.getSpec.getPriorityClassName === "high-criticality-job")
+  }
+
+  test("Test pod spec remain unchanged when no priority class name is set") {
+    val sparkConf = new SparkConf(false)
+    val kubernetesExecutorConf = KubernetesTestConf.createExecutorConf(sparkConf = sparkConf)
+    val executorStep = new PriorityClassFeatureStep(kubernetesExecutorConf)
+    val executorPod = executorStep.configurePod(SparkPod.initialPod())
+    val podWithoutStep = SparkPod.initialPod()
+    assert(executorPod.pod.getSpec.getPriorityClassName === null)
+    assert(executorPod.pod.getSpec === podWithoutStep.pod.getSpec)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
* Introduce a new spark configuration `spark.kubernetes.priorityclass.name`.
* Create a new FeatureStep class `PriorityClassFeatureStep` that passes configured priority class name to driver and executor pods. 
* Tests for `PriorityClassFeatureStep.scala`


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently when running spark on k8s, with spark-submit approach, in order to specify priority class name, the only possible way is to specify in the pod template. In a cluster with numerous priority classes, it means multiple pod template files are to be used, each of which has variant priority class name only.

One could dynamically generate the pod templates based on priority classes, however this introduces additional overhead on user side (e.g. building a process to dynamically generate templates just for priority class name, making sure dynamically generated templates are still valid)

Furthermore, for SPARK on YARN there is a configuration `spark.yarn.priority` that is flexible and easy to use for users. It is good to achieve the similar level of simplicity for users moving from SPARK on YARN to SPARK on K8s.




### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. With this PR, users can use `spark.kubernetes.priorityclass.name` to specify the priority class name for driver and executor pods. 


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Tests were added in this pull request


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
