### PR TITLE
[SPARK-51473][ML][CONNECT] ML transformed dataframe keep a reference to the model

### DIFF
--- a/python/pyspark/ml/base.py
+++ b/python/pyspark/ml/base.py
@@ -255,25 +255,9 @@ class Transformer(Params, metaclass=ABCMeta):
             params = dict()
         if isinstance(params, dict):
             if params:
-                transformed = self.copy(params)._transform(dataset)
+                return self.copy(params)._transform(dataset)
             else:
-                transformed = self._transform(dataset)
-
-            from pyspark.sql.connect.dataframe import DataFrame as ConnectDataFrame
-
-            # Keep a reference to the source transformer in the transformed dataframe and all its descendants.
-            # To dealy the GC of the model. For this case:
-            #
-            # def fit_transform(df):
-            #     model = estimator.fit(df)
-            #     return model.transform(df)
-            #
-            # output = fit_transform(df)
-            #
-            if isinstance(transformed, ConnectDataFrame):
-                transformed._plan.__source_transformer__ = self  # type: ignore[attr-defined]
-
-            return transformed
+                return self._transform(dataset)
         else:
             raise TypeError("Params must be a param map but got %s." % type(params))
 

--- a/python/pyspark/ml/base.py
+++ b/python/pyspark/ml/base.py
@@ -259,18 +259,18 @@ class Transformer(Params, metaclass=ABCMeta):
             else:
                 transformed = self._transform(dataset)
 
-            from pyspark.sql.utils import is_remote
+            from pyspark.sql.connect.dataframe import DataFrame as ConnectDataFrame
 
-            # Keep a reference to the source transformer in the client side, for this case:
+            # Keep a reference to the source transformer in the transformed dataframe and all its descendants.
+            # To dealy the GC of the model. For this case:
             #
             # def fit_transform(df):
             #     model = estimator.fit(df)
             #     return model.transform(df)
             #
             # output = fit_transform(df)
-            if is_remote():
-                # attach the source transformer to the internal plan,
-                # so that all descendant plans also keep it.
+            #
+            if isinstance(transformed, ConnectDataFrame):
                 transformed._plan.__source_transformer__ = self  # type: ignore[attr-defined]
 
             return transformed

--- a/python/pyspark/ml/base.py
+++ b/python/pyspark/ml/base.py
@@ -269,7 +269,9 @@ class Transformer(Params, metaclass=ABCMeta):
             #
             # output = fit_transform(df)
             if is_remote():
