### PR TITLE
[SPARK-51324][SQL] Fix nested FOR statement throwing error if empty result

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -208,7 +208,7 @@ class TriggerToExceptionHandlerMap(
 }
 
 object TriggerToExceptionHandlerMap {
-  def createEmptyMap: TriggerToExceptionHandlerMap = new TriggerToExceptionHandlerMap(
+  def createEmptyMap(): TriggerToExceptionHandlerMap = new TriggerToExceptionHandlerMap(
     Map.empty[String, ExceptionHandlerExec],
     Map.empty[String, ExceptionHandlerExec],
     None,
@@ -982,7 +982,7 @@ class ForStatementExec(
             label = variableName.orElse(Some(UUID.randomUUID().toString.toLowerCase(Locale.ROOT))),
             isScope = true,
             context = context,
-            triggerToExceptionHandlerMap = TriggerToExceptionHandlerMap.createEmptyMap
+            triggerToExceptionHandlerMap = TriggerToExceptionHandlerMap.createEmptyMap()
           )
 
           state = ForState.Body

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -631,9 +631,9 @@ class SimpleCaseStatementExec(
   }
 
   private var state = CaseState.Condition
-  var bodyExec: Option[CompoundBodyExec] = None
+  private var bodyExec: Option[CompoundBodyExec] = None
 
-  var conditionBodyTupleIterator: Iterator[(SingleStatementExec, CompoundBodyExec)] = _
+  private var conditionBodyTupleIterator: Iterator[(SingleStatementExec, CompoundBodyExec)] = _
   private var caseVariableLiteral: Literal = _
 
   private var isCacheValid = false
@@ -934,11 +934,16 @@ class ForStatementExec(
    */
   private var interrupted: Boolean = false
 
+  /**
+   * Whether this iteration of the FOR loop is the first one.
+   */
+  private var firstIteration: Boolean = true
+
   private lazy val treeIterator: Iterator[CompoundStatementExec] =
     new Iterator[CompoundStatementExec] {
 
       override def hasNext: Boolean = !interrupted && (state match {
-          case ForState.VariableAssignment => cachedQueryResult().hasNext
+          case ForState.VariableAssignment => cachedQueryResult().hasNext || firstIteration
           case ForState.Body => bodyWithVariables.getTreeIterator.hasNext
         })
 
@@ -946,6 +951,17 @@ class ForStatementExec(
       override def next(): CompoundStatementExec = state match {
 
         case ForState.VariableAssignment =>
+          // If result set is empty and we are on the first iteration, we return NO-OP statement
+          // to prevent compound statements from not having anything to return. For example,
+          // if a FOR statement is nested in REPEAT, REPEAT will assume that FOR has at least
+          // one statement to return. In the case the result set is empty, FOR doesn't have
+          // anything to return naturally, so we return NO-OP instead.
+          if (!cachedQueryResult().hasNext && firstIteration) {
+            firstIteration = false
+            return new NoOpStatementExec
+          }
+          firstIteration = false
+
           val row = cachedQueryResult().next()
 
           val variableInitStatements = row.schema.names.toSeq
@@ -1070,6 +1086,7 @@ class ForStatementExec(
     isResultCacheValid = false
     interrupted = false
     bodyWithVariables = null
+    firstIteration = true
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
@@ -929,7 +929,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
       )
     )).getTreeIterator
     val statements = iter.map(extractStatementValue).toSeq
-    assert(statements === Seq.empty[String])
+    assert(statements === List("NOOP"))
   }
 
   test("for statement - nested") {
@@ -1035,7 +1035,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
       )
     )).getTreeIterator
     val statements = iter.map(extractStatementValue).toSeq
-    assert(statements === Seq.empty[String])
+    assert(statements === List("NOOP"))
   }
 
   test("for statement no variable - nested") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -2400,8 +2400,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  // ignored until loops are fixed to support empty bodies
-  ignore("for statement - nested - empty result set") {
+  test("for statement - nested - empty result set") {
     withTable("t") {
       val sqlScript =
         """
@@ -2417,20 +2416,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
           |""".stripMargin
 
       val expected = Seq(
-        Seq.empty[Row], // declare cnt
-        Seq.empty[Row], // create table
-        Seq.empty[Row], // insert
-        Seq.empty[Row], // set cnt
-        Seq(Row(0)), // select intCol
-        Seq.empty[Row], // insert
-        Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
-        Seq.empty[Row], // set cnt
-        Seq(Row(0)), // select intCol
-        Seq(Row(1)), // select intCol
-        Seq.empty[Row], // insert
-        Seq.empty[Row], // drop local var
-        Seq.empty[Row] // drop local var
+        Seq.empty[Row] // create table
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -3007,8 +2993,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  // ignored until loops are fixed to support empty bodies
-  ignore("for statement - no variable - nested - empty result set") {
+  test("for statement - no variable - nested - empty result set") {
     withTable("t") {
       val sqlScript =
         """
@@ -3024,18 +3009,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
           |""".stripMargin
 
       val expected = Seq(
-        Seq.empty[Row], // declare cnt
-        Seq.empty[Row], // create table
-        Seq.empty[Row], // insert
-        Seq.empty[Row], // set cnt
-        Seq(Row(0)), // select intCol
-        Seq.empty[Row], // insert
-        Seq.empty[Row], // drop local var
-        Seq.empty[Row], // set cnt
-        Seq(Row(0)), // select intCol
-        Seq(Row(1)), // select intCol
-        Seq.empty[Row], // insert
-        Seq.empty[Row] // drop local var
+        Seq.empty[Row] // create table
       )
       verifySqlScriptResult(sqlScript, expected)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
FOR statement will currently fail if it is nested in a compound statement, is the only statement in that body AND returns an empty result. For example:

```
BEGIN
 CREATE TABLE t (intCol INT) using parquet;
 REPEAT
   FOR SELECT * FROM t ORDER BY intCol DO
     SELECT intCol;
   END FOR;
 UNTIL 1 = 1
 END REPEAT;
END
```

throws 
`[INTERNAL_ERROR] No more elements to iterate through in the current SQL compound statement. SQLSTATE: XX000
`
This happens because the enclosing statement (REPEAT in this case) always expects at least one single statement in it's body which it can return. However, if the FOR has an empty result it doesn't have anything to return, and there is no other statement in the body, so the exception is thrown.

In this PR, FOR is updated to return NOOP statement in this specific case.

### Why are the changes needed?
To fix the bug.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Tests which were previously ignored due to this bug are no longer ignored.


### Was this patch authored or co-authored using generative AI tooling?
No.
