### PR TITLE
[SPARK-51574][PYTHON] Filter serialization for Python Data Source filter pushdown

### DIFF
--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -309,75 +309,124 @@ class Filter(ABC):
 
 @dataclass(frozen=True)
 class EqualTo(Filter):
+    """
+    A filter that evaluates to `True` iff the column evaluates to a value
+    equal to `value`.
+    """
     attribute: ColumnPath
     value: Any
 
 
 @dataclass(frozen=True)
 class EqualNullSafe(Filter):
+    """
+    Performs equality comparison, similar to EqualTo. However, this differs from EqualTo
+    in that it returns `true` (rather than NULL) if both inputs are NULL, and `false`
+    (rather than NULL) if one of the input is NULL and the other is not NULL.
+    """
     attribute: ColumnPath
     value: Any
 
-
 @dataclass(frozen=True)
 class GreaterThan(Filter):
+    """
+    A filter that evaluates to `True` iff the attribute evaluates to a value
+    greater than `value`.
+    """
     attribute: ColumnPath
     value: Any
 
 
 @dataclass(frozen=True)
 class GreaterThanOrEqual(Filter):
+    """
+    A filter that evaluates to `True` iff the attribute evaluates to a value
+    greater than or equal to `value`.
+    """
     attribute: ColumnPath
     value: Any
 
 
 @dataclass(frozen=True)
 class LessThan(Filter):
+    """
+    A filter that evaluates to `True` iff the attribute evaluates to a value
+    less than `value`.
+    """
     attribute: ColumnPath
     value: Any
 
 
 @dataclass(frozen=True)
 class LessThanOrEqual(Filter):
+    """
+    A filter that evaluates to `True` iff the attribute evaluates to a value
+    less than or equal to `value`.
+    """
     attribute: ColumnPath
     value: Any
 
 
 @dataclass(frozen=True)
 class In(Filter):
+    """
+    A filter that evaluates to `True` iff the attribute evaluates to one of the values
+    in the array.
+    """
     attribute: ColumnPath
     value: Tuple[Any, ...]
 
 
 @dataclass(frozen=True)
 class IsNull(Filter):
+    """
+    A filter that evaluates to `True` iff the attribute evaluates to null.
+    """
     attribute: ColumnPath
 
 
 @dataclass(frozen=True)
 class IsNotNull(Filter):
+    """
+    A filter that evaluates to `True` iff the attribute evaluates to a non-null value.
+    """
     attribute: ColumnPath
 
 
 @dataclass(frozen=True)
 class Not(Filter):
+    """
+    A filter that evaluates to `True` iff `child` is evaluated to `False`.
+    """
     child: Filter
 
 
 @dataclass(frozen=True)
 class StringStartsWith(Filter):
+    """
+    A filter that evaluates to `True` iff the attribute evaluates to
+    a string that starts with `value`.
+    """
     attribute: ColumnPath
     value: str
 
 
 @dataclass(frozen=True)
 class StringEndsWith(Filter):
+    """
+    A filter that evaluates to `True` iff the attribute evaluates to
+    a string that ends with `value`.
+    """
     attribute: ColumnPath
     value: str
 
 
 @dataclass(frozen=True)
 class StringContains(Filter):
+    """
+    A filter that evaluates to `True` iff the attribute evaluates to
+    a string that contains the string `value`.
+    """
     attribute: ColumnPath
     value: str
 

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -296,6 +296,7 @@ class Filter(ABC):
     | `a = 1`             | `EqualTo(("a", "b", "c"), 1)`              |
     | `a = 'hi'`          | `EqualTo(("a",), "hi")`                    |
     | `a = array(1, 2)`   | `EqualTo(("a",), [1, 2])`                  |
+    | `a <> 1`            | `Not(EqualTo(("a",), 1))`                  |
     +---------------------+--------------------------------------------+
 
     Unsupported filters
