### PR TITLE
[SPARK-51518][SQL] Support | as an alternative to |> for the SQL pipe operator token

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -40,6 +40,13 @@ options { tokenVocab = SqlBaseLexer; }
    * When true, double quoted literals are identifiers rather than STRINGs.
    */
   public boolean double_quoted_identifiers = false;
+
+  /**
+   * When true, the single character operator pipe token is enabled. This allows the use of a single
+   * '|' character as the operator pipe token, which is a shorthand for the full two-character token
+   * '|>'."
+   */
+  public boolean single_character_pipe_operator_token_enabled = false;
 }
 
 compoundOrSingleStatement
@@ -663,6 +670,8 @@ queryTerm
     | left=queryTerm {!legacy_setops_precedence_enabled}?
         operator=(UNION | EXCEPT | SETMINUS) setQuantifier? right=queryTerm              #setOperation
     | left=queryTerm OPERATOR_PIPE operatorPipeRightSide                                 #operatorPipeStatement
+    | left=queryTerm PIPE {single_character_pipe_operator_token_enabled}?
+        operatorPipeRightSide                                                            #operatorPipeStatement
     ;
 
 queryPrimary

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/parsers.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/parsers.scala
@@ -70,6 +70,8 @@ abstract class AbstractParser extends DataTypeParserInterface with Logging {
     parser.legacy_exponent_literal_as_decimal_enabled = conf.exponentLiteralAsDecimalEnabled
     parser.SQL_standard_keyword_behavior = conf.enforceReservedKeywords
     parser.double_quoted_identifiers = conf.doubleQuotedIdentifiers
+    parser.single_character_pipe_operator_token_enabled =
+      conf.singleCharacterOperatorPipeTokenEnabled
 
     // https://github.com/antlr/antlr4/issues/192#issuecomment-15238595
     // Save a great deal of time on correct inputs by using a two-stage parsing strategy.

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
@@ -47,6 +47,7 @@ private[sql] trait SqlApiConf {
   def stackTracesInDataFrameContext: Int
   def dataFrameQueryContextEnabled: Boolean
   def legacyAllowUntypedScalaUDFs: Boolean
+  def singleCharacterOperatorPipeTokenEnabled: Boolean
 }
 
 private[sql] object SqlApiConf {
@@ -88,4 +89,5 @@ private[sql] object DefaultSqlApiConf extends SqlApiConf {
   override def stackTracesInDataFrameContext: Int = 1
   override def dataFrameQueryContextEnabled: Boolean = true
   override def legacyAllowUntypedScalaUDFs: Boolean = false
+  override def singleCharacterOperatorPipeTokenEnabled: Boolean = true
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5352,6 +5352,17 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val SINGLE_CHARACTER_OPERATOR_PIPE_TOKEN_ENABLED =
+    buildConf("spark.sql.singleCharacterOperatorPipeTokenEnabled")
+      .internal()
+      .doc("When set to true, and 'spark.sql.operatorPipeSyntaxEnabled' is also true, the " +
+        "single character operator pipe token is enabled. This allows the use of a single " +
+        "'|' character as the operator pipe token, which is a shorthand for the full " +
+        "two-character token '|>'.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val LEGACY_PERCENTILE_DISC_CALCULATION = buildConf("spark.sql.legacy.percentileDiscCalculation")
     .internal()
     .doc("If true, the old bogus percentile_disc calculation is used. The old calculation " +
@@ -6584,6 +6595,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def legacyCodingErrorAction: Boolean = getConf(SQLConf.LEGACY_CODING_ERROR_ACTION)
 
   def legacyEvalCurrentTime: Boolean = getConf(SQLConf.LEGACY_EVAL_CURRENT_TIME)
+
+  override def singleCharacterOperatorPipeTokenEnabled: Boolean =
+    getConf(SQLConf.SINGLE_CHARACTER_OPERATOR_PIPE_TOKEN_ENABLED)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -3977,6 +3977,48 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 
 
 -- !query
+from t
+| select x, y
+-- !query analysis
+Project [x#x, y#x]
++- SubqueryAlias spark_catalog.default.t
+   +- Relation spark_catalog.default.t[x#x,y#x] csv
+
+
+-- !query
+from t
+| select x | 8
+| select 1 | 8
+-- !query analysis
+Project [(1 | 8) AS (1 | 8)#x]
++- Project [(x#x | 8) AS (x | 8)#x]
+   +- SubqueryAlias spark_catalog.default.t
+      +- Relation spark_catalog.default.t[x#x,y#x] csv
+
+
+-- !query
+from t
+| select x | (select 8)
+-- !query analysis
+Project [(x#x | scalar-subquery#x []) AS (x | scalarsubquery())#x]
+:  +- Project [8 AS 8#x]
+:     +- OneRowRelation
++- SubqueryAlias spark_catalog.default.t
+   +- Relation spark_catalog.default.t[x#x,y#x] csv
+
+
+-- !query
+from t
+| select x
+| select 8
+-- !query analysis
+Project [8 AS 8#x]
++- Project [x#x]
+   +- SubqueryAlias spark_catalog.default.t
+      +- Relation spark_catalog.default.t[x#x,y#x] csv
+
+
+-- !query
 with customer_total_return as
 (select
     sr_customer_sk as ctr_customer_sk,

--- a/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
@@ -1251,6 +1251,24 @@ table windowTestData
 |> select cate, val, sum(val) over w as sum_val
    window w as (order by val);
 
+-- Exercise the use of '|' as an alternative to '|>' for the pipe operator token.
+-- Note that '|' is also a valid token for performing bit operations between integers in SQL
+-- expressions, so we exercise a combination of both cases here. In general, the parser should
+-- prefer the case that matches first when proceeding through the rules of the grammar.
+from t
+| select x, y;
+
+from t
+| select x | 8
+| select 1 | 8;
+
+from t
+| select x | (select 8);
+
+from t
+| select x
+| select 8;
+
 -- Exercise SQL compilation using a subset of TPC-DS table schemas.
 -------------------------------------------------------------------
 

--- a/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
@@ -3629,6 +3629,48 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 
 
 -- !query
+from t
+| select x, y
+-- !query schema
+struct<x:int,y:string>
+-- !query output
+0	abc
+1	def
+
+
+-- !query
+from t
+| select x | 8
+| select 1 | 8
+-- !query schema
+struct<(1 | 8):int>
+-- !query output
+9
+9
+
+
+-- !query
+from t
+| select x | (select 8)
+-- !query schema
+struct<(x | scalarsubquery()):int>
+-- !query output
+8
+9
+
+
+-- !query
+from t
+| select x
+| select 8
+-- !query schema
+struct<8:int>
+-- !query output
+8
+8
+
+
+-- !query
 with customer_total_return as
 (select
     sr_customer_sk as ctr_customer_sk,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
@@ -1007,5 +1007,18 @@ class SparkSqlParserSuite extends AnalysisTest with SharedSparkSession {
           start = 0,
           stop = sql.length - 1))
     }
+    // Check usage of the '|' token as an alternative to the '|>' token.
+    checkPipeSelect("TABLE t | SELECT 1 AS X")
+    checkPipeSelect("TABLE t | SELECT 1 AS X, 2 AS Y | SELECT X + Y AS Z")
+    withSQLConf(SQLConf.SINGLE_CHARACTER_OPERATOR_PIPE_TOKEN_ENABLED.key -> "false") {
+      val sql = "TABLE t | SELECT 1 AS X"
+      checkError(
+        exception = parseException(sql),
+        condition = "PARSE_SYNTAX_ERROR",
+        parameters = Map(
+          "error" ->
+            "rule queryTerm failed predicate: {single_character_pipe_operator_token_enabled}?",
+          "hint" -> ""))
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR supports `|` as an alternative to `|>` for the SQL pipe operator token.

For example, this is now supported:

```
from t
| select x, y;
```

as an alternative to this:

```
from t
|> select x, y;
```

The change is controlled by a new Spark configuration `SQLConf.SINGLE_CHARACTER_OPERATOR_PIPE_TOKEN_ENABLED` (`spark.sql.singleCharacterOperatorPipeTokenEnabled`).

Background:

* We talked with Jeff Shute, the author of the SQL pipe syntax paper from Google.
* He mentions that they went with `|>` because all implementing engines can support it without any issues with their parsers.
* Specifically, Google uses an LALR parser [1] which makes it impossible to use | as the token due to ambiguity with bit operations. They won't be able to add support for this.

It seems like a growing consensus in the industry is that we should all support `|>` as the primary token, but some engines may also decide to support alternative tokens in addition. This blog [2] describes the situation and mentions how another engine decided to go this direction.

[1] https://github.com/google/zetasql/blob/master/bazel/bison.bzl

[2] https://superdb.org/docs/language/pipe-ambiguity/

### Why are the changes needed?

This is a simple and safe change and provides syntax compatibility with other languages that use `|` for this purpose such as [Splunk SPL](https://www.splunk.com/en_us/blog/learn/splunk-cheat-sheet-query-spl-regex-commands.html) and [Kusto](https://learn.microsoft.com/en-us/kusto/query/?view=microsoft-fabric).

### Does this PR introduce _any_ user-facing change?

Yes, per above. Note this change is fully backwards-compatible.

### How was this patch tested?

This PR provides unit tests and golden file tests.

### Was this patch authored or co-authored using generative AI tooling?

No.