### PR TITLE
[SPARK-51492][SS]FileStreamSource: Avoid expensive string concatenation if not needed

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -305,7 +305,10 @@ class FileStreamSource(
     logInfo(log"Processing ${MDC(LogKeys.NUM_FILES, files.length)} files from " +
       log"${MDC(LogKeys.FILE_START_OFFSET, startOffset + 1)}:" +
       log"${MDC(LogKeys.FILE_END_OFFSET, endOffset)}")
-    logTrace(s"Files are:\n\t" + files.mkString("\n\t"))
+    // files.mkString() is expensive if the list is long. Avoid it if not needed.
+    if (log.isTraceEnabled()) {
+      logTrace(s"Files are:\n\t" + files.mkString("\n\t"))
+    }
     val newDataSource =
       DataSource(
         sparkSession,
@@ -399,7 +402,12 @@ class FileStreamSource(
     } else {
       logTrace(s"Listed ${files.size} file(s) in $listingTimeMs ms")
     }
-    logTrace(s"Files are:\n\t" + files.mkString("\n\t"))
+
+    // files.mkString() is expensive if the list is long. Avoid it if trace level is
+    // not enabled.
+    if (log.isTraceEnabled()) {
+      logTrace(s"Files are:\n\t" + files.mkString("\n\t"))
+    }
     files
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In two places where constructing a log line can be very or a little bit expensive, avoid logTrace() call as a whole.


### Why are the changes needed?
In this statement:
https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala#L402

files.mkString("\n\t") can be really expensive if there are many files. It could even cause OOM.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Use existing CI

### Was this patch authored or co-authored using generative AI tooling?
No.
