### PR TITLE
[SPARK-51337][SQL] Add maxRows to CTERelationDef and CTERelationRef

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CTESubstitution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CTESubstitution.scala
@@ -344,7 +344,8 @@ object CTESubstitution extends Rule[LogicalPlan] {
       recursiveCTERelation.map {
         case (_, d) =>
           SubqueryAlias(table,
-            CTERelationRef(d.id, d.resolved, d.output, d.isStreaming, recursive = true))
+            CTERelationRef(
+              d.id, d.resolved, d.output, d.isStreaming, recursive = true, maxRows = d.maxRows))
       }.get
     } else {
       cteRelations
@@ -357,7 +358,7 @@ object CTESubstitution extends Rule[LogicalPlan] {
               // Add a `SubqueryAlias` for hint-resolving rules to match relation names.
               // This is a non-recursive reference, recursive parameter is by default set to false
               SubqueryAlias(table,
-                CTERelationRef(d.id, d.resolved, d.output, d.isStreaming))
+                CTERelationRef(d.id, d.resolved, d.output, d.isStreaming, maxRows = d.maxRows))
             }
         }
         .getOrElse(unresolvedRelation)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveWithCTE.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveWithCTE.scala
@@ -157,7 +157,8 @@ object ResolveWithCTE extends Rule[LogicalPlan] {
       case ref: CTERelationRef if !ref.resolved =>
         cteDefMap.get(ref.cteId).map { cteDef =>
           // cteDef is certainly resolved, otherwise it would not have been in the map.
-          CTERelationRef(cteDef.id, cteDef.resolved, cteDef.output, cteDef.isStreaming)
+          CTERelationRef(
+            cteDef.id, cteDef.resolved, cteDef.output, cteDef.isStreaming, maxRows = cteDef.maxRows)
         }.getOrElse {
           ref
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/Resolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/Resolver.scala
@@ -439,7 +439,8 @@ class Resolver(
       _resolved = true,
       isStreaming = unresolvedCteRelationDef.isStreaming,
       output = unresolvedCteRelationDef.output,
-      recursive = false
+      recursive = false,
+      maxRows = unresolvedCteRelationDef.maxRows
     )
 
     handleLeafOperator(cteRelationRef)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushdownPredicatesAndPruneColumnsForCTEDef.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushdownPredicatesAndPruneColumnsForCTEDef.scala
@@ -141,7 +141,7 @@ object PushdownPredicatesAndPruneColumnsForCTEDef extends Rule[LogicalPlan] {
         cteDef
       }
 
-    case cteRef @ CTERelationRef(cteId, _, output, _, _, _) =>
+    case cteRef @ CTERelationRef(cteId, _, output, _, _, _, _) =>
       val (cteDef, _, _, newAttrSet) = cteMap(cteId)
       if (needsPruning(cteDef.child, newAttrSet)) {
         val indices = newAttrSet.toSeq.map(cteDef.output.indexOf)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/cteOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/cteOperators.scala
@@ -95,13 +95,19 @@ case class CTERelationDef(
 
   final override val nodePatterns: Seq[TreePattern] = Seq(CTE)
 
+  override def maxRows: Option[Long] = if (conf.getConf(SQLConf.CTE_RELATION_DEF_MAX_ROWS)) {
+    child.maxRows
+  } else {
+    None
+  }
+
   override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan =
     copy(child = newChild)
 
   override def output: Seq[Attribute] = if (resolved) child.output else Nil
 
   lazy val hasSelfReferenceAsCTERef: Boolean = child.exists{
-    case CTERelationRef(this.id, _, _, _, _, true) => true
+    case CTERelationRef(this.id, _, _, _, _, true, _) => true
     case _ => false
   }
   lazy val hasSelfReferenceAsUnionLoopRef: Boolean = child.exists{
@@ -132,7 +138,8 @@ case class CTERelationRef(
     override val output: Seq[Attribute],
     override val isStreaming: Boolean,
     statsOpt: Option[Statistics] = None,
-    recursive: Boolean = false) extends LeafNode with MultiInstanceRelation {
+    recursive: Boolean = false,
+    override val maxRows: Option[Long] = None) extends LeafNode with MultiInstanceRelation {
 
   final override val nodePatterns: Seq[TreePattern] = Seq(CTE)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5575,6 +5575,18 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val CTE_RELATION_DEF_MAX_ROWS =
+    buildConf("spark.sql.cteRelationDefMaxRows.enabled")
+      .internal()
+      .doc(
+        "When set to true, CTERelationDef.maxRows would output the correct value from the " +
+        "child plan. This is necessary for correct scalar subquery validation in the " +
+        "single-pass Analyzer."
+      )
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(true)
+
   /**
    * Holds information about keys that have been deprecated.
    *

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-command.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-command.sql.out
@@ -10,7 +10,7 @@ CreateDataSourceTableAsSelectCommand `spark_catalog`.`default`.`cte_tbl`, ErrorI
       :        +- OneRowRelation
       +- Project [col#x]
          +- SubqueryAlias s
-            +- CTERelationRef xxxx, true, [col#x], false, false
+            +- CTERelationRef xxxx, true, [col#x], false, false, 1
 
 
 -- !query
@@ -32,7 +32,7 @@ CreateViewCommand `cte_view`, WITH s AS (SELECT 42 AS col) SELECT * FROM s, fals
       :        +- OneRowRelation
       +- Project [col#x]
          +- SubqueryAlias s
-            +- CTERelationRef xxxx, true, [col#x], false, false
+            +- CTERelationRef xxxx, true, [col#x], false, false, 1
 
 
 -- !query
@@ -49,7 +49,7 @@ Project [col#x]
             :        +- OneRowRelation
             +- Project [col#x]
                +- SubqueryAlias s
-                  +- CTERelationRef xxxx, true, [col#x], false, false
+                  +- CTERelationRef xxxx, true, [col#x], false, false, 1
 
 
 -- !query
@@ -64,7 +64,7 @@ InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_d
    :        +- OneRowRelation
    +- Project [col#x]
       +- SubqueryAlias S
-         +- CTERelationRef xxxx, true, [col#x], false, false
+         +- CTERelationRef xxxx, true, [col#x], false, false, 1
 
 
 -- !query
@@ -86,7 +86,7 @@ InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_d
    :        +- OneRowRelation
    +- Project [col#x]
       +- SubqueryAlias s
-         +- CTERelationRef xxxx, true, [col#x], false, false
+         +- CTERelationRef xxxx, true, [col#x], false, false, 1
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-nested.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-nested.sql.out
@@ -15,10 +15,10 @@ WithCTE
 :  +- SubqueryAlias t
 :     +- Project [1#x]
 :        +- SubqueryAlias t2
-:           +- CTERelationRef xxxx, true, [1#x], false, false
+:           +- CTERelationRef xxxx, true, [1#x], false, false, 1
 +- Project [1#x]
    +- SubqueryAlias t
-      +- CTERelationRef xxxx, true, [1#x], false, false
+      +- CTERelationRef xxxx, true, [1#x], false, false, 1
 
 
 -- !query
@@ -37,7 +37,7 @@ Aggregate [max(c#x) AS max(c)#x]
       :           +- OneRowRelation
       +- Project [c#x]
          +- SubqueryAlias t
-            +- CTERelationRef xxxx, true, [c#x], false, false
+            +- CTERelationRef xxxx, true, [c#x], false, false, 1
 
 
 -- !query
@@ -54,7 +54,7 @@ Project [scalar-subquery#x [] AS scalarsubquery()#x]
 :     :        +- OneRowRelation
 :     +- Project [1#x]
 :        +- SubqueryAlias t
-:           +- CTERelationRef xxxx, true, [1#x], false, false
+:           +- CTERelationRef xxxx, true, [1#x], false, false, 1
 +- OneRowRelation
 
 
@@ -140,10 +140,10 @@ WithCTE
 :  +- SubqueryAlias t2
 :     +- Project [2#x]
 :        +- SubqueryAlias t
-:           +- CTERelationRef xxxx, true, [2#x], false, false
+:           +- CTERelationRef xxxx, true, [2#x], false, false, 1
 +- Project [2#x]
    +- SubqueryAlias t2
-      +- CTERelationRef xxxx, true, [2#x], false, false
+      +- CTERelationRef xxxx, true, [2#x], false, false, 1
 
 
 -- !query
@@ -178,11 +178,11 @@ WithCTE
 :        :           :           +- OneRowRelation
 :        :           +- Project [c#x]
 :        :              +- SubqueryAlias t
-:        :                 +- CTERelationRef xxxx, true, [c#x], false, false
+:        :                 +- CTERelationRef xxxx, true, [c#x], false, false, 1
 :        +- OneRowRelation
 +- Project [scalarsubquery()#x]
    +- SubqueryAlias t2
-      +- CTERelationRef xxxx, true, [scalarsubquery()#x], false, false
+      +- CTERelationRef xxxx, true, [scalarsubquery()#x], false, false, 1
 
 
 -- !query
@@ -215,15 +215,15 @@ WithCTE
 :  +- SubqueryAlias t2
 :     +- Project [3#x]
 :        +- SubqueryAlias t
-:           +- CTERelationRef xxxx, true, [3#x], false, false
+:           +- CTERelationRef xxxx, true, [3#x], false, false, 1
 :- CTERelationDef xxxx, false
 :  +- SubqueryAlias t2
 :     +- Project [3#x]
 :        +- SubqueryAlias t2
-:           +- CTERelationRef xxxx, true, [3#x], false, false
+:           +- CTERelationRef xxxx, true, [3#x], false, false, 1
 +- Project [3#x]
    +- SubqueryAlias t2
-      +- CTERelationRef xxxx, true, [3#x], false, false
+      +- CTERelationRef xxxx, true, [3#x], false, false, 1
 
 
 -- !query
@@ -248,7 +248,7 @@ WithCTE
    +- SubqueryAlias __auto_generated_subquery_name
       +- Project [c#x]
          +- SubqueryAlias t
-            +- CTERelationRef xxxx, true, [c#x], false, false
+            +- CTERelationRef xxxx, true, [c#x], false, false, 1
 
 
 -- !query
@@ -277,7 +277,7 @@ WithCTE
          +- SubqueryAlias __auto_generated_subquery_name
             +- Project [c#x]
                +- SubqueryAlias t
-                  +- CTERelationRef xxxx, true, [c#x], false, false
+                  +- CTERelationRef xxxx, true, [c#x], false, false, 1
 
 
 -- !query
@@ -312,7 +312,7 @@ WithCTE
          +- SubqueryAlias __auto_generated_subquery_name
             +- Project [c#x]
                +- SubqueryAlias t
-                  +- CTERelationRef xxxx, true, [c#x], false, false
+                  +- CTERelationRef xxxx, true, [c#x], false, false, 1
 
 
 -- !query
@@ -335,7 +335,7 @@ WithCTE
    :     :        +- OneRowRelation
    :     +- Project [2#x]
    :        +- SubqueryAlias t
-   :           +- CTERelationRef xxxx, true, [2#x], false, false
+   :           +- CTERelationRef xxxx, true, [2#x], false, false, 1
    +- OneRowRelation
 
 
@@ -362,7 +362,7 @@ WithCTE
    :     :     :        +- OneRowRelation
    :     :     +- Project [2#x]
    :     :        +- SubqueryAlias t
-   :     :           +- CTERelationRef xxxx, true, [2#x], false, false
+   :     :           +- CTERelationRef xxxx, true, [2#x], false, false, 1
    :     +- OneRowRelation
    +- OneRowRelation
 
@@ -396,7 +396,7 @@ WithCTE
    :        :     :        +- OneRowRelation
    :        :     +- Project [3#x]
    :        :        +- SubqueryAlias t
-   :        :           +- CTERelationRef xxxx, true, [3#x], false, false
+   :        :           +- CTERelationRef xxxx, true, [3#x], false, false, 1
    :        +- OneRowRelation
    +- OneRowRelation
 
@@ -425,9 +425,9 @@ WithCTE
       :     :           +- OneRowRelation
       :     +- Project [c#x]
       :        +- SubqueryAlias t
-      :           +- CTERelationRef xxxx, true, [c#x], false, false
+      :           +- CTERelationRef xxxx, true, [c#x], false, false, 1
       +- SubqueryAlias t
-         +- CTERelationRef xxxx, true, [c#x], false, false
+         +- CTERelationRef xxxx, true, [c#x], false, false, 1
 
 
 -- !query
@@ -448,14 +448,14 @@ WithCTE
 :  +- SubqueryAlias t
 :     +- Project [1#x]
 :        +- SubqueryAlias t2
-:           +- CTERelationRef xxxx, true, [1#x], false, false
+:           +- CTERelationRef xxxx, true, [1#x], false, false, 1
 :- CTERelationDef xxxx, false
 :  +- SubqueryAlias t2
 :     +- Project [2 AS 2#x]
 :        +- OneRowRelation
 +- Project [1#x]
    +- SubqueryAlias t
-      +- CTERelationRef xxxx, true, [1#x], false, false
+      +- CTERelationRef xxxx, true, [1#x], false, false, 1
 
 
 -- !query
@@ -480,10 +480,10 @@ WithCTE
 :  +- SubqueryAlias t
 :     +- Project [2#x]
 :        +- SubqueryAlias aBC
-:           +- CTERelationRef xxxx, true, [2#x], false, false
+:           +- CTERelationRef xxxx, true, [2#x], false, false, 1
 +- Project [2#x]
    +- SubqueryAlias t
-      +- CTERelationRef xxxx, true, [2#x], false, false
+      +- CTERelationRef xxxx, true, [2#x], false, false, 1
 
 
 -- !query
@@ -506,7 +506,7 @@ WithCTE
    :     :        +- OneRowRelation
    :     +- Project [2#x]
    :        +- SubqueryAlias aBC
-   :           +- CTERelationRef xxxx, true, [2#x], false, false
+   :           +- CTERelationRef xxxx, true, [2#x], false, false, 1
    +- OneRowRelation
 
 
@@ -530,15 +530,15 @@ WithCTE
 :  +- SubqueryAlias t3
 :     +- Project [1#x]
 :        +- SubqueryAlias t1
-:           +- CTERelationRef xxxx, true, [1#x], false, false
+:           +- CTERelationRef xxxx, true, [1#x], false, false, 1
 :- CTERelationDef xxxx, false
 :  +- SubqueryAlias t2
 :     +- Project [1#x]
 :        +- SubqueryAlias t3
-:           +- CTERelationRef xxxx, true, [1#x], false, false
+:           +- CTERelationRef xxxx, true, [1#x], false, false, 1
 +- Project [1#x]
    +- SubqueryAlias t2
-      +- CTERelationRef xxxx, true, [1#x], false, false
+      +- CTERelationRef xxxx, true, [1#x], false, false, 1
 
 
 -- !query
@@ -561,12 +561,12 @@ WithCTE
 :  +- SubqueryAlias cte_inner
 :     +- Project [1#x]
 :        +- SubqueryAlias cte_outer
-:           +- CTERelationRef xxxx, true, [1#x], false, false
+:           +- CTERelationRef xxxx, true, [1#x], false, false, 1
 +- Project [1#x]
    +- SubqueryAlias __auto_generated_subquery_name
       +- Project [1#x]
          +- SubqueryAlias cte_inner
-            +- CTERelationRef xxxx, true, [1#x], false, false
+            +- CTERelationRef xxxx, true, [1#x], false, false, 1
 
 
 -- !query
@@ -594,19 +594,19 @@ WithCTE
 :  +- SubqueryAlias cte_inner_inner
 :     +- Project [1#x]
 :        +- SubqueryAlias cte_outer
-:           +- CTERelationRef xxxx, true, [1#x], false, false
+:           +- CTERelationRef xxxx, true, [1#x], false, false, 1
 :- CTERelationDef xxxx, false
 :  +- SubqueryAlias cte_inner
 :     +- Project [1#x]
 :        +- SubqueryAlias __auto_generated_subquery_name
 :           +- Project [1#x]
 :              +- SubqueryAlias cte_inner_inner
-:                 +- CTERelationRef xxxx, true, [1#x], false, false
+:                 +- CTERelationRef xxxx, true, [1#x], false, false, 1
 +- Project [1#x]
    +- SubqueryAlias __auto_generated_subquery_name
       +- Project [1#x]
          +- SubqueryAlias cte_inner
-            +- CTERelationRef xxxx, true, [1#x], false, false
+            +- CTERelationRef xxxx, true, [1#x], false, false, 1
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-nonlegacy.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-nonlegacy.sql.out
@@ -15,10 +15,10 @@ WithCTE
 :  +- SubqueryAlias t
 :     +- Project [1#x]
 :        +- SubqueryAlias t2
-:           +- CTERelationRef xxxx, true, [1#x], false, false
+:           +- CTERelationRef xxxx, true, [1#x], false, false, 1
 +- Project [1#x]
    +- SubqueryAlias t
-      +- CTERelationRef xxxx, true, [1#x], false, false
+      +- CTERelationRef xxxx, true, [1#x], false, false, 1
 
 
 -- !query
@@ -37,7 +37,7 @@ Aggregate [max(c#x) AS max(c)#x]
       :           +- OneRowRelation
       +- Project [c#x]
          +- SubqueryAlias t
-            +- CTERelationRef xxxx, true, [c#x], false, false
+            +- CTERelationRef xxxx, true, [c#x], false, false, 1
 
 
 -- !query
@@ -54,7 +54,7 @@ Project [scalar-subquery#x [] AS scalarsubquery()#x]
 :     :        +- OneRowRelation
 :     +- Project [1#x]
 :        +- SubqueryAlias t
-:           +- CTERelationRef xxxx, true, [1#x], false, false
+:           +- CTERelationRef xxxx, true, [1#x], false, false, 1
 +- OneRowRelation
 
 
@@ -171,11 +171,11 @@ WithCTE
 :        :           :           +- OneRowRelation
 :        :           +- Project [c#x]
 :        :              +- SubqueryAlias t
-:        :                 +- CTERelationRef xxxx, true, [c#x], false, false
+:        :                 +- CTERelationRef xxxx, true, [c#x], false, false, 1
 :        +- OneRowRelation
 +- Project [scalarsubquery()#x]
    +- SubqueryAlias t2
-      +- CTERelationRef xxxx, true, [scalarsubquery()#x], false, false
+      +- CTERelationRef xxxx, true, [scalarsubquery()#x], false, false, 1
 
 
 -- !query
@@ -225,7 +225,7 @@ WithCTE
    +- SubqueryAlias __auto_generated_subquery_name
       +- Project [c#x]
          +- SubqueryAlias t
-            +- CTERelationRef xxxx, true, [c#x], false, false
+            +- CTERelationRef xxxx, true, [c#x], false, false, 1
 
 
 -- !query
@@ -254,7 +254,7 @@ WithCTE
          +- SubqueryAlias __auto_generated_subquery_name
             +- Project [c#x]
                +- SubqueryAlias t
-                  +- CTERelationRef xxxx, true, [c#x], false, false
+                  +- CTERelationRef xxxx, true, [c#x], false, false, 1
 
 
 -- !query
@@ -289,7 +289,7 @@ WithCTE
          +- SubqueryAlias __auto_generated_subquery_name
             +- Project [c#x]
                +- SubqueryAlias t
-                  +- CTERelationRef xxxx, true, [c#x], false, false
+                  +- CTERelationRef xxxx, true, [c#x], false, false, 1
 
 
 -- !query
@@ -392,14 +392,14 @@ WithCTE
 :  +- SubqueryAlias t
 :     +- Project [1#x]
 :        +- SubqueryAlias t2
-:           +- CTERelationRef xxxx, true, [1#x], false, false
+:           +- CTERelationRef xxxx, true, [1#x], false, false, 1
 :- CTERelationDef xxxx, false
 :  +- SubqueryAlias t2
 :     +- Project [2 AS 2#x]
 :        +- OneRowRelation
 +- Project [1#x]
    +- SubqueryAlias t
-      +- CTERelationRef xxxx, true, [1#x], false, false
+      +- CTERelationRef xxxx, true, [1#x], false, false, 1
 
 
 -- !query
@@ -462,15 +462,15 @@ WithCTE
 :  +- SubqueryAlias t3
 :     +- Project [1#x]
 :        +- SubqueryAlias t1
-:           +- CTERelationRef xxxx, true, [1#x], false, false
+:           +- CTERelationRef xxxx, true, [1#x], false, false, 1
 :- CTERelationDef xxxx, false
 :  +- SubqueryAlias t2
 :     +- Project [1#x]
 :        +- SubqueryAlias t3
-:           +- CTERelationRef xxxx, true, [1#x], false, false
+:           +- CTERelationRef xxxx, true, [1#x], false, false, 1
 +- Project [1#x]
    +- SubqueryAlias t2
-      +- CTERelationRef xxxx, true, [1#x], false, false
+      +- CTERelationRef xxxx, true, [1#x], false, false, 1
 
 
 -- !query
@@ -493,12 +493,12 @@ WithCTE
 :  +- SubqueryAlias cte_inner
 :     +- Project [1#x]
 :        +- SubqueryAlias cte_outer
-:           +- CTERelationRef xxxx, true, [1#x], false, false
+:           +- CTERelationRef xxxx, true, [1#x], false, false, 1
 +- Project [1#x]
    +- SubqueryAlias __auto_generated_subquery_name
       +- Project [1#x]
          +- SubqueryAlias cte_inner
-            +- CTERelationRef xxxx, true, [1#x], false, false
+            +- CTERelationRef xxxx, true, [1#x], false, false, 1
 
 
 -- !query
@@ -526,19 +526,19 @@ WithCTE
 :  +- SubqueryAlias cte_inner_inner
 :     +- Project [1#x]
 :        +- SubqueryAlias cte_outer
-:           +- CTERelationRef xxxx, true, [1#x], false, false
+:           +- CTERelationRef xxxx, true, [1#x], false, false, 1
 :- CTERelationDef xxxx, false
 :  +- SubqueryAlias cte_inner
 :     +- Project [1#x]
 :        +- SubqueryAlias __auto_generated_subquery_name
 :           +- Project [1#x]
 :              +- SubqueryAlias cte_inner_inner
-:                 +- CTERelationRef xxxx, true, [1#x], false, false
+:                 +- CTERelationRef xxxx, true, [1#x], false, false, 1
 +- Project [1#x]
    +- SubqueryAlias __auto_generated_subquery_name
       +- Project [1#x]
          +- SubqueryAlias cte_inner
-            +- CTERelationRef xxxx, true, [1#x], false, false
+            +- CTERelationRef xxxx, true, [1#x], false, false, 1
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte.sql.out
@@ -210,7 +210,7 @@ WithCTE
 +- Project [x#x]
    +- Filter (x#x = 1)
       +- SubqueryAlias t
-         +- CTERelationRef xxxx, true, [x#x], false, false
+         +- CTERelationRef xxxx, true, [x#x], false, false, 1
 
 
 -- !query
@@ -226,7 +226,7 @@ WithCTE
 +- Project [x#x, y#x]
    +- Filter ((x#x = 1) AND (y#x = 2))
       +- SubqueryAlias t
-         +- CTERelationRef xxxx, true, [x#x, y#x], false, false
+         +- CTERelationRef xxxx, true, [x#x, y#x], false, false, 1
 
 
 -- !query
@@ -241,7 +241,7 @@ WithCTE
 :           +- OneRowRelation
 +- Project [x#x, x#x]
    +- SubqueryAlias t
-      +- CTERelationRef xxxx, true, [x#x, x#x], false, false
+      +- CTERelationRef xxxx, true, [x#x, x#x], false, false, 1
 
 
 -- !query
@@ -344,46 +344,46 @@ WithCTE
 :     +- Project [c8#x AS c7#x]
 :        +- Project [c8#x]
 :           +- SubqueryAlias w8
-:              +- CTERelationRef xxxx, true, [c8#x], false, false
+:              +- CTERelationRef xxxx, true, [c8#x], false, false, 1
 :- CTERelationDef xxxx, false
 :  +- SubqueryAlias w6
 :     +- Project [c7#x AS c6#x]
 :        +- Project [c7#x]
 :           +- SubqueryAlias w7
-:              +- CTERelationRef xxxx, true, [c7#x], false, false
+:              +- CTERelationRef xxxx, true, [c7#x], false, false, 1
 :- CTERelationDef xxxx, false
 :  +- SubqueryAlias w5
 :     +- Project [c6#x AS c5#x]
 :        +- Project [c6#x]
 :           +- SubqueryAlias w6
-:              +- CTERelationRef xxxx, true, [c6#x], false, false
+:              +- CTERelationRef xxxx, true, [c6#x], false, false, 1
 :- CTERelationDef xxxx, false
 :  +- SubqueryAlias w4
 :     +- Project [c5#x AS c4#x]
 :        +- Project [c5#x]
 :           +- SubqueryAlias w5
-:              +- CTERelationRef xxxx, true, [c5#x], false, false
+:              +- CTERelationRef xxxx, true, [c5#x], false, false, 1
 :- CTERelationDef xxxx, false
 :  +- SubqueryAlias w3
 :     +- Project [c4#x AS c3#x]
 :        +- Project [c4#x]
 :           +- SubqueryAlias w4
-:              +- CTERelationRef xxxx, true, [c4#x], false, false
+:              +- CTERelationRef xxxx, true, [c4#x], false, false, 1
 :- CTERelationDef xxxx, false
 :  +- SubqueryAlias w2
 :     +- Project [c3#x AS c2#x]
 :        +- Project [c3#x]
 :           +- SubqueryAlias w3
-:              +- CTERelationRef xxxx, true, [c3#x], false, false
+:              +- CTERelationRef xxxx, true, [c3#x], false, false, 1
 :- CTERelationDef xxxx, false
 :  +- SubqueryAlias w1
 :     +- Project [c2#x AS c1#x]
 :        +- Project [c2#x]
 :           +- SubqueryAlias w2
-:              +- CTERelationRef xxxx, true, [c2#x], false, false
+:              +- CTERelationRef xxxx, true, [c2#x], false, false, 1
 +- Project [c1#x]
    +- SubqueryAlias w1
-      +- CTERelationRef xxxx, true, [c1#x], false, false
+      +- CTERelationRef xxxx, true, [c1#x], false, false, 1
 
 
 -- !query
@@ -420,7 +420,7 @@ WithCTE
 +- Project [42#x, 10#x]
    +- Join Inner
       :- SubqueryAlias same_name
-      :  +- CTERelationRef xxxx, true, [42#x], false, false
+      :  +- CTERelationRef xxxx, true, [42#x], false, false, 1
       +- SubqueryAlias same_name
          +- Project [10 AS 10#x]
             +- OneRowRelation
@@ -459,7 +459,7 @@ WithCTE
 :        +- OneRowRelation
 +- Project [x#x, typeof(x#x) AS typeof(x)#x]
    +- SubqueryAlias q
-      +- CTERelationRef xxxx, true, [x#x], false, false
+      +- CTERelationRef xxxx, true, [x#x], false, false, 1
 
 
 -- !query
@@ -519,7 +519,7 @@ Project [y#x]
       :        +- OneRowRelation
       +- Project [(x#x + 1) AS y#x]
          +- SubqueryAlias q
-            +- CTERelationRef xxxx, true, [x#x], false, false
+            +- CTERelationRef xxxx, true, [x#x], false, false, 1
 
 
 -- !query
@@ -533,7 +533,7 @@ Project [scalar-subquery#x [] AS scalarsubquery()#x]
 :     :        +- OneRowRelation
 :     +- Project [x#x]
 :        +- SubqueryAlias q
-:           +- CTERelationRef xxxx, true, [x#x], false, false
+:           +- CTERelationRef xxxx, true, [x#x], false, false, 1
 +- OneRowRelation
 
 
@@ -548,7 +548,7 @@ Project [1 IN (list#x []) AS (1 IN (listquery()))#x]
 :     :        +- OneRowRelation
 :     +- Project [1#x]
 :        +- SubqueryAlias q
-:           +- CTERelationRef xxxx, true, [1#x], false, false
+:           +- CTERelationRef xxxx, true, [1#x], false, false, 1
 +- OneRowRelation
 
 
@@ -596,14 +596,14 @@ WithCTE
       :- Join Inner
       :  :- SubqueryAlias x
       :  :  +- SubqueryAlias T1
-      :  :     +- CTERelationRef xxxx, true, [a#x], false, false
+      :  :     +- CTERelationRef xxxx, true, [a#x], false, false, 1
       :  +- SubqueryAlias y
       :     +- Project [b#x]
       :        +- SubqueryAlias T1
-      :           +- CTERelationRef xxxx, true, [b#x], false, false
+      :           +- CTERelationRef xxxx, true, [b#x], false, false, 1
       +- SubqueryAlias z
          +- SubqueryAlias T1
-            +- CTERelationRef xxxx, true, [a#x], false, false
+            +- CTERelationRef xxxx, true, [a#x], false, false, 1
 
 
 -- !query
@@ -631,9 +631,9 @@ WithCTE
       +- Project [c#x, a#x]
          +- Join Inner
             :- SubqueryAlias ttTT
-            :  +- CTERelationRef xxxx, true, [c#x], false, false
+            :  +- CTERelationRef xxxx, true, [c#x], false, false, 1
             +- SubqueryAlias tttT_2
-               +- CTERelationRef xxxx, true, [a#x], false, false
+               +- CTERelationRef xxxx, true, [a#x], false, false, 1
 
 
 -- !query
@@ -649,7 +649,7 @@ Project [scalar-subquery#x [x#x] AS scalarsubquery(x)#x]
 :     :        +- OneRowRelation
 :     +- Project [x#x]
 :        +- SubqueryAlias q
-:           +- CTERelationRef xxxx, true, [x#x], false, false
+:           +- CTERelationRef xxxx, true, [x#x], false, false, 1
 +- SubqueryAlias T
    +- Project [1 AS x#x, 2 AS y#x]
       +- OneRowRelation
@@ -668,7 +668,7 @@ Project [scalar-subquery#x [x#x && y#x] AS scalarsubquery(x, y)#x]
 :     :        +- OneRowRelation
 :     +- Project [((outer(x#x) + outer(y#x)) + z#x) AS ((outer(T.x) + outer(T.y)) + z)#x]
 :        +- SubqueryAlias q
-:           +- CTERelationRef xxxx, true, [z#x], false, false
+:           +- CTERelationRef xxxx, true, [z#x], false, false, 1
 +- SubqueryAlias T
    +- Project [1 AS x#x, 2 AS y#x]
       +- OneRowRelation
@@ -688,12 +688,12 @@ WithCTE
 :  +- SubqueryAlias q2
 :     +- Project [x#x]
 :        +- SubqueryAlias q1
-:           +- CTERelationRef xxxx, true, [x#x], false, false
+:           +- CTERelationRef xxxx, true, [x#x], false, false, 1
 +- Project [x#x]
    +- SubqueryAlias __auto_generated_subquery_name
       +- Project [x#x]
          +- SubqueryAlias q2
-            +- CTERelationRef xxxx, true, [x#x], false, false
+            +- CTERelationRef xxxx, true, [x#x], false, false, 1
 
 
 -- !query
@@ -710,12 +710,12 @@ WithCTE
 :  +- SubqueryAlias q1
 :     +- Project [(x#x + 1) AS (x + 1)#x]
 :        +- SubqueryAlias q1
-:           +- CTERelationRef xxxx, true, [x#x], false, false
+:           +- CTERelationRef xxxx, true, [x#x], false, false, 1
 +- Project [(x + 1)#x]
    +- SubqueryAlias __auto_generated_subquery_name
       +- Project [(x + 1)#x]
          +- SubqueryAlias q1
-            +- CTERelationRef xxxx, true, [(x + 1)#x], false, false
+            +- CTERelationRef xxxx, true, [(x + 1)#x], false, false, 1
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/double-quoted-identifiers-enabled.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/double-quoted-identifiers-enabled.sql.out
@@ -418,7 +418,7 @@ CreateViewCommand `myview`, [(c1,None)], WITH "v"("a") AS (SELECT 1) SELECT "a" 
       :           +- OneRowRelation
       +- Project [a#x]
          +- SubqueryAlias v
-            +- CTERelationRef xxxx, true, [a#x], false, false
+            +- CTERelationRef xxxx, true, [a#x], false, false, 1
 
 
 -- !query
@@ -438,7 +438,7 @@ Project [a1#x AS a2#x]
                   :           +- OneRowRelation
                   +- Project [a#x]
                      +- SubqueryAlias v
-                        +- CTERelationRef xxxx, true, [a#x], false, false
+                        +- CTERelationRef xxxx, true, [a#x], false, false, 1
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/identifier-clause.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/identifier-clause.sql.out
@@ -1022,7 +1022,7 @@ WithCTE
 :        +- LocalRelation [col1#x, col2#x]
 +- Aggregate [max(c1#x) AS max(c1)#x]
    +- SubqueryAlias T
-      +- CTERelationRef xxxx, true, [c1#x, c2#x], false, false
+      +- CTERelationRef xxxx, true, [c1#x, c2#x], false, false, 2
 
 
 -- !query
@@ -1041,7 +1041,7 @@ WithCTE
 :        +- LocalRelation [col1#x, col2#x]
 +- Aggregate [max(c1#x) AS max(c1)#x]
    +- SubqueryAlias T
-      +- CTERelationRef xxxx, true, [c1#x, c2#x], false, false
+      +- CTERelationRef xxxx, true, [c1#x, c2#x], false, false, 2
 
 
 -- !query
@@ -1055,7 +1055,7 @@ WithCTE
 :        +- LocalRelation [col1#x, col2#x]
 +- Aggregate [max(c1#x) AS max(c1)#x]
    +- SubqueryAlias ABC
-      +- CTERelationRef xxxx, true, [c1#x, c2#x], false, false
+      +- CTERelationRef xxxx, true, [c1#x, c2#x], false, false, 2
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/non-excludable-rule.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/non-excludable-rule.sql.out
@@ -47,7 +47,7 @@ WithCTE
    +- Filter (id#xL > scalar-subquery#x [])
       :  +- Aggregate [max(id#xL) AS max(id)#xL]
       :     +- SubqueryAlias tmp
-      :        +- CTERelationRef xxxx, true, [id#xL], false, false
+      :        +- CTERelationRef xxxx, true, [id#xL], false, false, 2
       +- Range (0, 3, step=1)
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/window_part3.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/window_part3.sql.out
@@ -99,7 +99,7 @@ WithCTE
       +- Window [sum(x#xL) windowspecdefinition(x#xL ASC NULLS FIRST, specifiedwindowframe(RowFrame, -1, 1)) AS sum(x) OVER (ORDER BY x ASC NULLS FIRST ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)#xL], [x#xL ASC NULLS FIRST]
          +- Project [x#xL]
             +- SubqueryAlias cte
-               +- CTERelationRef xxxx, true, [x#xL], false, false
+               +- CTERelationRef xxxx, true, [x#xL], false, false, 18
 
 
 -- !query
@@ -121,7 +121,7 @@ WithCTE
       +- Window [sum(x#xL) windowspecdefinition(x#xL ASC NULLS FIRST, specifiedwindowframe(RangeFrame, cast(-1 as bigint), cast(1 as bigint))) AS sum(x) OVER (ORDER BY x ASC NULLS FIRST RANGE BETWEEN (- 1) FOLLOWING AND 1 FOLLOWING)#xL], [x#xL ASC NULLS FIRST]
          +- Project [x#xL]
             +- SubqueryAlias cte
-               +- CTERelationRef xxxx, true, [x#xL], false, false
+               +- CTERelationRef xxxx, true, [x#xL], false, false, 18
 
 
 -- !query
@@ -154,7 +154,7 @@ WithCTE
       +- Window [sum(x#xL) windowspecdefinition(x#xL ASC NULLS FIRST, specifiedwindowframe(RowFrame, -1, 1)) AS sum(x) OVER (ORDER BY x ASC NULLS FIRST ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)#xL], [x#xL ASC NULLS FIRST]
          +- Project [x#xL]
             +- SubqueryAlias cte
-               +- CTERelationRef xxxx, true, [x#xL], false, false
+               +- CTERelationRef xxxx, true, [x#xL], false, false, 26
 
 
 -- !query
@@ -187,7 +187,7 @@ WithCTE
       +- Window [sum(x#xL) windowspecdefinition(x#xL ASC NULLS FIRST, specifiedwindowframe(RangeFrame, cast(-1 as bigint), cast(1 as bigint))) AS sum(x) OVER (ORDER BY x ASC NULLS FIRST RANGE BETWEEN (- 1) FOLLOWING AND 1 FOLLOWING)#xL], [x#xL ASC NULLS FIRST]
          +- Project [x#xL]
             +- SubqueryAlias cte
-               +- CTERelationRef xxxx, true, [x#xL], false, false
+               +- CTERelationRef xxxx, true, [x#xL], false, false, 26
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/with.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/with.sql.out
@@ -12,10 +12,10 @@ WithCTE
 +- Project [x#x, y#x, x#x, y#x]
    +- Join Inner
       :- SubqueryAlias q1
-      :  +- CTERelationRef xxxx, true, [x#x, y#x], false, false
+      :  +- CTERelationRef xxxx, true, [x#x, y#x], false, false, 1
       +- SubqueryAlias q2
          +- SubqueryAlias q1
-            +- CTERelationRef xxxx, true, [x#x, y#x], false, false
+            +- CTERelationRef xxxx, true, [x#x, y#x], false, false, 1
 
 
 -- !query
@@ -194,7 +194,7 @@ WithCTE
    +- SubqueryAlias q
       +- Project [foo#x]
          +- SubqueryAlias cte
-            +- CTERelationRef xxxx, true, [foo#x], false, false
+            +- CTERelationRef xxxx, true, [foo#x], false, false, 1
 
 
 -- !query
@@ -222,13 +222,13 @@ WithCTE
 :                 +- Union false, false
 :                    :- Project [2#x]
 :                    :  +- SubqueryAlias innermost
-:                    :     +- CTERelationRef xxxx, true, [2#x], false, false
+:                    :     +- CTERelationRef xxxx, true, [2#x], false, false, 1
 :                    +- Project [3 AS 3#x]
 :                       +- OneRowRelation
 +- Sort [x#x ASC NULLS FIRST], true
    +- Project [x#x]
       +- SubqueryAlias outermost
-         +- CTERelationRef xxxx, true, [x#x], false, false
+         +- CTERelationRef xxxx, true, [x#x], false, false, 3
 
 
 -- !query
@@ -418,7 +418,7 @@ WithCTE
 :        +- OneRowRelation
 +- Project [x#x]
    +- SubqueryAlias ordinality
-      +- CTERelationRef xxxx, true, [x#x], false, false
+      +- CTERelationRef xxxx, true, [x#x], false, false, 1
 
 
 -- !query
@@ -459,7 +459,7 @@ InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_d
       :        +- OneRowRelation
       +- Project [42#x]
          +- SubqueryAlias test
-            +- CTERelationRef xxxx, true, [42#x], false, false
+            +- CTERelationRef xxxx, true, [42#x], false, false, 1
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
@@ -2050,7 +2050,7 @@ WithCTE
 :        +- OneRowRelation
 +- Project [c1#x AS 1#x]
    +- SubqueryAlias v1
-      +- CTERelationRef xxxx, true, [c1#x], false, false
+      +- CTERelationRef xxxx, true, [c1#x], false, false, 1
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/scalar-subquery/scalar-subquery-select.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/scalar-subquery/scalar-subquery-select.sql.out
@@ -623,7 +623,7 @@ Project [c1#x, scalar-subquery#x [c1#x] AS scalarsubquery(c1)#x]
 :     :        +- OneRowRelation
 :     +- Project [(a#x + outer(c1#x)) AS (a + outer(t1.c1))#x]
 :        +- SubqueryAlias t
-:           +- CTERelationRef xxxx, true, [a#x], false, false
+:           +- CTERelationRef xxxx, true, [a#x], false, false, 1
 +- SubqueryAlias t1
    +- View (`t1`, [c1#x, c2#x])
       +- Project [cast(c1#x as int) AS c1#x, cast(c2#x as int) AS c2#x]
@@ -779,7 +779,7 @@ WithCTE
    :  +- Project [a#x]
    :     +- Filter (a#x = outer(c1#x))
    :        +- SubqueryAlias t
-   :           +- CTERelationRef xxxx, true, [a#x], false, false
+   :           +- CTERelationRef xxxx, true, [a#x], false, false, 1
    +- SubqueryAlias t1
       +- View (`t1`, [c1#x, c2#x])
          +- Project [cast(c1#x as int) AS c1#x, cast(c2#x as int) AS c2#x]
@@ -1027,7 +1027,7 @@ WithCTE
    :  +- Aggregate [sum(1) AS sum(1)#xL]
    :     +- Filter ((a#x = cast(outer(col#x) as int)) OR (upper(cast(outer(col#x) as string)) = Y))
    :        +- SubqueryAlias T
-   :           +- CTERelationRef xxxx, true, [a#x], false, false
+   :           +- CTERelationRef xxxx, true, [a#x], false, false, 1
    +- SubqueryAlias foo
       +- Project [null AS col#x]
          +- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/using-join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/using-join.sql.out
@@ -833,6 +833,6 @@ WithCTE
          +- Project [coalesce(key#x, key#x) AS key#x, key#x, key#x, key#x]
             +- Join FullOuter, (key#x = key#x)
                :- SubqueryAlias t1
-               :  +- CTERelationRef xxxx, true, [key#x], false, false
+               :  +- CTERelationRef xxxx, true, [key#x], false, false, 1
                +- SubqueryAlias t2
-                  +- CTERelationRef xxxx, true, [key#x], false, false
+                  +- CTERelationRef xxxx, true, [key#x], false, false, 1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Add `maxRows` field to `CTERelationRef`.

### Why are the changes needed?

The Analyzer validates scalar subqueries by checking if it outputs just one row or not: https://github.com/vladimirg-db/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ValidateSubqueryExpression.scala#L144.

This works in fixed-point Analyzer, because CTEs are inlined before `CheckAnalysis`. However, in single-pass Analyzer, we validate the subquery right after its validation, so `CTERelationRef` must output correct `maxRows` as well, based on the related `CTERelationDef`'s `maxRows`.

### Does this PR introduce _any_ user-facing change?

There should be no changes to existing Catalyst behavior.
Added a flag to mitigate the potential edge-cases: `spark.sql.cteRelationDefMaxRows.enabled`.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.