### PR TITLE
[SPARK-51097] [SS] [4.0] Revert RocksDB instance metrics changes

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2218,19 +2218,6 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT =
-    buildConf("spark.sql.streaming.stateStore.numStateStoreInstanceMetricsToReport")
-      .internal()
-      .doc(
-        "Number of state store instance metrics included in streaming query progress messages " +
-        "per stateful operator. Instance metrics are selected based on metric-specific ordering " +
-        "to minimize noise in the progress report."
-      )
-      .version("4.0.0")
-      .intConf
-      .checkValue(k => k >= 0, "Must be greater than or equal to 0")
-      .createWithDefault(5)
-
   val STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT =
     buildConf("spark.sql.streaming.stateStore.minDeltasForSnapshot")
       .internal()
@@ -5762,9 +5749,6 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def isStateSchemaCheckEnabled: Boolean = getConf(STATE_SCHEMA_CHECK_ENABLED)
 
   def numStateStoreMaintenanceThreads: Int = getConf(NUM_STATE_STORE_MAINTENANCE_THREADS)
-
-  def numStateStoreInstanceMetricsToReport: Int =
-    getConf(STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT)
 
   def stateStoreMinDeltasForSnapshot: Int = getConf(STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -224,7 +224,7 @@ case class StreamingSymmetricHashJoinExec(
 
   override def shortName: String = "symmetricHashJoin"
 
-  override val stateStoreNames: Seq[String] =
+  private val stateStoreNames =
     SymmetricHashJoinStateManager.allStateStoreNames(LeftSide, RightSide)
 
   override def operatorStateMetadata(
@@ -527,8 +527,9 @@ case class StreamingSymmetricHashJoinExec(
           (leftSideJoiner.numUpdatedStateRows + rightSideJoiner.numUpdatedStateRows)
         numTotalStateRows += combinedMetrics.numKeys
         stateMemory += combinedMetrics.memoryUsedBytes
-        setStoreCustomMetrics(combinedMetrics.customMetrics)
-        setStoreInstanceMetrics(combinedMetrics.instanceMetrics)
+        combinedMetrics.customMetrics.foreach { case (metric, value) =>
+          longMetric(metric.name) += value
+        }
       }
 
       val stateStoreNames = SymmetricHashJoinStateManager.allStateStoreNames(LeftSide, RightSide);

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -22,7 +22,7 @@ import java.util.Locale
 import java.util.Set
 import java.util.UUID
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentLinkedQueue, TimeUnit}
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import javax.annotation.concurrent.GuardedBy
 
 import scala.collection.{mutable, Map}
@@ -146,10 +146,6 @@ class RocksDB(
   @volatile private var changelogWriter: Option[StateStoreChangelogWriter] = None
   private val enableChangelogCheckpointing: Boolean = conf.enableChangelogCheckpointing
   @volatile protected var loadedVersion: Long = -1L   // -1 = nothing valid is loaded
-
-  // Can be updated by whichever thread uploaded a snapshot, which could be either task,
-  // maintenance, or both. -1 represents no version has ever been uploaded.
-  protected val lastUploadedSnapshotVersion: AtomicLong = new AtomicLong(-1L)
 
   // variables to manage checkpoint ID. Once a checkpointing finishes, it needs to return
   // `lastCommittedStateStoreCkptId` as the committed checkpointID, as well as
@@ -1301,7 +1297,6 @@ class RocksDB(
       bytesCopied = fileManagerMetrics.bytesCopied,
       filesCopied = fileManagerMetrics.filesCopied,
       filesReused = fileManagerMetrics.filesReused,
-      lastUploadedSnapshotVersion = lastUploadedSnapshotVersion.get(),
       zipFileBytesUncompressed = fileManagerMetrics.zipFileBytesUncompressed,
       nativeOpsMetrics = nativeOpsMetrics)
   }
@@ -1470,7 +1465,6 @@ class RocksDB(
         log"with uniqueId: ${MDC(LogKeys.UUID, snapshot.uniqueId)} " +
         log"time taken: ${MDC(LogKeys.TIME_UNITS, uploadTime)} ms. " +
         log"Current lineage: ${MDC(LogKeys.LINEAGE, lineageManager)}")
-      lastUploadedSnapshotVersion.set(snapshot.version)
     } finally {
       snapshot.close()
     }
@@ -1922,8 +1916,7 @@ case class RocksDBMetrics(
     bytesCopied: Long,
     filesReused: Long,
     zipFileBytesUncompressed: Option[Long],
-    nativeOpsMetrics: Map[String, Long],
-    lastUploadedSnapshotVersion: Long) {
+    nativeOpsMetrics: Map[String, Long]) {
   def json: String = Serialization.write(this)(RocksDBMetrics.format)
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -316,20 +316,14 @@ private[sql] class RocksDBStateStoreProvider
         ) ++ rocksDBMetrics.zipFileBytesUncompressed.map(bytes =>
           Map(CUSTOM_METRIC_ZIP_FILE_BYTES_UNCOMPRESSED -> bytes)).getOrElse(Map())
 
-        val stateStoreInstanceMetrics = Map[StateStoreInstanceMetric, Long](
-          CUSTOM_INSTANCE_METRIC_SNAPSHOT_LAST_UPLOADED
-            .withNewId(id.partitionId, id.storeName) -> rocksDBMetrics.lastUploadedSnapshotVersion
-        )
-
         StateStoreMetrics(
           rocksDBMetrics.numUncommittedKeys,
           rocksDBMetrics.totalMemUsageBytes,
-          stateStoreCustomMetrics,
-          stateStoreInstanceMetrics)
+          stateStoreCustomMetrics)
       } else {
         logInfo(log"Failed to collect metrics for store_id=${MDC(STATE_STORE_ID, id)} " +
           log"and version=${MDC(VERSION_NUM, version)}")
-        StateStoreMetrics(0, 0, Map.empty, Map.empty)
+        StateStoreMetrics(0, 0, Map.empty)
       }
     }
 
