### PR TITLE
session extension comments enhancement

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensions.scala
@@ -35,6 +35,9 @@ import org.apache.spark.sql.execution.{ColumnarRule, SparkPlan}
  * :: Experimental ::
  * Holder for injection points to the [[SparkSession]]. We make NO guarantee about the stability
  * regarding binary compatibility and source compatibility of methods here.
+ * 
+ * These extension points doesn't follow the exact order of sql execution
+ * E.g. Analyzer Rules are not the first point that gets called when sql execution begins.
  *
  * This current provides the following extension points:
  *


### PR DESCRIPTION
**What changes were proposed in this pull request?**
Spark session extensions comments enhancement

**Why are the changes needed?**
The list of sequence given in spark session extensions seems to follow a specific order up to Planning Strategies, and the Customized Parser comes below that, this may sound a bit confusing for certain users, who are trying to modify the sql in the initial stage, they may think that before the sql hits parser there is some kind of pre-analyzer and pre-optimization happening,  therefore I am requesting to add a note regarding this.

**Does this PR introduce any user-facing change?**
No

**How was this patch tested?**
N/A

**Was this patch authored or co-authored using generative AI tooling?**
No