### PR TITLE
[SPARK-51380][SQL] Add visitSQLFunction and visitAggregateFunction to improve the flexibility of V2ExpressionSQLBuilder

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -273,11 +273,11 @@ public class V2ExpressionSQLBuilder {
     return sb.toString();
   }
 
-  protected String visitSQLFunction(String funcName, String[] inputs) {
+  public String visitSQLFunction(String funcName, String[] inputs) {
     return joinArrayToString(inputs, ", ", funcName + "(", ")");
   }
 
-  protected String visitAggregateFunction(
+  public String visitAggregateFunction(
       String funcName, boolean isDistinct, String[] inputs) {
     if (isDistinct) {
       return joinArrayToString(inputs, ", ", funcName + "(DISTINCT ", ")");

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -119,7 +119,7 @@ public class V2ExpressionSQLBuilder {
           "RADIANS", "SIGN", "WIDTH_BUCKET", "SUBSTRING", "UPPER", "LOWER", "TRANSLATE",
           "DATE_ADD", "DATE_DIFF", "TRUNC", "AES_ENCRYPT", "AES_DECRYPT", "SHA1", "SHA2", "MD5",
           "CRC32", "BIT_LENGTH", "CHAR_LENGTH", "CONCAT", "RPAD", "LPAD" ->
-          visitSQLFunction(name, expressionsToStringArray(e.children()));
+          visitSQLFunction(name, e.children());
         case "CASE_WHEN" -> visitCaseWhen(expressionsToStringArray(e.children()));
         case "TRIM" -> visitTrim("BOTH", expressionsToStringArray(e.children()));
         case "LTRIM" -> visitTrim("LEADING", expressionsToStringArray(e.children()));
@@ -147,8 +147,7 @@ public class V2ExpressionSQLBuilder {
         expressionsToStringArray(avg.children()));
     } else if (expr instanceof GeneralAggregateFunc f) {
       if (f.orderingWithinGroups().length == 0) {
-        return visitAggregateFunction(f.name(), f.isDistinct(),
-          expressionsToStringArray(f.children()));
+        return visitAggregateFunction(f.name(), f.isDistinct(), f.children());
       } else {
         return visitInverseDistributionFunction(
           f.name(),
@@ -273,12 +272,20 @@ public class V2ExpressionSQLBuilder {
     return sb.toString();
   }
 
-  public String visitSQLFunction(String funcName, String[] inputs) {
+  protected String visitSQLFunction(String funcName, Expression[] inputs) {
+    return visitSQLFunction(funcName, expressionsToStringArray(inputs));
+  }
+
+  protected String visitSQLFunction(String funcName, String[] inputs) {
     return joinArrayToString(inputs, ", ", funcName + "(", ")");
   }
 
-  public String visitAggregateFunction(
-      String funcName, boolean isDistinct, String[] inputs) {
+  protected String visitAggregateFunction(
+      String funcName, boolean isDistinct, Expression[] inputs) {
+    return visitAggregateFunction(funcName, isDistinct, expressionsToStringArray(inputs));
+  }
+
+  protected String visitAggregateFunction(String funcName, boolean isDistinct, String[] inputs) {
     if (isDistinct) {
       return joinArrayToString(inputs, ", ", funcName + "(DISTINCT ", ")");
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
@@ -48,7 +48,7 @@ private case class DB2Dialect() extends JdbcDialect with SQLConfHelper with NoLe
     supportedFunctions.contains(funcName)
 
   class DB2SQLBuilder extends JDBCSQLBuilder {
-    override def visitAggregateFunction(
+    override def aggregateFunctionToSQL(
         funcName: String, isDistinct: Boolean, inputs: Array[String]): String =
       if (isDistinct && distinctUnsupportedAggregateFunctions.contains(funcName)) {
         throw new SparkUnsupportedOperationException(
@@ -57,7 +57,7 @@ private case class DB2Dialect() extends JdbcDialect with SQLConfHelper with NoLe
             "class" -> this.getClass.getSimpleName,
             "funcName" -> funcName))
       } else {
-        super.visitAggregateFunction(funcName, isDistinct, inputs)
+        super.aggregateFunctionToSQL(funcName, isDistinct, inputs)
       }
 
     override def dialectFunctionName(funcName: String): String = funcName match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
@@ -48,7 +48,8 @@ private case class DB2Dialect() extends JdbcDialect with SQLConfHelper with NoLe
     supportedFunctions.contains(funcName)
 
   class DB2SQLBuilder extends JDBCSQLBuilder {
-    override def aggregateFunctionToSQL(
+
+    override def visitAggregateFunction(
         funcName: String, isDistinct: Boolean, inputs: Array[String]): String =
       if (isDistinct && distinctUnsupportedAggregateFunctions.contains(funcName)) {
         throw new SparkUnsupportedOperationException(
@@ -57,7 +58,7 @@ private case class DB2Dialect() extends JdbcDialect with SQLConfHelper with NoLe
             "class" -> this.getClass.getSimpleName,
             "funcName" -> funcName))
       } else {
-        super.aggregateFunctionToSQL(funcName, isDistinct, inputs)
+        super.visitAggregateFunction(funcName, isDistinct, inputs)
       }
 
     override def dialectFunctionName(funcName: String): String = funcName match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
@@ -260,7 +260,7 @@ private[sql] case class H2Dialect() extends JdbcDialect with NoLegacyJDBCError {
 
   class H2SQLBuilder extends JDBCSQLBuilder {
 
-    override def aggregateFunctionToSQL(
+    override def visitAggregateFunction(
         funcName: String, isDistinct: Boolean, inputs: Array[String]): String =
       if (isDistinct && distinctUnsupportedAggregateFunctions.contains(funcName)) {
         throw new SparkUnsupportedOperationException(
@@ -269,7 +269,7 @@ private[sql] case class H2Dialect() extends JdbcDialect with NoLegacyJDBCError {
             "class" -> this.getClass.getSimpleName,
             "funcName" -> funcName))
       } else {
-        super.aggregateFunctionToSQL(funcName, isDistinct, inputs)
+        super.visitAggregateFunction(funcName, isDistinct, inputs)
       }
 
     override def visitExtract(field: String, source: String): String = {
@@ -282,7 +282,7 @@ private[sql] case class H2Dialect() extends JdbcDialect with NoLegacyJDBCError {
       s"EXTRACT($newField FROM $source)"
     }
 
-    override def functionToSQL(funcName: String, inputs: Array[String]): String = {
+    override def visitSQLFunction(funcName: String, inputs: Array[String]): String = {
       funcName match {
         case "MD5" =>
           "RAWTOHEX(HASH('MD5', " + inputs.mkString(",") + "))"
@@ -290,7 +290,7 @@ private[sql] case class H2Dialect() extends JdbcDialect with NoLegacyJDBCError {
           "RAWTOHEX(HASH('SHA-1', " + inputs.mkString(",") + "))"
         case "SHA2" =>
           "RAWTOHEX(HASH('SHA-" + inputs(1) + "'," + inputs(0) + "))"
-        case _ => super.functionToSQL(funcName, inputs)
+        case _ => super.visitSQLFunction(funcName, inputs)
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
@@ -260,7 +260,7 @@ private[sql] case class H2Dialect() extends JdbcDialect with NoLegacyJDBCError {
 
   class H2SQLBuilder extends JDBCSQLBuilder {
 
-    override def visitAggregateFunction(
+    override def aggregateFunctionToSQL(
         funcName: String, isDistinct: Boolean, inputs: Array[String]): String =
       if (isDistinct && distinctUnsupportedAggregateFunctions.contains(funcName)) {
         throw new SparkUnsupportedOperationException(
@@ -269,7 +269,7 @@ private[sql] case class H2Dialect() extends JdbcDialect with NoLegacyJDBCError {
             "class" -> this.getClass.getSimpleName,
             "funcName" -> funcName))
       } else {
-        super.visitAggregateFunction(funcName, isDistinct, inputs)
+        super.aggregateFunctionToSQL(funcName, isDistinct, inputs)
       }
 
     override def visitExtract(field: String, source: String): String = {
@@ -282,23 +282,15 @@ private[sql] case class H2Dialect() extends JdbcDialect with NoLegacyJDBCError {
       s"EXTRACT($newField FROM $source)"
     }
 
-    override def visitSQLFunction(funcName: String, inputs: Array[String]): String = {
-      if (isSupportedFunction(funcName)) {
-        funcName match {
-          case "MD5" =>
-            "RAWTOHEX(HASH('MD5', " + inputs.mkString(",") + "))"
-          case "SHA1" =>
-            "RAWTOHEX(HASH('SHA-1', " + inputs.mkString(",") + "))"
-          case "SHA2" =>
-            "RAWTOHEX(HASH('SHA-" + inputs(1) + "'," + inputs(0) + "))"
-          case _ => super.visitSQLFunction(funcName, inputs)
-        }
-      } else {
-        throw new SparkUnsupportedOperationException(
-          errorClass = "_LEGACY_ERROR_TEMP_3177",
-          messageParameters = Map(
-            "class" -> this.getClass.getSimpleName,
-            "funcName" -> funcName))
+    override def functionToSQL(funcName: String, inputs: Array[String]): String = {
+      funcName match {
+        case "MD5" =>
+          "RAWTOHEX(HASH('MD5', " + inputs.mkString(",") + "))"
+        case "SHA1" =>
+          "RAWTOHEX(HASH('SHA-1', " + inputs.mkString(",") + "))"
+        case "SHA2" =>
+          "RAWTOHEX(HASH('SHA-" + inputs(1) + "'," + inputs(0) + "))"
+        case _ => super.functionToSQL(funcName, inputs)
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -413,7 +413,7 @@ abstract class JdbcDialect extends Serializable with Logging {
 
     override def visitSQLFunction(funcName: String, inputs: Array[String]): String = {
       if (isSupportedFunction(funcName)) {
-        s"""${dialectFunctionName(funcName)}(${inputs.mkString(", ")})"""
+        functionToSQL(funcName, inputs)
       } else {
         // The framework will catch the error and give up the push-down.
         // Please see `JdbcDialect.compileExpression(expr: Expression)` for more details.
@@ -425,16 +425,29 @@ abstract class JdbcDialect extends Serializable with Logging {
       }
     }
 
+    protected def functionToSQL(funcName: String, inputs: Array[String]): String = {
+      s"""${dialectFunctionName(funcName)}(${inputs.mkString(", ")})"""
+    }
+
     override def visitAggregateFunction(
         funcName: String, isDistinct: Boolean, inputs: Array[String]): String = {
       if (isSupportedFunction(funcName)) {
-        super.visitAggregateFunction(dialectFunctionName(funcName), isDistinct, inputs)
+        aggregateFunctionToSQL(funcName, isDistinct, inputs)
       } else {
         throw new SparkUnsupportedOperationException(
           errorClass = "_LEGACY_ERROR_TEMP_3177",
           messageParameters = Map(
             "class" -> this.getClass.getSimpleName,
             "funcName" -> funcName))
+      }
+    }
+
+    protected def aggregateFunctionToSQL(
+        funcName: String, isDistinct: Boolean, inputs: Array[String]): String = {
+      if (isDistinct) {
+        s"""${dialectFunctionName(funcName)}(DISTINCT ${inputs.mkString(", ")})"""
+      } else {
+        s"""${dialectFunctionName(funcName)}(${inputs.mkString(", ")})"""
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -62,13 +62,13 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
       }
     }
 
-    override def functionToSQL(funcName: String, inputs: Array[String]): String = {
+    override def visitSQLFunction(funcName: String, inputs: Array[String]): String = {
       funcName match {
         case "DATE_ADD" =>
           s"DATE_ADD(${inputs(0)}, INTERVAL ${inputs(1)} DAY)"
         case "DATE_DIFF" =>
           s"DATEDIFF(${inputs(0)}, ${inputs(1)})"
-        case _ => super.functionToSQL(funcName, inputs)
+        case _ => super.visitSQLFunction(funcName, inputs)
       }
     }
 
@@ -101,7 +101,7 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
       s"$l LIKE '%${escapeSpecialCharsForLikePattern(value)}%' ESCAPE '\\\\'"
     }
 
-    override def aggregateFunctionToSQL(
+    override def visitAggregateFunction(
         funcName: String, isDistinct: Boolean, inputs: Array[String]): String =
       if (isDistinct && distinctUnsupportedAggregateFunctions.contains(funcName)) {
         throw new SparkUnsupportedOperationException(
@@ -110,7 +110,7 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
             "class" -> this.getClass.getSimpleName,
             "funcName" -> funcName))
       } else {
-        super.aggregateFunctionToSQL(funcName, isDistinct, inputs)
+        super.visitAggregateFunction(funcName, isDistinct, inputs)
       }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -62,13 +62,13 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
       }
     }
 
-    override def visitSQLFunction(funcName: String, inputs: Array[String]): String = {
+    override def functionToSQL(funcName: String, inputs: Array[String]): String = {
       funcName match {
         case "DATE_ADD" =>
           s"DATE_ADD(${inputs(0)}, INTERVAL ${inputs(1)} DAY)"
         case "DATE_DIFF" =>
           s"DATEDIFF(${inputs(0)}, ${inputs(1)})"
-        case _ => super.visitSQLFunction(funcName, inputs)
+        case _ => super.functionToSQL(funcName, inputs)
       }
     }
 
@@ -101,7 +101,7 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
       s"$l LIKE '%${escapeSpecialCharsForLikePattern(value)}%' ESCAPE '\\\\'"
     }
 
-    override def visitAggregateFunction(
+    override def aggregateFunctionToSQL(
         funcName: String, isDistinct: Boolean, inputs: Array[String]): String =
       if (isDistinct && distinctUnsupportedAggregateFunctions.contains(funcName)) {
         throw new SparkUnsupportedOperationException(
@@ -110,7 +110,7 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
             "class" -> this.getClass.getSimpleName,
             "funcName" -> funcName))
       } else {
-        super.visitAggregateFunction(funcName, isDistinct, inputs)
+        super.aggregateFunctionToSQL(funcName, isDistinct, inputs)
       }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -50,7 +50,8 @@ private case class OracleDialect() extends JdbcDialect with SQLConfHelper with N
     supportedFunctions.contains(funcName)
 
   class OracleSQLBuilder extends JDBCSQLBuilder {
-    override def aggregateFunctionToSQL(
+
+    override def visitAggregateFunction(
         funcName: String, isDistinct: Boolean, inputs: Array[String]): String =
       if (isDistinct && distinctUnsupportedAggregateFunctions.contains(funcName)) {
         throw new SparkUnsupportedOperationException(
@@ -59,7 +60,7 @@ private case class OracleDialect() extends JdbcDialect with SQLConfHelper with N
             "class" -> this.getClass.getSimpleName,
             "funcName" -> funcName))
       } else {
-        super.aggregateFunctionToSQL(funcName, isDistinct, inputs)
+        super.visitAggregateFunction(funcName, isDistinct, inputs)
       }
 
     override def visitBinaryComparison(name: String, le: Expression, re: Expression): String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -50,7 +50,7 @@ private case class OracleDialect() extends JdbcDialect with SQLConfHelper with N
     supportedFunctions.contains(funcName)
 
   class OracleSQLBuilder extends JDBCSQLBuilder {
-    override def visitAggregateFunction(
+    override def aggregateFunctionToSQL(
         funcName: String, isDistinct: Boolean, inputs: Array[String]): String =
       if (isDistinct && distinctUnsupportedAggregateFunctions.contains(funcName)) {
         throw new SparkUnsupportedOperationException(
@@ -59,7 +59,7 @@ private case class OracleDialect() extends JdbcDialect with SQLConfHelper with N
             "class" -> this.getClass.getSimpleName,
             "funcName" -> funcName))
       } else {
-        super.visitAggregateFunction(funcName, isDistinct, inputs)
+        super.aggregateFunctionToSQL(funcName, isDistinct, inputs)
       }
 
     override def visitBinaryComparison(name: String, le: Expression, re: Expression): String = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to add `visitSQLFunction` and `visitAggregateFunction`, so as increase the flexibility of `V2ExpressionSQLBuilder`.

### Why are the changes needed?
The original `visitSQLFunction` of `JDBCSQLBuilder` provides the check about the supported functions. But many subclass of `JDBCSQLBuilder` overrides the `visitSQLFunction` and skips the check.

### Does this PR introduce _any_ user-facing change?
'No'.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
'No'.
