### PR TITLE
[SPARK-51268][SQL] Make `TreeNode` lock-free

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -96,8 +96,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    */
   def outputOrdering: Seq[SortOrder] = Nil
 
-  // Override `treePatternBits` to propagate bits for its expressions.
-  override lazy val treePatternBits: BitSet = {
+  private val _treePatternBits = new BestEffortLazyVal[BitSet](() => {
     val bits: BitSet = getDefaultTreePatternBits
     // Propagate expressions' pattern bits
     val exprIterator = expressions.iterator
@@ -105,7 +104,10 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
       bits.union(exprIterator.next().treePatternBits)
     }
     bits
-  }
+  })
+
+  // Override `treePatternBits` to propagate bits for its expressions.
+  override def treePatternBits: BitSet = _treePatternBits()
 
   /**
    * The set of all attributes that are input to this operator by its children.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -96,6 +96,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    */
   def outputOrdering: Seq[SortOrder] = Nil
 
+  // Override `treePatternBits` to propagate bits for its expressions.
   private val _treePatternBits = new BestEffortLazyVal[BitSet](() => {
     val bits: BitSet = getDefaultTreePatternBits
     // Propagate expressions' pattern bits
@@ -105,8 +106,6 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
     }
     bits
   })
-
-  // Override `treePatternBits` to propagate bits for its expressions.
   override def treePatternBits: BitSet = _treePatternBits()
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -49,8 +49,8 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.storage.StorageLevel
+import org.apache.spark.util.{BestEffortLazyVal, Utils}
 import org.apache.spark.util.ArrayImplicits._
-import org.apache.spark.util.Utils
 import org.apache.spark.util.collection.BitSet
 
 /** Used by [[TreeNode.getNodeNumbered]] when traversing the tree for a given number */
@@ -109,6 +109,8 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
     bits
   }
 
+  private val _treePatternBits = new BestEffortLazyVal[BitSet](() => getDefaultTreePatternBits)
+
   /**
    * For child classes to validate `nodePatterns`.
    */
@@ -118,7 +120,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
    * A BitSet of tree patterns for this TreeNode and its subtree. If this TreeNode and its
    * subtree contains a pattern `P`, the corresponding bit for `P.id` is set in this BitSet.
    */
-  override lazy val treePatternBits: BitSet = getDefaultTreePatternBits
+  override def treePatternBits: BitSet = _treePatternBits()
 
   /**
    * A BitSet of rule ids to record ineffective rules for this TreeNode and its subtree.
@@ -204,12 +206,15 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
    */
   def children: Seq[BaseType]
 
-  lazy val containsChild: Set[TreeNode[_]] = children.toSet
+  private val _containsChild = new BestEffortLazyVal[Set[TreeNode[_]]](() => children.toSet)
+  def containsChild: Set[TreeNode[_]] = _containsChild()
 
-  lazy val height: Int = children.map(_.height).reduceOption(_ max _).getOrElse(0) + 1
+  private val _height = new BestEffortLazyVal[Integer](() =>
+    children.map(_.height).reduceOption(_ max _).getOrElse(0) + 1)
+  def height: Int = _height()
 
-  private lazy val _hashCode: Int = MurmurHash3.productHash(this)
-  override def hashCode(): Int = _hashCode
+  private val _hashCode = new BestEffortLazyVal[Integer](() => MurmurHash3.productHash(this))
+  override def hashCode(): Int = _hashCode()
 
   /**
    * Faster version of equality which short-circuits when two treeNodes are the same instance.
@@ -847,13 +852,14 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
    */
   protected def stringArgs: Iterator[Any] = productIterator
 
-  private lazy val allChildren: IdentityHashMap[TreeNode[_], Any] = {
+  private val _allChildren = new BestEffortLazyVal[IdentityHashMap[TreeNode[_], Any]](() => {
     val set = new IdentityHashMap[TreeNode[_], Any]()
     (children ++ innerChildren).foreach {
       set.put(_, null)
     }
     set
-  }
+  })
+  private def allChildren = _allChildren()
 
   private def redactMapString[K, V](map: Map[K, V], maxFields: Int): List[String] = {
     // For security reason, redact the map value if the key is in certain patterns

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -109,8 +109,6 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
     bits
   }
 
-  private val _treePatternBits = new BestEffortLazyVal[BitSet](() => getDefaultTreePatternBits)
-
   /**
    * For child classes to validate `nodePatterns`.
    */
@@ -120,6 +118,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
    * A BitSet of tree patterns for this TreeNode and its subtree. If this TreeNode and its
    * subtree contains a pattern `P`, the corresponding bit for `P.id` is set in this BitSet.
    */
+  private val _treePatternBits = new BestEffortLazyVal[BitSet](() => getDefaultTreePatternBits)
   override def treePatternBits: BitSet = _treePatternBits()
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatternBits.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatternBits.scala
@@ -22,7 +22,7 @@ import org.apache.spark.util.collection.BitSet
 
 // A wrapper of BitSet for pattern enums.
 trait TreePatternBits {
-  protected val treePatternBits: BitSet
+  protected def treePatternBits: BitSet
 
   /**
    * @param t, the tree pattern enum to be tested.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Make `TreeNode` lock-free, by replace `lazy val` with `BestEffortLazyVal`


### Why are the changes needed?
In several deadlock issues, we observed that the lock of `TreeNode._hashCode` is the root cause.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
