### PR TITLE
[SPARK-50692][SQL][FOLLOWUP] Add the LPAD and RPAD pushdown support for H2

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
@@ -52,7 +52,7 @@ private[sql] case class H2Dialect() extends JdbcDialect with NoLegacyJDBCError {
       "POWER", "SQRT", "FLOOR", "CEIL", "ROUND", "SIN", "SINH", "COS", "COSH", "TAN",
       "TANH", "COT", "ASIN", "ACOS", "ATAN", "ATAN2", "DEGREES", "RADIANS", "SIGN",
       "PI", "SUBSTRING", "UPPER", "LOWER", "TRANSLATE", "TRIM", "MD5", "SHA1", "SHA2",
-      "BIT_LENGTH", "CHAR_LENGTH", "CONCAT")
+      "BIT_LENGTH", "CHAR_LENGTH", "CONCAT", "RPAD", "LPAD")
 
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -1922,6 +1922,16 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     checkFiltersRemoved(df8)
     checkPushedInfo(df8, "[(CONCAT(NAME, ',', CAST(SALARY AS string))) = 'cathy,9000.00']")
     checkAnswer(df8, Seq(Row(1, "cathy", 9000, 1200, false)))
+
+    val df9 = sql("SELECT * FROM h2.test.employee WHERE " +
+      "lpad(name, 5, '*') = '**amy'")
+    checkPushedInfo(df9, "[NAME IS NOT NULL, (LPAD(NAME, 5, '*')) = '**amy']")
+    checkAnswer(df9, Seq(Row(1, "amy", 10000, 1000, true)))
+
+    val df10 = sql("SELECT * FROM h2.test.employee WHERE " +
+      "rpad(name, 5, '*') = 'jen**'")
+    checkPushedInfo(df10, "[NAME IS NOT NULL, (RPAD(NAME, 5, '*')) = 'jen**']")
+    checkAnswer(df10, Seq(Row(6, "jen", 12000, 1200, true)))
   }
 
   test("scan with aggregate push-down: MAX AVG with filter and group by") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to add the `LPAD` and `RPAD` pushdown support for H2.


### Why are the changes needed?
https://github.com/apache/spark/pull/49325 added the support for `RPAD` pushdown.
H2 as a built-in JDBC dialect for the test purpose, should add the `LPAD` and `RPAD` pushdown support for H2.


### Does this PR introduce _any_ user-facing change?
'Yes'.
Spark will supports pushdown for `LPAD` and `RPAD` for H2.


### How was this patch tested?
GA>


### Was this patch authored or co-authored using generative AI tooling?
'No'.