@@ -502,8 +496,6 @@ private[sql] class RocksDBStateStoreProvider
   }
 
   override def supportedCustomMetrics: Seq[StateStoreCustomMetric] = ALL_CUSTOM_METRICS
-
-  override def supportedInstanceMetrics: Seq[StateStoreInstanceMetric] = ALL_INSTANCE_METRICS
 
   private[state] def latestVersion: Long = rocksDB.getLatestVersion()
 
@@ -896,10 +888,6 @@ object RocksDBStateStoreProvider {
     CUSTOM_METRIC_COMPACT_WRITTEN_BYTES, CUSTOM_METRIC_FLUSH_WRITTEN_BYTES,
     CUSTOM_METRIC_PINNED_BLOCKS_MEM_USAGE, CUSTOM_METRIC_NUM_INTERNAL_COL_FAMILIES_KEYS,
     CUSTOM_METRIC_NUM_EXTERNAL_COL_FAMILIES, CUSTOM_METRIC_NUM_INTERNAL_COL_FAMILIES)
-
-  val CUSTOM_INSTANCE_METRIC_SNAPSHOT_LAST_UPLOADED = StateStoreSnapshotLastUploadInstanceMetric()
-
-  val ALL_INSTANCE_METRICS = Seq(CUSTOM_INSTANCE_METRIC_SNAPSHOT_LAST_UPLOADED)
 }
 
 /** [[StateStoreChangeDataReader]] implementation for [[RocksDBStateStoreProvider]] */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManager.scala
@@ -447,9 +447,7 @@ class SymmetricHashJoinStateManager(
       keyToNumValuesMetrics.memoryUsedBytes + keyWithIndexToValueMetrics.memoryUsedBytes,
       keyWithIndexToValueMetrics.customMetrics.map {
         case (metric, value) => (metric.withNewDesc(desc = newDesc(metric.desc)), value)
-      },
-      // We want to collect instance metrics from both state stores
-      keyWithIndexToValueMetrics.instanceMetrics ++ keyToNumValuesMetrics.instanceMetrics
+      }
     )
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -216,14 +216,7 @@ trait StateStoreWriter
     "stateMemory" -> SQLMetrics.createSizeMetric(sparkContext, "memory used by state"),
     "numStateStoreInstances" -> SQLMetrics.createMetric(sparkContext,
       "number of state store instances")
-  ) ++ stateStoreCustomMetrics ++ pythonMetrics ++ stateStoreInstanceMetrics
-
-  val stateStoreNames: Seq[String] = Seq(StateStoreId.DEFAULT_STORE_NAME)
-
-  // This is used to relate metric names back to their original metric object,
-  // which holds information on how to report the metric during getProgress.
-  lazy val instanceMetricConfiguration: Map[String, StateStoreInstanceMetric] =
-    stateStoreInstanceMetricObjects
+  ) ++ stateStoreCustomMetrics ++ pythonMetrics
 
   // This method is only used to fetch the state schema directory path for
   // operators that use StateSchemaV3, as prior versions only use a single
