### PR TITLE
[SPARK-51310][SQL] Resolve the type of default string producing expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
@@ -137,8 +137,7 @@ object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
   }
 
   private def shouldCastDefaultStringExpr(expression: Expression): Boolean = expression match {
-    case ex: DefaultStringProducingExpression =>
-      ex.getTagValue(CAST_ADDED_TAG).isEmpty
+    case ex: DefaultStringProducingExpression => ex.getTagValue(CAST_ADDED_TAG).isEmpty
     case _ => false
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.catalyst.analysis
 import org.apache.spark.sql.catalyst.expressions.{Cast, DefaultStringProducingExpression, Expression, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.{AddColumns, AlterColumns, AlterColumnSpec, AlterTableCommand, AlterViewAs, ColumnDefinition, CreateTable, CreateView, LogicalPlan, QualifiedColType, ReplaceColumns, V2CreateTablePlan}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.connector.catalog.TableCatalog
 import org.apache.spark.sql.types.{DataType, StringType}
 
@@ -29,9 +28,6 @@ import org.apache.spark.sql.types.{DataType, StringType}
  * collation from the corresponding object (table/view -> schema -> catalog).
  */
 object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
-  // Tag to mark expressions that have been cast to a new type so that we can
-  // avoid infinite recursion when resolving the same expression multiple times.
-  private val CAST_ADDED_TAG = new TreeNodeTag[Unit]("defaultStringExpressionCastAdded")
 
   def apply(plan: LogicalPlan): LogicalPlan = {
     if (isDDLCommand(plan)) {
@@ -105,11 +101,13 @@ object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
    * new type instead of the default string type.
    */
   private def transformPlan(plan: LogicalPlan, newType: StringType): LogicalPlan = {
-    plan resolveExpressionsUp { expression =>
+    val transformedPlan = plan resolveExpressionsUp { expression =>
       transformExpression
         .andThen(_.apply(newType))
         .applyOrElse(expression, identity[Expression])
     }
+
+    castDefaultStringExpressions(transformedPlan, newType)
   }
 
   /**
@@ -124,21 +122,29 @@ object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
 
     case Literal(value, dt) if hasDefaultStringType(dt) =>
       newType => Literal(value, replaceDefaultStringType(dt, newType))
-
-    case expression if shouldCastDefaultStringExpr(expression) =>
-      expression.setTagValue(CAST_ADDED_TAG, ())
-      newType => {
-        if (newType == StringType) {
-          expression
-        } else {
-          Cast(expression, replaceDefaultStringType(expression.dataType, newType))
-        }
-      }
   }
 
-  private def shouldCastDefaultStringExpr(expression: Expression): Boolean = expression match {
-    case ex: DefaultStringProducingExpression => ex.getTagValue(CAST_ADDED_TAG).isEmpty
-    case _ => false
+  /**
+   * Casts [[DefaultStringProducingExpression]] in the plan to the `newType`.
+   */
+  private def castDefaultStringExpressions(plan: LogicalPlan, newType: StringType): LogicalPlan = {
+    if (newType == StringType) return plan
+
+    plan.mapChildren { operator =>
+      operator.mapExpressions { expression =>
+        expression.mapChildren {
+          // Skip if we already added a cast in the previous pass.
+          case cast @ Cast(_: DefaultStringProducingExpression, dt, _, _) if newType == dt =>
+            cast
+
+          case e: DefaultStringProducingExpression =>
+            Cast(e, replaceDefaultStringType(e.dataType, newType))
+
+          case other =>
+            other
+        }
+      }
+    }
   }
 
   private def hasDefaultStringType(dataType: DataType): Boolean =

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
@@ -262,39 +262,6 @@ abstract class DefaultCollationTestSuite extends QueryTest with SharedSparkSessi
     }
   }
 
-  test("view has utf8 binary collation by default") {
-    withView(testTable) {
-      sql(s"CREATE VIEW $testTable AS SELECT current_database() AS db")
-      assertTableColumnCollation(testTable, "db", "UTF8_BINARY")
-    }
-  }
-
-  test("default string producing expressions in view definition") {
-    val viewDefaultCollation = Seq(
-      "UTF8_BINARY", "UNICODE"
-    )
-
-    viewDefaultCollation.foreach { collation =>
-      withView(testTable) {
-
-        val columns = defaultStringProducingExpressions.zipWithIndex.map {
-          case (expr, index) => s"$expr AS c${index + 1}"
-        }.mkString(", ")
-
-        sql(
-          s"""
-             |CREATE view $testTable
-             |DEFAULT COLLATION $collation
-             |AS SELECT $columns
-             |""".stripMargin)
-
-        (1 to defaultStringProducingExpressions.length).foreach { index =>
-          assertTableColumnCollation(testTable, s"c$index", collation)
-        }
-      }
-    }
-  }
-
   // endregion
 }
 
@@ -366,6 +333,39 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
                  |ON $testView.c1 = $joinTableName.c1 COLLATE UNICODE_CI
                  |""".stripMargin),
           Row(fullyQualifiedPrefix + "UNICODE_CI", fullyQualifiedPrefix + "UTF8_LCASE"))
+      }
+    }
+  }
+
+  test("view has utf8 binary collation by default") {
+    withView(testTable) {
+      sql(s"CREATE VIEW $testTable AS SELECT current_database() AS db")
+      assertTableColumnCollation(testTable, "db", "UTF8_BINARY")
+    }
+  }
+
+  test("default string producing expressions in view definition") {
+    val viewDefaultCollation = Seq(
+      "UTF8_BINARY", "UNICODE"
+    )
+
+    viewDefaultCollation.foreach { collation =>
+      withView(testTable) {
+
+        val columns = defaultStringProducingExpressions.zipWithIndex.map {
+          case (expr, index) => s"$expr AS c${index + 1}"
+        }.mkString(", ")
+
+        sql(
+          s"""
+             |CREATE view $testTable
+             |DEFAULT COLLATION $collation
+             |AS SELECT $columns
+             |""".stripMargin)
+
+        (1 to defaultStringProducingExpressions.length).foreach { index =>
+          assertTableColumnCollation(testTable, s"c$index", collation)
+        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
@@ -369,6 +369,25 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
       }
     }
   }
+
+  test("default string producing expressions in view definition - nested in expr tree") {
+    withView(testTable) {
+      sql(
+        s"""
+           |CREATE view $testTable
+           |DEFAULT COLLATION UNICODE AS SELECT
+           |SUBSTRING(current_database(), 1, 1) AS c1,
+           |SUBSTRING(SUBSTRING(current_database(), 1, 2), 1, 1) AS c2,
+           |SUBSTRING(current_database()::STRING, 1, 1) AS c3,
+           |SUBSTRING(CAST(current_database() AS STRING COLLATE UTF8_BINARY), 1, 1) AS c4
+           |""".stripMargin)
+
+      assertTableColumnCollation(testTable, "c1", "UNICODE")
+      assertTableColumnCollation(testTable, "c2", "UNICODE")
+      assertTableColumnCollation(testTable, "c3", "UNICODE")
+      assertTableColumnCollation(testTable, "c4", "UTF8_BINARY")
+    }
+  }
 }
 
 class DefaultCollationTestSuiteV2 extends DefaultCollationTestSuite with DatasourceV2SQLBase {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add casts to `DefaultStringProducingExpression` to have the correct type based on the default string type.

Currently, we can only test this on views, until we implement schema level collations when we will be able to test the behavior on newly created tables as well.

### Why are the changes needed?
These expressions should return the default string type, which could be different in some DDL commands.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added unit tests for view creation.

### Was this patch authored or co-authored using generative AI tooling?
No.