@@ -356,6 +357,11 @@ class IsNull(Filter):
 @dataclass(frozen=True)
 class IsNotNull(Filter):
     attribute: ColumnPath
+
+
+@dataclass(frozen=True)
+class Not(Filter):
+    child: Filter
 
 
 @dataclass(frozen=True)

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -312,6 +312,70 @@ class EqualTo(Filter):
     value: Any
 
 
+@dataclass(frozen=True)
+class EqualNullSafe(Filter):
+    attribute: ColumnPath
+    value: Any
+
+
+@dataclass(frozen=True)
+class GreaterThan(Filter):
+    attribute: ColumnPath
+    value: Any
+
+
+@dataclass(frozen=True)
+class GreaterThanOrEqual(Filter):
+    attribute: ColumnPath
+    value: Any
+
+
+@dataclass(frozen=True)
+class LessThan(Filter):
+    attribute: ColumnPath
+    value: Any
+
+
+@dataclass(frozen=True)
+class LessThanOrEqual(Filter):
+    attribute: ColumnPath
+    value: Any
+
+
+@dataclass(frozen=True)
+class In(Filter):
+    attribute: ColumnPath
+    value: Tuple[Any, ...]
+
+
+@dataclass(frozen=True)
+class IsNull(Filter):
+    attribute: ColumnPath
+
+
+@dataclass(frozen=True)
+class IsNotNull(Filter):
+    attribute: ColumnPath
+
+
+@dataclass(frozen=True)
+class StringStartsWith(Filter):
+    attribute: ColumnPath
+    value: str
+
+
+@dataclass(frozen=True)
+class StringEndsWith(Filter):
+    attribute: ColumnPath
+    value: str
+
+
+@dataclass(frozen=True)
+class StringContains(Filter):
+    attribute: ColumnPath
+    value: str
+
+
 class InputPartition:
     """
     A base class representing an input partition returned by the `partitions()`

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -282,9 +282,6 @@ class Filter(ABC):
     See `Data Types <https://spark.apache.org/docs/latest/sql-ref-datatypes.html>`_
     for more information about how values are represented in Python.
 
-    Currently only the equality of attribute and literal value is supported for
-    filter pushdown. Other types of filters cannot be pushed down.
-
     Examples
     --------
     Supported filters
@@ -293,10 +290,22 @@ class Filter(ABC):
     | SQL filter          | Representation                             |
     +---------------------+--------------------------------------------+
     | `a.b.c = 1`         | `EqualTo(("a", "b", "c"), 1)`              |
-    | `a = 1`             | `EqualTo(("a", "b", "c"), 1)`              |
+    | `a = 1`             | `EqualTo(("a",), 1)`                       |
     | `a = 'hi'`          | `EqualTo(("a",), "hi")`                    |
     | `a = array(1, 2)`   | `EqualTo(("a",), [1, 2])`                  |
+    | `a`                 | `EqualTo(("a",), True)`                    |
+    | `not a`             | `Not(EqualTo(("a",), True))`               |
     | `a <> 1`            | `Not(EqualTo(("a",), 1))`                  |
+    | `a > 1`             | `GreaterThan(("a",), 1)`                   |
+    | `a >= 1`            | `GreaterThanOrEqual(("a",), 1)`            |
+    | `a < 1`             | `LessThan(("a",), 1)`                      |
+    | `a <= 1`            | `LessThanOrEqual(("a",), 1)`               |
+    | `a in (1, 2, 3)`    | `In(("a",), (1, 2, 3))`                    |
+    | `a is null`         | `IsNull(("a",))`                           |
+    | `a is not null`     | `IsNotNull(("a",))`                        |
+    | `a like 'abc%'`     | `StringStartsWith(("a",), "abc")`          |
+    | `a like '%abc'`     | `StringEndsWith(("a",), "abc")`            |
+    | `a like '%abc%'`    | `StringContains(("a",), "abc")`            |
     +---------------------+--------------------------------------------+
 
     Unsupported filters
@@ -304,6 +313,10 @@ class Filter(ABC):
     - `f(a, b) = 1`
     - `a % 2 = 1`
     - `a[0] = 1`
+    - `a < 0 or a > 1`
+    - `a like 'c%c%'`
+    - `a ilike 'hi'`
+    - `a = 'hi' collate zh`
     """
 
 

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -326,6 +326,7 @@ class EqualTo(Filter):
     A filter that evaluates to `True` iff the column evaluates to a value
     equal to `value`.
     """
+
     attribute: ColumnPath
     value: Any
 
@@ -337,8 +338,10 @@ class EqualNullSafe(Filter):
     in that it returns `true` (rather than NULL) if both inputs are NULL, and `false`
     (rather than NULL) if one of the input is NULL and the other is not NULL.
     """
