### PR TITLE
[SPARK-51453] [SQL] AssertTrue uses toPrettySQL instead of simpleString

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.trees.TreePattern.{CURRENT_LIKE, TreePattern}
-import org.apache.spark.sql.catalyst.util.{MapData, RandomUUIDGenerator}
+import org.apache.spark.sql.catalyst.util.{toPrettySQL, MapData, RandomUUIDGenerator}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.errors.QueryExecutionErrors.raiseError
 import org.apache.spark.sql.internal.SQLConf
@@ -179,7 +179,7 @@ case class AssertTrue(left: Expression, right: Expression, replacement: Expressi
   }
 
   def this(left: Expression) = {
-    this(left, Literal(s"'${left.simpleString(SQLConf.get.maxToStringFields)}' is not true!"))
+    this(left, Literal(s"'${toPrettySQL(left)}' is not true!"))
   }
 
   override def parameters: Seq[Expression] = Seq(left, right)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/misc-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/misc-functions.sql.out
@@ -50,7 +50,7 @@ Project [typeof(array(1, 2)) AS typeof(array(1, 2))#x, typeof(map(1, 2)) AS type
 -- !query
 SELECT assert_true(true), assert_true(boolean(1))
 -- !query analysis
-Project [assert_true(true, 'true' is not true!) AS assert_true(true, 'true' is not true!)#x, assert_true(cast(1 as boolean), 'cast(1 as boolean)' is not true!) AS assert_true(1, 'cast(1 as boolean)' is not true!)#x]
+Project [assert_true(true, 'true' is not true!) AS assert_true(true, 'true' is not true!)#x, assert_true(cast(1 as boolean), '1' is not true!) AS assert_true(1, '1' is not true!)#x]
 +- OneRowRelation
 
 
@@ -64,21 +64,21 @@ Project [assert_true(false, 'false' is not true!) AS assert_true(false, 'false' 
 -- !query
 SELECT assert_true(boolean(0))
 -- !query analysis
-Project [assert_true(cast(0 as boolean), 'cast(0 as boolean)' is not true!) AS assert_true(0, 'cast(0 as boolean)' is not true!)#x]
+Project [assert_true(cast(0 as boolean), '0' is not true!) AS assert_true(0, '0' is not true!)#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT assert_true(null)
 -- !query analysis
-Project [assert_true(null, 'null' is not true!) AS assert_true(NULL, 'null' is not true!)#x]
+Project [assert_true(null, 'NULL' is not true!) AS assert_true(NULL, 'NULL' is not true!)#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT assert_true(boolean(null))
 -- !query analysis
-Project [assert_true(cast(null as boolean), 'cast(null as boolean)' is not true!) AS assert_true(NULL, 'cast(null as boolean)' is not true!)#x]
+Project [assert_true(cast(null as boolean), 'NULL' is not true!) AS assert_true(NULL, 'NULL' is not true!)#x]
 +- OneRowRelation
 
 

--- a/sql/core/src/test/resources/sql-tests/results/misc-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/misc-functions.sql.out
@@ -58,7 +58,7 @@ array<int>	map<int,int>	struct<a:int,b:string>
 -- !query
 SELECT assert_true(true), assert_true(boolean(1))
 -- !query schema
-struct<assert_true(true, 'true' is not true!):void,assert_true(1, 'cast(1 as boolean)' is not true!):void>
+struct<assert_true(true, 'true' is not true!):void,assert_true(1, '1' is not true!):void>
 -- !query output
 NULL	NULL
 
@@ -88,7 +88,7 @@ org.apache.spark.SparkRuntimeException
   "errorClass" : "USER_RAISED_EXCEPTION",
   "sqlState" : "P0001",
   "messageParameters" : {
-    "errorMessage" : "'cast(0 as boolean)' is not true!"
+    "errorMessage" : "'0' is not true!"
   }
 }
 
@@ -103,7 +103,7 @@ org.apache.spark.SparkRuntimeException
   "errorClass" : "USER_RAISED_EXCEPTION",
   "sqlState" : "P0001",
   "messageParameters" : {
-    "errorMessage" : "'null' is not true!"
+    "errorMessage" : "'NULL' is not true!"
   }
 }
 
@@ -118,7 +118,7 @@ org.apache.spark.SparkRuntimeException
   "errorClass" : "USER_RAISED_EXCEPTION",
   "sqlState" : "P0001",
   "messageParameters" : {
-    "errorMessage" : "'cast(null as boolean)' is not true!"
+    "errorMessage" : "'NULL' is not true!"
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -2596,8 +2596,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
     val e3 = intercept[SparkRuntimeException] {
       intDf.select(assert_true($"a" > $"b")).collect()
     }
-    assert(e3.getMessage.matches(
-      "\\[USER_RAISED_EXCEPTION\\] '\\(a#\\d+ > b#\\d+\\)' is not true! SQLSTATE: P0001"))
+    assert(e3.getMessage.equals("[USER_RAISED_EXCEPTION] '(a > b)' is not true! SQLSTATE: P0001"))
   }
 
   test("raise_error") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `AssertTrue` constructor use `toPrettySQL` instead of `simpleString`.

### Why are the changes needed?
Because of `simpleString` usage we end up having `ExpressionId`s in expression values (and thus in output schema) which can be queried. This is invalid because the behavior of this feature is non-deterministic (query which passes will fail with a cluster restart). Example:

```
SELECT assert_true(col <= col_2) FROM (VALUES ('2025-03-01', '2025-03-10')) t(col,col_2)
```
Output schema will be: `assert_true((col <= col_2), '(col#1214095 <= col_2#1214096)' is not true!)`

### Does this PR introduce _any_ user-facing change?
Some SQL queries are going to fail (but they would fail with every cluster reset, as explained).

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.