### PR TITLE
[SPARK-51259][SQL] Refactor natural and using join keys computation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/NaturalAndUsingJoinResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/NaturalAndUsingJoinResolution.scala
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.catalyst.SQLConfHelper
+import org.apache.spark.sql.catalyst.expressions.{
+  Alias,
+  And,
+  Attribute,
+  Coalesce,
+  EqualTo,
+  Expression,
+  NamedExpression
+}
+import org.apache.spark.sql.catalyst.plans.{
+  FullOuter,
+  InnerLike,
+  JoinType,
+  LeftExistence,
+  LeftOuter,
+  RightOuter
+}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.errors.{
+  DataTypeErrorsBase,
+  QueryCompilationErrors,
+  QueryExecutionErrors
+}
+
+object NaturalAndUsingJoinResolution extends DataTypeErrorsBase with SQLConfHelper {
+
+  /**
+   * For a given [[Join]], computes output, hidden output and new condition, if such exists.
+   */
+  def computeJoinOutputsAndNewCondition(
+      left: LogicalPlan,
+      leftOutput: Seq[Attribute],
+      right: LogicalPlan,
+      rightOutput: Seq[Attribute],
+      joinType: JoinType,
+      joinNames: Seq[String],
+      condition: Option[Expression],
+      resolveName: (String, String) => Boolean)
+      : (Seq[NamedExpression], Seq[Attribute], Option[Expression]) = {
+    val (leftKeys, rightKeys) = resolveKeysForNaturalAndUsingJoin(
+      left,
+      leftOutput,
+      right,
+      rightOutput,
+      joinNames,
+      resolveName
+    )
+    val joinPairs = leftKeys.zip(rightKeys)
+
+    val newCondition = (condition ++ joinPairs.map(EqualTo.tupled)).reduceOption(And)
+
+    // the output list looks like: join keys, columns from left, columns from right
+    val (output, hiddenOutput) = computeOutputAndHiddenOutput(
+      leftOutput,
+      leftKeys,
+      rightOutput,
+      rightKeys,
+      joinPairs,
+      joinType
+    )
+    (output, hiddenOutput, newCondition)
+  }
+
+  /**
+   * Returns resolved keys for joining based on the output of [[Join]]'s children or throws and
+   * error if a key name doesn't exist.
+   */
+  private def resolveKeysForNaturalAndUsingJoin(
+      left: LogicalPlan,
+      leftOutput: Seq[Attribute],
+      right: LogicalPlan,
+      rightOutput: Seq[Attribute],
+      joinNames: Seq[String],
+      resolveName: (String, String) => Boolean): (Seq[Attribute], Seq[Attribute]) = {
+    val leftKeys = joinNames.map { keyName =>
+      leftOutput.find(attribute => resolveName(attribute.name, keyName)).getOrElse {
+        throw QueryCompilationErrors.unresolvedUsingColForJoinError(
+          keyName,
+          left.schema.fieldNames.sorted.map(toSQLId).mkString(", "),
+          "left"
+        )
+      }
+    }
+    val rightKeys = joinNames.map { keyName =>
+      rightOutput.find(attribute => resolveName(attribute.name, keyName)).getOrElse {
+        throw QueryCompilationErrors.unresolvedUsingColForJoinError(
+          keyName,
+          right.schema.fieldNames.sorted.map(toSQLId).mkString(", "),
+          "right"
+        )
+      }
+    }
+    (leftKeys, rightKeys)
+  }
+
+  /**
+   * Computes the output and hidden output for a given [[Join]], based on the output of its
+   * children.
+   */
+  private def computeOutputAndHiddenOutput(
+      leftOutput: Seq[Attribute],
+      leftKeys: Seq[Attribute],
+      rightOutput: Seq[Attribute],
+      rightKeys: Seq[Attribute],
+      joinPairs: Seq[(Attribute, Attribute)],
+      joinType: JoinType): (Seq[NamedExpression], Seq[Attribute]) = {
+    // columns not in joinPairs
+    val lUniqueOutput = leftOutput.filterNot(att => leftKeys.contains(att))
+    val rUniqueOutput = rightOutput.filterNot(att => rightKeys.contains(att))
+    joinType match {
+      case LeftOuter =>
+        (
+          leftKeys ++ lUniqueOutput ++ rUniqueOutput.map(_.withNullability(true)),
+          rightKeys.map(_.withNullability(true))
+        )
+      case LeftExistence(_) =>
+        (leftKeys ++ lUniqueOutput, Seq.empty)
+      case RightOuter =>
+        (
+          rightKeys ++ lUniqueOutput.map(_.withNullability(true)) ++ rUniqueOutput,
+          leftKeys.map(_.withNullability(true))
+        )
+      case FullOuter =>
+        // In full outer join, we should return non-null values for the join columns
+        // if either side has non-null values for those columns. Therefore, for each
+        // join column pair, add a coalesce to return the non-null value, if it exists.
+        val joinedCols = joinPairs.map {
+          case (l, r) =>
+            // Since this is a full outer join, either side could be null, so we explicitly
+            // set the nullability to true for both sides.
+            Alias(Coalesce(Seq(l.withNullability(true), r.withNullability(true))), l.name)()
+        }
+        (
+          joinedCols ++
+          lUniqueOutput.map(_.withNullability(true)) ++
+          rUniqueOutput.map(_.withNullability(true)),
+          leftKeys.map(_.withNullability(true)) ++
+          rightKeys.map(_.withNullability(true))
+        )
+      case _: InnerLike =>
+        (leftKeys ++ lUniqueOutput ++ rUniqueOutput, rightKeys)
+      case _ =>
+        throw QueryExecutionErrors.unsupportedNaturalJoinTypeError(joinType)
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Refactor natural and using join key computation to a separate component so that it can be reused in single-pass resolver.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
To reuse code in single-pass resolver.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No.
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Existing tests.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
