### PR TITLE
[SPARK-51029][INFRA][FOLLOWUP] Remove LICENSE and NOTICE for unused/duplicated hive deps

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -328,7 +328,6 @@ org.apache.hive:hive-cli
 org.apache.hive:hive-common
 org.apache.hive:hive-exec
 org.apache.hive:hive-jdbc
-org.apache.hive:hive-llap-common
 org.apache.hive:hive-metastore
 org.apache.hive:hive-serde
 org.apache.hive:hive-service-rpc

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -592,9 +592,6 @@ Copyright 2015 The Apache Software Foundation
 Apache Extras Companion for log4j 1.2.
 Copyright 2007 The Apache Software Foundation
 
-Hive Metastore
-Copyright 2016 The Apache Software Foundation
-
 Apache Commons Logging
 Copyright 2003-2013 The Apache Software Foundation
 
@@ -969,12 +966,6 @@ The Derby build relies on a jar file supplied by the JSON Simple
 project, hosted at https://code.google.com/p/json-simple/.
 The JSON simple jar file is licensed under the Apache 2.0 License.
 
-Hive CLI
-Copyright 2016 The Apache Software Foundation
-
-Hive JDBC
-Copyright 2016 The Apache Software Foundation
-
 
 Chill is a set of Scala extensions for Kryo.
 Copyright 2012 Twitter, Inc.
@@ -1056,9 +1047,6 @@ Copyright 2019 The Apache Software Foundation
 Hive Query Language
 Copyright 2019 The Apache Software Foundation
 
-Hive Llap Common
-Copyright 2019 The Apache Software Foundation
-
 Hive Metastore
 Copyright 2019 The Apache Software Foundation
 
@@ -1083,8 +1071,6 @@ Copyright 2019 The Apache Software Foundation
 Hive Storage API
 Copyright 2018 The Apache Software Foundation
 
-Hive Vector-Code-Gen Utilities
-Copyright 2019 The Apache Software Foundation
 
 
                                  Apache License


### PR DESCRIPTION

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
SPARK-51029 removed hive-llap, this PR removes all related license statements, while it also removes some duplicated hive items

### Why are the changes needed?

code cleaning


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?


existing tests

### Was this patch authored or co-authored using generative AI tooling?
no