### PR TITLE
[SPARK-51489][SQL] Represent SQL Script in Spark UI

### DIFF
--- a/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
+++ b/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
@@ -424,6 +424,7 @@ message SQLExecutionUIData {
   repeated int64 stages = 12;
   bool metric_values_is_null = 13;
   map<int64, string> metric_values = 14;
+  optional string sql_script_id = 15;
 }
 
 message SparkPlanGraphNode {

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
@@ -117,7 +117,12 @@ private[sql] object Dataset {
       new Dataset[Row](qe, () => RowEncoder.encoderFor(qe.analyzed.schema))
     }
 
-  def ofRows(sparkSession: SparkSession, logicalPlan: LogicalPlan, scriptId: UUID): DataFrame =
+  /** A variant of ofRows that allows passing in a SQL Script ID.
+   * Should only be called from SQL Scripts. */
+  private[sql] def ofRows(
+      sparkSession: SparkSession,
+      logicalPlan: LogicalPlan,
+      scriptId: UUID): DataFrame =
     sparkSession.withActive {
       val qe = sparkSession.sessionState.executePlan(logicalPlan)
       qe.scriptId = Option(scriptId)

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala
@@ -444,7 +444,9 @@ class SparkSession private(
   private def executeSqlScript(
       script: CompoundBody,
       args: Map[String, Expression] = Map.empty): DataFrame = {
-    val sse = new SqlScriptingExecution(script, this, args)
+    val scriptId: UUID = UUID.randomUUID()
+
+    val sse = new SqlScriptingExecution(script, this, scriptId, args)
     sse.withLocalVariableManager {
       var result: Option[Seq[Row]] = None
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -65,7 +65,7 @@ class QueryExecution(
     val shuffleCleanupMode: ShuffleCleanupMode = DoNotCleanup) extends Logging {
 
   val id: Long = QueryExecution.nextExecutionId
-  var scriptId: Option[String] = Some("testID")
+  @volatile var scriptId: Option[UUID] = None
 
   // TODO: Move the planner an optimizer into here from SessionState.
   protected def planner = sparkSession.sessionState.planner

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -65,6 +65,7 @@ class QueryExecution(
     val shuffleCleanupMode: ShuffleCleanupMode = DoNotCleanup) extends Logging {
 
   val id: Long = QueryExecution.nextExecutionId
+  var scriptId: Option[String] = Some("testID")
 
   // TODO: Move the planner an optimizer into here from SessionState.
   protected def planner = sparkSession.sessionState.planner

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -135,7 +135,8 @@ object SQLExecution extends Logging {
               time = System.currentTimeMillis(),
               modifiedConfigs = redactedConfigs,
               jobTags = sc.getJobTags(),
-              jobGroupId = Option(sc.getLocalProperty(SparkContext.SPARK_JOB_GROUP_ID))
+              jobGroupId = Option(sc.getLocalProperty(SparkContext.SPARK_JOB_GROUP_ID)),
+              sqlScriptId = queryExecution.scriptId.map(_.toString)
             )
             try {
               body match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/AllExecutionsPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/AllExecutionsPage.scala
@@ -301,7 +301,8 @@ private[ui] class ExecutionPagedTable(
       ("Description", true, None),
       ("Submitted", true, None),
       ("Duration", true, Some("Time from query submission to completion (or if still executing," +
-        " time since submission)"))) ++ {
+        " time since submission)")),
+      ("SQL Script ID", true, None)) ++ {
       if (showRunningJobs && showSucceededJobs && showFailedJobs) {
         Seq(
           ("Running Job IDs", true, None),
@@ -381,6 +382,9 @@ private[ui] class ExecutionPagedTable(
         <td sorttable_customkey={duration.toString}>
           {UIUtils.formatDuration(duration)}
         </td>
+        <td sorttable_customkey={executionUIData.sqlScriptId.getOrElse("")}>
+          {executionUIData.sqlScriptId.getOrElse("")}
+        </td>
         {if (showRunningJobs) {
           <td>
             {jobLinks(executionTableRow.runningJobData)}
@@ -436,6 +440,9 @@ private[ui] class ExecutionPagedTable(
                     </td>
                     <td sorttable_customkey={duration.toString}>
                       {UIUtils.formatDuration(duration)}
+                    </td>
+                    <td sorttable_customkey={executionUIData.sqlScriptId.getOrElse("")}>
+                      {executionUIData.sqlScriptId.getOrElse("")}
                     </td>
                     {if (showRunningJobs) {
                       <td>
@@ -569,6 +576,7 @@ private[ui] class ExecutionDataSource(
       case "Description" => Ordering.by(_.executionUIData.description)
       case "Submitted" => Ordering.by(_.executionUIData.submissionTime)
       case "Duration" => Ordering.by(_.duration)
+      case "SQL Script ID" => Ordering.by(_.executionUIData.sqlScriptId)
       case "Job IDs" | "Succeeded Job IDs" => Ordering by (_.completedJobData.headOption)
       case "Running Job IDs" => Ordering.by(_.runningJobData.headOption)
       case "Failed Job IDs" => Ordering.by(_.failedJobData.headOption)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
@@ -71,9 +71,13 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
             <li>
               <strong>Duration: </strong>{UIUtils.formatDuration(duration)}
             </li>
-            <li>
-              <Strong>Script ID: </Strong>{executionUIData.sqlScriptId.getOrElse("No script ID")}
-            </li>
+            {
+              if (executionUIData.sqlScriptId.isDefined) {
+                <li>
+                  <Strong>SQL Script ID: </Strong>{executionUIData.sqlScriptId.get}
+                </li>
+              }
+            }
             {jobLinks(JobExecutionStatus.RUNNING, "Running Jobs:")}
             {jobLinks(JobExecutionStatus.SUCCEEDED, "Succeeded Jobs:")}
             {jobLinks(JobExecutionStatus.FAILED, "Failed Jobs:")}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
@@ -71,6 +71,9 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
             <li>
               <strong>Duration: </strong>{UIUtils.formatDuration(duration)}
             </li>
+            <li>
+              <Strong>Script ID: </Strong>{executionUIData.sqlScriptId.getOrElse("No script ID")}
+            </li>
             {jobLinks(JobExecutionStatus.RUNNING, "Running Jobs:")}
             {jobLinks(JobExecutionStatus.SUCCEEDED, "Succeeded Jobs:")}
             {jobLinks(JobExecutionStatus.FAILED, "Failed Jobs:")}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
@@ -102,7 +102,8 @@ class SQLExecutionUIData(
      * from the SQL listener instance.
      */
     @JsonDeserialize(keyAs = classOf[JLong])
-    val metricValues: Map[Long, String]) {
+    val metricValues: Map[Long, String],
+    val sqlScriptId: Option[String]) {
 
   @JsonIgnore @KVIndex("completionTime")
   private def completionTimeIndex: Long = completionTime.map(_.getTime).getOrElse(-1L)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLListener.scala
@@ -55,7 +55,8 @@ case class SparkListenerSQLExecutionStart(
     time: Long,
     modifiedConfigs: Map[String, String] = Map.empty,
     jobTags: Set[String] = Set.empty,
-    jobGroupId: Option[String] = None)
+    jobGroupId: Option[String] = None,
+    sqlScriptId: Option[String] = None)
   extends SparkListenerEvent
 
 @DeveloperApi

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.scripting
 
+import java.util.UUID
+
 import org.apache.spark.SparkThrowable
 import org.apache.spark.sql.catalyst.SqlScriptingLocalVariableManager
 import org.apache.spark.sql.catalyst.expressions.Expression
@@ -38,6 +40,7 @@ import org.apache.spark.sql.classic.{DataFrame, SparkSession}
 class SqlScriptingExecution(
     sqlScript: CompoundBody,
     session: SparkSession,
+    scriptId: UUID,
     args: Map[String, Expression]) {
 
   private val interpreter = SqlScriptingInterpreter(session)
@@ -45,7 +48,7 @@ class SqlScriptingExecution(
   // Frames to keep what is being executed.
   private val context: SqlScriptingExecutionContext = {
     val ctx = new SqlScriptingExecutionContext()
-    val executionPlan = interpreter.buildExecutionPlan(sqlScript, args, ctx)
+    val executionPlan = interpreter.buildExecutionPlan(sqlScript, scriptId, args, ctx)
     // Add frame which represents SQL Script to the context.
     ctx.frames.append(
       new SqlScriptingExecutionFrame(executionPlan, SqlScriptingFrameType.SQL_SCRIPT))

--- a/sql/core/src/main/scala/org/apache/spark/status/protobuf/sql/SQLExecutionUIDataSerializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/protobuf/sql/SQLExecutionUIDataSerializer.scala
@@ -57,6 +57,7 @@ private[protobuf] class SQLExecutionUIDataSerializer extends ProtobufSerDe[SQLEx
         case (k, v) => builder.putMetricValues(k, v)
       }
     }
+    builder.setSqlScriptId(ui.sqlScriptId.orNull)
     builder.build().toByteArray
   }
 
@@ -92,7 +93,8 @@ private[protobuf] class SQLExecutionUIDataSerializer extends ProtobufSerDe[SQLEx
       errorMessage = errorMessage,
       jobs = jobs,
       stages = ui.getStagesList.asScala.map(_.toInt).toSet,
-      metricValues = metricValues
+      metricValues = metricValues,
+      sqlScriptId = Option(ui.getSqlScriptId)
     )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
@@ -344,7 +344,7 @@ abstract class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTes
       val listener = new SparkListener {
         override def onOtherEvent(event: SparkListenerEvent): Unit = {
           event match {
-            case SparkListenerSQLExecutionStart(_, _, _, _, planDescription, _, _, _, _, _) =>
+            case SparkListenerSQLExecutionStart(_, _, _, _, planDescription, _, _, _, _, _, _) =>
               assert(expected.forall(planDescription.contains))
               checkDone = true
             case _ => // ignore other events

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.scripting
 
+import java.util.UUID
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Literal}
@@ -39,7 +41,8 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
       isScope: Boolean = false,
       context: SqlScriptingExecutionContext = null,
       triggerToExceptionHandlerMap: TriggerToExceptionHandlerMap = null)
-    extends CompoundBodyExec(statements, label, isScope, context, triggerToExceptionHandlerMap) {
+    extends CompoundBodyExec(
+      statements, label, isScope, context, UUID.randomUUID(), triggerToExceptionHandlerMap) {
 
     // No-op to remove unnecessary logic for these tests.
     override def enterScope(): Unit = ()
@@ -60,6 +63,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
       variableName,
       body.statements,
       label,
+      UUID.randomUUID(),
       session,
       context)
 
@@ -71,6 +75,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
     extends SingleStatementExec(
       parsedPlan = Project(Seq(Alias(Literal(condVal), description)()), OneRowRelation()),
       Origin(startIndex = Some(0), stopIndex = Some(description.length)),
+      UUID.randomUUID(),
       Map.empty,
       isInternal = false,
       null
@@ -80,6 +85,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
     extends SingleStatementExec(
       parsedPlan = Project(Seq(Alias(Literal(value), description)()), OneRowRelation()),
       Origin(startIndex = Some(0), stopIndex = Some(description.length)),
+      UUID.randomUUID(),
       Map.empty,
       isInternal = false,
       null
@@ -103,6 +109,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
     extends SingleStatementExec(
       parsedPlan = DummyLogicalPlan(),
       Origin(startIndex = Some(0), stopIndex = Some(description.length)),
+      UUID.randomUUID(),
       Map.empty,
       isInternal = false,
       null
@@ -152,6 +159,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
       extends SingleStatementExec(
         DummyLogicalPlan(),
         Origin(startIndex = Some(0), stopIndex = Some(description.length)),
+        UUID.randomUUID(),
         Map.empty,
         isInternal = false,
         null) {
@@ -766,6 +774,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
           TestCompoundBody(Seq(TestLeafStatement("body2")))
         ),
         elseBody = Some(TestCompoundBody(Seq(TestLeafStatement("body3")))),
+        scriptId = UUID.randomUUID(),
         session = spark,
         context = MockScriptingContext()
       )
@@ -785,6 +794,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
           TestCompoundBody(Seq(TestLeafStatement("body1")))
         ),
         elseBody = Some(TestCompoundBody(Seq(TestLeafStatement("body2")))),
+        scriptId = UUID.randomUUID(),
         session = spark,
         context = MockScriptingContext()
       )
@@ -806,6 +816,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
           TestCompoundBody(Seq(TestLeafStatement("body2")))
         ),
         elseBody = Some(TestCompoundBody(Seq(TestLeafStatement("body3")))),
+        scriptId = UUID.randomUUID(),
         session = spark,
         context = MockScriptingContext()
       )
@@ -827,6 +838,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
           TestCompoundBody(Seq(TestLeafStatement("body2")))
         ),
         elseBody = None,
+        scriptId = UUID.randomUUID(),
         session = spark,
         context = MockScriptingContext()
       )
@@ -848,6 +860,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
           TestCompoundBody(Seq(TestLeafStatement("body2")))
         ),
         elseBody = None,
+        scriptId = UUID.randomUUID(),
         session = spark,
         context = MockScriptingContext()
       )

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.scripting
 
+import java.util.UUID
+
 import scala.collection.mutable.ListBuffer
 
 import org.apache.spark.{SparkArithmeticException, SparkConf}
@@ -49,7 +51,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
       args: Map[String, Expression] = Map.empty): Seq[Array[Row]] = {
     val compoundBody = spark.sessionState.sqlParser.parsePlan(sqlText).asInstanceOf[CompoundBody]
 
-    val sse = new SqlScriptingExecution(compoundBody, spark, args)
+    val sse = new SqlScriptingExecution(compoundBody, spark, UUID.randomUUID(), args)
     sse.withLocalVariableManager {
       val result: ListBuffer[Array[Row]] = ListBuffer.empty
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.scripting
 
+import java.util.UUID
+
 import org.apache.spark.{SparkConf, SparkException, SparkNumberFormatException}
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.{QueryPlanningTracker, SqlScriptingLocalVariableManager}
@@ -49,7 +51,8 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
 
     // Initialize context so scopes can be entered correctly.
     val context = new SqlScriptingExecutionContext()
-    val executionPlan = interpreter.buildExecutionPlan(compoundBody, args, context)
+    val executionPlan = interpreter
+      .buildExecutionPlan(compoundBody, UUID.randomUUID(), args, context)
     context.frames.append(new SqlScriptingExecutionFrame(
       executionPlan, SqlScriptingFrameType.SQL_SCRIPT))
     executionPlan.enterScope()

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -2530,42 +2530,6 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("for statement - nulls") {
-    withTable("t") {
-      val sqlScript =
-        """
-          |BEGIN
-          |create table t ( id int not null, name string) using parquet;
-          |
-          |insert into t values (1, 'A'), (2, null);
-          |
-          |begin
-          |  for c_test as (select * from t order by Id asc)
-          |  do
-          |      select coalesce(c_test.name, 'NULL');
-          |  end for;
-          |end;
-          |END
-          |""".stripMargin
-
-      val expected = Seq(
-        Seq.empty[Row], // create table
-        Seq.empty[Row], // insert
-        Seq.empty[Row], // insert
-        Seq.empty[Row], // insert
-        Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
-        Seq(Row("A")), // drop local var
-        Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
-        Seq(Row("NULL")), // drop local var
-      )
-      verifySqlScriptResult(sqlScript, expected)
-    }
-  }
-
   test("for statement - nested - leave inner loop") {
     withTable("t", "t2") {
       val sqlScript =

--- a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
@@ -94,7 +94,8 @@ object SqlResourceSuite {
         1 -> JobExecutionStatus.SUCCEEDED),
       stages = Set[Int](),
       metricValues = getMetricValues(),
-      errorMessage = None
+      errorMessage = None,
+      sqlScriptId = Some("scriptid")
     )
   }
 
@@ -217,7 +218,8 @@ class SqlResourceSuite extends SparkFunSuite with PrivateMethodTester {
       jobs = Map.empty[Int, JobExecutionStatus],
       stages = Set[Int](),
       metricValues = getMetricValues(),
-      errorMessage = Some("now you see me, now you don't"))
+      errorMessage = Some("now you see me, now you don't"),
+      sqlScriptId = Some("scriptid"))
     val executionData =
       sqlResource invokePrivate prepareExecutionData(
         d,

--- a/sql/core/src/test/scala/org/apache/spark/status/protobuf/sql/KVStoreProtobufSerializerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/protobuf/sql/KVStoreProtobufSerializerSuite.scala
@@ -51,7 +51,8 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
       errorMessage = normal.errorMessage,
       jobs = normal.jobs,
       stages = normal.stages,
-      metricValues = normal.metricValues
+      metricValues = normal.metricValues,
+      sqlScriptId = normal.sqlScriptId
     )
     Seq(normal, withNull).foreach { input =>
       val bytes = serializer.serialize(input)
@@ -88,7 +89,8 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
       errorMessage = templateData.errorMessage,
       jobs = templateData.jobs,
       stages = templateData.stages,
-      metricValues = Map.empty
+      metricValues = Map.empty,
+      sqlScriptId = templateData.sqlScriptId
     )
     val bytes1 = serializer.serialize(input1)
     val result1 = serializer.deserialize(bytes1, classOf[SQLExecutionUIData])
@@ -108,7 +110,8 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
       errorMessage = templateData.errorMessage,
       jobs = templateData.jobs,
       stages = templateData.stages,
-      metricValues = null
+      metricValues = null,
+      sqlScriptId = templateData.sqlScriptId
     )
     val bytes2 = serializer.serialize(input2)
     val result2 = serializer.deserialize(bytes2, classOf[SQLExecutionUIData])


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Initial representation of SQL Scripts in the Spark UI. This PR introduces a `"SQL Script ID"` column in the All Executions table in `SQL / Dataframe` tab of Spark UI. Also, it introduces a SQL Script ID label in the single SQL Execution page, which is only present if the SQL Execution is executed by a script.

To achieve this, this PR also introduces the concept of SQL Script ID, which is propagated throughout the script execution. A `Dataset.ofRows` overload which supports script id propagation is introduced.

Screenshots:

All Executions table:
<img width="1476" alt="image" src="https://github.com/user-attachments/assets/18f5cca9-5748-47f8-93dc-5d7ef6800e7d" />

Single Execution page:
<img width="1479" alt="image" src="https://github.com/user-attachments/assets/8e8c0f7d-09f8-40ce-bf11-abb28e36aa95" />

Non script Single Execution page remains the same:
<img width="1478" alt="image" src="https://github.com/user-attachments/assets/123c60ec-a00b-424b-8190-54976b355387" />



### Why are the changes needed?
Currently, there is no way to debug / view SQL scripts in the Spark UI.


### Does this PR introduce _any_ user-facing change?
Yes, the Spark UI is updated to include SQL Script data.


### How was this patch tested?
Existing unit tests, manual UI validation.

### Was this patch authored or co-authored using generative AI tooling?
No.
