### PR TITLE
[SPARK-51298][SQL] Support variant in CSV scan

### DIFF
--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
@@ -559,7 +559,7 @@ public class VariantBuilder {
   // Try to parse a JSON number as a decimal. Return whether the parsing succeeds. The input must
   // only use the decimal format (an integer value with an optional '.' in it) and must not use
   // scientific notation. It also must fit into the precision limitation of decimal types.
-  private boolean tryParseDecimal(String input) {
+  public boolean tryParseDecimal(String input) {
     for (int i = 0; i < input.length(); ++i) {
       char ch = input.charAt(i);
       if (ch != '-' && ch != '.' && !(ch >= '0' && ch <= '9')) {

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
@@ -559,7 +559,7 @@ public class VariantBuilder {
   // Try to parse a JSON number as a decimal. Return whether the parsing succeeds. The input must
   // only use the decimal format (an integer value with an optional '.' in it) and must not use
   // scientific notation. It also must fit into the precision limitation of decimal types.
-  public boolean tryParseDecimal(String input) {
+  private boolean tryParseDecimal(String input) {
     for (int i = 0; i < input.length(); ++i) {
       char ch = input.charAt(i);
       if (ch != '-' && ch != '.' && !(ch >= '0' && ch <= '9')) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVHeaderChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVHeaderChecker.scala
@@ -52,10 +52,6 @@ class CSVHeaderChecker(
   // the column name don't conform to the schema, an exception is thrown.
   private val enforceSchema = options.enforceSchema
 
-  // When `options.needHeaderForSingleVariantColumn` is true, it will be set to the header column
-  // names and no check will happen (because any name is valid).
-  private[csv] var headerColumnNames: Option[Array[String]] = None
-
   /**
    * Checks that column names in a CSV header and field names in the schema are the same
    * by taking into account case sensitivity.
@@ -63,12 +59,7 @@ class CSVHeaderChecker(
    * @param columnNames names of CSV columns that must be checked against to the schema.
    */
   private def checkHeaderColumnNames(columnNames: Array[String]): Unit = {
-    if (columnNames != null) {
-      if (options.needHeaderForSingleVariantColumn) {
-        headerColumnNames = Some(columnNames)
-        return
-      }
-
+    if (columnNames != null && options.singleVariantColumn.isEmpty) {
       val fieldNames = schema.map(_.name).toIndexedSeq
       val (headerLen, schemaSize) = (columnNames.length, fieldNames.length)
       var errorMessage: Option[MessageWithContext] = None

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVHeaderChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVHeaderChecker.scala
@@ -52,6 +52,8 @@ class CSVHeaderChecker(
   // the column name don't conform to the schema, an exception is thrown.
   private val enforceSchema = options.enforceSchema
 
+  private[csv] var headerColumnNames: Option[Array[String]] = None
+
   /**
    * Checks that column names in a CSV header and field names in the schema are the same
    * by taking into account case sensitivity.
@@ -60,6 +62,11 @@ class CSVHeaderChecker(
    */
   private def checkHeaderColumnNames(columnNames: Array[String]): Unit = {
     if (columnNames != null) {
+      if (options.singleVariantColumn.isDefined) {
+        headerColumnNames = Some(columnNames)
+        return
+      }
+
       val fieldNames = schema.map(_.name).toIndexedSeq
       val (headerLen, schemaSize) = (columnNames.length, fieldNames.length)
       var errorMessage: Option[MessageWithContext] = None

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVHeaderChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVHeaderChecker.scala
@@ -52,6 +52,12 @@ class CSVHeaderChecker(
   // the column name don't conform to the schema, an exception is thrown.
   private val enforceSchema = options.enforceSchema
 
+  // When `options.singleVariantColumn` is defined, it will be set to the header column
+  // names and no check will happen (because any name is valid).
+  private var headerColumnNames: Option[Array[String]] = None
+  // See `CSVDataSource.setHeaderForSingleVariantColumn` for details.
+  var setHeaderForSingleVariantColumn: Option[Option[Array[String]] => Unit] = None
+
   /**
    * Checks that column names in a CSV header and field names in the schema are the same
    * by taking into account case sensitivity.
@@ -59,7 +65,12 @@ class CSVHeaderChecker(
    * @param columnNames names of CSV columns that must be checked against to the schema.
    */
   private def checkHeaderColumnNames(columnNames: Array[String]): Unit = {
-    if (columnNames != null && options.singleVariantColumn.isEmpty) {
+    if (columnNames != null) {
+      if (options.singleVariantColumn.isDefined) {
+        headerColumnNames = Some(columnNames)
+        return
+      }
+
       val fieldNames = schema.map(_.name).toIndexedSeq
       val (headerLen, schemaSize) = (columnNames.length, fieldNames.length)
       var errorMessage: Option[MessageWithContext] = None
@@ -122,6 +133,7 @@ class CSVHeaderChecker(
       val firstRecord = tokenizer.parseNext()
       checkHeaderColumnNames(firstRecord)
     }
+    setHeaderForSingleVariantColumn.foreach(f => f(headerColumnNames))
   }
 
   // This is currently only used to parse CSV with non-multiLine mode.
@@ -137,5 +149,6 @@ class CSVHeaderChecker(
         checkHeaderColumnNames(tokenizer.parseLine(header))
       }
     }
+    setHeaderForSingleVariantColumn.foreach(f => f(headerColumnNames))
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVHeaderChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVHeaderChecker.scala
@@ -52,6 +52,8 @@ class CSVHeaderChecker(
   // the column name don't conform to the schema, an exception is thrown.
   private val enforceSchema = options.enforceSchema
 
+  // When `options.needHeaderForSingleVariantColumn` is true, it will be set to the header column
+  // names and no check will happen (because any name is valid).
   private[csv] var headerColumnNames: Option[Array[String]] = None
 
   /**
@@ -62,7 +64,7 @@ class CSVHeaderChecker(
    */
   private def checkHeaderColumnNames(columnNames: Array[String]): Unit = {
     if (columnNames != null) {
-      if (options.singleVariantColumn.isDefined) {
+      if (options.needHeaderForSingleVariantColumn) {
         headerColumnNames = Some(columnNames)
         return
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -306,6 +306,9 @@ class CSVOptions(
   private val isColumnPruningOptionEnabled: Boolean =
     getBool(COLUMN_PRUNING, !multiLine && columnPruning)
 
+  // This option takes in a column name and specifies that the entire CSV record should be stored
+  // as a single VARIANT type column in the table with the given column name.
+  // E.g. spark.read.format("csv").option("singleVariantColumn", "colName")
   val singleVariantColumn: Option[String] = parameters.get(SINGLE_VARIANT_COLUMN)
 
   def needHeaderForSingleVariantColumn: Boolean =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -415,5 +415,5 @@ object CSVOptions extends DataSourceOptions {
   val DELIMITER = "delimiter"
   newOption(SEP, DELIMITER)
   val COLUMN_PRUNING = newOption("columnPruning")
-  val SINGLE_VARIANT_COLUMN = newOption("singleVariantColumn")
+  val SINGLE_VARIANT_COLUMN = newOption(DataSourceOptions.SINGLE_VARIANT_COLUMN)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -306,6 +306,11 @@ class CSVOptions(
   private val isColumnPruningOptionEnabled: Boolean =
     getBool(COLUMN_PRUNING, !multiLine && columnPruning)
 
+  val singleVariantColumn: Option[String] = parameters.get(SINGLE_VARIANT_COLUMN)
+
+  def needHeaderForSingleVariantColumn: Boolean =
+    singleVariantColumn.isDefined && headerFlag
+
   def asWriterSettings: CsvWriterSettings = {
     val writerSettings = new CsvWriterSettings()
     val format = writerSettings.getFormat
@@ -407,4 +412,5 @@ object CSVOptions extends DataSourceOptions {
   val DELIMITER = "delimiter"
   newOption(SEP, DELIMITER)
   val COLUMN_PRUNING = newOption("columnPruning")
+  val SINGLE_VARIANT_COLUMN = newOption("singleVariantColumn")
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
@@ -500,7 +500,7 @@ class UnivocityParser(
             // possible decimal type to store the value.
             DecimalType.USER_DEFAULT
           } else {
-            parseDate()
+            if (options.preferDate) parseDate() else parseTimestampNTZ()
           }
         } catch {
           case NonFatal(_) =>
@@ -513,7 +513,7 @@ class UnivocityParser(
           builder.appendDate(dateFormatter.parse(s))
           DateType
         } catch {
-          case NonFatal(_) => parseTimestamp()
+          case NonFatal(_) => parseTimestampNTZ()
         }
       }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csv/CsvExpressionEvalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csv/CsvExpressionEvalUtils.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.csv.{CSVInferSchema, CSVOptions, UnivocityP
 import org.apache.spark.sql.catalyst.expressions.ExprUtils
 import org.apache.spark.sql.catalyst.util.{FailFastMode, FailureSafeParser, PermissiveMode}
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.types.{DataType, NullType, StructType}
+import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
 /**
@@ -65,6 +65,11 @@ case class CsvToStructsEvaluator(
     val mode = parsedOptions.parseMode
     if (mode != PermissiveMode && mode != FailFastMode) {
       throw QueryCompilationErrors.parseModeUnsupportedError("from_csv", mode)
+    }
+    if (parsedOptions.singleVariantColumn.isDefined) {
+      if (nullableSchema.length != 1 || nullableSchema.head.dataType != VariantType) {
+        throw QueryCompilationErrors.invalidSingleVariantColumn()
+      }
     }
     ExprUtils.verifyColumnNameOfCorruptRecord(
       nullableSchema,

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDataSource.scala
@@ -140,6 +140,6 @@ class ResolveDataSource(sparkSession: SparkSession) extends Rule[LogicalPlan] {
         paths = finalPaths,
         userSpecifiedSchema = userSpecifiedSchema,
         className = source,
-        options = finalOptions.originalMap).resolveRelation())
+        options = finalOptions.originalMap).resolveRelation(readOnly = true))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -352,7 +352,7 @@ case class DataSource(
    *                        is considered as a non-streaming file based data source. Since we know
    *                        that files already exist, we don't need to check them again.
    */
-  def resolveRelation(checkFilesExist: Boolean = true): BaseRelation = {
+  def resolveRelation(checkFilesExist: Boolean = true, readOnly: Boolean = false): BaseRelation = {
     val relation = (providingInstance(), userSpecifiedSchema) match {
       // TODO: Throw when too much is given.
       case (dataSource: SchemaRelationProvider, Some(schema)) =>
@@ -443,7 +443,7 @@ case class DataSource(
         SchemaUtils.checkSchemaColumnNameDuplication(
           hs.partitionSchema,
           equality)
-        DataSourceUtils.verifySchema(hs.fileFormat, hs.dataSchema)
+        DataSourceUtils.verifySchema(hs.fileFormat, hs.dataSchema, readOnly)
       case _ =>
         SchemaUtils.checkSchemaColumnNameDuplication(
           relation.schema,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -262,7 +262,8 @@ case class DataSource(
 
         val isSchemaInferenceEnabled = sparkSession.sessionState.conf.streamingSchemaInference
         val isTextSource = providingClass == classOf[text.TextFileFormat]
-        val isSingleVariantColumn = providingClass == classOf[json.JsonFileFormat] &&
+        val isSingleVariantColumn = (providingClass == classOf[json.JsonFileFormat] ||
+          providingClass == classOf[csv.CSVFileFormat]) &&
           caseInsensitiveOptions.contains(DataSourceOptions.SINGLE_VARIANT_COLUMN)
         // If the schema inference is disabled, only text sources require schema to be specified
         if (!isSchemaInferenceEnabled && !isTextSource && !isSingleVariantColumn &&

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -91,9 +91,14 @@ object DataSourceUtils extends PredicateHelper {
    * Verify if the schema is supported in datasource. This verification should be done
    * in a driver side.
    */
-  def verifySchema(format: FileFormat, schema: StructType): Unit = {
+  def verifySchema(format: FileFormat, schema: StructType, readOnly: Boolean = false): Unit = {
     schema.foreach { field =>
-      if (!format.supportDataType(field.dataType)) {
+      val supported = if (readOnly) {
+        format.supportDataTypeReadOnly(field.dataType)
+      } else {
+        format.supportDataType(field.dataType)
+      }
+      if (!supported) {
         throw QueryCompilationErrors.dataTypeUnsupportedByDataSourceError(format.toString, field)
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -94,7 +94,7 @@ object DataSourceUtils extends PredicateHelper {
   def verifySchema(format: FileFormat, schema: StructType, readOnly: Boolean = false): Unit = {
     schema.foreach { field =>
       val supported = if (readOnly) {
-        format.supportDataTypeReadOnly(field.dataType)
+        format.supportReadDataType(field.dataType)
       } else {
         format.supportDataType(field.dataType)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -182,7 +182,12 @@ trait FileFormat {
    */
   def supportDataType(dataType: DataType): Boolean = true
 
-  def supportDataTypeReadOnly(dataType: DataType): Boolean = supportDataType(dataType)
+  /**
+   * Returns whether this format supports the given [[DataType]] in the read-only path.
+   * By default, it is the same as `supportDataType`. In certain file formats, it can allow more
+   * data types than `supportDataType`. At this point, only `CSVFileFormat` overrides it.
+   */
+  def supportReadDataType(dataType: DataType): Boolean = supportDataType(dataType)
 
   /**
    * Returns whether this format supports the given filed name in read/write path.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -182,6 +182,8 @@ trait FileFormat {
    */
   def supportDataType(dataType: DataType): Boolean = true
 
+  def supportDataTypeReadOnly(dataType: DataType): Boolean = supportDataType(dataType)
+
   /**
    * Returns whether this format supports the given filed name in read/write path.
    * By default all field name is supported.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.text.TextFileFormat
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
 /**
@@ -68,10 +68,14 @@ abstract class CSVDataSource extends Serializable {
       sparkSession: SparkSession,
       inputPaths: Seq[FileStatus],
       parsedOptions: CSVOptions): Option[StructType] = {
-    if (inputPaths.nonEmpty) {
-      Some(infer(sparkSession, inputPaths, parsedOptions))
-    } else {
-      None
+    parsedOptions.singleVariantColumn match {
+      case Some(columnName) => Some(StructType(Array(StructField(columnName, VariantType))))
+      case None =>
+        if (inputPaths.nonEmpty) {
+          Some(infer(sparkSession, inputPaths, parsedOptions))
+        } else {
+          None
+        }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
@@ -48,7 +48,6 @@ class CSVFileFormat extends TextBasedFileFormat with DataSourceRegister {
       columnPruning = sparkSession.sessionState.conf.csvColumnPruning,
       sparkSession.sessionState.conf.sessionLocalTimeZone)
     val csvDataSource = CSVDataSource(parsedOptions)
-    !parsedOptions.needHeaderForSingleVariantColumn &&
     csvDataSource.isSplitable && super.isSplitable(sparkSession, options, path)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -315,7 +315,7 @@ class FileStreamSource(
         className = fileFormatClassName,
         options = optionsForInnerDataSource)
     Dataset.ofRows(sparkSession, LogicalRelation(newDataSource.resolveRelation(
-      checkFilesExist = false), isStreaming = true))
+      checkFilesExist = false, readOnly = true), isStreaming = true))
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
@@ -734,7 +734,7 @@ class CsvFunctionsSuite extends QueryTest with SharedSparkSession {
     checkAnswer(actual, Row("-"))
   }
 
-  test("SPARK-47497: from_csv/to_csv does not support VariantType data") {
+  test("SPARK-47497: to_csv does not support VariantType data") {
     val rows = new java.util.ArrayList[Row]()
     rows.add(Row(1L, Row(2L, "Alice", new VariantVal(Array[Byte](1, 2, 3), Array[Byte](4, 5)))))
 
@@ -758,14 +758,6 @@ class CsvFunctionsSuite extends QueryTest with SharedSparkSession {
         "dataType" -> "\"STRUCT<age: BIGINT, name: STRING, v: VARIANT>\"",
         "sqlExpr" -> "\"to_csv(value)\""),
       context = ExpectedContext(fragment = "to_csv", getCurrentClassCallSitePattern)
-    )
-
-    checkError(
-      exception = intercept[SparkUnsupportedOperationException] {
-        df.select(from_csv(lit("data"), valueSchema, Map.empty[String, String])).collect()
-      },
-      condition = "UNSUPPORTED_DATATYPE",
-      parameters = Map("typeName" -> "\"VARIANT\"")
     )
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
@@ -759,11 +759,55 @@ class CsvFunctionsSuite extends QueryTest with SharedSparkSession {
         "sqlExpr" -> "\"to_csv(value)\""),
       context = ExpectedContext(fragment = "to_csv", getCurrentClassCallSitePattern)
     )
+  }
 
-    checkAnswer(
-      df.select(from_csv(lit("1,2,3"), valueSchema, Map.empty[String, String])),
-      Seq(Row(Row(1L, "2", new VariantVal(Array[Byte](12, 3), Array[Byte](1, 0, 0)))))
-    )
+  test("from_csv with variant") {
+    val df = Seq(
+      "100,1.1",
+      "2000-01-01,2000-01-01 01:02:03",
+      ",true",
+      "1e9,hello,extra",
+      "missing").toDF("value").coalesce(1)
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      // The `header` option doesn't affect results, just like non-variant from_csv.
+      for (header <- Seq("true", "false")) {
+        checkAnswer(
+          df.select(
+            from_csv(
+              $"value",
+              StructType.fromDDL("a variant, b variant"),
+              Map("header" -> header)
+            ).cast("string")),
+          Seq(
+            Row("{100, 1.1}"),
+            Row("""{"2000-01-01", "2000-01-01 01:02:03+00:00"}"""),
+            Row("{null, true}"),
+            Row("""{"1e9", "hello"}"""),
+            Row("""{"missing", null}""")))
+        checkAnswer(
+          df.select(
+            from_csv(
+              $"value",
+              StructType.fromDDL("v variant"),
+              Map("header" -> header, "singleVariantColumn" -> "true")
+            ).cast("string")),
+          Seq(
+            Row("""{{"_c0":100,"_c1":1.1}}"""),
+            Row("""{{"_c0":"2000-01-01","_c1":"2000-01-01 01:02:03+00:00"}}"""),
+            Row("""{{"_c0":null,"_c1":true}}"""),
+            Row("""{{"_c0":"1e9","_c1":"hello","_c2":"extra"}}"""),
+            Row("""{{"_c0":"missing"}}""")))
+      }
+    }
+    checkError(
+      exception = intercept[AnalysisException] {
+        df.select(
+          from_csv(
+          $"value",
+          StructType.fromDDL("a variant, b variant"),
+          Map("singleVariantColumn" -> "true"))).collect()
+      },
+      condition = "INVALID_SINGLE_VARIANT_COLUMN")
   }
 
   test("SPARK-47497: the input of to_csv must be StructType") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
@@ -759,6 +759,11 @@ class CsvFunctionsSuite extends QueryTest with SharedSparkSession {
         "sqlExpr" -> "\"to_csv(value)\""),
       context = ExpectedContext(fragment = "to_csv", getCurrentClassCallSitePattern)
     )
+
+    checkAnswer(
+      df.select(from_csv(lit("1,2,3"), valueSchema, Map.empty[String, String])),
+      Seq(Row(Row(1L, "2", new VariantVal(Array[Byte](12, 3), Array[Byte](1, 0, 0)))))
+    )
   }
 
   test("SPARK-47497: the input of to_csv must be StructType") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -3514,9 +3514,6 @@ abstract class CSVSuite
         )
       }
 
-      val legacy = SQLConf.get.legacyTimeParserPolicy == LegacyBehaviorPolicy.LEGACY
-      val timestampResult = if (legacy) "2000-01-01" else "2000-01-01 01:02:03+00:00"
-
       checkSingleVariant(Map(),
         """{"_c0":"field 1","_c1":"field2"}""",
         """{"_c0":"100","_c1":"1.1"}""",
@@ -3532,7 +3529,7 @@ abstract class CSVSuite
         checkSingleVariant(Map(),
           """{"_c0":"field 1","_c1":"field2"}""",
           """{"_c0":100,"_c1":1.1}""",
-          s"""{"_c0":"2000-01-01","_c1":"$timestampResult"}""",
+          """{"_c0":"2000-01-01","_c1":"2000-01-01 01:02:03+00:00"}""",
           """{"_c0":null,"_c1":true}""",
           """{"_c0":1000000000,"_c1":"hello","_c2":"extra"}""",
           """{"_c0":"missing"}""")
@@ -3541,7 +3538,7 @@ abstract class CSVSuite
       withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
         checkSingleVariant(Map("header" -> "true"),
           """{"field 1":100,"field2":1.1}""",
-          s"""{"field 1":"2000-01-01","field2":"$timestampResult"}""",
+          """{"field 1":"2000-01-01","field2":"2000-01-01 01:02:03+00:00"}""",
           """{"field 1":null,"field2":true}""",
           """{"field 1":"1e9","field2":"hello"}""",
           """{"field 1":"missing"}""")
@@ -3553,7 +3550,7 @@ abstract class CSVSuite
         SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
         checkSingleVariant(Map("header" -> "true"),
           """{"field 1":100,"field2":1.1}""",
-          s"""{"field 1":"2000-01-01","field2":"$timestampResult"}""",
+          """{"field 1":"2000-01-01","field2":"2000-01-01 01:02:03+00:00"}""",
           """{"field 1":null,"field2":true}""",
           """{"field 1":1000000000,"field2":"hello"}""",
           """{"field 1":"missing"}""")
@@ -3588,7 +3585,7 @@ abstract class CSVSuite
 
       checkSchema(Map("header" -> "true"),
         ("100", "1.1"),
-        ("2000-01-01", if (legacy) "2000-01-01" else "2000-01-01 01:02:03"),
+        ("2000-01-01", "2000-01-01 01:02:03"),
         (null, "true"),
         ("1e9", "hello"),
         ("missing", null))
@@ -3682,7 +3679,10 @@ class CSVv2Suite extends CSVSuite {
 class CSVLegacyTimeParserSuite extends CSVSuite {
 
   override def excluded: Seq[String] =
-    Seq("Write timestamps correctly in ISO8601 format by default")
+    Seq("Write timestamps correctly in ISO8601 format by default",
+      // The result is different because the date/timestamp parser behavior is different. Not too
+      // much value to test it.
+      "csv with variant")
 
   override protected def sparkConf: SparkConf =
     super

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -3510,10 +3510,6 @@ abstract class CSVSuite
           spark.read.options(allOptions).csv(path.getCanonicalPath).selectExpr("cast(v as string)"),
           expected.map(Row(_))
         )
-        checkAnswer(
-          spark.read.options(allOptions).csv(path.getCanonicalPath).selectExpr("count(*)"),
-          Row(expected.length)
-        )
       }
 
       checkSingleVariant(Map(),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -3583,6 +3583,25 @@ abstract class CSVSuite
       )
     }
   }
+
+  test("write variant with csv is disallowed") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.sql("create table test_table(v variant) using csv")
+      },
+      condition = "UNSUPPORTED_DATA_TYPE_FOR_DATASOURCE",
+      parameters = Map("columnName" -> "`v`", "columnType" -> "\"VARIANT\"", "format" -> "CSV")
+    )
+    checkError(
+      exception = intercept[AnalysisException] {
+        withTempPath { path =>
+          spark.sql("select cast(1 as variant) v").write.csv(path.getCanonicalPath)
+        }
+      },
+      condition = "UNSUPPORTED_DATA_TYPE_FOR_DATASOURCE",
+      parameters = Map("columnName" -> "`v`", "columnType" -> "\"VARIANT\"", "format" -> "CSV")
+    )
+  }
 }
 
 class CSVv1Suite extends CSVSuite {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -3516,17 +3516,17 @@ abstract class CSVSuite
         """{"_c0":"field 1","_c1":"field2"}""",
         """{"_c0":1.1,"_c1":"1e9"}""",
         """{"_c0":null,"_c1":"hello"}""",
-        """{"_c0":"world\"","_c1":"true"}""")
+        """{"_c0":"world\"","_c1":true}""")
 
       checkSingleVariant(Map("header" -> "true"),
         """{"field 1":1.1,"field2":"1e9"}""",
         """{"field 1":null,"field2":"hello"}""",
-        """{"field 1":"world\"","field2":"true"}""")
+        """{"field 1":"world\"","field2":true}""")
 
       checkSingleVariant(Map("multiLine" -> "true"),
         """{"_c0":"field 1","_c1":"field2"}""",
         """{"_c0":1.1,"_c1":"1e9"}""",
-        """{"_c0":null,"_c1":"hello\nworld","_c2":"true"}""")
+        """{"_c0":null,"_c1":"hello\nworld","_c2":true}""")
 
       checkSingleVariant(Map("multiLine" -> "true", "header" -> "true"),
         """{"field 1":1.1,"field2":"1e9"}""",


### PR DESCRIPTION
### What changes were proposed in this pull request?

It supports reading CSV data into the variant data type (including CSV scan and the from_csv expression). Writing variant data as CSV currently is and will remain unsupported.

If a column is specified as the variant type when reading CSV data, the corresponding comma-separated value will be converted into variant data. The CSV parser will maintain the current content type of the variant column (long, decimal, date, timestamp, boolean). When encountering a new value, it tries to parse the input as the current content type. If the parsing fails, the parser moves to the next type and continues the trial. It either successfully parses the input as a specific scalar type, or fails after trying all the types and defaults to the string type.

Similar to JSON scan, we will support the singleVariantColumn option in CSV scan. The option value is a string that specifies the name of the single output column of variant type. When this option is set, the entire line of CSV data is collected into a single variant object. The existing header option in CSV scan interacts with singleVariantColumn. If header is set to true when using singleVariantColumn, the first line of the CSV file will be treated as the header row, and the field names will be extracted from it.

### Why are the changes needed?

It allows users to ingest CSV data with variant.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.

### Was this patch authored or co-authored using generative AI tooling?

No.