+
     attribute: ColumnPath
     value: Any
+
 
 @dataclass(frozen=True)
 class GreaterThan(Filter):
@@ -346,6 +349,7 @@ class GreaterThan(Filter):
     A filter that evaluates to `True` iff the attribute evaluates to a value
     greater than `value`.
     """
+
     attribute: ColumnPath
     value: Any
 
@@ -356,6 +360,7 @@ class GreaterThanOrEqual(Filter):
     A filter that evaluates to `True` iff the attribute evaluates to a value
     greater than or equal to `value`.
     """
+
     attribute: ColumnPath
     value: Any
 
@@ -366,6 +371,7 @@ class LessThan(Filter):
     A filter that evaluates to `True` iff the attribute evaluates to a value
     less than `value`.
     """
+
     attribute: ColumnPath
     value: Any
 
@@ -376,6 +382,7 @@ class LessThanOrEqual(Filter):
     A filter that evaluates to `True` iff the attribute evaluates to a value
     less than or equal to `value`.
     """
+
     attribute: ColumnPath
     value: Any
 
@@ -386,6 +393,7 @@ class In(Filter):
     A filter that evaluates to `True` iff the attribute evaluates to one of the values
     in the array.
     """
+
     attribute: ColumnPath
     value: Tuple[Any, ...]
 
@@ -395,6 +403,7 @@ class IsNull(Filter):
     """
     A filter that evaluates to `True` iff the attribute evaluates to null.
     """
+
     attribute: ColumnPath
 
 
@@ -403,6 +412,7 @@ class IsNotNull(Filter):
     """
     A filter that evaluates to `True` iff the attribute evaluates to a non-null value.
     """
+
     attribute: ColumnPath
 
 
@@ -411,6 +421,7 @@ class Not(Filter):
     """
     A filter that evaluates to `True` iff `child` is evaluated to `False`.
     """
+
     child: Filter
 
 
@@ -420,6 +431,7 @@ class StringStartsWith(Filter):
     A filter that evaluates to `True` iff the attribute evaluates to
     a string that starts with `value`.
     """
+
     attribute: ColumnPath
     value: str
 
@@ -430,6 +442,7 @@ class StringEndsWith(Filter):
     A filter that evaluates to `True` iff the attribute evaluates to
     a string that ends with `value`.
     """
+
     attribute: ColumnPath
     value: str
 
@@ -440,6 +453,7 @@ class StringContains(Filter):
     A filter that evaluates to `True` iff the attribute evaluates to
     a string that contains the string `value`.
     """
