### PR TITLE
[SPARK-51261][ML][PYTHON][CONNECT] Introduce model size estimation to control ml cache

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -780,7 +780,7 @@
           "Cannot retrieve <objectName> from the ML cache. It is probably because the entry has been evicted."
         ]
       },
-      "MODEL_ITEM_EXCEEDED" : {
+      "CACHE_ITEM_EXCEEDED" : {
         "message" : [
           "Cannot <operation> object <name>, since its estimated size <estimatedSize> exceeds the limitation <maximumSize>."
         ]

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -780,6 +780,11 @@
           "Cannot retrieve <objectName> from the ML cache. It is probably because the entry has been evicted."
         ]
       },
+      "MODEL_ITEM_EXCEEDED" : {
+        "message" : [
+          "Cannot <operation> object <name>, since its estimated size <estimatedSize> exceeds the limitation <maximumSize>."
+        ]
+      },
       "UNSUPPORTED_EXCEPTION" : {
         "message" : [
           "<message>"

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -1113,6 +1113,7 @@ pyspark_ml_connect = Module(
         # ml doctests
         "pyspark.ml.connect.functions",
         # ml unittests
+        "pyspark.ml.tests.connect.test_connect_cache",
         "pyspark.ml.tests.connect.test_connect_function",
         "pyspark.ml.tests.connect.test_parity_torch_distributor",
         "pyspark.ml.tests.connect.test_parity_torch_data_loader",

--- a/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
@@ -81,4 +81,13 @@ abstract class Estimator[M <: Model[M]] extends PipelineStage {
   }
 
   override def copy(extra: ParamMap): Estimator[M]
+
+  /**
+   * For ml connect only.
+   * Estimate the size of the model to be fitted in bytes, based on the parameters and
+   * the dataset, e.g., using $(k) and numFeatures to estimate a k-means model size.
+   * Only driver side memory usage is counted, distributed objects (like DataFrame,
+   * RDD, Graph, Training Summary) are ignored.
+   */
+  private[spark] def estimateModelSize(dataset: Dataset[_]): Long = throw new NotImplementedError
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
@@ -84,10 +84,17 @@ abstract class Estimator[M <: Model[M]] extends PipelineStage {
 
   /**
    * For ml connect only.
-   * Estimate the size of the model to be fitted in bytes, based on the parameters and
-   * the dataset, e.g., using $(k) and numFeatures to estimate a k-means model size.
-   * Only driver side memory usage is counted, distributed objects (like DataFrame,
+   * Estimate an upper-bound size of the model to be fitted in bytes, based on the
+   * parameters and the dataset, e.g., using $(k) and numFeatures to estimate a
+   * k-means model size.
+   * 1, Only driver side memory usage is counted, distributed objects (like DataFrame,
    * RDD, Graph, Training Summary) are ignored.
+   * 2, If there is no enough information to get an accurate size, try to estimate the
+   * upper-bound size, e.g.
+   *    - Given a LogisticRegression estimator, assume the coefficients are dense, even
+   *      though the actual fitted model might be sparse (by L1 penalty).
+   *    - Given a tree model, assume all underlying trees are complete binary trees, even
+   *      though some branches might be pruned or truncated.
    */
   private[spark] def estimateModelSize(dataset: Dataset[_]): Long = throw new NotImplementedError
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/Model.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Model.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.ml
 
 import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.util.SizeEstimator
 
 /**
  * A fitted model, i.e., a [[Transformer]] produced by an [[Estimator]].
@@ -43,4 +44,28 @@ abstract class Model[M <: Model[M]] extends Transformer {
   def hasParent: Boolean = parent != null
 
   override def copy(extra: ParamMap): M
+
+  /**
+   * For ml connect only.
+   * Estimate the upper-bound size of this model in bytes, This is an approximation,
+   * the real size might be different.
+   * 1, If there is no enough information to get an accurate size, try to estimate the
+   * upper-bound size, e.g.
+   *    - Given a LogisticRegression estimator, assume the coefficients are dense, even
+   *      though the actual fitted model might be sparse (by L1 penalty).
+   *    - Given a tree model, assume all underlying trees are complete binary trees, even
+   *      though some branches might be pruned or truncated.
+   * 2, Only driver side memory usage is counted, distributed objects (like DataFrame,
+   * RDD, Graph, Training Summary) are ignored.
+   * 3, Using SizeEstimator to estimate the driver memory usage of distributed objects
+   * is not accurate, because the size of SparkSession/SparkContext is also included, e.g.
+   *    val df = spark.range(1)
+   *    SizeEstimator.estimate(df)                   -> 3310984
+   *    SizeEstimator.estimate(df.rdd)               -> 3331352
+   *    SizeEstimator.estimate(df.sparkSession)      -> 3249464
+   *    SizeEstimator.estimate(df.rdd.sparkContext)  -> 3249744
+   * 4, For 3-rd extension, if external languages are used, it is recommended to override
+   * this method and return a proper size.
+   */
+  private[spark] def estimatedSize: Long = SizeEstimator.estimate(this)
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/Model.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Model.scala
@@ -47,24 +47,18 @@ abstract class Model[M <: Model[M]] extends Transformer {
 
   /**
    * For ml connect only.
-   * Estimate the upper-bound size of this model in bytes, This is an approximation,
-   * the real size might be different.
-   * 1, If there is no enough information to get an accurate size, try to estimate the
-   * upper-bound size, e.g.
-   *    - Given a LogisticRegression estimator, assume the coefficients are dense, even
-   *      though the actual fitted model might be sparse (by L1 penalty).
-   *    - Given a tree model, assume all underlying trees are complete binary trees, even
-   *      though some branches might be pruned or truncated.
-   * 2, Only driver side memory usage is counted, distributed objects (like DataFrame,
+   * Estimate the size of this model in bytes.
+   * This is an approximation, the real size might be different.
+   * 1, Only driver side memory usage is counted, distributed objects (like DataFrame,
    * RDD, Graph, Training Summary) are ignored.
-   * 3, Using SizeEstimator to estimate the driver memory usage of distributed objects
+   * 2, Using SizeEstimator to estimate the driver memory usage of distributed objects
    * is not accurate, because the size of SparkSession/SparkContext is also included, e.g.
    *    val df = spark.range(1)
    *    SizeEstimator.estimate(df)                   -> 3310984
    *    SizeEstimator.estimate(df.rdd)               -> 3331352
    *    SizeEstimator.estimate(df.sparkSession)      -> 3249464
    *    SizeEstimator.estimate(df.rdd.sparkContext)  -> 3249744
-   * 4, For 3-rd extension, if external languages are used, it is recommended to override
+   * 3, For 3-rd extension, if external languages are used, it is recommended to override
    * this method and return a proper size.
    */
   private[spark] def estimatedSize: Long = SizeEstimator.estimate(this)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -45,7 +45,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.util.VersionUtils
+import org.apache.spark.util._
 
 /**
  * Params for logistic regression.
@@ -1041,6 +1041,21 @@ class LogisticRegression @Since("1.2.0") (
     (solution, arrayBuilder.result())
   }
 
+  private[spark] override def estimateModelSize(dataset: Dataset[_]): Long = {
+    // TODO: get numClasses and numFeatures together from dataset
+    val numClasses = DatasetUtils.getNumClasses(dataset, $(labelCol))
+    val numFeatures = DatasetUtils.getNumFeatures(dataset, $(featuresCol))
+    var size = SizeEstimator.estimate((this.params, this.uid))
+    if (checkMultinomial(numClasses)) {
+      size += Matrices.getDenseSize(numFeatures, numClasses)
+      size += Vectors.getDenseSize(numClasses)
+    } else {
+      size += Matrices.getDenseSize(numFeatures, 1)
+      size += Vectors.getDenseSize(1)
+    }
+    size
+  }
+
   @Since("1.4.0")
   override def copy(extra: ParamMap): LogisticRegression = defaultCopy(extra)
 }
@@ -1246,6 +1261,11 @@ class LogisticRegressionModel private[spark] (
       val m = margin(features)
       Vectors.dense(-m, m)
     }
+  }
+
+  private[spark] override def estimatedSize: Long = {
+    SizeEstimator.estimate((this.params, this.uid,
+      this.coefficientMatrix, this.interceptVector))
   }
 
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -1265,7 +1265,7 @@ class LogisticRegressionModel private[spark] (
 
   private[spark] override def estimatedSize: Long = {
     SizeEstimator.estimate((this.params, this.uid,
-      this.coefficientMatrix, this.interceptVector))
+      this.coefficientMatrix, this.interceptVector, this.numClasses, this.isMultinomial))
   }
 
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifier.scala
@@ -29,6 +29,7 @@ import org.apache.spark.ml.util._
 import org.apache.spark.ml.util.DatasetUtils._
 import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.sql._
+import org.apache.spark.util.SizeEstimator
 import org.apache.spark.util.VersionUtils.majorMinorVersion
 
 /** Params for Multilayer Perceptron. */
@@ -172,6 +173,13 @@ class MultilayerPerceptronClassifier @Since("1.5.0") (
 
   @Since("1.5.0")
   override def copy(extra: ParamMap): MultilayerPerceptronClassifier = defaultCopy(extra)
+
+  private[spark] override def estimateModelSize(dataset: Dataset[_]): Long = {
+    val topology = FeedForwardTopology.multiLayerPerceptron($(layers), softmaxOnTop = true)
+    val expectedWeightSize = topology.layers.map(_.weightSize).sum
+    SizeEstimator.estimate((this.params, this.uid)) +
+      Vectors.getDenseSize(expectedWeightSize)
+  }
 
   /**
    * Train a model using the given dataset and parameters.
@@ -326,6 +334,10 @@ class MultilayerPerceptronClassificationModel private[ml] (
     val copied = new MultilayerPerceptronClassificationModel(uid, weights)
       .setParent(parent)
     copyValues(copied, extra)
+  }
+
+  private[spark] override def estimatedSize: Long = {
+    SizeEstimator.estimate((this.params, this.uid, this.weights))
   }
 
   @Since("2.0.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/util/Summary.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/Summary.scala
@@ -18,11 +18,21 @@
 package org.apache.spark.ml.util
 
 import org.apache.spark.annotation.Since
+import org.apache.spark.util.KnownSizeEstimation
 
 /**
+ * For ml connect only.
  * Trait for the Summary
  * All the summaries should extend from this Summary in order to
  * support connect.
  */
 @Since("4.0.0")
-private[spark] trait Summary
+private[spark] trait Summary extends KnownSizeEstimation {
+
+  // A summary is normally a small object, with several RDDs or DataFrame.
+  // The SizeEstimator is likely to overestimate the size of the summary,
+  // because it will also count the underlying SparkSession and/or SparkContext,
+  // which mainly contributes to the size of the summary.
+  // So we set the default size as 256KB.
+  override def estimatedSize: Long = 256 * 1024
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/ModelSizeEstimationSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/ModelSizeEstimationSuite.scala
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml
+
+import scala.util.Random
+
+import org.apache.spark.ml.classification.LogisticRegression
+import org.apache.spark.ml.linalg._
+import org.apache.spark.ml.util.MLTest
+import org.apache.spark.util.SizeEstimator
+
+// scalastyle:off println
+class ModelSizeEstimationSuite extends MLTest {
+
+  import testImplicits._
+
+  test("estimate vector") {
+    Seq(100, 1000, 10000, 100000).foreach { n =>
+      val vec = Vectors.dense(Array.fill(n)(0.1))
+      // This is used to estimate a vector, with the assumption that it is dense
+      val size1 = Vectors.getDenseSize(n)
+      // This is used to estimate a vector in a model
+      val size2 = SizeEstimator.estimate(vec)
+
+      // currently the Vectors.getDenseSize is slightly smaller than SizeEstimator.estimate
+      // (n, size1, size2)
+      // (100,808,832)
+      // (1000,8008,8032)
+      // (10000,80008,80032)
+      // (100000,800008,800032)
+      val rel = (size1 - size2).toDouble / size2
+      assert(math.abs(rel) < 0.05, (n, size1, size2))
+    }
+  }
+
+  test("estimate matrix") {
+    Seq(10, 100, 1000).foreach { m =>
+      Seq(10, 100, 1000).foreach { n =>
+        val mat = Matrices.dense(m, n, Array.fill(m * n)(0.1))
+        // This is used to estimate a matrix, with the assumption that it is dense
+        val size1 = Matrices.getDenseSize(m, n)
+        // This is used to estimate a matrix in a model
+        val size2 = SizeEstimator.estimate(mat)
+
+        // currently the Matrices.getDenseSize is slightly smaller than SizeEstimator.estimate
+        // (m,n, size1)
+        // (10,10,821,848)
+        // (10,100,8021,8048)
+        // (10,1000,80021,80048)
+        // (100,10,8021,8048)
+        // (100,100,80021,80048)
+        // (100,1000,800021,800048)
+        // (1000,10,80021,80048)
+        // (1000,100,800021,800048)
+        // (1000,1000,8000021,8000048)
+        println((m, n, size1, size2))
+        val rel = (size1 - size2).toDouble / size2
+        assert(math.abs(rel) < 0.05, (m, n, size1, size2))
+      }
+    }
+  }
+
+  test("test binary logistic regression: dense") {
+    val rng = new Random(1)
+
+    Seq(10, 100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 0.0),
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 1.0)
+      ).toDF("features", "label")
+
+      val lor = new LogisticRegression().setMaxIter(1)
+      val size1 = lor.estimateModelSize(df)
+      val model = lor.fit(df)
+      assert(model.coefficientMatrix.isInstanceOf[DenseMatrix])
+      val size2 = model.estimatedSize
+
+      // the model is dense, the estimation should be relatively accurate
+      // (n, size1, size2)
+      // (10,7021,7120)   <- when the model is small, model.params matters
+      // (100,7741,7840)
+      // (1000,14941,15040)
+      // (10000,86941,87040)
+      // (100000,806941,807040)
+      val rel = (size1 - size2).toDouble / size2
+      assert(math.abs(rel) < 0.05, (n, size1, size2))
+    }
+  }
+
+  test("test binary logistic regression: sparse") {
+    val rng = new Random(1)
+
+    Seq(100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 0.0),
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 1.0)
+      ).toDF("features", "label")
+
+      val lor = new LogisticRegression().setMaxIter(1).setRegParam(10.0)
+      val size1 = lor.estimateModelSize(df)
+      val model = lor.fit(df)
+      assert(model.coefficientMatrix.isInstanceOf[SparseMatrix])
+      val size2 = model.estimatedSize
+
+      // the model is sparse, the estimated size should be larger
+      // (n, size1, size2)
+      // (100,7741,7208)
+      // (1000,14941,7208)
+      // (10000,86941,7208)
+      // (100000,806941,7208)
+      assert(size1 > size2, (n, size1, size2))
+    }
+  }
+
+  test("test multinomial logistic regression: dense") {
+    val rng = new Random(1)
+
+    Seq(10, 100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 0.0),
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 1.0),
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 2.0)
+      ).toDF("features", "label")
+
+      val lor = new LogisticRegression().setMaxIter(1)
+      val size1 = lor.estimateModelSize(df)
+      val model = lor.fit(df)
+      assert(model.coefficientMatrix.isInstanceOf[DenseMatrix])
+      val size2 = model.estimatedSize
+
+      // the model is dense, the estimation should be relatively accurate
+      // (n, size1, size2)
+      // (10,7197,7296)   <- when the model is small, model.params matters
+      // (100,9357,9456)
+      // (1000,30957,31056)
+      // (10000,246957,247056)
+      // (100000,2406957,2407056)
+      val rel = (size1 - size2).toDouble / size2
+      assert(math.abs(rel) < 0.05, (n, size1, size2))
+    }
+  }
+
+  test("test multinomial logistic regression: sparse") {
+    val rng = new Random(1)
+
+    Seq(100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 0.0),
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 1.0),
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 2.0)
+      ).toDF("features", "label")
+
+      val lor = new LogisticRegression().setMaxIter(1).setRegParam(10.0)
+      val size1 = lor.estimateModelSize(df)
+      val model = lor.fit(df)
+      assert(model.coefficientMatrix.isInstanceOf[SparseMatrix])
+      val size2 = model.estimatedSize
+
+      // the model is sparse, the estimated size should be larger
+      // (100,9357,7472)
+      // (1000,30957,7472)
+      // (10000,246957,7472)
+      // (100000,2406957,7472)
+      assert(size1 > size2, (n, size1, size2))
+    }
+  }
+}

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -35,6 +35,8 @@ import com.typesafe.tools.mima.core.*
 object MimaExcludes {
 
   lazy val v41excludes = v40excludes ++ Seq(
+    // [SPARK-51261][ML][CONNECT] Introduce model size estimation to control ml cache
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.ml.linalg.Vector.getSizeInBytes")
   )
 
   // Exclude rules for 4.0.x from 3.5.0

--- a/python/pyspark/ml/tests/connect/test_connect_cache.py
+++ b/python/pyspark/ml/tests/connect/test_connect_cache.py
@@ -1,0 +1,121 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import unittest
+
+import numpy as np
+
+from pyspark.errors import AnalysisException, PySparkTypeError, PySparkException
+from pyspark.sql import DataFrame, Row, SparkSession
+from pyspark.ml.linalg import Vectors, Matrices, DenseMatrix
+from pyspark.ml.classification import LogisticRegression
+
+
+class ConnectCacheTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.spark = (
+            SparkSession.builder.remote(os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[2]"))
+            .config("spark.connect.session.mlCache.singleItemSize", "2MB")
+            .config("spark.connect.session.mlCache.totalItemSize", "10MB")
+            .getOrCreate()
+        )
+
+    def test_assert_remote_mode(self):
+        from pyspark.sql import is_remote
+
+        self.assertTrue(is_remote())
+
+    def test_ml_cache_config(self):
+        spark = self.spark
+        self.assertEqual(
+            spark.conf.get("spark.connect.session.mlCache.singleItemSize"),
+            "2MB",
+        )
+        self.assertEqual(
+            spark.conf.get("spark.connect.session.mlCache.totalItemSize"),
+            "10MB",
+        )
+
+    def test_large_single_model(self):
+        spark = self.spark
+        df = spark.createDataFrame(
+            [
+                (1.0, 1.0, Vectors.sparse(1000000000, [(1, 1.0), (3, 5.5)])),
+                (0.0, 2.0, Vectors.sparse(1000000000, [(1, 1.0), (3, 5.5)])),
+            ],
+            ["label", "weight", "features"],
+        )
+
+        lor = LogisticRegression(
+            maxIter=0,
+            regParam=0.0,
+            weightCol="weight",
+        )
+
+        with self.assertRaisesRegex(PySparkException, "CONNECT_ML.MODEL_ITEM_EXCEEDED") as e:
+            lor.fit(df)
+
+    def test_model_eviction(self):
+        spark = self.spark
+
+        rng = np.random.default_rng(seed=1)
+        df = spark.createDataFrame(
+            [
+                (1.0, 1.0, Vectors.dense(rng.random(100000))),
+                (0.0, 1.0, Vectors.dense(rng.random(100000))),
+            ],
+            ["label", "weight", "features"],
+        )
+
+        lor = LogisticRegression(
+            maxIter=1,
+            regParam=0.0,
+            weightCol="weight",
+        )
+        first_model = lor.fit(df)
+
+        # The model coefficients should be a dense matrix
+        # 100000 double values, 800KB, plus other overhead
+        self.assertIsInstance(first_model.coefficientMatrix, DenseMatrix)
+        self.assertEqual(first_model.coefficientMatrix.toArray().shape, (1, 100000))
+
+        # The first model works
+        self.assertEqual(first_model.transform(df).count(), 2)
+
+        # cache more and more models
+        models = []
+        for _ in range(20):
+            model = lor.fit(df)
+            self.assertIsInstance(model.coefficientMatrix, DenseMatrix)
+            models.append(model)
+
+        # The first model should have been evicted
+        with self.assertRaisesRegex(PySparkException, "CONNECT_ML.CACHE_INVALID") as e:
+            first_model.transform(df).count()
+
+
+if __name__ == "__main__":
+    from pyspark.ml.tests.connect.test_connect_cache import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/ml/tests/connect/test_connect_cache.py
+++ b/python/pyspark/ml/tests/connect/test_connect_cache.py
@@ -67,7 +67,7 @@ class ConnectCacheTests(unittest.TestCase):
             weightCol="weight",
         )
 
-        with self.assertRaisesRegex(PySparkException, "CONNECT_ML.MODEL_ITEM_EXCEEDED") as e:
+        with self.assertRaisesRegex(PySparkException, "CONNECT_ML.CACHE_ITEM_EXCEEDED") as e:
             lor.fit(df)
 
     def test_model_eviction(self):

--- a/python/pyspark/ml/tests/connect/test_connect_cache.py
+++ b/python/pyspark/ml/tests/connect/test_connect_cache.py
@@ -31,7 +31,7 @@ class ConnectCacheTests(unittest.TestCase):
         self.spark = (
             SparkSession.builder.remote(os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[2]"))
             .config("spark.connect.session.mlCache.singleItemSize", "2MB")
-            .config("spark.connect.session.mlCache.totalItemSize", "10MB")
+            .config("spark.connect.session.mlCache.totalItemSize", "5MB")
             .getOrCreate()
         )
 
@@ -48,7 +48,7 @@ class ConnectCacheTests(unittest.TestCase):
         )
         self.assertEqual(
             spark.conf.get("spark.connect.session.mlCache.totalItemSize"),
-            "10MB",
+            "5MB",
         )
 
     def test_large_single_model(self):

--- a/python/pyspark/ml/tests/connect/test_connect_cache.py
+++ b/python/pyspark/ml/tests/connect/test_connect_cache.py
@@ -20,9 +20,9 @@ import unittest
 
 import numpy as np
 
-from pyspark.errors import AnalysisException, PySparkTypeError, PySparkException
-from pyspark.sql import DataFrame, Row, SparkSession
-from pyspark.ml.linalg import Vectors, Matrices, DenseMatrix
+from pyspark.errors import PySparkException
+from pyspark.sql import SparkSession
+from pyspark.ml.linalg import Vectors, DenseMatrix
 from pyspark.ml.classification import LogisticRegression
 
 
@@ -105,7 +105,7 @@ class ConnectCacheTests(unittest.TestCase):
             models.append(model)
 
         # The first model should have been evicted
-        with self.assertRaisesRegex(PySparkException, "CONNECT_ML.CACHE_INVALID") as e:
+        with self.assertRaisesRegex(PySparkException, "CONNECT_ML.CACHE_INVALID"):
             first_model.transform(df).count()
 
 

--- a/python/pyspark/ml/tests/connect/test_connect_cache.py
+++ b/python/pyspark/ml/tests/connect/test_connect_cache.py
@@ -67,7 +67,7 @@ class ConnectCacheTests(unittest.TestCase):
             weightCol="weight",
         )
 
