### PR TITLE
[MINOR][SQL] Slightly refactor and optimize illegaility check in Recursive CTE Subqueries

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveWithCTE.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveWithCTE.scala
@@ -188,22 +188,6 @@ object ResolveWithCTE extends Rule[LogicalPlan] {
   }
 
   /**
-   * Checks if there is any self-reference within subqueries and throws an error
-   * if that is the case.
-   */
-  def checkForSelfReferenceInSubquery(plan: LogicalPlan): Unit = {
-    plan.subqueriesAll.foreach { subquery =>
-      subquery.foreach {
-        case r: CTERelationRef if r.recursive =>
-          throw new AnalysisException(
-            errorClass = "INVALID_RECURSIVE_REFERENCE.PLACE",
-            messageParameters = Map.empty)
-        case _ =>
-      }
-    }
-  }
-
-  /**
    * Counts number of self-references in a recursive CTE definition and throws an error
    * if that number is bigger than 1.
    */


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the place where we check whether there is a recursive CTE within a subquery. Also, change implementation to be instead of collecting all subqueries into one array, we do an in-place traversal of everything to check.

### Why are the changes needed?

It's more efficient to do in-place traversal instead of collecting subqueries to an array and traverse, so this change is a small optimization.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Will be tested in [49955](https://github.com/apache/spark/pull/49955).

### Was this patch authored or co-authored using generative AI tooling?

No.
