### PR TITLE
[SPARK-51288][DOCS] Add link for Scala API of Spark Connect

### DIFF
--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -85,13 +85,21 @@
 
                     <li class="nav-item dropdown">
                         <a href="#" class="nav-link dropdown-toggle" id="navbarAPIDocs" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">API Docs</a>
-                        <div class="dropdown-menu" aria-labelledby="navbarAPIDocs">
-                            <a class="dropdown-item" href="{{ rel_path_to_root }}api/python/index.html">Python</a>
-                            <a class="dropdown-item" href="{{ rel_path_to_root }}api/scala/org/apache/spark/index.html">Scala</a>
-                            <a class="dropdown-item" href="{{ rel_path_to_root }}api/java/index.html">Java</a>
-                            <a class="dropdown-item" href="{{ rel_path_to_root }}api/R/index.html">R</a>
-                            <a class="dropdown-item" href="{{ rel_path_to_root }}api/sql/index.html">SQL, Built-in Functions</a>
-                        </div>
+                        <ul class="dropdown-menu" aria-labelledby="navbarAPIDocs">
+                            <li><a class="dropdown-item" href="api/python/index.html">Python</a></li>
+                            <li>
+                                <a class="dropdown-item" href="#">Scala &raquo; </a>
+                                <ul class="dropdown-menu dropdown-submenu">
+                                    <li>
+                                        <a class="dropdown-item" href="api/scala/org/apache/spark/index.html">Classic</a>
+                                        <a class="dropdown-item" href="api/connect/scala/org/apache/spark/index.html">Connect</a>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li><a class="dropdown-item" href="api/java/index.html">Java</a></li>
+                            <li><a class="dropdown-item" href="api/R/index.html">R</a></li>
+                            <li><a class="dropdown-item" href="api/sql/index.html">SQL, Built-in Functions</a></li>
+                        </ul>
                     </li>
 
                     <li class="nav-item dropdown">

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -61,6 +61,10 @@ links.
     margin-top: 0;
   }
 
+  .navbar .dropdown-menu li {
+    position: relative;
+  }
+
   .navbar .dropdown-menu.fade-down {
     top: 80%;
     transform: none !important;
@@ -76,6 +80,17 @@ links.
     visibility: visible;
     top: 100%;
     font-size: calc(0.51rem + 0.55vw);
+  }
+
+  .navbar .dropdown-menu .dropdown-submenu {
+    display: none;
+    position: absolute;
+    left: 100%;
+    top: -1px !important;
+  }
+
+  .navbar .dropdown-menu li:hover > .dropdown-submenu {
+    display: block;
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follows https://github.com/apache/spark/pull/47332.

This PR adds Spark Connect doc to the website menu.

<img width="402" alt="Screenshot 2025-02-21 at 12 16 43" src="https://github.com/user-attachments/assets/41b456a3-b1fd-4728-babd-60d09a25c143" />

### Does this PR introduce _any_ user-facing change?

Yes, it's modifying the Spark website.

### How was this patch tested?

Manually. 

### Was this patch authored or co-authored using generative AI tooling?

No.