### PR TITLE
[SPARK-51535][SQL][FOLLOWUP] Don't compare hash codes directly in ProtobufCatalystDataConversionSuite

### DIFF
--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufCatalystDataConversionSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufCatalystDataConversionSuite.scala
@@ -381,9 +381,6 @@ class ProtobufCatalystDataConversionSuite
     )
 
     assert(
-      protobufDataToCatalyst.hashCode == -937893175
-    )
-    assert(
       protobufDataToCatalyst
         .copy(options = Map("mode" -> "FAILFAST"))
         .hashCode != protobufDataToCatalyst.hashCode


### PR DESCRIPTION
### What changes were proposed in this pull request?

Don't compare hash codes directly in `ProtobufCatalystDataConversionSuite`

A followup for https://github.com/apache/spark/pull/50295

### Why are the changes needed?

`hashCode` implementations are not guaranteed to be the same across different JVMs and platforms.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`build/sbt "testOnly org.apache.spark.sql.protobuf.ProtobufCatalystDataConversionSuite -- -z \"hash\""`

### Was this patch authored or co-authored using generative AI tooling?

No.
