### PR TITLE
[SPARK-50015][PYTHON][FOLLOW-UP] Update _minimum_grpc_version in setup.py for pyspark-client

### DIFF
--- a/python/packaging/client/setup.py
+++ b/python/packaging/client/setup.py
@@ -133,7 +133,7 @@ try:
     _minimum_pandas_version = "2.0.0"
     _minimum_numpy_version = "1.21"
     _minimum_pyarrow_version = "11.0.0"
-    _minimum_grpc_version = "1.59.3"
+    _minimum_grpc_version = "1.67.0"
     _minimum_googleapis_common_protos_version = "1.56.4"
 
     with open("README.md") as f:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/48524 that updates _minimum_grpc_version in setup.py for pyspark-client

### Why are the changes needed?

To match the version with pyspark.

### Does this PR introduce _any_ user-facing change?

No, `pyspark-client` has not been released yet.

### How was this patch tested?

It will be tested in "Debug Build / Spark Connect Python-only (master, Python 3.11) " build.

### Was this patch authored or co-authored using generative AI tooling?

No.