### PR TITLE
[SPARK-51452][UI] Improve Thread dump table search

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/table.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/table.js
@@ -94,7 +94,6 @@ function onSearchStringChange() {
       let i = 0;
       while(!found && i < children.length) {
         if (children.eq(i).text().toLowerCase().indexOf(searchString) >= 0) {
-          console.log(children.eq(i).text());
           found = true;
         } else {
           i++;

--- a/core/src/main/resources/org/apache/spark/ui/static/table.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/table.js
@@ -82,31 +82,27 @@ function onMouseOverAndOut(threadId) {
 }
 
 function onSearchStringChange() {
-  var searchString = $('#search').val().toLowerCase();
+  const searchString = $('#search').val().toLowerCase();
   //remove the stacktrace
   collapseAllThreadStackTrace(false);
-  if (searchString.length == 0) {
-    $('tr').each(function() {
+  $('tr[id^="thread_"]').each(function() {
+    if (searchString.length === 0) {
       $(this).removeClass('d-none')
-    })
-  } else {
-    $('tr').each(function(){
-      if($(this).attr('id') && $(this).attr('id').match(/thread_[0-9]+_tr/) ) {
-        var children = $(this).children();
-        var found = false;
-        for (var i = 0; i < children.length; i++) {
-          if (children.eq(i).text().toLowerCase().indexOf(searchString) >= 0) {
-            found = true;
-          }
-        }
-        if (found) {
-          $(this).removeClass('d-none')
+    } else {
+      let found = false;
+      const children = $(this).children();
+      let i = 0;
+      while(!found && i < children.length) {
+        if (children.eq(i).text().toLowerCase().indexOf(searchString) >= 0) {
+          console.log(children.eq(i).text());
+          found = true;
         } else {
-          $(this).addClass('d-none')
+          i++;
         }
       }
-    });
-  }
+      $(this).toggleClass('d-none', !found);
+    }
+  });
 }
 /* eslint-enable no-unused-vars */
 


### PR DESCRIPTION
### What changes were proposed in this pull request?


This PR improves thread dump search by:
- query with pattern `tr[id^="thread_"]` w/o further patten matching
- short-circuit the searching loop if found
- 
### Why are the changes needed?

code refactoring for perf & cost


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
![image](https://github.com/user-attachments/assets/306c6d72-8182-4a96-85a0-c3a19d733be7)


### Was this patch authored or co-authored using generative AI tooling?
no