### PR TITLE
[SPARK-51270] Support nanosecond precision timestamp in Variant

### DIFF
--- a/common/variant/src/main/java/org/apache/spark/types/variant/ShreddingUtils.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/ShreddingUtils.java
@@ -108,6 +108,12 @@ public class ShreddingUtils {
           builder.appendDecimal(row.getDecimal(typedIdx, dt.precision, dt.scale));
         } else if (scalar instanceof VariantSchema.DateType) {
           builder.appendDate(row.getInt(typedIdx));
+        } else if (scalar instanceof VariantSchema.TimeType) {
+          builder.appendTime(row.getLong(typedIdx));
+        } else if (scalar instanceof VariantSchema.TimestampNanosType) {
+          builder.appendTimestampNanos(row.getLong(typedIdx));
+        } else if (scalar instanceof VariantSchema.TimestampNanosNTZType) {
+          builder.appendTimestampNanosNtz(row.getLong(typedIdx));
         } else if (scalar instanceof VariantSchema.TimestampType) {
           builder.appendTimestamp(row.getLong(typedIdx));
         } else {

--- a/common/variant/src/main/java/org/apache/spark/types/variant/ShreddingUtils.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/ShreddingUtils.java
@@ -108,8 +108,6 @@ public class ShreddingUtils {
           builder.appendDecimal(row.getDecimal(typedIdx, dt.precision, dt.scale));
         } else if (scalar instanceof VariantSchema.DateType) {
           builder.appendDate(row.getInt(typedIdx));
-        } else if (scalar instanceof VariantSchema.TimeType) {
-          builder.appendTime(row.getLong(typedIdx));
         } else if (scalar instanceof VariantSchema.TimestampNanosType) {
           builder.appendTimestampNanos(row.getLong(typedIdx));
         } else if (scalar instanceof VariantSchema.TimestampNanosNTZType) {

--- a/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -271,13 +270,6 @@ public final class Variant {
       .appendOffset("+HH:MM", "+00:00")
       .toFormatter(Locale.US);
 
-  private static final DateTimeFormatter TIME_FORMATTER = new DateTimeFormatterBuilder()
-      .appendPattern("HH:mm:ss")
-      .optionalStart()
-      .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
-      .optionalEnd()
-      .toFormatter(Locale.US);
-
   private static Instant microsToInstant(long timestamp) {
     return Instant.EPOCH.plus(timestamp, ChronoUnit.MICROS);
   }
@@ -337,10 +329,6 @@ public final class Variant {
         break;
       case DATE:
         appendQuoted(sb, LocalDate.ofEpochDay((int) VariantUtil.getLong(value, pos)).toString());
-        break;
-      case TIME:
-        appendQuoted(sb, TIME_FORMATTER.format(
-            LocalTime.ofNanoOfDay(VariantUtil.getLong(value, pos) * 1_000)));
         break;
       case TIMESTAMP_NANOS:
         appendQuoted(sb, TIMESTAMP_FORMATTER.format(

--- a/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
@@ -29,7 +29,6 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
-import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Base64;

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
@@ -226,13 +226,6 @@ public class VariantBuilder {
     writePos += 8;
   }
 
-  public void appendTime(long microsSinceMidnight) {
-    checkCapacity(1 + 8);
-    writeBuffer[writePos++] = primitiveHeader(TIME);
-    writeLong(writeBuffer, writePos, microsSinceMidnight, 8);
-    writePos += 8;
-  }
-
   public void appendTimestampNanos(long nanosSinceEpoch) {
     checkCapacity(1 + 8);
     writeBuffer[writePos++] = primitiveHeader(VariantUtil.TIMESTAMP_NANOS);

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
@@ -226,6 +226,27 @@ public class VariantBuilder {
     writePos += 8;
   }
 
+  public void appendTime(long microsSinceMidnight) {
+    checkCapacity(1 + 8);
+    writeBuffer[writePos++] = primitiveHeader(TIME);
+    writeLong(writeBuffer, writePos, microsSinceMidnight, 8);
+    writePos += 8;
+  }
+
+  public void appendTimestampNanos(long nanosSinceEpoch) {
+    checkCapacity(1 + 8);
+    writeBuffer[writePos++] = primitiveHeader(VariantUtil.TIMESTAMP_NANOS);
+    writeLong(writeBuffer, writePos, nanosSinceEpoch, 8);
+    writePos += 8;
+  }
+
+  public void appendTimestampNanosNtz(long nanosSinceEpoch) {
+    checkCapacity(1 + 8);
+    writeBuffer[writePos++] = primitiveHeader(VariantUtil.TIMESTAMP_NANOS_NTZ);
+    writeLong(writeBuffer, writePos, nanosSinceEpoch, 8);
+    writePos += 8;
+  }
+
   public void appendFloat(float f) {
     checkCapacity(1 + 4);
     writeBuffer[writePos++] = primitiveHeader(FLOAT);

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantSchema.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantSchema.java
@@ -99,6 +99,15 @@ public class VariantSchema {
   public static final class TimestampNTZType extends ScalarType {
   }
 
+  public static final class TimestampNanosType extends ScalarType {
+  }
+
+  public static final class TimestampNanosNTZType extends ScalarType {
+  }
+
+  public static final class TimeType extends ScalarType {
+  }
+
   public static final class UuidType extends ScalarType {
   }
 

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantSchema.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantSchema.java
@@ -105,9 +105,6 @@ public class VariantSchema {
   public static final class TimestampNanosNTZType extends ScalarType {
   }
 
-  public static final class TimeType extends ScalarType {
-  }
-
   public static final class UuidType extends ScalarType {
   }
 

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantShreddingWriter.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantShreddingWriter.java
@@ -283,11 +283,6 @@ public class VariantShreddingWriter {
           return v.getLong();
         }
         break;
-      case TIME:
-        if (targetType instanceof VariantSchema.TimeType) {
-          return v.getLong();
-        }
-        break;
       case FLOAT:
         if (targetType instanceof VariantSchema.FloatType) {
           return v.getFloat();

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantShreddingWriter.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantShreddingWriter.java
@@ -273,6 +273,21 @@ public class VariantShreddingWriter {
           return v.getLong();
         }
         break;
+      case TIMESTAMP_NANOS:
+        if (targetType instanceof VariantSchema.TimestampNanosType) {
+          return v.getLong();
+        }
+        break;
+      case TIMESTAMP_NANOS_NTZ:
+        if (targetType instanceof VariantSchema.TimestampNanosNTZType) {
+          return v.getLong();
+        }
+        break;
+      case TIME:
+        if (targetType instanceof VariantSchema.TimeType) {
+          return v.getLong();
+        }
+        break;
       case FLOAT:
         if (targetType instanceof VariantSchema.FloatType) {
           return v.getFloat();

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantUtil.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantUtil.java
@@ -123,6 +123,15 @@ public class VariantUtil {
   // Long string value. The content is (4-byte little-endian unsigned integer representing the
   // string size) + (size bytes of string content).
   public static final int LONG_STR = 16;
+  // Time value. Can be from 00:00:00 to 23:59:59.999999. Content is 8-byte little-endian unisgned
+  // integer that represents the number of microseconds since midnight.
+  public static final int TIME = 17;
+  // Similar to TIMESTAMP, but the 8-byte value represents the number of nanoseconds since the
+  // epoch.
+  public static final int TIMESTAMP_NANOS = 18;
+  // Similar to TIMESTAMP_NTZ, but the 8-byte value represents the number of nanoseconds since the
+  // epoch.
+  public static final int TIMESTAMP_NANOS_NTZ  = 19;
 
   // UUID, 16-byte big-endian.
   public static final int UUID = 20;
@@ -243,6 +252,9 @@ public class VariantUtil {
     DATE,
     TIMESTAMP,
     TIMESTAMP_NTZ,
+    TIMESTAMP_NANOS,
+    TIMESTAMP_NANOS_NTZ,
+    TIME,
     FLOAT,
     BINARY,
     UUID,
@@ -292,6 +304,12 @@ public class VariantUtil {
             return Type.TIMESTAMP;
           case TIMESTAMP_NTZ:
             return Type.TIMESTAMP_NTZ;
+          case TIMESTAMP_NANOS:
+            return Type.TIMESTAMP_NANOS;
+          case TIMESTAMP_NANOS_NTZ:
+            return Type.TIMESTAMP_NANOS_NTZ;
+          case TIME:
+            return Type.TIME;
           case FLOAT:
             return Type.FLOAT;
           case BINARY:
@@ -341,6 +359,9 @@ public class VariantUtil {
           case DOUBLE:
           case TIMESTAMP:
           case TIMESTAMP_NTZ:
+          case TIMESTAMP_NANOS:
+          case TIMESTAMP_NANOS_NTZ:
+          case TIME:
             return 9;
           case DECIMAL4:
             return 6;
@@ -377,10 +398,14 @@ public class VariantUtil {
 
   // Get a long value from variant value `value[pos...]`.
   // It is only legal to call it if `getType` returns one of `Type.LONG/DATE/TIMESTAMP/
-  // TIMESTAMP_NTZ`. If the type is `DATE`, the return value is guaranteed to fit into an int and
-  // represents the number of days from the Unix epoch.
+  // TIMESTAMP_NTZ/TIMESTAMP_NANOS/TIMESTAMP_NANOS_NTZ/TIME`.
+  // If the type is `DATE`, the return value is guaranteed to fit into an int and represents the
+  // number of days from the Unix epoch.
   // If the type is `TIMESTAMP/TIMESTAMP_NTZ`, the return value represents the number of
   // microseconds from the Unix epoch.
+  // If the type is `TIMESTAMP_NANOS/TIMESTAMP_NANOS_NTZ`, the return value represents the number of
+  // microseconds from the Unix epoch.
+  // If the type is `TIME`, the return value represents the number of microseconds since midnight.
   // Throw `MALFORMED_VARIANT` if the variant is malformed.
   public static long getLong(byte[] value, int pos) {
     checkIndex(pos, value.length);
@@ -399,6 +424,9 @@ public class VariantUtil {
       case INT8:
       case TIMESTAMP:
       case TIMESTAMP_NTZ:
+      case TIMESTAMP_NANOS:
+      case TIMESTAMP_NANOS_NTZ:
+      case TIME:
         return readLong(value, pos + 1, 8);
       default:
         throw new IllegalStateException(exceptionMessage);

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantUtil.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantUtil.java
@@ -123,9 +123,6 @@ public class VariantUtil {
   // Long string value. The content is (4-byte little-endian unsigned integer representing the
   // string size) + (size bytes of string content).
   public static final int LONG_STR = 16;
-  // Time value. Can be from 00:00:00 to 23:59:59.999999. Content is 8-byte little-endian unisgned
-  // integer that represents the number of microseconds since midnight.
-  public static final int TIME = 17;
   // Similar to TIMESTAMP, but the 8-byte value represents the number of nanoseconds since the
   // epoch.
   public static final int TIMESTAMP_NANOS = 18;
@@ -254,7 +251,6 @@ public class VariantUtil {
     TIMESTAMP_NTZ,
     TIMESTAMP_NANOS,
     TIMESTAMP_NANOS_NTZ,
-    TIME,
     FLOAT,
     BINARY,
     UUID,
@@ -308,8 +304,6 @@ public class VariantUtil {
             return Type.TIMESTAMP_NANOS;
           case TIMESTAMP_NANOS_NTZ:
             return Type.TIMESTAMP_NANOS_NTZ;
-          case TIME:
-            return Type.TIME;
           case FLOAT:
             return Type.FLOAT;
           case BINARY:
@@ -361,7 +355,6 @@ public class VariantUtil {
           case TIMESTAMP_NTZ:
           case TIMESTAMP_NANOS:
           case TIMESTAMP_NANOS_NTZ:
-          case TIME:
             return 9;
           case DECIMAL4:
             return 6;
@@ -405,7 +398,6 @@ public class VariantUtil {
   // microseconds from the Unix epoch.
   // If the type is `TIMESTAMP_NANOS/TIMESTAMP_NANOS_NTZ`, the return value represents the number of
   // microseconds from the Unix epoch.
-  // If the type is `TIME`, the return value represents the number of microseconds since midnight.
   // Throw `MALFORMED_VARIANT` if the variant is malformed.
   public static long getLong(byte[] value, int pos) {
     checkIndex(pos, value.length);
@@ -426,7 +418,6 @@ public class VariantUtil {
       case TIMESTAMP_NTZ:
       case TIMESTAMP_NANOS:
       case TIMESTAMP_NANOS_NTZ:
-      case TIME:
         return readLong(value, pos + 1, 8);
       default:
         throw new IllegalStateException(exceptionMessage);

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala
@@ -117,6 +117,16 @@ trait SparkDateTimeUtils {
   }
 
   /**
+   * Obtains an instance of `java.time.Instant` using nanoseconds from the epoch of 1970-01-01
+   * 00:00:00Z.
+   */
+  def nanosToInstant(nanos: Long): Instant = {
+    val secs = Math.floorDiv(nanos, NANOS_PER_SECOND)
+    val nos = nanos - secs * NANOS_PER_SECOND
+    Instant.ofEpochSecond(secs, nos)
+  }
+
+  /**
    * Gets the number of microseconds since the epoch of 1970-01-01 00:00:00Z from the given
    * instance of `java.time.Instant`. The epoch microsecond count is a simple incrementing count
    * of microseconds where microsecond 0 is 1970-01-01 00:00:00Z.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
@@ -473,7 +473,7 @@ case object VariantGet {
               val result = TimestampFormatter.getFractionFormatter(castArgs.zoneId).format(instant)
               return UTF8String.fromString(result)
             } else {
-              Literal(v.getLong / 1000, TimestampType)
+              Literal(v.getLong / NANOS_PER_MICROS, TimestampType)
             }
           case Type.TIMESTAMP_NANOS_NTZ =>
             if (dataType.isInstanceOf[StringType]) {
@@ -481,7 +481,7 @@ case object VariantGet {
               val result = TimestampFormatter.getFractionFormatter(ZoneOffset.UTC).format(instant)
               return UTF8String.fromString(result)
             } else {
-              Literal(v.getLong / 1000, TimestampNTZType)
+              Literal(v.getLong / NANOS_PER_MICROS, TimestampNTZType)
             }
           // We have handled other cases and should never reach here. This case is only intended
           // to by pass the compiler exhaustiveness check.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
@@ -478,7 +478,6 @@ case object VariantGet {
           case Type.TIMESTAMP_NTZ => Literal(v.getLong, TimestampNTZType)
           case Type.FLOAT => Literal(v.getFloat, FloatType)
           case Type.BINARY => Literal(v.getBinary, BinaryType)
-          case Type.TIME => Literal(v.getLong, TimeType(6))
           // We have handled other cases and should never reach here. This case is only intended
           // to by pass the compiler exhaustiveness check.
           case _ => throw new SparkRuntimeException(
@@ -906,7 +905,6 @@ object SchemaOfVariant {
     case Type.UUID => UuidType
     case Type.TIMESTAMP_NANOS => TimestampNanosType
     case Type.TIMESTAMP_NANOS_NTZ => TimestampNanosNtzType
-    case Type.TIME => TimeType(6)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
@@ -857,12 +857,12 @@ object SchemaOfVariant {
     private[spark] override def asNullable: TimestampNanosType = this
   }
   private case object TimestampNanosType extends TimestampNanosType
-  private class TimestampNanosNtzType extends DataType {
+  private class TimestampNanosNTZType extends DataType {
     override def defaultSize: Int = 16
     override def typeName: String = "timestamp_nanos_ntz"
-    private[spark] override def asNullable: TimestampNanosNtzType = this
+    private[spark] override def asNullable: TimestampNanosNTZType = this
   }
-  private case object TimestampNanosNtzType extends TimestampNanosNtzType
+  private case object TimestampNanosNTZType extends TimestampNanosNTZType
 
   /**
    * Return the schema of a variant. Struct fields are guaranteed to be sorted alphabetically.
@@ -904,7 +904,7 @@ object SchemaOfVariant {
     case Type.BINARY => BinaryType
     case Type.UUID => UuidType
     case Type.TIMESTAMP_NANOS => TimestampNanosType
-    case Type.TIMESTAMP_NANOS_NTZ => TimestampNanosNtzType
+    case Type.TIMESTAMP_NANOS_NTZ => TimestampNanosNTZType
   }
 
   /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
@@ -866,17 +866,21 @@ class VariantExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
         ("1970-01-01T00:00:00.123456789-08:00", "1970-01-01 00:00:00.123456789",
          "1970-01-01 00:00:00.123456789-08:00"),
         ("2100-12-31T23:59:59.00100-08:00", "2100-12-31 23:59:59.001",
-         "2100-12-31 23:59:59.001-08:00")
+         "2100-12-31 23:59:59.001-08:00"),
+        ("1677-09-20T16:12:45.291448384-08:00", "1677-09-20 16:12:45.291448384",
+         "1677-09-20 16:12:45.291448384-08:00")
     )
-    timestamps.foreach { case (in, cast, toJson) =>
-      val instant = Instant.from(ISO_DATE_TIME.parse(in))
-      val nanos = TimeUnit.SECONDS.toNanos(instant.getEpochSecond()) + instant.getNano();
-      val builder = new VariantBuilder(false)
-      builder.appendTimestampNanos(nanos)
-      val bytes = builder.result().getValue()
-      checkToJson(bytes, "\"" + toJson + "\"")
-      checkCast(bytes, StringType, cast)
-      checkCast(bytes, TimestampType, nanos / NANOS_PER_MICROS)
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "-08:00") {
+      timestamps.foreach { case (in, cast, toJson) =>
+        val instant = Instant.from(ISO_DATE_TIME.parse(in))
+        val nanos = TimeUnit.SECONDS.toNanos(instant.getEpochSecond()) + instant.getNano();
+        val builder = new VariantBuilder(false)
+        builder.appendTimestampNanos(nanos)
+        val bytes = builder.result().getValue()
+        checkToJson(bytes, "\"" + toJson + "\"")
+        checkCast(bytes, StringType, cast)
+        checkCast(bytes, TimestampType, nanos / NANOS_PER_MICROS)
+      }
     }
 
     // TimestampNanosNtz
@@ -885,7 +889,9 @@ class VariantExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
         ("1970-01-01T00:00:00.123456789Z", "1970-01-01 00:00:00.123456789",
          "1970-01-01 00:00:00.123456789"),
         ("2100-12-31T23:59:59.00100Z", "2100-12-31 23:59:59.001",
-         "2100-12-31 23:59:59.001")
+         "2100-12-31 23:59:59.001"),
+        ("1677-09-21T00:12:45.291448384Z", "1677-09-21 00:12:45.291448384",
+         "1677-09-21 00:12:45.291448384")
     )
     timestamps_ntz.foreach { case (in, cast, toJson) =>
       val instant = Instant.from(ISO_DATE_TIME.parse(in))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
@@ -1032,12 +1032,12 @@ class VariantExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       val variantNull = Literal(new VariantVal(Array(primitiveHeader(NULL)), emptyMetadata))
       val array = Cast(CreateArray(Seq(v, variantNull)), VariantType)
       checkEvaluation(SchemaOfVariant(array), s"ARRAY<$typeString>")
-      // Merge with another type results in VARIANT.
+      // Merge with non-nanos timestamp type results in VARIANT.
       val variantString = Literal(new VariantVal(
             Array(primitiveHeader(TIMESTAMP)) ++ Array.fill(8)(0.toByte), emptyMetadata))
-      val array2 = Cast(CreateArray(Seq(uuid, variantString)), VariantType)
+      val array2 = Cast(CreateArray(Seq(v, variantString)), VariantType)
+      checkEvaluation(SchemaOfVariant(array2), s"ARRAY<VARIANT>")
     }
-
   }
 
   test("schema_of_variant - schema merge") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
@@ -868,14 +868,15 @@ class VariantExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
         ("2100-12-31T23:59:59.00100-08:00", "2100-12-31 23:59:59.001",
          "2100-12-31 23:59:59.001-08:00")
     )
-    timestamps.foreach { case (in, cast, to_json) =>
+    timestamps.foreach { case (in, cast, toJson) =>
       val instant = Instant.from(ISO_DATE_TIME.parse(in))
       val nanos = TimeUnit.SECONDS.toNanos(instant.getEpochSecond()) + instant.getNano();
       val builder = new VariantBuilder(false)
       builder.appendTimestampNanos(nanos)
       val bytes = builder.result().getValue()
-      checkToJson(bytes, "\"" + to_json + "\"")
+      checkToJson(bytes, "\"" + toJson + "\"")
       checkCast(bytes, StringType, cast)
+      checkCast(bytes, TimestampType, nanos / NANOS_PER_MICROS)
     }
 
     // TimestampNanosNtz
@@ -886,14 +887,15 @@ class VariantExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
         ("2100-12-31T23:59:59.00100Z", "2100-12-31 23:59:59.001",
          "2100-12-31 23:59:59.001")
     )
-    timestamps_ntz.foreach { case (in, cast, to_json) =>
+    timestamps_ntz.foreach { case (in, cast, toJson) =>
       val instant = Instant.from(ISO_DATE_TIME.parse(in))
       val nanos = TimeUnit.SECONDS.toNanos(instant.getEpochSecond()) + instant.getNano();
       val builder = new VariantBuilder(false)
       builder.appendTimestampNanosNtz(nanos)
       val bytes = builder.result().getValue()
-      checkToJson(bytes, "\"" + to_json + "\"")
+      checkToJson(bytes, "\"" + toJson + "\"")
       checkCast(bytes, StringType, cast)
+      checkCast(bytes, TimestampNTZType, nanos / NANOS_PER_MICROS)
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
@@ -859,18 +859,6 @@ class VariantExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkCast(bytes, StringType,
       "01020304-0506-0708-090a-0b0c0d0e0f10")
 
-// Time
-// TODO: Wait until we have OSS support?
-//    val times = Seq("23:23:59", "01:23:45.123", "00:00:00.123456")
-//    times.foreach { t =>
-//      val micros = LocalTime.parse(t).toNanoOfDay() / 1000
-//      val builder = new VariantBuilder(false)
-//      builder.appendTime(micros)
-//      val bytes = builder.result().getValue()
-//      checkToJson(bytes, "\"" + t + "\"")
-//      checkCast(bytes, StringType, t)
-//    }
-
     // TimestampNanos
     // Cast and to_json produce slightly different formats.
     val timestamps = Seq(
@@ -1035,8 +1023,7 @@ class VariantExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     val array2 = Cast(CreateArray(Seq(uuid, variantString)), VariantType)
     checkEvaluation(SchemaOfVariant(array2), s"ARRAY<VARIANT>")
 
-    Seq((TIME, "TIME(6)"),
-        (TIMESTAMP_NANOS, "TIMESTAMP_NANOS"),
+    Seq((TIMESTAMP_NANOS, "TIMESTAMP_NANOS"),
         (TIMESTAMP_NANOS_NTZ, "TIMESTAMP_NANOS_NTZ")).foreach { case (hdr, typeString) =>
       val value = Array(primitiveHeader(hdr)) ++ Array.fill(8)(0.toByte)
       val v = Literal(new VariantVal(value, emptyMetadata))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Adds Variant support for the nanosecond precision timestamp types in https://github.com/apache/parquet-format/commit/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2, similar to the UUID support added in https://github.com/apache/spark/pull/50025.

Cast support: the PR allows casting to any type that the corresponding microsecond value supports. For strings, we retain the nanosecond precision, and for all other casts, we truncate to a microsecond timestamp and then cast. An alternative is to round to the nearest microsecond, but truncation is consistent with our current timestamp-to-integer cast, which truncates to the nearest second. We could also consider disabling some of these casts, but I didn't see a strong argument to.

SchemaOfVariant: The types are reported as `timestamp_nanos` and `timestamp_nanos_ntz`. If Spark eventually adds native support for these types, we would either need to use these names, or change the behaviour of SchemaOfVariant.

### Why are the changes needed?

Support Variant values written by other tools.

### Does this PR introduce _any_ user-facing change?

Yes, operations on Variant binaries with these types would have previously failed, and will now succeed.

### How was this patch tested?

Unit tests.

### Was this patch authored or co-authored using generative AI tooling?

No.