### PR TITLE
[SPARK-51496][SQL] CaseInsensitiveStringMap comparison should ignore case

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2Writes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2Writes.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
-import java.util.UUID
+import java.util.{Locale, UUID}
 
 import scala.jdk.CollectionConverters._
 
@@ -125,7 +125,14 @@ object V2Writes extends Rule[LogicalPlan] with PredicateHelper {
     // for DataFrame API cases, same options are carried by both Command and DataSourceV2Relation
     // for DataFrameV2 API cases, options are only carried by Command
     // for SQL cases, options are only carried by DataSourceV2Relation
-    assert(commandOptions == dsOptions || commandOptions.isEmpty || dsOptions.isEmpty)
+    // Since both options are CaseInsensitiveStringMap, change the key values to lower
+    // before comparison.
+    val lowerCaseCommandOptions =
+      commandOptions.map { case (k, v) => (k.toLowerCase(Locale.ROOT), v.toLowerCase(Locale.ROOT)) }
+    val lowerCaseDsOptions =
+      dsOptions.map { case (k, v) => (k.toLowerCase(Locale.ROOT), v.toLowerCase(Locale.ROOT)) }
+    assert(lowerCaseCommandOptions ==
+      lowerCaseDsOptions || commandOptions.isEmpty || dsOptions.isEmpty)
     commandOptions ++ dsOptions
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2Writes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2Writes.scala
@@ -128,9 +128,9 @@ object V2Writes extends Rule[LogicalPlan] with PredicateHelper {
     // Since both options are CaseInsensitiveStringMap, change the key values to lower
     // before comparison.
     val lowerCaseCommandOptions =
-      commandOptions.map { case (k, v) => (k.toLowerCase(Locale.ROOT), v.toLowerCase(Locale.ROOT)) }
+      commandOptions.map { case (k, v) => (k.toLowerCase(Locale.ROOT), v) }
     val lowerCaseDsOptions =
-      dsOptions.map { case (k, v) => (k.toLowerCase(Locale.ROOT), v.toLowerCase(Locale.ROOT)) }
+      dsOptions.map { case (k, v) => (k.toLowerCase(Locale.ROOT), v) }
     assert(lowerCaseCommandOptions ==
       lowerCaseDsOptions || commandOptions.isEmpty || dsOptions.isEmpty)
     commandOptions ++ dsOptions


### PR DESCRIPTION


### What changes were proposed in this pull request?
Since both `commandOptions` and `dsOptions` are `CaseInsensitiveStringMap` objects, I think we should convert the keys and values to lowercase before comparing them

### Why are the changes needed?

In iceberg/spark4.0 integration, I got a few assertion errors:
```
assertion failed
java.lang.AssertionError: assertion failed
	at scala.Predef$.assert(Predef.scala:264)
	at org.apache.spark.sql.execution.datasources.v2.V2Writes$.org$apache$spark$sql$execution$datasources$v2$V2Writes$$mergeOptions(V2Writes.scala:128)
```

The assertion error occurs when comparing commandOptions and dsOptions; the cases of the keys don't match.
```
assert(commandOptions == dsOptions)
```



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
I have verified that the iceberg tests can pass with this fix.


### Was this patch authored or co-authored using generative AI tooling?
no
