### PR TITLE
[SPARK-51544][SQL] Add only unique and necessary metadata columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -240,6 +240,15 @@ object SQLConf {
     }
   }
 
+  val ONLY_NECESSARY_AND_UNIQUE_METADATA_COLUMNS =
+    buildConf("spark.sql.analyzer.uniqueNecessaryMetadataColumns")
+    .internal()
+    .doc(
+      "When this conf is enabled, AddMetadataColumns rule should only add necessary metadata " +
+      "columns and only if those columns are not already present in the project list.")
+    .booleanConf
+    .createWithDefault(true)
+
   val ANALYZER_MAX_ITERATIONS = buildConf("spark.sql.analyzer.maxIterations")
     .internal()
     .doc("The max number of iterations the analyzer runs.")

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -1025,10 +1025,10 @@ Project [a#x, a#x, z2#x]
                   +- PipeOperator
                      +- Filter (z2#x = 0)
                         +- PipeOperator
-                           +- Project [a#x, z2#x, a#x, a#x]
-                              +- Project [a#x, z1#x, (a#x - a#x) AS z2#x, a#x, a#x]
-                                 +- Project [a#x, (a#x + a#x) AS z1#x, a#x, a#x, a#x]
-                                    +- Project [a#x, a#x, a#x, a#x, a#x]
+                           +- Project [a#x, z2#x, a#x]
+                              +- Project [a#x, z1#x, (a#x - a#x) AS z2#x, a#x]
+                                 +- Project [a#x, (a#x + a#x) AS z1#x, a#x]
+                                    +- Project [a#x, a#x]
                                        +- Join Inner, (a#x = a#x)
                                           :- SubqueryAlias lhs
                                           :  +- LocalRelation [a#x]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/using-join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/using-join.sql.out
@@ -568,7 +568,7 @@ SELECT k FROM (SELECT nt2.k FROM nt1 full outer join nt2 using (k))
 Project [k#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [k#x]
-      +- Project [coalesce(k#x, k#x) AS k#x, v1#x, v2#x, k#x, k#x]
+      +- Project [coalesce(k#x, k#x) AS k#x, v1#x, v2#x, k#x]
          +- Join FullOuter, (k#x = k#x)
             :- SubqueryAlias nt1
             :  +- View (`nt1`, [k#x, v1#x])
@@ -589,7 +589,7 @@ SELECT nt2.k AS key FROM nt1 full outer join nt2 using (k) ORDER BY key
 -- !query analysis
 Sort [key#x ASC NULLS FIRST], true
 +- Project [k#x AS key#x]
-   +- Project [coalesce(k#x, k#x) AS k#x, v1#x, v2#x, k#x, k#x]
+   +- Project [coalesce(k#x, k#x) AS k#x, v1#x, v2#x, k#x]
       +- Join FullOuter, (k#x = k#x)
          :- SubqueryAlias nt1
          :  +- View (`nt1`, [k#x, v1#x])
@@ -609,7 +609,7 @@ Sort [key#x ASC NULLS FIRST], true
 SELECT k, nt1.k FROM nt1 full outer join nt2 using (k)
 -- !query analysis
 Project [k#x, k#x]
-+- Project [coalesce(k#x, k#x) AS k#x, v1#x, v2#x, k#x, k#x]
++- Project [coalesce(k#x, k#x) AS k#x, v1#x, v2#x, k#x]
    +- Join FullOuter, (k#x = k#x)
       :- SubqueryAlias nt1
       :  +- View (`nt1`, [k#x, v1#x])
@@ -629,7 +629,7 @@ Project [k#x, k#x]
 SELECT k, nt2.k FROM nt1 full outer join nt2 using (k)
 -- !query analysis
 Project [k#x, k#x]
-+- Project [coalesce(k#x, k#x) AS k#x, v1#x, v2#x, k#x, k#x]
++- Project [coalesce(k#x, k#x) AS k#x, v1#x, v2#x, k#x]
    +- Join FullOuter, (k#x = k#x)
       :- SubqueryAlias nt1
       :  +- View (`nt1`, [k#x, v1#x])
@@ -828,9 +828,9 @@ WithCTE
 :        +- SubqueryAlias t
 :           +- LocalRelation [key#x]
 +- Project [key#x]
-   +- Project [key#x, key#x, key#x]
+   +- Project [key#x, key#x]
       +- Filter NOT key#x LIKE bb.%
-         +- Project [coalesce(key#x, key#x) AS key#x, key#x, key#x, key#x]
+         +- Project [coalesce(key#x, key#x) AS key#x, key#x]
             +- Join FullOuter, (key#x = key#x)
                :- SubqueryAlias t1
                :  +- CTERelationRef xxxx, true, [key#x], false, false, 1

--- a/sql/core/src/test/scala/org/apache/spark/sql/AddMetadataColumnSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/AddMetadataColumnSuite.scala
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.expressions.NamedExpression
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, Project}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class AddMetadataColumnsSuite extends QueryTest with SharedSparkSession {
+
+  test("Add only necessary metadata columns") {
+    // For a query like:
+    //
+    // {{{
+    // SELECT t1.k
+    // FROM VALUES(1,2) AS t1(k,v1) FULL OUTER JOIN VALUES(1,2) AS t2(k,v2) USING (k)
+    // }}}
+    //
+    // the analyzed plan would look like:
+    // Project [k#0]
+    // +- Project [coalesce(k#0, k#2) AS k#4, v1#1, v2#3, k#0, k#2]
+    //    +- Join FullOuter, (k#0 = k#2)
+    //       :- SubqueryAlias nt1
+    //       :  +- LocalRelation [k#0, v1#1]
+    //       +- SubqueryAlias nt2
+    //          +- LocalRelation [k#2, v2#3]
+    // The inner project in this case contains a reference to k#2, which is not needed in the
+    // top-most project. With `spark.sql.analyzer.uniqueNecessaryMetadataColumns` set to false, we
+    // will add k#2 to the project list because it is a metadata column. Otherwise, we don't need
+    // it and can avoid adding it in AddMetadataColumns rule.
+    withTable("t1", "t2") {
+      sql("CREATE TABLE t1(k INT, v1 INT)")
+      sql("CREATE TABLE t2(k INT, v2 INT)")
+      val left = sql("select * from t1")
+      val right = sql("select * from t2")
+      val join = left.join(right, Seq("k"), "full_outer")
+
+      val rightKeyExprId = right
+        .select(right("k"))
+        .queryExecution
+        .analyzed
+        .asInstanceOf[Project]
+        .projectList
+        .head
+        .exprId
+
+      withSQLConf(SQLConf.ONLY_NECESSARY_AND_UNIQUE_METADATA_COLUMNS.key -> "true") {
+        // Inner project list shouldn't contain a reference to the right key.
+        val analyzed = join.select(left("k")).queryExecution.analyzed
+        analyzed match {
+          case Project(_, Project(innerProjectList: Seq[NamedExpression], _)) =>
+            assert(Seq("k", "v1", "v2", "k") == innerProjectList.map(_.name))
+            assert(!innerProjectList.map(_.exprId).contains(rightKeyExprId))
+        }
+      }
+
+      withSQLConf(SQLConf.ONLY_NECESSARY_AND_UNIQUE_METADATA_COLUMNS.key -> "false") {
+        // Inner project list should contain a reference to the right key.
+        val analyzed = join.select(left("k")).queryExecution.analyzed
+        analyzed match {
+          case Project(_, Project(innerProjectList: Seq[NamedExpression], _)) =>
+            assert(Seq("k", "v1", "v2", "k", "k") == innerProjectList.map(_.name))
+            assert(innerProjectList.map(_.exprId).contains(rightKeyExprId))
+        }
+      }
+    }
+  }
+
+  test("Add only unique metadata columns") {
+    // For a query like:
+    // {{{
+    // SELECT t1.k
+    // FROM VALUES(1,2) AS t1(k, v1) FULL OUTER JOIN VALUES(1,2) AS t2(k,v2) USING (k)
+    // WHERE t1.k IS NOT NULL
+    // }}}
+    //
+    // the analyzed plan will look like:
+    // Project [k#0]
+    // +- Project [k#4, v1#1, v2#3, k#0, k#2]
+    //    +- Filter isnotnull(k#0)
+    //       +- Project [coalesce(k#0, k#2) AS k#4, v1#1, v2#3, k#0, k#0, k#2]
+    //          +- Join FullOuter, (k#0 = k#2)
+    //             :- SubqueryAlias t1
+    //             :  +- LocalRelation [k#0, v1#1]
+    //             +- SubqueryAlias t2
+    //                +- LocalRelation [k#2, v2#3]
+    //
+    // In this case, the Project under Filter contains a duplicate #k#0 attribute reference as well
+    // as an unnecessary k#2 attribute reference. Additionally, the second top-most Project has an
+    // extra k#2 that can also be removed. Duplicate reference comes from the fact that this
+    // attribute will first be added by ResolveReferences rule as missing input, but
+    // AddMetadataColumns doesn't respect the fact that this attribute already exists in the
+    // project list and duplicates it. With `spark.sql.analyzer.uniqueNecessaryMetadataColumns` set
+    // to true, we remove this duplication and the unnecessary attribute.
+    withTable("t1", "t2") {
+      sql("CREATE TABLE t1(k INT, v1 INT)")
+      sql("CREATE TABLE t2(k INT, v2 INT)")
+      val left = sql("select * from t1")
+      val right = sql("select * from t2")
+      val join = left.join(right, Seq("k"), "full_outer")
+      val filter = join.filter(left("k").isNull)
+
+      val leftKeyExprId = left
+        .select(left("k"))
+        .queryExecution
+        .analyzed
+        .asInstanceOf[Project]
+        .projectList
+        .head
+        .exprId
+      val rightKeyExprId = right
+        .select(right("k"))
+        .queryExecution
+        .analyzed
+        .asInstanceOf[Project]
+        .projectList
+        .head
+        .exprId
+
+      withSQLConf(SQLConf.ONLY_NECESSARY_AND_UNIQUE_METADATA_COLUMNS.key -> "true") {
+        // With conf on, no duplication of left key and no unnecessary right key.
+        val analyzed = filter.select(left("k")).queryExecution.analyzed
+        analyzed match {
+          case Project(
+              _,
+              Project(_, Filter(_, Project(innerProjectList: Seq[NamedExpression], _)))
+              ) =>
+            assert(Seq("k", "v1", "v2", "k") == innerProjectList.map(_.name))
+            assert(innerProjectList.map(_.exprId).count(_ == rightKeyExprId) == 0)
+            assert(innerProjectList.map(_.exprId).count(_ == leftKeyExprId) == 1)
+        }
+      }
+
+      withSQLConf(SQLConf.ONLY_NECESSARY_AND_UNIQUE_METADATA_COLUMNS.key -> "false") {
+        // With conf off, duplication of left key and an unnecessary right key.
+        val analyzed = filter.select(left("k")).queryExecution.analyzed
+        analyzed match {
+          case Project(
+              _,
+              Project(_, Filter(_, Project(innerProjectList: Seq[NamedExpression], _)))
+              ) =>
+            assert(Seq("k", "v1", "v2", "k", "k", "k") == innerProjectList.map(_.name))
+            assert(innerProjectList.map(_.exprId).count(_ == rightKeyExprId) == 1)
+            assert(innerProjectList.map(_.exprId).count(_ == leftKeyExprId) == 2)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
AddMetadataColumns should add only unique and necessary metadata columns, not the entire child's metadata output 
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
There are 3 reasons to make this change:
1. Adding duplicates of metadata columns creates problems for single-pass analyzer, where we need to hack our way around adding these columns, because both `AddMetadataColumns` and `ResolveReferences` can add same attributes.
2. Adding unique and only necessary metadata columns is more semantically correct
3. This PR is also a preparation to fix [SPARK-51545 ](https://issues.apache.org/jira/browse/SPARK-51545)
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  4. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Added a new suite to test `AddMetadataColumns` rule. Existing tests
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
