### PR TITLE
[SPARK-51330][PYTHON] Enable spark.sql.execution.pythonUDTF.arrow.enabled by default

### DIFF
--- a/python/docs/source/migration_guide/pyspark_upgrade.rst
+++ b/python/docs/source/migration_guide/pyspark_upgrade.rst
@@ -77,6 +77,7 @@ Upgrading from PySpark 3.5 to 4.0
 * In Spark 4.0, items other than functions (e.g. ``DataFrame``, ``Column``, ``StructType``) have been removed from the wildcard import ``from pyspark.sql.functions import *``, you should import these items from proper modules (e.g. ``from pyspark.sql import DataFrame, Column``, ``from pyspark.sql.types import StructType``).
 * In Spark 4.0, ``spark.sql.execution.pythonUDF.arrow.enabled`` is enabled by default. If users have PyArrow and pandas installed in their local and Spark Cluster, it automatically optimizes the regular Python UDFs with Arrow. To turn off the Arrow optimization, set ``spark.sql.execution.pythonUDF.arrow.enabled`` to ``false``.
 * In Spark 4.0, ``spark.sql.execution.arrow.pyspark.enabled`` is enabled by default. If users have PyArrow and pandas installed in their local and Spark Cluster, it automatically makes use of Apache Arrow for columnar data transfers in PySpark. This optimization applies to ``pyspark.sql.DataFrame.toPandas`` and ``pyspark.sql.SparkSession.createDataFrame`` when its input is a Pandas DataFrame or a NumPy ndarray. To turn off the Arrow optimization, set ``spark.sql.execution.arrow.pyspark.enabled`` to ``false``.
+* In Spark 4.0, ``spark.sql.execution.pythonUDTF.arrow.enabled`` is enabled by default. If users have PyArrow and pandas installed in their local and Spark Cluster, it automatically optimizes the regular Python UDFTs with Arrow. To turn off the Arrow optimization, set ``spark.sql.execution.pythonUDTF.arrow.enabled`` to ``false``.
 
 
 Upgrading from PySpark 3.3 to 3.4

--- a/python/docs/source/user_guide/sql/python_udtf.rst
+++ b/python/docs/source/user_guide/sql/python_udtf.rst
@@ -417,8 +417,9 @@ data between Java and Python processes. Apache Arrow is disabled by default for 
 
 Arrow can improve performance when each input row generates a large result table from the UDTF.
 
-To enable Arrow optimization, set the ``spark.sql.execution.pythonUDTF.arrow.enabled``
-configuration to ``true``. You can also enable it by specifying the ``useArrow`` parameter
+This is enabled by default with ``spark.sql.execution.pythonUDTF.arrow.enabled`` set ``true``.
+To disable Arrow optimization, set the ``spark.sql.execution.pythonUDTF.arrow.enabled``
+configuration to ``false``. You can also disable it by specifying the ``useArrow`` parameter
 when declaring the UDTF.
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/udtf.py

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3509,7 +3509,7 @@ object SQLConf {
       .doc("Enable Arrow optimization for Python UDTFs.")
       .version("3.5.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val PYTHON_PLANNER_EXEC_MEMORY =
     buildConf("spark.sql.planner.pythonExecution.memory")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enables `spark.sql.execution.pythonUDTF.arrow.enabled` by default.

### Why are the changes needed?

We enabled Arrow optimization https://github.com/apache/spark/pull/49482 and https://github.com/apache/spark/pull/50036. We should also enable it for UDTF too.

### Does this PR introduce _any_ user-facing change?

It will fallback to non-optimized code path so it impact will be minimized. Users will leverage Arrow optimization by default.

### How was this patch tested?

Existing tests in the CI.

### Was this patch authored or co-authored using generative AI tooling?


No