### PR TITLE
[SPARK-51505][SQL] Log empty partition number metrics in AQE coalesce

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEShuffleReadExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEShuffleReadExec.scala
@@ -204,6 +204,7 @@ case class AQEShuffleReadExec private(
       val y = child match {
         case s: ShuffleQueryStageExec =>
           s.mapStats.map(stats => stats.bytesByPartitionId.count(_ == 0)).getOrElse(0)
+        case _ => 0
       }
       numEmptyPartitionsMetric.set(y)
       driverAccumUpdates ++= Seq(numCoalescedPartitionsMetric.id -> x,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEShuffleReadExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEShuffleReadExec.scala
@@ -200,7 +200,14 @@ case class AQEShuffleReadExec private(
       val numCoalescedPartitionsMetric = metrics("numCoalescedPartitions")
       val x = partitionSpecs.count(isCoalescedSpec)
       numCoalescedPartitionsMetric.set(x)
-      driverAccumUpdates += numCoalescedPartitionsMetric.id -> x
+      val numEmptyPartitionsMetric = metrics("numEmptyPartitions")
+      val y = child match {
+        case s: ShuffleQueryStageExec =>
+          s.mapStats.map(stats => stats.bytesByPartitionId.count(_ == 0)).getOrElse(0)
+      }
+      numEmptyPartitionsMetric.set(y)
+      driverAccumUpdates ++= Seq(numCoalescedPartitionsMetric.id -> x,
+        numEmptyPartitionsMetric.id -> y)
     }
 
     partitionDataSizes.foreach { dataSizes =>
@@ -236,7 +243,9 @@ case class AQEShuffleReadExec private(
       } ++ {
         if (hasCoalescedPartition) {
           Map("numCoalescedPartitions" ->
-            SQLMetrics.createMetric(sparkContext, "number of coalesced partitions"))
+            SQLMetrics.createMetric(sparkContext, "number of coalesced partitions"),
+            "numEmptyPartitions" ->
+              SQLMetrics.createMetric(sparkContext, "number of empty partitions"))
         } else {
           Map.empty
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/CoalesceShufflePartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/CoalesceShufflePartitionsSuite.scala
@@ -493,6 +493,23 @@ class CoalesceShufflePartitionsSuite extends SparkFunSuite with SQLConfHelper
       withSparkSession(test, Int.MaxValue, None, enableIOEncryption)
     }
   }
+
+  test("SPARK-51505: log empty partition number metrics") {
+    val test: SparkSession => Unit = { spark: SparkSession =>
+      withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "5") {
+        val df = spark.range(0, 1000, 1, 5).withColumn("value", when(col("id") < 500, 0)
+            .otherwise(1)).groupBy("value").agg("value" -> "sum")
+        df.collect()
+        val plan = df.queryExecution.executedPlan
+        val coalesce = collectFirst(plan) {
+          case e: AQEShuffleReadExec => e
+        }.get
+        assert(coalesce.numEmptyPartitions.get == 3)
+        assert(coalesce.metrics("numEmptyPartitions").value == 3)
+      }
+    }
+    withSparkSession(test, 100, None)
+  }
 }
 
 object CoalescedShuffleRead {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/CoalesceShufflePartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/CoalesceShufflePartitionsSuite.scala
@@ -504,7 +504,6 @@ class CoalesceShufflePartitionsSuite extends SparkFunSuite with SQLConfHelper
         val coalesce = collectFirst(plan) {
           case e: AQEShuffleReadExec => e
         }.get
-        assert(coalesce.numEmptyPartitions.get == 3)
         assert(coalesce.metrics("numEmptyPartitions").value == 3)
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1100,7 +1100,7 @@ class AdaptiveQueryExecSuite
       assert(!read.hasSkewedPartition)
       assert(read.hasCoalescedPartition)
       assert(read.metrics.keys.toSeq.sorted == Seq(
-        "numCoalescedPartitions", "numPartitions", "partitionDataSize"))
+        "numCoalescedPartitions", "numEmptyPartitions", "numPartitions", "partitionDataSize"))
       assert(read.metrics("numCoalescedPartitions").value == 1)
       assert(read.metrics("numPartitions").value == read.partitionSpecs.length)
       assert(read.metrics("partitionDataSize").value > 0)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Log empty partition number metrics in AQE coalesce

Spark UI Before:
<img width="428" alt="before" src="https://github.com/user-attachments/assets/c817384f-a049-40d6-9bca-140255ea479f" />


Spark UI After:
<img width="469" alt="after" src="https://github.com/user-attachments/assets/c3ad79b7-5ac4-441a-ac74-50f765df85b1" />



### Why are the changes needed?

There're cases where shuffle is highly skewed and many partitions are empty (probably due to small NDV) and only a few partitons contains data and are very large. AQE coalesce here basically did nothing by eliminate the empty partitions. AQE coalesce metrics might look confusing and user might think it wrongly coalesce to large partitions.

We'd better log empty partition number in the metrics.


### Does this PR introduce _any_ user-facing change?
Added `numEmptyPartitions` metrics to AQEShuffleReadExec when there is coalescing.


### How was this patch tested?

New test case.

### Was this patch authored or co-authored using generative AI tooling?
NO
