### PR TITLE
[SPARK-51315][SQL] Enabling object level collations by default

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
@@ -58,8 +58,7 @@ object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
             StringType(defaultCollation)
           }
         } else {
-          // Object level collation is not supported for materialized views (instance of
-          // ResolvedPersistentView) for now.
+          // As a safeguard, use the default collation for unknown cases.
           StringType(defaultCollation)
         }
       case _ => StringType(defaultCollation)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
@@ -45,22 +45,22 @@ object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
     table match {
       case createTable: CreateTable if createTable.tableSpec.collation.isDefined =>
         StringType(createTable.tableSpec.collation.get)
+
       case createView: CreateView if createView.collation.isDefined =>
         StringType(createView.collation.get)
+
       case alterTable: AlterTableCommand if alterTable.table.resolved =>
-        if (alterTable.table.isInstanceOf[ResolvedTable]) {
-          val collation = Option(alterTable
-            .table.asInstanceOf[ResolvedTable]
-            .table.properties.get(TableCatalog.PROP_COLLATION))
-          if (collation.isDefined) {
-            StringType(collation.get)
-          } else {
+        alterTable.table match {
+          case resolvedTbl: ResolvedTable =>
+            val collation = resolvedTbl.table.properties.getOrDefault(
+              TableCatalog.PROP_COLLATION, defaultCollation)
+            StringType(collation)
+
+          case _ =>
+            // As a safeguard, use the default collation for unknown cases.
             StringType(defaultCollation)
-          }
-        } else {
-          // As a safeguard, use the default collation for unknown cases.
-          StringType(defaultCollation)
         }
+
       case _ => StringType(defaultCollation)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -868,7 +868,7 @@ object SQLConf {
       )
       .version("4.0.0")
       .booleanConf
-      .createWithDefault(Utils.isTesting)
+      .createWithDefault(true)
 
   lazy val TRIM_COLLATION_ENABLED =
     buildConf("spark.sql.collation.trim.enabled")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Enabling the flag for object level collations by default, as the feature is now working end-to-end.
Also, a minor fix is made in DDL command resolution for AlterTableCommand, ensuring that the altered object is an instance of ResolvedTable, to avoid exposing this path for other types such as ResolvedPersistentView. This is just additional safety mechanism.


### Why are the changes needed?

The feature is now working end-to-end, and can be enabled accordingly.


### Does this PR introduce _any_ user-facing change?

No. Previous PRs related to this functionality already introduced all underlying user facing changes.


### How was this patch tested?

Existing dedicated tests already cover this functionality (the flag was already enabled in testing environment).


### Was this patch authored or co-authored using generative AI tooling?

No.