@@ -327,40 +320,11 @@ trait StateStoreWriter
    * the driver after this SparkPlan has been executed and metrics have been updated.
    */
   def getProgress(): StateOperatorProgress = {
-    val instanceMetricsToReport = instanceMetricConfiguration
-      .filter {
-        case (name, metricConfig) =>
-          // Keep instance metrics that are updated or aren't marked to be ignored,
-          // as their initial value could still be important.
-          !metricConfig.ignoreIfUnchanged || !longMetric(name).isZero
-      }
-      .groupBy {
-        // Group all instance metrics underneath their common metric prefix
-        // to ignore partition and store names.
-        case (name, metricConfig) => metricConfig.metricPrefix
-      }
-      .flatMap {
-        case (_, metrics) =>
-          // Select at most N metrics based on the metric's defined ordering
-          // to report to the driver. For example, ascending order would be taking the N smallest.
-          val metricConf = metrics.head._2
-          metrics
-            .map {
-              case (_, metric) =>
-                metric.name -> (if (longMetric(metric.name).isZero) metricConf.initValue
-                                else longMetric(metric.name).value)
-            }
-            .toSeq
-            .sortBy(_._2)(metricConf.ordering)
-            .take(conf.numStateStoreInstanceMetricsToReport)
-            .toMap
-      }
     val customMetrics = (stateStoreCustomMetrics ++ statefulOperatorCustomMetrics)
       .map(entry => entry._1 -> longMetric(entry._1).value)
-    val allCustomMetrics = customMetrics ++ instanceMetricsToReport
 
     val javaConvertedCustomMetrics: java.util.HashMap[String, java.lang.Long] =
-      new java.util.HashMap(allCustomMetrics.transform((_, v) => long2Long(v)).asJava)
+      new java.util.HashMap(customMetrics.transform((_, v) => long2Long(v)).asJava)
 
     // We now don't report number of shuffle partitions inside the state operator. Instead,
     // it will be filled when the stream query progress is reported
@@ -409,8 +373,9 @@ trait StateStoreWriter
     val storeMetrics = store.metrics
     longMetric("numTotalStateRows") += storeMetrics.numKeys
     longMetric("stateMemory") += storeMetrics.memoryUsedBytes
-    setStoreCustomMetrics(storeMetrics.customMetrics)
-    setStoreInstanceMetrics(storeMetrics.instanceMetrics)
+    storeMetrics.customMetrics.foreach { case (metric, value) =>
+      longMetric(metric.name) += value
+    }
 
     if (StatefulOperatorStateInfo.enableStateStoreCheckpointIds(conf)) {
       // Set the state store checkpoint information for the driver to collect
@@ -426,47 +391,10 @@ trait StateStoreWriter
     }
   }
 
