### PR TITLE
[SPARK-51112][PYTHON][CONNECT][FOLLOW-UP] Explicitly set index=range(0) for empty table

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -958,7 +958,7 @@ class SparkConnectClient(object):
         # DataFrame, as it may fail with a segmentation fault. Instead, we create an empty pandas
         # DataFrame manually with the correct schema.
         if table.num_rows == 0:
-            pdf = pd.DataFrame(columns=schema.names)
+            pdf = pd.DataFrame(columns=schema.names, index=range(0))
         else:
             # Rename columns to avoid duplicated column names.
             renamed_table = table.rename_columns([f"col_{i}" for i in range(table.num_columns)])


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/49834 that uses `range(0)` for its index explicitly.

### Why are the changes needed?

In order to avoid having behaviour changes.

Without this fix / pandas 1.5.3

```python
>>> import pandas as pd
>>> pd.DataFrame(columns=["a"]).index
Index([], dtype='object')
```


With this fix / pandas 1.5.3

```python
>>> import pandas as pd
>>> pd.DataFrame(columns=["a"], index=range(0)).index
RangeIndex(start=0, stop=0, step=1)
```

pandas 2.x

```python
>>> import pandas as pd
>>> pd.DataFrame(columns=["a"]).index
RangeIndex(start=0, stop=0, step=1)
```

### Does this PR introduce _any_ user-facing change?

No, this PR technically fixes a regression.

### How was this patch tested?

Manually ran tests against pandas 1.5.3

### Was this patch authored or co-authored using generative AI tooling?

No.
