### PR TITLE
[SPARK-51409][SS] Add error classification in the changelog writer creation path

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -292,8 +292,8 @@
           "Error reading streaming state file of <fileToRead> does not exist. If the stream job is restarted with a new or updated state operation, please create a new checkpoint location or clear the existing checkpoint location."
         ]
       },
-      "FAILED_TO_GET_CHANGELOG_WRITER": {
-        "message": [
+      "FAILED_TO_GET_CHANGELOG_WRITER" : {
+        "message" : [
           "Failed to get the changelog writer for state store at version <version>."
         ]
       },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -292,6 +292,11 @@
           "Error reading streaming state file of <fileToRead> does not exist. If the stream job is restarted with a new or updated state operation, please create a new checkpoint location or clear the existing checkpoint location."
         ]
       },
+      "FAILED_TO_GET_CHANGELOG_WRITER": {
+        "message": [
+          "Failed to get the changelog writer for state store at version <version>."
+        ]
+      },
       "HDFS_STORE_PROVIDER_OUT_OF_MEMORY" : {
         "message" : [
           "Could not load HDFS state store with id <stateStoreId> because of an out of memory exception."

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
@@ -212,6 +212,11 @@ object StateStoreErrors {
     StateStoreInvalidVariableTypeChange = {
     new StateStoreInvalidVariableTypeChange(stateName, oldType, newType)
   }
+
+  def failedToGetChangelogWriter(version: Long, e: Throwable):
+    StateStoreFailedToGetChangelogWriter = {
+    new StateStoreFailedToGetChangelogWriter(version, e)
+  }
 }
 
 class StateStoreDuplicateStateVariableDefined(stateVarName: String)
@@ -409,6 +414,12 @@ class StateStoreSnapshotPartitionNotFound(
       "snapshotPartitionId" -> snapshotPartitionId.toString,
       "operatorId" -> operatorId.toString,
       "checkpointLocation" -> checkpointLocation))
+
+class StateStoreFailedToGetChangelogWriter(version: Long, e: Throwable)
+  extends SparkRuntimeException(
+    errorClass = "CANNOT_LOAD_STATE_STORE.FAILED_TO_GET_CHANGELOG_WRITER",
+    messageParameters = Map("version" -> version.toString),
+    cause = e)
 
 class StateStoreKeyRowFormatValidationFailure(errorMsg: String)
   extends SparkRuntimeException(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add error classification in the changelog writer creation path


### Why are the changes needed?
We have seen some transient errors thrown around file creation, running out of disk space etc which don't get classified with the right sub-classification. This change should fix that issue in this path.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing unit tests

```
[info] Run completed in 8 minutes, 51 seconds.
[info] Total number of tests run: 306
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 306, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```


### Was this patch authored or co-authored using generative AI tooling?
No
