### PR TITLE
[MINOR][CORE] Remove unused `private[executor] var httpUrlConnectionTimeoutMillis` from `ExecutorClassLoader`

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/ExecutorClassLoader.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorClassLoader.scala
@@ -59,9 +59,6 @@ class ExecutorClassLoader(
 
   val parentLoader = new ParentClassLoader(parent)
 
-  // Allows HTTP connect and read timeouts to be controlled for testing / debugging purposes
-  private[executor] var httpUrlConnectionTimeoutMillis: Int = -1
-
   private val fetchFn: (String) => InputStream = uri.getScheme() match {
     case "spark" => getClassFileInputStreamFromSparkRPC
     case _ =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to remove unused `private[executor] var httpUrlConnectionTimeoutMillis` from `ExecutorClassLoader`.

The definition of `httpUrlConnectionTimeoutMillis` was introduced in SPARK-6209 (https://github.com/apache/spark/pull/4944) and was used by the function `getClassFileInputStreamFromHttpServer`. After SPARK-23538(https://github.com/apache/spark/pull/20723), the function `getClassFileInputStreamFromHttpServer` was removed from `ExecutorClassLoader`, and `httpUrlConnectionTimeoutMillis` is no longer used either.


### Why are the changes needed?
Code cleanup


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Action


### Was this patch authored or co-authored using generative AI tooling?
No