### PR TITLE
[SPARK-51366][SQL] Add a new visitCaseWhen method to V2ExpressionSQLBuilder

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -42,7 +42,6 @@ import org.apache.spark.sql.connector.expressions.aggregate.CountStar;
 import org.apache.spark.sql.connector.expressions.aggregate.GeneralAggregateFunc;
 import org.apache.spark.sql.connector.expressions.aggregate.Sum;
 import org.apache.spark.sql.connector.expressions.aggregate.UserDefinedAggregateFunc;
-import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.apache.spark.sql.types.DataType;
 
 /**
@@ -98,8 +97,7 @@ public class V2ExpressionSQLBuilder {
         case "STARTS_WITH" -> visitStartsWith(build(e.children()[0]), build(e.children()[1]));
         case "ENDS_WITH" -> visitEndsWith(build(e.children()[0]), build(e.children()[1]));
         case "CONTAINS" -> visitContains(build(e.children()[0]), build(e.children()[1]));
-        case "=", "<>", "<=>", "<", "<=", ">", ">=" ->
-          visitBinaryComparison(name, e.children()[0], e.children()[1]);
+        case "=", "<>", "<=>", "<", "<=", ">", ">=" -> visitBinaryComparison(e);
         case "+", "*", "/", "%", "&", "|", "^" ->
           visitBinaryArithmetic(name, inputToSQL(e.children()[0]), inputToSQL(e.children()[1]));
         case "-" -> {
@@ -220,6 +218,10 @@ public class V2ExpressionSQLBuilder {
     }
   }
 
+  protected String visitBinaryComparison(GeneralScalarExpression e) {
+    return visitBinaryComparison(e.name(), e.children()[0], e.children()[1]);
+  }
+
   protected String visitBinaryComparison(String name, Expression le, Expression re) {
     return visitBinaryComparison(name, inputToSQL(le), inputToSQL(re));
   }
@@ -255,11 +257,7 @@ public class V2ExpressionSQLBuilder {
   protected String visitUnaryArithmetic(String name, String v) { return name + v; }
 
   protected String visitCaseWhen(GeneralScalarExpression e) {
-    if (e instanceof Predicate) {
-      return visitCaseWhen(e.children());
-    } else {
-      return visitCaseWhen(expressionsToStringArray(e.children()));
-    }
+    return visitCaseWhen(e.children());
   }
 
   protected String visitCaseWhen(Expression[] children) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -26,7 +26,6 @@ import org.apache.spark.SparkThrowable
 import org.apache.spark.sql.catalyst.analysis.NonEmptyNamespaceException
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.expressions.{Expression, NullOrdering, SortDirection}
-import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.sql.internal.SQLConf
@@ -84,34 +83,26 @@ private case class MsSqlServerDialect() extends JdbcDialect with NoLegacyJDBCErr
       case _ => super.dialectFunctionName(funcName)
     }
 
-    override def build(expr: Expression): String = {
-      // MsSqlServer does not support boolean comparison using standard comparison operators
-      // We shouldn't propagate these queries to MsSqlServer
-      expr match {
-        case e: Predicate => e.name() match {
-          case "=" | "<>" | "<=>" | "<" | "<=" | ">" | ">=" =>
-            val Array(l, r) = e.children().map(inputToSQLNoBool)
-            visitBinaryComparison(e.name(), l, r)
-          case "CASE_WHEN" =>
-            // Since MsSqlServer cannot handle boolean expressions inside
-            // a CASE WHEN, it is necessary to convert those to another
-            // CASE WHEN expression that will return 1 or 0 depending on
-            // the result.
-            // Example:
-            // In:  ... CASE WHEN a = b THEN c = d ... END
-            // Out: ... CASE WHEN a = b THEN CASE WHEN c = d THEN 1 ELSE 0 END ... END = 1
-            val stringArray = e.children().grouped(2).flatMap {
-              case Array(whenExpression, thenExpression) =>
-                Array(inputToSQL(whenExpression), inputToSQLNoBool(thenExpression))
-              case Array(elseExpression) =>
-                Array(inputToSQLNoBool(elseExpression))
-            }.toArray
+    override def visitBinaryComparison(name: String, le: Expression, re: Expression): String = {
+      super.visitBinaryComparison(name, inputToSQLNoBool(le), inputToSQLNoBool(re));
+    }
 
-            visitCaseWhen(stringArray) + " = 1"
-          case _ => super.build(expr)
-        }
-        case _ => super.build(expr)
-      }
+    override def visitCaseWhen(children: Array[Expression]): String = {
+      // Since MsSqlServer cannot handle boolean expressions inside
+      // a CASE WHEN, it is necessary to convert those to another
+      // CASE WHEN expression that will return 1 or 0 depending on
+      // the result.
+      // Example:
+      // In:  ... CASE WHEN a = b THEN c = d ... END
+      // Out: ... CASE WHEN a = b THEN CASE WHEN c = d THEN 1 ELSE 0 END ... END = 1
+      val stringArray = children.grouped(2).flatMap {
+        case Array(whenExpression, thenExpression) =>
+          Array(inputToSQL(whenExpression), inputToSQLNoBool(thenExpression))
+        case Array(elseExpression) =>
+          Array(inputToSQLNoBool(elseExpression))
+      }.toArray
+
+      super.visitCaseWhen(stringArray) + " = 1"
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to add a new `visitCaseWhen` method to `V2ExpressionSQLBuilder`.


### Why are the changes needed?
The origin `visitCaseWhen` method is not good for users when the case when statments is related to the data type.
Such as: MsSqlServer cannot handle boolean expressions inside a CASE WHEN, it is necessary to convert those to another CASE WHEN expression that will return 1 or 0 depending on the result.
So the old `visitCaseWhen` method is not flexible and introduce some hacker code.


### Does this PR introduce _any_ user-facing change?
'No'.
Just add a new API.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
