### PR TITLE
Revert "[SPARK-51396][SQL] RuntimeConfig.getOption shouldn't use exceptions for control flow"

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -6607,14 +6607,12 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   /** Return the value of Spark SQL configuration property for the given key. */
   @throws[NoSuchElementException]("if key is not set")
   def getConfString(key: String): String = {
-    getConfStringOption(key).getOrElse(throw QueryExecutionErrors.sqlConfigNotFoundError(key))
-  }
-
-  private[sql] def getConfStringOption(key: String): Option[String] = {
-    Option(settings.get(key)).orElse {
-      // Try to use the default value
-      Option(getConfigEntry(key)).map { e => e.stringConverter(e.readFrom(reader)) }
-    }
+    Option(settings.get(key)).
+      orElse {
+        // Try to use the default value
+        Option(getConfigEntry(key)).map { e => e.stringConverter(e.readFrom(reader)) }
+      }.
+      getOrElse(throw QueryExecutionErrors.sqlConfigNotFoundError(key))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/RuntimeConfig.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/RuntimeConfig.scala
@@ -82,7 +82,9 @@ class RuntimeConfig private[sql](val sqlConf: SQLConf = new SQLConf) extends sql
 
   /** @inheritdoc */
   def getOption(key: String): Option[String] = {
-    sqlConf.getConfStringOption(key)
+    try Option(get(key)) catch {
+      case _: NoSuchElementException => None
+    }
   }
 
   /** @inheritdoc */


### PR DESCRIPTION
### What changes were proposed in this pull request?

This reverts commit db06293dd100b4f2a4efe3e7624a9be2345e6575 / https://github.com/apache/spark/pull/50167.

That PR introduced a subtle bug which could lead to NullPointerExceptions in the `SET` command if any `ConfigEntry`'s string form was `null`, which can happen when reading an `OptionalConfigEntry` where no value is set.

I have some ideas for a fix-forward, but for now let's revert so as not to leave things in a broken state.

### Why are the changes needed?


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Clean revert, n/a.


### Was this patch authored or co-authored using generative AI tooling?

No.