### PR TITLE
[SPARK-51333][ML][PYTHON][CONNECT] Unwrap `InvocationTargetException` thrown by `invokeMethod`

### DIFF
--- a/python/pyspark/ml/tests/test_stat.py
+++ b/python/pyspark/ml/tests/test_stat.py
@@ -18,6 +18,7 @@
 import numpy as np
 import unittest
 
+from pyspark.errors import PySparkException
 from pyspark.ml.linalg import Vectors, DenseVector
 from pyspark.ml.stat import (
     ChiSquareTest,
@@ -191,6 +192,18 @@ class StatTestsMixin:
             np.allclose(row2.statistic, 0.1746780794018764, atol=1e-4),
             row2.statistic,
         )
+
+    def test_illegal_argument(self):
+        spark = self.spark
+        data = [
+            [0, Vectors.dense([0, 1, 2])],
+            [1, Vectors.dense([1, 1, 1])],
+            [2, Vectors.dense([2, 1, 0])],
+        ]
+        df = spark.createDataFrame(data, ["label", "feat"])
+
+        with self.assertRaisesRegex(PySparkException, "No such struct field"):
+            ChiSquareTest.test(df, "feat", "labelx").count()
 
 
 class StatTests(StatTestsMixin, ReusedSQLTestCase):

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.connect.ml
 
+import java.lang.reflect.InvocationTargetException
 import java.util.{Optional, ServiceLoader}
 import java.util.stream.Collectors
 
@@ -688,7 +689,12 @@ private[ml] object MLUtils {
 
   def invokeMethodAllowed(obj: Object, methodName: String): Object = {
     validate(obj, methodName)
-    invokeMethod(obj, methodName)
+    try {
+      invokeMethod(obj, methodName)
+    } catch {
+      case e: InvocationTargetException =>
+        throw e.getCause
+    }
   }
 
   def invokeMethodAllowed(
@@ -697,7 +703,12 @@ private[ml] object MLUtils {
       args: Array[Object],
       parameterTypes: Array[Class[_]]): Object = {
     validate(obj, methodName)
-    invokeMethod(obj, methodName, args, parameterTypes)
+    try {
+      invokeMethod(obj, methodName, args, parameterTypes)
+    } catch {
+      case e: InvocationTargetException =>
+        throw e.getCause
+    }
   }
 
   def write(instance: MLWritable, writeProto: proto.MlCommand.Write): Unit = {

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -692,7 +692,7 @@ private[ml] object MLUtils {
     try {
       invokeMethod(obj, methodName)
     } catch {
-      case e: InvocationTargetException =>
+      case e: InvocationTargetException if e.getCause != null =>
         throw e.getCause
     }
   }
@@ -706,7 +706,7 @@ private[ml] object MLUtils {
     try {
       invokeMethod(obj, methodName, args, parameterTypes)
     } catch {
-      case e: InvocationTargetException =>
+      case e: InvocationTargetException if e.getCause != null =>
         throw e.getCause
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Unwrap `InvocationTargetException` thrown by `invokeMethod`

https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/reflect/MethodUtils.html#invokeMethod(java.lang.Object,boolean,java.lang.String)



[InvocationTargetException](https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/InvocationTargetException.html) - wraps an exception thrown by the method invoked

### Why are the changes needed?
existing error message is useless in debug


### Does this PR introduce _any_ user-facing change?
yes

```
from pyspark.ml.linalg import Vectors

from pyspark.ml.stat import ChiSquareTest

data = [
    [0, Vectors.dense([0, 1, 2])],
    [1, Vectors.dense([1, 1, 1])],
    [2, Vectors.dense([2, 1, 0])],
]
df = spark.createDataFrame(data, ["label", "feat"])

ChiSquareTest.test(df, 'feat', 'labelx')
```

before
```
java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.apache.commons.lang3.reflect.MethodUtils.invokeMethod(MethodUtils.java:851)
	at org.apache.commons.lang3.reflect.MethodUtils.invokeMethod(MethodUtils.java:931)
	at org.apache.spark.sql.connect.ml.MLUtils$.invokeMethodAllowed(MLUtils.scala:700)
	at org.apache.spark.sql.connect.ml.AttributeHelper.$anonfun$getAttribute$1(MLHandler.scala:58)
	at scala.collection.ArrayOps$.foldLeft$extension(ArrayOps.scala:784)
	at org.apache.spark.sql.connect.ml.AttributeHelper.getAttribute(MLHandler.scala:54)
	at org.apache.spark.sql.connect.ml.MLHandler$.transformMLRelation(MLHandler.scala:333)
	at org.apache.spark.sql.connect.planner.SparkConnectPlanner.$anonfun$transformRelation$1(SparkConnectPlanner.scala:231)
	at org.apache.spark.sql.connect.service.SessionHolder.$anonfun$usePlanCache$3(SessionHolder.scala:477)
	at scala.Option.getOrElse(Option.scala:201)
...
```

after:
```
IllegalArgumentException: [FIELD_NOT_FOUND] No such struct field `labelx` in `label`, `feat`. SQLSTATE: 42704

JVM stacktrace:
org.apache.spark.SparkIllegalArgumentException
	at org.apache.spark.ml.util.SchemaUtils$.getSchemaField(SchemaUtils.scala:227)
	at org.apache.spark.ml.util.SchemaUtils$.getSchemaFieldType(SchemaUtils.scala:239)
	at org.apache.spark.ml.util.SchemaUtils$.checkNumericType(SchemaUtils.scala:77)
	at org.apache.spark.ml.stat.ChiSquareTest$.test(ChiSquareTest.scala:75)
```

### How was this patch tested?
added ut


### Was this patch authored or co-authored using generative AI tooling?
no