### PR TITLE
Revert "[SPARK-51309][BUILD] Upgrade rocksdbjni to 9.10.0"

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -251,7 +251,7 @@ parquet-jackson/1.15.0//parquet-jackson-1.15.0.jar
 pickle/1.5//pickle-1.5.jar
 py4j/0.10.9.9//py4j-0.10.9.9.jar
 remotetea-oncrpc/1.1.2//remotetea-oncrpc-1.1.2.jar
-rocksdbjni/9.10.0//rocksdbjni-9.10.0.jar
+rocksdbjni/9.8.4//rocksdbjni-9.8.4.jar
 scala-collection-compat_2.13/2.7.0//scala-collection-compat_2.13-2.7.0.jar
 scala-compiler/2.13.16//scala-compiler-2.13.16.jar
 scala-library/2.13.16//scala-library-2.13.16.jar

--- a/pom.xml
+++ b/pom.xml
@@ -724,7 +724,7 @@
       <dependency>
         <groupId>org.rocksdb</groupId>
         <artifactId>rocksdbjni</artifactId>
-        <version>9.10.0</version>
+        <version>9.8.4</version>
       </dependency>
       <dependency>
         <groupId>${leveldbjni.group}</groupId>

--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk21-results.txt
@@ -2,143 +2,143 @@
 put rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                            8              9           1          1.2         822.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                              45             47           2          0.2        4455.4       0.2X
-RocksDB (trackTotalNumberOfRows: false)                             17             17           1          0.6        1655.9       0.5X
+In-memory                                                            8              9           1          1.2         815.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              46             47           2          0.2        4559.1       0.2X
+RocksDB (trackTotalNumberOfRows: false)                             17             18           1          0.6        1678.7       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              9           1          1.2         805.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            46             47           1          0.2        4561.6       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           16             17           1          0.6        1637.5       0.5X
+In-memory                                                          8              9           1          1.3         798.1       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            47             48           2          0.2        4659.8       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           17             17           1          0.6        1663.4       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              8           1          1.3         782.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            45             47           1          0.2        4537.4       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           16             17           1          0.6        1633.0       0.5X
+In-memory                                                          8              9           1          1.3         794.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            46             48           1          0.2        4625.7       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           17             17           1          0.6        1660.7       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                      8              8           1          1.3         783.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                        45             46           1          0.2        4484.9       0.2X
-RocksDB (trackTotalNumberOfRows: false)                       16             17           1          0.6        1641.4       0.5X
+In-memory                                                      8              8           1          1.3         788.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        46             47           1          0.2        4557.0       0.2X
+RocksDB (trackTotalNumberOfRows: false)                       17             17           1          0.6        1650.3       0.5X
 
 
 ================================================================================================
 merge rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                    565            579           7          0.0       56471.0       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                   182            188           3          0.1       18161.0       3.1X
+RocksDB (trackTotalNumberOfRows: true)                                                    574            585           6          0.0       57387.8       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                   181            186           3          0.1       18065.2       3.2X
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                  500            512           5          0.0       50023.6       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                 183            188           3          0.1       18312.9       2.7X
+RocksDB (trackTotalNumberOfRows: true)                                                  504            515           5          0.0       50382.4       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                 179            185           3          0.1       17882.2       2.8X
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                  436            447           5          0.0       43613.9       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                 181            186           3          0.1       18065.5       2.4X
+RocksDB (trackTotalNumberOfRows: true)                                                  442            455           6          0.0       44235.2       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                 180            185           3          0.1       17971.5       2.5X
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                              413            425           5          0.0       41349.9       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                             181            187           4          0.1       18075.6       2.3X
+RocksDB (trackTotalNumberOfRows: true)                                              424            436           5          0.0       42391.9       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                             179            185           4          0.1       17923.5       2.4X
 
 
 ================================================================================================
 delete rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                        0              0           0         26.8          37.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                          44             45           1          0.2        4396.1       0.0X
-RocksDB (trackTotalNumberOfRows: false)                                                         15             16           1          0.7        1522.7       0.0X
+In-memory                                                                                        0              1           0         27.1          36.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          45             46           1          0.2        4470.0       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         16             17           1          0.6        1583.0       0.0X
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              7           0          1.5         666.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        44             46           1          0.2        4392.1       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       15             16           0          0.7        1511.0       0.4X
+In-memory                                                                                      7              7           0          1.5         651.4       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        46             47           1          0.2        4580.3       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       16             17           0          0.6        1582.7       0.4X
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              8           1          1.4         714.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        44             45           1          0.2        4362.1       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       15             16           1          0.7        1520.6       0.5X
+In-memory                                                                                      7              8           0          1.4         713.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        45             47           1          0.2        4538.6       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                       16             16           0          0.6        1579.3       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                  7              8           0          1.4         725.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                    43             45           1          0.2        4310.1       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                   15             16           1          0.7        1528.4       0.5X
+In-memory                                                                                  7              8           0          1.4         716.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    45             46           1          0.2        4459.8       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                   16             16           1          0.6        1580.7       0.5X
 
 
 ================================================================================================
 evict rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                            7              8           0          1.4         715.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                              44             45           1          0.2        4386.8       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                             17             17           0          0.6        1686.7       0.4X
