### PR TITLE
[SPARK-51442][SQL] Add time formatters

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -264,17 +264,27 @@ private object DateTimeFormatterHelper {
     toFormatter(builder, locale)
   }
 
-  lazy val fractionFormatter: DateTimeFormatter = {
-    val builder = createBuilder()
-      .append(DateTimeFormatter.ISO_LOCAL_DATE)
-      .appendLiteral(' ')
+  private def appendTimeBuilder(builder: DateTimeFormatterBuilder) = {
+    builder
       .appendValue(ChronoField.HOUR_OF_DAY, 2)
       .appendLiteral(':')
       .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
       .appendLiteral(':')
       .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
       .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+  }
+
+  lazy val fractionFormatter: DateTimeFormatter = {
+    val dateBuilder = createBuilder()
+      .append(DateTimeFormatter.ISO_LOCAL_DATE)
+      .appendLiteral(' ')
+    val builder = appendTimeBuilder(dateBuilder)
     toFormatter(builder, TimestampFormatter.defaultLocale)
+  }
+
+  lazy val fractionTimeFormatter: DateTimeFormatter = {
+    val builder = appendTimeBuilder(createBuilder())
+    toFormatter(builder, TimeFormatter.defaultLocale)
   }
 
   // SPARK-31892: The week-based date fields are rarely used and really confusing for parsing values

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimeFormatter.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimeFormatter.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.util
 
 import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 import org.apache.spark.sql.catalyst.util.SparkDateTimeUtils._
@@ -40,7 +41,8 @@ class Iso8601TimeFormatter(pattern: String, locale: Locale, isParsing: Boolean)
     with DateTimeFormatterHelper {
 
   @transient
-  protected lazy val formatter = getOrCreateFormatter(pattern, locale, isParsing)
+  protected lazy val formatter: DateTimeFormatter =
+    getOrCreateFormatter(pattern, locale, isParsing)
 
   override def parse(s: String): Long = {
     val localTime = toLocalTime(formatter.parse(s))
@@ -76,7 +78,8 @@ class FractionTimeFormatter
       isParsing = false) {
 
   @transient
-  override protected lazy val formatter = DateTimeFormatterHelper.fractionTimeFormatter
+  override protected lazy val formatter: DateTimeFormatter =
+    DateTimeFormatterHelper.fractionTimeFormatter
 }
 
 object TimeFormatter {

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimeFormatter.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimeFormatter.scala
@@ -26,9 +26,15 @@ sealed trait TimeFormatter extends Serializable {
   def parse(s: String): Long // returns microseconds since midnight
 
   def format(localTime: LocalTime): String
+  // Converts microseconds since the midnight to time string
   def format(micros: Long): String
+
+  def validatePatternString(): Unit
 }
 
+/**
+ * The ISO time formatter is capable of formatting and parsing the ISO-8601 extended time format.
+ */
 class Iso8601TimeFormatter(pattern: String, locale: Locale, isParsing: Boolean)
     extends TimeFormatter
     with DateTimeFormatterHelper {
@@ -47,6 +53,13 @@ class Iso8601TimeFormatter(pattern: String, locale: Locale, isParsing: Boolean)
 
   override def format(micros: Long): String = {
     format(microsToLocalTime(micros))
+  }
+
+  override def validatePatternString(): Unit = {
+    try {
+      formatter
+    } catch checkInvalidPattern(pattern)
+    ()
   }
 }
 
@@ -76,6 +89,8 @@ object TimeFormatter {
       format: String = defaultPattern,
       locale: Locale = defaultLocale,
       isParsing: Boolean = false): TimeFormatter = {
-    new Iso8601TimeFormatter(format, locale, isParsing)
+    val formatter = new Iso8601TimeFormatter(format, locale, isParsing)
+    formatter.validatePatternString()
+    formatter
   }
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimeFormatter.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimeFormatter.scala
@@ -29,10 +29,7 @@ sealed trait TimeFormatter extends Serializable {
   def format(micros: Long): String
 }
 
-class Iso8601TimeFormatter(
-    pattern: String,
-    locale: Locale,
-    isParsing: Boolean)
+class Iso8601TimeFormatter(pattern: String, locale: Locale, isParsing: Boolean)
     extends TimeFormatter
     with DateTimeFormatterHelper {
 
@@ -59,14 +56,14 @@ object TimeFormatter {
 
   def defaultPattern(): String = "HH:mm:ss[.SSSSSS]"
 
-  private def getFormatter(
+  def apply(
       format: Option[String],
       locale: Locale = defaultLocale,
       isParsing: Boolean): TimeFormatter = {
     new Iso8601TimeFormatter(format.getOrElse(defaultPattern()), locale, isParsing)
   }
 
-  private def getFormatter(): TimeFormatter = {
-    getFormatter(format = None, isParsing = false)
-  }
+  def apply(isParsing: Boolean): TimeFormatter = apply(format = None, isParsing = isParsing)
+
+  def apply(): TimeFormatter = apply(isParsing = false)
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimeFormatter.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimeFormatter.scala
@@ -34,7 +34,7 @@ class Iso8601TimeFormatter(pattern: String, locale: Locale, isParsing: Boolean)
     with DateTimeFormatterHelper {
 
   @transient
-  private lazy val formatter = getOrCreateFormatter(pattern, locale, isParsing)
+  protected lazy val formatter = getOrCreateFormatter(pattern, locale, isParsing)
 
   override def parse(s: String): Long = {
     val localTime = toLocalTime(formatter.parse(s))
@@ -50,17 +50,33 @@ class Iso8601TimeFormatter(pattern: String, locale: Locale, isParsing: Boolean)
   }
 }
 
+/**
+ * The formatter parses/formats times according to the pattern `HH:mm:ss.[..fff..]` where
+ * `[..fff..]` is a fraction of second up to microsecond resolution. The formatter does not output
+ * trailing zeros in the fraction. For example, the time `15:00:01.123400` is formatted as the
+ * string `15:00:01.1234`.
+ */
+class FractionTimeFormatter
+    extends Iso8601TimeFormatter(
+      TimeFormatter.defaultPattern,
+      TimeFormatter.defaultLocale,
+      isParsing = false) {
+
+  @transient
+  override protected lazy val formatter = DateTimeFormatterHelper.fractionTimeFormatter
+}
+
 object TimeFormatter {
 
   val defaultLocale: Locale = Locale.US
 
-  def defaultPattern(): String = "HH:mm:ss.SSSSSS"
+  val defaultPattern: String = "HH:mm:ss"
 
   def apply(
       format: Option[String],
       locale: Locale = defaultLocale,
       isParsing: Boolean): TimeFormatter = {
-    new Iso8601TimeFormatter(format.getOrElse(defaultPattern()), locale, isParsing)
+    new Iso8601TimeFormatter(format.getOrElse(defaultPattern), locale, isParsing)
   }
 
   def apply(isParsing: Boolean): TimeFormatter = apply(format = None, isParsing = isParsing)

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimeFormatter.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimeFormatter.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import java.time.LocalTime
+import java.util.Locale
+
+import org.apache.spark.sql.catalyst.util.SparkDateTimeUtils._
+
+sealed trait TimeFormatter extends Serializable {
+  def parse(s: String): Long // returns microseconds since midnight
+
+  def format(localTime: LocalTime): String
+  def format(micros: Long): String
+}
+
+class Iso8601TimeFormatter(
+    pattern: String,
+    locale: Locale,
+    isParsing: Boolean)
+    extends TimeFormatter
+    with DateTimeFormatterHelper {
+
+  @transient
+  private lazy val formatter = getOrCreateFormatter(pattern, locale, isParsing)
+
+  override def parse(s: String): Long = {
+    val localTime = toLocalTime(formatter.parse(s))
+    localTimeToMicros(localTime)
+  }
+
+  override def format(localTime: LocalTime): String = {
+    localTime.format(formatter)
+  }
+
+  override def format(micros: Long): String = {
+    format(microsToLocalTime(micros))
+  }
+}
+
+object TimeFormatter {
+
+  val defaultLocale: Locale = Locale.US
+
+  def defaultPattern(): String = "HH:mm:ss[.SSSSSS]"
+
+  private def getFormatter(
+      format: Option[String],
+      locale: Locale = defaultLocale,
+      isParsing: Boolean): TimeFormatter = {
+    new Iso8601TimeFormatter(format.getOrElse(defaultPattern()), locale, isParsing)
+  }
+
+  private def getFormatter(): TimeFormatter = {
+    getFormatter(format = None, isParsing = false)
+  }
+}

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimeFormatter.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimeFormatter.scala
@@ -54,7 +54,7 @@ object TimeFormatter {
 
   val defaultLocale: Locale = Locale.US
 
-  def defaultPattern(): String = "HH:mm:ss[.SSSSSS]"
+  def defaultPattern(): String = "HH:mm:ss.SSSSSS"
 
   def apply(
       format: Option[String],

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimeFormatter.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimeFormatter.scala
@@ -73,13 +73,9 @@ object TimeFormatter {
   val defaultPattern: String = "HH:mm:ss"
 
   def apply(
-      format: Option[String],
+      format: String = defaultPattern,
       locale: Locale = defaultLocale,
-      isParsing: Boolean): TimeFormatter = {
-    new Iso8601TimeFormatter(format.getOrElse(defaultPattern), locale, isParsing)
+      isParsing: Boolean = false): TimeFormatter = {
+    new Iso8601TimeFormatter(format, locale, isParsing)
   }
-
-  def apply(isParsing: Boolean): TimeFormatter = apply(format = None, isParsing = isParsing)
-
-  def apply(): TimeFormatter = apply(isParsing = false)
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
@@ -545,7 +545,8 @@ object TimestampFormatter {
 
   val defaultLocale: Locale = Locale.US
 
-  def defaultPattern(): String = s"${DateFormatter.defaultPattern} HH:mm:ss"
+  def defaultPattern(): String =
+    s"${DateFormatter.defaultPattern} ${TimeFormatter.defaultPattern}"
 
   private def getFormatter(
       format: Option[String],

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeTestUtils.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeTestUtils.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
-import org.apache.spark.sql.catalyst.util.DateTimeUtils.getZoneId
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.{getZoneId, localTimeToMicros}
 
 /**
  * Helper functions for testing date and time functionality.
@@ -111,5 +111,16 @@ object DateTimeTestUtils {
     result = Math.addExact(result, Math.multiplyExact(milliseconds, MICROS_PER_MILLIS))
     result = Math.addExact(result, Math.multiplyExact(seconds, MICROS_PER_SECOND))
     result
+  }
+
+  // Returns microseconds since midnight
+  def localtime(
+      hour: Byte = 0,
+      minute: Byte = 0,
+      sec: Byte = 0,
+      micros: Int = 0): Long = {
+    val nanos = TimeUnit.MICROSECONDS.toNanos(micros).toInt
+    val localTime = LocalTime.of(hour, minute, sec, nanos)
+    localTimeToMicros(localTime)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeTestUtils.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeTestUtils.scala
@@ -114,7 +114,7 @@ object DateTimeTestUtils {
   }
 
   // Returns microseconds since midnight
-  def localtime(
+  def localTime(
       hour: Byte = 0,
       minute: Byte = 0,
       sec: Byte = 0,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TimeFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TimeFormatterSuite.scala
@@ -39,7 +39,7 @@ class TimeFormatterSuite extends SparkFunSuite with SQLHelper {
       ("23:59:59.000000", "HH:mm:ss.SSSSSS") -> (23 * 3600 + 59 * 60 + 59) * 1000000L,
       ("23:59:59.999999", "HH:mm:ss.SSSSSS") -> ((23 * 3600 + 59 * 60 + 59) * 1000000L + 999999)
     ).foreach { case ((inputStr, pattern), expectedMicros) =>
-      val formatter = TimeFormatter(format = Some(pattern), isParsing = true)
+      val formatter = TimeFormatter(format = pattern, isParsing = true)
       assert(formatter.parse(inputStr) === expectedMicros)
     }
   }
@@ -57,16 +57,16 @@ class TimeFormatterSuite extends SparkFunSuite with SQLHelper {
       ((23 * 3600 + 59 * 60 + 59) * 1000000L, "HH:mm:ss.SSSSSS") -> "23:59:59.000000",
       ((23 * 3600 + 59 * 60 + 59) * 1000000L + 999999, "HH:mm:ss.SSSSSS") -> "23:59:59.999999"
     ).foreach { case ((micros, pattern), expectedStr) =>
-      val formatter = TimeFormatter(format = Some(pattern), isParsing = false)
+      val formatter = TimeFormatter(format = pattern)
       assert(formatter.format(micros) === expectedStr)
     }
   }
 
   test("round trip with the default pattern: format -> parse") {
     val data = Seq.tabulate(10) { _ => Random.between(0, 24 * 60 * 60 * 1000000L) }
-    val pattern = Some("HH:mm:ss.SSSSSS")
+    val pattern = "HH:mm:ss.SSSSSS"
     val (formatter, parser) =
-      (TimeFormatter(pattern, isParsing = false), TimeFormatter(pattern, isParsing = true))
+      (TimeFormatter(pattern), TimeFormatter(pattern, isParsing = true))
     data.foreach { micros =>
       val str = formatter.format(micros)
       assert(parser.parse(str) === micros, s"micros = $micros")
@@ -89,22 +89,22 @@ class TimeFormatterSuite extends SparkFunSuite with SQLHelper {
 
   test("missing am/pm field") {
     Seq("HH", "hh", "KK", "kk").foreach { hour =>
-      val formatter = TimeFormatter(Some(s"$hour:mm:ss"), isParsing = true)
+      val formatter = TimeFormatter(format = s"$hour:mm:ss", isParsing = true)
       val micros = formatter.parse("11:30:01")
       assert(micros === localtime(11, 30, 1))
     }
   }
 
   test("missing hour field") {
-    val f1 = TimeFormatter(format = Some("mm:ss a"), isParsing = true)
+    val f1 = TimeFormatter(format = "mm:ss a", isParsing = true)
     val t1 = f1.parse("30:01 PM")
     assert(t1 === localtime(12, 30, 1))
     val t2 = f1.parse("30:01 AM")
     assert(t2 === localtime(0, 30, 1))
-    val f2 = TimeFormatter(format = Some("mm:ss"), isParsing = true)
+    val f2 = TimeFormatter(format = "mm:ss", isParsing = true)
     val t3 = f2.parse("30:01")
     assert(t3 === localtime(0, 30, 1))
-    val f3 = TimeFormatter(format = Some("a"), isParsing = true)
+    val f3 = TimeFormatter(format = "a", isParsing = true)
     val t4 = f3.parse("PM")
     assert(t4 === localtime(12))
     val t5 = f3.parse("AM")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TimeFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TimeFormatterSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import scala.util.Random
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.plans.SQLHelper
+
+class TimeFormatterSuite extends SparkFunSuite with SQLHelper {
+
+  test("time parsing") {
+    Seq(
+      ("12", "HH") -> 12 * 3600 * 1000000L,
+      ("01:02", "HH:mm") -> (1 * 3600 + 2 * 60) * 1000000L,
+      ("10:20", "HH:mm") -> (10 * 3600 + 20 * 60) * 1000000L,
+      ("00:00:00", "HH:mm:ss") -> 0L,
+      ("01:02:03", "HH:mm:ss") -> (1 * 3600 + 2 * 60 + 3) * 1000000L,
+      ("23:59:59", "HH:mm:ss") -> (23 * 3600 + 59 * 60 + 59) * 1000000L,
+      ("00:00:00.000000", "HH:mm:ss.SSSSSS") -> 0L,
+      ("12:34:56.789012", "HH:mm:ss.SSSSSS") -> ((12 * 3600 + 34 * 60 + 56) * 1000000L + 789012),
+      ("23:59:59.000000", "HH:mm:ss.SSSSSS") -> (23 * 3600 + 59 * 60 + 59) * 1000000L,
+      ("23:59:59.999999", "HH:mm:ss.SSSSSS") -> ((23 * 3600 + 59 * 60 + 59) * 1000000L + 999999)
+    ).foreach { case ((inputStr, pattern), expectedMicros) =>
+      val formatter = TimeFormatter(format = Some(pattern), isParsing = true)
+      assert(formatter.parse(inputStr) === expectedMicros)
+    }
+  }
+
+  test("time formatting") {
+    Seq(
+      (12 * 3600 * 1000000L, "HH") -> "12",
+      ((1 * 3600 + 2 * 60) * 1000000L, "HH:mm") -> "01:02",
+      ((10 * 3600 + 20 * 60) * 1000000L, "HH:mm") -> "10:20",
+      (0L, "HH:mm:ss") -> "00:00:00",
+      ((1 * 3600 + 2 * 60 + 3) * 1000000L, "HH:mm:ss") -> "01:02:03",
+      ((23 * 3600 + 59 * 60 + 59) * 1000000L, "HH:mm:ss") -> "23:59:59",
+      (0L, "HH:mm:ss.SSSSSS") -> "00:00:00.000000",
+      ((12 * 3600 + 34 * 60 + 56) * 1000000L + 789012, "HH:mm:ss.SSSSSS") -> "12:34:56.789012",
+      ((23 * 3600 + 59 * 60 + 59) * 1000000L, "HH:mm:ss.SSSSSS") -> "23:59:59.000000",
+      ((23 * 3600 + 59 * 60 + 59) * 1000000L + 999999, "HH:mm:ss.SSSSSS") -> "23:59:59.999999"
+    ).foreach { case ((micros, pattern), expectedStr) =>
+      val formatter = TimeFormatter(format = Some(pattern), isParsing = false)
+      assert(formatter.format(micros) === expectedStr)
+    }
+  }
+
+  test("round trip with the default pattern: format -> parse") {
+    val data = Seq.tabulate(10) { _ => Random.between(0, 24 * 60 * 60 * 1000000L) }
+    val (formatter, parser) = (TimeFormatter(isParsing = false), TimeFormatter(isParsing = true))
+    data.foreach { micros =>
+      assert(parser.parse(formatter.format(micros)) === micros, s"micros = $micros")
+    }
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TimeFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TimeFormatterSuite.scala
@@ -127,23 +127,23 @@ class TimeFormatterSuite extends SparkFunSuite with SQLHelper {
     Seq("HH", "hh", "KK", "kk").foreach { hour =>
       val formatter = TimeFormatter(format = s"$hour:mm:ss", isParsing = true)
       val micros = formatter.parse("11:30:01")
-      assert(micros === localtime(11, 30, 1))
+      assert(micros === localTime(11, 30, 1))
     }
   }
 
   test("missing hour field") {
     val f1 = TimeFormatter(format = "mm:ss a", isParsing = true)
     val t1 = f1.parse("30:01 PM")
-    assert(t1 === localtime(12, 30, 1))
+    assert(t1 === localTime(12, 30, 1))
     val t2 = f1.parse("30:01 AM")
-    assert(t2 === localtime(0, 30, 1))
+    assert(t2 === localTime(0, 30, 1))
     val f2 = TimeFormatter(format = "mm:ss", isParsing = true)
     val t3 = f2.parse("30:01")
-    assert(t3 === localtime(0, 30, 1))
+    assert(t3 === localTime(0, 30, 1))
     val f3 = TimeFormatter(format = "a", isParsing = true)
     val t4 = f3.parse("PM")
-    assert(t4 === localtime(12))
+    assert(t4 === localTime(12))
     val t5 = f3.parse("AM")
-    assert(t5 === localtime())
+    assert(t5 === localTime())
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose two new formatters: `Iso8601TimeFormatter` and `FractionTimeFormatter` similar to the date or timestamp formatters:
- The ISO 8601 formatter is capable of formatting and parsing the ISO-8601 extended time format,
- The fraction formatter is similar to the previous one but does not output trailing zeros in the fraction.

### Why are the changes needed?
The datetime formatters are used in `CAST` and other parsing/formatting expressions.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running new test suite:
```
$ build/sbt "test:testOnly *TimeFormatterSuite"
$ build/sbt "test:testOnly *TimestampFormatterSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.