### PR TITLE
[SPARK-51447][SQL] Add `stringToTime` and `stringToTimeAnsi`

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeTestUtils.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeTestUtils.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
-import org.apache.spark.sql.catalyst.util.DateTimeUtils.getZoneId
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.{getZoneId, localTimeToMicros}
 
 /**
  * Helper functions for testing date and time functionality.
@@ -111,5 +111,16 @@ object DateTimeTestUtils {
     result = Math.addExact(result, Math.multiplyExact(milliseconds, MICROS_PER_MILLIS))
     result = Math.addExact(result, Math.multiplyExact(seconds, MICROS_PER_SECOND))
     result
+  }
+
+  // Returns microseconds since midnight
+  def localtime(
+      hour: Byte = 0,
+      minute: Byte = 0,
+      sec: Byte = 0,
+      micros: Int = 0): Long = {
+    val nanos = TimeUnit.MICROSECONDS.toNanos(micros).toInt
+    val localTime = LocalTime.of(hour, minute, sec, nanos)
+    localTimeToMicros(localTime)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -1126,4 +1126,30 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     }.getMessage
     assert(msg == "long overflow")
   }
+
+  test("stringToTime") {
+    def checkStringToTime(str: String, expected: Option[Long]): Unit = {
+      assert( stringToTime(UTF8String.fromString(str)) === expected)
+    }
+
+    checkStringToTime("00:00", Some(localtime()))
+    checkStringToTime("00:00:00", Some(localtime()))
+    checkStringToTime("00:00:00.1", Some(localtime(micros = 100000)))
+    checkStringToTime("00:00:59.01", Some(localtime(sec = 59, micros = 10000)))
+    checkStringToTime("00:59:00.001", Some(localtime(minute = 59, micros = 1000)))
+    checkStringToTime("23:00:00.0001", Some(localtime(hour = 23, micros = 100)))
+    checkStringToTime("23:59:00.00001", Some(localtime(hour = 23, minute = 59, micros = 10)))
+    checkStringToTime("23:59:59.000001",
+      Some(localtime(hour = 23, minute = 59, sec = 59, micros = 1)))
+    checkStringToTime("23:59:59.999999",
+      Some(localtime(hour = 23, minute = 59, sec = 59, micros = 999999)))
+
+    checkStringToTime("1:2:3.0", Some(localtime(hour = 1, minute = 2, sec = 3)))
+    checkStringToTime("T1:02:3.04", Some(localtime(hour = 1, minute = 2, sec = 3, micros = 40000)))
+
+    // Negative tests
+    checkStringToTime("2025-03-09 00:00:00", None)
+    checkStringToTime("00", None)
+    checkStringToTime("00:01:02 UTC", None)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose two new functions to SparkDateTimeUtils:
1. `stringToTime()` parses an input string to micros since the midnight using `[h]h:[m]m:[s]s.[ms][ms][ms][us][us][us]`. This pattern is the same as the time pattern in `stringToTimestamp()`
2. `stringToTimeAnsi` is similar to the above function but raises the `CAST_INVALID_INPUT` error when it cannot parse the input.

### Why are the changes needed?
This functions should be used in the cases when time pattern is not set during parsing: casting, time literals, datasources and so on.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running new tests:
```
$ build/sbt "test:testOnly *DateTimeUtilsSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.