### PR TITLE
[SPARK-51258][SQL][FOLLOWUP] Remove unnecessary inheritance from SQLConfHelper

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ConditionalExpressionResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ConditionalExpressionResolver.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.catalyst.analysis.resolver
 
-import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.analysis.{AnsiTypeCoercion, TypeCoercion}
 import org.apache.spark.sql.catalyst.expressions.{ConditionalExpression, Expression}
 
@@ -28,8 +27,7 @@ class ConditionalExpressionResolver(
     expressionResolver: ExpressionResolver,
     timezoneAwareExpressionResolver: TimezoneAwareExpressionResolver)
   extends TreeNodeResolver[ConditionalExpression, Expression]
-  with ResolvesExpressionChildren
-  with SQLConfHelper {
+  with ResolvesExpressionChildren {
 
   private val typeCoercionTransformations: Seq[Expression => Expression] =
     if (conf.ansiEnabled) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/PlanTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/PlanTest.scala
@@ -22,7 +22,6 @@ import org.scalatest.Suite
 import org.scalatest.Tag
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
@@ -62,7 +61,7 @@ trait CodegenInterpretedPlanTest extends PlanTest {
  * Provides helper methods for comparing plans, but without the overhead of
  * mandating a FunSuite.
  */
-trait PlanTestBase extends PredicateHelper with SQLHelper with SQLConfHelper { self: Suite =>
+trait PlanTestBase extends PredicateHelper with SQLHelper { self: Suite =>
 
   protected def normalizeExprIds(plan: LogicalPlan): LogicalPlan =
     NormalizePlan.normalizeExprIds(plan)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
@@ -48,7 +48,7 @@ class V2SessionCatalog(catalog: SessionCatalog)
   extends TableCatalog with FunctionCatalog with SupportsNamespaces with SQLConfHelper {
   import V2SessionCatalog._
 
-  override val defaultNamespace: Array[String] = Array(SQLConf.get.defaultDatabase)
+  override val defaultNamespace: Array[String] = Array(conf.defaultDatabase)
 
   override def name: String = CatalogManager.SESSION_CATALOG_NAME
 
@@ -83,7 +83,7 @@ class V2SessionCatalog(catalog: SessionCatalog)
   }
 
   private def hasCustomSessionCatalog: Boolean = {
-    catalog.conf.getConf(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION) != "builtin"
+    conf.getConf(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION) != "builtin"
   }
 
   override def loadTable(ident: Identifier): Table = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/NameScopeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/NameScopeSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.analysis.resolver
 
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.analysis.UnresolvedStar
 import org.apache.spark.sql.catalyst.analysis.resolver.{NameScope, NameScopeStack, NameTarget}
 import org.apache.spark.sql.catalyst.expressions.{
@@ -41,7 +40,7 @@ import org.apache.spark.sql.types.{
   StructType
 }
 
-class NameScopeSuite extends PlanTest with SQLConfHelper {
+class NameScopeSuite extends PlanTest {
   private val col1Integer = AttributeReference(name = "col1", dataType = IntegerType)()
   private val col1IntegerOther = AttributeReference(name = "col1", dataType = IntegerType)()
   private val col2Integer = AttributeReference(name = "col2", dataType = IntegerType)()


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to remove unnecessary inheritance from `SQLConfHelper`.

### Why are the changes needed?

1. There are some trait already extends `SQLConfHelper`, so we should avoid the duplicated inheritance.
```
trait TreeNodeResolver[UnresolvedNode <: TreeNode[_], ResolvedNode <: TreeNode[_]]
    extends SQLConfHelper
    with QueryErrorsBase {
  def resolve(unresolvedNode: UnresolvedNode): ResolvedNode
}
```
```
trait SQLHelper extends SQLConfHelper {
...
}
```
```
trait PlanTestBase extends PredicateHelper with SQLHelper { self: Suite =>
..
}
trait PlanTest extends SparkFunSuite with PlanTestBase
```
2. `V2SessionCatalog` already with `SQLConfHelper`, so we should use `conf` directly.

### Does this PR introduce _any_ user-facing change?
'No'.
Just update the inner code.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
'No'.