+In-memory                                                                            7              7           0          1.5         689.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              44             45           1          0.2        4424.0       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                             18             18           0          0.6        1784.2       0.4X
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           7              7           0          1.5         667.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             23             24           1          0.4        2292.5       0.3X
-RocksDB (trackTotalNumberOfRows: false)                                            10             10           0          1.0         994.3       0.7X
+In-memory                                                                           6              7           0          1.5         650.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             23             24           1          0.4        2347.8       0.3X
+RocksDB (trackTotalNumberOfRows: false)                                            10             11           0          1.0        1037.1       0.6X
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                          6              6           0          1.7         603.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             7              8           0          1.3         749.5       0.8X
-RocksDB (trackTotalNumberOfRows: false)                                            5              5           0          2.1         482.2       1.3X
+In-memory                                                                          6              6           0          1.7         585.4       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             8              8           0          1.3         766.5       0.8X
+RocksDB (trackTotalNumberOfRows: false)                                            5              5           0          2.0         503.2       1.2X
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                      0              0           0         23.7          42.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                         3              4           0          2.9         345.1       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                        3              4           0          2.9         344.6       0.1X
+In-memory                                                                      0              0           0         25.0          40.1       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         4              4           0          2.8         359.1       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                        4              4           0          2.8         359.9       0.1X
 
 

--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-results.txt
@@ -2,143 +2,143 @@
 put rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                            8             10           1          1.2         842.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                              45             47           2          0.2        4529.0       0.2X
-RocksDB (trackTotalNumberOfRows: false)                             16             17           1          0.6        1635.3       0.5X
+In-memory                                                            8              9           1          1.2         816.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              45             47           1          0.2        4514.1       0.2X
+RocksDB (trackTotalNumberOfRows: false)                             17             18           1          0.6        1682.7       0.5X
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8             10           1          1.2         831.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            47             48           1          0.2        4662.3       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           16             17           1          0.6        1625.5       0.5X
+In-memory                                                          8             10           1          1.2         811.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            47             49           1          0.2        4694.9       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           17             18           1          0.6        1680.2       0.5X
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              9           1          1.2         802.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            46             48           1          0.2        4634.4       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           16             17           1          0.6        1616.5       0.5X
+In-memory                                                          8              9           1          1.3         786.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            47             48           1          0.2        4679.7       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           17             18           1          0.6        1650.0       0.5X
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                      8              9           1          1.2         828.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                        46             47           1          0.2        4593.4       0.2X
-RocksDB (trackTotalNumberOfRows: false)                       16             17           1          0.6        1596.2       0.5X
+In-memory                                                      8              8           1          1.3         778.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        46             48           1          0.2        4629.4       0.2X
+RocksDB (trackTotalNumberOfRows: false)                       17             17           1          0.6        1664.9       0.5X
 
 
 ================================================================================================
 merge rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                    574            593           7          0.0       57382.2       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                   186            191           3          0.1       18572.6       3.1X
+RocksDB (trackTotalNumberOfRows: true)                                                    570            585           6          0.0       56996.2       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                   184            190           3          0.1       18411.4       3.1X
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                  502            513           5          0.0       50183.7       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                 185            191           3          0.1       18542.0       2.7X
+RocksDB (trackTotalNumberOfRows: true)                                                  493            505           5          0.0       49327.2       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                 181            188           3          0.1       18140.8       2.7X
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                  439            453           6          0.0       43896.3       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                 184            190           3          0.1       18384.9       2.4X
+RocksDB (trackTotalNumberOfRows: true)                                                  435            448           5          0.0       43484.3       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                 183            188           3          0.1       18289.1       2.4X
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                              421            433           5          0.0       42057.9       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                             184            192           3          0.1       18421.4       2.3X
+RocksDB (trackTotalNumberOfRows: true)                                              416            432           5          0.0       41606.2       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                             183            189           3          0.1       18282.2       2.3X
 
 
 ================================================================================================
 delete rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                        0              1           0         26.3          38.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                          45             46           1          0.2        4510.4       0.0X
-RocksDB (trackTotalNumberOfRows: false)                                                         16             17           0          0.6        1585.4       0.0X
+In-memory                                                                                        0              1           0         26.6          37.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          45             47           1          0.2        4514.1       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         16             17           0          0.6        1587.8       0.0X
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              7           0          1.5         673.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        46             47           1          0.2        4566.1       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       16             16           0          0.6        1572.0       0.4X
+In-memory                                                                                      6              7           1          1.6         644.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        45             47           1          0.2        4524.6       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       16             17           1          0.6        1579.1       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              8           1          1.4         725.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        45             46           1          0.2        4481.0       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       16             16           0          0.6        1582.0       0.5X
+In-memory                                                                                      7              8           1          1.4         698.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        45             46           1          0.2        4481.1       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                       16             17           1          0.6        1585.3       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                  7              8           1          1.4         736.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                    44             46           1          0.2        4449.2       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                   16             16           1          0.6        1570.2       0.5X
+In-memory                                                                                  7              8           1          1.4         707.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    43             45           1          0.2        4326.6       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                   16             17           1          0.6        1560.6       0.5X
 
 
 ================================================================================================
 evict rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                            7              8           0          1.4         719.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                              43             44           1          0.2        4313.7       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                             17             17           1          0.6        1652.9       0.4X
