### PR TITLE
[SPARK-50098][PYTHON][FOLLOW-UP] Update _minimum_googleapis_common_protos_version in setup.py for pyspark-client

### DIFF
--- a/python/packaging/client/setup.py
+++ b/python/packaging/client/setup.py
@@ -134,7 +134,7 @@ try:
     _minimum_numpy_version = "1.21"
     _minimum_pyarrow_version = "11.0.0"
     _minimum_grpc_version = "1.59.3"
-    _minimum_googleapis_common_protos_version = "1.56.4"
+    _minimum_googleapis_common_protos_version = "1.65.0"
 
     with open("README.md") as f:
         long_description = f.read()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/48643 that updates _minimum_googleapis_common_protos_version in setup.py for pyspark-client

### Why are the changes needed?

To match the version with pyspark.

### Does this PR introduce _any_ user-facing change?

No, `pyspark-client` has not been released yet.

### How was this patch tested?

It will be tested in "Debug Build / Spark Connect Python-only (master, Python 3.11) " build.

### Was this patch authored or co-authored using generative AI tooling?

No.