### PR TITLE
[SPARK-51494][BUILD] Upgrade to Apache parent pom 33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>18</version>
+    <version>33</version>
   </parent>
   <groupId>org.apache.spark</groupId>
   <artifactId>spark-parent_2.13</artifactId>
@@ -341,6 +341,7 @@
     <terajdbc.version>20.00.00.39</terajdbc.version>
     <!-- Used for SBT build to retrieve the Spark version -->
     <spark.version>${project.version}</spark.version>
+    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
   </properties>
   <repositories>
     <repository>
@@ -2969,7 +2970,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>${maven-jar-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -3659,7 +3660,7 @@
                       <pluginExecutionFilter>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-jar-plugin</artifactId>
-                        <versionRange>3.4.0</versionRange>
+                        <versionRange>${maven-jar-plugin.version}</versionRange>
                         <goals>
                           <goal>test-jar</goal>
                         </goals>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Spark currently uses Apache parent pom 18. This is a proposed upgrade to the latest version, which is 33.

### Why are the changes needed?

Spark has not updated the parent pom since [SPARK-22511](https://issues.apache.org/jira/browse/SPARK-22511) 8 years ago. The full delta is visible here:

https://github.com/apache/maven-apache-parent/compare/apache-18...apache-33

Summary of notable changes:
* [MPOM-118](https://issues.apache.org/jira/browse/MPOM-118): Enforce strong GPG signatures by default
* [MPOM-225](https://issues.apache.org/jira/browse/MPOM-225): add ASF snapshots repository to pluginRepositories
* [MPOM-260](https://issues.apache.org/jira/browse/MPOM-260): Configure Maven Javadoc Plugin for more reproducible builds
* [MPOM-287](https://issues.apache.org/jira/browse/MPOM-287): Disable m2e warning for m-remote-resource-p
* [MPOM-378](https://issues.apache.org/jira/browse/MPOM-378): Using an SPDX identifier as the license name is recommended by Maven
* [MPOM-486](https://issues.apache.org/jira/browse/MPOM-486): Enable autoVersionSubmodules for maven-release-plugin
* Version management and upgrades for various Maven plugins. For the most part, Spark was already managing these plugins to versions equal to or greater than the parent pom. The one exception is maven-jar-plugin, which I've upgraded to match the parent.

### Does this PR introduce _any_ user-facing change?

No, this does not introduce changes to user-facing Spark functionality. Version updates will be visible to developers.

### How was this patch tested?

Local `mvn` build with the new parent pom succeeds. I also verified elapsed time for a full build is approximately the same before and after, because maven-jar-plugin has occasionally had performance regressions in the past.

### Was this patch authored or co-authored using generative AI tooling?

No.
