### PR TITLE
[SPARK-51383][PYTHON][CONNECT] Avoid making RPC calls if clients are already known as stopped

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -458,7 +458,9 @@ class SparkSession:
         _num_cols: Optional[int] = None
 
         if isinstance(schema, str):
-            schema = self.client._analyze(method="ddl_parse", ddl_string=schema).parsed
+            schema = self.client._analyze(  # type: ignore[assignment]
+                method="ddl_parse", ddl_string=schema
+            ).parsed
 
         if isinstance(schema, (AtomicType, StructType)):
             _schema = schema

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -458,9 +458,7 @@ class SparkSession:
         _num_cols: Optional[int] = None
 
         if isinstance(schema, str):
-            schema = self.client._analyze(  # type: ignore[assignment]
-                method="ddl_parse", ddl_string=schema
-            ).parsed
+            schema = self.client._analyze(method="ddl_parse", ddl_string=schema).parsed
 
         if isinstance(schema, (AtomicType, StructType)):
             _schema = schema


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is sort of a followup of https://github.com/apache/spark/pull/40536 that fails fast if clients are already known as stopped.

### Why are the changes needed?

To avoid overhead of making RPC calls when the clients are closed. Failing fast.

### Does this PR introduce _any_ user-facing change?

No. Internal changes.

### How was this patch tested?

Existing tests added in https://github.com/apache/spark/pull/40536

### Was this patch authored or co-authored using generative AI tooling?

No.
