### PR TITLE
[SPARK-51424][BUILD] Upgrade ORC to 2.1.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -235,10 +235,10 @@ opencsv/2.3//opencsv-2.3.jar
 opentracing-api/0.33.0//opentracing-api-0.33.0.jar
 opentracing-noop/0.33.0//opentracing-noop-0.33.0.jar
 opentracing-util/0.33.0//opentracing-util-0.33.0.jar
-orc-core/2.1.0/shaded-protobuf/orc-core-2.1.0-shaded-protobuf.jar
+orc-core/2.1.1/shaded-protobuf/orc-core-2.1.1-shaded-protobuf.jar
 orc-format/1.0.0/shaded-protobuf/orc-format-1.0.0-shaded-protobuf.jar
-orc-mapreduce/2.1.0/shaded-protobuf/orc-mapreduce-2.1.0-shaded-protobuf.jar
-orc-shims/2.1.0//orc-shims-2.1.0.jar
+orc-mapreduce/2.1.1/shaded-protobuf/orc-mapreduce-2.1.1-shaded-protobuf.jar
+orc-shims/2.1.1//orc-shims-2.1.1.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <!-- After 10.17.1.0, the minimum required version is JDK19 -->
     <derby.version>10.16.1.1</derby.version>
     <parquet.version>1.15.0</parquet.version>
-    <orc.version>2.1.0</orc.version>
+    <orc.version>2.1.1</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
     <jetty.version>11.0.24</jetty.version>
     <jakartaservlet.version>5.0.0</jakartaservlet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade ORC to 2.1.1.

### Why are the changes needed?

To use the most recent version. 
- https://orc.apache.org/news/2025/03/06/ORC-2.1.1/
- https://github.com/apache/orc/releases/tag/v2.1.1

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.