### PR TITLE
[SPARK-51390][INFRA] Add more dependencies in LICENSE-binary for Spark 4.0.0 release

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -215,8 +215,10 @@ com.github.joshelser:dropwizard-metrics-hadoop-metrics2-reporter
 com.google.code.findbugs:jsr305
 com.google.code.gson:gson
 com.google.crypto.tink:tink
+com.google.errorprone:error_prone_annotations
 com.google.flatbuffers:flatbuffers-java
 com.google.guava:guava
+com.google.j2objc:j2objc-annotations
 com.jamesmurty.utils:java-xmlbuilder
 com.ning:compress-lzf
 com.squareup.okhttp3:logging-interceptor
@@ -226,7 +228,7 @@ com.tdunning:json
 com.twitter:chill-java
 com.twitter:chill_2.13
 com.univocity:univocity-parsers
-com.zaxxer.HikariCP
+com.zaxxer:HikariCP
 commons-cli:commons-cli
 commons-codec:commons-codec
 commons-collections:commons-collections
@@ -273,6 +275,7 @@ io.jsonwebtoken:jjwt-jackson
 io.netty:netty-all
 io.netty:netty-buffer
 io.netty:netty-codec
+io.netty:netty-codec-dns
 io.netty:netty-codec-http
 io.netty:netty-codec-http2
 io.netty:netty-codec-socks
@@ -280,6 +283,7 @@ io.netty:netty-common
 io.netty:netty-handler
 io.netty:netty-handler-proxy
 io.netty:netty-resolver
+io.netty:netty-resolver-dns
 io.netty:netty-tcnative-boringssl-static
 io.netty:netty-tcnative-classes
 io.netty:netty-transport
@@ -383,6 +387,8 @@ org.glassfish.jersey.core:jersey-client
 org.glassfish.jersey.core:jersey-common
 org.glassfish.jersey.core:jersey-server
 org.glassfish.jersey.inject:jersey-hk2
+org.javassist:javassist
+org.jetbrains:annotations
 org.json4s:json4s-ast_2.13
 org.json4s:json4s-core_2.13
 org.json4s:json4s-jackson-core_2.13


### PR DESCRIPTION
### What changes were proposed in this pull request?

While reviewing Spark 4.0.0 RC2, I noticed the binary distribution included several jars that were not covered in the license file. This change covers all of the missing dependencies that I found.

Additionally, I have corrected a minor syntax problem regarding HikariCP, using the ':' delimiter to separate group from artifact ID.

### Why are the changes needed?

Provide complete license information on bundled dependencies in binary distributions for the 4.0.0 release.

### Does this PR introduce _any_ user-facing change?

Yes. These changes will be visible in the license file of the binary distribution. There is no change in functionality.

### How was this patch tested?

Existing tests

### Was this patch authored or co-authored using generative AI tooling?

No.
