### PR TITLE
[SPARK-51457][R][INFRA] Use R 4.4.3 in `windows` R GitHub Action job

### DIFF
--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: "Build / SparkR-only (master, 4.4.2, windows-2022)"
+name: "Build / SparkR-only (master, 4.4.3, windows-2022)"
 
 on:
   schedule:
@@ -51,10 +51,10 @@ jobs:
       with:
         distribution: zulu
         java-version: 17
-    - name: Install R 4.4.2
+    - name: Install R 4.4.3
       uses: r-lib/actions/setup-r@v2
       with:
-        r-version: 4.4.2
+        r-version: 4.4.3
     - name: Install R dependencies
       run: |
         Rscript -e "install.packages(c('knitr', 'rmarkdown', 'testthat', 'e1071', 'survival', 'arrow', 'xml2'), repos='https://cloud.r-project.org/')"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use R 4.4.3 in `windows` R GitHub Action job.

### Why are the changes needed?

To have a test coverage for the latest R version.
- [R 4.4.3 (2025-02-28, Trophy Case) Announcement](https://stat.ethz.ch/pipermail/r-announce/2024/000699.html)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.