### PR TITLE
[SPARK-51884][SQL]Part 1.a Add outer scope attributes for SubqueryExpression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2319,21 +2319,21 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
      */
     private def resolveSubQueries(plan: LogicalPlan, outer: LogicalPlan): LogicalPlan = {
       plan.transformAllExpressionsWithPruning(_.containsPattern(PLAN_EXPRESSION), ruleId) {
-        case s @ ScalarSubquery(sub, _, exprId, _, _, _, _) if !sub.resolved =>
-          resolveSubQuery(s, outer)(ScalarSubquery(_, _, exprId))
-        case e @ Exists(sub, _, exprId, _, _) if !sub.resolved =>
-          resolveSubQuery(e, outer)(Exists(_, _, exprId))
-        case InSubquery(values, l @ ListQuery(_, _, exprId, _, _, _))
+        case s @ ScalarSubquery(sub, _, _, exprId, _, _, _, _) if !sub.resolved =>
+          resolveSubQuery(s, outer)(ScalarSubquery(_, _, Seq.empty, exprId))
+        case e @ Exists(sub, _, _, exprId, _, _) if !sub.resolved =>
+          resolveSubQuery(e, outer)(Exists(_, _, Seq.empty, exprId))
+        case InSubquery(values, l @ ListQuery(_, _, _, exprId, _, _))
             if values.forall(_.resolved) && !l.resolved =>
           val expr = resolveSubQuery(l, outer)((plan, exprs) => {
-            ListQuery(plan, exprs, exprId, plan.output.length)
+            ListQuery(plan, exprs, Seq.empty, exprId, plan.output.length)
           })
           InSubquery(values, expr.asInstanceOf[ListQuery])
-        case s @ LateralSubquery(sub, _, exprId, _, _) if !sub.resolved =>
-          resolveSubQuery(s, outer)(LateralSubquery(_, _, exprId))
+        case s @ LateralSubquery(sub, _, _, exprId, _, _) if !sub.resolved =>
+          resolveSubQuery(s, outer)(LateralSubquery(_, _, Seq.empty, exprId))
         case a: FunctionTableSubqueryArgumentExpression if !a.plan.resolved =>
           resolveSubQuery(a, outer)(
-            (plan, outerAttrs) => a.copy(plan = plan, outerAttrs = outerAttrs))
+            (plan, outerAttrs) => a.copy(plan = plan, outerAttrs = outerAttrs, unresolvedOuterAttrs = Seq.empty))
       }
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2323,7 +2323,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
           resolveSubQuery(s, outer)(ScalarSubquery(_, _, Seq.empty, exprId))
         case e @ Exists(sub, _, _, exprId, _, _) if !sub.resolved =>
           resolveSubQuery(e, outer)(Exists(_, _, Seq.empty, exprId))
