### PR TITLE
[SPARK-51329][ML][PYTHON] Add `numFeatures` for clustering models

### DIFF
--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -215,6 +215,14 @@ class GaussianMixtureModel(
         return self._set(probabilityCol=value)
 
     @property
+    @since("4.1.0")
+    def numFeatures(self) -> int:
+        """
+        Number of features, i.e., length of Vectors which this transforms.
+        """
+        return self._call_java("numFeatures")
+
+    @property
     @since("2.0.0")
     def weights(self) -> List[float]:
         """
@@ -687,6 +695,14 @@ class KMeansModel(
         return [vec for vec in matrix.toArray()]
 
     @property
+    @since("4.1.0")
+    def numFeatures(self) -> int:
+        """
+        Number of features, i.e., length of Vectors which this transforms.
+        """
+        return self._call_java("numFeatures")
+
+    @property
     @since("2.1.0")
     def summary(self) -> KMeansSummary:
         """
@@ -1024,6 +1040,14 @@ class BisectingKMeansModel(
             FutureWarning,
         )
         return self._call_java("computeCost", dataset)
+
+    @property
+    @since("4.1.0")
+    def numFeatures(self) -> int:
+        """
+        Number of features, i.e., length of Vectors which this transforms.
+        """
+        return self._call_java("numFeatures")
 
     @property
     @since("2.1.0")

--- a/python/pyspark/ml/tests/test_clustering.py
+++ b/python/pyspark/ml/tests/test_clustering.py
@@ -73,11 +73,9 @@ class ClusteringTestsMixin:
 
         centers = model.clusterCenters()
         self.assertEqual(len(centers), 2)
+        self.assertEqual(model.numFeatures, 2)
         self.assertTrue(np.allclose(centers[0], [-0.372, -0.338], atol=1e-3), centers[0])
         self.assertTrue(np.allclose(centers[1], [0.8625, 0.83375], atol=1e-3), centers[1])
-
-        # TODO: support KMeansModel.numFeatures in Python
-        # self.assertEqual(model.numFeatures, 2)
 
         output = model.transform(df)
         expected_cols = ["weight", "features", "prediction"]
@@ -148,11 +146,9 @@ class ClusteringTestsMixin:
 
         centers = model.clusterCenters()
         self.assertEqual(len(centers), 2)
+        self.assertEqual(model.numFeatures, 2)
         self.assertTrue(np.allclose(centers[0], [-0.372, -0.338], atol=1e-3), centers[0])
         self.assertTrue(np.allclose(centers[1], [0.8625, 0.83375], atol=1e-3), centers[1])
-
-        # TODO: support KMeansModel.numFeatures in Python
-        # self.assertEqual(model.numFeatures, 2)
 
         output = model.transform(df)
         expected_cols = ["weight", "features", "prediction"]
@@ -224,8 +220,7 @@ class ClusteringTestsMixin:
 
         model = gmm.fit(df)
         self.assertEqual(gmm.uid, model.uid)
-        # TODO: support GMM.numFeatures in Python
-        # self.assertEqual(model.numFeatures, 2)
+        self.assertEqual(model.numFeatures, 2)
         self.assertEqual(len(model.weights), 2)
         self.assertTrue(
             np.allclose(model.weights, [0.541014115744985, 0.4589858842550149], atol=1e-4),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add `numFeatures` for clustering models


### Why are the changes needed?
for feature parity between python and scala, these methods were missing in python world


### Does this PR introduce _any_ user-facing change?
yes, new methods

### How was this patch tested?
updated tests


### Was this patch authored or co-authored using generative AI tooling?
no