### PR TITLE
[SPARK-51284][SQL] Fix SQL Script execution for empty result

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
@@ -145,7 +145,7 @@ class SqlScriptingE2eSuite extends QueryTest with SharedSparkSession {
     verifySqlScriptResult(sqlScript, Seq.empty)
   }
 
-  test("script with empty result") {
+  test("SPARK-51284: script with empty result") {
     withTable("scripting_test_table") {
       val sqlScript =
         """

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
@@ -43,9 +43,7 @@ class SqlScriptingE2eSuite extends QueryTest with SharedSparkSession {
     val df = spark.sql(sqlText)
     checkAnswer(df, expected)
 
-    if (expectedSchema.isDefined) {
-      assert(df.schema === expectedSchema.get)
-    }
+    assert(expectedSchema.forall(_ === df.schema))
   }
 
   private def verifySqlScriptResultWithNamedParams(

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.util.QuotingUtils.toSQLConf
 import org.apache.spark.sql.exceptions.SqlScriptingException
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 
 /**
@@ -35,9 +36,16 @@ import org.apache.spark.sql.test.SharedSparkSession
  */
 class SqlScriptingE2eSuite extends QueryTest with SharedSparkSession {
   // Helpers
-  private def verifySqlScriptResult(sqlText: String, expected: Seq[Row]): Unit = {
+  private def verifySqlScriptResult(
+      sqlText: String,
+      expected: Seq[Row],
+      expectedSchema: Option[StructType] = None): Unit = {
     val df = spark.sql(sqlText)
     checkAnswer(df, expected)
+
+    if (expectedSchema.isDefined) {
+      assert(df.schema === expectedSchema.get)
+    }
   }
 
   private def verifySqlScriptResultWithNamedParams(
@@ -137,6 +145,24 @@ class SqlScriptingE2eSuite extends QueryTest with SharedSparkSession {
         |END
         |""".stripMargin
     verifySqlScriptResult(sqlScript, Seq.empty)
+  }
+
+  test("script with empty result") {
+    withTable("scripting_test_table") {
+      val sqlScript =
+        """
+          |BEGIN
+          |  CREATE TABLE scripting_test_table (id INT);
+          |  SELECT * FROM scripting_test_table;
+          |  DROP TABLE scripting_test_table;
+          |END
+          |""".stripMargin
+      verifySqlScriptResult(
+        sqlScript,
+        Seq.empty,
+        Some(StructType(Seq(StructField("id", IntegerType)).toArray))
+      )
+    }
   }
 
   test("empty script") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This pull request proposes changes to fix the empty result returned from the SQL Script.
Change is quite simple, it just introduces the `resultSchema` var to track the schema of the last resulting statement in the SQL Script.
This way, the case when `result` is empty and there are no rows (and thus the schema cannot be fetched this way) is fixed, because the schema is now read from `DataFrame`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fixing a bug - if the result statement in the SQL Script exists, but returns nothing, there were few problems:
- Tests were missing.
- Execution was failing.
- Schema would be missing.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Already existing tests.
Adapted the `SqlScriptingE2eSuite` to support output schema checks.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
