### PR TITLE
[SPARK-51354][K8S][TEST][DOC] Fix sbt K8s integration test arg javaImageTag

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1002,9 +1002,10 @@ object KubernetesIntegrationTests {
         if (excludeTags.exists(_.equalsIgnoreCase("r"))) {
           rDockerFile = ""
         }
-        val extraOptions = javaImageTag match {
-          case Some(tag) => Seq("-b", s"java_image_tag=$tag")
-          case _ => Seq("-f", s"$dockerFile")
+        val extraOptions = if (javaImageTag.isDefined) {
+          Seq("-b", s"java_image_tag=${javaImageTag.get}")
+        } else {
+          Seq("-f", s"$dockerFile")
         }
         val cmd = Seq(dockerTool,
           "-r", imageRepo,

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1002,10 +1002,9 @@ object KubernetesIntegrationTests {
         if (excludeTags.exists(_.equalsIgnoreCase("r"))) {
           rDockerFile = ""
         }
-        val extraOptions = if (javaImageTag.isDefined) {
-          Seq("-b", s"java_image_tag=$javaImageTag")
-        } else {
-          Seq("-f", s"$dockerFile")
+        val extraOptions = javaImageTag match {
+          case Some(tag) => Seq("-b", s"java_image_tag=$tag")
+          case _ => Seq("-f", s"$dockerFile")
         }
         val cmd = Seq(dockerTool,
           "-r", imageRepo,

--- a/resource-managers/kubernetes/integration-tests/README.md
+++ b/resource-managers/kubernetes/integration-tests/README.md
@@ -199,9 +199,9 @@ to the wrapper scripts and using the wrapper scripts will simply set these appro
   <tr>
     <td><code>spark.kubernetes.test.javaImageTag</code></td>
     <td>
-      A specific OpenJDK base image tag to use, when set uses it instead of azul/zulu-openjdk.
+      A specific Azul Zulu OpenJDK base image tag to use, when set uses it instead of 21.
     </td>
-    <td><code>azul/zulu-openjdk</code></td>
+    <td><code>N/A</code></td>
   </tr>
   <tr>
     <td><code>spark.kubernetes.test.imageTagFile</code></td>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
As title.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When I follow the dev docs to run K8s IT using sbt, and set `spark.kubernetes.test.javaImageTag` to change the JDK image

```
$ build/sbt -Pkubernetes -Pkubernetes-integration-tests \
  -Dspark.kubernetes.test.javaImageTag=17 \
  -Dspark.kubernetes.test.namespace=default \
  -Dtest.exclude.tags=local,r,minikube \
  "kubernetes-integration-tests/test"
```

I face the following errors
```
Dockerfile:19
--------------------
  17 |     ARG java_image_tag=21
  18 |
  19 | >>> FROM azul/zulu-openjdk:${java_image_tag}
  20 |     LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"
  21 |     LABEL org.opencontainers.image.licenses="Apache-2.0"
--------------------
ERROR: failed to solve: failed to parse stage name "azul/zulu-openjdk:Some(17)": invalid reference format
Failed to build Spark JVM Docker image, please refer to Docker build output for details.
[error] java.lang.IllegalStateException: Process '/Users/chengpan/Projects/apache-spark/bin/docker-image-tool.sh -r docker.io/kubespark -t dev -p /Users/chengpan/Projects/apache-spark/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile -R  -b java_image_tag=Some(17) build' exited with 1.
[error] 	at KubernetesIntegrationTests$.$anonfun$settings$66(SparkBuild.scala:1020)
...
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, dev only.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
```
$ build/sbt -Pkubernetes -Pkubernetes-integration-tests \
  -Dspark.kubernetes.test.javaImageTag=17 \
  -Dspark.kubernetes.test.namespace=default \
  -Dtest.exclude.tags=local,r,minikube \
  "kubernetes-integration-tests/test"
```
Correctly trigger the K8s integration tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.