### PR TITLE
[SPARK-51277][PYTHON][FOLLOW-UP] Remove 0-arg check in Spark Connect side as well

### DIFF
--- a/python/pyspark/sql/connect/udf.py
+++ b/python/pyspark/sql/connect/udf.py
@@ -23,8 +23,6 @@ check_dependencies(__name__)
 
 import sys
 import functools
-import warnings
-from inspect import getfullargspec
 from typing import cast, Callable, Any, List, TYPE_CHECKING, Optional, Union
 
 from pyspark.util import PythonEvalType
@@ -79,18 +77,7 @@ def _create_py_udf(
     eval_type: int = PythonEvalType.SQL_BATCHED_UDF
 
     if is_arrow_enabled:
-        try:
-            is_func_with_args = len(getfullargspec(f).args) > 0
-        except TypeError:
-            is_func_with_args = False
-        if is_func_with_args:
-            eval_type = PythonEvalType.SQL_ARROW_BATCHED_UDF
-        else:
-            warnings.warn(
-                "Arrow optimization for Python UDFs cannot be enabled for functions"
-                " without arguments.",
-                UserWarning,
-            )
+        eval_type = PythonEvalType.SQL_ARROW_BATCHED_UDF
 
     return _create_udf(f, returnType, eval_type)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/commit/9efaa91deb502cadbaddb8ca4c934bd8529aeaad that removes the 0-arg check in Spark Connect side as well.

### Why are the changes needed?

To allow 0-arg support with Arrow-optimized Python UDFs as well.

### Does this PR introduce _any_ user-facing change?

No, the main change has not been released out yet.

### How was this patch tested?

Existing test cases.

### Was this patch authored or co-authored using generative AI tooling?

No.