### PR TITLE
[SPARK-51417][CONNECT] Give a second to wait for Spark Connect server to fully start

### DIFF
--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SparkSession.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SparkSession.scala
@@ -802,6 +802,9 @@ object SparkSession extends SparkSessionCompanion with Logging {
             }
           }
 
+        // Let the server fully start to make less noise from retrying.
+        Thread.sleep(1000L)
+
         System.setProperty("spark.remote", s"sc://localhost/;token=$token")
 
         // scalastyle:off runtimeaddshutdownhook


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a folllowup of https://github.com/apache/spark/pull/50039 that gives a second to remove retrying logs.

### Why are the changes needed?

To remove retrying logs.

### Does this PR introduce _any_ user-facing change?

No the main change has not been released yet.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.
