### PR TITLE
[SPARK-51339][BUILD] Remove `IllegalImportsChecker` for `s.c.Seq/IndexedSeq` from `scalastyle-config.xml`

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -364,18 +364,6 @@ This file is divided into 3 sections:
   <check level="error" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"></check>
 
   <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
-    <parameters><parameter name="illegalImports"><![CDATA[scala.collection.Seq,scala.collection.IndexedSeq]]></parameter></parameters>
-    <customMessage><![CDATA[
-      Don't import scala.collection.Seq and scala.collection.IndexedSeq as it may bring some problems with cross-build between Scala 2.12 and 2.13.
-
-      Please refer below page to see the details of changes around Seq / IndexedSeq.
-      https://docs.scala-lang.org/overviews/core/collections-migration-213.html
-
-      If you really need to use scala.collection.Seq or scala.collection.IndexedSeq, please use the fully-qualified name instead.
-    ]]></customMessage>
-  </check>
-
-  <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
     <parameters><parameter name="illegalImports"><![CDATA[collection]]></parameter></parameters>
     <customMessage>Please use scala.collection instead.</customMessage>
   </check>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to remove `IllegalImportsChecker` for `s.c.Seq/IndexedSeq` from `scalastyle-config.xml` because after Spark 4.0, only Scala 2.13 is supported, eliminating the issue of cross-compilation.



### Why are the changes needed?
Cleaning up outdated scala style checking rule.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No