### PR TITLE
[SPARK-51316][PYTHON] Allow Arrow batches in bytes instead of number of rows

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_map.py
@@ -205,7 +205,7 @@ class MapInArrowWithArrowBatchSlicingTestsAndReducedBatchSizeTests(MapInArrowTes
         MapInArrowTests.setUpClass()
         # Set it to a small odd value to exercise batching logic for all test cases
         cls.spark.conf.set("spark.sql.execution.arrow.maxRecordsPerBatch", "3")
-        cls.spark.conf.set("spark.sql.execution.arrow.maxBytesPerBatch", "1000")
+        cls.spark.conf.set("spark.sql.execution.arrow.maxBytesPerBatch", "10")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/arrow/test_arrow_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_map.py
@@ -170,6 +170,11 @@ class MapInArrowTestsMixin(object):
 
         df.mapInArrow(func2, "id long", True).collect()
 
+    def test_negative_and_zero_batch_size(self):
+        for batch_size in [0, -1]:
+            with self.sql_conf({"spark.sql.execution.arrow.maxRecordsPerBatch": batch_size}):
+                MapInArrowTests.test_map_in_arrow(self)
+
 
 class MapInArrowTests(MapInArrowTestsMixin, ReusedSQLTestCase):
     @classmethod
@@ -192,6 +197,15 @@ class MapInArrowTests(MapInArrowTestsMixin, ReusedSQLTestCase):
             os.environ["TZ"] = cls.tz_prev
         time.tzset()
         ReusedSQLTestCase.tearDownClass()
+
+
+class MapInArrowWithArrowBatchSlicingTestsAndReducedBatchSizeTests(MapInArrowTests):
+    @classmethod
+    def setUpClass(cls):
+        MapInArrowTests.setUpClass()
+        # Set it to a small odd value to exercise batching logic for all test cases
+        cls.spark.conf.set("spark.sql.execution.arrow.maxRecordsPerBatch", "3")
+        cls.spark.conf.set("spark.sql.execution.arrow.maxBytesPerBatch", "1000")
 
 
 if __name__ == "__main__":

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
@@ -112,6 +112,16 @@ class ArrowWriter(val root: VectorSchemaRoot, fields: Array[ArrowFieldWriter]) {
     count += 1
   }
 
+  def sizeInBytes(): Int = {
+    var i = 0
+    var bytes = 0
+    while (i < fields.size) {
+      bytes += fields(i).getSizeInBytes()
+      i += 1
+    }
+    bytes
+  }
+
   def finish(): Unit = {
     root.setRowCount(count)
     fields.foreach(_.finish())
@@ -148,6 +158,13 @@ private[arrow] abstract class ArrowFieldWriter {
 
   def finish(): Unit = {
     valueVector.setValueCount(count)
+  }
+
+  def getSizeInBytes(): Int = {
+    valueVector.setValueCount(count)
+    // Before calling getBufferSizeFor, we need to call
+    // `setValueCount`, see https://github.com/apache/arrow/pull/9187#issuecomment-763362710
+    valueVector.getBufferSizeFor(count)
   }
 
   def reset(): Unit = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3397,10 +3397,31 @@ object SQLConf {
       .doc("When using Apache Arrow, limit the maximum number of records that can be written " +
         "to a single ArrowRecordBatch in memory. This configuration is not effective for the " +
         "grouping API such as DataFrame(.cogroup).groupby.applyInPandas because each group " +
-        "becomes each ArrowRecordBatch. If set to zero or negative there is no limit.")
+        "becomes each ArrowRecordBatch. If set to zero or negative there is no limit. " +
+        "See also spark.sql.execution.arrow.maxBytesPerBatch. If both are set, each batch " +
+        "is created when any condition of both is met.")
       .version("2.3.0")
       .intConf
       .createWithDefault(10000)
+
+  val ARROW_EXECUTION_MAX_BYTES_PER_BATCH =
+    buildConf("spark.sql.execution.arrow.maxBytesPerBatch")
+      .internal()
+      .doc("When using Apache Arrow, limit the maximum bytes in each batch that can be written " +
+        "to a single ArrowRecordBatch in memory. This configuration is not effective for the " +
+        "grouping API such as DataFrame(.cogroup).groupby.applyInPandas because each group " +
+        "becomes each ArrowRecordBatch. Unlike 'spark.sql.execution.arrow.maxRecordsPerBatch', " +
+        "this configuration does not work for createDataFrame/toPandas with Arrow/pandas " +
+        "instances. " +
+        "See also spark.sql.execution.arrow.maxRecordsPerBatch. If both are set, each batch " +
+        "is created when any condition of both is met.")
+      .version("4.0.0")
+      .bytesConf(ByteUnit.BYTE)
+      .checkValue(x => x > 0 && x <= Int.MaxValue,
+        errorMsg = "The value of " +
+          "spark.sql.execution.arrow.maxBytesPerBatch should be greater " +
+          "than zero and less than INT_MAX.")
+      .createWithDefaultString("256MB")
 
   val ARROW_TRANSFORM_WITH_STATE_IN_PANDAS_MAX_RECORDS_PER_BATCH =
     buildConf("spark.sql.execution.arrow.transformWithStateInPandas.maxRecordsPerBatch")
@@ -6286,6 +6307,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def arrowPySparkFallbackEnabled: Boolean = getConf(ARROW_PYSPARK_FALLBACK_ENABLED)
 
   def arrowMaxRecordsPerBatch: Int = getConf(ARROW_EXECUTION_MAX_RECORDS_PER_BATCH)
+
+  def arrowMaxBytesPerBatch: Long = getConf(ARROW_EXECUTION_MAX_BYTES_PER_BATCH)
 
   def arrowTransformWithStateInPandasMaxRecordsPerBatch: Int =
     getConf(ARROW_TRANSFORM_WITH_STATE_IN_PANDAS_MAX_RECORDS_PER_BATCH)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
@@ -36,7 +36,6 @@ import org.apache.spark.sql.catalyst.plans.ReferenceAllColumns
 import org.apache.spark.sql.catalyst.plans.logical.{EventTimeWatermark, FunctionUtils, LogicalGroupState}
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.execution.python.BatchIterator
 import org.apache.spark.sql.execution.r.ArrowRRunner
 import org.apache.spark.sql.execution.streaming.GroupStateImpl
 import org.apache.spark.sql.internal.SQLConf
@@ -219,17 +218,13 @@ case class MapPartitionsInRWithArrowExec(
     child: SparkPlan) extends UnaryExecNode {
   override def producedAttributes: AttributeSet = AttributeSet(output)
 
-  private val batchSize = conf.arrowMaxRecordsPerBatch
-
   override def outputPartitioning: Partitioning = child.outputPartitioning
 
   override protected def doExecute(): RDD[InternalRow] = {
     child.execute().mapPartitionsInternal { inputIter =>
       val outputTypes = schema.map(_.dataType)
 
-      // DO NOT use iter.grouped(). See BatchIterator.
-      val batchIter =
-        if (batchSize > 0) new BatchIterator(inputIter, batchSize) else Iterator(inputIter)
+      val batchIter = Iterator(inputIter)
 
       val runner = new ArrowRRunner(func, packageNames, broadcastVars, inputSchema,
         SQLConf.get.sessionLocalTimeZone, RRunnerModes.DATAFRAME_DAPPLY)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowPythonUDTFRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowPythonUDTFRunner.scala
@@ -44,7 +44,7 @@ class ArrowPythonUDTFRunner(
   extends BasePythonRunner[Iterator[InternalRow], ColumnarBatch](
       Seq(ChainedPythonFunctions(Seq(udtf.func))), evalType, Array(argMetas.map(_.offset)),
       jobArtifactUUID, pythonMetrics)
-  with BasicPythonArrowInput
+  with BatchedPythonArrowInput
   with BasicPythonArrowOutput {
 
   override protected def writeUDF(dataOut: DataOutputStream): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
@@ -57,11 +57,9 @@ class MapInBatchEvaluatorFactory(
       // as a DataFrame.
       val wrappedIter = inputIter.map(InternalRow(_))
 
-      // DO NOT use iter.grouped(). See BatchIterator.
-      val batchIter =
-        if (batchSize > 0) new BatchIterator(wrappedIter, batchSize) else Iterator(wrappedIter)
+      val batchIter = Iterator(wrappedIter)
 
-      val columnarBatchIter = new ArrowPythonRunner(
+      val pyRunner = new ArrowPythonRunner(
         chainedFunc,
         pythonEvalType,
         argOffsets,
@@ -71,7 +69,8 @@ class MapInBatchEvaluatorFactory(
         pythonRunnerConf,
         pythonMetrics,
         jobArtifactUUID,
-        None).compute(batchIter, context.partitionId(), context)
+        None)
+      val columnarBatchIter = pyRunner.compute(batchIter, context.partitionId(), context)
 
       val unsafeProj = UnsafeProjection.create(output, output)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonArrowInput.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonArrowInput.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.arrow
 import org.apache.spark.sql.execution.arrow.ArrowWriter
 import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.util.Utils
@@ -48,7 +49,7 @@ private[python] trait PythonArrowInput[IN] { self: BasePythonRunner[IN, _] =>
 
   protected def pythonMetrics: Map[String, SQLMetric]
 
-  protected def writeNextInputToArrowStream(
+  protected def writeNextBatchToArrowStream(
       root: VectorSchemaRoot,
       writer: ArrowStreamWriter,
       dataOut: DataOutputStream,
@@ -71,17 +72,17 @@ private[python] trait PythonArrowInput[IN] { self: BasePythonRunner[IN, _] =>
   protected val root = VectorSchemaRoot.create(arrowSchema, allocator)
   protected var writer: ArrowStreamWriter = _
 
-protected def close(): Unit = {
-  Utils.tryWithSafeFinally {
-    // end writes footer to the output stream and doesn't clean any resources.
-    // It could throw exception if the output stream is closed, so it should be
-    // in the try block.
-    writer.end()
-  } {
-    root.close()
-    allocator.close()
+  protected def close(): Unit = {
+    Utils.tryWithSafeFinally {
+      // end writes footer to the output stream and doesn't clean any resources.
+      // It could throw exception if the output stream is closed, so it should be
+      // in the try block.
+      writer.end()
+    } {
+      root.close()
+      allocator.close()
+    }
   }
-}
 
   protected override def newWriter(
       env: SparkEnv,
@@ -104,7 +105,7 @@ protected def close(): Unit = {
         }
 
         assert(writer != null)
-        writeNextInputToArrowStream(root, writer, dataOut, inputIterator)
+        writeNextBatchToArrowStream(root, writer, dataOut, inputIterator)
       }
     }
   }
@@ -112,9 +113,9 @@ protected def close(): Unit = {
 
 private[python] trait BasicPythonArrowInput extends PythonArrowInput[Iterator[InternalRow]] {
   self: BasePythonRunner[Iterator[InternalRow], _] =>
-  private val arrowWriter: arrow.ArrowWriter = ArrowWriter.create(root)
+  protected val arrowWriter: arrow.ArrowWriter = ArrowWriter.create(root)
 
-  protected def writeNextInputToArrowStream(
+  protected def writeNextBatchToArrowStream(
       root: VectorSchemaRoot,
       writer: ArrowStreamWriter,
       dataOut: DataOutputStream,
@@ -136,6 +137,56 @@ private[python] trait BasicPythonArrowInput extends PythonArrowInput[Iterator[In
       true
     } else {
       super[PythonArrowInput].close()
+      false
+    }
+  }
+}
+
+
+private[python] trait BatchedPythonArrowInput extends BasicPythonArrowInput {
+  self: BasePythonRunner[Iterator[InternalRow], _] =>
+  private val arrowMaxRecordsPerBatch = SQLConf.get.arrowMaxRecordsPerBatch
+
+  private val maxBytesPerBatch = SQLConf.get.arrowMaxBytesPerBatch
+
+  // Marker inside the input iterator to indicate the start of the next batch.
+  private var nextBatchStart: Iterator[InternalRow] = Iterator.empty
+
+  override protected def writeNextBatchToArrowStream(
+      root: VectorSchemaRoot,
+      writer: ArrowStreamWriter,
+      dataOut: DataOutputStream,
+      inputIterator: Iterator[Iterator[InternalRow]]): Boolean = {
+    if (!nextBatchStart.hasNext) {
+      if (inputIterator.hasNext) {
+        nextBatchStart = inputIterator.next()
+      }
+    }
+    if (nextBatchStart.hasNext) {
+      val startData = dataOut.size()
+
+      var numRowsInBatch: Int = 0
+
+      def underBatchSizeLimit: Boolean =
+        (maxBytesPerBatch == Int.MaxValue) || (arrowWriter.sizeInBytes() < maxBytesPerBatch)
+
+      while (nextBatchStart.hasNext && numRowsInBatch < arrowMaxRecordsPerBatch &&
+        underBatchSizeLimit) {
+        arrowWriter.write(nextBatchStart.next())
+        numRowsInBatch += 1
+      }
+
+      assert(numRowsInBatch > 0)
+      assert(numRowsInBatch <= arrowMaxRecordsPerBatch)
+      arrowWriter.finish()
+      writer.writeBatch()
+
+      arrowWriter.reset()
+      val deltaData = dataOut.size() - startData
+      pythonMetrics("pythonDataSent") += deltaData
+      true
+    } else {
+      super[BasicPythonArrowInput].close()
       false
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/ApplyInPandasWithStatePythonRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/ApplyInPandasWithStatePythonRunner.scala
@@ -135,7 +135,7 @@ class ApplyInPandasWithStatePythonRunner(
    *
    * See [[ApplyInPandasWithStateWriter]] for more details.
    */
-  protected def writeNextInputToArrowStream(
+  protected def writeNextBatchToArrowStream(
       root: VectorSchemaRoot,
       writer: ArrowStreamWriter,
       dataOut: DataOutputStream,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPandasPythonRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPandasPythonRunner.scala
@@ -63,7 +63,7 @@ class TransformWithStateInPandasPythonRunner(
 
   private var pandasWriter: BaseStreamingArrowWriter = _
 
-  override protected def writeNextInputToArrowStream(
+  override protected def writeNextBatchToArrowStream(
       root: VectorSchemaRoot,
       writer: ArrowStreamWriter,
       dataOut: DataOutputStream,
@@ -122,7 +122,7 @@ class TransformWithStateInPandasPythonInitialStateRunner(
 
   private var pandasWriter: BaseStreamingArrowWriter = _
 
-  override protected def writeNextInputToArrowStream(
+  override protected def writeNextBatchToArrowStream(
       root: VectorSchemaRoot,
       writer: ArrowStreamWriter,
       dataOut: DataOutputStream,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR allows Arrow batches in bytes instead of number of rows

### Why are the changes needed?

We enabled `spark.sql.execution.pythonUDF.arrow.enabled` by default, and we should make sure users won't hit OOM.

### Does this PR introduce _any_ user-facing change?

Yes. Now we will make the Arrow batches in bytes 256MB by default, and users can configure this

### How was this patch tested?

Tested with changing default value to 1KB, and added a unittest. Also manually tested as below:

```python
from pyspark.sql.functions import pandas_udf
import pandas as pd

# spark.conf.set("spark.sql.execution.arrow.maxBytesPerBatch", "1K")
# spark.conf.set("spark.sql.execution.arrow.maxBytesPerBatch", "2K")
# spark.conf.set("spark.sql.execution.arrow.maxRecordsPerBatch", "1")
# spark.conf.set("spark.sql.execution.arrow.maxRecordsPerBatch", "10")


@pandas_udf("long")
def func(s: pd.Series) -> pd.Series:
    return s


a = spark.range(100000).select(func("id")).collect()
```

### Was this patch authored or co-authored using generative AI tooling?

No.