### PR TITLE
[SPARK-51323][PYTHON] Duplicate "total" on Py SQL metrics

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonSQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonSQLMetrics.scala
@@ -44,9 +44,9 @@ object PythonSQLMetrics {
 
   val pythonTimingMetricsDesc: Map[String, String] = {
     Map(
-      "pythonBootTime" -> "total time to start Python workers",
-      "pythonInitTime" -> "total time to initialize Python workers",
-      "pythonTotalTime" -> "total time to run Python workers"
+      "pythonBootTime" -> "time to start Python workers",
+      "pythonInitTime" -> "time to initialize Python workers",
+      "pythonTotalTime" -> "time to run Python workers"
     )
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
@@ -92,9 +92,9 @@ class PythonUDFSuite extends QueryTest with SharedSparkSession {
       "data sent to Python workers",
       "data returned from Python workers",
       "number of output rows",
-      "total time to initialize Python workers",
-      "total time to start Python workers",
-      "total time to run Python workers")
+      "time to initialize Python workers",
+      "time to start Python workers",
+      "time to run Python workers")
 
     val df = base.groupBy(pythonTestUDF(base("a") + 1))
       .agg(pythonTestUDF(pythonTestUDF(base("a") + 1)))


### PR DESCRIPTION
### What changes were proposed in this pull request?

"total" is mentioned twice for PythonSQLMetrics.


### Why are the changes needed?

Make metrics less confusing.


### Does this PR introduce _any_ user-facing change?

Updates the metric presentation string.


### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.