### PR TITLE
[SPARK-51432][SQL][PYTHON] Throw a proper exception when Arrow schemas are mismatched

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4416,6 +4416,12 @@
     ],
     "sqlState" : "42K0G"
   },
+  "ARROW_TYPE_MISMATCH": {
+    "message": [
+      "Invalid schema from <operation>: expected <outputTypes>, got <actualDataTypes>."
+    ],
+    "sqlState" : "42K0G"
+  },
   "PROTOBUF_MESSAGE_NOT_FOUND" : {
     "message" : [
       "Unable to locate Message <messageName> in Descriptor."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -82,6 +82,12 @@
     ],
     "sqlState" : "22003"
   },
+  "ARROW_TYPE_MISMATCH" : {
+    "message" : [
+      "Invalid schema from <operation>: expected <outputTypes>, got <actualDataTypes>."
+    ],
+    "sqlState" : "42K0G"
+  },
   "ARTIFACT_ALREADY_EXISTS" : {
     "message" : [
       "The artifact <normalizedRemoteRelativePath> already exists. Please choose a different name for the new artifact because it cannot be overwritten."
@@ -4413,12 +4419,6 @@
   "PROTOBUF_FIELD_TYPE_MISMATCH" : {
     "message" : [
       "Type mismatch encountered for field: <field>."
-    ],
-    "sqlState" : "42K0G"
-  },
-  "ARROW_TYPE_MISMATCH": {
-    "message": [
-      "Invalid schema from <operation>: expected <outputTypes>, got <actualDataTypes>."
     ],
     "sqlState" : "42K0G"
   },

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -844,6 +844,19 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       cause = e)
   }
 
+  def arrowDataTypeMismatchError(
+      operation: String,
+      outputTypes: Seq[DataType],
+      actualDataTypes: Seq[DataType]): Throwable = {
+    new SparkException(
+      errorClass = "ARROW_TYPE_MISMATCH",
+      messageParameters = Map(
+        "operation" -> operation,
+        "outputTypes" -> outputTypes.mkString(", "),
+        "actualDataTypes" -> actualDataTypes.mkString(", ")),
+      cause = null)
+  }
+
   def cannotReadFilesError(
       e: Throwable,
       path: String): Throwable = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.catalyst.plans.ReferenceAllColumns
 import org.apache.spark.sql.catalyst.plans.logical.{EventTimeWatermark, FunctionUtils, LogicalGroupState}
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
+import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.python.BatchIterator
 import org.apache.spark.sql.execution.r.ArrowRRunner
 import org.apache.spark.sql.execution.streaming.GroupStateImpl
@@ -252,8 +253,10 @@ case class MapPartitionsInRWithArrowExec(
       val outputProject = UnsafeProjection.create(output, output)
       columnarBatchIter.flatMap { batch =>
         val actualDataTypes = (0 until batch.numCols()).map(i => batch.column(i).dataType())
-        assert(outputTypes == actualDataTypes, "Invalid schema from dapply(): " +
-          s"expected ${outputTypes.mkString(", ")}, got ${actualDataTypes.mkString(", ")}")
+        if (outputTypes == actualDataTypes) {
+          throw QueryExecutionErrors.arrowDataTypeMismatchError(
+            "dapply()", outputTypes, actualDataTypes)
+        }
         batch.rowIterator.asScala
       }.map(outputProject)
     }
