### PR TITLE
[SPARK-51099][PYTHON][FOLLOWUP] Avoid logging when selector.select returns 0 without waiting the configured timeout

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -707,6 +707,7 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
       }
     }
 
+    private[this] val idleTimeoutMillis: Long = TimeUnit.SECONDS.toMillis(idleTimeoutSeconds)
     private[this] var pythonWorkerKilled: Boolean = false
 
     override def read(b: Array[Byte], off: Int, len: Int): Int = {
@@ -742,8 +743,13 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
       val buf = ByteBuffer.wrap(b, off, len)
       var n = 0
       while (n == 0) {
-        val selected = worker.selector.select(TimeUnit.SECONDS.toMillis(idleTimeoutSeconds))
-        if (selected == 0) {
+        val start = System.currentTimeMillis()
+        val selected = worker.selector.select(idleTimeoutMillis)
+        val end = System.currentTimeMillis()
+        if (selected == 0
+          // Avoid logging if no timeout or the selector doesn't wait for the idle timeout
+          // as it can return 0 in some case.
+          && idleTimeoutMillis > 0 && (end - start) >= idleTimeoutMillis) {
           if (pythonWorkerKilled) {
             logWarning(
               log"Waiting for Python worker process to terminate after idle timeout: " +


### PR DESCRIPTION
### What changes were proposed in this pull request?

Avoids logging when `selector.select` returns `0` without waiting the configured timeout.

### Why are the changes needed?

There is a case of spurious wakeup while waiting the selector.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing tests should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.
