### PR TITLE
[SPARK-51297][DOCS] Fixed the scope of the query option in sql-data-sources-jdbc.md

### DIFF
--- a/docs/sql-data-sources-jdbc.md
+++ b/docs/sql-data-sources-jdbc.md
@@ -96,7 +96,7 @@ logging into the data sources.
             </code></li>
       </ol>
     </td>
-    <td>read/write</td>
+    <td>read</td>
   </tr>
   <tr>
     <td><code>prepareQuery</code></td>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The documentation shows that the scope of jdbc's option is read/write, but after looking at the source code and testing it, it should actually only be read.
This error has persisted for multiple versions and is still not fixed.

source code:
https://github.com/apache/spark/blob/a661f9f305d96331338938e14b6ea0075f234aee/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala#L287
code snippet:
![SnBKfLO4Fu](https://github.com/user-attachments/assets/93162fc6-fd3f-4c7a-8e36-413c50e3d8ff)
test snippet:
![WWWQRqH6jS](https://github.com/user-attachments/assets/07e3191e-406e-46aa-85a9-9c7902892db3)



### Why are the changes needed?
This avoids user confusion about the use of this option and avoids errors in its use


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
No testing required, just modifying the document


### Was this patch authored or co-authored using generative AI tooling?
No