-                transformed.__source_transformer__ = self
+                # attach the source transformer to the internal plan,
+                # so that all descendant plans also keep it.
+                transformed._plan.__source_transformer__ = self  # type: ignore[attr-defined]
 
             return transformed
         else:

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -889,7 +889,10 @@ class LinearSVCModel(
         trained on the training set. An exception is thrown if `trainingSummary is None`.
         """
         if self.hasSummary:
-            return LinearSVCTrainingSummary(super(LinearSVCModel, self).summary)
+            s = LinearSVCTrainingSummary(super(LinearSVCModel, self).summary)
+            if is_remote():
+                s.__source_transformer__ = self  # type: ignore[attr-defined]
+            return s
         else:
             raise RuntimeError(
                 "No training summary available for this %s" % self.__class__.__name__
@@ -909,7 +912,10 @@ class LinearSVCModel(
         if not isinstance(dataset, DataFrame):
             raise TypeError("dataset must be a DataFrame but got %s." % type(dataset))
         java_lsvc_summary = self._call_java("evaluate", dataset)
-        return LinearSVCSummary(java_lsvc_summary)
+        s = LinearSVCSummary(java_lsvc_summary)
+        if is_remote():
+            s.__source_transformer__ = self  # type: ignore[attr-defined]
+        return s
 
 
 class LinearSVCSummary(_BinaryClassificationSummary):
@@ -1579,13 +1585,14 @@ class LogisticRegressionModel(
         """
         if self.hasSummary:
             if self.numClasses <= 2:
-                return BinaryLogisticRegressionTrainingSummary(
+                s = BinaryLogisticRegressionTrainingSummary(
                     super(LogisticRegressionModel, self).summary
                 )
             else:
-                return LogisticRegressionTrainingSummary(
-                    super(LogisticRegressionModel, self).summary
-                )
+                s = LogisticRegressionTrainingSummary(super(LogisticRegressionModel, self).summary)
+            if is_remote():
+                s.__source_transformer__ = self  # type: ignore[attr-defined]
+            return s
         else:
             raise RuntimeError(
                 "No training summary available for this %s" % self.__class__.__name__
@@ -1606,9 +1613,12 @@ class LogisticRegressionModel(
             raise TypeError("dataset must be a DataFrame but got %s." % type(dataset))
         java_blr_summary = self._call_java("evaluate", dataset)
         if self.numClasses <= 2:
-            return BinaryLogisticRegressionSummary(java_blr_summary)
+            s = BinaryLogisticRegressionSummary(java_blr_summary)
         else:
-            return LogisticRegressionSummary(java_blr_summary)
+            s = LogisticRegressionSummary(java_blr_summary)
+        if is_remote():
+            s.__source_transformer__ = self  # type: ignore[attr-defined]
+        return s
 
 
 class LogisticRegressionSummary(_ClassificationSummary):
@@ -2305,13 +2315,16 @@ class RandomForestClassificationModel(
         """
         if self.hasSummary:
             if self.numClasses <= 2:
-                return BinaryRandomForestClassificationTrainingSummary(
+                s = BinaryRandomForestClassificationTrainingSummary(
                     super(RandomForestClassificationModel, self).summary
                 )
             else:
-                return RandomForestClassificationTrainingSummary(
+                s = RandomForestClassificationTrainingSummary(
                     super(RandomForestClassificationModel, self).summary
                 )
+            if is_remote():
+                s.__source_transformer__ = self  # type: ignore[attr-defined]
+            return s
         else:
             raise RuntimeError(
                 "No training summary available for this %s" % self.__class__.__name__
@@ -2334,9 +2347,12 @@ class RandomForestClassificationModel(
             raise TypeError("dataset must be a DataFrame but got %s." % type(dataset))
         java_rf_summary = self._call_java("evaluate", dataset)
         if self.numClasses <= 2:
-            return BinaryRandomForestClassificationSummary(java_rf_summary)
+            s = BinaryRandomForestClassificationSummary(java_rf_summary)
         else:
-            return RandomForestClassificationSummary(java_rf_summary)
+            s = RandomForestClassificationSummary(java_rf_summary)
+        if is_remote():
+            s.__source_transformer__ = self  # type: ignore[attr-defined]
+        return s
 
 
 class RandomForestClassificationSummary(_ClassificationSummary):
@@ -3341,9 +3357,12 @@ class MultilayerPerceptronClassificationModel(
         trained on the training set. An exception is thrown if `trainingSummary is None`.
         """
         if self.hasSummary:
-            return MultilayerPerceptronClassificationTrainingSummary(
+            s = MultilayerPerceptronClassificationTrainingSummary(
                 super(MultilayerPerceptronClassificationModel, self).summary
             )
+            if is_remote():
+                s.__source_transformer__ = self  # type: ignore[attr-defined]
+            return s
         else:
             raise RuntimeError(
                 "No training summary available for this %s" % self.__class__.__name__
@@ -3363,7 +3382,10 @@ class MultilayerPerceptronClassificationModel(
         if not isinstance(dataset, DataFrame):
             raise TypeError("dataset must be a DataFrame but got %s." % type(dataset))
         java_mlp_summary = self._call_java("evaluate", dataset)
-        return MultilayerPerceptronClassificationSummary(java_mlp_summary)
+        s = MultilayerPerceptronClassificationSummary(java_mlp_summary)
+        if is_remote():
+            s.__source_transformer__ = self  # type: ignore[attr-defined]
+        return s
 
 
 class MultilayerPerceptronClassificationSummary(_ClassificationSummary):
@@ -4290,7 +4312,10 @@ class FMClassificationModel(
         trained on the training set. An exception is thrown if `trainingSummary is None`.
         """
         if self.hasSummary:
-            return FMClassificationTrainingSummary(super(FMClassificationModel, self).summary)
+            s = FMClassificationTrainingSummary(super(FMClassificationModel, self).summary)
+            if is_remote():
+                s.__source_transformer__ = self  # type: ignore[attr-defined]
+            return s
         else:
             raise RuntimeError(
                 "No training summary available for this %s" % self.__class__.__name__
@@ -4310,7 +4335,10 @@ class FMClassificationModel(
         if not isinstance(dataset, DataFrame):
             raise TypeError("dataset must be a DataFrame but got %s." % type(dataset))
         java_fm_summary = self._call_java("evaluate", dataset)
-        return FMClassificationSummary(java_fm_summary)
+        s = FMClassificationSummary(java_fm_summary)
+        if is_remote():
+            s.__source_transformer__ = self  # type: ignore[attr-defined]
+        return s
 
 
 class FMClassificationSummary(_BinaryClassificationSummary):

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -1584,6 +1584,7 @@ class LogisticRegressionModel(
         trained on the training set. An exception is thrown if `trainingSummary is None`.
         """
         if self.hasSummary:
+            s: LogisticRegressionTrainingSummary
             if self.numClasses <= 2:
                 s = BinaryLogisticRegressionTrainingSummary(
                     super(LogisticRegressionModel, self).summary
@@ -1612,6 +1613,7 @@ class LogisticRegressionModel(
         if not isinstance(dataset, DataFrame):
             raise TypeError("dataset must be a DataFrame but got %s." % type(dataset))
         java_blr_summary = self._call_java("evaluate", dataset)
+        s: LogisticRegressionSummary
         if self.numClasses <= 2:
             s = BinaryLogisticRegressionSummary(java_blr_summary)
         else:
@@ -2314,6 +2316,7 @@ class RandomForestClassificationModel(
         trained on the training set. An exception is thrown if `trainingSummary is None`.
         """
         if self.hasSummary:
+            s: RandomForestClassificationTrainingSummary
             if self.numClasses <= 2:
                 s = BinaryRandomForestClassificationTrainingSummary(
                     super(RandomForestClassificationModel, self).summary
@@ -2330,9 +2333,7 @@ class RandomForestClassificationModel(
                 "No training summary available for this %s" % self.__class__.__name__
             )
 
-    def evaluate(
-        self, dataset: DataFrame
-    ) -> Union["BinaryRandomForestClassificationSummary", "RandomForestClassificationSummary"]:
+    def evaluate(self, dataset: DataFrame) -> "RandomForestClassificationSummary":
         """
         Evaluates the model on a test dataset.
 
@@ -2346,6 +2347,7 @@ class RandomForestClassificationModel(
         if not isinstance(dataset, DataFrame):
             raise TypeError("dataset must be a DataFrame but got %s." % type(dataset))
         java_rf_summary = self._call_java("evaluate", dataset)
+        s: RandomForestClassificationSummary
         if self.numClasses <= 2:
             s = BinaryRandomForestClassificationSummary(java_rf_summary)
         else:
@@ -2379,7 +2381,10 @@ class RandomForestClassificationTrainingSummary(
 
 
 @inherit_doc
-class BinaryRandomForestClassificationSummary(_BinaryClassificationSummary):
+class BinaryRandomForestClassificationSummary(
+    _BinaryClassificationSummary,
+    RandomForestClassificationSummary,
+):
     """
     BinaryRandomForestClassification results for a given model.
 

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -263,7 +263,10 @@ class GaussianMixtureModel(
         training set. An exception is thrown if no summary exists.
         """
         if self.hasSummary:
-            return GaussianMixtureSummary(super(GaussianMixtureModel, self).summary)
+            s = GaussianMixtureSummary(super(GaussianMixtureModel, self).summary)
+            if is_remote():
+                s.__source_transformer__ = self  # type: ignore[attr-defined]
+            return s
         else:
             raise RuntimeError(
                 "No training summary available for this %s" % self.__class__.__name__
@@ -710,7 +713,10 @@ class KMeansModel(
         training set. An exception is thrown if no summary exists.
         """
         if self.hasSummary:
-            return KMeansSummary(super(KMeansModel, self).summary)
+            s = KMeansSummary(super(KMeansModel, self).summary)
+            if is_remote():
+                s.__source_transformer__ = self  # type: ignore[attr-defined]
+            return s
         else:
             raise RuntimeError(
                 "No training summary available for this %s" % self.__class__.__name__
@@ -1057,7 +1063,10 @@ class BisectingKMeansModel(
         training set. An exception is thrown if no summary exists.
         """
         if self.hasSummary:
-            return BisectingKMeansSummary(super(BisectingKMeansModel, self).summary)
+            s = BisectingKMeansSummary(super(BisectingKMeansModel, self).summary)
+            if is_remote():
+                s.__source_transformer__ = self  # type: ignore[attr-defined]
+            return s
         else:
             raise RuntimeError(
                 "No training summary available for this %s" % self.__class__.__name__

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -487,7 +487,10 @@ class LinearRegressionModel(
         `trainingSummary is None`.
         """
         if self.hasSummary:
-            return LinearRegressionTrainingSummary(super(LinearRegressionModel, self).summary)
+            s = LinearRegressionTrainingSummary(super(LinearRegressionModel, self).summary)
+            if is_remote():
+                s.__source_transformer__ = self  # type: ignore[attr-defined]
+            return s
         else:
             raise RuntimeError(
                 "No training summary available for this %s" % self.__class__.__name__
@@ -508,7 +511,10 @@ class LinearRegressionModel(
         if not isinstance(dataset, DataFrame):
             raise TypeError("dataset must be a DataFrame but got %s." % type(dataset))
         java_lr_summary = self._call_java("evaluate", dataset)
-        return LinearRegressionSummary(java_lr_summary)
+        s = LinearRegressionSummary(java_lr_summary)
+        if is_remote():
+            s.__source_transformer__ = self  # type: ignore[attr-defined]
+        return s
 
 
 class LinearRegressionSummary(JavaWrapper):
@@ -2766,9 +2772,12 @@ class GeneralizedLinearRegressionModel(
         `trainingSummary is None`.
         """
         if self.hasSummary:
-            return GeneralizedLinearRegressionTrainingSummary(
+            s = GeneralizedLinearRegressionTrainingSummary(
                 super(GeneralizedLinearRegressionModel, self).summary
             )
+            if is_remote():
+                s.__source_transformer__ = self  # type: ignore[attr-defined]
+            return s
         else:
             raise RuntimeError(
                 "No training summary available for this %s" % self.__class__.__name__
@@ -2789,7 +2798,10 @@ class GeneralizedLinearRegressionModel(
         if not isinstance(dataset, DataFrame):
             raise TypeError("dataset must be a DataFrame but got %s." % type(dataset))
         java_glr_summary = self._call_java("evaluate", dataset)
-        return GeneralizedLinearRegressionSummary(java_glr_summary)
+        s = GeneralizedLinearRegressionSummary(java_glr_summary)
+        if is_remote():
+            s.__source_transformer__ = self  # type: ignore[attr-defined]
+        return s
 
 
 class GeneralizedLinearRegressionSummary(JavaWrapper):

--- a/python/pyspark/ml/tests/test_pipeline.py
+++ b/python/pyspark/ml/tests/test_pipeline.py
@@ -29,7 +29,7 @@ from pyspark.ml.feature import (
 )
 from pyspark.ml.linalg import Vectors
 from pyspark.ml.classification import LogisticRegression, LogisticRegressionModel
-from pyspark.ml.clustering import KMeans, KMeansModel
+from pyspark.ml.clustering import KMeans, KMeansModel, GaussianMixture
 from pyspark.testing.mlutils import MockDataset, MockEstimator, MockTransformer
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 
@@ -176,7 +176,7 @@ class PipelineTestsMixin:
 
     def test_model_gc(self):
         spark = self.spark
-        df = spark.createDataFrame(
+        df1 = spark.createDataFrame(
             [
                 Row(label=0.0, weight=0.1, features=Vectors.dense([0.0, 0.0])),
                 Row(label=0.0, weight=0.5, features=Vectors.dense([0.0, 1.0])),
@@ -189,10 +189,19 @@ class PipelineTestsMixin:
             model = lr.fit(df)
             return model.transform(df)
 
-        output = fit_transform(df)
-        self.assertEqual(output.count(), 3)
+        output1 = fit_transform(df1)
+        self.assertEqual(output1.count(), 3)
 
-    def test_model_gc_II(self):
+        df2 = spark.range(10)
+
+        def fit_transform_and_union(df1, df2):
+            output1 = fit_transform(df1)
+            return output1.unionByName(df2, True)
+
+        output2 = fit_transform_and_union(df1, df2)
+        self.assertEqual(output2.count(), 13)
+
+    def test_model_training_summary_gc(self):
         spark = self.spark
         df1 = spark.createDataFrame(
             [
@@ -202,19 +211,85 @@ class PipelineTestsMixin:
             ]
         )
 
-        df2 = spark.range(10)
-
-        def fit_transform(df):
+        def fit_predictions(df):
             lr = LogisticRegression(maxIter=1, regParam=0.01, weightCol="weight")
             model = lr.fit(df)
-            return model.transform(df)
+            return model.summary.predictions
 
-        def fit_transform_and_union(df1, df2):
-            output1 = fit_transform(df1)
+        output1 = fit_predictions(df1)
+        self.assertEqual(output1.count(), 3)
+
+        df2 = spark.range(10)
+
+        def fit_predictions_and_union(df1, df2):
+            output1 = fit_predictions(df1)
             return output1.unionByName(df2, True)
 
-        output = fit_transform_and_union(df1, df2)
-        self.assertEqual(output.count(), 13)
+        output2 = fit_predictions_and_union(df1, df2)
+        self.assertEqual(output2.count(), 13)
+
+    def test_model_testing_summary_gc(self):
+        spark = self.spark
+        df1 = spark.createDataFrame(
+            [
+                Row(label=0.0, weight=0.1, features=Vectors.dense([0.0, 0.0])),
+                Row(label=0.0, weight=0.5, features=Vectors.dense([0.0, 1.0])),
+                Row(label=1.0, weight=1.0, features=Vectors.dense([1.0, 0.0])),
+            ]
+        )
+
+        def fit_predictions(df):
+            lr = LogisticRegression(maxIter=1, regParam=0.01, weightCol="weight")
+            model = lr.fit(df)
+            return model.evaluate(df).predictions
+
+        output1 = fit_predictions(df1)
+        self.assertEqual(output1.count(), 3)
+
+        df2 = spark.range(10)
+
+        def fit_predictions_and_union(df1, df2):
+            output1 = fit_predictions(df1)
+            return output1.unionByName(df2, True)
+
+        output2 = fit_predictions_and_union(df1, df2)
+        self.assertEqual(output2.count(), 13)
+
+    def test_model_attr_df_gc(self):
+        spark = self.spark
+        df1 = (
+            spark.createDataFrame(
+                [
+                    (1, 1.0, Vectors.dense([-0.1, -0.05])),
+                    (2, 2.0, Vectors.dense([-0.01, -0.1])),
+                    (3, 3.0, Vectors.dense([0.9, 0.8])),
+                    (4, 1.0, Vectors.dense([0.75, 0.935])),
+                    (5, 1.0, Vectors.dense([-0.83, -0.68])),
+                    (6, 1.0, Vectors.dense([-0.91, -0.76])),
+                ],
+                ["index", "weight", "features"],
+            )
+            .coalesce(1)
+            .sortWithinPartitions("index")
+            .select("weight", "features")
+        )
+
+        def fit_attr_df(df):
+            gmm = GaussianMixture(k=2, maxIter=2, weightCol="weight", seed=1)
+            model = gmm.fit(df)
+            return model.gaussiansDF
+
+        output1 = fit_attr_df(df1)
+        self.assertEqual(output1.count(), 2)
+
+        df2 = spark.range(10)
+
+        def fit_attr_df_and_union(df1, df2):
+            output1 = fit_attr_df(df1)
+            return output1.unionByName(df2, True)
+
+        output2 = fit_attr_df_and_union(df1, df2)
+        self.assertEqual(output2.count(), 12)
 
 
 class PipelineTests(PipelineTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -284,7 +284,7 @@ def try_remote_del(f: FuncT) -> FuncT:
         if in_remote:
             # Delete the model if possible
             model_id = self._java_obj
-            del_remote_cache(model_id)
+            del_remote_cache(cast(str, model_id))
             return
         else:
             return f(self)

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -207,8 +207,8 @@ def try_remote_transform_relation(f: FuncT) -> FuncT:
             else:
                 raise RuntimeError(f"Unsupported {self}")
 
-            # Keep a reference to the source transformer in the transformed dataframe and all its descendants.
-            # To delay the GC of the model.
+            # To delay the GC of the model, keep a reference to the source transformer
+            # in the transformed dataframe and all its descendants.
             # For this case:
             #
             # def fit_transform(df):

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -283,18 +283,8 @@ def try_remote_del(f: FuncT) -> FuncT:
 
         if in_remote:
             # Delete the model if possible
-            # model_id = self._java_obj
-            # del_remote_cache(model_id)
-            #
-            # Above codes delete the model from the ml cache eagerly, and may cause
-            # NPE in the server side in the case of 'fit_transform':
-            #
-            # def fit_transform(df):
-            #     model = estimator.fit(df)
-            #     return model.transform(df)
-            #
-            # output = fit_transform(df)
-            # output.show()
+            model_id = self._java_obj
+            del_remote_cache(model_id)
             return
         else:
             return f(self)

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -113,6 +113,11 @@ def invoke_remote_attribute_relation(
     methods, obj_ref = _extract_id_methods(instance._java_obj)
     methods.append(pb2.Fetch.Method(method=method, args=serialize(session.client, *args)))
     plan = AttributeRelation(obj_ref, methods)
+
+    # To delay the GC of the model, keep a reference to the source instance,
+    # might be a model or a summary.
+    plan.__source_instance__ = instance  # type: ignore[attr-defined]
+
     return ConnectDataFrame(plan, session)
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
add the model link in the transformed dataframe

### Why are the changes needed?
https://github.com/apache/spark/pull/49948 disabled the model GC for `fit_transform`, this PR add the model link in the transformed dataframe, so that the model will be GCed together with the transformed dataframe


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
existing test should cover this change

### Was this patch authored or co-authored using generative AI tooling?
no