@@ -598,8 +601,10 @@ case class FlatMapGroupsInRWithArrowExec(
 
       columnarBatchIter.flatMap { batch =>
         val actualDataTypes = (0 until batch.numCols()).map(i => batch.column(i).dataType())
-        assert(outputTypes == actualDataTypes, "Invalid schema from gapply(): " +
-          s"expected ${outputTypes.mkString(", ")}, got ${actualDataTypes.mkString(", ")}")
+        if (outputTypes == actualDataTypes) {
+          throw QueryExecutionErrors.arrowDataTypeMismatchError(
+            "gapply()", outputTypes, actualDataTypes)
+        }
         batch.rowIterator().asScala
       }.map(outputProject)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
@@ -253,7 +253,7 @@ case class MapPartitionsInRWithArrowExec(
       val outputProject = UnsafeProjection.create(output, output)
       columnarBatchIter.flatMap { batch =>
         val actualDataTypes = (0 until batch.numCols()).map(i => batch.column(i).dataType())
-        if (outputTypes == actualDataTypes) {
+        if (outputTypes != actualDataTypes) {
           throw QueryExecutionErrors.arrowDataTypeMismatchError(
             "dapply()", outputTypes, actualDataTypes)
         }
@@ -601,7 +601,7 @@ case class FlatMapGroupsInRWithArrowExec(
 
       columnarBatchIter.flatMap { batch =>
         val actualDataTypes = (0 until batch.numCols()).map(i => batch.column(i).dataType())
-        if (outputTypes == actualDataTypes) {
+        if (outputTypes != actualDataTypes) {
           throw QueryExecutionErrors.arrowDataTypeMismatchError(
             "gapply()", outputTypes, actualDataTypes)
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -126,7 +126,7 @@ class ArrowEvalPythonEvaluatorFactory(
 
     columnarBatchIter.flatMap { batch =>
       val actualDataTypes = (0 until batch.numCols()).map(i => batch.column(i).dataType())
-      if (outputTypes == actualDataTypes) {
+      if (outputTypes != actualDataTypes) {
         throw QueryExecutionErrors.arrowDataTypeMismatchError(
           "pandas_udf()", outputTypes, actualDataTypes)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -23,6 +23,7 @@ import org.apache.spark.{JobArtifactSet, TaskContext}
 import org.apache.spark.api.python.ChainedPythonFunctions
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
@@ -125,8 +126,10 @@ class ArrowEvalPythonEvaluatorFactory(
 
     columnarBatchIter.flatMap { batch =>
       val actualDataTypes = (0 until batch.numCols()).map(i => batch.column(i).dataType())
-      assert(outputTypes == actualDataTypes, "Invalid schema from pandas_udf: " +
-        s"expected ${outputTypes.mkString(", ")}, got ${actualDataTypes.mkString(", ")}")
+      if (outputTypes == actualDataTypes) {
+        throw QueryExecutionErrors.arrowDataTypeMismatchError(
+          "pandas_udf()", outputTypes, actualDataTypes)
+      }
       batch.rowIterator.asScala
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonUDTFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonUDTFExec.scala
@@ -82,7 +82,7 @@ case class ArrowEvalPythonUDTFExec(
 
       val actualDataTypes = (0 until flattenedBatch.numCols()).map(
         i => flattenedBatch.column(i).dataType())
-      if (outputTypes == actualDataTypes) {
+      if (outputTypes != actualDataTypes) {
         throw QueryExecutionErrors.arrowDataTypeMismatchError(
           "Python UDTF", outputTypes, actualDataTypes)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonUDTFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonUDTFExec.scala
@@ -22,6 +22,7 @@ import scala.jdk.CollectionConverters._
 import org.apache.spark.{JobArtifactSet, TaskContext}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
 import org.apache.spark.sql.types.StructType
@@ -81,8 +82,10 @@ case class ArrowEvalPythonUDTFExec(
 
       val actualDataTypes = (0 until flattenedBatch.numCols()).map(
         i => flattenedBatch.column(i).dataType())
-      assert(outputTypes == actualDataTypes, "Invalid schema from arrow-enabled Python UDTF: " +
-        s"expected ${outputTypes.mkString(", ")}, got ${actualDataTypes.mkString(", ")}")
+      if (outputTypes == actualDataTypes) {
+        throw QueryExecutionErrors.arrowDataTypeMismatchError(
+          "Python UDTF", outputTypes, actualDataTypes)
+      }
 
       flattenedBatch.setNumRows(batch.numRows())
       flattenedBatch.rowIterator().asScala


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to raise a proper error instead of `assert` when the returned Arrow schema is mismatched with specified SQL return type. Users can see this error, and this is not an internal error mssage.

### Why are the changes needed?


```python
import pandas as pd
from pyspark.sql.functions import pandas_udf

@pandas_udf("int")
def func(s: pd.Series) -> pd.Series:
    return pd.Series([1.0] * len(s))

spark.range(1).select(func("id")).show()
```

Now it throws

```
org.apache.spark.SparkException: [ARROW_TYPE_MISMATCH] Invalid schema from pandas_udf(): expected IntegerType, got IntegerType. SQLSTATE: 42K0G
	at org.apache.spark.sql.errors.QueryExecutionErrors$.arrowDataTypeMismatchError(QueryExecutionErrors.scala:857)
	at org.apache.spark.sql.execution.python.ArrowEvalPythonEvaluatorFactory.$anonfun$evaluate$2(ArrowEvalPythonExec.scala:131)
	at scala.collection.Iterator$$anon$10.nextCur(Iterator.scala:594)
```

### Does this PR introduce _any_ user-facing change?

Yes, it changes the user-facing error mesasge.

### How was this patch tested?

Manually tested as described above.

### Was this patch authored or co-authored using generative AI tooling?

No.