### PR TITLE
[SPARK-51385][SQL] Normalize out projection added in DeduplicateRelations for union child output deduplication

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeduplicateRelations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeduplicateRelations.scala
@@ -22,9 +22,12 @@ import scala.collection.mutable
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, AttributeReference, AttributeSet, Expression, NamedExpression, OuterReference, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.trees.TreePattern._
 
 object DeduplicateRelations extends Rule[LogicalPlan] {
+  val PROJECT_FOR_EXPRESSION_ID_DEDUPLICATION =
+    TreeNodeTag[Unit]("project_for_expression_id_deduplication")
 
   type ExprIdMap = mutable.HashMap[Class[_], mutable.HashSet[Long]]
 
@@ -67,7 +70,9 @@ object DeduplicateRelations extends Rule[LogicalPlan] {
               val projectList = child.output.map { attr =>
                 Alias(attr, attr.name)()
               }
-              Project(projectList, child)
+              val project = Project(projectList, child)
+              project.setTagValue(DeduplicateRelations.PROJECT_FOR_EXPRESSION_ID_DEDUPLICATION, ())
+              project
           }
         }
         u.copy(children = newChildren)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Strip away extra projection added by `DeduplicateRelations` when comparing logical plans.

`DeduplicateRelations` puts one extra `Project` on the right branch of `Union` when the outputs of children are conflicting. This is a hack for streaming relations. Unfortunately this logic is generalized an the extra projection is used for simple cases like views:

```
CREATE VIEW IF NOT EXISTS v1 AS SELECT * FROM VALUES (1, 2);

SELECT * FROM (
  SELECT col1, col2 FROM v1
  UNION ALL
  SELECT col1, col2 FROM v1
);
```

Single-pass Analyzer should not produce this projection, because it assigns expression IDs in single-pass, so we strip it in `NormalizePlan` to correctly compare the plans.

### Why are the changes needed?

This is to make sure that single-pass and fixed-point Analyzed plans are the same.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.