### PR TITLE
[SPARK-51364][SQL][TESTS] Improve the integration tests for external data source by check filter pushed down

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
@@ -136,16 +136,19 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JD
   test("SPARK-47440: SQLServer does not support boolean expression in binary comparison") {
     val df1 = sql("SELECT name FROM " +
       s"$catalogName.employee WHERE ((name LIKE 'am%') = (name LIKE '%y'))")
+    checkFilterPushed(df1)
     assert(df1.collect().length == 4)
 
     val df2 = sql("SELECT name FROM " +
       s"$catalogName.employee " +
       "WHERE ((name NOT LIKE 'am%') = (name NOT LIKE '%y'))")
+    checkFilterPushed(df2)
     assert(df2.collect().length == 4)
 
     val df3 = sql("SELECT name FROM " +
       s"$catalogName.employee " +
       "WHERE (dept > 1 AND ((name LIKE 'am%') = (name LIKE '%y')))")
+    checkFilterPushed(df3)
     assert(df3.collect().length == 3)
   }
 
@@ -159,6 +162,7 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JD
         |SELECT * FROM tbl
         |WHERE deptString = 'first'
         |""".stripMargin)
+    checkFilterPushed(df)
     assert(df.collect().length == 2)
   }
 
@@ -169,6 +173,7 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JD
           |""".stripMargin
     )
 
+    checkFilterPushed(df)
     // scalastyle:off
     assert(getExternalEngineQuery(df.queryExecution.executedPlan) ==
       """SELECT  "dept","name","salary","bonus" FROM "employee" WHERE (CASE WHEN ("name" = 'Legolas') THEN IIF(("name" = 'Elf'), 1, 0) ELSE IIF(("name" <> 'Wizard'), 1, 0) END = 1)  """
@@ -184,6 +189,7 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JD
           |""".stripMargin
     )
 
+    checkFilterPushed(df)
     // scalastyle:off
     assert(getExternalEngineQuery(df.queryExecution.executedPlan) ==
       """SELECT  "dept","name","salary","bonus" FROM "employee" WHERE (CASE WHEN ("name" = 'Legolas') THEN IIF(("name" = 'Elf'), 1, 0) ELSE 1 END = 1)  """
@@ -201,6 +207,7 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JD
           |""".stripMargin
     )
 
+    checkFilterPushed(df)
     // scalastyle:off
     assert(getExternalEngineQuery(df.queryExecution.executedPlan) ==
       """SELECT  "dept","name","salary","bonus" FROM "employee" WHERE (CASE WHEN ("name" = 'Legolas') THEN IIF((CASE WHEN ("name" = 'Elf') THEN IIF(("name" = 'Elrond'), 1, 0) ELSE IIF(("name" = 'Gandalf'), 1, 0) END = 1), 1, 0) ELSE IIF(("name" = 'Sauron'), 1, 0) END = 1)  """
@@ -218,6 +225,7 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JD
           |""".stripMargin
     )
 
+    checkFilterPushed(df)
     // scalastyle:off
     assert(getExternalEngineQuery(df.queryExecution.executedPlan) ==
       """SELECT  "dept","name","salary","bonus" FROM "employee" WHERE ("name" IS NOT NULL) AND ((CASE WHEN "name" = 'Legolas' THEN CASE WHEN "name" = 'Elf' THEN 'Elf' ELSE 'Wizard' END ELSE 'Sauron' END) = "name")  """

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
@@ -22,7 +22,6 @@ import java.sql.Connection
 import org.apache.spark.{SparkConf, SparkSQLException}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
-import org.apache.spark.sql.execution.FilterExec
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
 import org.apache.spark.sql.jdbc.PostgresDatabaseOnDocker
 import org.apache.spark.sql.types._
@@ -250,7 +249,7 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
   test("SPARK-49695: Postgres fix xor push-down") {
     val df = spark.sql(s"select dept, name from $catalogName.employee where dept ^ 6 = 0")
     val rows = df.collect()
-    assert(!df.queryExecution.sparkPlan.exists(_.isInstanceOf[FilterExec]))
+    checkFilterPushed(df)
     assert(rows.length == 1)
     assert(rows(0).getInt(0) === 6)
     assert(rows(0).getString(1) === "jen")


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to improve the integration tests for external data source by check filter pushed down.


### Why are the changes needed?
The integration tests have many test cases not check the filter whether or not pushed down.


### Does this PR introduce _any_ user-facing change?
'No'.
Just update test cases.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
