### PR TITLE
[SPARK-51511][INFRA] Upgrade `apache-rat` in the `dev/check-license to` 0.16.1

### DIFF
--- a/dev/check-license
+++ b/dev/check-license
@@ -58,7 +58,7 @@ else
     declare java_cmd=java
 fi
 
-export RAT_VERSION=0.15
+export RAT_VERSION=0.16.1
 export rat_jar="$FWDIR"/lib/apache-rat-${RAT_VERSION}.jar
 mkdir -p "$FWDIR"/lib
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This ps upgraded `apache-rat` used in the `dev/check-license` from 0.15 to 0.16.1

### Why are the changes needed?
The full release notes as follow:
- https://creadur.apache.org/release-notes/RELEASE-NOTES-016.txt
- https://creadur.apache.org/release-notes/RELEASE-NOTES-0161.txt

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- manual check:

Manually remove the license of a file, and then execute `dev/check-license`

```
dev/check-license 
ERROR: Ignored 0 lines in your exclusion files as comments or empty lines.
Could not find Apache license headers in the following files:
 !????? /Users/yangjie01/SourceCode/git/spark-maven/core/src/main/scala/org/apache/spark/paths/SparkPath.scala
```

After restoring the file, execute dev/check-license again.

```
dev/check-license
ERROR: Ignored 0 lines in your exclusion files as comments or empty lines.
RAT checks passed.
```

### Was this patch authored or co-authored using generative AI tooling?
No