### PR TITLE
[SPARK-51446][SQL] Improve the codecNameMap for the compression codec

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/HadoopCompressionCodec.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/HadoopCompressionCodec.java
@@ -18,8 +18,8 @@
 package org.apache.spark.sql.catalyst.util;
 
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.Locale;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.io.compress.BZip2Codec;
@@ -53,11 +53,15 @@ public enum HadoopCompressionCodec {
     return this.compressionCodec;
   }
 
-  private static final Map<String, String> codecNameMap =
+  private static final EnumMap<HadoopCompressionCodec, String> codecNameMap =
     Arrays.stream(HadoopCompressionCodec.values()).collect(
-      Collectors.toMap(Enum::name, codec -> codec.name().toLowerCase(Locale.ROOT)));
+      Collectors.toMap(
+        codec -> codec,
+        codec -> codec.name().toLowerCase(Locale.ROOT),
+        (oldValue, newValue) -> oldValue,
+        () -> new EnumMap<>(HadoopCompressionCodec.class)));
 
   public String lowerCaseName() {
-    return codecNameMap.get(this.name());
+    return codecNameMap.get(this);
   }
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/avro/AvroCompressionCodec.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/avro/AvroCompressionCodec.java
@@ -18,8 +18,8 @@
 package org.apache.spark.sql.avro;
 
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.Locale;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.avro.file.DataFileConstants;
@@ -53,15 +53,19 @@ public enum AvroCompressionCodec {
     return this.supportCompressionLevel;
   }
 
-  private static final Map<String, String> codecNameMap =
-    Arrays.stream(AvroCompressionCodec.values()).collect(
-      Collectors.toMap(codec -> codec.name(), codec -> codec.name().toLowerCase(Locale.ROOT)));
-
-  public String lowerCaseName() {
-    return codecNameMap.get(this.name());
-  }
-
   public static AvroCompressionCodec fromString(String s) {
     return AvroCompressionCodec.valueOf(s.toUpperCase(Locale.ROOT));
+  }
+
+  private static final EnumMap<AvroCompressionCodec, String> codecNameMap =
+    Arrays.stream(AvroCompressionCodec.values()).collect(
+      Collectors.toMap(
+        codec -> codec,
+        codec -> codec.name().toLowerCase(Locale.ROOT),
+        (oldValue, newValue) -> oldValue,
+        () -> new EnumMap<>(AvroCompressionCodec.class)));
+
+  public String lowerCaseName() {
+    return codecNameMap.get(this);
   }
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcCompressionCodec.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcCompressionCodec.java
@@ -18,8 +18,8 @@
 package org.apache.spark.sql.execution.datasources.orc;
 
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.Locale;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.orc.CompressionKind;
@@ -47,11 +47,15 @@ public enum OrcCompressionCodec {
     return this.compressionKind;
   }
 
-  public static final Map<String, String> codecNameMap =
+  private static final EnumMap<OrcCompressionCodec, String> codecNameMap =
     Arrays.stream(OrcCompressionCodec.values()).collect(
-      Collectors.toMap(codec -> codec.name(), codec -> codec.name().toLowerCase(Locale.ROOT)));
+      Collectors.toMap(
+        codec -> codec,
+        codec -> codec.name().toLowerCase(Locale.ROOT),
+        (oldValue, newValue) -> oldValue,
+        () -> new EnumMap<>(OrcCompressionCodec.class)));
 
   public String lowerCaseName() {
-    return codecNameMap.get(this.name());
+    return codecNameMap.get(this);
   }
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetCompressionCodec.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetCompressionCodec.java
@@ -18,9 +18,9 @@
 package org.apache.spark.sql.execution.datasources.parquet;
 
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
@@ -53,12 +53,16 @@ public enum ParquetCompressionCodec {
     return ParquetCompressionCodec.valueOf(s.toUpperCase(Locale.ROOT));
   }
 
-  private static final Map<String, String> codecNameMap =
+  private static final EnumMap<ParquetCompressionCodec, String> codecNameMap =
     Arrays.stream(ParquetCompressionCodec.values()).collect(
-      Collectors.toMap(codec -> codec.name(), codec -> codec.name().toLowerCase(Locale.ROOT)));
+      Collectors.toMap(
+        codec -> codec,
+        codec -> codec.name().toLowerCase(Locale.ROOT),
+        (oldValue, newValue) -> oldValue,
+        () -> new EnumMap<>(ParquetCompressionCodec.class)));
 
   public String lowerCaseName() {
-    return codecNameMap.get(this.name());
+    return codecNameMap.get(this);
   }
 
   public static final List<ParquetCompressionCodec> availableCodecs =


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to improve the `codecNameMap` for the [hadoop|avro|orc|parquet] compression codecs.


### Why are the changes needed?
Currently, [hadoop|avro|orc|parquet] compression codecs select java.util.Map to store the mapping between compression codec to the short name.
Enum Map has the following advantages.

- High performance: Due to the limited number of enumeration values, Enum Map uses arrays internally to store data, with an access speed close to O (1).

- Low memory usage: Enum Map only stores key value pairs of enumeration values, without the need for a hash table structure, resulting in smaller memory usage.

- Orderliness: The Enum Map maintains key value pairs in the order defined by the enumeration, making it suitable for scenarios that require ordered traversal.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
No
