### PR TITLE
[SPARK-51353][INFRA][BUILD] Retry dyn/closer.lua for mvn before falling back to archive.a.o

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -130,7 +130,7 @@ install_mvn() {
     local MIRROR_URL_QUERY="?action=download"
 
     if [ $(command -v curl) ]; then
-      if ! curl -L --output /dev/null --silent --head --fail "${APACHE_MIRROR}/${FILE_PATH}${MIRROR_URL_QUERY}" ; then
+      if ! curl -L --output /dev/null --retry 3 --silent --head --fail "${APACHE_MIRROR}/${FILE_PATH}.asc${MIRROR_URL_QUERY}" ; then
         # Fall back to archive.apache.org for older Maven
         echo "Falling back to archive.apache.org to download Maven"
         APACHE_MIRROR="https://archive.apache.org/dist"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enables retry for dyn/closer.lua for mvn before falling back to archive.a.o.

Before this PR, we used `curl` w/o retry to download the whole maven tar ball once to check if we need to fall back to archive.a.o. This is unreliable and a bit wasteful.

In this PR, we enable retry to reduce service transient errors and only fetch asc to reduce network/time cost.

```
apache-maven-3.9.9-bin.tar.gz  2024-08-17 18:44  8.7M  
apache-maven-3.9.9-bin.tar.gz.asc 2024-08-17 18:44  228   
apache-maven-3.9.9-bin.tar.gz.sha512 2024-08-17 18:44  128
```

### Why are the changes needed?
Make dyn/closer.lua mirror first and reliable


### Does this PR introduce _any_ user-facing change?
no, dev only


### How was this patch tested?
```
build/mvn clean
exec: curl --retry 3 --silent --show-error -L https://www.apache.org/dyn/closer.lua/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz?action=download
exec: curl --retry 3 --silent --show-error -L https://www.apache.org/dyn/closer.lua/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz.sha512?action=download
Verifying checksum from /Users/hzyaoqin/spark/build/apache-maven-3.9.9-bin.tar.gz.sha512
Using `mvn` from path: /Users/hzyaoqin/spark/build/apache-maven-3.9.9/bin/mvn
```


### Was this patch authored or co-authored using generative AI tooling?
no
