### PR TITLE
[SPARK-51270][SQL] Support UUID type in Variant

### DIFF
--- a/common/variant/src/main/java/org/apache/spark/types/variant/ShreddingUtils.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/ShreddingUtils.java
@@ -19,6 +19,7 @@ package org.apache.spark.types.variant;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.UUID;
 
 import static org.apache.spark.types.variant.VariantUtil.*;
 
@@ -37,6 +38,7 @@ public class ShreddingUtils {
     BigDecimal getDecimal(int ordinal, int precision, int scale);
     String getString(int ordinal);
     byte[] getBinary(int ordinal);
+    UUID getUuid(int ordinal);
     ShreddedRow getStruct(int ordinal, int numFields);
     ShreddedRow getArray(int ordinal);
     int numElements();
@@ -99,6 +101,8 @@ public class ShreddingUtils {
           builder.appendBoolean(row.getBoolean(typedIdx));
         } else if (scalar instanceof VariantSchema.BinaryType) {
           builder.appendBinary(row.getBinary(typedIdx));
+        } else if (scalar instanceof VariantSchema.UuidType) {
+          builder.appendUuid(row.getUuid(typedIdx));
         } else if (scalar instanceof VariantSchema.DecimalType) {
           VariantSchema.DecimalType dt = (VariantSchema.DecimalType) scalar;
           builder.appendDecimal(row.getDecimal(typedIdx, dt.precision, dt.scale));

--- a/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
@@ -33,6 +33,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Locale;
+import java.util.UUID;
 
 import static org.apache.spark.types.variant.VariantUtil.*;
 
@@ -121,6 +122,11 @@ public final class Variant {
   // Get the value type of the variant.
   public Type getType() {
     return VariantUtil.getType(value, pos);
+  }
+
+  // Get a UUID value from the variant.
+  public UUID getUuid() {
+    return VariantUtil.getUuid(value, pos);
   }
 
   // Get the number of object fields in the variant.
@@ -332,6 +338,9 @@ public final class Variant {
         break;
       case BINARY:
         appendQuoted(sb, Base64.getEncoder().encodeToString(VariantUtil.getBinary(value, pos)));
+        break;
+      case UUID:
+        appendQuoted(sb, VariantUtil.getUuid(value, pos).toString());
         break;
     }
   }

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
@@ -247,11 +247,10 @@ public class VariantBuilder {
     writeBuffer[writePos++] = primitiveHeader(UUID);
 
     // UUID is stored big-endian, so don't use writeLong.
-    ByteBuffer buffer = ByteBuffer.allocate(16);
+    ByteBuffer buffer = ByteBuffer.wrap(writeBuffer, writePos, 16);
     buffer.order(ByteOrder.BIG_ENDIAN);
     buffer.putLong(0, uuid.getMostSignificantBits());
     buffer.putLong(8, uuid.getLeastSignificantBits());
-    System.arraycopy(buffer.array(), 0, writeBuffer, writePos, 16);
     writePos += 16;
   }
 

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
@@ -249,8 +249,8 @@ public class VariantBuilder {
     // UUID is stored big-endian, so don't use writeLong.
     ByteBuffer buffer = ByteBuffer.wrap(writeBuffer, writePos, 16);
     buffer.order(ByteOrder.BIG_ENDIAN);
-    buffer.putLong(0, uuid.getMostSignificantBits());
-    buffer.putLong(8, uuid.getLeastSignificantBits());
+    buffer.putLong(writePos, uuid.getMostSignificantBits());
+    buffer.putLong(writePos + 8, uuid.getLeastSignificantBits());
     writePos += 16;
   }
 

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.*;
 
 import com.fasterxml.jackson.core.JsonFactory;
@@ -238,6 +240,19 @@ public class VariantBuilder {
     writePos += U32_SIZE;
     System.arraycopy(binary, 0, writeBuffer, writePos, binary.length);
     writePos += binary.length;
+  }
+
+  public void appendUuid(UUID uuid) {
+    checkCapacity(1 + 16);
+    writeBuffer[writePos++] = primitiveHeader(UUID);
+
+    // UUID is stored big-endian, so don't use writeLong.
+    ByteBuffer buffer = ByteBuffer.allocate(16);
+    buffer.order(ByteOrder.BIG_ENDIAN);
+    buffer.putLong(0, uuid.getMostSignificantBits());
+    buffer.putLong(8, uuid.getLeastSignificantBits());
+    System.arraycopy(buffer.array(), 0, writeBuffer, writePos, 16);
+    writePos += 16;
   }
 
   // Add a key to the variant dictionary. If the key already exists, the dictionary is not modified.

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantSchema.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantSchema.java
@@ -99,6 +99,9 @@ public class VariantSchema {
   public static final class TimestampNTZType extends ScalarType {
   }
 
+  public static final class UuidType extends ScalarType {
+  }
+
   // The index of the typed_value, value, and metadata fields in the schema, respectively. If a
   // given field is not in the schema, its value must be set to -1 to indicate that it is invalid.
   // The indices of valid fields should be contiguous and start from 0.

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantShreddingWriter.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantShreddingWriter.java
@@ -283,6 +283,11 @@ public class VariantShreddingWriter {
           return v.getBinary();
         }
         break;
+      case UUID:
+        if (targetType instanceof VariantSchema.UuidType) {
+          return v.getUuid();
+        }
+        break;
     }
     // The stored type does not match the requested shredding type. Return null, and the caller
     // will store the result in untyped_value.

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantUtil.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantUtil.java
@@ -516,6 +516,7 @@ public class VariantUtil {
     int typeInfo = (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;
     if (basicType != PRIMITIVE || typeInfo != UUID) throw unexpectedType(Type.UUID);
     int start = pos + 1;
+    checkIndex(start + 15, value.length);
     // UUID values are big-endian, so we can't use VariantUtil.readLong().
     ByteBuffer bb = ByteBuffer.wrap(value, start, 16).order(ByteOrder.BIG_ENDIAN);
     return new UUID(bb.getLong(), bb.getLong());

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantUtil.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantUtil.java
@@ -23,7 +23,10 @@ import scala.collection.immutable.Map$;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Arrays;
+import java.util.UUID;
 
 /**
  * This class defines constants related to the variant format and provides functions for
@@ -120,6 +123,9 @@ public class VariantUtil {
   // Long string value. The content is (4-byte little-endian unsigned integer representing the
   // string size) + (size bytes of string content).
   public static final int LONG_STR = 16;
+
+  // UUID, 16-byte big-endian.
+  public static final int UUID = 20;
 
   public static final byte VERSION = 1;
   // The lower 4 bits of the first metadata byte contain the version.
@@ -239,6 +245,7 @@ public class VariantUtil {
     TIMESTAMP_NTZ,
     FLOAT,
     BINARY,
+    UUID,
   }
 
   public static int getTypeInfo(byte[] value, int pos) {
@@ -291,6 +298,8 @@ public class VariantUtil {
             return Type.BINARY;
           case LONG_STR:
             return Type.STRING;
+          case UUID:
+            return Type.UUID;
           default:
             throw unknownPrimitiveTypeInVariant(typeInfo);
         }
@@ -342,6 +351,8 @@ public class VariantUtil {
           case BINARY:
           case LONG_STR:
             return 1 + U32_SIZE + readUnsigned(value, pos + 1, U32_SIZE);
+          case UUID:
+            return 17;
           default:
             throw unknownPrimitiveTypeInVariant(typeInfo);
         }
@@ -495,6 +506,19 @@ public class VariantUtil {
       return new String(value, start, length);
     }
     throw unexpectedType(Type.STRING);
+  }
+
+  // Get a UUID value from variant value `value[pos...]`.
+  // Throw `MALFORMED_VARIANT` if the variant is malformed.
+  public static UUID getUuid(byte[] value, int pos) {
+    checkIndex(pos, value.length);
+    int basicType = value[pos] & BASIC_TYPE_MASK;
+    int typeInfo = (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;
+    if (basicType != PRIMITIVE || typeInfo != UUID) throw unexpectedType(Type.UUID);
+    int start = pos + 1;
+    // UUID values are big-endian, so we can't use VariantUtil.readLong().
+    ByteBuffer bb = ByteBuffer.wrap(value, start, 16).order(ByteOrder.BIG_ENDIAN);
+    return new UUID(bb.getLong(), bb.getLong());
   }
 
   public interface ObjectHandler<T> {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
@@ -868,6 +868,14 @@ class VariantExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       "\u0001\u0002\u0003")
     checkCast(Array(primitiveHeader(BINARY), 5, 0, 0, 0, 72, 101, 108, 108, 111), StringType,
       "Hello")
+
+    // UUID
+    checkToJson(Array(primitiveHeader(UUID),
+      0, 17, 34, 51, 68, 85, 102, 119, -120, -103, -86, -69, -52, -35, -18, -1),
+      "\"00112233-4455-6677-8899-aabbccddeeff\"")
+    checkCast(Array(primitiveHeader(UUID),
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16), StringType,
+      "01020304-0506-0708-090a-0b0c0d0e0f10")
   }
 
   test("SPARK-48150: ParseJson expression nullability") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.types.variant.VariantBuilder
 import org.apache.spark.types.variant.VariantUtil._
 import org.apache.spark.unsafe.types.{UTF8String, VariantVal}
 
@@ -847,8 +848,13 @@ class VariantExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkToJson(Array(primitiveHeader(UUID),
       0, 17, 34, 51, 68, 85, 102, 119, -120, -103, -86, -69, -52, -35, -18, -1),
       "\"00112233-4455-6677-8899-aabbccddeeff\"")
-    checkCast(Array(primitiveHeader(UUID),
-      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16), StringType,
+    // Test cast to string. Incidentally, also test construction of UUID via VariantBuilder
+    // interface, since we can't currently do it as a Spark cast.
+    val uuid = java.util.UUID.fromString("01020304-0506-0708-090a-0b0c0d0e0f10")
+    val builder = new VariantBuilder(false)
+    builder.appendUuid(uuid)
+    val bytes = builder.result().getValue
+    checkCast(bytes, StringType,
       "01020304-0506-0708-090a-0b0c0d0e0f10")
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
@@ -440,28 +440,6 @@ class VariantExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     // day-time interval to variant
     assert(!resolver.resolveTimeZones(Cast(Cast(Literal(0L), DayTimeIntervalType(0, 0)),
       VariantType)).resolved)
-
-    // Remove test when overriding type ID 19: old variant year-month interval type ID (19) to int
-    checkErrorInExpression[SparkRuntimeException](
-      VariantGet(
-        Literal(new VariantVal(Array(primitiveHeader(19), 0, 0, 0, 0, 0),
-          emptyMetadata)), Literal("$"), IntegerType, failOnError = true
-      ),
-      "UNKNOWN_PRIMITIVE_TYPE_IN_VARIANT",
-      Map("id" -> "19")
-    )
-
-    // Remove test when overriding type ID 20: old variant day-time interval type ID (20) to int
-    checkErrorInExpression[SparkRuntimeException](
-      VariantGet(
-        Literal(
-          new VariantVal(Array(primitiveHeader(20), 0, 0, 0, 0, 0, 0, 0, 0, 0),
-            emptyMetadata)
-        ), Literal("$"), IntegerType, failOnError = true
-      ),
-      "UNKNOWN_PRIMITIVE_TYPE_IN_VARIANT",
-      Map("id" -> "20")
-    )
   }
 
   test("variant_get path extraction") {
@@ -782,10 +760,6 @@ class VariantExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
 
     checkToJsonFail(Array(primitiveHeader(25)), 25)
-    // Remove these test cases when overriding type IDs 19 and 20.
-    // SPARK-49985: Disable support for interval types in the variant spec.
-    checkToJsonFail(Array(primitiveHeader(19)), 19)
-    checkToJsonFail(Array(primitiveHeader(20)), 20)
 
     def littleEndianLong(value: Long): Array[Byte] =
       BigInt(value).toByteArray.reverse.padTo(8, 0.toByte)
@@ -986,11 +960,6 @@ class VariantExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       )
     }
     checkErrorInSchemaOf(Array(primitiveHeader(25)), 25)
-
-    // SPARK-49985: Disable support for interval types in the variant spec.
-    // Remove these test cases when overriding type ids 19 and 20
-    checkErrorInSchemaOf(Array(primitiveHeader(19)), 19)
-    checkErrorInSchemaOf(Array(primitiveHeader(20)), 20)
   }
 
   test("schema_of_variant - schema merge") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/SparkShreddingUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/SparkShreddingUtils.scala
@@ -52,6 +52,9 @@ case class SparkShreddedRow(row: SpecializedGetters) extends ShreddingUtils.Shre
     SparkShreddedRow(row.getStruct(ordinal, numFields))
   override def getArray(ordinal: Int): SparkShreddedRow =
     SparkShreddedRow(row.getArray(ordinal))
+  override def getUuid(ordinal: Int): java.util.UUID =
+    // Spark currently does not shred UUID.
+    throw QueryExecutionErrors.malformedVariant()
   override def numElements(): Int = row.asInstanceOf[ArrayData].numElements()
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Four new types were added to the Parquet Variant spec (https://github.com/apache/parquet-format/commit/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2): UUID, Time, Timestamp(NANOS) and TimestampNTZ(NANOS). They don't correspond to an existing Spark type, so there is no need to allow them to be constructed in Spark. But when reading from another tool, we should be able to handle them gracefully: specifically, casts to JSON/string should work, and SchemaOfVariant should produce a reasonable result.

This PR only adds support for UUID. Support for the other types should be similar, mainly differing in the details of casting to string.

### Why are the changes needed?

Support reading Variant values produced by other tools.

### Does this PR introduce _any_ user-facing change?

In Spark 4.0, we would fail when trying to read a Variant value containing UUID. With this change, we should be able to handle it.

### How was this patch tested?

Added unit tests.

### Was this patch authored or co-authored using generative AI tooling?

No.