### PR TITLE
[SPARK-51497][SQL] Add the default time formatter

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimeFormatter.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimeFormatter.scala
@@ -22,6 +22,7 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 import org.apache.spark.sql.catalyst.util.SparkDateTimeUtils._
+import org.apache.spark.unsafe.types.UTF8String
 
 sealed trait TimeFormatter extends Serializable {
   def parse(s: String): Long // returns microseconds since midnight
@@ -82,18 +83,54 @@ class FractionTimeFormatter
     DateTimeFormatterHelper.fractionTimeFormatter
 }
 
+/**
+ * The formatter for time values which doesn't require users to specify a pattern. While
+ * formatting, it uses the default pattern [[TimeFormatter.defaultPattern()]]. In parsing, it
+ * follows the CAST logic in conversion of strings to Catalyst's TimeType.
+ *
+ * @param locale
+ *   The locale overrides the system locale and is used in formatting.
+ * @param isParsing
+ *   Whether the formatter is used for parsing (`true`) or for formatting (`false`).
+ */
+class DefaultTimeFormatter(locale: Locale, isParsing: Boolean)
+    extends Iso8601TimeFormatter(TimeFormatter.defaultPattern, locale, isParsing) {
+
+  override def parse(s: String): Long = {
+    SparkDateTimeUtils.stringToTimeAnsi(UTF8String.fromString(s))
+  }
+}
+
 object TimeFormatter {
 
   val defaultLocale: Locale = Locale.US
 
   val defaultPattern: String = "HH:mm:ss"
 
-  def apply(
-      format: String = defaultPattern,
+  private def getFormatter(
+      format: Option[String],
       locale: Locale = defaultLocale,
-      isParsing: Boolean = false): TimeFormatter = {
-    val formatter = new Iso8601TimeFormatter(format, locale, isParsing)
+      isParsing: Boolean): TimeFormatter = {
+    val formatter = format
+      .map(new Iso8601TimeFormatter(_, locale, isParsing))
+      .getOrElse(new DefaultTimeFormatter(locale, isParsing))
     formatter.validatePatternString()
     formatter
+  }
+
+  def apply(format: String, locale: Locale, isParsing: Boolean): TimeFormatter = {
+    getFormatter(Some(format), locale, isParsing)
+  }
+
+  def apply(format: String, isParsing: Boolean): TimeFormatter = {
+    getFormatter(Some(format), defaultLocale, isParsing)
+  }
+
+  def apply(format: String): TimeFormatter = {
+    getFormatter(Some(format), defaultLocale, isParsing = false)
+  }
+
+  def apply(isParsing: Boolean): TimeFormatter = {
+    getFormatter(None, defaultLocale, isParsing)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TimeFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TimeFormatterSuite.scala
@@ -48,7 +48,9 @@ class TimeFormatterSuite extends SparkFunSuite with SQLHelper {
 
   test("time strings do not match to the pattern") {
     def assertError(str: String, expectedMsg: String): Unit = {
-      val e = intercept[DateTimeException](TimeFormatter(isParsing = true).parse(str))
+      val e = intercept[DateTimeException] {
+        TimeFormatter(format = "HH:mm:ss", isParsing = true).parse(str)
+      }
       assert(e.getMessage.contains(expectedMsg))
     }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TimeFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TimeFormatterSuite.scala
@@ -21,7 +21,7 @@ import java.time.DateTimeException
 
 import scala.util.Random
 
-import org.apache.spark.{SPARK_DOC_ROOT, SparkFunSuite, SparkRuntimeException}
+import org.apache.spark.{SPARK_DOC_ROOT, SparkDateTimeException, SparkFunSuite, SparkRuntimeException}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.microsToLocalTime
@@ -48,7 +48,7 @@ class TimeFormatterSuite extends SparkFunSuite with SQLHelper {
 
   test("time strings do not match to the pattern") {
     def assertError(str: String, expectedMsg: String): Unit = {
-      val e = intercept[DateTimeException](TimeFormatter().parse(str))
+      val e = intercept[DateTimeException](TimeFormatter(isParsing = true).parse(str))
       assert(e.getMessage.contains(expectedMsg))
     }
 
@@ -76,7 +76,7 @@ class TimeFormatterSuite extends SparkFunSuite with SQLHelper {
 
   test("micros are out of supported range") {
     def assertError(micros: Long, expectedMsg: String): Unit = {
-      val e = intercept[DateTimeException](TimeFormatter().format(micros))
+      val e = intercept[DateTimeException](TimeFormatter(isParsing = false).format(micros))
       assert(e.getMessage.contains(expectedMsg))
     }
 
@@ -102,7 +102,7 @@ class TimeFormatterSuite extends SparkFunSuite with SQLHelper {
     val data = Seq.tabulate(10) { _ => Random.between(0, 24 * 60 * 60 * 1000000L) }
     val pattern = "HH:mm:ss.SSSSSS"
     val (formatter, parser) =
-      (TimeFormatter(pattern), TimeFormatter(pattern, isParsing = true))
+      (TimeFormatter(pattern, isParsing = false), TimeFormatter(pattern, isParsing = true))
     data.foreach { micros =>
       val str = formatter.format(micros)
       assert(parser.parse(str) === micros, s"micros = $micros")
@@ -145,5 +145,30 @@ class TimeFormatterSuite extends SparkFunSuite with SQLHelper {
     assert(t4 === localTime(12))
     val t5 = f3.parse("AM")
     assert(t5 === localTime())
+  }
+
+  test("default parsing w/o pattern") {
+    val formatter = new DefaultTimeFormatter(
+      locale = DateFormatter.defaultLocale,
+      isParsing = true)
+    Seq(
+      "00:00:00" -> localTime(),
+      "00:00:00.000001" -> localTime(micros = 1),
+      "01:02:03" -> localTime(1, 2, 3),
+      "1:2:3.999999" -> localTime(1, 2, 3, 999999),
+      "23:59:59.1" -> localTime(23, 59, 59, 100000)
+    ).foreach { case (inputStr, micros) =>
+      assert(formatter.parse(inputStr) === micros)
+    }
+
+    checkError(
+      exception = intercept[SparkDateTimeException] {
+        formatter.parse("x123")
+      },
+      condition = "CAST_INVALID_INPUT",
+      parameters = Map(
+        "expression" -> "'x123'",
+        "sourceType" -> "\"STRING\"",
+        "targetType" -> "\"TIME(6)\""))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to add new time formatter `DefaultTimeFormatter` which behaves like `CAST` in parsing, and uses the default pattern in formatting.

### Why are the changes needed?
The default time formatter can be used in the situation when time pattern is unknown or not set like in text datasources, partition discovery, time expressions and so on.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running new test:
```
$ build/sbt "test:testOnly *TimeFormatterSuite"
```


### Was this patch authored or co-authored using generative AI tooling?
No.
