### PR TITLE
[SPARK-51222][SQL][FOLLOW-UP] Optimize ReplaceCurrentLike

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -148,16 +148,16 @@ object ComputeCurrentTime extends Rule[LogicalPlan] {
 case class ReplaceCurrentLike(catalogManager: CatalogManager) extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = {
     import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+    lazy val currentNamespace = catalogManager.currentNamespace.quoted
+    lazy val currentCatalog = catalogManager.currentCatalog.name()
+    lazy val currentUser = CurrentUserContext.getCurrentUser
 
     plan.transformAllExpressionsWithPruning(_.containsPattern(CURRENT_LIKE)) {
       case CurrentDatabase() =>
-        val currentNamespace = catalogManager.currentNamespace.quoted
         Literal.create(currentNamespace, StringType)
       case CurrentCatalog() =>
-        val currentCatalog = catalogManager.currentCatalog.name()
         Literal.create(currentCatalog, StringType)
       case CurrentUser() =>
-        val currentUser = CurrentUserContext.getCurrentUser
         Literal.create(currentUser, StringType)
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Minor follow up for https://github.com/apache/spark/pull/49963 to use lazy vals


### Why are the changes needed?
The original pr would have a small potential behavior change, if there are multiple current_xx() functions in the query, it could evaluate different results for each if the catalog is updated in the backend in between.  Making a lazy val allows the FinishAnalysis phase to resolve the same value for each function.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing unit test


### Was this patch authored or co-authored using generative AI tooling?
No
