### PR TITLE
[SPARK-51433][PYTHON][CONNECT] Change release script to release pyspark-client

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -137,6 +137,12 @@ if [[ "$1" == "finalize" ]]; then
     --repository-url https://upload.pypi.org/legacy/ \
     "pyspark_connect-$PYSPARK_VERSION.tar.gz" \
     "pyspark_connect-$PYSPARK_VERSION.tar.gz.asc"
+  svn update "pyspark-client-$RELEASE_VERSION.tar.gz"
+  svn update "pyspark-client-$RELEASE_VERSION.tar.gz.asc"
+  TWINE_USERNAME=spark-upload TWINE_PASSWORD="$PYPI_PASSWORD" twine upload \
+    --repository-url https://upload.pypi.org/legacy/ \
+    "pyspark-client-$RELEASE_VERSION.tar.gz" \
+    "pyspark-client-$RELEASE_VERSION.tar.gz.asc"
   cd ..
   rm -rf svn-spark
   echo "PySpark uploaded"
@@ -330,6 +336,14 @@ if [[ "$1" == "package" ]]; then
         --output $PYTHON_CONNECT_DIST_NAME.asc \
         --detach-sig $PYTHON_CONNECT_DIST_NAME
       shasum -a 512 $PYTHON_CONNECT_DIST_NAME > $PYTHON_CONNECT_DIST_NAME.sha512
+
+      PYTHON_CLIENT_DIST_NAME=pyspark-client-$PYSPARK_VERSION.tar.gz
+      cp spark-$SPARK_VERSION-bin-$NAME/python/dist/$PYTHON_CLIENT_DIST_NAME .
+
+      echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour \
+        --output $PYTHON_CLIENT_DIST_NAME.asc \
+        --detach-sig $PYTHON_CLIENT_DIST_NAME
+      shasum -a 512 $PYTHON_CLIENT_DIST_NAME > $PYTHON_CLIENT_DIST_NAME.sha512
     fi
 
     echo "Copying and signing regular binary distribution"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to change release script to publish `pyspark-client`.

### Why are the changes needed?

We should have the release available in PyPI.

### Does this PR introduce _any_ user-facing change?

Yes, it releases `pyspark-client` package into PyPI.

### How was this patch tested?

Did the basic test for individual commands. This is similar with https://github.com/apache/spark/pull/46049

### Was this patch authored or co-authored using generative AI tooling?

No.