### PR TITLE
[SPARK-51265][SQL][SS] Throw proper error for eagerlyExecuteCommands containing streaming source marker

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
@@ -422,6 +422,24 @@ class QueryExecutionSuite extends SharedSparkSession {
     mockCallback.assertAnalyzed()
   }
 
+  test("SPARK-51265 Running eagerlyExecuteCommand with streaming source should give an user " +
+    "facing error") {
+    withTempView("s") {
+      val streamDf = spark.readStream.format("rate").load()
+      streamDf.createOrReplaceTempView("s")
+      withTable("output") {
+        val ex = intercept[AnalysisException] {
+          // Creates a table from streaming source with batch query. This should fail.
+          spark.sql("CREATE TABLE output AS SELECT * FROM s")
+        }
+        assert(
+          ex.getMessage.contains("Queries with streaming sources must be executed with " +
+            "writeStream.start()")
+        )
+      }
+    }
+  }
+
   case class MockCallbackEagerCommand(
       var trackerAnalyzed: QueryPlanningTracker = null,
       var trackerReadyForExecution: QueryPlanningTracker = null)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/ForeachBatchSinkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/ForeachBatchSinkSuite.scala
@@ -215,6 +215,44 @@ class ForeachBatchSinkSuite extends StreamTest {
     assert(ex.getCause == sparkEx)
   }
 
+  test("SPARK-51265 Running eagerlyExecuteCommand with streaming source in foreachBatch " +
+    "should give an user facing error") {
+    val mem = MemoryStream[Int]
+    val ds = mem.toDS().map(_ + 1)
+
+    def foreachBatchFn(df: Dataset[Int], batchId: Long): Unit = {
+      df.createOrReplaceTempView("param")
+      val streamDf = df.sparkSession.readStream.format("rate").load()
+      streamDf.createOrReplaceTempView("s")
+      withTable("output") {
+        val ex = intercept[AnalysisException] {
+          // Creates a table from streaming source with batch query. This should fail.
+          df.sparkSession.sql("CREATE TABLE output AS SELECT * FROM s")
+        }
+        assert(
+          ex.getMessage.contains("Queries with streaming sources must be executed with " +
+          "writeStream.start()")
+        )
+
+        // Creates a table from batch source (materialized RDD plan of streaming query).
+        // This should be work properly.
+        df.sparkSession.sql("CREATE TABLE output AS SELECT * from param")
+
+        checkAnswer(
+          df.sparkSession.sql("SELECT value FROM output"),
+          Seq(Row(2), Row(3), Row(4), Row(5), Row(6)))
+      }
+    }
+
+    mem.addData(1, 2, 3, 4, 5)
+
+    val query = ds.writeStream
+      .trigger(Trigger.AvailableNow())
+      .foreachBatch(foreachBatchFn _)
+      .start()
+    query.awaitTermination()
+  }
+
   // ============== Helper classes and methods =================
 
   private class ForeachBatchTester[T: Encoder](memoryStream: MemoryStream[Int]) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR checks whether the logical plan contains streaming source marker when eagerlyExecutedCommands are about to be executed. Here, the meaning of streaming source marker is a placeholder which will be materialized during microbatch planning. That means, if the plan has such a marker, the source is not materialized hence unable to read from that source.

This is easily triggered when user constructs the plan for the command (e.g. `df.write.saveToTable`), which includes `df.readStream`, or indirect reference (temp view against `df.readStream`).

This has to be caught by `UnsupportedOperationChecker.checkBatch` (which is called from `QueryExecution.assertSupported`), but if the query is a command which is meant to be eagerly executed, it throws an error before reaching to the code path, and the error is cryptic (either StackOverflowError, or AnalysisException but InternalError). 

We should provide the proper error message to tell user that they have to fix their query.

### Why are the changes needed?

Without the fix, StackOverflowError, or AnalysisException but InternalError is thrown for user's fault query.

### Does this PR introduce _any_ user-facing change?

Yes, we will provide clearer error (though TODO to be clarified for error class) for the error.

### How was this patch tested?

New UT.

### Was this patch authored or co-authored using generative AI tooling?

No.