### PR TITLE
[SPARK-51479][SQL] Nullable in Row Level Operation Column is not correct

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableUpdateAsDeleteAndInsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableUpdateAsDeleteAndInsertSuite.scala
@@ -82,4 +82,55 @@ class DeltaBasedMergeIntoTableUpdateAsDeleteAndInsertSuite
         insertWriteLogEntry(data = Row(6, 0, "new")))
     }
   }
+
+  test("SPARK-51479: Test Column Nullable") {
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |{ "pk": 4, "salary": 400, "dep": "hr" }
+            |{ "pk": 5, "salary": 500, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(3, 4, 5, 6).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        sql(
+          s"""MERGE INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | UPDATE SET t.salary = 1000
+             |WHEN NOT MATCHED THEN
+             | INSERT (pk, salary, dep) VALUES (s.pk, 0, 'new')
+             |WHEN NOT MATCHED BY SOURCE AND pk = 1 THEN
+             | DELETE
+             |""".stripMargin)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, 200, "software"), // unchanged
+            Row(3, 1000, "hr"), // update
+            Row(4, 1000, "hr"), // update
+            Row(5, 1000, "hr"), // update
+            Row(6, 0, "new"))) // insert
+
+        checkLastWriteInfo(
+          expectedRowSchema = table.schema,
+          expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+          expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
+
+        checkLastWriteLog(
+          deleteWriteLogEntry(id = 1, metadata = Row("hr", null)),
+          deleteWriteLogEntry(id = 3, metadata = Row("hr", null)),
+          reinsertWriteLogEntry(metadata = Row("hr", null), data = Row(3, 1000, "hr")),
+          deleteWriteLogEntry(id = 4, metadata = Row("hr", null)),
+          reinsertWriteLogEntry(metadata = Row("hr", null), data = Row(4, 1000, "hr")),
+          deleteWriteLogEntry(id = 5, metadata = Row("hr", null)),
+          reinsertWriteLogEntry(metadata = Row("hr", null), data = Row(5, 1000, "hr")),
+          insertWriteLogEntry(data = Row(6, 0, "new")))
+      }
+    }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateAsDeleteAndInsertTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateAsDeleteAndInsertTableSuite.scala
@@ -45,10 +45,7 @@ class DeltaBasedUpdateAsDeleteAndInsertTableSuite extends DeltaBasedUpdateTableS
       Row(1, -1, "hr") :: Row(2, 2, "software") :: Row(3, 3, "hr") :: Nil)
 
     checkLastWriteInfo(
-      expectedRowSchema = StructType(table.schema.map {
-        case attr if attr.name == "id" => attr.copy(nullable = false) // input is a constant
-        case attr => attr
-      }),
+      expectedRowSchema = table.schema,
       expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
       expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
 
@@ -82,10 +79,7 @@ class DeltaBasedUpdateAsDeleteAndInsertTableSuite extends DeltaBasedUpdateTableS
         Row(1, -1, "hr") :: Row(2, 2, "software") :: Row(3, 3, "hr") :: Nil)
 
       checkLastWriteInfo(
-        expectedRowSchema = StructType(table.schema.map {
-          case attr if attr.name == "id" => attr.copy(nullable = false) // input is a constant
-          case attr => attr
-        }),
+        expectedRowSchema = table.schema,
         expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
         expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateTableSuite.scala
@@ -44,10 +44,7 @@ class DeltaBasedUpdateTableSuite extends DeltaBasedUpdateTableSuiteBase {
       Row(1, -1, "hr") :: Row(2, 2, "software") :: Row(3, 3, "hr") :: Nil)
 
     checkLastWriteInfo(
-      expectedRowSchema = StructType(table.schema.map {
-        case attr if attr.name == "id" => attr.copy(nullable = false) // input is a constant
-        case attr => attr
-      }),
+      expectedRowSchema = table.schema,
       expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
       expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
 
@@ -80,10 +77,7 @@ class DeltaBasedUpdateTableSuite extends DeltaBasedUpdateTableSuiteBase {
         Row(1, -1, "hr") :: Row(2, 2, "software") :: Row(3, 3, "hr") :: Nil)
 
       checkLastWriteInfo(
-        expectedRowSchema = StructType(table.schema.map {
-          case attr if attr.name == "id" => attr.copy(nullable = false) // input is a constant
-          case attr => attr
-        }),
+        expectedRowSchema = table.schema,
         expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
         expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
 


### PR DESCRIPTION


### What changes were proposed in this pull request?
fix nullable in Row Level Operation column


### Why are the changes needed?
In iceberg/spark 4.0 integration, there are a few test failures because of nullable is not correctly computed. 

```
TestMergeOnReadUpdate > testUpdateWithMultiColumnInSubquery() > catalogName = spark_catalog, implementation = org.apache.iceberg.spark.SparkSessionCatalog, config = {type=hive, default-namespace=default, clients=1, parquet-enabled=false, cache-enabled=false}, format = AVRO, vectorized = false, distributionMode = range, fanout = false, branch = test, planningMode = DISTRIBUTED, formatVersion = 3 FAILED
    java.lang.IllegalArgumentException: Provided metadata schema is incompatible with expected schema:
    table {
      2147483643: _spec_id: required int (Spec ID used to track the file containing a row)
      2147483642: _partition: optional struct<> (Partition to which a row belongs to)
    }
    Provided schema:
    table {
      2147483643: _spec_id: optional int
      2147483642: _partition: optional struct<>
    }
    Problems:
    * _spec_id should be required, but is optional
        at org.apache.iceberg.types.TypeUtil.checkSchemaCompatibility(TypeUtil.java:493)
```

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
new test


### Was this patch authored or co-authored using generative AI tooling?
no