+
     attribute: ColumnPath
     value: str
 

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -40,6 +40,7 @@ from pyspark.sql.datasource import (
     IsNull,
     LessThan,
     LessThanOrEqual,
+    Not,
     StringContains,
     StringEndsWith,
     StringStartsWith,
@@ -416,11 +417,9 @@ class BasePythonDataSourceTestsMixin:
         self._check_filters(
             "struct<a:int, b:int, c:int>", "x.a = 1 and x.b = x.c", [EqualTo(("x", "a"), 1)]
         )
-        self._check_filters("int", "x <> 0", [])
         self._check_filters("int", "x = 1 or x > 2", [])
         self._check_filters("int", "(0 < x and x < 1) or x = 2", [])
         self._check_filters("int", "x % 5 = 1", [])
-        self._check_filters("boolean", "not x", [])
         self._check_filters("array<int>", "x[0] = 1", [])
 
     def test_filter_value_type(self):
@@ -448,7 +447,9 @@ class BasePythonDataSourceTestsMixin:
 
     def test_filter_type(self):
         self._check_filters("boolean", "x", [EqualTo(("x",), True)])
+        self._check_filters("boolean", "not x", [Not(EqualTo(("x",), True))])
         self._check_filters("int", "x is null", [IsNull(("x",))])
+        self._check_filters("int", "x <> 0", [Not(EqualTo(("x",), 0))])
         self._check_filters("int", "x <=> 1", [EqualNullSafe(("x",), 1)])
         self._check_filters("int", "1 < x", [GreaterThan(("x",), 1)])
         self._check_filters("int", "1 <= x", [GreaterThanOrEqual(("x",), 1)])

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -421,6 +421,9 @@ class BasePythonDataSourceTestsMixin:
         self._check_filters("int", "(0 < x and x < 1) or x = 2", [])
         self._check_filters("int", "x % 5 = 1", [])
         self._check_filters("array<int>", "x[0] = 1", [])
+        self._check_filters("string", "x like 'a%a%'", [])
+        self._check_filters("string", "x ilike 'a'", [])
+        self._check_filters("string", "x = 'a' collate zh", [])
 
     def test_filter_value_type(self):
         self._check_filters("int", "x = 1", [EqualTo(("x",), 1)])
@@ -455,9 +458,12 @@ class BasePythonDataSourceTestsMixin:
         self._check_filters("int", "1 <= x", [GreaterThanOrEqual(("x",), 1)])
         self._check_filters("int", "x < 1", [LessThan(("x",), 1)])
         self._check_filters("int", "x <= 1", [LessThanOrEqual(("x",), 1)])
-        self._check_filters("string", "startswith(x, 'a')", [StringStartsWith(("x",), "a")])
-        self._check_filters("string", "endswith(x, 'a')", [StringEndsWith(("x",), "a")])
-        self._check_filters("string", "contains(x, 'a')", [StringContains(("x",), "a")])
+        self._check_filters("string", "x like 'a%'", [StringStartsWith(("x",), "a")])
+        self._check_filters("string", "x like '%a'", [StringEndsWith(("x",), "a")])
+        self._check_filters("string", "x like '%a%'", [StringContains(("x",), "a")])
+        self._check_filters(
+            "string", "x like 'a%b'", [StringStartsWith(("x",), "a"), StringEndsWith(("x",), "b")]
+        )
         self._check_filters("int", "x in (1, 2)", [In(("x",), [1, 2])])
 
     def test_filter_nested_column(self):

--- a/python/pyspark/sql/worker/data_source_pushdown_filters.py
+++ b/python/pyspark/sql/worker/data_source_pushdown_filters.py
@@ -15,17 +15,37 @@
 # limitations under the License.
 #
 
+import base64
 import faulthandler
+import json
 import os
 import sys
+import typing
 from dataclasses import dataclass, field
-from typing import IO, List
+from typing import IO, Type, Union
 
 from pyspark.accumulators import _accumulatorRegistry
 from pyspark.errors import PySparkAssertionError, PySparkValueError
+from pyspark.errors.exceptions.base import PySparkNotImplementedError
 from pyspark.serializers import SpecialLengths, UTF8Deserializer, read_int, write_int
-from pyspark.sql.datasource import DataSource, DataSourceReader, EqualTo, Filter
-from pyspark.sql.types import StructType, _parse_datatype_json_string
+from pyspark.sql.datasource import (
+    DataSource,
+    DataSourceReader,
+    EqualNullSafe,
+    EqualTo,
+    Filter,
+    GreaterThan,
+    GreaterThanOrEqual,
+    In,
+    IsNotNull,
+    IsNull,
+    LessThan,
+    LessThanOrEqual,
+    StringContains,
+    StringEndsWith,
+    StringStartsWith,
+)
+from pyspark.sql.types import StructType, VariantVal, _parse_datatype_json_string
 from pyspark.util import handle_worker_exception, local_connect_and_auth
 from pyspark.worker_util import (
     check_python_version,
@@ -39,6 +59,25 @@ from pyspark.worker_util import (
 
 utf8_deserializer = UTF8Deserializer()
 
+BinaryFilter = Union[
+    EqualTo,
+    EqualNullSafe,
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThan,
+    LessThanOrEqual,
+    In,
+    StringStartsWith,
+    StringEndsWith,
+    StringContains,
+]
+
+binary_filters = {cls.__name__: cls for cls in typing.get_args(BinaryFilter)}
+
+UnaryFilter = Union[IsNotNull, IsNull]
+
+unary_filters = {cls.__name__: cls for cls in typing.get_args(UnaryFilter)}
+
 
 @dataclass(frozen=True)
 class FilterRef:
@@ -47,6 +86,30 @@ class FilterRef:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "id", id(self.filter))
+
+
+def deserializeVariant(variantDict: dict) -> VariantVal:
+    value = base64.b64decode(variantDict["value"])
+    metadata = base64.b64decode(variantDict["metadata"])
+    return VariantVal(value, metadata)
+
+
+def deserializeFilter(jsonDict: dict) -> Filter:
+    name = jsonDict["name"]
+    if name in binary_filters:
+        binary_filter_cls: Type[BinaryFilter] = binary_filters[name]
+        return binary_filter_cls(
+            attribute=tuple(jsonDict["columnPath"]),
+            value=deserializeVariant(jsonDict["value"]).toPython(),
+        )
+    elif name in unary_filters:
+        unary_filter_cls: Type[UnaryFilter] = unary_filters[name]
+        return unary_filter_cls(attribute=tuple(jsonDict["columnPath"]))
+    else:
+        raise PySparkNotImplementedError(
+            errorClass="UNSUPPORTED_FILTER",
+            messageParameters={"name": name},
+        )
 
 
 def main(infile: IO, outfile: IO) -> None:
@@ -126,22 +189,9 @@ def main(infile: IO, outfile: IO) -> None:
             )
 
         # Receive the pushdown filters.
-        num_filters = read_int(infile)
-        filters: List[FilterRef] = []
-        for _ in range(num_filters):
-            name = utf8_deserializer.loads(infile)
-            if name == "EqualTo":
-                num_parts = read_int(infile)
-                column_path = tuple(utf8_deserializer.loads(infile) for _ in range(num_parts))
-                value = read_int(infile)
-                filters.append(FilterRef(EqualTo(column_path, value)))
-            else:
-                raise PySparkAssertionError(
-                    errorClass="DATA_SOURCE_UNSUPPORTED_FILTER",
-                    messageParameters={
-                        "name": name,
-                    },
-                )
+        json_str = utf8_deserializer.loads(infile)
+        filter_dicts = json.loads(json_str)
+        filters = [FilterRef(deserializeFilter(f)) for f in filter_dicts]
 
         # Push down the filters and get the indices of the unsupported filters.
         unsupported_filters = set(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/UserDefinedPythonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/UserDefinedPythonDataSource.scala
@@ -22,10 +22,16 @@ import java.io.{DataInputStream, DataOutputStream}
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonInclude}
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import net.razorvine.pickle.Pickler
 
 import org.apache.spark.api.python._
+import org.apache.spark.sql.catalyst.CatalystTypeConverters
 import org.apache.spark.sql.catalyst.expressions.PythonUDF
+import org.apache.spark.sql.catalyst.expressions.variant.VariantExpressionEvalUtils
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.metric.{CustomMetric, CustomTaskMetric}
@@ -35,8 +41,9 @@ import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.python.{ArrowPythonRunner, MapInBatchEvaluatorFactory, PythonPlannerRunner, PythonSQLMetrics}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.types.{BinaryType, DataType, StructType}
+import org.apache.spark.sql.types.{ArrayType, BinaryType, DataType, StructField, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.unsafe.types.VariantVal
 import org.apache.spark.util.ArrayImplicits._
 
 /**
@@ -347,15 +354,75 @@ private class UserDefinedPythonDataSourceFilterPushdownRunner(
   private case class SerializedFilter(
       name: String,
       columnPath: collection.Seq[String],
-      value: Int,
+      @JsonInclude(JsonInclude.Include.NON_ABSENT)
+      value: Option[VariantVal],
+      @JsonIgnore
       index: Int)
+
+  private val mapper = new ObjectMapper().registerModules(DefaultScalaModule)
+
+  private def getField(attribute: String): (Seq[String], StructField) = {
+    val columnPath = CatalystSqlParser.parseMultipartIdentifier(attribute)
+    val (_, field) = schema
+      .findNestedField(columnPath, includeCollections = true)
+      .getOrElse(
+        throw QueryCompilationErrors.pythonDataSourceError(
+          action = "plan",
+          tpe = "filter",
+          msg = s"Cannot find field $columnPath in schema"
+        )
+      )
+    (columnPath, field)
+  }
 
   private val serializedFilters = filters.zipWithIndex.flatMap {
     case (filter, i) =>
+      def construct(
+          name: String,
+          attribute: String,
+          value: Option[Any],
+          mapDataType: DataType => DataType = identity): Option[SerializedFilter] = {
+        val (columnPath, field) = getField(attribute)
+        val dataType = mapDataType(field.dataType)
+        val variant = for (v <- value) yield {
+          val catalystValue = CatalystTypeConverters.convertToCatalyst(v)
+          try {
+            VariantExpressionEvalUtils.castToVariant(catalystValue, dataType)
+          } catch {
+            case _: MatchError =>
+              // filter is unsupported if we can't cast it to variant
+              return None
+          }
+        }
+        Some(SerializedFilter(name, columnPath, variant, i))
+      }
+
       filter match {
-        case filter @ org.apache.spark.sql.sources.EqualTo(_, value: Int) =>
-          val columnPath = filter.v2references.head
-          Some(SerializedFilter("EqualTo", columnPath, value, i))
+        case org.apache.spark.sql.sources.EqualTo(attribute, value) =>
+          construct("EqualTo", attribute, Some(value))
+        case org.apache.spark.sql.sources.EqualNullSafe(attribute, value) =>
+          construct("EqualNullSafe", attribute, Some(value))
+        case org.apache.spark.sql.sources.GreaterThan(attribute, value) =>
+          construct("GreaterThan", attribute, Some(value))
+        case org.apache.spark.sql.sources.GreaterThanOrEqual(attribute, value) =>
+          construct("GreaterThanOrEqual", attribute, Some(value))
+        case org.apache.spark.sql.sources.LessThan(attribute, value) =>
+          construct("LessThan", attribute, Some(value))
+        case org.apache.spark.sql.sources.LessThanOrEqual(attribute, value) =>
+          construct("LessThanOrEqual", attribute, Some(value))
+        case org.apache.spark.sql.sources.In(attribute, value) =>
+          construct("In", attribute, Some(value), ArrayType(_))
+        case org.apache.spark.sql.sources.IsNull(attribute) =>
+          construct("IsNull", attribute, None)
+        case org.apache.spark.sql.sources.IsNotNull(attribute) =>
+          construct("IsNotNull", attribute, None)
+        case org.apache.spark.sql.sources.StringStartsWith(attribute, value) =>
+          construct("StringStartsWith", attribute, Some(value))
+        case org.apache.spark.sql.sources.StringEndsWith(attribute, value) =>
+          construct("StringEndsWith", attribute, Some(value))
+        case org.apache.spark.sql.sources.StringContains(attribute, value) =>
+          construct("StringContains", attribute, Some(value))
+        // collation aware filters are currently not supported
         case _ =>
           None
       }
@@ -374,16 +441,8 @@ private class UserDefinedPythonDataSourceFilterPushdownRunner(
     PythonWorkerUtils.writeUTF(schema.json, dataOut)
 
     // Send the filters
-    // For now only handle EqualTo filter on int
-    dataOut.writeInt(serializedFilters.length)
-    for (f <- serializedFilters) {
-      PythonWorkerUtils.writeUTF(f.name, dataOut)
-      dataOut.writeInt(f.columnPath.length)
-      for (path <- f.columnPath) {
-        PythonWorkerUtils.writeUTF(path, dataOut)
-      }
-      dataOut.writeInt(f.value)
-    }
+    // For now only handle EqualTo filter
+    PythonWorkerUtils.writeUTF(mapper.writeValueAsString(serializedFilters), dataOut)
   }
 
   override protected def receiveFromPython(dataIn: DataInputStream): PythonFilterPushdownResult = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -236,7 +236,9 @@ class PythonDataSourceSuite extends PythonDataSourceSuiteBase {
          |        return [InputPartition(i) for i in range(2)]
          |
          |    def pushFilters(self, filters):
-         |        yield filters[filters.index(EqualTo(("id",), 1))]
+         |        for filter in filters:
+         |            if filter != EqualTo(("partition",), 0):
+         |                yield filter
          |
          |    def read(self, partition):
          |        yield (0, partition.value)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

Follow up of https://github.com/apache/spark/pull/49961

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds the serialization and deserialization required to pass V1 data source filters from JVM to Python. Also adds the equivalent Python dataclass representation of the filters.

To ensure that filter values are properly converted to Python values, we use `VariantVal` to serialize catalyst values into binary, then deserialize into Python `VariantVal`, then convert to Python values.

#### Examples

Supported filters

| SQL filter          | Representation                             |
|---------------------|--------------------------------------------|
| `a.b.c = 1`         | `EqualTo(("a", "b", "c"), 1)`              |
| `a = 1`             | `EqualTo(("a",), 1)`                       |
| `a = 'hi'`          | `EqualTo(("a",), "hi")`                    |
| `a = array(1, 2)`   | `EqualTo(("a",), [1, 2])`                  |
| `a`                 | `EqualTo(("a",), True)`                    |
| `not a`             | `Not(EqualTo(("a",), True))`               |
| `a <> 1`            | `Not(EqualTo(("a",), 1))`                  |
| `a > 1`             | `GreaterThan(("a",), 1)`                   |
| `a >= 1`            | `GreaterThanOrEqual(("a",), 1)`            |
| `a < 1`             | `LessThan(("a",), 1)`                      |
| `a <= 1`            | `LessThanOrEqual(("a",), 1)`               |
| `a in (1, 2, 3)`    | `In(("a",), (1, 2, 3))`                    |
| `a is null`         | `IsNull(("a",))`                           |
| `a is not null`     | `IsNotNull(("a",))`                        |
| `a like 'abc%'`     | `StringStartsWith(("a",), "abc")`          |
| `a like '%abc'`     | `StringEndsWith(("a",), "abc")`            |
| `a like '%abc%'`    | `StringContains(("a",), "abc")`            |

Unsupported filters
- `a = b`
- `f(a, b) = 1`
- `a % 2 = 1`
- `a[0] = 1`
- `a < 0 or a > 1`
- `a like 'c%c%'`
- `a ilike 'hi'`
- `a = 'hi' collate zh`


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The base PR https://github.com/apache/spark/pull/49961 only supported EqualTo int. This PR adds support for many other useful filter types making Python Data Source filter pushdown API actually useful.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. Python Data Source now supports more pushdown filter types.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

End-to-end tests in `test_python_datasource.py`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
