### PR TITLE
[SPARK-51379][ML] Move treeAggregate's final aggregation from driver to executor

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
@@ -107,7 +107,12 @@ private[ml] class WeightedLeastSquares(
       instr.logWarning("regParam is zero, which might cause numerical instability and overfitting.")
     }
 
-    val summary = instances.treeAggregate(new Aggregator)(_.add(_), _.merge(_), depth)
+    val summary = instances.treeAggregate[Aggregator](
+      zeroValue = new Aggregator,
+      seqOp = (agg: Aggregator, x: Instance) => agg.add(x),
+      combOp = (agg1: Aggregator, agg2: Aggregator) => agg1.merge(agg2),
+      depth = depth,
+      finalAggregateOnExecutor = true)
     summary.validate()
     instr.logInfo(log"Number of instances: ${MDC(COUNT, summary.count)}.")
     val k = if (fitIntercept) summary.k + 1 else summary.k

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/loss/RDDLossFunction.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/loss/RDDLossFunction.scala
@@ -58,7 +58,7 @@ private[ml] class RDDLossFunction[
     val thisAgg = getAggregator(bcCoefficients)
     val seqOp = (agg: Agg, x: T) => agg.add(x)
     val combOp = (agg1: Agg, agg2: Agg) => agg1.merge(agg2)
-    val newAgg = instances.treeAggregate(thisAgg)(seqOp, combOp, aggregationDepth)
+    val newAgg = instances.treeAggregate(thisAgg, seqOp, combOp, aggregationDepth, true)
     val gradient = newAgg.gradient
     val regLoss = regularization.map { regFun =>
       val (regLoss, regGradient) = regFun.calculate(Vectors.fromBreeze(coefficients))

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/Summarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/Summarizer.scala
@@ -217,15 +217,16 @@ object Summarizer extends Logging {
       aggregationDepth: Int = 2,
       requested: Seq[String] = Seq("mean", "std", "count")) = {
     instances.treeAggregate(
-      (Summarizer.createSummarizerBuffer(requested: _*),
-        Summarizer.createSummarizerBuffer("mean", "std", "count")))(
+      zeroValue = (Summarizer.createSummarizerBuffer(requested: _*),
+        Summarizer.createSummarizerBuffer("mean", "std", "count")),
       seqOp = (c: (SummarizerBuffer, SummarizerBuffer), instance: Instance) =>
         (c._1.add(instance.features, instance.weight),
           c._2.add(Vectors.dense(instance.label), instance.weight)),
       combOp = (c1: (SummarizerBuffer, SummarizerBuffer),
                 c2: (SummarizerBuffer, SummarizerBuffer)) =>
         (c1._1.merge(c2._1), c1._2.merge(c2._2)),
-      depth = aggregationDepth
+      depth = aggregationDepth,
+      finalAggregateOnExecutor = true
     )
   }
 
@@ -235,13 +236,14 @@ object Summarizer extends Logging {
       aggregationDepth: Int = 2,
       requested: Seq[String] = Seq("mean", "std", "count")) = {
     instances.treeAggregate(
-      (Summarizer.createSummarizerBuffer(requested: _*), new MultiClassSummarizer))(
+      zeroValue = (Summarizer.createSummarizerBuffer(requested: _*), new MultiClassSummarizer),
       seqOp = (c: (SummarizerBuffer, MultiClassSummarizer), instance: Instance) =>
         (c._1.add(instance.features, instance.weight), c._2.add(instance.label, instance.weight)),
       combOp = (c1: (SummarizerBuffer, MultiClassSummarizer),
                 c2: (SummarizerBuffer, MultiClassSummarizer)) =>
         (c1._1.merge(c2._1), c1._2.merge(c2._2)),
-      depth = aggregationDepth
+      depth = aggregationDepth,
+      finalAggregateOnExecutor = true
     )
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAOptimizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAOptimizer.scala
@@ -507,8 +507,8 @@ final class OnlineLDAOptimizer extends LDAOptimizer with Logging {
     }
 
     val (statsSum: BDM[Double], logphatOption: Option[BDV[Double]], nonEmptyDocsN: Long) = stats
-      .treeAggregate((null.asInstanceOf[BDM[Double]], logphatPartOptionBase(), 0L))(
-        elementWiseSum, elementWiseSum
+      .treeAggregate((null.asInstanceOf[BDM[Double]], logphatPartOptionBase(), 0L),
+        elementWiseSum, elementWiseSum, 2, true
       )
 
     expElogbetaBc.destroy()

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/MultilabelMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/MultilabelMetrics.scala
@@ -45,11 +45,13 @@ class MultilabelMetrics @Since("1.2.0") (predictionAndLabels: RDD[(Array[Double]
    * and labels on one pass.
    */
   private val summary: MultilabelSummarizer = {
-    predictionAndLabels
-      .treeAggregate(new MultilabelSummarizer)(
-        (summary, sample) => summary.add(sample._1, sample._2),
-        (sum1, sum2) => sum1.merge(sum2)
-      )
+    predictionAndLabels.treeAggregate[MultilabelSummarizer](
+      zeroValue = new MultilabelSummarizer,
+      seqOp = (summary: MultilabelSummarizer,
+               sample: (Array[Double], Array[Double])) => summary.add(sample._1, sample._2),
+      combOp = (sum1: MultilabelSummarizer, sum2: MultilabelSummarizer) => sum1.merge(sum2),
+      depth = 2,
+      finalAggregateOnExecutor = true)
   }
 
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/optimization/LBFGS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/optimization/LBFGS.scala
@@ -258,7 +258,8 @@ object LBFGS extends Logging {
        }
 
       val zeroSparseVector = Vectors.sparse(n, Seq.empty)
-      val (gradientSum, lossSum) = data.treeAggregate((zeroSparseVector, 0.0))(seqOp, combOp)
+      val (gradientSum, lossSum) = data.treeAggregate(
+        (zeroSparseVector, 0.0), seqOp, combOp, 2, true)
 
       // broadcasted model is not needed anymore
       bcW.destroy()

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/Statistics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/Statistics.scala
@@ -55,10 +55,13 @@ object Statistics {
    * @return [[SummarizerBuffer]] object containing column-wise summary statistics.
    */
   private[mllib] def colStats(X: RDD[(Vector, Double)], requested: Seq[String]) = {
-    X.treeAggregate(Summarizer.createSummarizerBuffer(requested: _*))(
-      seqOp = { case (c, (v, w)) => c.add(v.nonZeroIterator, v.size, w) },
-      combOp = { case (c1, c2) => c1.merge(c2) },
-      depth = 2
+    X.treeAggregate[SummarizerBuffer](
+      zeroValue = Summarizer.createSummarizerBuffer(requested: _*),
+      seqOp = (c: SummarizerBuffer,
+               vw: (Vector, Double)) => c.add(vw._1.nonZeroIterator, vw._1.size, vw._2),
+      combOp = (c1: SummarizerBuffer, c2: SummarizerBuffer) => c1.merge(c2),
+      depth = 2,
+      finalAggregateOnExecutor = true
     )
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Move treeAggregate's final aggregation from driver to executor.

https://github.com/apache/spark/commit/ee20fbb3dc8594e2c70758c0e2d140f50108a6c5 introduced an optimization that:

> Move final iteration of aggregation of RDD.treeAggregate to an executor with one partition and fetch that result to the driver

This PR tries to apply this optimization so that less memory is required for ML's treeAggregate.


### Why are the changes needed?
to optimize driver peak memory usage


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci and manually check

preparing data:
```
df = spark.read.format("libsvm").load("data/mllib/sample_libsvm_data.txt")
for i in range(10):
    df = df.union(df)

df.count()
df.repartition(1024).write.mode("overwrite").parquet("/tmp/test_data")
```

training a lr
```
from pyspark.ml.classification import *
df = spark.read.parquet("/tmp/test_data")
lr = LogisticRegression()
model = lr.fit(df)
```

before:
![image](https://github.com/user-attachments/assets/84e72882-667b-40fd-9f12-ea4d62cc8978)


after:
![image](https://github.com/user-attachments/assets/917e9634-2a90-4ca8-9621-02aac561b3e1)

In each iteration, the data sent to driver is reduced from 136.1 KiB to 21.3 KiB


</body></html>


### Was this patch authored or co-authored using generative AI tooling?
no
