### PR TITLE
[SPARK-51313][PYTHON] Fix timestamp format for PySparkLogger

### DIFF
--- a/python/pyspark/logger/logger.py
+++ b/python/pyspark/logger/logger.py
@@ -48,6 +48,8 @@ class JSONFormatter(logging.Formatter):
     - kwargs: Any additional keyword arguments passed to the logger.
     """
 
+    default_msec_format = "%s.%03d"
+
     def format(self, record: logging.LogRecord) -> str:
         """
         Format the specified record as a JSON string.

--- a/python/pyspark/logger/tests/test_logger.py
+++ b/python/pyspark/logger/tests/test_logger.py
@@ -179,9 +179,9 @@ class LoggerTestsMixin:
                         "msg",
                         sf.col("exception.class").alias("exception_class"),
                         sf.col("exception.msg").alias("exception_msg"),
-                        (sf.size(sf.col("exception.stacktrace")) > 0).alias(
-                            "exception_stacktrace_is_not_empty"
-                        ),
+                        sf.col("exception.stacktrace.class").alias("exception_stacktrace_class"),
+                        sf.col("exception.stacktrace.method").alias("exception_stacktrace_method"),
+                        sf.col("exception.stacktrace.file").alias("exception_stacktrace_file"),
                     ),
                     [
                         Row(
@@ -190,7 +190,9 @@ class LoggerTestsMixin:
                             msg="Test logging structure.",
                             exception_class=None,
                             exception_msg=None,
-                            exception_stacktrace_is_not_empty=None,
+                            exception_stacktrace_class=None,
+                            exception_stacktrace_method=None,
+                            exception_stacktrace_file=None,
                         ),
                         Row(
                             ts_is_not_null=True,
@@ -198,7 +200,9 @@ class LoggerTestsMixin:
                             msg="Exception occurred.",
                             exception_class="ZeroDivisionError",
                             exception_msg="division by zero",
-                            exception_stacktrace_is_not_empty=True,
+                            exception_stacktrace_class=[None],
+                            exception_stacktrace_method=["test_apply_schema"],
+                            exception_stacktrace_file=[__file__],
                         ),
                     ],
                 )


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes timestamp format for `PySparkLogger`.

### Why are the changes needed?

Currently the timestamp format in JSON string from `PySparkLogger` can't be read by Spark with the given schema, which results in the timestamps become `NULL`.

### Does this PR introduce _any_ user-facing change?

Yes, the JSON string written by `PySparkLogger` can be read by Spark with the given schema.

For example:

```py
>>> import logging
>>> from pyspark.logger import PySparkLogger, SPARK_LOG_SCHEMA
>>>
>>> logger = PySparkLogger.getLogger("TestLogger")
>>> logfile = 'test_log'
>>> handler = logging.FileHandler(logfile)
>>> logger.addHandler(handler)
>>> logger.setLevel(logging.INFO)
>>>
>>> logger.info("Test logging structure.")
```

- before

```py
>>> spark.read.format("json").schema(SPARK_LOG_SCHEMA).load(logfile).show(truncate=False)
+----+-----+-----------------------+-------+---------+----------+
|ts  |level|msg                    |context|exception|logger    |
+----+-----+-----------------------+-------+---------+----------+
|NULL|INFO |Test logging structure.|{}     |NULL     |TestLogger|
+----+-----+-----------------------+-------+---------+----------+
```

- after

```py
>>> spark.read.format("json").schema(SPARK_LOG_SCHEMA).load(logfile).show(truncate=False)
+-----------------------+-----+-----------------------+-------+---------+----------+
|ts                     |level|msg                    |context|exception|logger    |
+-----------------------+-----+-----------------------+-------+---------+----------+
|2025-02-25 16:13:18.306|INFO |Test logging structure.|{}     |NULL     |TestLogger|
+-----------------------+-----+-----------------------+-------+---------+----------+
```

### How was this patch tested?

Added the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
