### PR TITLE
[SPARK-51402][SQL][TESTS] Test TimeType in UDF

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -1219,7 +1219,7 @@ class UDFSuite extends QueryTest with SharedSparkSession {
     checkAnswer(constResult, Row(java.time.LocalTime.parse(mockTimeStr)) :: Nil)
     assert(constResult.schema === new StructType().add("zeroHour", TimeType()))
     // Error in the conversion of UDF result to the internal representation of time
-    val invalidFunc = udf((l: java.time.LocalTime) => l.plusHours("Zero").toLong)
+    val invalidFunc = udf((l: java.time.LocalTime) => "Zero".toLong)
     val e = intercept[SparkException] {
       input.select(invalidFunc($"currentTime")).collect()
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -1203,21 +1203,21 @@ class UDFSuite extends QueryTest with SharedSparkSession {
     // Regular case
     val input = Seq(java.time.LocalTime.parse(mockTimeStr)).toDF("currentTime")
     val plusHour = udf((l: java.time.LocalTime) => l.plusHours(1))
-    val result = input.select(plusHour($"currentTime").cast(TimeType).as("newTime"))
+    val result = input.select(plusHour($"currentTime").cast(TimeType()).as("newTime"))
     checkAnswer(result, Row(java.time.LocalTime.parse("01:00:00.000000")) :: Nil)
-    assert(result.schema === new StructType().add("newTime", TimeType))
+    assert(result.schema === new StructType().add("newTime", TimeType()))
     // VALIDAR: UDF produces `null`
     val nullFunc = udf((_: java.time.LocalTime) => null.asInstanceOf[java.time.LocalTime])
     val nullResult = input.select(nullFunc($"currentTime").as("nullTime"))
     checkAnswer(nullResult, Row(null) :: Nil)
-    assert(nullResult.schema === new StructType().add("nullTime", TimeType))
+    assert(nullResult.schema === new StructType().add("nullTime", TimeType()))
     // TODO: Input parameter of UDF is null
     val nullInput = Seq(null.asInstanceOf[java.time.LocalTime]).toDF("nullTime")
     val constDuration = udf((_: java.time.LocalTime) =>
       java.time.LocalTime.parse(mockTimeStr))
     val constResult = nullInput.select(constDuration($"nullTime").as("zeroHour"))
     checkAnswer(constResult, Row(java.time.LocalTime.parse(mockTimeStr)) :: Nil)
-    assert(constResult.schema === new StructType().add("zeroHour", TimeType))
+    assert(constResult.schema === new StructType().add("zeroHour", TimeType()))
     // TODO: Error in the conversion of UDF result to the internal representation of time
     val overflowFunc = udf((l: java.time.LocalTime) => l.plusHours(Long.MaxValue))
     val e = intercept[SparkException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -1219,12 +1219,11 @@ class UDFSuite extends QueryTest with SharedSparkSession {
     checkAnswer(constResult, Row(java.time.LocalTime.parse(mockTimeStr)) :: Nil)
     assert(constResult.schema === new StructType().add("zeroHour", TimeType()))
     // Error in the conversion of UDF result to the internal representation of time
-    val overflowFunc = udf((l: java.time.LocalTime) => l.plusHours(Long.MaxValue))
+    val invalidFunc = udf((l: java.time.LocalTime) => l.plusHours("Zero").toLong)
     val e = intercept[SparkException] {
-      input.select(overflowFunc($"currentTime")).collect()
+      input.select(invalidFunc($"currentTime")).collect()
     }
-    assert(e.getCondition == "FAILED_EXECUTE_UDF")
-    assert(e.getCause.isInstanceOf[java.lang.ArithmeticException])
+    assert(e.getCause.isInstanceOf[java.lang.NumberFormatException])
   }
 
   test("char/varchar as UDF return type") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 
 import java.math.BigDecimal
 import java.sql.Timestamp
-import java.time.{Instant, LocalDate}
+import java.time.{Instant, LocalDate, LocalTime}
 import java.time.format.DateTimeFormatter
 
 import scala.collection.immutable
@@ -1213,9 +1213,9 @@ class UDFSuite extends QueryTest with SharedSparkSession {
     assert(nullResult.schema === new StructType().add("nullTime", TimeType()))
     // Input parameter of UDF is null
     val nullInput = Seq(null.asInstanceOf[java.time.LocalTime]).toDF("nullTime")
-    val constDuration = udf((_: java.time.LocalTime) =>
+    val constTime = udf((_: java.time.LocalTime) =>
       java.time.LocalTime.parse(mockTimeStr))
-    val constResult = nullInput.select(constDuration($"nullTime").as("zeroHour"))
+    val constResult = nullInput.select(constTime($"nullTime").as("zeroHour"))
     checkAnswer(constResult, Row(java.time.LocalTime.parse(mockTimeStr)) :: Nil)
     assert(constResult.schema === new StructType().add("zeroHour", TimeType()))
     // Error in the conversion of UDF result to the internal representation of time

--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -862,7 +862,7 @@ class UDFSuite extends QueryTest with SharedSparkSession {
       .select(myUdf1(Column("col"))),
     Row(ArrayBuffer(100)))
 
-     val myUdf2 = udf((a: immutable.ArraySeq[Int]) =>
+    val myUdf2 = udf((a: immutable.ArraySeq[Int]) =>
       immutable.ArraySeq.unsafeWrapArray[Int]((a :+ 5 :+ 6).toArray))
     checkAnswer(Seq(Array(1, 2, 3))
       .toDF("col")
@@ -1195,6 +1195,34 @@ class UDFSuite extends QueryTest with SharedSparkSession {
       ds1.join(ds2, ds1("value") === ds2("value"), "left_outer")
         .select(f(struct(ds2("value").as("_1")))),
       Row(Row(null)))
+  }
+
+  test("SPARK-51402: Test TimeType in UDF") {
+    // Regular case
+    val input = Seq(java.time.LocalDateTime.parse("2021-01-01T00:00:00.000000")).toDF("dateTime")
+    val plusHour = udf((l: java.time.LocalDateTime) => l.plusHours(1))
+    val result = input.select(plusHour($"dateTime").cast(TimeType).as("newTime"))
+    checkAnswer(result, Row(java.time.LocalTime.parse("01:00:00.000000")) :: Nil)
+    assert(result.schema === new StructType().add("newTime", TimeType))
+    // VALIDAR: UDF produces `null`
+    val nullFunc = udf((_: java.time.LocalTime) => null.asInstanceOf[java.time.LocalTime])
+    val nullResult = input.select(nullFunc($"dateTime").as("nullTime"))
+    checkAnswer(nullResult, Row(null) :: Nil)
+    assert(nullResult.schema === new StructType().add("nullTime", TimeType))
+    // TODO: Input parameter of UDF is null
+    val nullInput = Seq(null.asInstanceOf[java.time.LocalTime]).toDF("nullTime")
+    val constDuration = udf((_: java.time.LocalTime) =>
+      java.time.LocalTime.parse("01:00:00.000000"))
+    val constResult = nullInput.select(constDuration($"nullTime").as("oneHour"))
+    checkAnswer(constResult, Row(java.time.LocalTime.parse("01:00:00.000000")) :: Nil)
+    assert(constResult.schema === new StructType().add("oneHour", TimeType))
+    // TODO: Error in the conversion of UDF result to the internal representation of time
+    val overflowFunc = udf((l: java.time.LocalTime) => l.plusDays(Long.MaxValue))
+    val e = intercept[SparkException] {
+      input.select(overflowFunc($"dateTime")).collect()
+    }
+    assert(e.getCondition == "FAILED_EXECUTE_UDF")
+    assert(e.getCause.isInstanceOf[java.lang.ArithmeticException])
   }
 
   test("char/varchar as UDF return type") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -1198,27 +1198,27 @@ class UDFSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-51402: Test TimeType in UDF") {
-    // Constant
+    // Mocks
     val mockTimeStr = "00:00:00.000000"
-    // Regular case
     val input = Seq(java.time.LocalTime.parse(mockTimeStr)).toDF("currentTime")
+    // Regular case
     val plusHour = udf((l: java.time.LocalTime) => l.plusHours(1))
     val result = input.select(plusHour($"currentTime").cast(TimeType()).as("newTime"))
     checkAnswer(result, Row(java.time.LocalTime.parse("01:00:00.000000")) :: Nil)
     assert(result.schema === new StructType().add("newTime", TimeType()))
-    // VALIDAR: UDF produces `null`
+    // UDF produces `null`
     val nullFunc = udf((_: java.time.LocalTime) => null.asInstanceOf[java.time.LocalTime])
     val nullResult = input.select(nullFunc($"currentTime").as("nullTime"))
     checkAnswer(nullResult, Row(null) :: Nil)
     assert(nullResult.schema === new StructType().add("nullTime", TimeType()))
-    // TODO: Input parameter of UDF is null
+    // Input parameter of UDF is null
     val nullInput = Seq(null.asInstanceOf[java.time.LocalTime]).toDF("nullTime")
     val constDuration = udf((_: java.time.LocalTime) =>
       java.time.LocalTime.parse(mockTimeStr))
     val constResult = nullInput.select(constDuration($"nullTime").as("zeroHour"))
     checkAnswer(constResult, Row(java.time.LocalTime.parse(mockTimeStr)) :: Nil)
     assert(constResult.schema === new StructType().add("zeroHour", TimeType()))
-    // TODO: Error in the conversion of UDF result to the internal representation of time
+    // Error in the conversion of UDF result to the internal representation of time
     val overflowFunc = udf((l: java.time.LocalTime) => l.plusHours(Long.MaxValue))
     val e = intercept[SparkException] {
       input.select(overflowFunc($"currentTime")).collect()

--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -1219,7 +1219,7 @@ class UDFSuite extends QueryTest with SharedSparkSession {
     checkAnswer(constResult, Row(java.time.LocalTime.parse(mockTimeStr)) :: Nil)
     assert(constResult.schema === new StructType().add("zeroHour", TimeType))
     // TODO: Error in the conversion of UDF result to the internal representation of time
-    val overflowFunc = udf((l: java.time.LocalTime) => l.plusDays(Long.MaxValue))
+    val overflowFunc = udf((l: java.time.LocalTime) => l.plusHours(Long.MaxValue))
     val e = intercept[SparkException] {
       input.select(overflowFunc($"currentTime")).collect()
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -1203,7 +1203,7 @@ class UDFSuite extends QueryTest with SharedSparkSession {
     val input = Seq(java.time.LocalTime.parse(mockTimeStr)).toDF("currentTime")
     // Regular case
     val plusHour = udf((l: java.time.LocalTime) => l.plusHours(1))
-    val result = input.select(plusHour($"currentTime").cast(TimeType()).as("newTime"))
+    val result = input.select(plusHour($"currentTime").as("newTime"))
     checkAnswer(result, Row(java.time.LocalTime.parse("01:00:00.000000")) :: Nil)
     assert(result.schema === new StructType().add("newTime", TimeType()))
     // UDF produces `null`
@@ -1219,7 +1219,7 @@ class UDFSuite extends QueryTest with SharedSparkSession {
     checkAnswer(constResult, Row(java.time.LocalTime.parse(mockTimeStr)) :: Nil)
     assert(constResult.schema === new StructType().add("zeroHour", TimeType()))
     // Error in the conversion of UDF result to the internal representation of time
-    val invalidFunc = udf((l: java.time.LocalTime) => "Zero".toLong)
+    val invalidFunc = udf((l: java.time.LocalTime) => l.plusHours("Zero").toLong)
     val e = intercept[SparkException] {
       input.select(invalidFunc($"currentTime")).collect()
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -1200,26 +1200,26 @@ class UDFSuite extends QueryTest with SharedSparkSession {
   test("SPARK-51402: Test TimeType in UDF") {
     // Mocks
     val mockTimeStr = "00:00:00.000000"
-    val input = Seq(java.time.LocalTime.parse(mockTimeStr)).toDF("currentTime")
+    val input = Seq(LocalTime.parse(mockTimeStr)).toDF("currentTime")
     // Regular case
-    val plusHour = udf((l: java.time.LocalTime) => l.plusHours(1))
+    val plusHour = udf((l: LocalTime) => l.plusHours(1))
     val result = input.select(plusHour($"currentTime").as("newTime"))
-    checkAnswer(result, Row(java.time.LocalTime.parse("01:00:00.000000")) :: Nil)
+    checkAnswer(result, Row(LocalTime.parse("01:00:00.000000")) :: Nil)
     assert(result.schema === new StructType().add("newTime", TimeType()))
     // UDF produces `null`
-    val nullFunc = udf((_: java.time.LocalTime) => null.asInstanceOf[java.time.LocalTime])
+    val nullFunc = udf((_: LocalTime) => null.asInstanceOf[LocalTime])
     val nullResult = input.select(nullFunc($"currentTime").as("nullTime"))
     checkAnswer(nullResult, Row(null) :: Nil)
     assert(nullResult.schema === new StructType().add("nullTime", TimeType()))
     // Input parameter of UDF is null
-    val nullInput = Seq(null.asInstanceOf[java.time.LocalTime]).toDF("nullTime")
-    val constTime = udf((_: java.time.LocalTime) =>
-      java.time.LocalTime.parse(mockTimeStr))
+    val nullInput = Seq(null.asInstanceOf[LocalTime]).toDF("nullTime")
+    val constTime = udf((_: LocalTime) =>
+      LocalTime.parse(mockTimeStr))
     val constResult = nullInput.select(constTime($"nullTime").as("zeroHour"))
-    checkAnswer(constResult, Row(java.time.LocalTime.parse(mockTimeStr)) :: Nil)
+    checkAnswer(constResult, Row(LocalTime.parse(mockTimeStr)) :: Nil)
     assert(constResult.schema === new StructType().add("zeroHour", TimeType()))
     // Error in the conversion of UDF result to the internal representation of time
-    val invalidFunc = udf((l: java.time.LocalTime) => "Zero".toLong)
+    val invalidFunc = udf((l: LocalTime) => "Zero".toLong)
     val e = intercept[SparkException] {
       input.select(invalidFunc($"currentTime")).collect()
     }


### PR DESCRIPTION
## **What changes were proposed in this pull request?**
Write tests for TimeType in UDF as input parameters and results.

## **Why are the changes needed?**
It follows https://issues.apache.org/jira/browse/SPARK-51402 to improve test coverage.

## **Does this PR introduce any user-facing change?**
No

## **How was this patch tested?**
Unit test