### PR TITLE
[SPARK-51340][ML][CONNECT] Model size estimation for linear classification & regression models

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
@@ -81,4 +81,21 @@ abstract class Estimator[M <: Model[M]] extends PipelineStage {
   }
 
   override def copy(extra: ParamMap): Estimator[M]
+
+  /**
+   * For ml connect only.
+   * Estimate an upper-bound size of the model to be fitted in bytes, based on the
+   * parameters and the dataset, e.g., using $(k) and numFeatures to estimate a
+   * k-means model size.
+   * 1, Only driver side memory usage is counted, distributed objects (like DataFrame,
+   * RDD, Graph, Summary) are ignored.
+   * 2, Lazy vals are not counted, e.g., an auxiliary object used in prediction.
+   * 3, If there is no enough information to get an accurate size, try to estimate the
+   * upper-bound size, e.g.
+   *    - Given a LogisticRegression estimator, assume the coefficients are dense, even
+   *      though the actual fitted model might be sparse (by L1 penalty).
+   *    - Given a tree model, assume all underlying trees are complete binary trees, even
+   *      though some branches might be pruned or truncated.
+   */
+  private[spark] def estimateModelSize(dataset: Dataset[_]): Long = throw new NotImplementedError
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/Model.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Model.scala
@@ -43,4 +43,23 @@ abstract class Model[M <: Model[M]] extends Transformer {
   def hasParent: Boolean = parent != null
 
   override def copy(extra: ParamMap): M
+
+  /**
+   * For ml connect only.
+   * Estimate the size of this model in bytes.
+   * This is an approximation, the real size might be different.
+   * 1, Only driver side memory usage is counted, distributed objects (like DataFrame,
+   * RDD, Graph, Summary) are ignored.
+   * 2, Lazy vals are not counted, e.g., an auxiliary object used in prediction.
+   * 3, Using SizeEstimator to estimate the driver memory usage of distributed objects
+   * is not accurate, because the size of SparkSession/SparkContext is also included, e.g.
+   *    val df = spark.range(1)
+   *    SizeEstimator.estimate(df)                   -> 3310984
+   *    SizeEstimator.estimate(df.rdd)               -> 3331352
+   *    SizeEstimator.estimate(df.sparkSession)      -> 3249464
+   *    SizeEstimator.estimate(df.rdd.sparkContext)  -> 3249744
+   * 4, For 3-rd extension, if external languages are used, it is recommended to override
+   * this method and return a proper size.
+   */
+  private[spark] def estimatedSize: Long = throw new NotImplementedError
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/FMClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/FMClassifier.scala
@@ -31,7 +31,6 @@ import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.mllib.linalg.{Vectors => OldVectors}
 import org.apache.spark.sql._
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.util.SizeEstimator
 
 /**
  * Params for FMClassifier.
@@ -242,7 +241,7 @@ class FMClassifier @Since("3.0.0") (
   override def estimateModelSize(dataset: Dataset[_]): Long = {
     val numFeatures = DatasetUtils.getNumFeatures(dataset, $(featuresCol))
 
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     size += java.lang.Double.BYTES // intercept
     size += Vectors.getDenseSize(numFeatures) // linear
     size += Matrices.getDenseSize(numFeatures, $(factorSize)) // factors
@@ -324,7 +323,7 @@ class FMClassificationModel private[classification] (
   }
 
   override def estimatedSize: Long = {
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     size += java.lang.Double.BYTES // intercept
     if (this.linear != null) {
       size += this.linear.getSizeInBytes

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
@@ -41,7 +41,6 @@ import org.apache.spark.mllib.util.MLUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.util.SizeEstimator
 
 /** Params for linear SVM Classifier. */
 private[classification] trait LinearSVCParams extends ClassifierParams with HasRegParam
@@ -171,7 +170,7 @@ class LinearSVC @Since("2.2.0") (
 
   private[spark] override def estimateModelSize(dataset: Dataset[_]): Long = {
     val numFeatures = DatasetUtils.getNumFeatures(dataset, $(featuresCol))
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     size += Vectors.getDenseSize(numFeatures) // coefficients
     size += java.lang.Double.BYTES // intercept
     size
@@ -431,7 +430,7 @@ class LinearSVCModel private[classification] (
   }
 
   private[spark] override def estimatedSize: Long = {
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     if (this.coefficients != null) {
       size += this.coefficients.getSizeInBytes
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -1046,7 +1046,7 @@ class LogisticRegression @Since("1.2.0") (
     val numClasses = DatasetUtils.getNumClasses(dataset, $(labelCol))
     val numFeatures = DatasetUtils.getNumFeatures(dataset, $(featuresCol))
 
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     if (checkMultinomial(numClasses)) {
       size += Matrices.getDenseSize(numFeatures, numClasses) // coefficientMatrix
       size += Vectors.getDenseSize(numClasses) // interceptVector
@@ -1267,7 +1267,7 @@ class LogisticRegressionModel private[spark] (
   }
 
   private[spark] override def estimatedSize: Long = {
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     if (this.coefficientMatrix != null) {
       size += this.coefficientMatrix.getSizeInBytes
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -45,7 +45,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.util.VersionUtils
+import org.apache.spark.util._
 
 /**
  * Params for logistic regression.
@@ -1041,6 +1041,24 @@ class LogisticRegression @Since("1.2.0") (
     (solution, arrayBuilder.result())
   }
 
+  private[spark] override def estimateModelSize(dataset: Dataset[_]): Long = {
+    // TODO: get numClasses and numFeatures together from dataset
+    val numClasses = DatasetUtils.getNumClasses(dataset, $(labelCol))
+    val numFeatures = DatasetUtils.getNumFeatures(dataset, $(featuresCol))
+
+    var size = SizeEstimator.estimate((this.params, this.uid))
+    if (checkMultinomial(numClasses)) {
+      size += Matrices.getDenseSize(numFeatures, numClasses) // coefficientMatrix
+      size += Vectors.getDenseSize(numClasses) // interceptVector
+    } else {
+      size += Matrices.getDenseSize(numFeatures, 1) // coefficientMatrix
+      size += Vectors.getDenseSize(1) // interceptVector
+    }
+    size += java.lang.Integer.BYTES // numClasses
+    size += 1 // isMultinomial
+    size
+  }
+
   @Since("1.4.0")
   override def copy(extra: ParamMap): LogisticRegression = defaultCopy(extra)
 }
@@ -1246,6 +1264,19 @@ class LogisticRegressionModel private[spark] (
       val m = margin(features)
       Vectors.dense(-m, m)
     }
+  }
+
+  private[spark] override def estimatedSize: Long = {
+    var size = SizeEstimator.estimate((this.params, this.uid))
+    if (this.coefficientMatrix != null) {
+      size += this.coefficientMatrix.getSizeInBytes
+    }
+    if (this.interceptVector != null) {
+      size += this.interceptVector.getSizeInBytes
+    }
+    size += java.lang.Integer.BYTES // numClasses
+    size += 1 // isMultinomial
+    size
   }
 
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifier.scala
@@ -29,7 +29,6 @@ import org.apache.spark.ml.util._
 import org.apache.spark.ml.util.DatasetUtils._
 import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.sql._
-import org.apache.spark.util.SizeEstimator
 import org.apache.spark.util.VersionUtils.majorMinorVersion
 
 /** Params for Multilayer Perceptron. */
@@ -178,7 +177,7 @@ class MultilayerPerceptronClassifier @Since("1.5.0") (
     val topology = FeedForwardTopology.multiLayerPerceptron($(layers), softmaxOnTop = true)
     val expectedWeightSize = topology.layers.map(_.weightSize).sum
 
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     size += Vectors.getDenseSize(expectedWeightSize) // weights
     size
   }
@@ -339,7 +338,7 @@ class MultilayerPerceptronClassificationModel private[ml] (
   }
 
   private[spark] override def estimatedSize: Long = {
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     if (this.weights != null) {
       size += this.weights.getSizeInBytes
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
@@ -34,7 +34,7 @@ import org.apache.spark.mllib.util.MLUtils
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
-import org.apache.spark.util.{SizeEstimator, VersionUtils}
+import org.apache.spark.util.VersionUtils
 
 /**
  * Params for Naive Bayes Classifiers.
@@ -348,7 +348,7 @@ class NaiveBayes @Since("1.5.0") (
     val numClasses = DatasetUtils.getNumClasses(dataset, $(labelCol))
     val numFeatures = DatasetUtils.getNumFeatures(dataset, $(featuresCol))
 
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     size += Vectors.getDenseSize(numClasses) // pi
     size += Matrices.getDenseSize(numClasses, numFeatures) // theta
     $(modelType) match {
@@ -568,7 +568,7 @@ class NaiveBayesModel private[ml] (
   }
 
   private[spark] override def estimatedSize: Long = {
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     if (this.pi != null) {
       size += this.pi.getSizeInBytes
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
@@ -34,7 +34,7 @@ import org.apache.spark.mllib.util.MLUtils
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
-import org.apache.spark.util.VersionUtils
+import org.apache.spark.util.{SizeEstimator, VersionUtils}
 
 /**
  * Params for Naive Bayes Classifiers.
@@ -344,6 +344,22 @@ class NaiveBayes @Since("1.5.0") (
     new NaiveBayesModel(uid, pi.compressed, theta.compressed, sigma.compressed)
   }
 
+  private[spark] override def estimateModelSize(dataset: Dataset[_]): Long = {
+    val numClasses = DatasetUtils.getNumClasses(dataset, $(labelCol))
+    val numFeatures = DatasetUtils.getNumFeatures(dataset, $(featuresCol))
+
+    var size = SizeEstimator.estimate((this.params, this.uid))
+    size += Vectors.getDenseSize(numClasses) // pi
+    size += Matrices.getDenseSize(numClasses, numFeatures) // theta
+    $(modelType) match {
+      case Multinomial | Bernoulli | Complement =>
+        size += Matrices.getDenseSize(0, 0) // sigma
+      case _ =>
+        size += Matrices.getDenseSize(numClasses, numFeatures) // sigma
+    }
+    size
+  }
+
   @Since("1.5.0")
   override def copy(extra: ParamMap): NaiveBayes = defaultCopy(extra)
 }
@@ -549,6 +565,20 @@ class NaiveBayesModel private[ml] (
         throw new RuntimeException("Unexpected error in NaiveBayesModel:" +
           " raw2probabilityInPlace encountered SparseVector")
     }
+  }
+
+  private[spark] override def estimatedSize: Long = {
+    var size = SizeEstimator.estimate((this.params, this.uid))
+    if (this.pi != null) {
+      size += this.pi.getSizeInBytes
+    }
+    if (this.theta != null) {
+      size += this.theta.getSizeInBytes
+    }
+    if (this.sigma != null) {
+      size += this.sigma.getSizeInBytes
+    }
+    size
   }
 
   @Since("1.5.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -33,6 +33,7 @@ import org.apache.spark.annotation.Since
 import org.apache.spark.ml.linalg.{JsonMatrixConverter, JsonVectorConverter, Matrix, Vector}
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.util.ArrayImplicits._
+import org.apache.spark.util.SizeEstimator
 
 /**
  * A param with self-contained documentation and optionally default value. Primitive-typed param
@@ -646,6 +647,10 @@ case class ParamPair[T] @Since("1.2.0") (
  * parameter values attached to the instance.
  */
 trait Params extends Identifiable with Serializable {
+
+  private[ml] def estimateMatadataSize: Long = {
+    SizeEstimator.estimate((this.paramMap, this.defaultParamMap, this.uid))
+  }
 
   /**
    * Returns all params sorted by their names. The default implementation uses Java reflection to

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -42,7 +42,6 @@ import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{DoubleType, StructType}
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.util.SizeEstimator
 
 /**
  * Params for accelerated failure time (AFT) regression.
@@ -355,7 +354,7 @@ class AFTSurvivalRegression @Since("1.6.0") (@Since("1.6.0") override val uid: S
   private[spark] override def estimateModelSize(dataset: Dataset[_]): Long = {
     val numFeatures = DatasetUtils.getNumFeatures(dataset, $(featuresCol))
 
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     size += Vectors.getDenseSize(numFeatures) // coefficients
     size += java.lang.Double.BYTES * 2 // intercept, scale
     size
@@ -480,7 +479,7 @@ class AFTSurvivalRegressionModel private[ml] (
   }
 
   private[spark] override def estimatedSize: Long = {
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     if (this.coefficients != null) {
       size += this.coefficients.getSizeInBytes
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/FMRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/FMRegressor.scala
@@ -42,7 +42,6 @@ import org.apache.spark.mllib.util.MLUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Dataset, Row}
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.util.SizeEstimator
 
 /**
  * Params for Factorization Machines
@@ -445,7 +444,7 @@ class FMRegressor @Since("3.0.0") (
   override def estimateModelSize(dataset: Dataset[_]): Long = {
     val numFeatures = DatasetUtils.getNumFeatures(dataset, $(featuresCol))
 
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     size += java.lang.Double.BYTES // intercept
     size += Vectors.getDenseSize(numFeatures) // linear
     size += Matrices.getDenseSize(numFeatures, $(factorSize)) // factors
@@ -489,7 +488,7 @@ class FMRegressionModel private[regression] (
   }
 
   override def estimatedSize: Long = {
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     size += java.lang.Double.BYTES // intercept
     if (this.linear != null) {
       size += this.linear.getSizeInBytes

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -41,7 +41,6 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{DataType, DoubleType, StructType}
-import org.apache.spark.util.SizeEstimator
 
 /**
  * Params for Generalized Linear Regression.
@@ -450,7 +449,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
   override def estimateModelSize(dataset: Dataset[_]): Long = {
     val numFeatures = DatasetUtils.getNumFeatures(dataset, $(featuresCol))
 
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     size += Vectors.getDenseSize(numFeatures) // coefficients
     size += java.lang.Double.BYTES // intercept
     size
@@ -1116,7 +1115,7 @@ class GeneralizedLinearRegressionModel private[ml] (
   }
 
   private[spark] override def estimatedSize: Long = {
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     if (this.coefficients != null) {
       size += this.coefficients.getSizeInBytes
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -48,7 +48,6 @@ import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{DataType, DoubleType, StructType}
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.util.SizeEstimator
 import org.apache.spark.util.VersionUtils.majorMinorVersion
 
 /**
@@ -654,7 +653,7 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
   override def estimateModelSize(dataset: Dataset[_]): Long = {
     val numFeatures = DatasetUtils.getNumFeatures(dataset, $(featuresCol))
 
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     size += Vectors.getDenseSize(numFeatures) // coefficients
     size += java.lang.Double.BYTES * 2 // intercept, scale
     size
@@ -764,7 +763,7 @@ class LinearRegressionModel private[ml] (
   }
 
   private[spark] override def estimatedSize: Long = {
-    var size = SizeEstimator.estimate((this.params, this.uid))
+    var size = this.estimateMatadataSize
     if (this.coefficients != null) {
       size += this.coefficients.getSizeInBytes
     }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/FMClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/FMClassifierSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.classification
 
+import scala.util.Random
+
 import org.apache.spark.ml.classification.LogisticRegressionSuite.generateLogisticInput
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param.ParamsSuite
@@ -242,6 +244,58 @@ class FMClassifierSuite extends MLTest with DefaultReadWriteTest {
       .withColumnRenamed("label", allParamSettings("labelCol").toString)
     testEstimatorAndModelReadWrite(fm, data, allParamSettings,
       allParamSettings, checkModelData)
+  }
+
+  test("model size estimation: dense data") {
+    val rng = new Random(1)
+
+    Seq(10, 100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 0.0),
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 1.0)
+      ).toDF("features", "label")
+
+      val fm = new FMClassifier().setMaxIter(1)
+      val size1 = fm.estimateModelSize(df)
+      val model = fm.fit(df)
+      assert(model.linear.isInstanceOf[DenseVector])
+      assert(model.factors.isInstanceOf[DenseMatrix])
+      val size2 = model.estimatedSize
+
+      // the model is dense, the estimation should be relatively accurate
+      //      (n, size1, size2)
+      //      (10,6329,6329) <- when the model is small, model.params matters
+      //      (100,12809,12809)
+      //      (1000,77609,77609)
+      //      (10000,725609,725609)
+      //      (100000,7205609,7205609)
+      val rel = (size1 - size2).toDouble / size2
+      assert(math.abs(rel) < 0.05, (n, size1, size2))
+    }
+  }
+
+  test("model size estimation: sparse data") {
+    val rng = new Random(1)
+
+    Seq(100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 0.0),
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 1.0)
+      ).toDF("features", "label")
+
+      val fm = new FMClassifier().setMaxIter(1).setRegParam(10.0)
+      val size1 = fm.estimateModelSize(df)
+      val model = fm.fit(df)
+      val size2 = model.estimatedSize
+
+      // the model is sparse, the estimated size is likely larger
+      //      (n, size1, size2)
+      //      (100,12809,12145)
+      //      (1000,77609,69745)
+      //      (10000,725609,645745)
+      //      (100000,7205609,6405745)
+      assert(size1 > size2, (n, size1, size2))
+    }
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LinearSVCSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LinearSVCSuite.scala
@@ -24,7 +24,7 @@ import org.scalatest.Assertions._
 
 import org.apache.spark.ml.classification.LinearSVCSuite._
 import org.apache.spark.ml.feature.LabeledPoint
-import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
+import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param.ParamsSuite
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
 import org.apache.spark.ml.util.TestingUtils._
@@ -335,6 +335,58 @@ class LinearSVCSuite extends MLTest with DefaultReadWriteTest {
     val svm = new LinearSVC()
     testEstimatorAndModelReadWrite(svm, smallBinaryDataset, LinearSVCSuite.allParamSettings,
       LinearSVCSuite.allParamSettings, checkModelData)
+  }
+
+  test("model size estimation: dense linear svc") {
+    val rng = new Random(1)
+
+    Seq(10, 100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 0.0),
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 1.0)
+      ).toDF("features", "label")
+
+      val svc = new LinearSVC().setMaxIter(1)
+      val size1 = svc.estimateModelSize(df)
+      val model = svc.fit(df)
+      assert(model.coefficients.isInstanceOf[DenseVector])
+      val size2 = model.estimatedSize
+
+      // the model is dense, the estimation should be relatively accurate
+      //      (n, size1, size2)
+      //      (10,3972,3972) <- when the model is small, model.params matters
+      //      (100,4692,4692)
+      //      (1000,11892,11892)
+      //      (10000,83892,83892)
+      //      (100000,803892,803892)
+      val rel = (size1 - size2).toDouble / size2
+      assert(math.abs(rel) < 0.05, (n, size1, size2))
+    }
+  }
+
+  test("model size estimation: sparse linear svc") {
+    val rng = new Random(1)
+
+    Seq(100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 0.0),
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 1.0)
+      ).toDF("features", "label")
+
+      val lor = new LinearSVC().setMaxIter(1).setRegParam(10.0)
+      val size1 = lor.estimateModelSize(df)
+      val model = lor.fit(df)
+      assert(model.coefficients.isInstanceOf[SparseVector])
+      val size2 = model.estimatedSize
+
+      // the model is sparse, the estimated size is likely larger
+      //      (n, size1, size2)
+      //      (100,4692,4028)
+      //      (1000,11892,4028)
+      //      (10000,83892,4028)
+      //      (100000,803892,4028)
+      assert(size1 > size2, (n, size1, size2))
+    }
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -3015,6 +3015,112 @@ class LogisticRegressionSuite extends MLTest with DefaultReadWriteTest {
     assert(p0 === p1)
     assert(p0 === p2)
   }
+
+  test("model size estimation: dense binary logistic regression") {
+    val rng = new Random(1)
+
+    Seq(10, 100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 0.0),
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 1.0)
+      ).toDF("features", "label")
+
+      val lor = new LogisticRegression().setMaxIter(1)
+      val size1 = lor.estimateModelSize(df)
+      val model = lor.fit(df)
+      assert(model.coefficientMatrix.isInstanceOf[DenseMatrix])
+      val size2 = model.estimatedSize
+
+      // the model is dense, the estimation should be relatively accurate
+      //      (n, size1, size2)
+      //      (10,7030,7030) <- when the model is small, model.params matters
+      //      (100,7750,7750)
+      //      (1000,14950,14950)
+      //      (10000,86950,86950)
+      //      (100000,806950,806950)
+      val rel = (size1 - size2).toDouble / size2
+      assert(math.abs(rel) < 0.05, (n, size1, size2))
+    }
+  }
+
+  test("model size estimation: sparse binary logistic regression") {
+    val rng = new Random(1)
+
+    Seq(100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 0.0),
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 1.0)
+      ).toDF("features", "label")
+
+      val lor = new LogisticRegression().setMaxIter(1).setRegParam(10.0)
+      val size1 = lor.estimateModelSize(df)
+      val model = lor.fit(df)
+      assert(model.coefficientMatrix.isInstanceOf[SparseMatrix])
+      val size2 = model.estimatedSize
+
+      // the model is sparse, the estimated size is likely larger
+      //      (n, size1, size2)
+      //      (100,7750,7102)
+      //      (1000,14950,7102)
+      //      (10000,86950,7102)
+      //      (100000,806950,7102)
+      assert(size1 > size2, (n, size1, size2))
+    }
+  }
+
+  test("model size estimation: dense multinomial logistic regression") {
+    val rng = new Random(1)
+
+    Seq(10, 100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 0.0),
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 1.0),
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 2.0)
+      ).toDF("features", "label")
+
+      val lor = new LogisticRegression().setMaxIter(1)
+      val size1 = lor.estimateModelSize(df)
+      val model = lor.fit(df)
+      assert(model.coefficientMatrix.isInstanceOf[DenseMatrix])
+      val size2 = model.estimatedSize
+
+      // the model is dense, the estimation should be relatively accurate
+      //      (n, size1, size2)
+      //      (10,7206,7206) <- when the model is small, model.params matters
+      //      (100,9366,9366)
+      //      (1000,30966,30966)
+      //      (10000,246966,246966)
+      //      (100000,2406966,2406966)
+      val rel = (size1 - size2).toDouble / size2
+      assert(math.abs(rel) < 0.05, (n, size1, size2))
+    }
+  }
+
+  test("model size estimation: sparse multinomial logistic regression") {
+    val rng = new Random(1)
+
+    Seq(100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 0.0),
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 1.0),
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 2.0)
+      ).toDF("features", "label")
+
+      val lor = new LogisticRegression().setMaxIter(1).setRegParam(10.0)
+      val size1 = lor.estimateModelSize(df)
+      val model = lor.fit(df)
+      assert(model.coefficientMatrix.isInstanceOf[SparseMatrix])
+      val size2 = model.estimatedSize
+
+      // the model is sparse, the estimated size is likely larger
+      //      (n, size1, size2)
+      //      (100,9366,7366)
+      //      (1000,30966,7366)
+      //      (10000,246966,7366)
+      //      (100000,2406966,7366)
+      assert(size1 > size2, (n, size1, size2))
+    }
+  }
 }
 
 object LogisticRegressionSuite {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
@@ -530,7 +530,6 @@ class NaiveBayesSuite extends MLTest with DefaultReadWriteTest {
     assert(preds(4)._2 ~= Vectors.dense(0.0, 1.0) relTol 1E-5)
   }
 
-  // scalastyle:off println
   test("model size estimation: dense data") {
     val rng = new Random(1)
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
@@ -530,6 +530,105 @@ class NaiveBayesSuite extends MLTest with DefaultReadWriteTest {
     assert(preds(4)._2 ~= Vectors.dense(0.0, 1.0) relTol 1E-5)
   }
 
+  // scalastyle:off println
+  test("model size estimation: dense data") {
+    val rng = new Random(1)
+
+    Seq(10, 100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.dense(Array.fill(n)(rng.nextInt(2).toDouble)), 0.0),
+        (Vectors.dense(Array.fill(n)(rng.nextInt(2).toDouble)), 1.0)
+      ).toDF("features", "label")
+
+      Seq("multinomial", "complement", "bernoulli", "gaussian").foreach { m =>
+        val nb = new NaiveBayes().setModelType(m)
+        val size1 = nb.estimateModelSize(df)
+        val model = nb.fit(df)
+        val isDense = model.pi.isInstanceOf[DenseVector] &&
+          model.theta.isInstanceOf[DenseMatrix] &&
+          model.sigma.isInstanceOf[DenseMatrix]
+
+        val size2 = model.estimatedSize
+
+        // non-gaussian nb models are likely dense, due to the smoothing
+        //        (n, m, isDense, size1, size2)
+        //        (10,multinomial,true,3462,3462)
+        //        (10,complement,true,3462,3462)
+        //        (10,bernoulli,true,3462,3462)
+        //        (10,gaussian,false,3622,3618)
+        //        (100,multinomial,true,4902,4902)
+        //        (100,complement,true,4902,4902)
+        //        (100,bernoulli,true,4902,4902)
+        //        (100,gaussian,false,6502,6066)
+        //        (1000,multinomial,true,19302,19302)
+        //        (1000,complement,true,19302,19302)
+        //        (1000,bernoulli,true,19302,19302)
+        //        (1000,gaussian,false,35302,31494)
+        //        (10000,multinomial,true,163302,163302)
+        //        (10000,complement,true,163302,163302)
+        //        (10000,bernoulli,true,163302,163302)
+        //        (10000,gaussian,false,323302,282474)
+        //        (100000,multinomial,true,1603302,1603302)
+        //        (100000,complement,true,1603302,1603302)
+        //        (100000,bernoulli,true,1603302,1603302)
+        //        (100000,gaussian,false,3203302,2803698)
+        if (isDense) {
+          val rel = (size1 - size2).toDouble / size2
+          assert(math.abs(rel) < 0.05, (n, m, isDense, size1, size2))
+        } else {
+          assert(size1 > size2, (n, m, isDense, size1, size2))
+        }
+      }
+    }
+  }
+
+  test("model size estimation: sparse data") {
+    val rng = new Random(1)
+
+    Seq(100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextInt(2).toDouble)), 0.0),
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextInt(2).toDouble)), 1.0)
+      ).toDF("features", "label")
+
+      Seq("multinomial", "complement", "bernoulli", "gaussian").foreach { m =>
+        val nb = new NaiveBayes().setModelType(m)
+        val size1 = nb.estimateModelSize(df)
+        val model = nb.fit(df)
+        val isDense = model.pi.isInstanceOf[DenseVector] &&
+          model.theta.isInstanceOf[DenseMatrix] &&
+          model.sigma.isInstanceOf[DenseMatrix]
+
+        val size2 = model.estimatedSize
+
+        // non-gaussian nb models are likely dense, due to the smoothing
+        //        (n, m, isDense, size1, size2)
+        //        (100,multinomial,true,4902,4902)
+        //        (100,complement,true,4902,4902)
+        //        (100,bernoulli,true,4902,4902)
+        //        (100,gaussian,false,6502,5058)
+        //        (1000,multinomial,true,19302,19302)
+        //        (1000,complement,true,19302,19302)
+        //        (1000,bernoulli,true,19302,19302)
+        //        (1000,gaussian,false,35302,19458)
+        //        (10000,multinomial,true,163302,163302)
+        //        (10000,complement,true,163302,163302)
+        //        (10000,bernoulli,true,163302,163302)
+        //        (10000,gaussian,false,323302,163458)
+        //        (100000,multinomial,true,1603302,1603302)
+        //        (100000,complement,true,1603302,1603302)
+        //        (100000,bernoulli,true,1603302,1603302)
+        //        (100000,gaussian,false,3203302,1603398)
+        if (isDense) {
+          val rel = (size1 - size2).toDouble / size2
+          assert(math.abs(rel) < 0.05, (n, m, isDense, size1, size2))
+        } else {
+          assert(size1 > size2, (n, m, isDense, size1, size2))
+        }
+      }
+    }
+  }
+
   test("read/write") {
     def checkModelData(model: NaiveBayesModel, model2: NaiveBayesModel): Unit = {
       assert(model.getModelType === model2.getModelType)

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.ml.regression
 
 import scala.util.Random
 
-import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param.ParamsSuite
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
 import org.apache.spark.ml.util.TestingUtils._
@@ -493,6 +493,22 @@ class AFTSurvivalRegressionSuite extends MLTest with DefaultReadWriteTest {
     val p2 = model.set(model.quantileProbabilities, quantileProbabilities).predictQuantiles(vec)
 
     assert(p1 === p2)
+  }
+
+  // scalastyle:off println
+  test("model size estimation: aft") {
+    val quantileProbabilities = Array(0.1, 0.5, 0.9)
+    val aft = new AFTSurvivalRegression()
+      .setQuantilesCol("quantiles")
+      .setQuantileProbabilities(quantileProbabilities)
+    val size1 = aft.estimateModelSize(datasetUnivariate)
+    val model = aft.fit(datasetUnivariate)
+    val size2 = model.estimatedSize
+
+    // (size1, size2)
+    // (3284,3284)
+    val rel = (size1 - size2).toDouble / size2
+    assert(math.abs(rel) < 0.05, (size1, size2))
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
@@ -495,7 +495,6 @@ class AFTSurvivalRegressionSuite extends MLTest with DefaultReadWriteTest {
     assert(p1 === p2)
   }
 
-  // scalastyle:off println
   test("model size estimation: aft") {
     val quantileProbabilities = Array(0.1, 0.5, 0.9)
     val aft = new AFTSurvivalRegression()

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/FMRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/FMRegressorSuite.scala
@@ -30,6 +30,8 @@ import org.apache.spark.sql.functions.{avg, col}
 
 class FMRegressorSuite extends MLTest with DefaultReadWriteTest {
 
+  import testImplicits._
+
   private val seed = 10
   @transient var crossDataset: DataFrame = _
 
@@ -178,6 +180,58 @@ class FMRegressorSuite extends MLTest with DefaultReadWriteTest {
       .withColumnRenamed("label", allParamSettings("labelCol").toString)
     testEstimatorAndModelReadWrite(fm, data, allParamSettings,
       allParamSettings, checkModelData)
+  }
+
+  test("model size estimation: dense data") {
+    val rng = new Random(1)
+
+    Seq(10, 100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 0.0),
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 1.0)
+      ).toDF("features", "label")
+
+      val fm = new FMRegressor().setMaxIter(1)
+      val size1 = fm.estimateModelSize(df)
+      val model = fm.fit(df)
+      assert(model.linear.isInstanceOf[DenseVector])
+      assert(model.factors.isInstanceOf[DenseMatrix])
+      val size2 = model.estimatedSize
+
+      // the model is dense, the estimation should be relatively accurate
+      //      (n, size1, size2)
+      //      (10,5081,5081) <- when the model is small, model.params matters
+      //      (100,11561,11561)
+      //      (1000,76361,76361)
+      //      (10000,724361,724361)
+      //      (100000,7204361,7204361)
+      val rel = (size1 - size2).toDouble / size2
+      assert(math.abs(rel) < 0.05, (n, size1, size2))
+    }
+  }
+
+  test("model size estimation: sparse data") {
+    val rng = new Random(1)
+
+    Seq(100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 0.0),
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 1.0)
+      ).toDF("features", "label")
+
+      val fm = new FMRegressor().setMaxIter(1).setRegParam(10.0)
+      val size1 = fm.estimateModelSize(df)
+      val model = fm.fit(df)
+      val size2 = model.estimatedSize
+
+      // the model is sparse, the estimated size is likely larger
+      //      (n, size1, size2)
+      //      (100,11561,10897)
+      //      (1000,76361,68497)
+      //      (10000,724361,644497)
+      //      (100000,7204361,6404497)
+      assert(size1 > size2, (n, size1, size2))
+    }
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -25,7 +25,7 @@ import org.dmg.pmml.regression.{RegressionModel => PMMLRegressionModel}
 
 import org.apache.spark.ml.feature.Instance
 import org.apache.spark.ml.feature.LabeledPoint
-import org.apache.spark.ml.linalg.{DenseVector, Vector, Vectors}
+import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param.{ParamMap, ParamsSuite}
 import org.apache.spark.ml.util._
 import org.apache.spark.ml.util.TestingUtils._
@@ -1373,6 +1373,58 @@ class LinearRegressionSuite extends MLTest with DefaultReadWriteTest with PMMLRe
     val model2 = trainer2.fit(datasetWithOutlier)
     assert(model1.coefficients ~== model2.coefficients relTol 1E-3)
     assert(model1.intercept ~== model2.intercept relTol 1E-3)
+  }
+
+  test("model size estimation: dense linear regression") {
+    val rng = new Random(1)
+
+    Seq(10, 100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 0.0),
+        (Vectors.dense(Array.fill(n)(rng.nextDouble())), 1.0)
+      ).toDF("features", "label")
+
+      val lir = new LinearRegression().setMaxIter(1)
+      val size1 = lir.estimateModelSize(df)
+      val model = lir.fit(df)
+      assert(model.coefficients.isInstanceOf[DenseVector])
+      val size2 = model.estimatedSize
+
+      // the model is dense, the estimation should be relatively accurate
+      //      (n, size1, size2)
+      //      (10,5028,5028) <- when the model is small, model.params matters
+      //      (100,5748,5748)
+      //      (1000,12948,12948)
+      //      (10000,84948,84948)
+      //      (100000,804948,804948)
+      val rel = (size1 - size2).toDouble / size2
+      assert(math.abs(rel) < 0.05, (n, size1, size2))
+    }
+  }
+
+  test("model size estimation: sparse linear regression") {
+    val rng = new Random(1)
+
+    Seq(100, 1000, 10000, 100000).foreach { n =>
+      val df = Seq(
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 0.0),
+        (Vectors.sparse(n, Array.range(0, 10), Array.fill(10)(rng.nextDouble())), 1.0)
+      ).toDF("features", "label")
+
+      val lir = new LinearRegression().setMaxIter(1).setRegParam(10.0)
+      val size1 = lir.estimateModelSize(df)
+      val model = lir.fit(df)
+      assert(model.coefficients.isInstanceOf[SparseVector])
+      val size2 = model.estimatedSize
+
+      // the model is sparse, the estimated size is likely larger
+      //      (n, size1, size2)
+      //      (100,5748,5084)
+      //      (1000,12948,5084)
+      //      (10000,84948,5084)
+      //      (100000,804948,5084)
+      assert(size1 > size2, (n, size1, size2))
+    }
   }
 }
 

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -35,6 +35,8 @@ import com.typesafe.tools.mima.core.*
 object MimaExcludes {
 
   lazy val v41excludes = v40excludes ++ Seq(
+    // [SPARK-51261][ML][CONNECT] Introduce model size estimation to control ml cache
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.ml.linalg.Vector.getSizeInBytes")
   )
 
   // Exclude rules for 4.0.x from 3.5.0


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Model size estimation for linear classification & regression models

This PR handles a group of linear models, whose coefficients are vectors and matrics, and their shape can be easily determined by

- dataset metadata like `numFeatures`, `numClasses`
- some parameters like `modelType` in `NaiveBayes`

We always assume the vectors and matrics are **dense**, so the actual size might be smaller.

This PR covers:

- FMClassifer
- LinearSVC
- LogisticRegression
- MultilayerPerceptronClassifier
- NaiveBayes
- AFTSurvivalRegression
- FMRegressor
- GeneralizedLinearRegression
- LinearRegression

For remaining classification and regression models:
1, tree models are quite different, will be handled in separate PR;
2, `IsotonicRegression` seems pretty complicated, I need more time to dig into it;
3, `OneVsRest` is a meta algorithm which is implemented in client side, no need to handle;



### Why are the changes needed?
pre-training model size estimation is required to control the model cache at driver


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
added tests


### Was this patch authored or co-authored using generative AI tooling?
no
