### PR TITLE
[MINOR][SQL] Improve readability of JDBC truncate table condition check

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcRelationProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcRelationProvider.scala
@@ -54,7 +54,7 @@ class JdbcRelationProvider extends CreatableRelationProvider
       if (tableExists) {
         mode match {
           case SaveMode.Overwrite =>
-            if (options.isTruncate && isCascadingTruncateTable(options.url) == Some(false)) {
+            if (options.isTruncate && isCascadingTruncateTable(options.url).contains(false)) {
               // In this case, we should truncate table and then load.
               truncateTable(conn, options)
               val tableSchema = JdbcUtils.getSchemaOption(conn, options)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -544,7 +544,7 @@ object JdbcUtils extends Logging with SQLConfHelper {
 
     case _: ArrayType if metadata.contains("pg_bit_array_type") =>
       // SPARK-47628: Handle PostgreSQL bit(n>1) array type ahead. As in the pgjdbc driver,
-      // bit(n>1)[] is not distinguishable from bit(1)[], and they are all recognized as boolen[].
+      // bit(n>1)[] is not distinguishable from bit(1)[], and they are all recognized as boolean[].
       // This is wrong for bit(n>1)[], so we need to handle it first as byte array.
       (rs: ResultSet, row: InternalRow, pos: Int) =>
         val fieldString = rs.getString(pos + 1)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR improves the readability of the JDBC truncate table condition check by clarifying the logic flow in the code. The commit rewrites the condition to make it clearer that truncation only occurs when both `isTruncate` is true and the database is confirmed not to cascade truncate.

### Why are the changes needed?

The original condition was slightly difficult to follow at first glance. This readability improvement makes the code easier to understand and maintain, especially for new contributors. It more explicitly shows the intent of the logic without changing any functional behavior.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests cover this functionality, and since this is purely a readability improvement with no functional changes, no additional tests were needed.

### Was this patch authored or co-authored using generative AI tooling?

No.