### PR TITLE
[SPARK-51367][BUILD] Upgrade slf4j to 2.0.17

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -129,7 +129,7 @@ javax.servlet-api/4.0.1//javax.servlet-api-4.0.1.jar
 javolution/5.5.1//javolution-5.5.1.jar
 jaxb-core/4.0.5//jaxb-core-4.0.5.jar
 jaxb-runtime/4.0.5//jaxb-runtime-4.0.5.jar
-jcl-over-slf4j/2.0.16//jcl-over-slf4j-2.0.16.jar
+jcl-over-slf4j/2.0.17//jcl-over-slf4j-2.0.17.jar
 jdo-api/3.0.1//jdo-api-3.0.1.jar
 jdom2/2.0.6//jdom2-2.0.6.jar
 jersey-client/3.0.16//jersey-client-3.0.16.jar
@@ -157,7 +157,7 @@ json4s-jackson_2.13/4.0.7//json4s-jackson_2.13-4.0.7.jar
 json4s-scalap_2.13/4.0.7//json4s-scalap_2.13-4.0.7.jar
 jsr305/3.0.0//jsr305-3.0.0.jar
 jta/1.1//jta-1.1.jar
-jul-to-slf4j/2.0.16//jul-to-slf4j-2.0.16.jar
+jul-to-slf4j/2.0.17//jul-to-slf4j-2.0.17.jar
 kryo-shaded/4.0.2//kryo-shaded-4.0.2.jar
 kubernetes-client-api/7.1.0//kubernetes-client-api-7.1.0.jar
 kubernetes-client/7.1.0//kubernetes-client-7.1.0.jar
@@ -259,7 +259,7 @@ scala-parallel-collections_2.13/1.2.0//scala-parallel-collections_2.13-1.2.0.jar
 scala-parser-combinators_2.13/2.4.0//scala-parser-combinators_2.13-2.4.0.jar
 scala-reflect/2.13.16//scala-reflect-2.13.16.jar
 scala-xml_2.13/2.3.0//scala-xml_2.13-2.3.0.jar
-slf4j-api/2.0.16//slf4j-api-2.0.16.jar
+slf4j-api/2.0.17//slf4j-api-2.0.17.jar
 snakeyaml-engine/2.9//snakeyaml-engine-2.9.jar
 snakeyaml/2.3//snakeyaml-2.3.jar
 snappy-java/1.1.10.7//snappy-java-1.1.10.7.jar

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.7.1</asm.version>
-    <slf4j.version>2.0.16</slf4j.version>
+    <slf4j.version>2.0.17</slf4j.version>
     <log4j.version>2.24.3</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.4.1</hadoop.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade slf4j from 2.0.16 to 2.0.17.

### Why are the changes needed?
The new version brings some bug fixes, like:

- As reported in https://github.com/qos-ch/slf4j/issues/450, in some rare cases where MDC could be initialized before LoggerFactory. Thus, MDC would be stuck using the wrong MDCAdapter instance. To fix this issue LoggerFactory and MDC have been modified. Implementations of SLF4JServiceProvider are encouraged to initialize their mdcAdapter and markerFactory fields as early as possible, preferably at construction time. Note that these changes are transparent to existing logging backends which will continue to work as is.

- Fixed incorrect interpretation of Level.OFF and Level.ALL in SLF4JPlatformLogger by mapping Level.OFF as Level.ERROR and Level.ALL as Level.TRACE. This issue was reported in https://github.com/qos-ch/slf4j/issues/430 by Peter Halicky.


The full release notes as follows:
- https://github.com/qos-ch/slf4j/releases/tag/v_2.0.17

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
