### PR TITLE
fix: handle compare_vals turn into str when parse IgnoreColumnType

### DIFF
--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -944,6 +944,9 @@ def assertDataFrameEqual(
                     return False
             elif isinstance(val1, VariantVal) and isinstance(val2, VariantVal):
                 return compare_vals(val1.toPython(), val2.toPython())
+            elif isinstance(val1, str) and isinstance(val2, str):
+                if abs(float(val1) - float(val2)) > (atol + rtol * abs(float(val2))):
+                    return False
             else:
                 if val1 != val2:
                     return False


### PR DESCRIPTION
when I parse ignoreColumnType=True when call the function, it cast all values to be 'str' which causing the comparison between val1 and val2 to be failed.
for example

val1 = 1505.76189560
val2= 1505.761896
assertDataFrameEqual(source_df, databricks_df, ignoreColumnType=True,)

I will convert the original data into string with this clause first
```
if ignoreColumnType:
    actual = cast_columns_to_string(actual)
    expected = cast_columns_to_string(expected)
.
.
compare_vals(val1, val2)
```
it will become string comparison instead of compare by using the tolerance equation
'1505.76189560' != '1505.761896'

Hence assertError, even if the atol and rtol already assigned



### What changes were proposed in this pull request?
add more elif case to convert str to float and parse into tolerant calculations

### Why are the changes needed?
I think it might not be the only way to fix it, but just to be your ideas Thank you !


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Test on my local data source, comparing 2 dataframes
by patch the code into my local env.



### Was this patch authored or co-authored using generative AI tooling?
No
