### PR TITLE
[SPARK-51305][SQL][CONNECT] Improve `SparkConnectPlanExecution.createObservedMetricsResponse`

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
@@ -266,8 +266,10 @@ private[execution] class SparkConnectPlanExecution(executeHolder: ExecuteHolder)
       dataframe: DataFrame): Option[ExecutePlanResponse] = {
     val observedMetrics = dataframe.queryExecution.observedMetrics.collect {
       case (name, row) if !executeHolder.observations.contains(name) =>
-        val values = (0 until row.length).map { i =>
-          (if (row.schema != null) Some(row.schema.fieldNames(i)) else None, row(i))
+        val values = if (row.schema == null) {
+          (0 until row.length).map { i => (None, row(i)) }
+        } else {
+          (0 until row.length).map { i => (Some(row.schema.fieldNames(i)), row(i)) }
         }
         name -> values
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to improve the code for `createObservedMetricsResponse`.


### Why are the changes needed?
There exists a duplicate judgement in loop, we should eliminate it.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
