### PR TITLE
[SPARK-50792][SQL][TESTS][FOLLOWUP] Test case should reuse the exists table

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -22,6 +22,7 @@ import java.util.Properties
 
 import scala.util.control.NonFatal
 
+import org.apache.commons.codec.binary.Hex
 import test.org.apache.spark.sql.connector.catalog.functions.JavaStrLen.JavaStrLenStaticMagic
 
 import org.apache.spark.{SparkConf, SparkException, SparkIllegalArgumentException}
@@ -222,9 +223,9 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       conn.prepareStatement("INSERT INTO \"test\".\"address\" VALUES " +
         "('abc_''%def@gmail.com')").executeUpdate()
 
-      conn.prepareStatement("CREATE TABLE \"test\".\"binary1\" (name TEXT(32),b BINARY(20))")
+      conn.prepareStatement("CREATE TABLE \"test\".\"binary_tab\" (name TEXT(32),b BINARY(20))")
         .executeUpdate()
-      val stmt = conn.prepareStatement("INSERT INTO \"test\".\"binary1\" VALUES (?, ?)")
+      val stmt = conn.prepareStatement("INSERT INTO \"test\".\"binary_tab\" VALUES (?, ?)")
       stmt.setString(1, "jen")
       stmt.setBytes(2, testBytes)
       stmt.executeUpdate()
@@ -1602,7 +1603,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
   }
 
   test("scan with filter push-down with misc functions") {
-    val df1 = sql("SELECT name FROM h2.test.binary1 WHERE " +
+    val df1 = sql("SELECT name FROM h2.test.binary_tab WHERE " +
       "md5(b) = '4371fe0aa613bcb081543a37d241adcb'")
     checkFiltersRemoved(df1)
     val expectedPlanFragment1 = "PushedFilters: [B IS NOT NULL, " +
@@ -1610,7 +1611,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     checkPushedInfo(df1, expectedPlanFragment1)
     checkAnswer(df1, Seq(Row("jen")))
 
-    val df2 = sql("SELECT name FROM h2.test.binary1 WHERE " +
+    val df2 = sql("SELECT name FROM h2.test.binary_tab WHERE " +
       "sha1(b) = 'cf355e86e8666f9300ef12e996acd5c629e0b0a1'")
     checkFiltersRemoved(df2)
     val expectedPlanFragment2 = "PushedFilters: [B IS NOT NULL, " +
@@ -1618,7 +1619,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     checkPushedInfo(df2, expectedPlanFragment2)
     checkAnswer(df2, Seq(Row("jen")))
 
-    val df3 = sql("SELECT name FROM h2.test.binary1 WHERE " +
+    val df3 = sql("SELECT name FROM h2.test.binary_tab WHERE " +
       "sha2(b, 256) = '911732d10153f859dec04627df38b19290ec707ff9f83910d061421fdc476109'")
     checkFiltersRemoved(df3)
     val expectedPlanFragment3 = "PushedFilters: [B IS NOT NULL, (SHA2(B, 256)) = " +
@@ -1777,7 +1778,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
         Row("test", "empty_table", false), Row("test", "employee", false),
         Row("test", "item", false), Row("test", "dept", false),
         Row("test", "person", false), Row("test", "view1", false), Row("test", "view2", false),
-        Row("test", "datetime", false), Row("test", "binary1", false),
+        Row("test", "datetime", false), Row("test", "binary_tab", false),
         Row("test", "employee_bonus", false),
         Row("test", "strings_with_nulls", false)))
   }
@@ -3109,19 +3110,13 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
   }
 
   test("SPARK-50792: Format binary data as a binary literal in JDBC.") {
-    val tableName = "h2.test.binary_literal"
-    withTable(tableName) {
-      // Create a table with binary column
-      val binary = "X'123456'"
-
-      sql(s"CREATE TABLE $tableName (binary_col BINARY)")
-      sql(s"INSERT INTO $tableName VALUES ($binary)")
-
-      val df = sql(s"SELECT * FROM $tableName WHERE binary_col = $binary")
-      checkFiltersRemoved(df)
-      checkPushedInfo(df, "PushedFilters: [binary_col IS NOT NULL, binary_col = 0x123456]")
-      checkAnswer(df, Row(Array(18, 52, 86)))
-    }
+    val hexBinary = Hex.encodeHexString(testBytes, false)
+    val binary = "X'" + hexBinary + "'"
+    val df = sql(s"SELECT * FROM h2.test.binary_tab WHERE b = $binary")
+    checkFiltersRemoved(df)
+    checkPushedInfo(df, s"PushedFilters: [B IS NOT NULL, B = 0x$hexBinary]")
+    checkAnswer(df,
+      Row("jen", Array(99, -122, -121, -56, -51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)))
   }
 
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes update the test case by reuse the exists table.


### Why are the changes needed?
https://github.com/apache/spark/pull/49452 created a new table for binary test.
But there are already exists a table with binary schema.

This PR also rename the test table with binary schema to a better name.

### Does this PR introduce _any_ user-facing change?
'No'.
Just update test case.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