-  protected def setStoreCustomMetrics(customMetrics: Map[StateStoreCustomMetric, Long]): Unit = {
-    customMetrics.foreach {
-      case (metric, value) =>
-        longMetric(metric.name) += value
-    }
-  }
-
-  protected def setStoreInstanceMetrics(
-      instanceMetrics: Map[StateStoreInstanceMetric, Long]): Unit = {
-    instanceMetrics.foreach {
-      case (metric, value) =>
-        val metricConfig = instanceMetricConfiguration(metric.name)
-        // Update the metric's value based on the defined combine method
-        longMetric(metric.name).set(metricConfig.combine(longMetric(metric.name), value))
-    }
-  }
-
   private def stateStoreCustomMetrics: Map[String, SQLMetric] = {
     val provider = StateStoreProvider.create(conf.stateStoreProviderClass)
     provider.supportedCustomMetrics.map {
       metric => (metric.name, metric.createSQLMetric(sparkContext))
-    }.toMap
-  }
-
-  private def stateStoreInstanceMetrics: Map[String, SQLMetric] = {
-    instanceMetricConfiguration.map {
-      case (name, metric) => (name, metric.createSQLMetric(sparkContext))
-    }
-  }
-
-  private def stateStoreInstanceMetricObjects: Map[String, StateStoreInstanceMetric] = {
-    val provider = StateStoreProvider.create(conf.stateStoreProviderClass)
-    val maxPartitions = stateInfo.map(_.numPartitions).getOrElse(conf.defaultNumShufflePartitions)
-
-    (0 until maxPartitions).flatMap { partitionId =>
-      provider.supportedInstanceMetrics.flatMap { metric =>
-        stateStoreNames.map { storeName =>
-          val metricWithPartition = metric.withNewId(partitionId, storeName)
-          (metricWithPartition.name, metricWithPartition)
-        }
-      }
     }.toMap
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreCheckpointFormatV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreCheckpointFormatV2Suite.scala
@@ -183,9 +183,6 @@ class CkptIdCollectingStateStoreProviderWrapper extends StateStoreProvider {
 
   override def supportedCustomMetrics: Seq[StateStoreCustomMetric] =
     innerProvider.supportedCustomMetrics
-
-  override def supportedInstanceMetrics: Seq[StateStoreInstanceMetric] =
-    innerProvider.supportedInstanceMetrics
 }
 
 class RocksDBStateStoreCheckpointFormatV2Suite extends StreamTest

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
@@ -19,35 +19,20 @@ package org.apache.spark.sql.execution.streaming.state
 
 import java.io.File
 
-import scala.concurrent.duration.DurationInt
-import scala.jdk.CollectionConverters.{MapHasAsScala, SetHasAsScala}
+import scala.jdk.CollectionConverters.SetHasAsScala
 
 import org.scalatest.time.{Minute, Span}
 
 import org.apache.spark.sql.execution.streaming.{MemoryStream, StreamingQueryWrapper}
-import org.apache.spark.sql.functions.{count, expr}
+import org.apache.spark.sql.functions.count
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming._
 import org.apache.spark.sql.streaming.OutputMode.Update
 import org.apache.spark.util.Utils
 
-// SkipMaintenanceOnCertainPartitionsProvider is a test-only provider that skips running
-// maintenance for partitions 0 and 1 (these are arbitrary choices). This is used to test
-// snapshot upload lag can be observed through StreamingQueryProgress metrics.
-class SkipMaintenanceOnCertainPartitionsProvider extends RocksDBStateStoreProvider {
-  override def doMaintenance(): Unit = {
-    if (stateStoreId.partitionId == 0 || stateStoreId.partitionId == 1) {
-      return
-    }
-    super.doMaintenance()
-  }
-}
-
 class RocksDBStateStoreIntegrationSuite extends StreamTest
   with AlsoTestWithRocksDBFeatures {
   import testImplicits._
-
-  private val SNAPSHOT_LAG_METRIC_PREFIX = "SnapshotLastUploaded.partition_"
 
   testWithColumnFamilies("RocksDBStateStore",
     TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
@@ -86,7 +71,6 @@ class RocksDBStateStoreIntegrationSuite extends StreamTest
         (SQLConf.STREAMING_NO_DATA_PROGRESS_EVENT_INTERVAL.key -> "10"),
         (SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName),
         (SQLConf.CHECKPOINT_LOCATION.key -> dir.getCanonicalPath),
-        (SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT.key -> "0"),
         (SQLConf.SHUFFLE_PARTITIONS.key, "1")) {
         val inputData = MemoryStream[Int]
 
@@ -285,238 +269,5 @@ class RocksDBStateStoreIntegrationSuite extends StreamTest
     )
     assert(changelogVersionsPresent(dirForPartition0) == List(3L, 4L))
     assert(snapshotVersionsPresent(dirForPartition0).contains(5L))
-  }
-
-  private def snapshotLagMetricName(
-      partitionId: Long,
-      storeName: String = StateStoreId.DEFAULT_STORE_NAME): String = {
-    s"$SNAPSHOT_LAG_METRIC_PREFIX${partitionId}_$storeName"
-  }
-
-  testWithChangelogCheckpointingEnabled(
-    "SPARK-51097: Verify snapshot lag metrics are updated correctly with RocksDBStateStoreProvider"
-  ) {
-    withSQLConf(
-      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName,
-      SQLConf.STREAMING_MAINTENANCE_INTERVAL.key -> "100",
-      SQLConf.STREAMING_NO_DATA_PROGRESS_EVENT_INTERVAL.key -> "10",
-      SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.key -> "1",
-      SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT.key -> "3"
-    ) {
-      withTempDir { checkpointDir =>
-        val inputData = MemoryStream[String]
-        val result = inputData.toDS().dropDuplicates()
-
-        testStream(result, outputMode = OutputMode.Update)(
-          StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
-          AddData(inputData, "a"),
-          ProcessAllAvailable(),
-          AddData(inputData, "b"),
-          ProcessAllAvailable(),
-          CheckNewAnswer("a", "b"),
-          Execute { q =>
-            // Make sure only smallest K active metrics are published
-            eventually(timeout(10.seconds)) {
-              val instanceMetrics = q.lastProgress
-                .stateOperators(0)
-                .customMetrics
-                .asScala
-                .view
-                .filterKeys(_.startsWith(SNAPSHOT_LAG_METRIC_PREFIX))
-              // Determined by STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT
-              assert(
-                instanceMetrics.size == q.sparkSession.conf
-                  .get(SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT)
-              )
-              assert(instanceMetrics.forall(_._2 == 1))
-            }
-          },
-          StopStream
-        )
-      }
-    }
-  }
-
-  testWithChangelogCheckpointingEnabled(
-    "SPARK-51097: Verify snapshot lag metrics are updated correctly with " +
-    "SkipMaintenanceOnCertainPartitionsProvider"
-  ) {
-    withSQLConf(
-      SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
-        classOf[SkipMaintenanceOnCertainPartitionsProvider].getName,
-      SQLConf.STREAMING_MAINTENANCE_INTERVAL.key -> "100",
-      SQLConf.STREAMING_NO_DATA_PROGRESS_EVENT_INTERVAL.key -> "10",
-      SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.key -> "1",
-      SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT.key -> "3"
-    ) {
-      withTempDir { checkpointDir =>
-        val inputData = MemoryStream[String]
-        val result = inputData.toDS().dropDuplicates()
-
-        testStream(result, outputMode = OutputMode.Update)(
-          StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
-          AddData(inputData, "a"),
-          ProcessAllAvailable(),
-          AddData(inputData, "b"),
-          ProcessAllAvailable(),
-          CheckNewAnswer("a", "b"),
-          Execute { q =>
-            // Partitions getting skipped (id 0 and 1) do not have an uploaded version, leaving
-            // those instance metrics as -1.
-            eventually(timeout(10.seconds)) {
-              assert(
-                q.lastProgress
-                  .stateOperators(0)
-                  .customMetrics
-                  .get(snapshotLagMetricName(0)) === -1
-              )
-              assert(
-                q.lastProgress
-                  .stateOperators(0)
-                  .customMetrics
-                  .get(snapshotLagMetricName(1)) === -1
-              )
-              // Make sure only smallest K active metrics are published
-              val instanceMetrics = q.lastProgress
-                .stateOperators(0)
-                .customMetrics
-                .asScala
-                .view
-                .filterKeys(_.startsWith(SNAPSHOT_LAG_METRIC_PREFIX))
-              // Determined by STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT
-              assert(
-                instanceMetrics.size == q.sparkSession.conf
-                  .get(SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT)
-              )
-              // Two metrics published are -1, the remainder should all be 1 as they
-              // uploaded properly.
-              assert(
-                instanceMetrics.count(_._2 == 1) == q.sparkSession.conf
-                  .get(SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT) - 2
-              )
-            }
-          },
-          StopStream
-        )
-      }
-    }
-  }
-
-  testWithChangelogCheckpointingEnabled(
-    "SPARK-51097: Verify snapshot lag metrics are updated correctly for join queries with " +
-    "RocksDBStateStoreProvider"
-  ) {
-    withSQLConf(
-      SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
-        classOf[RocksDBStateStoreProvider].getName,
-      SQLConf.STREAMING_MAINTENANCE_INTERVAL.key -> "100",
-      SQLConf.STREAMING_NO_DATA_PROGRESS_EVENT_INTERVAL.key -> "10",
-      SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.key -> "1",
-      SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT.key -> "10"
-    ) {
-      withTempDir { checkpointDir =>
-        val input1 = MemoryStream[Int]
-        val input2 = MemoryStream[Int]
-
-        val df1 = input1.toDF().select($"value" as "leftKey", ($"value" * 2) as "leftValue")
-        val df2 = input2
-          .toDF()
-          .select($"value" as "rightKey", ($"value" * 3) as "rightValue")
-        val joined = df1.join(df2, expr("leftKey = rightKey"))
-
-        testStream(joined)(
-          StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
-          AddData(input1, 1, 5),
-          ProcessAllAvailable(),
-          AddData(input2, 1, 5, 10),
-          ProcessAllAvailable(),
-          CheckNewAnswer((1, 2, 1, 3), (5, 10, 5, 15)),
-          Execute { q =>
-            eventually(timeout(10.seconds)) {
-              // Make sure only smallest K active metrics are published.
-              // There are 5 * 4 = 20 metrics in total because of join, but only 10 are published.
-              val instanceMetrics = q.lastProgress
-                .stateOperators(0)
-                .customMetrics
-                .asScala
-                .view
-                .filterKeys(_.startsWith(SNAPSHOT_LAG_METRIC_PREFIX))
-              // Determined by STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT
-              assert(
-                instanceMetrics.size == q.sparkSession.conf
-                  .get(SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT)
-              )
-              // All state store instances should have uploaded a version
-              assert(instanceMetrics.forall(_._2 == 1))
-            }
-          },
-          StopStream
-        )
-      }
-    }
-  }
-
-  testWithChangelogCheckpointingEnabled(
-    "SPARK-51097: Verify snapshot lag metrics are updated correctly for join queries with " +
-    "SkipMaintenanceOnCertainPartitionsProvider"
-  ) {
-    withSQLConf(
-      SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
-        classOf[SkipMaintenanceOnCertainPartitionsProvider].getName,
-      SQLConf.STREAMING_MAINTENANCE_INTERVAL.key -> "100",
-      SQLConf.STREAMING_NO_DATA_PROGRESS_EVENT_INTERVAL.key -> "10",
-      SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.key -> "1",
-      SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT.key -> "10"
-    ) {
-      withTempDir { checkpointDir =>
-        val input1 = MemoryStream[Int]
-        val input2 = MemoryStream[Int]
-
-        val df1 = input1.toDF().select($"value" as "leftKey", ($"value" * 2) as "leftValue")
-        val df2 = input2
-          .toDF()
-          .select($"value" as "rightKey", ($"value" * 3) as "rightValue")
-        val joined = df1.join(df2, expr("leftKey = rightKey"))
-
-        testStream(joined)(
-          StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
-          AddData(input1, 1, 5),
-          ProcessAllAvailable(),
-          AddData(input2, 1, 5, 10),
-          ProcessAllAvailable(),
-          CheckNewAnswer((1, 2, 1, 3), (5, 10, 5, 15)),
-          Execute { q =>
-            eventually(timeout(10.seconds)) {
-              // Make sure only smallest K active metrics are published.
-              // There are 5 * 4 = 20 metrics in total because of join, but only 10 are published.
-              val allInstanceMetrics = q.lastProgress
-                .stateOperators(0)
-                .customMetrics
-                .asScala
-                .view
-                .filterKeys(_.startsWith(SNAPSHOT_LAG_METRIC_PREFIX))
-              val badInstanceMetrics = allInstanceMetrics.filterKeys(
-                k =>
-                  k.startsWith(snapshotLagMetricName(0, "")) ||
-                  k.startsWith(snapshotLagMetricName(1, ""))
-              )
-              // Determined by STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT
-              assert(
-                allInstanceMetrics.size == q.sparkSession.conf
-                  .get(SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT)
-              )
-              // Two ids are blocked, each with four state stores
-              assert(badInstanceMetrics.count(_._2 == -1) == 2 * 4)
-              // The rest should have uploaded a version
-              assert(
-                allInstanceMetrics.count(_._2 == 1) == q.sparkSession.conf
-                  .get(SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT) - 2 * 4
-              )
-            }
-          },
-          StopStream
-        )
-      }
-    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

SPARK-51097

Similar to #50161, this PR reverts the changes in branch-4.0 introduced from SPARK-51097. More specifically, this reverts the following commit: https://github.com/apache/spark/commit/55fc6f5f3028c35fa7564e45daa7c0e3d4d456f9

The context of this issue is that the newly introduced instance metrics have been unexpectedly showing up in Spark UI regardless of whether they are being used or not by the state stores. As a result, a query using 500 shuffle partitions would result in 500 instance metrics showing up in Spark UI (specifically, the SQL tab visualizing execution plan).

The original PR from #49816 introduced a new type of SQL metrics denoting metrics for specific state store instances. This change only targeted RocksDB state stores.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This change is needed to revert an issue with the new instance metrics, where unused metrics would also show up on the Spark UI page. As a result, there would be hundreds of instance metrics showing up on the query visualizer.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Re-verified that RocksDBStateStoreIntegrationSuite is passing

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No