### PR TITLE
[SPARK-51407][DOCS][FOLLOWUP] Fix `spark.connect.ml.backend.classes` description

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3478,9 +3478,9 @@ Command types in proto.</td>
 <tr>
   <td><code>spark.connect.ml.backend.classes</code></td>
   <td>
-    Comma separated list of classes that implement the trait org.apache.spark.sql.connect.plugin.MLBackendPlugin to replace the specified Spark ML operators with a backend-specific implementation.
+    (none)
   </td>
-  <td>Comma separated list of class names that must implement the <code>io.grpc.ServerInterceptor</code> interface</td>
+  <td>Comma separated list of classes that implement the trait <code>org.apache.spark.sql.connect.plugin.MLBackendPlugin</code> to replace the specified Spark ML operators with a backend-specific implementation.</td>
   <td>4.0.0</td>
 </tr>
 <tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to fix a documentation to switch table columns of `spark.connect.ml.backend.classes` configuration description.

### Why are the changes needed?

**AFTER**
<img width="921" alt="Screenshot 2025-03-05 at 15 47 54" src="https://github.com/user-attachments/assets/e647d2b5-9671-4243-986a-e649e4c42ffc" />


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```
$ cd docs
$ bundle install
$ SKIP_API=1 bundle exec jekyll build
```

### Was this patch authored or co-authored using generative AI tooling?

No.