+In-memory                                                                            7              7           0          1.4         693.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              43             44           1          0.2        4285.3       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                             17             18           0          0.6        1726.3       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           7              7           0          1.5         670.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             23             24           1          0.4        2332.2       0.3X
-RocksDB (trackTotalNumberOfRows: false)                                            10             11           0          1.0        1026.8       0.7X
+In-memory                                                                           6              7           0          1.5         646.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             24             24           0          0.4        2351.2       0.3X
+RocksDB (trackTotalNumberOfRows: false)                                            11             11           0          0.9        1062.9       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                          6              7           0          1.6         610.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             8              8           0          1.3         767.9       0.8X
-RocksDB (trackTotalNumberOfRows: false)                                            5              5           0          2.0         507.6       1.2X
+In-memory                                                                          6              6           0          1.7         587.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             8              8           0          1.3         784.7       0.7X
+RocksDB (trackTotalNumberOfRows: false)                                            5              6           0          1.9         529.1       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                      0              0           0         23.1          43.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                         4              4           0          2.7         370.8       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                        4              4           0          2.7         371.8       0.1X
+In-memory                                                                      0              0           0         23.2          43.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         4              4           0          2.6         387.5       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                        4              4           0          2.6         389.4       0.1X
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr reverts commit 971b9a40c42a1d8c050941ce8088fdfc6ac442bc.


### Why are the changes needed?
A crash related to RocksDB has occurred in the macOS daily test after upgrade to 9.10.0:
- https://github.com/apache/spark/actions/runs/13608353684/job/38042505327
- https://github.com/apache/spark/actions/runs/13464386260/job/37626883152

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x0000000137105814, pid=32170, tid=707595
#
# JRE version: OpenJDK Runtime Environment Zulu21.40+17-CRaC-CA (21.0.6+7) (build 21.0.6+7-LTS)
# Java VM: OpenJDK 64-Bit Server VM Zulu21.40+17-CRaC-CA (21.0.6+7-LTS, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, bsd-aarch64)
# Problematic frame:
# C  [librocksdbjni16177160674801731666.jnilib+0x1d814]  Java_org_rocksdb_FlushOptions_disposeInternalJni+0x360
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# An error report file with more information is saved as:
# /Users/runner/work/spark/spark/sql/core/hs_err_pid32170.log
21:02:35.349 ERROR org.apache.spark.util.Utils: Aborting task
org.apache.spark.SparkException: [CANNOT_WRITE_STATE_STORE.CANNOT_COMMIT] Error writing state store files for provider RocksDBStateStore[id=(op=0,part=1),dir=file:/Users/runner/work/spark/spark/sql/core/target/tmp/streaming.metadata-aa0706db-1b92-485b-b2e6-f356f91ffda6/state/0/1]. Cannot perform commit during state checkpoint. SQLSTATE: 58030
	at org.apache.spark.sql.errors.QueryExecutionErrors$.failedToCommitStateFileError(QueryExecutionErrors.scala:2203)
	at org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider$RocksDBStateStore.commit(RocksDBStateStoreProvider.scala:243)
	at org.apache.spark.sql.execution.streaming.TransformWithStateExec.$anonfun$processDataWithPartition$5(TransformWithStateExec.scala:431)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at org.apache.spark.util.Utils$.timeTakenMs(Utils.scala:481)
	at org.apache.spark.sql.execution.streaming.StateStoreWriter.timeTakenMs(statefulOperators.scala:384)
	at org.apache.spark.sql.execution.streaming.StateStoreWriter.timeTakenMs$(statefulOperators.scala:384)
21:02:35.351 ERROR org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask: Aborting commit for partition 1 (task 6, attempt 0, stage 3.0)

21:02:35.351 ERROR org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask: Aborted commit for partition 1 (task 6, attempt 0, stage 3.0)

- transformWithState - streaming with rocksdb and invalid processor should fail (encoding = Avro) (without changelog checkpointing)
21:02:35.352 WARN org.apache.spark.scheduler.TaskSetManager: Lost task 1.0 in stage 3.0 (TID 6) (localhost executor driver): TaskKilled (Stage cancelled: [STATEFUL_PROCESSOR_CANNOT_PERFORM_OPERATION_WITH_INVALID_HANDLE_STATE] Failed to perform stateful processor operation=get_value_state with invalid handle state=INITIALIZED. SQLSTATE: 42802)

21:02:35.372 WARN org.apache.spark.sql.execution.streaming.ResolveWriteToStream: spark.sql.adaptive.enabled is not supported in streaming DataFrames/Datasets and will be disabled.

Warning: [1237.706s][warning][os] Loading hsdis library failed
#
# If you would like to submit a bug report, please visit:
#   http://www.azul.com/support/
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No