### PR TITLE
[SPARK-51317][PYTHON] Require pandas as well for Arrow-optimized Python UDF

### DIFF
--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -34,7 +34,7 @@ from pyspark.sql.types import (
     StructType,
     _parse_datatype_string,
 )
-from pyspark.sql.utils import get_active_spark_context, has_arrow
+from pyspark.sql.utils import get_active_spark_context
 from pyspark.sql.pandas.types import to_arrow_type
 from pyspark.sql.pandas.utils import require_minimum_pandas_version, require_minimum_pyarrow_version
 from pyspark.errors import PySparkTypeError, PySparkNotImplementedError, PySparkRuntimeError
@@ -131,13 +131,17 @@ def _create_py_udf(
     else:
         is_arrow_enabled = useArrow
 
-    if is_arrow_enabled and not has_arrow:
-        is_arrow_enabled = False
-        warnings.warn(
-            "Arrow optimization failed to enable because PyArrow is not installed. "
-            "Falling back to a non-Arrow-optimized UDF.",
-            RuntimeWarning,
-        )
+    if is_arrow_enabled:
+        try:
+            require_minimum_pandas_version()
+            require_minimum_pyarrow_version()
+        except ImportError:
+            is_arrow_enabled = False
+            warnings.warn(
+                "Arrow optimization failed to enable because PyArrow/pandas is not installed. "
+                "Falling back to a non-Arrow-optimized UDF.",
+                RuntimeWarning,
+            )
 
     eval_type: int = PythonEvalType.SQL_BATCHED_UDF
 
@@ -147,8 +151,6 @@ def _create_py_udf(
         except TypeError:
             is_func_with_args = False
         if is_func_with_args:
-            require_minimum_pandas_version()
-            require_minimum_pyarrow_version()
             eval_type = PythonEvalType.SQL_ARROW_BATCHED_UDF
         else:
             warnings.warn(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to require pandas as well for Arrow-optimized Python UDF

### Why are the changes needed?

Now it fails as below:

```
Driver stacktrace:)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../spark/python/pyspark/sql/classic/dataframe.py", line 285, in show
    print(self._show_string(n, truncate, vertical))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../spark/python/pyspark/sql/classic/dataframe.py", line 303, in _show_string
    return self._jdf.showString(n, 20, vertical)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../spark/python/lib/py4j-0.10.9.9-src.zip/py4j/java_gateway.py", line 1362, in __call__
  File "/.../spark/python/pyspark/errors/exceptions/captured.py", line 258, in deco
    raise converted from None
pyspark.errors.exceptions.captured.PythonException:
  An exception was thrown from the Python worker. Please see the stack trace below.
Traceback (most recent call last):
  File "/.../spark/python/lib/pyspark.zip/pyspark/worker.py", line 2012, in main
    func, profiler, deserializer, serializer = read_udfs(pickleSer, infile, eval_type)
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../spark/python/lib/pyspark.zip/pyspark/worker.py", line 1922, in read_udfs
    read_single_udf(
  File "/.../spark/python/lib/pyspark.zip/pyspark/worker.py", line 897, in read_single_udf
    return wrap_arrow_batch_udf(func, args_offsets, kwargs_offsets, return_type, runner_conf)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../spark/python/lib/pyspark.zip/pyspark/worker.py", line 192, in wrap_arrow_batch_udf
    def evaluate(*args: pd.Series) -> pd.Series:
                        ^^^^^^^^^
AttributeError: module 'pandas' has no attribute 'Series'
```

We should require it.

### Does this PR introduce _any_ user-facing change?

Yes, it requires pandas now explicitly.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.