### PR TITLE
[SPARK-51381][SQL][CONNECT] Show `Session ID` in `Spark Connect Session` page

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ui/SparkConnectServerSessionPage.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ui/SparkConnectServerSessionPage.scala
@@ -43,7 +43,7 @@ private[ui] class SparkConnectServerSessionPage(parent: SparkConnectServerTab)
       store
         .getSession(sessionId)
         .map { sessionStat =>
-          generateBasicStats() ++
+          generateBasicStats(sessionId) ++
             <br/> ++
             <h4>
             User
@@ -64,9 +64,12 @@ private[ui] class SparkConnectServerSessionPage(parent: SparkConnectServerTab)
   }
 
   /** Generate basic stats of the Spark Connect Server */
-  private def generateBasicStats(): Seq[Node] = {
+  private def generateBasicStats(sessionId: String): Seq[Node] = {
     val timeSinceStart = System.currentTimeMillis() - startTime.getTime
     <ul class ="list-unstyled">
+      <li>
+        <strong>Session ID: </strong> {sessionId}
+      </li>
       <li>
         <strong>Started at: </strong> {formatDate(startTime)}
       </li>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to show `Session ID` in `Spark Connect Session` page.

### Why are the changes needed?

When a user visits an individual session page via the link, we had better shows the `Session ID` intuitively on the page like the existing `Job` page or `Stage` page.
- http://localhost:4040/connect/session/?id=becfab2d-ed09-4080-836f-18958db128be

**BEFORE (Apache Spark 4.0.0 RC2)**
<img width="317" alt="Screenshot 2025-03-03 at 20 39 29" src="https://github.com/user-attachments/assets/fe69f1e8-c5ae-4a27-a34c-e20973763422" />

**AFTER (Apache Spark 4.1.0)**
<img width="378" alt="Screenshot 2025-03-03 at 20 37 59" src="https://github.com/user-attachments/assets/80922b2f-3ff2-4917-b9a3-e52ba276a53f" />

### Does this PR introduce _any_ user-facing change?

Yes, but this is a new item of the session information in the UI page.

### How was this patch tested?

Manually start `Spark Connect Server` and create a session by using a client.
```
$ sbin/start-connect-server.sh
$ bin/pyspark --remote sc://localhost:15002
...
>>> spark.version
'4.0.0'
```

### Was this patch authored or co-authored using generative AI tooling?

No.