### PR TITLE
[SPARK-51300][PS][DOCS] Fix broken link for `ps.sql`

### DIFF
--- a/python/pyspark/pandas/sql_formatter.py
+++ b/python/pyspark/pandas/sql_formatter.py
@@ -109,13 +109,12 @@ def sql(
     args : dict or list
         A dictionary of parameter names to Python objects or a list of Python objects
         that can be converted to SQL literal expressions. See
-        `Supported Data Types`_ for supported value types in Python.
+        `Supported Data Types <https://spark.apache.org/docs/latest/sql-ref-datatypes.html>`_
+        for supported value types in Python.
         For example, dictionary keys: "rank", "name", "birthdate";
         dictionary values: 1, "Steven", datetime.date(2023, 4, 2).
         A value can be also a `Column` of a literal or collection constructor functions such
         as `map()`, `array()`, `struct()`, in that case it is taken as is.
-
-        .. _Supported Data Types: https://spark.apache.org/docs/latest/sql-ref-datatypes.html
 
         .. versionadded:: 3.4.0
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix broken link for `ps.sql`

### Why are the changes needed?

There is broken link in official documentation for `ps.sql`


<img width="630" alt="Screenshot 2025-02-24 at 3 18 33 PM" src="https://github.com/user-attachments/assets/de70f1a9-35a2-4adb-80e4-d9726170344e" />


### Does this PR introduce _any_ user-facing change?

No API changes, but the user-facing documentation improvement.

### How was this patch tested?

Manually tested, and the existing doc build in CI should pass

### Was this patch authored or co-authored using generative AI tooling?

No