### PR TITLE
[SPARK-51363][SQL]`Desc As JSON` clustering column names

### DIFF
--- a/docs/sql-ref-syntax-aux-describe-table.md
+++ b/docs/sql-ref-syntax-aux-describe-table.md
@@ -97,6 +97,7 @@ to return the metadata pertaining to a partition or column respectively.
       "partition_values": {
         "<col_name>": "<val>"
       },
+      "partition_columns": ["col1", "col2"],
       "clustering_columns": ["col1", "col2"],
       "location": "<path>",
       "view_text": "<view_text>",

--- a/docs/sql-ref-syntax-aux-describe-table.md
+++ b/docs/sql-ref-syntax-aux-describe-table.md
@@ -97,6 +97,15 @@ to return the metadata pertaining to a partition or column respectively.
       "partition_values": {
         "<col_name>": "<val>"
       },
+      "clustering_information": [
+        {
+          "name": "<name>",
+          "type": <type_json>,
+          "comment": "<comment>",
+          "nullable": <boolean>,
+          "default": "<default_val>"
+        }
+      ],
       "location": "<path>",
       "view_text": "<view_text>",
       "view_original_text": "<view_original_text>",

--- a/docs/sql-ref-syntax-aux-describe-table.md
+++ b/docs/sql-ref-syntax-aux-describe-table.md
@@ -97,15 +97,7 @@ to return the metadata pertaining to a partition or column respectively.
       "partition_values": {
         "<col_name>": "<val>"
       },
-      "clustering_information": [
-        {
-          "name": "<name>",
-          "type": <type_json>,
-          "comment": "<comment>",
-          "nullable": <boolean>,
-          "default": "<default_val>"
-        }
-      ],
+      "clustering_columns": ["col1", "col2"],
       "location": "<path>",
       "view_text": "<view_text>",
       "view_original_text": "<view_original_text>",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DescribeRelationJsonCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DescribeRelationJsonCommand.scala
