### PR TITLE
[SPARK-51332][SQL] DS V2 supports push down BIT_AND, BIT_OR, BIT_XOR, BIT_COUNT and BIT_GET

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GeneralScalarExpression.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GeneralScalarExpression.java
@@ -428,6 +428,18 @@ import org.apache.spark.sql.internal.connector.ExpressionWithToString;
  *    <li>Since version: 4.0.0</li>
  *   </ul>
  *  </li>
+ *  <li>Name: <code>BIT_COUNT</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>BIT_COUNT(expr)</code></li>
+ *    <li>Since version: 4.1.0</li>
+ *   </ul>
+ *  </li>
+ *  <li>Name: <code>BIT_GET</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>BIT_GET(expr, pos)</code></li>
+ *    <li>Since version: 4.1.0</li>
+ *   </ul>
+ *  </li>
  * </ol>
  * Note: SQL semantic conforms ANSI standard, so some expressions are not supported when ANSI off,
  * including: add, subtract, multiply, divide, remainder, pmod.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/GeneralAggregateFunc.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/GeneralAggregateFunc.java
@@ -45,6 +45,9 @@ import org.apache.spark.sql.internal.connector.ExpressionWithToString;
  *  <li><pre>MODE() WITHIN (ORDER BY input1 [ASC|DESC])</pre> Since 4.0.0</li>
  *  <li><pre>PERCENTILE_CONT(input1) WITHIN (ORDER BY input2 [ASC|DESC])</pre> Since 4.0.0</li>
  *  <li><pre>PERCENTILE_DISC(input1) WITHIN (ORDER BY input2 [ASC|DESC])</pre> Since 4.0.0</li>
+ *  <li><pre>BIT_AND(input1)</pre> Since 4.1.0</li>
+ *  <li><pre>BIT_OR(input1)</pre> Since 4.1.0</li>
+ *  <li><pre>BIT_XOR(input1)</pre> Since 4.1.0</li>
  * </ol>
  *
  * @since 3.3.0

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -118,7 +118,7 @@ public class V2ExpressionSQLBuilder {
           "COT", "ASIN", "ASINH", "ACOS", "ACOSH", "ATAN", "ATANH", "ATAN2", "CBRT", "DEGREES",
           "RADIANS", "SIGN", "WIDTH_BUCKET", "SUBSTRING", "UPPER", "LOWER", "TRANSLATE",
           "DATE_ADD", "DATE_DIFF", "TRUNC", "AES_ENCRYPT", "AES_DECRYPT", "SHA1", "SHA2", "MD5",
-          "CRC32", "BIT_LENGTH", "CHAR_LENGTH", "CONCAT", "RPAD", "LPAD" ->
+          "CRC32", "BIT_LENGTH", "CHAR_LENGTH", "CONCAT", "RPAD", "LPAD", "BIT_COUNT", "BIT_GET" ->
           visitSQLFunction(name, e.children());
         case "CASE_WHEN" -> visitCaseWhen(expressionsToStringArray(e.children()));
         case "TRIM" -> visitTrim("BOTH", expressionsToStringArray(e.children()));

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -306,6 +306,8 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) extends L
     case _: Sha2 => generateExpressionWithName("SHA2", expr, isPredicate)
     case _: StringLPad => generateExpressionWithName("LPAD", expr, isPredicate)
     case _: StringRPad => generateExpressionWithName("RPAD", expr, isPredicate)
+    case _: BitwiseCount => generateExpressionWithName("BIT_COUNT", expr, isPredicate)
+    case _: BitwiseGet => generateExpressionWithName("BIT_GET", expr, isPredicate)
     // TODO supports other expressions
     case ApplyFunctionExpression(function, children) =>
       val childrenExpressions = children.flatMap(generateExpression(_))
@@ -387,6 +389,12 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) extends L
       PushableExpression(left), PushableExpression(right), reverse, _, _, _) =>
       Some(new GeneralAggregateFunc("PERCENTILE_DISC", isDistinct,
         Array(right), Array(generateSortValue(left, reverse))))
+    case aggregate.BitAndAgg(PushableExpression(expr)) =>
+      Some(new GeneralAggregateFunc("BIT_AND", isDistinct, Array(expr)))
+    case aggregate.BitOrAgg(PushableExpression(expr)) =>
+      Some(new GeneralAggregateFunc("BIT_OR", isDistinct, Array(expr)))
+    case aggregate.BitXorAgg(PushableExpression(expr)) =>
+      Some(new GeneralAggregateFunc("BIT_XOR", isDistinct, Array(expr)))
     // TODO supports other aggregate functions
     case aggregate.V2Aggregator(aggrFunc, children, _, _) =>
       val translatedExprs = children.flatMap(PushableExpression.unapply(_))


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to support `BIT_AND`, `BIT_OR`, `BIT_XOR`, `BIT_COUNT` and `BIT_GET`  in DS V2 pushdown.


### Why are the changes needed?
Many mainstream databases supports `BIT_AND`, `BIT_OR`, `BIT_XOR`, `BIT_COUNT` and `BIT_GET`. So did Spark.
So we should let DS V2 supports push down these functions.

### Does this PR introduce _any_ user-facing change?
No. New feature.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
