### PR TITLE
[SPARK-51396][SQL] RuntimeConfig.getOption shouldn't use exceptions for control flow

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -6623,12 +6623,14 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   /** Return the value of Spark SQL configuration property for the given key. */
   @throws[NoSuchElementException]("if key is not set")
   def getConfString(key: String): String = {
-    Option(settings.get(key)).
-      orElse {
-        // Try to use the default value
-        Option(getConfigEntry(key)).map { e => e.stringConverter(e.readFrom(reader)) }
-      }.
-      getOrElse(throw QueryExecutionErrors.sqlConfigNotFoundError(key))
+    getConfStringOption(key).getOrElse(throw QueryExecutionErrors.sqlConfigNotFoundError(key))
+  }
+
+  private[sql] def getConfStringOption(key: String): Option[String] = {
+    Option(settings.get(key)).orElse {
+      // Try to use the default value
+      Option(getConfigEntry(key)).map { e => e.stringConverter(e.readFrom(reader)) }
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/RuntimeConfig.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/RuntimeConfig.scala
@@ -82,9 +82,7 @@ class RuntimeConfig private[sql](val sqlConf: SQLConf = new SQLConf) extends sql
 
   /** @inheritdoc */
   def getOption(key: String): Option[String] = {
-    try Option(get(key)) catch {
-      case _: NoSuchElementException => None
-    }
+    sqlConf.getConfStringOption(key)
   }
 
   /** @inheritdoc */


### PR DESCRIPTION
### What changes were proposed in this pull request?

RuntimeConfig.getOption is defined as

```scala
  /** @inheritdoc */
  def getOption(key: String): Option[String] = {
    try Option(get(key)) catch {
      case _: NoSuchElementException => None
    }
  } 
```

This uses exceptions for control flow, which can be a performance problem.

This PR updates this code to use a new package-private `getConfStringOption` helper in order to avoid the exceptions.

### Why are the changes needed?

Address a perf. problem if `getOption` for non-existing configurations is called at a high frequency. It's usually not a good practice to perform configuration lookups at a high rate (e.g in a hot method or loop), but if someone _does_ do that then the exceptions make the perf. issue worse.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing unit tests in `RuntimeConfigSuite`.

### Was this patch authored or co-authored using generative AI tooling?

No.