@@ -250,22 +250,16 @@ case class DescribeRelationJsonCommand(
   private def describeClusteringInfoJson(
       table: CatalogTable, jsonMap: mutable.LinkedHashMap[String, JValue]): Unit = {
     table.clusterBySpec.foreach { clusterBySpec =>
-      val clusteringColumnsJson: JValue = JArray(
-        clusterBySpec.columnNames.map { fieldNames =>
-          val nestedFieldOpt = table.schema.findNestedField(fieldNames.fieldNames.toIndexedSeq)
-          assert(nestedFieldOpt.isDefined,
-            "The clustering column " +
-              s"${fieldNames.fieldNames.map(quoteIfNeeded).mkString(".")} " +
-              s"was not found in the table schema ${table.schema.catalogString}."
-          )
-          val (path, field) = nestedFieldOpt.get
-          JObject(
-            "name" -> JString((path :+ field.name).map(quoteIfNeeded).mkString(".")),
-            "type" -> jsonType(field.dataType),
-            "comment" -> field.getComment().map(JString).getOrElse(JNull)
-          )
-        }.toList
-      )
+      val clusteringColumnsJson = jsonType(StructType(clusterBySpec.columnNames.map { fieldNames =>
+        val nestedFieldOpt = table.schema.findNestedField(fieldNames.fieldNames.toIndexedSeq)
+        assert(nestedFieldOpt.isDefined,
+          "The clustering column " +
+            s"${fieldNames.fieldNames.map(quoteIfNeeded).mkString(".")} " +
+            s"was not found in the table schema ${table.schema.catalogString}."
+        )
+        val (_, field) = nestedFieldOpt.get
+        field
+      })).asInstanceOf[JObject].find(_.isInstanceOf[JArray]).get
       addKeyValueToMap("clustering_information", clusteringColumnsJson, jsonMap)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DescribeRelationJsonCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DescribeRelationJsonCommand.scala
@@ -250,17 +250,17 @@ case class DescribeRelationJsonCommand(
   private def describeClusteringInfoJson(
       table: CatalogTable, jsonMap: mutable.LinkedHashMap[String, JValue]): Unit = {
     table.clusterBySpec.foreach { clusterBySpec =>
-      val clusteringColumnsJson = jsonType(StructType(clusterBySpec.columnNames.map { fieldNames =>
+      val clusteringColumnsJson = JArray(clusterBySpec.columnNames.map { fieldNames =>
         val nestedFieldOpt = table.schema.findNestedField(fieldNames.fieldNames.toIndexedSeq)
         assert(nestedFieldOpt.isDefined,
           "The clustering column " +
             s"${fieldNames.fieldNames.map(quoteIfNeeded).mkString(".")} " +
             s"was not found in the table schema ${table.schema.catalogString}."
         )
-        val (_, field) = nestedFieldOpt.get
-        field
-      })).asInstanceOf[JObject].find(_.isInstanceOf[JArray]).get
-      addKeyValueToMap("clustering_information", clusteringColumnsJson, jsonMap)
+        JString(fieldNames.fieldNames.map(quoteIfNeeded).mkString("."))
+      }.toList)
+
+      addKeyValueToMap("clustering_columns", clusteringColumnsJson, jsonMap)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
@@ -248,7 +248,7 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
            |) USING parquet
            |OPTIONS ('compression' = 'snappy', 'max_records' = '1000')
            |PARTITIONED BY (department, hire_date)
-           |CLUSTER BY (employee_id) SORTED BY (employee_name ASC) INTO 4 BUCKETS
+           |CLUSTERED BY (employee_id) SORTED BY (employee_name ASC) INTO 4 BUCKETS
            |COMMENT 'Employee data table for testing partitions and buckets'
            |TBLPROPERTIES ('version' = '1.0')
            |""".stripMargin
@@ -290,7 +290,7 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
         )),
         partition_provider = Some("Catalog"),
         partition_columns = Some(List("department", "hire_date")),
-        clustering_columns = Some(List("employee_id"))
+        clustering_columns = None // no cluster spec for "CLUSTERED BY"
       )
 
       assert(parsedOutput.location.isDefined)
@@ -355,8 +355,7 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
         statistics = Some(Map(
           "size_in_bytes" -> 0,
           "num_rows" -> 0
-        )),
-        clustering_columns = None // no cluster spec
+        ))
       )
 
       assert(parsedOutput.location.isDefined)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
@@ -248,7 +248,7 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
            |) USING parquet
            |OPTIONS ('compression' = 'snappy', 'max_records' = '1000')
            |PARTITIONED BY (department, hire_date)
-           |CLUSTERED BY (employee_id) SORTED BY (employee_name ASC) INTO 4 BUCKETS
+           |CLUSTER BY (employee_id) SORTED BY (employee_name ASC) INTO 4 BUCKETS
            |COMMENT 'Employee data table for testing partitions and buckets'
            |TBLPROPERTIES ('version' = '1.0')
            |""".stripMargin
@@ -289,7 +289,8 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
           "max_records" -> "1000"
         )),
         partition_provider = Some("Catalog"),
-        partition_columns = Some(List("department", "hire_date"))
+        partition_columns = Some(List("department", "hire_date")),
+        clustering_columns = Some(List("employee_id"))
       )
 
       assert(parsedOutput.location.isDefined)
@@ -354,7 +355,8 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
         statistics = Some(Map(
           "size_in_bytes" -> 0,
           "num_rows" -> 0
-        ))
+        )),
+        clustering_columns = None // no cluster spec
       )
 
       assert(parsedOutput.location.isDefined)
@@ -413,10 +415,7 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
         } else {
           None
         },
-        clustering_information = Some(List(
-          TableColumn("id", Type("int"), true),
-          TableColumn("name", Type("string"), true)
-        ))
+        clustering_columns = Some(List("id", "name"))
       )
 
       assert(parsedOutput.location.isDefined)
@@ -818,7 +817,7 @@ case class DescribeTableJson(
     partition_provider: Option[String] = None,
     partition_columns: Option[List[String]] = Some(Nil),
     partition_values: Option[Map[String, String]] = None,
-    clustering_information: Option[List[TableColumn]] = Some(Nil),
+    clustering_columns: Option[List[String]] = None,
     statistics: Option[Map[String, Any]] = None,
     view_text: Option[String] = None,
     view_original_text: Option[String] = None,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
@@ -405,7 +405,8 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
         sort_columns = Some(Nil),
         comment = Some("test cluster spec"),
         table_properties = Some(Map(
-          "t" -> "test"
+          "t" -> "test",
+          "clusteringColumns" -> "[[\"id\"],[\"name\"]]"
         )),
         serde_library = if (getProvider() == "hive") {
           Some("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Include only column names for Desc As JSON `clustering_columns` field. Previously, `clustering_information` contained redundant column information, as clustering columns full StructType defn will already be included in the `columns` field of Desc As JSON.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Clean up code to ensure consistency and update docs to include the `clustering_columns` field (and similar `partition_columns` which was previously not documented). 


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, updates the output of SQL command `DESC AS JSON`


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added test


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
