### PR TITLE
[SPARK-51156][CONNECT][FOLLOWUP] Remove unused `private val AUTH_TOKEN_ON_INSECURE_CONN_ERROR_MSG` from `SparkConnectClient`

### DIFF
--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -406,10 +406,6 @@ object SparkConnectClient {
   private val AUTH_TOKEN_META_DATA_KEY: Metadata.Key[String] =
     Metadata.Key.of("Authentication", Metadata.ASCII_STRING_MARSHALLER)
 
-  private val AUTH_TOKEN_ON_INSECURE_CONN_ERROR_MSG: String =
-    "Authentication token cannot be passed over insecure connections. " +
-      "Either remove 'token' or set 'use_ssl=true'"
-
   // for internal tests
   private[sql] def apply(channel: ManagedChannel): SparkConnectClient = {
     new SparkConnectClient(Configuration(), channel)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to remove unused `private val AUTH_TOKEN_ON_INSECURE_CONN_ERROR_MSG` from `SparkConnectClient`  because it becomes a useless `private val` declaration after https://github.com/apache/spark/pull/50006.



### Why are the changes needed?
Remove unused `private val`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No