### PR TITLE
[SPARK-51444][CORE] Remove the unreachable `if` branch from `TaskSchedulerImpl#statusUpdate`

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -780,8 +780,6 @@ private[spark] class TaskSchedulerImpl(
   }
 
   def statusUpdate(tid: Long, state: TaskState, serializedData: ByteBuffer): Unit = {
-    var failedExecutor: Option[String] = None
-    var reason: Option[ExecutorLossReason] = None
     synchronized {
       try {
         Option(taskIdToTaskSetManager.get(tid)) match {
@@ -808,12 +806,6 @@ private[spark] class TaskSchedulerImpl(
       } catch {
         case e: Exception => logError("Exception in statusUpdate", e)
       }
-    }
-    // Update the DAGScheduler without holding a lock on this, since that can deadlock
-    if (failedExecutor.isDefined) {
-      assert(reason.isDefined)
-      dagScheduler.executorLost(failedExecutor.get, reason.get)
-      backend.reviveOffers()
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
After SPARK-51184 (https://github.com/apache/spark/pull/49913), the variables `failedExecutor` and `reason` defined in the function `TaskSchedulerImpl#statusUpdate` are not reassigned after being initialized to `None`. 

https://github.com/apache/spark/blob/f40bf4dd7166e86ea5cc9962e8c5b68b88f8dcb5/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala#L783-L811

Therefore, `failedExecutor.isDefined` will always be false, and the following `if` branch will never be entered: 

https://github.com/apache/spark/blob/f40bf4dd7166e86ea5cc9962e8c5b68b88f8dcb5/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala#L812-L817. 

So, the this pr cleans it up.


### Why are the changes needed?
Code cleanup.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
