### PR TITLE
[SPARK-51254][PYTHON][CONNECT] Disallow --master with Spark Connect URL

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -507,6 +507,11 @@
       "Variant binary is malformed. Please check the data source is valid."
     ]
   },
+  "MASTER_URL_INVALID": {
+    "message": [
+      "Master must either be yarn or start with spark, k8s, or local."
+    ]
+  },
   "MASTER_URL_NOT_SET": {
     "message": [
       "A master URL must be set in your configuration."

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -508,6 +508,11 @@ class SparkSession(SparkConversionMixin):
 
                             if url is None and is_api_mode_connect:
                                 url = opts.get("spark.master", os.environ.get("MASTER", "local"))
+                                if url.startswith("sc://"):
+                                    raise PySparkRuntimeError(
+                                        errorClass="MASTER_URL_INVALID",
+                                        messageParameters={},
+                                    )
 
                             if url is None:
                                 raise PySparkRuntimeError(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to disallow Spark Connect strings in `--master` when Spark API mode is `connect`. This is Python specific issue.

### Why are the changes needed?

Should work as documented in https://github.com/apache/spark/pull/49107

### Does this PR introduce _any_ user-facing change?

Not yet because the main change has not been released (https://github.com/apache/spark/pull/49107)

### How was this patch tested?

Manually tested:

```
 ./bin/pyspark --master "sc://localhost:15002" --conf spark.api.mode=connect
```
```
Python 3.11.9 (main, Apr 19 2024, 11:44:45) [Clang 14.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
/.../spark/python/pyspark/shell.py:77: UserWarning: Failed to initialize Spark session.
  warnings.warn("Failed to initialize Spark session.")
Traceback (most recent call last):
  File "/.../spark/python/pyspark/shell.py", line 52, in <module>
    spark = SparkSession.builder.getOrCreate()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../spark/python/pyspark/sql/session.py", line 512, in getOrCreate
    raise PySparkRuntimeError(
pyspark.errors.exceptions.base.PySparkRuntimeError: [MASTER_URL_INVALID] Master must either be yarn or start with spark, k8s, or local.
```

### Was this patch authored or co-authored using generative AI tooling?

No.
