### PR TITLE
[SPARK-51351][SS] Do not materialize the output in Python worker for TWS

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -1223,6 +1223,7 @@ class TransformWithStateInPandasSerializer(ArrowStreamPandasUDFSerializer):
         Read through an iterator of (iterator of pandas DataFrame), serialize them to Arrow
         RecordBatches, and write batches to stream.
         """
+
         def flatten_iterator():
             # iterator: iter[list[(iter[pandas.DataFrame], pdf_type)]]
             for packed in iterator:

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -1223,8 +1223,16 @@ class TransformWithStateInPandasSerializer(ArrowStreamPandasUDFSerializer):
         Read through an iterator of (iterator of pandas DataFrame), serialize them to Arrow
         RecordBatches, and write batches to stream.
         """
-        result = [(b, t) for x in iterator for y, t in x for b in y]
-        super().dump_stream(result, stream)
+        def flatten_iterator():
+            # iterator: iter[list[(iter[pandas.DataFrame], pdf_type)]]
+            for packed in iterator:
+                iter_pdf_with_type = packed[0]
+                iter_pdf = iter_pdf_with_type[0]
+                pdf_type = iter_pdf_with_type[1]
+                for pdf in iter_pdf:
+                    yield (pdf, pdf_type)
+
+        super().dump_stream(flatten_iterator(), stream)
 
 
 class TransformWithStateInPandasInitStateSerializer(TransformWithStateInPandasSerializer):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix the logic of serializer in TWS PySpark version to NOT materialize the output entirely. This PR changes the logic of creating a list to create a generator instead, so that it can be lazily consumed.

### Why are the changes needed?

Without this PR, all the outputs are materialized when JVM signals to Python worker that there is no further input (at task completion), which brings up two critical issues:

* downstream operator can only see outputs after TWS operator processes all inputs
* all the outputs are materialized into "memory" in Python worker, which could lead memory issue

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs. I've confirmed manually below:

* Before this PR, all the outputs are available after processing all inputs
* After this PR, outputs are available during processing inputs

The change I have made to verify the fix manually:
https://github.com/HeartSaVioR/spark/commit/cd30db0746bd59dde032d7f209e8657f4f7d93c5

If we call run_test() in testcode.py in PySpark, the log messages `Spark pulls the iterators` and `The data is being retrieved from Python worker` are interleaved with this fix. Without the fix, there is a sequence of log messages, all `Spark pulls the iterators` messages come first, and then all `The data is being retrieved from Python worker` messages come later.

### Was this patch authored or co-authored using generative AI tooling?

No.