### PR TITLE
[SPARK-51306][TESTS] Fix test errors caused by improper DROP TABLE/VIEW in describe.sql

### DIFF
--- a/sql/core/src/test/resources/sql-tests/analyzer-results/describe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/describe.sql.out
@@ -334,41 +334,9 @@ ExplainCommand 'DescribeRelationJsonCommand [c=Us, d=2], true, [json_metadata#x]
 
 
 -- !query
-DROP TABLE t
--- !query analysis
-DropTable false, false
-+- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.t
-
-
--- !query
-DROP VIEW temp_v
--- !query analysis
-DropTempViewCommand temp_v
-
-
--- !query
-DROP VIEW temp_Data_Source_View
--- !query analysis
-DropTempViewCommand temp_Data_Source_View
-
-
--- !query
-DROP VIEW v
--- !query analysis
-DropTableCommand `spark_catalog`.`default`.`v`, false, true, false
-
-
--- !query
 CREATE TABLE d (a STRING DEFAULT 'default-value', b INT DEFAULT 42) USING parquet COMMENT 'table_comment'
 -- !query analysis
-org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
-{
-  "errorClass" : "TABLE_OR_VIEW_ALREADY_EXISTS",
-  "sqlState" : "42P07",
-  "messageParameters" : {
-    "relationName" : "`spark_catalog`.`default`.`d`"
-  }
-}
+CreateDataSourceTableCommand `spark_catalog`.`default`.`d`, false
 
 
 -- !query
@@ -398,14 +366,7 @@ DescribeTableCommand `spark_catalog`.`default`.`d`, true, [col_name#x, data_type
 -- !query
 CREATE TABLE e (a STRING DEFAULT CONCAT('a\n b\n ', 'c\n d'), b INT DEFAULT 42) USING parquet COMMENT 'table_comment'
 -- !query analysis
-org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
-{
-  "errorClass" : "TABLE_OR_VIEW_ALREADY_EXISTS",
-  "sqlState" : "42P07",
-  "messageParameters" : {
-    "relationName" : "`spark_catalog`.`default`.`e`"
-  }
-}
+CreateDataSourceTableCommand `spark_catalog`.`default`.`e`, false
 
 
 -- !query
@@ -430,3 +391,42 @@ DescribeTableCommand `spark_catalog`.`default`.`e`, true, [col_name#x, data_type
 DESC FORMATTED e
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`e`, true, [col_name#x, data_type#x, comment#x]
+
+
+-- !query
+DROP VIEW temp_v
+-- !query analysis
+DropTempViewCommand temp_v
+
+
+-- !query
+DROP VIEW temp_Data_Source_View
+-- !query analysis
+DropTempViewCommand temp_Data_Source_View
+
+
+-- !query
+DROP VIEW v
+-- !query analysis
+DropTableCommand `spark_catalog`.`default`.`v`, false, true, false
+
+
+-- !query
+DROP TABLE t
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.t
+
+
+-- !query
+DROP TABLE d
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.d
+
+
+-- !query
+DROP TABLE e
+-- !query analysis
+DropTable false, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.e

--- a/sql/core/src/test/resources/sql-tests/inputs/describe.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/describe.sql
@@ -100,15 +100,6 @@ EXPLAIN DESCRIBE t b;
 EXPLAIN DESCRIBE t PARTITION (c='Us', d=2);
 EXPLAIN DESCRIBE EXTENDED t PARTITION (c='Us', d=2) AS JSON;
 
--- DROP TEST TABLES/VIEWS
-DROP TABLE t;
-
-DROP VIEW temp_v;
-
-DROP VIEW temp_Data_Source_View;
-
-DROP VIEW v;
-
 -- Show column default values
 CREATE TABLE d (a STRING DEFAULT 'default-value', b INT DEFAULT 42) USING parquet COMMENT 'table_comment';
 
@@ -131,3 +122,16 @@ DESC TABLE EXTENDED e;
 
 DESC FORMATTED e;
 
+-- DROP TEST TABLES/VIEWS
+
+DROP VIEW temp_v;
+
+DROP VIEW temp_Data_Source_View;
+
+DROP VIEW v;
+
+DROP TABLE t;
+
+DROP TABLE d;
+
+DROP TABLE e;

--- a/sql/core/src/test/resources/sql-tests/results/describe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/describe.sql.out
@@ -699,38 +699,6 @@ Execute DescribeRelationJsonCommand
 
 
 -- !query
-DROP TABLE t
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-DROP VIEW temp_v
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-DROP VIEW temp_Data_Source_View
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-DROP VIEW v
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
 CREATE TABLE d (a STRING DEFAULT 'default-value', b INT DEFAULT 42) USING parquet COMMENT 'table_comment'
 -- !query schema
 struct<>
@@ -920,3 +888,51 @@ Location [not included in comparison]/{warehouse_dir}/e
 # Column Default Values	                    	                    
 a                   	string              	CONCAT('a\n b\n ', 'c\n d')
 b                   	int                 	42
+
+
+-- !query
+DROP VIEW temp_v
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+DROP VIEW temp_Data_Source_View
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+DROP VIEW v
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+DROP TABLE t
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+DROP TABLE d
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+DROP TABLE e
+-- !query schema
+struct<>
+-- !query output
+


### PR DESCRIPTION


### What changes were proposed in this pull request?

This PR fixes test errors caused by improper DROP TABLE/VIEW in describe.sql

- Table Not Found Error when dropping views after dropping the base table
- Table Already Exists Error w/o proper drop



### Why are the changes needed?
test fix


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

the existing tests

### Was this patch authored or co-authored using generative AI tooling?
no
