### PR TITLE
[SPARK-51422][ML][PYTHON] Eliminate the JVM-Python data exchange in CrossValidator 

### DIFF
--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -58,7 +58,7 @@ from pyspark.ml.util import (
     is_remote,
 )
 from pyspark.ml.wrapper import JavaParams, JavaEstimator, JavaWrapper
-from pyspark.sql.functions import col, lit, rand
+from pyspark.sql import Column, functions as F
 from pyspark.sql.types import BooleanType
 from pyspark.sql.dataframe import DataFrame
 
@@ -887,7 +887,7 @@ class CrossValidator(
             seed = self.getOrDefault(self.seed)
             h = 1.0 / nFolds
             randCol = self.uid + "_rand"
-            df = dataset.select("*", rand(seed).alias(randCol))
+            df = dataset.select("*", F.rand(seed).alias(randCol))
             for i in range(nFolds):
                 validateLB = i * h
                 validateUB = (i + 1) * h
@@ -897,34 +897,31 @@ class CrossValidator(
                 datasets.append((train, validation))
         else:
             # Use user-specified fold numbers.
-            def checker(foldNum: int) -> bool:
-                if foldNum < 0 or foldNum >= nFolds:
-                    raise ValueError(
-                        "Fold number must be in range [0, %s), but got %s." % (nFolds, foldNum)
-                    )
-                return True
+            checked = dataset.withColumn(
+                foldCol,
+                F.when(
+                    (F.lit(0) <= F.col(foldCol)) & (F.col(foldCol) < F.lit(nFolds)), F.col(foldCol)
+                ).otherwise(
+                    F.raise_error(
+                        F.printf(
+                            F.lit(f"Fold number must be in range [0, {nFolds}), but got %s"),
+                            F.col(foldCol),
+                        )
+                    ),
+                ),
+            )
 
-            if is_remote():
-                from pyspark.sql.connect.udf import UserDefinedFunction
-            else:
-                from pyspark.sql.functions import UserDefinedFunction  # type: ignore[assignment]
-
-            checker_udf = UserDefinedFunction(checker, BooleanType())
+            # TODO(SPARK-48515): Use Arrow Python UDF
+            checker_udf = UserDefinedFunction(
+                checker, BooleanType(), evalType=PythonEvalType.SQL_BATCHED_UDF
+            )
             for i in range(nFolds):
-                training = dataset.filter(checker_udf(dataset[foldCol]) & (col(foldCol) != lit(i)))
-                validation = dataset.filter(
-                    checker_udf(dataset[foldCol]) & (col(foldCol) == lit(i))
-                )
-                if is_remote():
-                    if len(training.take(1)) == 0:
-                        raise ValueError("The training data at fold %s is empty." % i)
-                    if len(validation.take(1)) == 0:
-                        raise ValueError("The validation data at fold %s is empty." % i)
-                else:
-                    if training.rdd.getNumPartitions() == 0 or len(training.take(1)) == 0:
-                        raise ValueError("The training data at fold %s is empty." % i)
-                    if validation.rdd.getNumPartitions() == 0 or len(validation.take(1)) == 0:
-                        raise ValueError("The validation data at fold %s is empty." % i)
+                training = checked.filter(F.col(foldCol) != F.lit(i))
+                validation = checked.filter(F.col(foldCol) == F.lit(i))
+                if training.isEmpty():
+                    raise ValueError("The training data at fold %s is empty." % i)
+                if validation.isEmpty():
+                    raise ValueError("The validation data at fold %s is empty." % i)
                 datasets.append((training, validation))
 
         return datasets
@@ -1482,7 +1479,7 @@ class TrainValidationSplit(
         tRatio = self.getOrDefault(self.trainRatio)
         seed = self.getOrDefault(self.seed)
         randCol = self.uid + "_rand"
-        df = dataset.select("*", rand(seed).alias(randCol))
+        df = dataset.select("*", F.rand(seed).alias(randCol))
         condition = df[randCol] >= tRatio
         validation = df.filter(condition).cache()
         train = df.filter(~condition).cache()

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -909,10 +909,6 @@ class CrossValidator(
                 ),
             )
 
-            # TODO(SPARK-48515): Use Arrow Python UDF
-            checker_udf = UserDefinedFunction(
-                checker, BooleanType(), evalType=PythonEvalType.SQL_BATCHED_UDF
-            )
             for i in range(nFolds):
                 training = checked.filter(F.col(foldCol) != F.lit(i))
                 validation = checked.filter(F.col(foldCol) == F.lit(i))

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -55,11 +55,9 @@ from pyspark.ml.util import (
     JavaMLWriter,
     try_remote_write,
     try_remote_read,
-    is_remote,
 )
 from pyspark.ml.wrapper import JavaParams, JavaEstimator, JavaWrapper
-from pyspark.sql import Column, functions as F
-from pyspark.sql.types import BooleanType
+from pyspark.sql import functions as F
 from pyspark.sql.dataframe import DataFrame
 
 if TYPE_CHECKING:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Optimize CrossValidator by eliminating the JVM-Python data exchange

### Why are the changes needed?
the logic in CrossValidator's udf is very simple, no need to introduce such data exchange




### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci and manually test

```
import time
import tempfile
from pyspark.ml.classification import LogisticRegression
from pyspark.ml.evaluation import BinaryClassificationEvaluator
from pyspark.ml.linalg import Vectors
from pyspark.ml.tuning import CrossValidator, ParamGridBuilder, CrossValidatorModel


dataset = spark.createDataFrame(
    [(Vectors.dense([0.0]), 0.0),
     (Vectors.dense([0.4]), 1.0),
     (Vectors.dense([0.5]), 0.0),
     (Vectors.dense([0.6]), 1.0),
     (Vectors.dense([1.0]), 1.0)] * 1000,
    ["features", "label"])

dataset.persist()
dataset.count()
dataset.count()

lr = LogisticRegression()
grid = ParamGridBuilder().addGrid(lr.maxIter, [m for m in range(10)]).build()
evaluator = BinaryClassificationEvaluator()

cv = CrossValidator(estimator=lr, estimatorParamMaps=grid, evaluator=evaluator, parallelism=1)

tic = time.time()
cvModel = cv.fit(dataset)
toc = time.time()

toc - tic
```

master:
8.992794752120972



this PR:
7.696600914001465



### Was this patch authored or co-authored using generative AI tooling?
no
