### PR TITLE
[SPARK-51450][CORE] BarrierCoordinator thread not exiting in Spark standalone mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
@@ -51,7 +51,7 @@ private[spark] class BarrierCoordinator(
 
   // TODO SPARK-25030 Create a Timer() in the mainClass submitted to SparkSubmit makes it unable to
   // fetch result, we shall fix the issue.
-  private lazy val timer = new Timer("BarrierCoordinator barrier epoch increment timer")
+  private lazy val timer = new Timer("BarrierCoordinator barrier epoch increment timer", true)
 
   // Listen to StageCompleted event, clear corresponding ContextBarrierState.
   private val listener = new SparkListener {

--- a/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
@@ -77,6 +77,7 @@ private[spark] class BarrierCoordinator(
       states.forEachValue(1, clearStateConsumer)
       states.clear()
       listenerBus.removeListener(listener)
+      timer.cancel()
     } finally {
       super.onStop()
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Cancel the timer class when onStop method is called

### Why are the changes needed?
This change is needed to successfully exit the spark application else it hangs on completion.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
- Run the following scripts locally using spark-submit.
- Without this change, the JVM would hang there and not exit.
- With this change it would exit successfully.
- Code samples to simulate the problem and the corresponding fix is attached below:-

> [barrier_example.py](https://gist.github.com/jshmchenxi/5d7e7c61e1eedd03cd6d676699059e9b#file-barrier_example-py)
> [xgboost-test.py](https://gist.github.com/bcheena/510230e19120eb9ae631dcafa804409f).

### Was this patch authored or co-authored using generative AI tooling?
No
