### PR TITLE
[SPARK-51282][ML][PYTHON][CONNECT] Optimize OneVsRestModel transform by eliminating the JVM-Python data exchange

### DIFF
--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -16,7 +16,6 @@
 #
 
 import os
-import operator
 import sys
 import uuid
 import warnings
@@ -27,7 +26,6 @@ from typing import (
     Any,
     Dict,
     Generic,
-    Iterable,
     List,
     Optional,
     Type,
@@ -94,10 +92,9 @@ from pyspark.ml.util import (
 )
 from pyspark.ml.wrapper import JavaParams, JavaPredictor, JavaPredictionModel, JavaWrapper
 from pyspark.ml.common import inherit_doc
-from pyspark.ml.linalg import Matrix, Vector, Vectors, VectorUDT
+from pyspark.ml.linalg import Matrix, Vector
 from pyspark.sql import DataFrame, Row, SparkSession, functions as F
 from pyspark.sql.internal import InternalFunction as SF
-from pyspark.sql.types import ArrayType, DoubleType
 from pyspark.storagelevel import StorageLevel
 from pyspark.sql.utils import is_remote
 
@@ -3859,7 +3856,7 @@ class OneVsRestModel(
             transformedDataset = model.transform(aggregatedDataset).select(*columns)
             updatedDataset = transformedDataset.withColumn(
                 tmpColName,
-                F.array_append(accColName, SF.get_vector(F.col(rawPredictionCol), F.lit(1))),
+                F.array_append(accColName, SF.vector_get(F.col(rawPredictionCol), F.lit(1))),
             )
             newColumns = origCols + [tmpColName]
 

--- a/python/pyspark/sql/internal.py
+++ b/python/pyspark/sql/internal.py
@@ -132,7 +132,7 @@ class InternalFunction:
         return F.make_interval(**{unit_mapping[unit]: F.lit(e)})
 
     @staticmethod
-    def get_vector(vec: Column, idx: Column) -> Column:
+    def vector_get(vec: Column, idx: Column) -> Column:
         unwrapped = F.unwrap_udt(vec)
         is_dense = unwrapped.getField("type") == F.lit(1)
         values = unwrapped.getField("values")

--- a/python/pyspark/sql/internal.py
+++ b/python/pyspark/sql/internal.py
@@ -155,7 +155,7 @@ class InternalFunction:
             i = acc.getField("i")
             j = acc.getField("j")
             return F.when(
-                vv > v,
+                (~vv.isNaN()) & (vv > v),
                 F.struct(vv.alias("v"), j.alias("i"), j + 1),
             ).otherwise(F.struct(v.alias("v"), i.alias("i"), j + 1))
 

--- a/python/pyspark/sql/internal.py
+++ b/python/pyspark/sql/internal.py
@@ -130,3 +130,42 @@ class InternalFunction:
             "SECOND": "secs",
         }
         return F.make_interval(**{unit_mapping[unit]: F.lit(e)})
+
+    @staticmethod
+    def get_vector(vec: Column, idx: Column) -> Column:
+        unwrapped = F.unwrap_udt(vec)
+        is_dense = unwrapped.getField("type") == F.lit(1)
+        values = unwrapped.getField("values")
+        size = F.when(is_dense, F.array_size(values)).otherwise(unwrapped.getField("size"))
+        sparse_idx = InternalFunction.array_binary_search(unwrapped.getField("indices"), idx)
+        value = (
+            F.when(is_dense, F.get(values, idx))
+            .when(sparse_idx >= 0, F.get(values, sparse_idx))
+            .otherwise(F.lit(0.0))
+        )
+
+        return F.when((0 <= idx) & (idx < size), value).otherwise(
+            F.raise_error(F.printf(F.lit("Vector index must be in [0, %s), but got %s"), size, idx))
+        )
+
+    @staticmethod
+    def array_argmax(arr: Column) -> Column:
+        def merge(acc, vv):
+            v = acc.getField("v")
+            i = acc.getField("i")
+            j = acc.getField("j")
+            return F.when(
+                vv > v,
+                F.struct(vv.alias("v"), j.alias("i"), j + 1),
+            ).otherwise(F.struct(v.alias("v"), i.alias("i"), j + 1))
+
+        return F.aggregate(
+            arr,
+            F.struct(
+                F.lit(float("-inf")).alias("v"),  # max value
+                F.lit(-1).alias("i"),  # index of max value
+                F.lit(0).alias("j"),  # current index
+            ),
+            merge,
+            lambda acc: acc.getField("i"),
+        )

--- a/python/pyspark/sql/internal.py
+++ b/python/pyspark/sql/internal.py
@@ -150,7 +150,7 @@ class InternalFunction:
 
     @staticmethod
     def array_argmax(arr: Column) -> Column:
-        def merge(acc, vv):
+        def merge(acc: Column, vv: Column) -> Column:
             v = acc.getField("v")
             i = acc.getField("i")
             j = acc.getField("j")

--- a/python/pyspark/sql/internal.py
+++ b/python/pyspark/sql/internal.py
@@ -148,6 +148,8 @@ class InternalFunction:
             F.raise_error(F.printf(F.lit("Vector index must be in [0, %s), but got %s"), size, idx))
         )
 
+    # The main different between this function and the `array_max` + `array_position`:
+    # This function ignores NaN/NULL values, while `array_max` treats NaN values as largest values.
     @staticmethod
     def array_argmax(arr: Column) -> Column:
         def merge(acc: Column, vv: Column) -> Column:
@@ -155,7 +157,7 @@ class InternalFunction:
             i = acc.getField("i")
             j = acc.getField("j")
             return F.when(
-                (~vv.isNaN()) & (vv > v),
+                (~vv.isNaN()) & (~vv.isNull()) & (vv > v),
                 F.struct(vv.alias("v"), j.alias("i"), j + 1),
             ).otherwise(F.struct(v.alias("v"), i.alias("i"), j + 1))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Optimize OneVsRestModel transform by eliminating the JVM-Python data exchange


### Why are the changes needed?
for better performance, using builtin functions to replace the python UDFs, then optimize out the data exchange

my local test shows that it is **4.6** X faster than existing implementation


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci, and manually check

prepare model and test data
```
from pyspark.sql import Row
from pyspark.ml.classification import *
from pyspark.ml.linalg import Vectors

data_path = "data/mllib/sample_multiclass_classification_data.txt"

df = spark.read.format("libsvm").load(data_path)
lr = LogisticRegression(regParam=0.01)
ovr = OneVsRest(classifier=lr)
model = ovr.fit(df)
model.save("/tmp/ovrm")


for i in range(10):
    df = df.union(df)

df.write.mode("overwrite").parquet("/tmp/test_data")
```

benchmark transform performance
```
import time
from pyspark.sql import Row
from pyspark.ml.classification import *
from pyspark.ml.linalg import Vectors

df = spark.read.parquet("/tmp/test_data")

df.persist()
df.count()
df.count()

ovrm = OneVsRestModel.load("/tmp/ovrm")

tic = time.time()
ovrm.transform(df).write.mode("overwrite").parquet(f"/tmp/pred-{tic}")
toc = time.time()

toc - tic
```

master: 8.527473211288452 sec
![image](https://github.com/user-attachments/assets/d270b4c9-3470-4288-923a-c5f0738d1053)


this PR: 1.8552227020263672 sec
![image](https://github.com/user-attachments/assets/b3953a82-98fd-4483-b0a3-6546adbfde7c)



### Was this patch authored or co-authored using generative AI tooling?
no
