### PR TITLE
[SPARK-51484][SS] Remove unused function `private def newDFSFileName(String)` from `RocksDBFileManager`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -870,12 +870,6 @@ class RocksDBFileManager(
       log"${MDC(LogKeys.FILE_NAME, files.mkString("\n\t"))}")
   }
 
-  private def newDFSFileName(localFileName: String): String = {
-    val baseName = FilenameUtils.getBaseName(localFileName)
-    val extension = FilenameUtils.getExtension(localFileName)
-    s"$baseName-${UUID.randomUUID}.$extension"
-  }
-
   def newDFSFileName(localFileName: String, dfsFileSuffix: String): String = {
     val baseName = FilenameUtils.getBaseName(localFileName)
     val extension = FilenameUtils.getExtension(localFileName)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.execution.streaming.state
 import java.io.{File, FileInputStream, InputStream}
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
-import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.zip.{ZipEntry, ZipOutputStream}
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to remove unused function `private def newDFSFileName(String)` from `RocksDBFileManager`, It is no longer used after SPARK-49770 (https://github.com/apache/spark/pull/47875)



### Why are the changes needed?
Code cleanup.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No