### PR TITLE
[SPARK-34616] requireDbExists is called too many times

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -260,7 +260,8 @@ class SessionCatalog(
   }
 
   private def requireDbExists(db: String): Unit = {
-    if (!databaseExists(db)) {
+    val requireDbExistsEnabled = SQLConf.get.requireDbExistsEnabled
+    if("true".equals(requireDbExistsEnabled) && !databaseExists(db)) {
       throw new NoSuchNamespaceException(Seq(CatalogManager.SESSION_CATALOG_NAME, db))
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -46,6 +46,7 @@ import org.apache.spark.sql.catalyst.plans.logical.HintErrorHandler
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
+import org.apache.spark.sql.internal.StaticSQLConf.ENABLED_REQUIREDBEXISTS
 import org.apache.spark.sql.types.{AtomicType, TimestampNTZType, TimestampType}
 import org.apache.spark.storage.{StorageLevel, StorageLevelMapper}
 import org.apache.spark.unsafe.array.ByteArrayMethods
@@ -6763,4 +6764,6 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def isModifiable(key: String): Boolean = {
     containsConfigKey(key) && !isStaticConfigKey(key)
   }
+
+  def requireDbExistsEnabled: String = getConf(ENABLED_REQUIREDBEXISTS)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -314,4 +314,12 @@ object StaticSQLConf {
     .version("4.0.0")
     .booleanConf
     .createWithDefault(true)
+
+  val ENABLED_REQUIREDBEXISTS =
+    buildStaticConf("spark.sql.requireDbExists.enabled")
+      .internal()
+      .doc("spark sql is need to requireDbExists")
+      .version("4.0.0")
+      .stringConf
+      .createWithDefault("true")
 }


### PR DESCRIPTION
[SPARK-34616](https://issues.apache.org/jira/browse/SPARK-34616)
Almost all SQL need to check if database exist before execution.

Additionally, when Spark SQL reads Hive tables across databases, the logic for checking whether the database exists can also lead to permission issues.

This PR aims to disable the database existence check logic by introducing the configuration option --conf spark.sql.requireDbExists.enabled=false