### PR TITLE
[SPARK-51401][SQL] Change `ExplainUtils.generateFieldString` to directly call `QueryPlan.generateFieldString`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExplainUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExplainUtils.scala
@@ -297,14 +297,8 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
   /**
    * Generate detailed field string with different format based on type of input value
    */
-  // TODO(nemanja.petrovic@databricks.com) Delete method as it is duplicated in QueryPlan.scala.
-  def generateFieldString(fieldName: String, values: Any): String = values match {
-    case iter: Iterable[_] if (iter.size == 0) => s"${fieldName}: []"
-    case iter: Iterable[_] => s"${fieldName} [${iter.size}]: ${iter.mkString("[", ", ", "]")}"
-    case str: String if (str == null || str.isEmpty) => s"${fieldName}: None"
-    case str: String => s"${fieldName}: ${str}"
-    case _ => throw new IllegalArgumentException(s"Unsupported type for argument values: $values")
-  }
+  def generateFieldString(fieldName: String, values: Any): String =
+    QueryPlan.generateFieldString(fieldName, values)
 
   /**
    * Given a input plan, returns an array of tuples comprising of :


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr change `ExplainUtils.generateFieldString` to directly call `QueryPlan.generateFieldString` because these are identical methods.

https://github.com/apache/spark/blob/4b4bdcfe1fe9bfd38030b855139a12fc55034083/sql/core/src/main/scala/org/apache/spark/sql/execution/ExplainUtils.scala#L300-L307

https://github.com/apache/spark/blob/4b4bdcfe1fe9bfd38030b855139a12fc55034083/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala#L789-L795

Meanwhile, this is a TODO left by nemanjapetr-db  in SPARK-50739.


### Why are the changes needed?
Remove duplicated code.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No
