### PR TITLE
[SPARK-51527][SQL] Make codegen log level configurable via SQLConf

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -139,6 +139,7 @@ private[spark] object LogKeys {
   case object CLUSTER_LABEL extends LogKey
   case object CLUSTER_LEVEL extends LogKey
   case object CLUSTER_WEIGHT extends LogKey
+  case object CODE extends LogKey
   case object CODEC_LEVEL extends LogKey
   case object CODEC_NAME extends LogKey
   case object CODEGEN_STAGE_ID extends LogKey

--- a/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.core.appender.ConsoleAppender
 import org.apache.logging.log4j.core.config.DefaultConfiguration
 import org.apache.logging.log4j.core.filter.AbstractFilter
 import org.slf4j.{Logger, LoggerFactory}
+import org.slf4j.event.{Level => Slf4jLevel}
 
 import org.apache.spark.internal.Logging.SparkShellLoggingFilter
 import org.apache.spark.internal.LogKeys
@@ -305,6 +306,16 @@ trait Logging {
 
   protected def isTraceEnabled(): Boolean = {
     log.isTraceEnabled
+  }
+
+  protected def logBasedOnLevel(level: Slf4jLevel)(f: => MessageWithContext): Unit = {
+    level match {
+      case Slf4jLevel.TRACE => logTrace(f.message)
+      case Slf4jLevel.DEBUG => logDebug(f.message)
+      case Slf4jLevel.INFO => logInfo(f)
+      case Slf4jLevel.WARN => logWarning(f)
+      case Slf4jLevel.ERROR => logError(f)
+    }
   }
 
   protected def initializeLogIfNecessary(isInterpreter: Boolean): Unit = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/PlanLogger.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/PlanLogger.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.analysis.resolver
 
-import org.apache.spark.internal.{Logging, MDC, MessageWithContext}
+import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys.{MESSAGE, QUERY_PLAN}
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -32,65 +32,44 @@ class PlanLogger extends Logging {
   private val expressionTreeChangeLogLevel = SQLConf.get.expressionTreeChangeLogLevel
 
   def logPlanResolutionEvent(plan: LogicalPlan, event: String): Unit = {
-    log(() => log"""
-       |=== Plan resolution: ${MDC(MESSAGE, event)} ===
-       |${MDC(QUERY_PLAN, plan.treeString)}
-     """.stripMargin, planChangeLogLevel)
+    logBasedOnLevel(planChangeLogLevel) {
+      log"""
+         |=== Plan resolution: ${MDC(MESSAGE, event)} ===
+         |${MDC(QUERY_PLAN, plan.treeString)}
+         """.stripMargin
+    }
   }
 
   def logPlanResolution(unresolvedPlan: LogicalPlan, resolvedPlan: LogicalPlan): Unit = {
-    log(
-      () =>
-        log"""
-       |=== Unresolved plan -> Resolved plan ===
-       |${MDC(
-               QUERY_PLAN,
-               sideBySide(
-                 unresolvedPlan.treeString,
-                 resolvedPlan.treeString
-               ).mkString("\n")
-             )}
-     """.stripMargin,
-      planChangeLogLevel
-    )
+    logBasedOnLevel(planChangeLogLevel) {
+      val unresolved = unresolvedPlan.treeString
+      val resolved = resolvedPlan.treeString
+      log"""
+         |=== Unresolved plan -> Resolved plan ===
+         |${MDC(QUERY_PLAN, sideBySide(unresolved, resolved).mkString("\n"))}
+         """.stripMargin
+    }
   }
 
   def logExpressionTreeResolutionEvent(expressionTree: Expression, event: String): Unit = {
-    log(
-      () => log"""
-       |=== Expression tree resolution: ${MDC(MESSAGE, event)} ===
-       |${MDC(QUERY_PLAN, expressionTree.treeString)}
-     """.stripMargin,
-      expressionTreeChangeLogLevel
-    )
+    logBasedOnLevel(expressionTreeChangeLogLevel) {
+      log"""
+         |=== Expression tree resolution: ${MDC(MESSAGE, event)} ===
+         |${MDC(QUERY_PLAN, expressionTree.treeString)}
+         """.stripMargin
+    }
   }
 
   def logExpressionTreeResolution(
       unresolvedExpressionTree: Expression,
       resolvedExpressionTree: Expression): Unit = {
-    log(
-      () =>
-        log"""
-       |=== Unresolved expression tree -> Resolved expression tree ===
-       |${MDC(
-               QUERY_PLAN,
-               sideBySide(
-                 unresolvedExpressionTree.treeString,
-                 resolvedExpressionTree.treeString
-               ).mkString("\n")
-             )}
-     """.stripMargin,
-      expressionTreeChangeLogLevel
-    )
-  }
-
-  private def log(createMessage: () => MessageWithContext, logLevel: String): Unit =
-    logLevel match {
-      case "TRACE" => logTrace(createMessage().message)
-      case "DEBUG" => logDebug(createMessage().message)
-      case "INFO" => logInfo(createMessage())
-      case "WARN" => logWarning(createMessage())
-      case "ERROR" => logError(createMessage())
-      case _ => logTrace(createMessage().message)
+    logBasedOnLevel(expressionTreeChangeLogLevel) {
+      val unresolved = unresolvedExpressionTree.treeString
+      val resolved = resolvedExpressionTree.treeString
+      log"""
+         |=== Unresolved expression tree -> Resolved expression tree ===
+         |${MDC(QUERY_PLAN, sideBySide(unresolved, resolved).mkString("\n"))}
+         """.stripMargin
     }
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1537,11 +1537,11 @@ object CodeGenerator extends Logging {
     )
     evaluator.setExtendedClass(classOf[GeneratedClass])
 
-    logDebug({
+    logBasedOnLevel(SQLConf.get.codegenLogLevel) {
       // Only add extra debugging info to byte code when we are going to print the source code.
       evaluator.setDebuggingInformation(true, true, false)
-      s"\n${CodeFormatter.format(code)}"
-    })
+      log"\n${MDC(LogKeys.CODE, CodeFormatter.format(code))}"
+    }
 
     val codeStats = try {
       evaluator.cook("generated.java", code.body)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
@@ -65,7 +65,7 @@ class PlanChangeLogger[TreeType <: TreeNode[_]] extends Logging {
            """.stripMargin
         }
 
-        logBasedOnLevel(message())
+        logBasedOnLevel(logLevel)(message())
       }
     }
   }
@@ -83,7 +83,7 @@ class PlanChangeLogger[TreeType <: TreeNode[_]] extends Logging {
         }
       }
 
-      logBasedOnLevel(message())
+      logBasedOnLevel(logLevel)(message())
     }
   }
 
@@ -101,18 +101,7 @@ class PlanChangeLogger[TreeType <: TreeNode[_]] extends Logging {
       """.stripMargin
     // scalastyle:on line.size.limit
 
-    logBasedOnLevel(message)
-  }
-
-  private def logBasedOnLevel(f: => MessageWithContext): Unit = {
-    logLevel match {
-      case "TRACE" => logTrace(f.message)
-      case "DEBUG" => logDebug(f.message)
-      case "INFO" => logInfo(f)
-      case "WARN" => logWarning(f)
-      case "ERROR" => logError(f)
-      case _ => logTrace(f.message)
-    }
+    logBasedOnLevel(logLevel)(message)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -368,11 +368,6 @@ object SQLConf {
   private def isValidLogLevel(level: String): Boolean =
     VALID_LOG_LEVELS.contains(level.toUpperCase(Locale.ROOT))
 
-  private def toLogLevel(upperCaseValidLevel: String): Level = {
-    require(VALID_LOG_LEVELS.contains(upperCaseValidLevel))
-    Level.valueOf(upperCaseValidLevel)
-  }
-
   val PLAN_CHANGE_LOG_LEVEL = buildConf("spark.sql.planChangeLog.level")
     .internal()
     .doc("Configures the log level for logging the change from the original plan to the new " +
@@ -5780,13 +5775,13 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def optimizerInSetSwitchThreshold: Int = getConf(OPTIMIZER_INSET_SWITCH_THRESHOLD)
 
-  def planChangeLogLevel: Level = toLogLevel(getConf(PLAN_CHANGE_LOG_LEVEL))
+  def planChangeLogLevel: Level = Level.valueOf((getConf(PLAN_CHANGE_LOG_LEVEL))
 
   def planChangeRules: Option[String] = getConf(PLAN_CHANGE_LOG_RULES)
 
   def planChangeBatches: Option[String] = getConf(PLAN_CHANGE_LOG_BATCHES)
 
-  def expressionTreeChangeLogLevel: Level = toLogLevel(getConf(EXPRESSION_TREE_CHANGE_LOG_LEVEL))
+  def expressionTreeChangeLogLevel: Level = Level.valueOf((getConf(EXPRESSION_TREE_CHANGE_LOG_LEVEL))
 
   def dynamicPartitionPruningEnabled: Boolean = getConf(DYNAMIC_PARTITION_PRUNING_ENABLED)
 
@@ -6017,7 +6012,7 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def codegenComments: Boolean = getConf(StaticSQLConf.CODEGEN_COMMENTS)
 
-  def codegenLogLevel: Level = toLogLevel(getConf(CODEGEN_LOG_LEVEL))
+  def codegenLogLevel: Level = Level.valueOf((getConf(CODEGEN_LOG_LEVEL))
 
   def loggingMaxLinesForCodegen: Int = getConf(CODEGEN_LOGGING_MAX_LINES)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -31,6 +31,7 @@ import scala.util.matching.Regex
 import org.apache.avro.file.CodecFactory
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.OutputCommitter
+import org.slf4j.event.Level
 
 import org.apache.spark.{ErrorMessageFormat, SparkConf, SparkContext, SparkException, TaskContext}
 import org.apache.spark.internal.Logging
@@ -362,17 +363,35 @@ object SQLConf {
         "for using switch statements in InSet must be non-negative and less than or equal to 600")
       .createWithDefault(400)
 
+  private val VALIED_LOG_LEVELS: Array[String] = Level.values.map(_.toString)
+
+  private def isValidLogLevel(level: String): Boolean =
+    VALIED_LOG_LEVELS.contains(level.toUpperCase(Locale.ROOT))
+
+  private def toLogLevel(upperCaseValidLevel: String): Level = {
+    require(VALIED_LOG_LEVELS.contains(upperCaseValidLevel))
+    upperCaseValidLevel match {
+      case "TRACE" => Level.TRACE
+      case "DEBUG" => Level.DEBUG
+      case "INFO" => Level.INFO
+      case "WARN" => Level.WARN
+      case "ERROR" => Level.ERROR
+      case illegal => // unreachable code
+        throw new IllegalArgumentException(s"Illegal log level: $illegal")
+    }
+  }
+
   val PLAN_CHANGE_LOG_LEVEL = buildConf("spark.sql.planChangeLog.level")
     .internal()
     .doc("Configures the log level for logging the change from the original plan to the new " +
-      "plan after a rule or batch is applied. The value can be 'trace', 'debug', 'info', " +
-      "'warn', or 'error'. The default log level is 'trace'.")
+      s"plan after a rule or batch is applied. The value can be " +
+      s"${VALIED_LOG_LEVELS.mkString(", ")}.")
     .version("3.1.0")
     .stringConf
     .transform(_.toUpperCase(Locale.ROOT))
-    .checkValue(logLevel => Set("TRACE", "DEBUG", "INFO", "WARN", "ERROR").contains(logLevel),
+    .checkValue(isValidLogLevel,
       "Invalid value for 'spark.sql.planChangeLog.level'. Valid values are " +
-        "'trace', 'debug', 'info', 'warn' and 'error'.")
+        s"${VALIED_LOG_LEVELS.mkString(", ")}.")
     .createWithDefault("trace")
 
   val PLAN_CHANGE_LOG_RULES = buildConf("spark.sql.planChangeLog.rules")
@@ -403,13 +422,13 @@ object SQLConf {
     .internal()
     .doc("Configures the log level for logging the change from the unresolved expression tree to " +
       "the resolved expression tree in the single-pass bottom-up Resolver. The value can be " +
-      "'trace', 'debug', 'info', 'warn', or 'error'. The default log level is 'trace'.")
+      s"${VALIED_LOG_LEVELS.mkString(", ")}.")
     .version("4.0.0")
     .stringConf
     .transform(_.toUpperCase(Locale.ROOT))
-    .checkValue(logLevel => Set("TRACE", "DEBUG", "INFO", "WARN", "ERROR").contains(logLevel),
+    .checkValue(isValidLogLevel,
       "Invalid value for 'spark.sql.expressionTreeChangeLog.level'. Valid values are " +
-        "'trace', 'debug', 'info', 'warn' and 'error'.")
+        s"${VALIED_LOG_LEVELS.mkString(", ")}.")
     .createWithDefault("trace")
 
   val LIGHTWEIGHT_PLAN_CHANGE_VALIDATION = buildConf("spark.sql.lightweightPlanChangeValidation")
@@ -780,11 +799,13 @@ object SQLConf {
   val ADAPTIVE_EXECUTION_LOG_LEVEL = buildConf("spark.sql.adaptive.logLevel")
     .internal()
     .doc("Configures the log level for adaptive execution logging of plan changes. The value " +
-      "can be 'trace', 'debug', 'info', 'warn', or 'error'. The default log level is 'debug'.")
+      s"can be ${VALIED_LOG_LEVELS.mkString(", ")}.")
     .version("3.0.0")
     .stringConf
     .transform(_.toUpperCase(Locale.ROOT))
-    .checkValues(Set("TRACE", "DEBUG", "INFO", "WARN", "ERROR"))
+    .checkValue(isValidLogLevel,
+      "Invalid value for 'spark.sql.adaptive.logLevel'. Valid values are " +
+      s"${VALIED_LOG_LEVELS.mkString(", ")}.")
     .createWithDefault("debug")
 
   val ADVISORY_PARTITION_SIZE_IN_BYTES =
@@ -1806,15 +1827,15 @@ object SQLConf {
   val DATAFRAME_CACHE_LOG_LEVEL = buildConf("spark.sql.dataframeCache.logLevel")
     .internal()
     .doc("Configures the log level of Dataframe cache operations, including adding and removing " +
-      "entries from Dataframe cache, hit and miss on cache application. The default log " +
-      "level is 'trace'. This log should only be used for debugging purposes and not in the " +
-      "production environment, since it generates a large amount of logs.")
+      "entries from Dataframe cache, hit and miss on cache application. This log should only be " +
+      "used for debugging purposes and not in the production environment, since it generates a " +
+      "large amount of logs.")
     .version("4.0.0")
     .stringConf
     .transform(_.toUpperCase(Locale.ROOT))
-    .checkValue(logLevel => Set("TRACE", "DEBUG", "INFO", "WARN", "ERROR").contains(logLevel),
+    .checkValue(isValidLogLevel,
       "Invalid value for 'spark.sql.dataframeCache.logLevel'. Valid values are " +
-        "'trace', 'debug', 'info', 'warn' and 'error'.")
+      s"${VALIED_LOG_LEVELS.mkString(", ")}.")
     .createWithDefault("trace")
 
   val CROSS_JOINS_ENABLED = buildConf("spark.sql.crossJoin.enabled")
@@ -2013,6 +2034,18 @@ object SQLConf {
     .version("2.0.0")
     .booleanConf
     .createWithDefault(true)
+
+  val CODEGEN_LOG_LEVEL = buildConf("spark.sql.codegen.logLevel")
+    .internal()
+    .doc("Configures the log level for logging of codegen. " +
+      s"The value can be ${VALIED_LOG_LEVELS.mkString(", ")}.")
+    .version("4.1.0")
+    .stringConf
+    .transform(_.toUpperCase(Locale.ROOT))
+    .checkValue(isValidLogLevel,
+      "Invalid value for 'spark.sql.codegen.logLevel'. Valid values are " +
+       s"${VALIED_LOG_LEVELS.mkString(", ")}.")
+    .createWithDefault("DEBUG")
 
   val CODEGEN_LOGGING_MAX_LINES = buildConf("spark.sql.codegen.logging.maxLines")
     .internal()
@@ -5755,13 +5788,13 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def optimizerInSetSwitchThreshold: Int = getConf(OPTIMIZER_INSET_SWITCH_THRESHOLD)
 
-  def planChangeLogLevel: String = getConf(PLAN_CHANGE_LOG_LEVEL)
+  def planChangeLogLevel: Level = toLogLevel(getConf(PLAN_CHANGE_LOG_LEVEL))
 
   def planChangeRules: Option[String] = getConf(PLAN_CHANGE_LOG_RULES)
 
   def planChangeBatches: Option[String] = getConf(PLAN_CHANGE_LOG_BATCHES)
 
-  def expressionTreeChangeLogLevel: String = getConf(EXPRESSION_TREE_CHANGE_LOG_LEVEL)
+  def expressionTreeChangeLogLevel: Level = toLogLevel(getConf(EXPRESSION_TREE_CHANGE_LOG_LEVEL))
 
   def dynamicPartitionPruningEnabled: Boolean = getConf(DYNAMIC_PARTITION_PRUNING_ENABLED)
 
@@ -5991,6 +6024,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def codegenFactoryMode: String = getConf(CODEGEN_FACTORY_MODE)
 
   def codegenComments: Boolean = getConf(StaticSQLConf.CODEGEN_COMMENTS)
+
+  def codegenLogLevel: Level = toLogLevel(getConf(CODEGEN_LOG_LEVEL))
 
   def loggingMaxLinesForCodegen: Int = getConf(CODEGEN_LOGGING_MAX_LINES)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -363,35 +363,27 @@ object SQLConf {
         "for using switch statements in InSet must be non-negative and less than or equal to 600")
       .createWithDefault(400)
 
-  private val VALIED_LOG_LEVELS: Array[String] = Level.values.map(_.toString)
+  private val VALID_LOG_LEVELS: Array[String] = Level.values.map(_.toString)
 
   private def isValidLogLevel(level: String): Boolean =
-    VALIED_LOG_LEVELS.contains(level.toUpperCase(Locale.ROOT))
+    VALID_LOG_LEVELS.contains(level.toUpperCase(Locale.ROOT))
 
   private def toLogLevel(upperCaseValidLevel: String): Level = {
-    require(VALIED_LOG_LEVELS.contains(upperCaseValidLevel))
-    upperCaseValidLevel match {
-      case "TRACE" => Level.TRACE
-      case "DEBUG" => Level.DEBUG
-      case "INFO" => Level.INFO
-      case "WARN" => Level.WARN
-      case "ERROR" => Level.ERROR
-      case illegal => // unreachable code
-        throw new IllegalArgumentException(s"Illegal log level: $illegal")
-    }
+    require(VALID_LOG_LEVELS.contains(upperCaseValidLevel))
+    Level.valueOf(upperCaseValidLevel)
   }
 
   val PLAN_CHANGE_LOG_LEVEL = buildConf("spark.sql.planChangeLog.level")
     .internal()
     .doc("Configures the log level for logging the change from the original plan to the new " +
       s"plan after a rule or batch is applied. The value can be " +
-      s"${VALIED_LOG_LEVELS.mkString(", ")}.")
+      s"${VALID_LOG_LEVELS.mkString(", ")}.")
     .version("3.1.0")
     .stringConf
     .transform(_.toUpperCase(Locale.ROOT))
     .checkValue(isValidLogLevel,
       "Invalid value for 'spark.sql.planChangeLog.level'. Valid values are " +
-        s"${VALIED_LOG_LEVELS.mkString(", ")}.")
+        s"${VALID_LOG_LEVELS.mkString(", ")}.")
     .createWithDefault("trace")
 
   val PLAN_CHANGE_LOG_RULES = buildConf("spark.sql.planChangeLog.rules")
@@ -422,13 +414,13 @@ object SQLConf {
     .internal()
     .doc("Configures the log level for logging the change from the unresolved expression tree to " +
       "the resolved expression tree in the single-pass bottom-up Resolver. The value can be " +
-      s"${VALIED_LOG_LEVELS.mkString(", ")}.")
+      s"${VALID_LOG_LEVELS.mkString(", ")}.")
     .version("4.0.0")
     .stringConf
     .transform(_.toUpperCase(Locale.ROOT))
     .checkValue(isValidLogLevel,
       "Invalid value for 'spark.sql.expressionTreeChangeLog.level'. Valid values are " +
-        s"${VALIED_LOG_LEVELS.mkString(", ")}.")
+        s"${VALID_LOG_LEVELS.mkString(", ")}.")
     .createWithDefault("trace")
 
   val LIGHTWEIGHT_PLAN_CHANGE_VALIDATION = buildConf("spark.sql.lightweightPlanChangeValidation")
@@ -799,13 +791,13 @@ object SQLConf {
   val ADAPTIVE_EXECUTION_LOG_LEVEL = buildConf("spark.sql.adaptive.logLevel")
     .internal()
     .doc("Configures the log level for adaptive execution logging of plan changes. The value " +
-      s"can be ${VALIED_LOG_LEVELS.mkString(", ")}.")
+      s"can be ${VALID_LOG_LEVELS.mkString(", ")}.")
     .version("3.0.0")
     .stringConf
     .transform(_.toUpperCase(Locale.ROOT))
     .checkValue(isValidLogLevel,
       "Invalid value for 'spark.sql.adaptive.logLevel'. Valid values are " +
-      s"${VALIED_LOG_LEVELS.mkString(", ")}.")
+      s"${VALID_LOG_LEVELS.mkString(", ")}.")
     .createWithDefault("debug")
 
   val ADVISORY_PARTITION_SIZE_IN_BYTES =
@@ -1835,7 +1827,7 @@ object SQLConf {
     .transform(_.toUpperCase(Locale.ROOT))
     .checkValue(isValidLogLevel,
       "Invalid value for 'spark.sql.dataframeCache.logLevel'. Valid values are " +
-      s"${VALIED_LOG_LEVELS.mkString(", ")}.")
+      s"${VALID_LOG_LEVELS.mkString(", ")}.")
     .createWithDefault("trace")
 
   val CROSS_JOINS_ENABLED = buildConf("spark.sql.crossJoin.enabled")
@@ -2038,13 +2030,13 @@ object SQLConf {
   val CODEGEN_LOG_LEVEL = buildConf("spark.sql.codegen.logLevel")
     .internal()
     .doc("Configures the log level for logging of codegen. " +
-      s"The value can be ${VALIED_LOG_LEVELS.mkString(", ")}.")
+      s"The value can be ${VALID_LOG_LEVELS.mkString(", ")}.")
     .version("4.1.0")
     .stringConf
     .transform(_.toUpperCase(Locale.ROOT))
     .checkValue(isValidLogLevel,
       "Invalid value for 'spark.sql.codegen.logLevel'. Valid values are " +
-       s"${VALIED_LOG_LEVELS.mkString(", ")}.")
+       s"${VALID_LOG_LEVELS.mkString(", ")}.")
     .createWithDefault("DEBUG")
 
   val CODEGEN_LOGGING_MAX_LINES = buildConf("spark.sql.codegen.logging.maxLines")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5775,13 +5775,13 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def optimizerInSetSwitchThreshold: Int = getConf(OPTIMIZER_INSET_SWITCH_THRESHOLD)
 
-  def planChangeLogLevel: Level = Level.valueOf((getConf(PLAN_CHANGE_LOG_LEVEL))
+  def planChangeLogLevel: Level = Level.valueOf(getConf(PLAN_CHANGE_LOG_LEVEL))
 
   def planChangeRules: Option[String] = getConf(PLAN_CHANGE_LOG_RULES)
 
   def planChangeBatches: Option[String] = getConf(PLAN_CHANGE_LOG_BATCHES)
 
-  def expressionTreeChangeLogLevel: Level = Level.valueOf((getConf(EXPRESSION_TREE_CHANGE_LOG_LEVEL))
+  def expressionTreeChangeLogLevel: Level = Level.valueOf(getConf(EXPRESSION_TREE_CHANGE_LOG_LEVEL))
 
   def dynamicPartitionPruningEnabled: Boolean = getConf(DYNAMIC_PARTITION_PRUNING_ENABLED)
 
@@ -6012,7 +6012,7 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def codegenComments: Boolean = getConf(StaticSQLConf.CODEGEN_COMMENTS)
 
-  def codegenLogLevel: Level = Level.valueOf((getConf(CODEGEN_LOG_LEVEL))
+  def codegenLogLevel: Level = Level.valueOf(getConf(CODEGEN_LOG_LEVEL))
 
   def loggingMaxLinesForCodegen: Int = getConf(CODEGEN_LOGGING_MAX_LINES)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Introduce a new conf `spark.sql.codegen.logLevel` to allow user to adjust the generated code log level via SQL `SET spark.sql.codegen.logLevel=INFO`, with some code refactors to reduce duplicated code.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Simplify the codegen debug process, previously, it was hardcoded as DEBUG level, developers must tune the log4j configuration or change the log level globally to diagnose the codegen issue.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Introduce a new configuration, while the default value keeps existing behavior.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Add new UT.

Also test manually with `spark-sql`
```
$ apache-spark git:(SPARK-51527) SPARK_PREPEND_CLASSES=true bin/spark-sql
NOTE: SPARK_PREPEND_CLASSES is set, placing locally compiled Spark classes ahead of assembly.
WARNING: Using incubator modules: jdk.incubator.vector
Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties
25/03/19 15:41:05 WARN Utils: Your hostname, H27212-MAC-01.local, resolves to a loopback address: 127.0.0.1; using 10.243.76.75 instead (on interface en0)
25/03/19 15:41:05 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address
Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
25/03/19 15:41:05 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
25/03/19 15:41:09 WARN ObjectStore: Version information not found in metastore. hive.metastore.schema.verification is not enabled so recording the schema version 2.3.0
25/03/19 15:41:09 WARN ObjectStore: setMetaStoreSchemaVersion called but recording version is disabled: version = 2.3.0, comment = Set by MetaStore chengpan@127.0.0.1
25/03/19 15:41:09 WARN ObjectStore: Failed to get database default, returning NoSuchObjectException
Spark Web UI available at http://10.243.76.75:4040
Spark master: local[*], Application Id: local-1742370066718
spark-sql (default)> SET spark.sql.codegen.logLevel=WARN;
spark.sql.codegen.logLevel	WARN
Time taken: 0.661 seconds, Fetched 1 row(s)
spark-sql (default)> select 1+1;
25/03/19 15:41:28 WARN CodeGenerator:
/* 001 */ public Object generate(Object[] references) {
/* 002 */   return new GeneratedIteratorForCodegenStage1(references);
/* 003 */ }
/* 004 */
/* 005 */ // codegenStageId=1
/* 006 */ final class GeneratedIteratorForCodegenStage1 extends org.apache.spark.sql.execution.BufferedRowIterator {
/* 007 */   private Object[] references;
/* 008 */   private scala.collection.Iterator[] inputs;
/* 009 */   private scala.collection.Iterator rdd_input_0;
...
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
