### PR TITLE
[SPARK-51391][SQL][CONNECT] Fix `SparkConnectClient` to respect `SPARK_USER` and `user.name`

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -666,7 +666,7 @@ class SparkConnectClient(object):
         elif user_id is not None:
             self._user_id = user_id
         else:
-            self._user_id = os.getenv("USER", None)
+            self._user_id = os.getenv("SPARK_USER", os.getenv("USER", None))
 
         self._channel = self._builder.toChannel()
         self._closed = False

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientBuilderParseTestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientBuilderParseTestSuite.scala
@@ -99,7 +99,7 @@ class SparkConnectClientBuilderParseTestSuite extends ConnectFunSuite {
       assert(!builder.sslEnabled)
       assert(builder.token.isEmpty)
       assert(builder.userId.contains("Q12"))
-      assert(builder.userName.isEmpty)
+      assert(builder.userName.contains(System.getProperty("user.name", null)))
       assert(builder.options.isEmpty)
     }
     {
@@ -116,7 +116,7 @@ class SparkConnectClientBuilderParseTestSuite extends ConnectFunSuite {
       assert(builder.userAgent.contains("_SPARK_CONNECT_SCALA"))
       assert(builder.sslEnabled)
       assert(builder.token.isEmpty)
-      assert(builder.userId.isEmpty)
+      assert(builder.userId.contains(System.getProperty("user.name", null)))
       assert(builder.userName.contains("Nico"))
       assert(builder.options === Map(("mode", "turbo"), ("cluster", "mycl")))
     }
@@ -127,8 +127,8 @@ class SparkConnectClientBuilderParseTestSuite extends ConnectFunSuite {
       assert(builder.userAgent.contains("_SPARK_CONNECT_SCALA"))
       assert(!builder.sslEnabled)
       assert(builder.token.contains("thisismysecret"))
-      assert(builder.userId.isEmpty)
-      assert(builder.userName.isEmpty)
+      assert(builder.userId.contains(System.getProperty("user.name", null)))
+      assert(builder.userName.contains(System.getProperty("user.name", null)))
       assert(builder.options.isEmpty)
     }
   }

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -70,6 +70,11 @@ class SparkConnectClientSuite extends ConnectFunSuite with BeforeAndAfterEach {
     }
   }
 
+  test("SPARK-51391: Use 'user.name' by default") {
+    client = SparkConnectClient.builder().build()
+    assert(client.userId == System.getProperty("user.name"))
+  }
+
   test("Placeholder test: Create SparkConnectClient") {
     client = SparkConnectClient.builder().userId("abc123").build()
     assert(client.userId == "abc123")

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -423,7 +423,6 @@ object SparkConnectClient {
     def configuration: Configuration = _configuration
 
     def userId(id: String): Builder = {
-      // TODO this is not an optional field!
       require(id != null && id.nonEmpty)
       _configuration = _configuration.copy(userId = id)
       this
@@ -706,12 +705,15 @@ object SparkConnectClient {
       s"os/$osName").mkString(" ")
   }
 
+  private lazy val sparkUser =
+    sys.env.getOrElse("SPARK_USER", System.getProperty("user.name", null))
+
   /**
    * Helper class that fully captures the configuration for a [[SparkConnectClient]].
    */
   private[sql] case class Configuration(
-      userId: String = null,
-      userName: String = null,
+      userId: String = sparkUser,
+      userName: String = sparkUser,
       host: String = "localhost",
       port: Int = ConnectCommon.CONNECT_GRPC_BINDING_PORT,
       token: Option[String] = None,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `SparkConnectClient` to respect `SPARK_USER` and `user.name` for the feature parity with PySpark Connect client.

**BEFORE**
<img width="699" alt="Screenshot 2025-03-04 at 17 04 21" src="https://github.com/user-attachments/assets/19c95b89-0312-47f0-9285-2c824a3a077c" />

**AFTER**
<img width="698" alt="Screenshot 2025-03-04 at 17 05 04" src="https://github.com/user-attachments/assets/49f4dbc3-5e9a-46d4-9825-01e4e1f0cab6" />

### Why are the changes needed?

Like `pyspark`, `spark-shell` and `spark-connect-shell` should have a consistent default user when `--user_id` is not given.

```
$ bin/pyspark --remote sc://localhost:15002
>>> spark.version
'4.0.0'

// Spark Connect Server shows `userId: dongjoon`.
25/03/04 16:57:53 INFO SessionHolder: Session with userId: dongjoon and sessionId: 1fd1bc8f-233b-4a6b-9924-9f90af15f894 accessed,time 1741136273692 ms.
```

```
$ bin/spark-shell --remote sc://localhost:15002

// Spark Connect Server shows `userId: `.
25/03/04 16:58:54 INFO SessionHolder: Session with userId:  and sessionId: 00f7ac26-98c4-49ca-a027-5808e9e5b155 accessed,time 1741136334546 ms.
```

```
$ bin/spark-connect-shell --remote sc://localhost:15002

// Spark Connect Server shows `userId: `.
25/03/04 16:59:29 INFO SessionHolder: Session with userId:  and sessionId: 63afa7dd-8b95-41da-b90e-cd73918b33be accessed,time 1741136369060 ms.
```

### Does this PR introduce _any_ user-facing change?

Yes, this is a bug fix for feature parity across `Spark Connect` languages.

**BEFORE (Apache Spark 4.0.0 RC2)**
```
$ bin/spark-shell --remote sc://localhost:15002

// Spark Connect Server shows `userId: `.
25/03/04 17:01:03 INFO SessionHolder: Session with userId:  and sessionId: b9c7edd7-2209-4c53-b7b1-dfc3171d012a accessed,time 1741136463337 ms.
```

**AFTER**
```
$ bin/spark-shell --remote sc://localhost:15002

// Spark Connect Server shows `userId: dongjoon`.
25/03/04 17:01:35 INFO SessionHolder: Session with userId: dongjoon and sessionId: 3a9305ff-4dbf-4240-b3fd-edb8f3edab02 accessed,time 1741136495807 ms.
```

```
$ SPARK_USER=spark2005 bin/spark-shell --remote sc://localhost:15002

// Spark Connect Server shows `userId: spark2005 `.
25/03/04 17:02:24 INFO SessionHolder: Session with userId: spark2005 and sessionId: 72142325-94d8-4f67-a777-1ede6e02bbf3 accessed,time 1741136544444 ms.
```

### How was this patch tested?

Pass the CIs and manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.