-        case InSubquery(values, l @ ListQuery(_, _, _, exprId, _, _))
+        case InSubquery(values, l @ ListQuery(_, _, _, exprId, _, _, _))
             if values.forall(_.resolved) && !l.resolved =>
           val expr = resolveSubQuery(l, outer)((plan, exprs) => {
             ListQuery(plan, exprs, Seq.empty, exprId, plan.output.length)
@@ -2333,7 +2333,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
           resolveSubQuery(s, outer)(LateralSubquery(_, _, Seq.empty, exprId))
         case a: FunctionTableSubqueryArgumentExpression if !a.plan.resolved =>
           resolveSubQuery(a, outer)(
-            (plan, outerAttrs) => a.copy(plan = plan, outerAttrs = outerAttrs, unresolvedOuterAttrs = Seq.empty))
+            (plan, outerAttrs) => a.copy(plan = plan, outerAttrs = outerAttrs))
       }
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ValidateSubqueryExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ValidateSubqueryExpression.scala
@@ -129,7 +129,7 @@ object ValidateSubqueryExpression
     checkOuterReference(plan, expr)
 
     expr match {
-      case ScalarSubquery(query, outerAttrs, _, _, _, _, _) =>
+      case ScalarSubquery(query, outerAttrs, _, _, _, _, _, _) =>
         // Scalar subquery must return one column as output.
         if (query.output.size != 1) {
           throw QueryCompilationErrors.subqueryReturnMoreThanOneColumn(query.output.size,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SQLFunction.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SQLFunction.scala
@@ -85,7 +85,7 @@ case class SQLFunction(
       case (None, Some(Project(expr :: Nil, _: OneRowRelation)))
         if !isTableFunc =>
         (Some(expr), None)
-      case (Some(ScalarSubquery(Project(expr :: Nil, _: OneRowRelation), _, _, _, _, _, _)), None)
+      case (Some(ScalarSubquery(Project(expr :: Nil, _: OneRowRelation), _, _, _, _, _, _, _)), None)
         if !isTableFunc =>
         (Some(expr), None)
       case (_, _) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SQLFunction.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SQLFunction.scala
@@ -85,8 +85,8 @@ case class SQLFunction(
       case (None, Some(Project(expr :: Nil, _: OneRowRelation)))
         if !isTableFunc =>
         (Some(expr), None)
-      case (Some(ScalarSubquery(Project(expr :: Nil, _: OneRowRelation), _, _, _, _, _, _, _)), None)
-        if !isTableFunc =>
+      case (Some(ScalarSubquery(Project(expr :: Nil, _: OneRowRelation),
+        _, _, _, _, _, _, _)), None) if !isTableFunc =>
         (Some(expr), None)
       case (_, _) =>
         (parsedExpression, parsedQuery)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
@@ -73,12 +73,11 @@ case class DynamicPruningSubquery(
   override def withNewOuterScopeAttrs(
     outerScopeAttrs: Seq[Expression]
   ): DynamicPruningSubquery = {
-    // DynamicPruningSubquery should not have outer scope attrs
     if (outerScopeAttrs.nonEmpty) {
       throw SparkException.internalError(
         "DynamicPruningSubquery should not have outer scope attributes.")
     }
-    copy()
+    this
   }
 
   override def withNewHint(hint: Option[HintInfo]): SubqueryExpression = copy(hint = hint)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
@@ -31,7 +31,7 @@ trait DynamicPruning extends Predicate
  * join with a filter from the other side of the join. It is inserted in cases where partition
  * pruning can be applied.
  * The DynamicPruningSubquery expression should only have a single outer
- * attribute which is the pruning key and should not have any nested outer attributes.
+ * attribute which is the pruning key and should not have any outer scope attributes.
  *
  * @param pruningKey the filtering key of the plan to be pruned.
  * @param buildQuery the build side of the join.
@@ -70,13 +70,13 @@ case class DynamicPruningSubquery(
     copy()
   }
 
-  override def withNewNestedOuterAttrs(
-    nestedOuterAttrs: Seq[Expression]
+  override def withNewOuterScopeAttrs(
+    outerScopeAttrs: Seq[Expression]
   ): DynamicPruningSubquery = {
-    // DynamicPruningSubquery should not have nested outer attrs
-    if (nestedOuterAttrs.nonEmpty) {
+    // DynamicPruningSubquery should not have outer scope attrs
+    if (outerScopeAttrs.nonEmpty) {
       throw SparkException.internalError(
-        "DynamicPruningSubquery should not have nested outer attributes.")
+        "DynamicPruningSubquery should not have outer scope attributes.")
     }
     copy()
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
@@ -30,6 +30,8 @@ trait DynamicPruning extends Predicate
  * The DynamicPruningSubquery expression is only used in join operations to prune one side of the
  * join with a filter from the other side of the join. It is inserted in cases where partition
  * pruning can be applied.
+ * The DynamicPruningSubquery expression should only have a single outer
+ * attribute which is the pruning key and should not have any nested outer attributes.
  *
  * @param pruningKey the filtering key of the plan to be pruned.
  * @param buildQuery the build side of the join.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
@@ -47,7 +47,7 @@ case class DynamicPruningSubquery(
     onlyInBroadcast: Boolean,
     exprId: ExprId = NamedExpression.newExprId,
     hint: Option[HintInfo] = None)
-  extends SubqueryExpression(buildQuery, Seq(pruningKey), exprId, Seq.empty, hint)
+  extends SubqueryExpression(buildQuery, Seq(pruningKey), Seq.empty, exprId, Seq.empty, hint)
   with DynamicPruning
   with Unevaluable
   with UnaryLike[Expression] {
@@ -64,6 +64,12 @@ case class DynamicPruningSubquery(
     // Updating outer attrs of DynamicPruningSubquery is unsupported; assert that they match
     // pruningKey and return a copy without any changes.
     assert(outerAttrs.size == 1 && outerAttrs.head.semanticEquals(pruningKey))
+    copy()
+  }
+
+  override def withNewUnresolvedOuterAttrs(unresolvedOuterAttrs: Seq[Expression]): DynamicPruningSubquery = {
+    // DynamicPruningSubquery should not have unresolved outer attrs
+    assert(unresolvedOuterAttrs.isEmpty)
     copy()
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.plans.logical.{HintInfo, LogicalPlan}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
@@ -71,7 +71,10 @@ case class DynamicPruningSubquery(
     nestedOuterAttrs: Seq[Expression]
   ): DynamicPruningSubquery = {
     // DynamicPruningSubquery should not have nested outer attrs
-    assert(nestedOuterAttrs.isEmpty)
+    if (nestedOuterAttrs.nonEmpty) {
+      throw SparkException.internalError(
+        "DynamicPruningSubquery should not have nested outer attributes.")
+    }
     copy()
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
@@ -67,7 +67,9 @@ case class DynamicPruningSubquery(
     copy()
   }
 
-  override def withNewUnresolvedOuterAttrs(unresolvedOuterAttrs: Seq[Expression]): DynamicPruningSubquery = {
+  override def withNewUnresolvedOuterAttrs(
+    unresolvedOuterAttrs: Seq[Expression]
+  ): DynamicPruningSubquery = {
     // DynamicPruningSubquery should not have unresolved outer attrs
     assert(unresolvedOuterAttrs.isEmpty)
     copy()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
@@ -67,11 +67,11 @@ case class DynamicPruningSubquery(
     copy()
   }
 
-  override def withNewUnresolvedOuterAttrs(
-    unresolvedOuterAttrs: Seq[Expression]
+  override def withNewNestedOuterAttrs(
+    nestedOuterAttrs: Seq[Expression]
   ): DynamicPruningSubquery = {
-    // DynamicPruningSubquery should not have unresolved outer attrs
-    assert(unresolvedOuterAttrs.isEmpty)
+    // DynamicPruningSubquery should not have nested outer attrs
+    assert(nestedOuterAttrs.isEmpty)
     copy()
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
@@ -90,14 +90,20 @@ case class FunctionTableSubqueryArgumentExpression(
     "WITH SINGLE PARTITION is mutually exclusive with PARTITION BY")
 
   override def dataType: DataType = plan.schema
+
   override def nullable: Boolean = false
+
   override def withNewPlan(plan: LogicalPlan): FunctionTableSubqueryArgumentExpression =
     copy(plan = plan)
+
   override def withNewOuterAttrs(outerAttrs: Seq[Expression])
   : FunctionTableSubqueryArgumentExpression = copy(outerAttrs = outerAttrs)
+
   override def hint: Option[HintInfo] = None
+
   override def withNewHint(hint: Option[HintInfo]): FunctionTableSubqueryArgumentExpression =
     copy()
+
   override def withNewOuterScopeAttrs(
     outerScopeAttrs: Seq[Expression]
   ): FunctionTableSubqueryArgumentExpression = {
@@ -106,6 +112,7 @@ case class FunctionTableSubqueryArgumentExpression(
   }
 
   override def toString: String = s"table-argument#${exprId.id} $conditionString"
+
   override lazy val canonicalized: Expression = {
     FunctionTableSubqueryArgumentExpression(
       plan.canonicalized,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
@@ -105,10 +105,10 @@ case class FunctionTableSubqueryArgumentExpression(
     copy()
 
   override def withNewOuterScopeAttrs(
-    outerScopeAttrs: Seq[Expression]
+    newOuterScopeAttrs: Seq[Expression]
   ): FunctionTableSubqueryArgumentExpression = {
-    validateOuterScopeAttrs()
-    copy(outerScopeAttrs = outerScopeAttrs)
+    validateOuterScopeAttrs(newOuterScopeAttrs)
+    copy(outerScopeAttrs = newOuterScopeAttrs)
   }
 
   override def toString: String = s"table-argument#${exprId.id} $conditionString"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
@@ -47,9 +47,9 @@ import org.apache.spark.sql.types.DataType
  * @param outerAttrs outer references of this subquery plan, generally empty since these table
  *                   arguments do not allow correlated references currently
  * @param outerScopeAttrs outer references of the subquery plan that cannot be resolved by the
- *                         direct containing query of the subquery. They have to be the subset of
- *                         outerAttrs and are generally empty since these table arguments do not
- *                         allow correlated references currently
+ *                        direct containing query of the subquery. They have to be the subset of
+ *                        outerAttrs and are generally empty since these table arguments do not
+ *                        allow correlated references currently
  * @param exprId expression ID of this subquery expression, generally generated afresh each time
  * @param partitionByExpressions if non-empty, the TABLE argument included the PARTITION BY clause
  *                               to indicate that the input relation should be repartitioned by the

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
@@ -46,7 +46,7 @@ import org.apache.spark.sql.types.DataType
  *             relation or as a more complex logical plan in the event of a table subquery.
  * @param outerAttrs outer references of this subquery plan, generally empty since these table
  *                   arguments do not allow correlated references currently
- * @param nestedOuterAttrs outer references of the subquery plan that cannot be resolved by the
+ * @param outerScopeAttrs outer references of the subquery plan that cannot be resolved by the
  *                         direct containing query of the subquery. They have to be the subset of
  *                         outerAttrs and are generally empty since these table arguments do not
  *                         allow correlated references currently
@@ -71,7 +71,7 @@ import org.apache.spark.sql.types.DataType
 case class FunctionTableSubqueryArgumentExpression(
     plan: LogicalPlan,
     outerAttrs: Seq[Expression] = Seq.empty,
-    nestedOuterAttrs: Seq[Expression] = Seq.empty,
+    outerScopeAttrs: Seq[Expression] = Seq.empty,
     exprId: ExprId = NamedExpression.newExprId,
     partitionByExpressions: Seq[Expression] = Seq.empty,
     withSinglePartition: Boolean = false,
@@ -80,7 +80,7 @@ case class FunctionTableSubqueryArgumentExpression(
   extends SubqueryExpression(
       plan,
       outerAttrs,
-      nestedOuterAttrs,
+      outerScopeAttrs,
       exprId,
       Seq.empty,
       None
@@ -98,11 +98,11 @@ case class FunctionTableSubqueryArgumentExpression(
   override def hint: Option[HintInfo] = None
   override def withNewHint(hint: Option[HintInfo]): FunctionTableSubqueryArgumentExpression =
     copy()
-  override def withNewNestedOuterAttrs(
-    nestedOuterAttrs: Seq[Expression]
+  override def withNewOuterScopeAttrs(
+    outerScopeAttrs: Seq[Expression]
   ): FunctionTableSubqueryArgumentExpression = {
-    validateNestedOuterAttrs()
-    copy(nestedOuterAttrs = nestedOuterAttrs)
+    validateOuterScopeAttrs()
+    copy(outerScopeAttrs = outerScopeAttrs)
   }
 
   override def toString: String = s"table-argument#${exprId.id} $conditionString"
@@ -110,7 +110,7 @@ case class FunctionTableSubqueryArgumentExpression(
     FunctionTableSubqueryArgumentExpression(
       plan.canonicalized,
       outerAttrs.map(_.canonicalized),
-      nestedOuterAttrs.map(_.canonicalized),
+      outerScopeAttrs.map(_.canonicalized),
       ExprId(0),
       partitionByExpressions,
       withSinglePartition,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
@@ -73,7 +73,8 @@ case class FunctionTableSubqueryArgumentExpression(
     withSinglePartition: Boolean = false,
     orderByExpressions: Seq[SortOrder] = Seq.empty,
     selectedInputExpressions: Seq[PythonUDTFSelectedExpression] = Seq.empty)
-  extends SubqueryExpression(plan, outerAttrs, unresolvedOuterAttrs, exprId, Seq.empty, None) with Unevaluable {
+  extends SubqueryExpression(
+    plan, outerAttrs, unresolvedOuterAttrs, exprId, Seq.empty, None) with Unevaluable {
 
   assert(!(withSinglePartition && partitionByExpressions.nonEmpty),
     "WITH SINGLE PARTITION is mutually exclusive with PARTITION BY")
@@ -87,9 +88,12 @@ case class FunctionTableSubqueryArgumentExpression(
   override def hint: Option[HintInfo] = None
   override def withNewHint(hint: Option[HintInfo]): FunctionTableSubqueryArgumentExpression =
     copy()
-  override def withNewUnresolvedOuterAttrs(unresolvedOuterAttrs: Seq[Expression]): FunctionTableSubqueryArgumentExpression = {
+  override def withNewUnresolvedOuterAttrs(
+    unresolvedOuterAttrs: Seq[Expression]
+  ): FunctionTableSubqueryArgumentExpression = {
     assert(unresolvedOuterAttrs.toSet.subsetOf(outerAttrs.toSet),
-      s"unresolvedOuterAttrs must be a subset of outerAttrs, but got ${unresolvedOuterAttrs.mkString(", ")}")
+      s"unresolvedOuterAttrs must be a subset of outerAttrs, " +
+        s"but got ${unresolvedOuterAttrs.mkString(", ")}")
     copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
   }
   override def toString: String = s"table-argument#${exprId.id} $conditionString"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
@@ -88,7 +88,7 @@ case class FunctionTableSubqueryArgumentExpression(
   override def withNewHint(hint: Option[HintInfo]): FunctionTableSubqueryArgumentExpression =
     copy()
   override def withNewUnresolvedOuterAttrs(unresolvedOuterAttrs: Seq[Expression]): FunctionTableSubqueryArgumentExpression = {
-    assert(unresolvedOuterAttrs.subsetOf(outerAttrs),
+    assert(unresolvedOuterAttrs.toSet.subsetOf(outerAttrs.toSet),
       s"unresolvedOuterAttrs must be a subset of outerAttrs, but got ${unresolvedOuterAttrs.mkString(", ")}")
     copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
@@ -67,14 +67,14 @@ import org.apache.spark.sql.types.DataType
 case class FunctionTableSubqueryArgumentExpression(
     plan: LogicalPlan,
     outerAttrs: Seq[Expression] = Seq.empty,
-    unresolvedOuterAttrs: Seq[Expression] = Seq.empty,
+    nestedOuterAttrs: Seq[Expression] = Seq.empty,
     exprId: ExprId = NamedExpression.newExprId,
     partitionByExpressions: Seq[Expression] = Seq.empty,
     withSinglePartition: Boolean = false,
     orderByExpressions: Seq[SortOrder] = Seq.empty,
     selectedInputExpressions: Seq[PythonUDTFSelectedExpression] = Seq.empty)
   extends SubqueryExpression(
-    plan, outerAttrs, unresolvedOuterAttrs, exprId, Seq.empty, None) with Unevaluable {
+    plan, outerAttrs, nestedOuterAttrs, exprId, Seq.empty, None) with Unevaluable {
 
   assert(!(withSinglePartition && partitionByExpressions.nonEmpty),
     "WITH SINGLE PARTITION is mutually exclusive with PARTITION BY")
@@ -88,20 +88,20 @@ case class FunctionTableSubqueryArgumentExpression(
   override def hint: Option[HintInfo] = None
   override def withNewHint(hint: Option[HintInfo]): FunctionTableSubqueryArgumentExpression =
     copy()
-  override def withNewUnresolvedOuterAttrs(
-    unresolvedOuterAttrs: Seq[Expression]
+  override def withNewNestedOuterAttrs(
+    nestedOuterAttrs: Seq[Expression]
   ): FunctionTableSubqueryArgumentExpression = {
-    assert(unresolvedOuterAttrs.toSet.subsetOf(outerAttrs.toSet),
-      s"unresolvedOuterAttrs must be a subset of outerAttrs, " +
-        s"but got ${unresolvedOuterAttrs.mkString(", ")}")
-    copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
+    assert(nestedOuterAttrs.toSet.subsetOf(outerAttrs.toSet),
+      s"nestedOuterAttrs must be a subset of outerAttrs, " +
+        s"but got ${nestedOuterAttrs.mkString(", ")}")
+    copy(nestedOuterAttrs = nestedOuterAttrs)
   }
   override def toString: String = s"table-argument#${exprId.id} $conditionString"
   override lazy val canonicalized: Expression = {
     FunctionTableSubqueryArgumentExpression(
       plan.canonicalized,
       outerAttrs.map(_.canonicalized),
-      unresolvedOuterAttrs.map(_.canonicalized),
+      nestedOuterAttrs.map(_.canonicalized),
       ExprId(0),
       partitionByExpressions,
       withSinglePartition,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -97,10 +97,10 @@ abstract class SubqueryExpression(
 
   def withNewOuterScopeAttrs(outerScopeAttrs: Seq[Expression]): SubqueryExpression
 
-  def validateOuterScopeAttrs(): Unit = {
-    assert(outerScopeAttrs.toSet.subsetOf(outerAttrs.toSet),
+  def validateOuterScopeAttrs(newOuterScopeAttrs: Seq[Expression]): Unit = {
+    assert(newOuterScopeAttrs.toSet.subsetOf(outerAttrs.toSet),
       s"outerScopeAttrs must be a subset of outerAttrs, " +
-        s"but got ${outerScopeAttrs.mkString(", ")}")
+        s"but got ${newOuterScopeAttrs.mkString(", ")}")
   }
 
   def getOuterScopeAttrs: Seq[Expression] = outerScopeAttrs
@@ -446,10 +446,10 @@ case class ScalarSubquery(
     outerAttrs = outerAttrs)
 
   override def withNewOuterScopeAttrs(
-      outerScopeAttrs: Seq[Expression]
+      newOuterScopeAttrs: Seq[Expression]
   ): ScalarSubquery = {
-    validateOuterScopeAttrs()
-    copy(outerScopeAttrs = outerScopeAttrs)
+    validateOuterScopeAttrs(newOuterScopeAttrs)
+    copy(outerScopeAttrs = newOuterScopeAttrs)
   }
 
   override def withNewHint(hint: Option[HintInfo]): ScalarSubquery = copy(hint = hint)
@@ -534,10 +534,10 @@ case class LateralSubquery(
     outerAttrs = outerAttrs)
 
   override def withNewOuterScopeAttrs(
-    outerScopeAttrs: Seq[Expression]
+    newOuterScopeAttrs: Seq[Expression]
   ): LateralSubquery = {
-    validateOuterScopeAttrs()
-    copy(outerScopeAttrs = outerScopeAttrs)
+    validateOuterScopeAttrs(newOuterScopeAttrs)
+    copy(outerScopeAttrs = newOuterScopeAttrs)
   }
 
   override def withNewHint(hint: Option[HintInfo]): LateralSubquery = copy(hint = hint)
@@ -612,9 +612,9 @@ case class ListQuery(
   override def withNewOuterAttrs(outerAttrs: Seq[Expression]): ListQuery = copy(
     outerAttrs = outerAttrs)
 
-  override def withNewOuterScopeAttrs(outerScopeAttrs: Seq[Expression]): ListQuery = {
-    validateOuterScopeAttrs()
-    copy(outerScopeAttrs = outerScopeAttrs)
+  override def withNewOuterScopeAttrs(newOuterScopeAttrs: Seq[Expression]): ListQuery = {
+    validateOuterScopeAttrs(newOuterScopeAttrs)
+    copy(outerScopeAttrs = newOuterScopeAttrs)
   }
 
   override def withNewHint(hint: Option[HintInfo]): ListQuery = copy(hint = hint)
@@ -683,9 +683,9 @@ case class Exists(
   override def withNewOuterAttrs(outerAttrs: Seq[Expression]): Exists = copy(
     outerAttrs = outerAttrs)
 
-  override def withNewOuterScopeAttrs(outerScopeAttrs: Seq[Expression]): Exists = {
-    validateOuterScopeAttrs()
-    copy(outerScopeAttrs = outerScopeAttrs)
+  override def withNewOuterScopeAttrs(newOuterScopeAttrs: Seq[Expression]): Exists = {
+    validateOuterScopeAttrs(newOuterScopeAttrs)
+    copy(outerScopeAttrs = newOuterScopeAttrs)
   }
 
   override def withNewHint(hint: Option[HintInfo]): Exists = copy(hint = hint)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -89,6 +89,11 @@ abstract class SubqueryExpression(
   override def withNewPlan(plan: LogicalPlan): SubqueryExpression
   def withNewOuterAttrs(outerAttrs: Seq[Expression]): SubqueryExpression
   def withNewNestedOuterAttrs(nestedOuterAttrs: Seq[Expression]): SubqueryExpression
+  def validateNestedOuterAttrs(): Unit = {
+    assert(nestedOuterAttrs.toSet.subsetOf(outerAttrs.toSet),
+      s"nestedOuterAttrs must be a subset of outerAttrs, " +
+        s"but got ${nestedOuterAttrs.mkString(", ")}")
+  }
   def getNestedOuterAttrs: Seq[Expression] = nestedOuterAttrs
   def getOuterAttrs: Seq[Expression] = outerAttrs
   def getJoinCond: Seq[Expression] = joinCond
@@ -424,9 +429,7 @@ case class ScalarSubquery(
   override def withNewNestedOuterAttrs(
       nestedOuterAttrs: Seq[Expression]
   ): ScalarSubquery = {
-    assert(nestedOuterAttrs.toSet.subsetOf(outerAttrs.toSet),
-      s"nestedOuterAttrs must be a subset of outerAttrs, " +
-        s"but got ${nestedOuterAttrs.mkString(", ")}")
+    validateNestedOuterAttrs()
     copy(nestedOuterAttrs = nestedOuterAttrs)
   }
   override def withNewHint(hint: Option[HintInfo]): ScalarSubquery = copy(hint = hint)
@@ -507,9 +510,7 @@ case class LateralSubquery(
   override def withNewNestedOuterAttrs(
     nestedOuterAttrs: Seq[Expression]
   ): LateralSubquery = {
-    assert(nestedOuterAttrs.toSet.subsetOf(outerAttrs.toSet),
-      s"nestedOuterAttrs must be a subset of outerAttrs, " +
-        s"but got ${nestedOuterAttrs.mkString(", ")}")
+    validateNestedOuterAttrs()
     copy(nestedOuterAttrs = nestedOuterAttrs)
   }
 
@@ -577,9 +578,7 @@ case class ListQuery(
   override def withNewOuterAttrs(outerAttrs: Seq[Expression]): ListQuery = copy(
     outerAttrs = outerAttrs)
   override def withNewNestedOuterAttrs(nestedOuterAttrs: Seq[Expression]): ListQuery = {
-    assert(nestedOuterAttrs.toSet.subsetOf(outerAttrs.toSet),
-      s"nestedOuterAttrs must be a subset of outerAttrs, " +
-        s"but got ${nestedOuterAttrs.mkString(", ")}")
+    validateNestedOuterAttrs()
     copy(nestedOuterAttrs = nestedOuterAttrs)
   }
   override def withNewHint(hint: Option[HintInfo]): ListQuery = copy(hint = hint)
@@ -643,9 +642,7 @@ case class Exists(
   override def withNewOuterAttrs(outerAttrs: Seq[Expression]): Exists = copy(
     outerAttrs = outerAttrs)
   override def withNewNestedOuterAttrs(nestedOuterAttrs: Seq[Expression]): Exists = {
-    assert(nestedOuterAttrs.toSet.subsetOf(outerAttrs.toSet),
-      s"nestedOuterAttrs must be a subset of outerAttrs, " +
-        s"but got ${nestedOuterAttrs.mkString(", ")}")
+    validateNestedOuterAttrs()
     copy(nestedOuterAttrs = nestedOuterAttrs)
   }
   override def withNewHint(hint: Option[HintInfo]): Exists = copy(hint = hint)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -408,7 +408,8 @@ case class ScalarSubquery(
     hint: Option[HintInfo] = None,
     mayHaveCountBug: Option[Boolean] = None,
     needSingleJoin: Option[Boolean] = None)
-  extends SubqueryExpression(plan, outerAttrs, unresolvedOuterAttrs, exprId, joinCond, hint) with Unevaluable {
+  extends SubqueryExpression(
+    plan, outerAttrs, unresolvedOuterAttrs, exprId, joinCond, hint) with Unevaluable {
   override def dataType: DataType = {
     if (!plan.schema.fields.nonEmpty) {
       throw QueryCompilationErrors.subqueryReturnMoreThanOneColumn(plan.schema.fields.length,
@@ -424,7 +425,8 @@ case class ScalarSubquery(
       unresolvedOuterAttrs: Seq[Expression]
   ): ScalarSubquery = {
     assert(unresolvedOuterAttrs.toSet.subsetOf(outerAttrs.toSet),
-      s"unresolvedOuterAttrs must be a subset of outerAttrs, but got ${unresolvedOuterAttrs.mkString(", ")}")
+      s"unresolvedOuterAttrs must be a subset of outerAttrs, " +
+        s"but got ${unresolvedOuterAttrs.mkString(", ")}")
     copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
   }
   override def withNewHint(hint: Option[HintInfo]): ScalarSubquery = copy(hint = hint)
@@ -494,15 +496,19 @@ case class LateralSubquery(
     exprId: ExprId = NamedExpression.newExprId,
     joinCond: Seq[Expression] = Seq.empty,
     hint: Option[HintInfo] = None)
-  extends SubqueryExpression(plan, outerAttrs, unresolvedOuterAttrs, exprId, joinCond, hint) with Unevaluable {
+  extends SubqueryExpression(
+    plan, outerAttrs, unresolvedOuterAttrs, exprId, joinCond, hint) with Unevaluable {
   override def dataType: DataType = plan.output.toStructType
   override def nullable: Boolean = true
   override def withNewPlan(plan: LogicalPlan): LateralSubquery = copy(plan = plan)
   override def withNewOuterAttrs(outerAttrs: Seq[Expression]): LateralSubquery = copy(
     outerAttrs = outerAttrs)
-  override def withNewUnresolvedOuterAttrs(unresolvedOuterAttrs: Seq[Expression]): LateralSubquery = {
+  override def withNewUnresolvedOuterAttrs(
+    unresolvedOuterAttrs: Seq[Expression]
+  ): LateralSubquery = {
     assert(unresolvedOuterAttrs.toSet.subsetOf(outerAttrs.toSet),
-      s"unresolvedOuterAttrs must be a subset of outerAttrs, but got ${unresolvedOuterAttrs.mkString(", ")}")
+      s"unresolvedOuterAttrs must be a subset of outerAttrs, " +
+        s"but got ${unresolvedOuterAttrs.mkString(", ")}")
     copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
   }
   override def withNewHint(hint: Option[HintInfo]): LateralSubquery = copy(hint = hint)
@@ -547,7 +553,8 @@ case class ListQuery(
     numCols: Int = -1,
     joinCond: Seq[Expression] = Seq.empty,
     hint: Option[HintInfo] = None)
-  extends SubqueryExpression(plan, outerAttrs, unresolvedOuterAttrs, exprId, joinCond, hint) with Unevaluable {
+  extends SubqueryExpression(
+    plan, outerAttrs, unresolvedOuterAttrs, exprId, joinCond, hint) with Unevaluable {
   def childOutputs: Seq[Attribute] = plan.output.take(numCols)
   override def dataType: DataType = if (numCols > 1) {
     childOutputs.toStructType
@@ -569,7 +576,8 @@ case class ListQuery(
     outerAttrs = outerAttrs)
   override def withNewUnresolvedOuterAttrs(unresolvedOuterAttrs: Seq[Expression]): ListQuery = {
     assert(unresolvedOuterAttrs.toSet.subsetOf(outerAttrs.toSet),
-      s"unresolvedOuterAttrs must be a subset of outerAttrs, but got ${unresolvedOuterAttrs.mkString(", ")}")
+      s"unresolvedOuterAttrs must be a subset of outerAttrs, " +
+        s"but got ${unresolvedOuterAttrs.mkString(", ")}")
     copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
   }
   override def withNewHint(hint: Option[HintInfo]): ListQuery = copy(hint = hint)
@@ -634,7 +642,8 @@ case class Exists(
     outerAttrs = outerAttrs)
   override def withNewUnresolvedOuterAttrs(unresolvedOuterAttrs: Seq[Expression]): Exists = {
     assert(unresolvedOuterAttrs.toSet.subsetOf(outerAttrs.toSet),
-      s"unresolvedOuterAttrs must be a subset of outerAttrs, but got ${unresolvedOuterAttrs.mkString(", ")}")
+      s"unresolvedOuterAttrs must be a subset of outerAttrs, " +
+        s"but got ${unresolvedOuterAttrs.mkString(", ")}")
     copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
   }
   override def withNewHint(hint: Option[HintInfo]): Exists = copy(hint = hint)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -501,6 +501,7 @@ case class LateralSubquery(
   override def dataType: DataType = plan.output.toStructType
   override def nullable: Boolean = true
   override def withNewPlan(plan: LogicalPlan): LateralSubquery = copy(plan = plan)
+
   override def withNewOuterAttrs(outerAttrs: Seq[Expression]): LateralSubquery = copy(
     outerAttrs = outerAttrs)
   override def withNewNestedOuterAttrs(
@@ -511,6 +512,7 @@ case class LateralSubquery(
         s"but got ${nestedOuterAttrs.mkString(", ")}")
     copy(nestedOuterAttrs = nestedOuterAttrs)
   }
+  
   override def withNewHint(hint: Option[HintInfo]): LateralSubquery = copy(hint = hint)
   override def toString: String = s"lateral-subquery#${exprId.id} $conditionString"
   override lazy val canonicalized: Expression = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -512,7 +512,7 @@ case class LateralSubquery(
         s"but got ${nestedOuterAttrs.mkString(", ")}")
     copy(nestedOuterAttrs = nestedOuterAttrs)
   }
-  
+
   override def withNewHint(hint: Option[HintInfo]): LateralSubquery = copy(hint = hint)
   override def toString: String = s"lateral-subquery#${exprId.id} $conditionString"
   override lazy val canonicalized: Expression = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -421,7 +421,7 @@ case class ScalarSubquery(
   override def withNewUnresolvedOuterAttrs(
       unresolvedOuterAttrs: Seq[Expression]
   ): ScalarSubquery = {
-    assert(unresolvedOuterAttrs.subsetOf(outerAttrs),
+    assert(unresolvedOuterAttrs.toSet.subsetOf(outerAttrs.toSet),
       s"unresolvedOuterAttrs must be a subset of outerAttrs, but got ${unresolvedOuterAttrs.mkString(", ")}")
     copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
   }
@@ -499,7 +499,7 @@ case class LateralSubquery(
   override def withNewOuterAttrs(outerAttrs: Seq[Expression]): LateralSubquery = copy(
     outerAttrs = outerAttrs)
   override def withNewUnresolvedOuterAttrs(unresolvedOuterAttrs: Seq[Expression]): LateralSubquery = {
-    assert(unresolvedOuterAttrs.subsetOf(outerAttrs),
+    assert(unresolvedOuterAttrs.toSet.subsetOf(outerAttrs.toSet),
       s"unresolvedOuterAttrs must be a subset of outerAttrs, but got ${unresolvedOuterAttrs.mkString(", ")}")
     copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
   }
@@ -566,7 +566,7 @@ case class ListQuery(
   override def withNewOuterAttrs(outerAttrs: Seq[Expression]): ListQuery = copy(
     outerAttrs = outerAttrs)
   override def withNewUnresolvedOuterAttrs(unresolvedOuterAttrs: Seq[Expression]): ListQuery = {
-    assert(unresolvedOuterAttrs.subsetOf(outerAttrs),
+    assert(unresolvedOuterAttrs.toSet.subsetOf(outerAttrs.toSet),
       s"unresolvedOuterAttrs must be a subset of outerAttrs, but got ${unresolvedOuterAttrs.mkString(", ")}")
     copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
   }
@@ -631,7 +631,7 @@ case class Exists(
   override def withNewOuterAttrs(outerAttrs: Seq[Expression]): Exists = copy(
     outerAttrs = outerAttrs)
   override def withNewUnresolvedOuterAttrs(unresolvedOuterAttrs: Seq[Expression]): Exists = {
-    assert(unresolvedOuterAttrs.subsetOf(outerAttrs),
+    assert(unresolvedOuterAttrs.toSet.subsetOf(outerAttrs.toSet),
       s"unresolvedOuterAttrs must be a subset of outerAttrs, but got ${unresolvedOuterAttrs.mkString(", ")}")
     copy(unresolvedOuterAttrs = unresolvedOuterAttrs)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -418,6 +418,8 @@ case class ScalarSubquery(
   }
   override def nullable: Boolean = true
   override def withNewPlan(plan: LogicalPlan): ScalarSubquery = copy(plan = plan)
+  override def withNewOuterAttrs(outerAttrs: Seq[Expression]): ScalarSubquery = copy(
+    outerAttrs = outerAttrs)
   override def withNewUnresolvedOuterAttrs(
       unresolvedOuterAttrs: Seq[Expression]
   ): ScalarSubquery = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -364,7 +364,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
       case d: DynamicPruningSubquery => d
       case s @ ScalarSubquery(
         PhysicalOperation(projections, predicates, a @ Aggregate(group, _, child, _)),
-        _, _, _, _, mayHaveCountBug, _)
+        _, _, _, _, _, mayHaveCountBug, _)
         if conf.getConf(SQLConf.DECORRELATE_SUBQUERY_PREVENT_CONSTANT_FOLDING_FOR_COUNT_BUG) &&
           mayHaveCountBug.nonEmpty && mayHaveCountBug.get =>
         // This is a subquery with an aggregate that may suffer from a COUNT bug.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -90,7 +90,7 @@ object ConstantFolding extends Rule[LogicalPlan] {
       }
 
     // Don't replace ScalarSubquery if its plan is an aggregate that may suffer from a COUNT bug.
-    case s @ ScalarSubquery(_, _, _, _, _, mayHaveCountBug, _)
+    case s @ ScalarSubquery(_, _, _, _, _, _, mayHaveCountBug, _)
       if conf.getConf(SQLConf.DECORRELATE_SUBQUERY_PREVENT_CONSTANT_FOLDING_FOR_COUNT_BUG) &&
         mayHaveCountBug.nonEmpty && mayHaveCountBug.get =>
       s

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -891,7 +891,7 @@ object NullPropagation extends Rule[LogicalPlan] {
       case InSubquery(Seq(Literal(null, _)), _)
         if SQLConf.get.legacyNullInEmptyBehavior =>
         Literal.create(null, BooleanType)
-      case InSubquery(Seq(Literal(null, _)), ListQuery(sub, _, _, _, conditions, _))
+      case InSubquery(Seq(Literal(null, _)), ListQuery(sub, _, _, _, _, conditions, _))
         if !SQLConf.get.legacyNullInEmptyBehavior
         && conditions.isEmpty =>
         If(Exists(sub), Literal(null, BooleanType), FalseLiteral)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -587,7 +587,7 @@ object PullupCorrelatedPredicates extends Rule[LogicalPlan] with PredicateHelper
     }
 
     plan.transformExpressionsWithPruning(_.containsPattern(PLAN_EXPRESSION)) {
-      case ScalarSubquery(sub, children, nestedOuterAttrs, exprId, conditions, hint,
+      case ScalarSubquery(sub, children, outerScopeAttrs, exprId, conditions, hint,
       mayHaveCountBugOld, needSingleJoinOld)
         if children.nonEmpty =>
 
@@ -639,26 +639,26 @@ object PullupCorrelatedPredicates extends Rule[LogicalPlan] with PredicateHelper
         } else {
           conf.getConf(SQLConf.SCALAR_SUBQUERY_USE_SINGLE_JOIN) && !guaranteedToReturnOneRow(sub)
         }
-        ScalarSubquery(newPlan, children, nestedOuterAttrs, exprId, getJoinCondition(newCond, conditions),
+        ScalarSubquery(newPlan, children, outerScopeAttrs, exprId, getJoinCondition(newCond, conditions),
           hint, Some(mayHaveCountBug), Some(needSingleJoin))
-      case Exists(sub, children, nestedOuterAttrs, exprId, conditions, hint) if children.nonEmpty =>
+      case Exists(sub, children, outerScopeAttrs, exprId, conditions, hint) if children.nonEmpty =>
         val (newPlan, newCond) = if (SQLConf.get.decorrelateInnerQueryEnabledForExistsIn) {
           decorrelate(sub, plan, handleCountBug = true)
         } else {
           pullOutCorrelatedPredicates(sub, plan)
         }
-        Exists(newPlan, children, nestedOuterAttrs, exprId, getJoinCondition(newCond, conditions), hint)
-      case ListQuery(sub, children, nestedOuterAttrs, exprId, numCols, conditions, hint) if children.nonEmpty =>
+        Exists(newPlan, children, outerScopeAttrs, exprId, getJoinCondition(newCond, conditions), hint)
+      case ListQuery(sub, children, outerScopeAttrs, exprId, numCols, conditions, hint) if children.nonEmpty =>
         val (newPlan, newCond) = if (SQLConf.get.decorrelateInnerQueryEnabledForExistsIn) {
           decorrelate(sub, plan, handleCountBug = true)
         } else {
           pullOutCorrelatedPredicates(sub, plan)
         }
         val joinCond = getJoinCondition(newCond, conditions)
-        ListQuery(newPlan, children, nestedOuterAttrs, exprId, numCols, joinCond, hint)
-      case LateralSubquery(sub, children, nestedOuterAttrs, exprId, conditions, hint) if children.nonEmpty =>
+        ListQuery(newPlan, children, outerScopeAttrs, exprId, numCols, joinCond, hint)
+      case LateralSubquery(sub, children, outerScopeAttrs, exprId, conditions, hint) if children.nonEmpty =>
         val (newPlan, newCond) = decorrelate(sub, plan, handleCountBug = true)
-        LateralSubquery(newPlan, children, nestedOuterAttrs, exprId, getJoinCondition(newCond, conditions), hint)
+        LateralSubquery(newPlan, children, outerScopeAttrs, exprId, getJoinCondition(newCond, conditions), hint)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -587,7 +587,7 @@ object PullupCorrelatedPredicates extends Rule[LogicalPlan] with PredicateHelper
     }
 
     plan.transformExpressionsWithPruning(_.containsPattern(PLAN_EXPRESSION)) {
-      case ScalarSubquery(sub, children, unresolvedOuterAttrs, exprId, conditions, hint,
+      case ScalarSubquery(sub, children, nestedOuterAttrs, exprId, conditions, hint,
       mayHaveCountBugOld, needSingleJoinOld)
         if children.nonEmpty =>
 
@@ -639,26 +639,26 @@ object PullupCorrelatedPredicates extends Rule[LogicalPlan] with PredicateHelper
         } else {
           conf.getConf(SQLConf.SCALAR_SUBQUERY_USE_SINGLE_JOIN) && !guaranteedToReturnOneRow(sub)
         }
-        ScalarSubquery(newPlan, children, unresolvedOuterAttrs, exprId, getJoinCondition(newCond, conditions),
+        ScalarSubquery(newPlan, children, nestedOuterAttrs, exprId, getJoinCondition(newCond, conditions),
           hint, Some(mayHaveCountBug), Some(needSingleJoin))
-      case Exists(sub, children, unresolvedOuterAttrs, exprId, conditions, hint) if children.nonEmpty =>
+      case Exists(sub, children, nestedOuterAttrs, exprId, conditions, hint) if children.nonEmpty =>
         val (newPlan, newCond) = if (SQLConf.get.decorrelateInnerQueryEnabledForExistsIn) {
           decorrelate(sub, plan, handleCountBug = true)
         } else {
           pullOutCorrelatedPredicates(sub, plan)
         }
-        Exists(newPlan, children, unresolvedOuterAttrs, exprId, getJoinCondition(newCond, conditions), hint)
-      case ListQuery(sub, children, unresolvedOuterAttrs, exprId, numCols, conditions, hint) if children.nonEmpty =>
+        Exists(newPlan, children, nestedOuterAttrs, exprId, getJoinCondition(newCond, conditions), hint)
+      case ListQuery(sub, children, nestedOuterAttrs, exprId, numCols, conditions, hint) if children.nonEmpty =>
         val (newPlan, newCond) = if (SQLConf.get.decorrelateInnerQueryEnabledForExistsIn) {
           decorrelate(sub, plan, handleCountBug = true)
         } else {
           pullOutCorrelatedPredicates(sub, plan)
         }
         val joinCond = getJoinCondition(newCond, conditions)
-        ListQuery(newPlan, children, unresolvedOuterAttrs, exprId, numCols, joinCond, hint)
-      case LateralSubquery(sub, children, unresolvedOuterAttrs, exprId, conditions, hint) if children.nonEmpty =>
+        ListQuery(newPlan, children, nestedOuterAttrs, exprId, numCols, joinCond, hint)
+      case LateralSubquery(sub, children, nestedOuterAttrs, exprId, conditions, hint) if children.nonEmpty =>
         val (newPlan, newCond) = decorrelate(sub, plan, handleCountBug = true)
-        LateralSubquery(newPlan, children, unresolvedOuterAttrs, exprId, getJoinCondition(newCond, conditions), hint)
+        LateralSubquery(newPlan, children, nestedOuterAttrs, exprId, getJoinCondition(newCond, conditions), hint)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -587,7 +587,7 @@ object PullupCorrelatedPredicates extends Rule[LogicalPlan] with PredicateHelper
     }
 
     plan.transformExpressionsWithPruning(_.containsPattern(PLAN_EXPRESSION)) {
-      case ScalarSubquery(sub, children, exprId, conditions, hint,
+      case ScalarSubquery(sub, children, unresolvedOuterAttrs, exprId, conditions, hint,
       mayHaveCountBugOld, needSingleJoinOld)
         if children.nonEmpty =>
 
@@ -639,26 +639,26 @@ object PullupCorrelatedPredicates extends Rule[LogicalPlan] with PredicateHelper
         } else {
           conf.getConf(SQLConf.SCALAR_SUBQUERY_USE_SINGLE_JOIN) && !guaranteedToReturnOneRow(sub)
         }
-        ScalarSubquery(newPlan, children, exprId, getJoinCondition(newCond, conditions),
+        ScalarSubquery(newPlan, children, unresolvedOuterAttrs, exprId, getJoinCondition(newCond, conditions),
           hint, Some(mayHaveCountBug), Some(needSingleJoin))
-      case Exists(sub, children, exprId, conditions, hint) if children.nonEmpty =>
+      case Exists(sub, children, unresolvedOuterAttrs, exprId, conditions, hint) if children.nonEmpty =>
         val (newPlan, newCond) = if (SQLConf.get.decorrelateInnerQueryEnabledForExistsIn) {
           decorrelate(sub, plan, handleCountBug = true)
         } else {
           pullOutCorrelatedPredicates(sub, plan)
         }
-        Exists(newPlan, children, exprId, getJoinCondition(newCond, conditions), hint)
-      case ListQuery(sub, children, exprId, numCols, conditions, hint) if children.nonEmpty =>
+        Exists(newPlan, children, unresolvedOuterAttrs, exprId, getJoinCondition(newCond, conditions), hint)
+      case ListQuery(sub, children, unresolvedOuterAttrs, exprId, numCols, conditions, hint) if children.nonEmpty =>
         val (newPlan, newCond) = if (SQLConf.get.decorrelateInnerQueryEnabledForExistsIn) {
           decorrelate(sub, plan, handleCountBug = true)
         } else {
           pullOutCorrelatedPredicates(sub, plan)
         }
         val joinCond = getJoinCondition(newCond, conditions)
-        ListQuery(newPlan, children, exprId, numCols, joinCond, hint)
-      case LateralSubquery(sub, children, exprId, conditions, hint) if children.nonEmpty =>
+        ListQuery(newPlan, children, unresolvedOuterAttrs, exprId, numCols, joinCond, hint)
+      case LateralSubquery(sub, children, unresolvedOuterAttrs, exprId, conditions, hint) if children.nonEmpty =>
         val (newPlan, newCond) = decorrelate(sub, plan, handleCountBug = true)
-        LateralSubquery(newPlan, children, exprId, getJoinCondition(newCond, conditions), hint)
+        LateralSubquery(newPlan, children, unresolvedOuterAttrs, exprId, getJoinCondition(newCond, conditions), hint)
     }
   }
 
@@ -1122,7 +1122,7 @@ object OptimizeOneRowRelationSubquery extends Rule[LogicalPlan] {
    */
   private def rewrite(plan: LogicalPlan): LogicalPlan = plan.transformUpWithSubqueries {
     case LateralJoin(
-      left, right @ LateralSubquery(OneRowSubquery(plan), _, _, _, _), _, None)
+      left, right @ LateralSubquery(OneRowSubquery(plan), _, _, _, _, _), _, None)
         if !hasCorrelatedSubquery(right.plan) && right.joinCond.isEmpty =>
       plan match {
         case Project(projectList, _: OneRowRelation) =>
@@ -1145,7 +1145,7 @@ object OptimizeOneRowRelationSubquery extends Rule[LogicalPlan] {
 
     case p: LogicalPlan => p.transformExpressionsUpWithPruning(
       _.containsPattern(SCALAR_SUBQUERY)) {
-      case s @ ScalarSubquery(OneRowSubquery(p @ Project(_, _: OneRowRelation)), _, _, _, _, _, _)
+      case s @ ScalarSubquery(OneRowSubquery(p @ Project(_, _: OneRowRelation)), _, _, _, _, _, _, _)
           if !hasCorrelatedSubquery(s.plan) && s.joinCond.isEmpty =>
         assert(p.projectList.size == 1)
         stripOuterReferences(p.projectList).head

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveSubqueries.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveSubqueries.scala
@@ -30,11 +30,11 @@ case class PlanAdaptiveSubqueries(
   def apply(plan: SparkPlan): SparkPlan = {
     plan.transformAllExpressionsWithPruning(
       _.containsAnyPattern(SCALAR_SUBQUERY, IN_SUBQUERY, DYNAMIC_PRUNING_SUBQUERY)) {
-      case expressions.ScalarSubquery(_, _, exprId, _, _, _, _) =>
+      case expressions.ScalarSubquery(_, _, _, exprId, _, _, _, _) =>
         val subquery = SubqueryExec.createForScalarSubquery(
           s"subquery#${exprId.id}", subqueryMap(exprId.id))
         execution.ScalarSubquery(subquery, exprId)
-      case expressions.InSubquery(values, ListQuery(_, _, exprId, _, _, _)) =>
+      case expressions.InSubquery(values, ListQuery(_, _, _, exprId, _, _, _)) =>
         val expr = if (values.length == 1) {
           values.head
         } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
@@ -187,7 +187,7 @@ case class PlanSubqueries(sparkSession: SparkSession) extends Rule[SparkPlan] {
           SubqueryExec.createForScalarSubquery(
             s"scalar-subquery#${subquery.exprId.id}", executedPlan),
           subquery.exprId)
-      case expressions.InSubquery(values, ListQuery(query, _, exprId, _, _, _)) =>
+      case expressions.InSubquery(values, ListQuery(query, _, _, exprId, _, _, _)) =>
         val expr = if (values.length == 1) {
           values.head
         } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -1012,7 +1012,7 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
           query match {
             case ListQuery(Project(projects, SubqueryAlias(AliasIdentifier("s", Seq()),
                 UnresolvedSubqueryColumnAliases(outputColumnNames, Project(_, _: OneRowRelation)))),
-                _, _, _, _, _) =>
+                _, _, _, _, _, _) =>
               assert(projects.size == 1 && projects.head.name == "s.name")
               assert(outputColumnNames.size == 1 && outputColumnNames.head == "name")
             case o => fail("Unexpected subquery: \n" + o.treeString)
@@ -1093,7 +1093,7 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
           query match {
             case ListQuery(Project(projects, SubqueryAlias(AliasIdentifier("s", Seq()),
                 UnresolvedSubqueryColumnAliases(outputColumnNames, Project(_, _: OneRowRelation)))),
-                _, _, _, _, _) =>
+                _, _, _, _, _, _) =>
               assert(projects.size == 1 && projects.head.name == "s.name")
               assert(outputColumnNames.size == 1 && outputColumnNames.head == "name")
             case o => fail("Unexpected subquery: \n" + o.treeString)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
- Add OuterScopeAttrs and related getter and setter methods for SubqueryExpression
- All attributes in OuterScopeAttrs must be contained in the OuterAttrs AttributeSet of SubqueryExpression
- Update the usage of SubqueryExpression and classes extending SubqueryExpression

For reviewers:
This pr only contains definition changes and there are no codes in this pr containing usage or setting of the OuterScopeAttrs. It is safe to merge. 
I separate this pr from the usage of OuterScopeAttrs for simplify the reviewing process of later prs.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Spark only supports one layer of correlation now and does not support nested correlation.
For example, 
```sql
SELECT col1 FROM VALUES (1, 2) t1 (col1, col2) WHERE EXISTS (
 SELECT col1 FROM VALUES (1, 2) t2 (col1, col2) WHERE t2.col2 == MAX(t1.col2)
)GROUP BY col1;
```
is supported and 
```sql
SELECT col1 FROM VALUES (1, 2) t1 (col1, col2) WHERE EXISTS (
 SELECT col1 FROM VALUES (1, 2) t2 (col1, col2) WHERE t2.col2 == (
   SELECT MAX(t1.col2)
 )
)GROUP BY col1;
```
is not supported.

The reason spark does not support it is because the Analyzer and Optimizer resolves and plans Subquery in a recursive way. 

The definition change for the SubqueryExpression adds the metadata OuterScopeAttrs which helps later rewrites for the Analyzer and Optimizer.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Current UT and Suite.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: cursor + claude-3.5-sonnet