### PR TITLE
[SPARK-51420][SQL] Get minutes of TIME datatype

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -642,7 +642,7 @@ object FunctionRegistry {
     expression[FromUTCTimestamp]("from_utc_timestamp"),
     expression[Hour]("hour"),
     expression[LastDay]("last_day"),
-    expression[Minute]("minute"),
+    expressionBuilder("minute", MinuteExpressionBuilder),
     expression[Month]("month"),
     expression[MonthsBetween]("months_between"),
     expression[NextDay]("next_day"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -199,6 +199,19 @@ case class MinutesOfTime(child: Expression)
   }
 }
 
+// scalastyle:off line.size.limit
+@ExpressionDescription(
+  usage = """
+    _FUNC_(time_expr) - Returns the minute component of the given time.
+  """,
+  examples = """
+    Examples:
+      > SELECT _FUNC_(TIME'23:59:59.999999');
+       59
+  """,
+  since = "4.1.0",
+  group = "datetime_funcs")
+// scalastyle:on line.size.limit
 object MinuteExpressionBuilder extends ExpressionBuilder {
   override def build(name: String, expressions: Seq[Expression]): Expression = {
     val child = expressions.head

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -20,11 +20,12 @@ package org.apache.spark.sql.catalyst.expressions
 import java.time.DateTimeException
 
 import org.apache.spark.sql.catalyst.analysis.ExpressionBuilder
-import org.apache.spark.sql.catalyst.expressions.objects.Invoke
+import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, StaticInvoke}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.catalyst.util.TimeFormatter
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.types.StringTypeWithCollation
-import org.apache.spark.sql.types.{AbstractDataType, ObjectType, TimeType}
+import org.apache.spark.sql.types.{AbstractDataType, IntegerType, ObjectType, TimeType}
 import org.apache.spark.unsafe.types.UTF8String
 
 /**
@@ -157,6 +158,55 @@ object TryToTimeExpressionBuilder extends ExpressionBuilder {
       TryEval(ToTime(expressions.head, expressions.drop(1).lastOption))
     } else {
       throw QueryCompilationErrors.wrongNumArgsError(funcName, Seq(1, 2), numArgs)
+    }
+  }
+}
+
+// scalastyle:off line.size.limit
+@ExpressionDescription(
+  usage = """
+    _FUNC_(time_expr) - Returns the minute component of the given time.
+  """,
+  examples = """
+    Examples:
+      > SELECT _FUNC_(TIME'23:59:59.999999');
+       59
+  """,
+  since = "4.1.0",
+  group = "datetime_funcs")
+// scalastyle:on line.size.limit
+case class MinutesOfTime(child: Expression)
+  extends RuntimeReplaceable
+    with ExpectsInputTypes {
+
+  override def replacement: Expression = StaticInvoke(
+    classOf[DateTimeUtils.type],
+    IntegerType,
+    "getMinutesOfTime",
+    Seq(child),
+    Seq(child.dataType)
+  )
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(TimeType())
+
+  override def children: Seq[Expression] = Seq(child)
+
+  override def prettyName: String = "minute"
+
+  override protected def withNewChildrenInternal(
+    newChildren: IndexedSeq[Expression]): Expression = {
+    copy(child = newChildren.head)
+  }
+}
+
+object MinuteExpressionBuilder extends ExpressionBuilder {
+  override def build(name: String, expressions: Seq[Expression]): Expression = {
+    val child = expressions.head
+    child.dataType match {
+      case _: TimeType =>
+        MinutesOfTime(child)
+      case _ =>
+        Minute(child)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -202,24 +202,34 @@ case class MinutesOfTime(child: Expression)
 // scalastyle:off line.size.limit
 @ExpressionDescription(
   usage = """
-    _FUNC_(time_expr) - Returns the minute component of the given time.
+    _FUNC_(expr) - Returns the minute component of the given expression.
+
+    If `expr` is a TIMESTAMP or a string that can be cast to timestamp,
+    it returns the minute of that timestamp.
+    If `expr` is a TIME type (since 4.1.0), it returns the minute of the time-of-day.
   """,
   examples = """
     Examples:
+      > SELECT _FUNC_('2009-07-30 12:58:59');
+       58
       > SELECT _FUNC_(TIME'23:59:59.999999');
        59
   """,
-  since = "4.1.0",
+  since = "1.5.0",
   group = "datetime_funcs")
 // scalastyle:on line.size.limit
 object MinuteExpressionBuilder extends ExpressionBuilder {
   override def build(name: String, expressions: Seq[Expression]): Expression = {
-    val child = expressions.head
-    child.dataType match {
-      case _: TimeType =>
-        MinutesOfTime(child)
-      case _ =>
-        Minute(child)
+    if (expressions.isEmpty) {
+      throw QueryCompilationErrors.wrongNumArgsError(name, Seq("> 0"), expressions.length)
+    } else {
+      val child = expressions.head
+      child.dataType match {
+        case _: TimeType =>
+          MinutesOfTime(child)
+        case _ =>
+          Minute(child)
+      }
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -114,6 +114,13 @@ object DateTimeUtils extends SparkDateTimeUtils {
   }
 
   /**
+   * Returns the minute value of a given TIME (TimeType) value.
+   */
+  def getMinutesOfTime(micros: Long): Int = {
+    microsToLocalTime(micros).getMinute
+  }
+
+  /**
    * Returns the second value of a given timestamp value. The timestamp is expressed in
    * microseconds since the epoch.
    */

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -73,7 +73,7 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     assert(builtExprForTime.isInstanceOf[MinutesOfTime])
     assert(builtExprForTime.asInstanceOf[MinutesOfTime].child eq timeExpr)
 
-    // test non TIME-typed child should build MinutesOfTime
+    // test non TIME-typed child should build Minute
     val tsExpr = Literal("2009-07-30 12:58:59")
     val builtExprForTs = MinuteExpressionBuilder.build("minute", Seq(tsExpr))
     assert(builtExprForTs.isInstanceOf[Minute])


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds support for extracting the minute component from TIME (TimeType) values in Spark SQL.

``` bash
scala> spark.sql("SELECT minute(TIME'07:01:09.12312321231232');").show()
+------------------------------+
|minute(TIME '07:01:09.123123')|
+------------------------------+
|                             1|
+------------------------------+
```

### Why are the changes needed?
- Spark previously supported minute() for only TIMESTAMP type values.
- TIME support was missing, leading to implicit casting attempt to TIMESTAMP, which was incorrect.
- This PR ensures that `minute(TIME'HH:MM:SS.######')` behaves correctly without unnecessary type coercion.

### Does this PR introduce _any_ user-facing change?
Yes

- Before this PR, calling `minute(TIME'HH:MM:SS.######')` resulted in a type mismatch error or an implicit cast attempt to TIMESTAMP, which was incorrect.
- With this PR, `minute(TIME'HH:MM:SS.######')` now works correctly for TIME values without implicit casting.
- Users can now extract the minute component from TIME values natively.


### How was this patch tested?
By running new tests:
```
$ build/sbt "test:testOnly *TimeExpressionsSuite.scala"
```


### Was this patch authored or co-authored using generative AI tooling?
No
