### PR TITLE
[SPARK-51501][SQL] Disable ObjectHashAggregate for group by on collated columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/MergeScalarSubqueries.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/MergeScalarSubqueries.scala
@@ -366,8 +366,10 @@ object MergeScalarSubqueries extends Rule[LogicalPlan] {
     newPlanSupportsHashAggregate && cachedPlanSupportsHashAggregate ||
       newPlanSupportsHashAggregate == cachedPlanSupportsHashAggregate && {
         val Seq(newPlanSupportsObjectHashAggregate, cachedPlanSupportsObjectHashAggregate) =
-          aggregateExpressionsSeq.map(aggregateExpressions =>
-            Aggregate.supportsObjectHashAggregate(aggregateExpressions))
+          aggregateExpressionsSeq.zip(groupByExpressionSeq).map {
+            case (aggregateExpressions, groupByExpressions) =>
+              Aggregate.supportsObjectHashAggregate(aggregateExpressions, groupByExpressions)
+          }
         newPlanSupportsObjectHashAggregate && cachedPlanSupportsObjectHashAggregate ||
           newPlanSupportsObjectHashAggregate == cachedPlanSupportsObjectHashAggregate
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1189,7 +1189,14 @@ object Aggregate {
       groupingExpression.forall(e => UnsafeRowUtils.isBinaryStable(e.dataType))
   }
 
-  def supportsObjectHashAggregate(aggregateExpressions: Seq[AggregateExpression]): Boolean = {
+  def supportsObjectHashAggregate(
+      aggregateExpressions: Seq[AggregateExpression],
+      groupingExpressions: Seq[Expression]): Boolean = {
+    // We should not use hash aggregation on binary unstable types.
+    if (groupingExpressions.exists(e => !UnsafeRowUtils.isBinaryStable(e.dataType))) {
+      return false
+    }
+
     aggregateExpressions.map(_.aggregateFunction).exists {
       case _: TypedImperativeAggregate[_] => true
       case _ => false

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
@@ -94,7 +94,8 @@ object AggUtils {
         child = child)
     } else {
       val objectHashEnabled = child.conf.useObjectHashAggregation
-      val useObjectHash = Aggregate.supportsObjectHashAggregate(aggregateExpressions)
+      val useObjectHash = Aggregate.supportsObjectHashAggregate(
+        aggregateExpressions, groupingExpressions)
 
       if (forceObjHashAggregate || (objectHashEnabled && useObjectHash && !forceSortAggregate)) {
         ObjectHashAggregateExec(

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.collation
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
+import org.apache.spark.sql.test.SharedSparkSession
+
+class CollationAggregationSuite
+  extends QueryTest
+  with SharedSparkSession
+  with AdaptiveSparkPlanHelper {
+
+  test("group by collated column doesn't work with obj hash aggregate") {
+    val tblName = "grp_by_tbl"
+    withTable(tblName) {
+      sql(s"CREATE TABLE $tblName (c1 STRING COLLATE UTF8_LCASE, c2 INT) USING PARQUET")
+      sql(s"INSERT INTO $tblName VALUES ('hello', 1), ('HELLO', 2), ('HeLlO', 3)")
+
+      // Result is correct without forcing object hash aggregate.
+      checkAnswer(
+        sql(s"SELECT COUNT(*) FROM $tblName GROUP BY c1"),
+        Seq(Row(3)))
+
+      withSQLConf("spark.sql.test.forceApplyObjectHashAggregate" -> true.toString) {
+        checkAnswer(
+          sql(s"SELECT COUNT(*) FROM $tblName GROUP BY c1"),
+          Seq(Row(1), Row(1), Row(1)))
+
+        checkAnswer(
+          sql(s"SELECT COLLECT_LIST(c2) AS c3 FROM $tblName GROUP BY c1 ORDER BY c3"),
+          Seq(Row(Seq(1)), Row(Seq(2)), Row(Seq(3))))
+      }
+    }
+  }
+
+  test("imperative aggregate fn does not use objectHashAggregate when group by collated column") {
+    val tblName = "imp_agg"
+    Seq(true, false).foreach { useObjHashAgg =>
+      withTable(tblName) {
+        withSQLConf("spark.sql.execution.useObjectHashAggregateExec" -> useObjHashAgg.toString) {
+          sql(
+            s"""
+               |CREATE TABLE $tblName (
+               |  c1 STRING COLLATE UTF8_LCASE,
+               |  c2 INT
+               |) USING PARQUET
+               |""".stripMargin)
+          sql(s"INSERT INTO $tblName VALUES ('HELLO', 1), ('hello', 2), ('HeLlO', 3)")
+
+          val df = sql(s"SELECT COLLECT_LIST(c2) as list FROM $tblName GROUP BY c1")
+          val executedPlan = df.queryExecution.executedPlan
+
+          // Plan should not have any hash aggregate nodes.
+          collectFirst(executedPlan) {
+            case _: ObjectHashAggregateExec => fail("ObjectHashAggregateExec should not be used.")
+            case _: HashAggregateExec => fail("HashAggregateExec should not be used.")
+          }
+
+          // Plan should have a [[SortAggregateExec]] node.
+          assert(collectFirst(executedPlan) {
+            case _: SortAggregateExec => true
+          }.nonEmpty)
+
+          checkAnswer(
+            // Sort the values to get deterministic output.
+            df.selectExpr("array_sort(list)"),
+            Seq(Row(Seq(1, 2, 3)))
+          )
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Disabling `ObjectHashAggregate` when grouping on columns with collations.


### Why are the changes needed?
https://github.com/apache/spark/pull/45290 added support for sort based aggregation on collated columns and explicitly forbade the use of hash aggregate for collated columns. However, it did not consider the third type of aggregate, the object hash aggregate, which is only used when there are also TypedImperativeAggregate expressions present ([source](https://github.com/apache/spark/blob/f3b081066393e1568c364b6d3bc0bceabd1e7e9f/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala#L1204)).

That means that if we group by a collated column and also have a TypedImperativeAggregate we will end up using the object has aggregate which can lead to incorrect results like in the example below:

```code
CREATE TABLE tbl(c1 STRING COLLATE UTF8_LCASE, c2 INT) USING PARQUET;
INSERT INTO tbl VALUES ('HELLO', 1), ('hello', 2), ('HeLlO', 3);
SELECT COLLECT_LIST(c2) as list FROM tbl GROUP BY c1;
```
where the result would have three rows with values [1], [2] and [3] instead of one row with value [1, 2, 3].

For this reason we should do the same thing as we did for the regular hash aggregate, make it so that it doesn't support grouping expressions on collated columns.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New unit tests.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.