### PR TITLE
[SPARK-51540][PS][DOCS] Best practice for distributed-sequence misalignment case

### DIFF
--- a/python/docs/source/user_guide/pandas_on_spark/options.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/options.rst
@@ -209,14 +209,17 @@ This is conceptually equivalent to the PySpark example as below:
     [0, 1, 2]
 
 .. warning::
-    Unlike `sequence`, since `distributed-sequence` is executed in a distributed environment,
-    the rows corresponding to each index may vary although the index itself still
-    remains globally sequential.
+    Unlike ``sequence``, since ``distributed-sequence`` is executed in a distributed environment,
+    the rows corresponding to each index may vary although the index itself still remains globally sequential.
+
     This happens because the rows are distributed across multiple partitions and nodes,
     leading to indeterministic row-to-index mappings when the data is loaded.
-    Therefore, it is recommended to explicitly set an index column by using `index_col` parameter
-    instead of relying on the default index when creating `DataFrame`
-    if the row-to-index mapping is critical for your application.
+
+    Additionally, when using operations such as ``apply()``, ``groupby()``, or ``transform()``,
+    a new ``distributed-sequence`` index may be generated, which does not necessarily match the original index of the DataFrame.
+    This can result in misaligned row-to-index mappings, leading to incorrect calculations.
+
+    To avoid this issue, see `Handling index misalignment with distributed-sequence <best_practices.rst#handling-index-misalignment-with-distributed-sequence>`_
 
 **distributed**: It implements a monotonically increasing sequence simply by using
 PySpark's `monotonically_increasing_id` function in a fully distributed manner. The


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to update the warning and add best practice for handling index misalignment case with distributed-sequence when using specific operations.

### Why are the changes needed?

To clearly document the inconsistent behavior with Pandas and let users know about the workarounds.

### Does this PR introduce _any_ user-facing change?

User-facing documentation updated

<img width="797" alt="Screenshot 2025-03-18 at 3 07 38 PM" src="https://github.com/user-attachments/assets/966b0449-0b96-4f59-9eb3-ede12d19bc73" />

### How was this patch tested?

Manually tested

### Was this patch authored or co-authored using generative AI tooling?

No.