### PR TITLE
[SPARK-51150][ML][FOLLOW-UP] Pass session in `OneVsRestParams.saveImpl`

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -105,7 +105,8 @@ private[ml] object OneVsRestParams extends ClassifierTypeTrait {
     DefaultParamsWriter.saveMetadata(instance, path, spark, extraMetadata, Some(jsonParams))
 
     val classifierPath = new Path(path, "classifier").toString
-    instance.getClassifier.asInstanceOf[MLWritable].save(classifierPath)
+    instance.getClassifier.asInstanceOf[MLWritable]
+      .write.session(spark).save(classifierPath)
   }
 
   def loadImpl(

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -105,8 +105,7 @@ private[ml] object OneVsRestParams extends ClassifierTypeTrait {
     DefaultParamsWriter.saveMetadata(instance, path, spark, extraMetadata, Some(jsonParams))
 
     val classifierPath = new Path(path, "classifier").toString
-    instance.getClassifier.asInstanceOf[MLWritable]
-      .write.session(spark).save(classifierPath)
+    instance.getClassifier.asInstanceOf[MLWritable].write.session(spark).save(classifierPath)
   }
 
   def loadImpl(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
followup of https://github.com/apache/spark/pull/49871

I don't find other similar place in jvm side

### Why are the changes needed?
avoid session recreation

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