-        with self.assertRaisesRegex(PySparkException, "CONNECT_ML.CACHE_ITEM_EXCEEDED") as e:
+        with self.assertRaisesRegex(PySparkException, "CONNECT_ML.CACHE_ITEM_EXCEEDED"):
             lor.fit(df)
 
     def test_model_eviction(self):

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -313,4 +313,49 @@ object Connect {
       .internal()
       .booleanConf
       .createWithDefault(true)
+
+  val CONNECT_SESSION_ML_CACHE_TIMEOUT =
+    buildConf("spark.connect.session.mlCache.timeout")
+      .doc(
+        "How long to wait in seconds for ML cache to automatically remove a cached entry " +
+          "after the entry's creation or its last access. " +
+          "If set to a non-positive value, the limitation will be disabled.")
+      .version("4.1.0")
+      .internal()
+      .timeConf(TimeUnit.SECONDS)
+      .createWithDefault(3600)
+
+  val CONNECT_SESSION_ML_CACHE_SINGLE_ITEM_SIZE =
+    buildConf("spark.connect.session.mlCache.singleItemSize")
+      .doc("Sets the maximum size of single cached ML object in Spark Connect Session. " +
+        "If set to a value less or equal than zero, this config will take no effect.")
+      .version("4.1.0")
+      .internal()
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefault(-1)
+      // TODO: Enable this config when all builtin algorithms support model size estimation
+      // .createWithDefaultString("16MB")
+
+  val CONNECT_SESSION_ML_CACHE_TOTAL_ITEM_SIZE =
+    buildConf("spark.connect.session.mlCache.totalItemSize")
+      .doc(
+        "Sets the maximum size of all cached ML objects in Spark Connect Session. " +
+          "If the total size exceeds this limitation, some cached items are likely be evicted. " +
+          "If set to a value less or equal than zero, this config will take no effect.")
+      .version("4.1.0")
+      .internal()
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("256MB")
+
+  val CONNECT_SESSION_ML_CACHE_SIZE =
+    buildConf("spark.connect.session.mlCache.maxSize")
+      .doc(
+        "Sets the maximum number of cached ML objects in Spark Connect Session. " +
+          "If set to a value less or equal than zero, or " +
+          s"'${CONNECT_SESSION_ML_CACHE_TOTAL_ITEM_SIZE.key}' is enabled, " +
+          "this config will take no effect.")
+      .version("4.1.0")
+      .internal()
+      .intConf
+      .createWithDefault(256)
 }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -333,8 +333,8 @@ object Connect {
       .internal()
       .bytesConf(ByteUnit.BYTE)
       .createWithDefault(-1)
-      // TODO: Enable this config when all builtin algorithms support model size estimation
-      // .createWithDefaultString("16MB")
+  // TODO: Enable this config when all builtin algorithms support model size estimation
+  // .createWithDefaultString("16MB")
 
   val CONNECT_SESSION_ML_CACHE_TOTAL_ITEM_SIZE =
     buildConf("spark.connect.session.mlCache.totalItemSize")

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLException.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLException.scala
@@ -43,7 +43,7 @@ private[spark] case class MlItemSizeExceededException(
     estimatedSize: Long,
     maximumSize: Long)
     extends SparkException(
-      errorClass = "CONNECT_ML.MODEL_ITEM_EXCEEDED",
+      errorClass = "CONNECT_ML.CACHE_ITEM_EXCEEDED",
       messageParameters = Map(
         "operation" -> operation,
         "name" -> name,

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLException.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLException.scala
@@ -36,3 +36,17 @@ private[spark] case class MLCacheInvalidException(objectName: String)
       errorClass = "CONNECT_ML.CACHE_INVALID",
       messageParameters = Map("objectName" -> objectName),
       cause = null)
+
+private[spark] case class MlItemSizeExceededException(
+    operation: String,
+    name: String,
+    estimatedSize: Long,
+    maximumSize: Long)
+    extends SparkException(
+      errorClass = "CONNECT_ML.MODEL_ITEM_EXCEEDED",
+      messageParameters = Map(
+        "operation" -> operation,
+        "name" -> name,
+        "estimatedSize" -> estimatedSize.toString,
+        "maximumSize" -> maximumSize.toString),
+      cause = null)

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -112,7 +112,7 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
     new ConcurrentHashMap()
 
   // ML model cache
-  private[connect] lazy val mlCache = new MLCache()
+  private[connect] lazy val mlCache = new MLCache(this.session)
 
   // Mapping from id to StreamingQueryListener. Used for methods like removeListener() in
   // StreamingQueryManager.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce model size estimation to control ml cache:

```
class Model {
  ...
  private[spark] def estimatedSize: Long
}

class Estimator {
  ...
  private[spark] def estimateModelSize(dataset: Dataset[_]): Long
}
```
This PR implements this estimation for builtin classification models




1, When `CONNECT_SESSION_ML_CACHE_SINGLE_ITEM_SIZE>0`,
   before training a new model, estimate its size, fail the training if the estimated size > `CONNECT_SESSION_ML_CACHE_SINGLE_ITEM_SIZE`
   before caching a new model, fail if `model.estimatedSize > CONNECT_SESSION_ML_CACHE_SINGLE_ITEM_SIZE`;

2, When `CONNECT_SESSION_ML_CACHE_TOTAL_ITEM_SIZE>0`,
   set the `maximumWeight` of the cache, and apply the model size as the `weighter`, the guava cache will evict old model (because it hasn't been used recently or very often) when necessary.

3, Add config `CONNECT_SESSION_ML_CACHE_SIZE` to control the number of cached items, it only take effect when `CONNECT_SESSION_ML_CACHE_TOTAL_ITEM_SIZE<=0`, because guava cache doesn't support set `maximumWeight` and `maximumSize` together.

4, Add config `CONNECT_SESSION_ML_CACHE_TIMEOUT`, to evict cached item when a duration has elapsed after the creation or last access.



### Why are the changes needed?
We should control the memory usage of cached ml models



### Does this PR introduce _any_ user-facing change?
Only for ML connect

```
(spark_312) ➜  spark git:(ml_connect_model_size_control) bin/pyspark --remote local --driver-memory 16G --conf spark.connect.session.mlCache.singleItemSize=16MB
...

Using Python version 3.12.9 (main, Feb  4 2025 14:38:38)
Client connected to the Spark Connect server at localhost
SparkSession available as 'spark'.

In [1]: spark.conf.get("spark.connect.session.mlCache.singleItemSize")
Out[1]: '16MB'

In [2]: from pyspark.ml.linalg import Vectors, Matrices
   ...: from pyspark.sql import SparkSession, DataFrame, Row
   ...: from pyspark.ml.classification import *

In [3]:
   ...: df = spark.createDataFrame(
   ...:    [
   ...:          (1.0, 1.0, Vectors.sparse(1000000000, [(1, 1.0), (3, 5.5)])),
   ...:          (0.0, 2.0, Vectors.sparse(1000000000, [(1, 1.0), (3, 5.5)])),
   ...:    ],
   ...:    ["label", "weight", "features"],
   ...: )
   ...:
   ...: lor = LogisticRegression(
   ...:    maxIter=1,
   ...:    regParam=0.01,
   ...:    weightCol="weight",
   ...: )
   ...: lor_model = lor.fit(df)
25/02/20 11:04:15 WARN MLCache: Both spark.connect.session.mlCache.totalItemSize and spark.connect.session.mlCache.maxSize are set, spark.connect.session.mlCache.maxSize will be ignored.
---------------------------------------------------------------------------
SparkException                            Traceback (most recent call last)
Cell In[3], line 14
      1 df = spark.createDataFrame(
      2    [
      3          (1.0, 1.0, Vectors.sparse(1000000000, [(1, 1.0), (3, 5.5)])),
   (...)
      6    ["label", "weight", "features"],
      7 )
      9 lor = LogisticRegression(
     10    maxIter=1,
     11    regParam=0.01,
     12    weightCol="weight",
     13 )
---> 14 lor_model = lor.fit(df)

...

SparkException: [CONNECT_ML.MODEL_ITEM_EXCEEDED] Generic Spark Connect ML error. Cannot fit object LogisticRegression_4ce586585244, since its estimated size 8000007213 exceeds the limitation 16777216. SQLSTATE: XX000

JVM stacktrace:
org.apache.spark.sql.connect.ml.MlItemSizeExceededException
	at org.apache.spark.sql.connect.ml.MLHandler$.handleMlCommand(MLHandler.scala:136)
	at org.apache.spark.sql.connect.planner.SparkConnectPlanner.handleMlCommand(SparkConnectPlanner.scala:2543)
...
```


### How was this patch tested?
added tests


### Was this patch authored or co-authored using generative AI tooling?
no