### PR TITLE
[SPARK-51296][SQL] Support collecting corrupt data in singleVariantColumn mode

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -56,7 +56,14 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
       sparkSession.sessionState.conf.sessionLocalTimeZone,
       sparkSession.sessionState.conf.columnNameOfCorruptRecord)
     parsedOptions.singleVariantColumn match {
-      case Some(columnName) => Some(StructType(Array(StructField(columnName, VariantType))))
+      case Some(singleVariantColumn) =>
+        parsedOptions.corruptRecordColumnWithSingleVariantColumn match {
+          case Some(corruptRecordColumn) =>
+            Some(StructType(Array(StructField(singleVariantColumn, VariantType),
+              StructField(corruptRecordColumn, StringType))))
+          case _ =>
+            Some(StructType(Array(StructField(singleVariantColumn, VariantType))))
+        }
       case None => JsonDataSource(parsedOptions).inferSchema(sparkSession, files, parsedOptions)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -3777,7 +3777,7 @@ abstract class JsonSuite
   }
 
   test("SPARK-40667: validate JSON Options") {
-    assert(JSONOptions.getAllOptions.size == 30)
+    assert(JSONOptions.getAllOptions.size == 31)
     // Please add validation on any new Json options here
     assert(JSONOptions.isValidOption("samplingRatio"))
     assert(JSONOptions.isValidOption("primitivesAsString"))
@@ -3806,6 +3806,7 @@ abstract class JsonSuite
     assert(JSONOptions.isValidOption("timeZone"))
     assert(JSONOptions.isValidOption("writeNonAsciiCharacterAsCodePoint"))
     assert(JSONOptions.isValidOption("singleVariantColumn"))
+    assert(JSONOptions.isValidOption("corruptRecordColumnWithSingleVariantColumn"))
     assert(JSONOptions.isValidOption("useUnsafeRow"))
     assert(JSONOptions.isValidOption("encoding"))
     assert(JSONOptions.isValidOption("charset"))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, if the `singleVariantColumn` is specified, the schema will be a single variant column. It is then impossible to collect corrupt data, which requires the schema to contain a column for corrupt data. This PR enables collecting corrupt data in `singleVariantColumn` mode by adding a new option, `corruptRecordColumnWithSingleVariantColumn`. It only takes effect when `singleVariantColumn` is specified. It defines the column name for the corrupt record, and the schema will contain exactly two columns: the single variant column to capture valid data, and the corrupt record column to capture corrupt data. 

### Why are the changes needed?

It allows collecting corrupt data in `singleVariantColumn` mode.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.

### Was this patch authored or co-authored using generative AI tooling?

No.