### PR TITLE
[SPARK-47208][DOCS][FOLLOWUP] Replace `spark.driver.minMemoryOverhead` with `spark.executor.minMemoryOverhead`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -321,7 +321,7 @@ of the most common options to set are:
   <td>2.3.0</td>
 </tr>
 <tr>
-  <td><code>spark.driver.minMemoryOverhead</code></td>
+  <td><code>spark.executor.minMemoryOverhead</code></td>
   <td>384m</td>
   <td>
     The minimum amount of non-heap memory to be allocated per executor process, in MiB unless otherwise specified, if <code>spark.executor.memoryOverhead</code> is not defined.


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->


### What changes were proposed in this pull request?
Replace spark.driver.minMemoryOverhead with spark.executor.minMemoryOverhead

### Why are the changes needed?
docfix


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
doc build


### Was this patch authored or co-authored using generative AI tooling?
no
