### PR TITLE
[SPARK-51277][PYTHON] Implement 0-arg implementation in Arrow-optimized Python UDF

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
@@ -192,15 +192,6 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
             },
         )
 
-    def test_warn_no_args(self):
-        with self.assertWarns(UserWarning) as w:
-            udf(lambda: print("do"), useArrow=True)
-        self.assertEqual(
-            str(w.warning),
-            "Arrow optimization for Python UDFs cannot be enabled for functions"
-            " without arguments.",
-        )
-
     def test_named_arguments_negative(self):
         @udf("int")
         def test_udf(a, b):

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -1166,6 +1166,26 @@ class BaseUDFTestsMixin(object):
             with self.subTest(with_b=True, query_no=i):
                 assertDataFrameEqual(df, [Row(0), Row(101)])
 
+    def test_num_arguments(self):
+        @udf("long")
+        def f():
+            return 10
+
+        @udf("long")
+        def f2(arg):
+            return arg
+
+        [v1, v2] = self.spark.range(1).select(f(), f2(col("id"))).first()
+        self.assertEqual(v1, 10)
+        self.assertEqual(v2, 0)
+
+        [v1, v2] = self.spark.range(1).select(f2(col("id")), f()).first()
+        self.assertEqual(v1, 0)
+        self.assertEqual(v2, 10)
+
+        [v] = self.spark.range(1).select(f()).first()
+        self.assertEqual(v, 10)
+
     def test_raise_stop_iteration(self):
         @udf("int")
         def test_udf(a):

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -146,18 +146,7 @@ def _create_py_udf(
     eval_type: int = PythonEvalType.SQL_BATCHED_UDF
 
     if is_arrow_enabled:
-        try:
-            is_func_with_args = len(getfullargspec(f).args) > 0
-        except TypeError:
-            is_func_with_args = False
-        if is_func_with_args:
-            eval_type = PythonEvalType.SQL_ARROW_BATCHED_UDF
-        else:
-            warnings.warn(
-                "Arrow optimization for Python UDFs cannot be enabled for functions"
-                " without arguments.",
-                UserWarning,
-            )
+        eval_type = PythonEvalType.SQL_ARROW_BATCHED_UDF
 
     return _create_udf(f, returnType, eval_type)
 

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -17,8 +17,6 @@
 """
 User-defined function related classes and functions
 """
-from inspect import getfullargspec
-
 import functools
 import inspect
 import sys

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -160,6 +160,10 @@ def wrap_arrow_batch_udf(f, args_offsets, kwargs_offsets, return_type, runner_co
     import pandas as pd
 
     func, args_kwargs_offsets = wrap_kwargs_support(f, args_offsets, kwargs_offsets)
+    zero_arg_exec = False
+    if len(args_kwargs_offsets) == 0:
+        args_kwargs_offsets = (0,)  # Series([pyspark._NoValue, ...]) is used for 0-arg execution.
+        zero_arg_exec = True
 
     arrow_return_type = to_arrow_type(
         return_type, prefers_large_types=use_large_var_types(runner_conf)
@@ -176,6 +180,16 @@ def wrap_arrow_batch_udf(f, args_offsets, kwargs_offsets, return_type, runner_co
     elif type(return_type) == BinaryType:
         result_func = lambda r: bytes(r) if r is not None else r  # noqa: E731
 
+    if zero_arg_exec:
+
+        def get_args(*args: pd.Series):
+            return [() for _ in range(len(args[0]))]
+
+    else:
+
+        def get_args(*args: pd.Series):
+            return zip(*args)
+
     if "spark.sql.execution.pythonUDF.arrow.concurrency.level" in runner_conf:
         from concurrent.futures import ThreadPoolExecutor
 
@@ -184,13 +198,15 @@ def wrap_arrow_batch_udf(f, args_offsets, kwargs_offsets, return_type, runner_co
         @fail_on_stopiteration
         def evaluate(*args: pd.Series) -> pd.Series:
             with ThreadPoolExecutor(max_workers=c) as pool:
-                return pd.Series(list(pool.map(lambda row: result_func(func(*row)), zip(*args))))
+                return pd.Series(
+                    list(pool.map(lambda row: result_func(func(*row)), get_args(*args)))
+                )
 
     else:
 
         @fail_on_stopiteration
         def evaluate(*args: pd.Series) -> pd.Series:
-            return pd.Series([result_func(func(*row)) for row in zip(*args)])
+            return pd.Series([result_func(func(*row)) for row in get_args(*args)])
 
     def verify_result_length(result, length):
         if len(result) != length:

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -183,7 +183,7 @@ def wrap_arrow_batch_udf(f, args_offsets, kwargs_offsets, return_type, runner_co
     if zero_arg_exec:
 
         def get_args(*args: pd.Series):
-            return [() for _ in range(len(args[0]))]
+            return [() for _ in args[0]]
 
     else:
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR implements 0-arg implementation in Arrow-optimized Python UDF.

### Why are the changes needed?

We enabled `spark.sql.execution.pythonUDF.arrow.enabled` by default. We should make sure edge cases work.

### Does this PR introduce _any_ user-facing change?

Yes, it will optimize with the Arrow for regular Python UDFs with 0-arg implementation.

### How was this patch tested?

A lot of existing unit tests.

### Was this patch authored or co-authored using generative AI tooling?

No.