### PR TITLE
[SPARK-51566][PYTHON] Python UDF traceback improvement

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -445,7 +445,7 @@ jline:jline
 org.jodd:jodd-core
 pl.edu.icm:JLargeArrays
 
-python/pyspark/errors/exceptions/traceback.py
+python/pyspark/errors/exceptions/tblib.py
 
 
 BSD 3-Clause

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -445,6 +445,8 @@ jline:jline
 org.jodd:jodd-core
 pl.edu.icm:JLargeArrays
 
+python/pyspark/errors/exceptions/traceback.py
+
 
 BSD 3-Clause
 ------------

--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -48,6 +48,7 @@ jquery.mustache.js
 pyspark-coverage-site/*
 cloudpickle/*
 join.py
+tblib.py
 SparkILoop.scala
 sbt
 sbt-launch-lib.bash

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -1466,6 +1466,8 @@ pyspark_errors = Module(
     python_test_goals=[
         # unittests
         "pyspark.errors.tests.test_errors",
+        "pyspark.errors.tests.test_traceback",
+        "pyspark.errors.tests.connect.test_parity_traceback",
     ],
 )
 

--- a/python/packaging/client/setup.py
+++ b/python/packaging/client/setup.py
@@ -68,6 +68,7 @@ in_spark = os.path.isfile("../core/src/main/scala/org/apache/spark/SparkContext.
 test_packages = []
 if "SPARK_TESTING" in os.environ:
     test_packages = [
+        "pyspark.errors.tests.connect",
         "pyspark.tests",  # for Memory profiler parity tests
         "pyspark.resource.tests",
         "pyspark.sql.tests",

--- a/python/pyspark/errors/exceptions/base.py
+++ b/python/pyspark/errors/exceptions/base.py
@@ -478,6 +478,6 @@ def recover_python_exception(e: T) -> T:
         tb = Traceback.from_string(python_exception_string)
         tb.populate_linecache()
         return e.with_traceback(tb.as_traceback())
-    except Exception:
+    except BaseException:
         # Parsing the stacktrace is best effort.
         return e

--- a/python/pyspark/errors/exceptions/base.py
+++ b/python/pyspark/errors/exceptions/base.py
@@ -19,6 +19,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Dict, Optional, TypeVar, cast, Iterable, TYPE_CHECKING, List
 
+from pyspark.errors.exceptions.tblib import Traceback
 from pyspark.errors.utils import ErrorClassesReader
 from pyspark.logger import PySparkLogger
 from pickle import PicklingError
@@ -464,8 +465,6 @@ def recover_python_exception(e: T) -> T:
     """
     python_exception_header = "Traceback (most recent call last):"
     try:
-        from pyspark.errors.exceptions.tblib import Traceback
-
         message = str(e)
         start = message.find(python_exception_header)
         if start == -1:

--- a/python/pyspark/errors/exceptions/base.py
+++ b/python/pyspark/errors/exceptions/base.py
@@ -464,7 +464,7 @@ def recover_python_exception(e: T) -> T:
     """
     python_exception_header = "Traceback (most recent call last):"
     try:
-        from pyspark.errors.exceptions.traceback import Traceback
+        from pyspark.errors.exceptions.tblib import Traceback
 
         message = str(e)
         start = message.find(python_exception_header)

--- a/python/pyspark/errors/exceptions/base.py
+++ b/python/pyspark/errors/exceptions/base.py
@@ -451,10 +451,10 @@ class QueryContext(ABC):
         ...
 
 
-TException = TypeVar("TException", bound=PySparkException)
+T = TypeVar("T", bound=PySparkException)
 
 
-def recover_python_exception(e: TException) -> TException:
+def recover_python_exception(e: T) -> T:
     """
     Recover Python exception stack trace.
 

--- a/python/pyspark/errors/exceptions/base.py
+++ b/python/pyspark/errors/exceptions/base.py
@@ -27,6 +27,9 @@ if TYPE_CHECKING:
     from pyspark.sql.types import Row
 
 
+T = TypeVar("T", bound="PySparkException")
+
+
 class PySparkException(Exception):
     """
     Base Exception for handling errors generated from PySpark.
@@ -449,9 +452,6 @@ class QueryContext(ABC):
         Summary of the exception cause.
         """
         ...
-
-
-T = TypeVar("T", bound=PySparkException)
 
 
 def recover_python_exception(e: T) -> T:

--- a/python/pyspark/errors/exceptions/base.py
+++ b/python/pyspark/errors/exceptions/base.py
@@ -458,7 +458,9 @@ def recover_python_exception(e: TException) -> TException:
     """
     Recover Python exception stack trace.
 
-    .. versionadded:: 4.0.0
+    Many JVM exceptions types may wrap Python exceptions. For example:
+    - UDFs can cause PythonException
+    - UDTFs and Data Sources can cause AnalysisException
     """
     python_exception_header = "Traceback (most recent call last):"
     try:

--- a/python/pyspark/errors/exceptions/captured.py
+++ b/python/pyspark/errors/exceptions/captured.py
@@ -248,8 +248,9 @@ def convert_exception(e: "Py4JJavaError") -> CapturedException:
         )
         ex = PythonException(msg, stacktrace)
         try:
-            tb = Traceback.from_string(python_stacktrace).as_traceback()
-            return ex.with_traceback(tb)
+            tb = Traceback.from_string(python_stacktrace)
+            tb.populate_linecache()
+            return ex.with_traceback(tb.as_traceback())
         except Exception:
             return ex
 

--- a/python/pyspark/errors/exceptions/connect.py
+++ b/python/pyspark/errors/exceptions/connect.py
@@ -93,10 +93,12 @@ def convert_exception(
             "\n  An exception was thrown from the Python worker. "
             "Please see the stack trace below.\n%s" % message
         )
-        ex = PythonException(msg, stacktrace)
+        ex = PythonException(msg)
         try:
-            tb = Traceback.from_string(message).as_traceback()
-            return ex.with_traceback(tb)
+            print("asdfklsfj", message)
+            tb = Traceback.from_string(message)
+            tb.populate_linecache()
+            return ex.with_traceback(tb.as_traceback())
         except Exception:
             return ex
 

--- a/python/pyspark/errors/exceptions/tblib.py
+++ b/python/pyspark/errors/exceptions/tblib.py
@@ -8,24 +8,24 @@ BSD 2-Clause License
 
 Copyright (c) 2013-2023, Ionel Cristian Mărieș. All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are 
+Redistribution and use in source and binary forms, with or without modification, are
 permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of 
+1. Redistributions of source code must retain the above copyright notice, this list of
     conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list 
-    of conditions and the following disclaimer in the documentation and/or other materials 
+2. Redistributions in binary form must reproduce the above copyright notice, this list
+    of conditions and the following disclaimer in the documentation and/or other materials
     provided with the distribution.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL 
-THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
-OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) 
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR 
-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
@@ -63,7 +63,8 @@ class TracebackParseError(Exception):
 
 class Code:
     """
-    Class that replicates just enough of the builtin Code object to enable serialization and traceback rendering.
+    Class that replicates just enough of the builtin Code object to enable serialization
+    and traceback rendering.
     """
 
     co_code: Optional[bytes] = None
@@ -82,7 +83,8 @@ class Code:
 
 class Frame:
     """
-    Class that replicates just enough of the builtin Frame object to enable serialization and traceback rendering.
+    Class that replicates just enough of the builtin Frame object to enable serialization
+    and traceback rendering.
 
     Args:
 
@@ -123,7 +125,8 @@ class Traceback:
     Args:
         get_locals (callable): A function that take a frame argument and returns a dict.
 
-            Ideally you will only return exactly what you need, and only with simple types that can be json serializable.
+            Ideally you will only return exactly what you need, and only with simple types
+            that can be json serializable.
 
             Example:
 
@@ -225,8 +228,8 @@ class Traceback:
 
     def as_dict(self) -> dict:
         """
-        Converts to a dictionary representation. You can serialize the result to JSON as it only has
-        builtin objects like dicts, lists, ints or strings.
+        Converts to a dictionary representation. You can serialize the result to JSON
+        as it only has builtin objects like dicts, lists, ints or strings.
         """
         if self.tb_next is None:
             tb_next = None

--- a/python/pyspark/errors/exceptions/tblib.py
+++ b/python/pyspark/errors/exceptions/tblib.py
@@ -188,17 +188,18 @@ class Traceback:
         current: Optional[Traceback] = self
         top_tb = None
         tb = None
+        compiled = compile(
+            "raise __traceback_maker",
+            "<string>",
+            "exec",
+        )
         while current:
             f_code = current.tb_frame.f_code
-            code = compile(
-                "\n" * (current.tb_lineno - 1) + "raise __traceback_maker",
-                current.tb_frame.f_code.co_filename,
-                "exec",
-            )
-            code = code.replace(
+            code = compiled.replace(
+                co_firstlineno=current.tb_lineno,
                 co_argcount=0,
                 co_filename=f_code.co_filename,
-                co_name=f_code.co_name or code.co_name,
+                co_name=f_code.co_name or compiled.co_name,
                 co_freevars=(),
                 co_cellvars=(),
             )

--- a/python/pyspark/errors/exceptions/tblib.py
+++ b/python/pyspark/errors/exceptions/tblib.py
@@ -1,20 +1,3 @@
-#
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 """
 Class for parsing Python tracebacks.
 

--- a/python/pyspark/errors/exceptions/tblib.py
+++ b/python/pyspark/errors/exceptions/tblib.py
@@ -188,18 +188,18 @@ class Traceback:
         current: Optional[Traceback] = self
         top_tb = None
         tb = None
-        compiled = compile(
+        stub = compile(
             "raise __traceback_maker",
             "<string>",
             "exec",
         )
         while current:
             f_code = current.tb_frame.f_code
-            code = compiled.replace(
+            code = stub.replace(
                 co_firstlineno=current.tb_lineno,
                 co_argcount=0,
                 co_filename=f_code.co_filename,
-                co_name=f_code.co_name or compiled.co_name,
+                co_name=f_code.co_name or stub.co_name,
                 co_freevars=(),
                 co_cellvars=(),
             )

--- a/python/pyspark/errors/exceptions/tblib.py
+++ b/python/pyspark/errors/exceptions/tblib.py
@@ -305,9 +305,10 @@ class Traceback:
             if frame_match:
                 frames.append(frame_match.groupdict())
                 if lines and lines[-1].startswith("    "):  # code for the frame
+                    code = lines.pop().strip()
                     filename = frame_match.group("co_filename")
                     lineno = int(frame_match.group("tb_lineno"))
-                    cached_lines.setdefault(filename, {}).setdefault(lineno, lines.pop().strip())
+                    cached_lines.setdefault(filename, {}).setdefault(lineno, code)
             elif line.startswith("  "):
                 pass
             elif strict:

--- a/python/pyspark/errors/exceptions/traceback.py
+++ b/python/pyspark/errors/exceptions/traceback.py
@@ -1,0 +1,293 @@
+"""
+Class for parsing Python tracebacks.
+
+This module was extracted from the `tblib` package:
+https://github.com/ionelmc/python-tblib
+
+BSD 2-Clause License
+
+Copyright (c) 2013-2023, Ionel Cristian Mărieș. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are 
+permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of 
+    conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list 
+    of conditions and the following disclaimer in the documentation and/or other materials 
+    provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL 
+THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) 
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR 
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+import re
+import sys
+from types import CodeType, FrameType, TracebackType
+from typing import Any, Optional
+
+__version__ = "3.0.0"
+__all__ = "Traceback", "TracebackParseError", "Frame", "Code"
+
+FRAME_RE = re.compile(
+    r'^\s*File "(?P<co_filename>.+)", line (?P<tb_lineno>\d+)(, in (?P<co_name>.+))?$'
+)
+
+
+class _AttrDict(dict):
+    __slots__ = ()
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError(name) from None
+
+
+# noinspection PyPep8Naming
+class __traceback_maker(Exception):
+    pass
+
+
+class TracebackParseError(Exception):
+    pass
+
+
+class Code:
+    """
+    Class that replicates just enough of the builtin Code object to enable serialization and traceback rendering.
+    """
+
+    co_code: Optional[bytes] = None
+
+    def __init__(self, code: CodeType) -> None:
+        self.co_filename = code.co_filename
+        self.co_name: Optional[str] = code.co_name
+        self.co_argcount = 0
+        self.co_kwonlyargcount = 0
+        self.co_varnames = ()
+        self.co_nlocals = 0
+        self.co_stacksize = 0
+        self.co_flags = 64
+        self.co_firstlineno = 0
+
+
+class Frame:
+    """
+    Class that replicates just enough of the builtin Frame object to enable serialization and traceback rendering.
+
+    Args:
+
+        get_locals (callable): A function that take a frame argument and returns a dict.
+
+            See :class:`Traceback` class for example.
+    """
+
+    def __init__(self, frame: FrameType, *, get_locals: Any = None) -> None:
+        self.f_locals = {} if get_locals is None else get_locals(frame)
+        self.f_globals = {k: v for k, v in frame.f_globals.items() if k in ("__file__", "__name__")}
+        self.f_code = Code(frame.f_code)
+        self.f_lineno = frame.f_lineno
+
+    def clear(self) -> None:
+        """
+        For compatibility with PyPy 3.5;
+        clear() was added to frame in Python 3.4
+        and is called by traceback.clear_frames(), which
+        in turn is called by unittest.TestCase.assertRaises
+        """
+
+
+class Traceback:
+    """
+    Class that wraps builtin Traceback objects.
+
+    Args:
+        get_locals (callable): A function that take a frame argument and returns a dict.
+
+            Ideally you will only return exactly what you need, and only with simple types that can be json serializable.
+
+            Example:
+
+            .. code:: python
+
+                def get_locals(frame):
+                    if frame.f_locals.get("__tracebackhide__"):
+                        return {"__tracebackhide__": True}
+                    else:
+                        return {}
+    """
+
+    tb_next: Optional["Traceback"] = None
+
+    def __init__(self, tb: TracebackType, *, get_locals: Any = None):
+        self.tb_frame = Frame(tb.tb_frame, get_locals=get_locals)
+        self.tb_lineno = int(tb.tb_lineno)
+
+        # Build in place to avoid exceeding the recursion limit
+        _tb = tb.tb_next
+        prev_traceback = self
+        cls = type(self)
+        while _tb is not None:
+            traceback = object.__new__(cls)
+            traceback.tb_frame = Frame(_tb.tb_frame, get_locals=get_locals)
+            traceback.tb_lineno = int(_tb.tb_lineno)
+            prev_traceback.tb_next = traceback
+            prev_traceback = traceback
+            _tb = _tb.tb_next
+
+    def as_traceback(self) -> Optional[TracebackType]:
+        """
+        Convert to a builtin Traceback object that is usable for raising or rendering a stacktrace.
+        """
+        current: Optional[Traceback] = self
+        top_tb = None
+        tb = None
+        while current:
+            f_code = current.tb_frame.f_code
+            code = compile(
+                "\n" * (current.tb_lineno - 1) + "raise __traceback_maker",
+                current.tb_frame.f_code.co_filename,
+                "exec",
+            )
+            code = code.replace(
+                co_argcount=0,
+                co_filename=f_code.co_filename,
+                co_name=f_code.co_name or code.co_name,
+                co_freevars=(),
+                co_cellvars=(),
+            )
+
+            # noinspection PyBroadException
+            try:
+                exec(
+                    code, dict(current.tb_frame.f_globals), dict(current.tb_frame.f_locals)
+                )  # noqa: S102
+            except Exception:
+                next_tb = sys.exc_info()[2].tb_next  # type: ignore
+                if top_tb is None:
+                    top_tb = next_tb
+                if tb is not None:
+                    tb.tb_next = next_tb
+                tb = next_tb
+                del next_tb
+
+            current = current.tb_next
+        try:
+            return top_tb
+        finally:
+            del top_tb
+            del tb
+
+    to_traceback = as_traceback
+
+    def as_dict(self) -> dict:
+        """
+        Converts to a dictionary representation. You can serialize the result to JSON as it only has
+        builtin objects like dicts, lists, ints or strings.
+        """
+        if self.tb_next is None:
+            tb_next = None
+        else:
+            tb_next = self.tb_next.as_dict()
+
+        code = {
+            "co_filename": self.tb_frame.f_code.co_filename,
+            "co_name": self.tb_frame.f_code.co_name,
+        }
+        frame = {
+            "f_globals": self.tb_frame.f_globals,
+            "f_locals": self.tb_frame.f_locals,
+            "f_code": code,
+            "f_lineno": self.tb_frame.f_lineno,
+        }
+        return {
+            "tb_frame": frame,
+            "tb_lineno": self.tb_lineno,
+            "tb_next": tb_next,
+        }
+
+    to_dict = as_dict
+
+    @classmethod
+    def from_dict(cls, dct: dict) -> "Traceback":
+        """
+        Creates an instance from a dictionary with the same structure as ``.as_dict()`` returns.
+        """
+        if dct["tb_next"]:
+            tb_next = cls.from_dict(dct["tb_next"])
+        else:
+            tb_next = None
+
+        code = _AttrDict(
+            co_filename=dct["tb_frame"]["f_code"]["co_filename"],
+            co_name=dct["tb_frame"]["f_code"]["co_name"],
+        )
+        frame = _AttrDict(
+            f_globals=dct["tb_frame"]["f_globals"],
+            f_locals=dct["tb_frame"].get("f_locals", {}),
+            f_code=code,
+            f_lineno=dct["tb_frame"]["f_lineno"],
+        )
+        tb = _AttrDict(
+            tb_frame=frame,
+            tb_lineno=dct["tb_lineno"],
+            tb_next=tb_next,
+        )
+        return cls(tb, get_locals=get_all_locals)  # type: ignore
+
+    @classmethod
+    def from_string(cls, string: str, strict: bool = True) -> "Traceback":
+        """
+        Creates an instance by parsing a stacktrace.
+        Strict means that parsing stops when lines are not indented by at least two spaces anymore.
+        """
+        frames = []
+        header = strict
+
+        for line in string.splitlines():
+            line = line.rstrip()
+            if header:
+                if line == "Traceback (most recent call last):":
+                    header = False
+                continue
+            frame_match = FRAME_RE.match(line)
+            if frame_match:
+                frames.append(frame_match.groupdict())
+            elif line.startswith("  "):
+                pass
+            elif strict:
+                break  # traceback ended
+
+        if frames:
+            previous = None
+            for frame in reversed(frames):
+                previous = _AttrDict(
+                    frame,
+                    tb_frame=_AttrDict(
+                        frame,
+                        f_globals=_AttrDict(
+                            __file__=frame["co_filename"],
+                            __name__="?",
+                        ),
+                        f_locals={},
+                        f_code=_AttrDict(frame),
+                        f_lineno=int(frame["tb_lineno"]),
+                    ),
+                    tb_next=previous,
+                )
+            return cls(previous)  # type: ignore
+        else:
+            raise TracebackParseError("Could not find any frames in %r." % string)
+
+
+def get_all_locals(frame: FrameType) -> dict:
+    return dict(frame.f_locals)

--- a/python/pyspark/errors/exceptions/traceback.py
+++ b/python/pyspark/errors/exceptions/traceback.py
@@ -1,8 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 """
 Class for parsing Python tracebacks.
 
 This module was adapted from the `tblib` package https://github.com/ionelmc/python-tblib
-modified to recover line content from the traceback.
+modified to also recover line content from the traceback.
 
 BSD 2-Clause License
 

--- a/python/pyspark/errors/tests/connect/__init__.py
+++ b/python/pyspark/errors/tests/connect/__init__.py
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/pyspark/errors/tests/connect/test_parity_traceback.py
+++ b/python/pyspark/errors/tests/connect/test_parity_traceback.py
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pyspark.errors.tests.test_traceback import BaseTracebackSqlTestsMixin
+from pyspark.testing.connectutils import ReusedConnectTestCase
+
+
+class TracebackSqlConnectTests(BaseTracebackSqlTestsMixin, ReusedConnectTestCase):
+    pass
+
+
+if __name__ == "__main__":
+    import unittest
+    from pyspark.errors.tests.connect.test_parity_traceback import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/errors/tests/test_traceback.py
+++ b/python/pyspark/errors/tests/test_traceback.py
@@ -161,7 +161,6 @@ class BaseTracebackSqlTestsMixin:
         raise ValueError("bar")
 
     def test_udf(self):
-
         @sf.udf()
         def foo():
             raise ValueError("bar")
@@ -220,7 +219,6 @@ class BaseTracebackSqlTestsMixin:
         self.assertIn("""raise ValueError("bar")""", s)
 
     def test_udtf_analysis(self):
-
         @sf.udtf()
         class MyUdtf:
             @staticmethod
@@ -242,7 +240,6 @@ class BaseTracebackSqlTestsMixin:
         self.assertIn("""raise ValueError("bar")""", s)
 
     def test_udtf_execution(self):
-
         @sf.udtf(returnType="x int")
         class MyUdtf:
             def eval(self):

--- a/python/pyspark/errors/tests/test_traceback.py
+++ b/python/pyspark/errors/tests/test_traceback.py
@@ -14,46 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
-import platform
+import importlib.util
+import linecache
 import sys
 import tempfile
 import traceback
 import unittest
-from datetime import datetime
-from decimal import Decimal
-from typing import Callable, Iterable, List, Union
 
-from pyspark.errors import AnalysisException, PythonException
-from pyspark.sql.datasource import (
-    CaseInsensitiveDict,
-    DataSource,
-    DataSourceArrowWriter,
-    DataSourceReader,
-    DataSourceWriter,
-    EqualNullSafe,
-    EqualTo,
-    Filter,
-    GreaterThan,
-    GreaterThanOrEqual,
-    In,
-    InputPartition,
-    IsNotNull,
-    IsNull,
-    LessThan,
-    LessThanOrEqual,
-    StringContains,
-    StringEndsWith,
-    StringStartsWith,
-    WriterCommitMessage,
-)
-from pyspark.sql.functions import spark_partition_id
+from pyspark.errors import PythonException
+from pyspark.errors.exceptions.base import AnalysisException
+from pyspark.errors.exceptions.traceback import Traceback
 from pyspark.sql.functions import udf
 from pyspark.sql.session import SparkSession
-from pyspark.sql.types import Row, StructType
-from pyspark.testing import assertDataFrameEqual
+from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.sqlutils import (
-    SPARK_HOME,
     ReusedSQLTestCase,
     have_pandas,
     have_pyarrow,
@@ -62,15 +36,64 @@ from pyspark.testing.sqlutils import (
 )
 
 
-have_requirements = have_pandas and have_pyarrow
-message = pandas_requirement_message or pyarrow_requirement_message
+class TracebackTests(unittest.TestCase):
+    def make_traceback(self):
+        try:
+            raise ValueError("bar")
+        except ValueError:
+            return traceback.format_exc()
+
+    def make_traceback_with_temp_file(self, code: str):
+        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=True) as f:
+            f.write(code)
+            f.flush()
+            spec = importlib.util.spec_from_file_location("foo", f.name)
+            foo = importlib.util.module_from_spec(spec)
+            try:
+                spec.loader.exec_module(foo)
+                foo.f()
+            except Exception:
+                return traceback.format_exc()
+            else:
+                assert False, "ZeroDivisionError not raised"
+
+    def assert_traceback(self, tb: Traceback, error: str):
+        tb.populate_linecache()
+        expected = "".join(error.splitlines(keepends=True)[1:-1])  # keep only the traceback
+        actual = "".join(traceback.format_tb(tb.as_traceback()))
+        self.assertEqual(actual, expected)
+
+    def test_simple(self):
+        s = self.make_traceback()
+        self.assert_traceback(Traceback.from_string(s), s)
+
+    def test_missing_source(self):
+        s = self.make_traceback_with_temp_file("""def f(): 1 / 0""")
+        linecache.clearcache()  # remove temp file from cache
+        self.assert_traceback(Traceback.from_string(s), s)
+
+    def test_syntax_error(self):
+        self.maxDiff = None
+        s = self.make_traceback_with_temp_file("""bad syntax""")
+        tb = Traceback.from_string(s)
+        tb.populate_linecache()
+        actual = "".join(traceback.format_tb(tb.as_traceback()))
+        self.assertIn("bad syntax", actual)
+        self.assertNotIn("^", actual)
 
 
-@unittest.skipIf(not have_requirements, message)
-class BaseTracebackTestsMixin:
+@unittest.skipIf(
+    not have_pandas or not have_pyarrow,
+    pandas_requirement_message or pyarrow_requirement_message,
+)
+class BaseTracebackSqlTestsMixin:
     spark: SparkSession
 
-    def test_udf_traceback(self):
+    @staticmethod
+    def raise_exception():
+        raise ValueError("bar")
+
+    def test_udf(self):
         @udf()
         def foo():
             raise ValueError("bar")
@@ -87,8 +110,32 @@ class BaseTracebackTestsMixin:
         self.assertIn("""df.show()""", s)
         self.assertIn("""raise ValueError("bar")""", s)
 
+    def test_datasource(self):
+        from pyspark.sql.datasource import DataSource
 
-class TracebackTests(BaseTracebackTestsMixin, ReusedSQLTestCase):
+        class MyDataSource(DataSource):
+            def schema(self):
+                raise ValueError("bar")
+
+        self.spark.dataSource.register(MyDataSource)
+        try:
+            self.spark.read.format("MyDataSource").load().show()
+        except AnalysisException as e:
+            traceback.print_exc()
+            _, _, tb = sys.exc_info()
+        else:
+            self.fail("AnalysisException not raised")
+
+        s = "\n".join(traceback.format_tb(tb))
+        self.assertIn("""self.spark.read.format("MyDataSource").load().show()""", s)
+        self.assertIn("""raise ValueError("bar")""", s)
+
+
+class TracebackSqlClassicTests(BaseTracebackSqlTestsMixin, ReusedSQLTestCase):
+    ...
+
+
+class TracebackSqlConnectTests(BaseTracebackSqlTestsMixin, ReusedConnectTestCase):
     ...
 
 

--- a/python/pyspark/errors/tests/test_traceback.py
+++ b/python/pyspark/errors/tests/test_traceback.py
@@ -1,0 +1,93 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+import platform
+import tempfile
+import unittest
+from datetime import datetime
+from decimal import Decimal
+from typing import Callable, Iterable, List, Union
+
+from pyspark.errors import AnalysisException, PythonException
+from pyspark.sql.datasource import (
+    CaseInsensitiveDict,
+    DataSource,
+    DataSourceArrowWriter,
+    DataSourceReader,
+    DataSourceWriter,
+    EqualNullSafe,
+    EqualTo,
+    Filter,
+    GreaterThan,
+    GreaterThanOrEqual,
+    In,
+    InputPartition,
+    IsNotNull,
+    IsNull,
+    LessThan,
+    LessThanOrEqual,
+    StringContains,
+    StringEndsWith,
+    StringStartsWith,
+    WriterCommitMessage,
+)
+from pyspark.sql.functions import spark_partition_id
+from pyspark.sql.functions import udf
+from pyspark.sql.session import SparkSession
+from pyspark.sql.types import Row, StructType
+from pyspark.testing import assertDataFrameEqual
+from pyspark.testing.sqlutils import (
+    SPARK_HOME,
+    ReusedSQLTestCase,
+    have_pandas,
+    have_pyarrow,
+    pandas_requirement_message,
+    pyarrow_requirement_message,
+)
+
+
+have_requirements = have_pandas and have_pyarrow
+message = pandas_requirement_message or pyarrow_requirement_message
+
+
+@unittest.skipIf(not have_requirements, message)
+class BaseTracebackTestsMixin:
+    spark: SparkSession
+
+    def test_basic_data_source_class(self):
+        @udf()
+        def foo():
+            raise ValueError("bar")
+
+        df = self.spark.range(1).select(foo())
+        df.show()
+
+
+class TracebackTests(BaseTracebackTestsMixin, ReusedSQLTestCase):
+    ...
+
+
+if __name__ == "__main__":
+    from pyspark.errors.tests.test_traceback import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/errors/tests/test_traceback.py
+++ b/python/pyspark/errors/tests/test_traceback.py
@@ -28,7 +28,6 @@ from pyspark.errors.exceptions.base import AnalysisException
 from pyspark.errors.exceptions.tblib import Traceback
 from pyspark.sql.datasource import DataSource, DataSourceReader
 from pyspark.sql.session import SparkSession
-from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.sqlutils import (
     ReusedSQLTestCase,
     have_pandas,
@@ -229,11 +228,7 @@ class BaseTracebackSqlTestsMixin:
 
 
 class TracebackSqlClassicTests(BaseTracebackSqlTestsMixin, ReusedSQLTestCase):
-    ...
-
-
-class TracebackSqlConnectTests(BaseTracebackSqlTestsMixin, ReusedConnectTestCase):
-    ...
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/errors/tests/test_traceback.py
+++ b/python/pyspark/errors/tests/test_traceback.py
@@ -24,7 +24,7 @@ import unittest
 import pyspark.sql.functions as F
 from pyspark.errors import PythonException
 from pyspark.errors.exceptions.base import AnalysisException
-from pyspark.errors.exceptions.traceback import Traceback
+from pyspark.errors.exceptions.tblib import Traceback
 from pyspark.sql.datasource import DataSource, DataSourceReader
 from pyspark.sql.session import SparkSession
 from pyspark.testing.connectutils import ReusedConnectTestCase

--- a/python/pyspark/errors/tests/test_traceback.py
+++ b/python/pyspark/errors/tests/test_traceback.py
@@ -40,6 +40,7 @@ from pyspark.testing.sqlutils import (
 
 class TracebackTests(unittest.TestCase):
     """Tests for the Traceback class."""
+
     def make_traceback(self):
         try:
             raise ValueError("bar")
@@ -123,6 +124,7 @@ class TracebackTests(unittest.TestCase):
 )
 class BaseTracebackSqlTestsMixin:
     """Tests for recovering the original traceback from JVM exceptions."""
+
     spark: SparkSession
 
     @staticmethod
@@ -130,7 +132,6 @@ class BaseTracebackSqlTestsMixin:
         raise ValueError("bar")
 
     def test_udf(self):
-
         @F.udf()
         def foo():
             raise ValueError("bar")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### Motivation

Currently, when a Python UDF raises an error, the traceback only includes the file name and the line number, but doesn't include the content of that specific line. This behavior is different from local code tracebacks that show the line content. See following example.

Error inside UDF.
![image](https://github.com/user-attachments/assets/03d6dc6a-c821-4601-9074-95377d03f80c)

Local error. Notice that IPython additionally includes more more lines around the line where error happens, with links to the notebook cell, making it even easier to understand.
![image](https://github.com/user-attachments/assets/54886061-b90d-4449-a500-a81ee30c19db)

### What changes were proposed in this pull request?

This PR changes `convert_exception` to detect Python tracebacks in the JVM error message, parse them back to a traceback object, and include them in the converted exception. This way, these frames will be included in the exception traceback as if they were part of the call stack.

If we fail to parse the traceback, we will silently ignore the failure, keeping the original behavior. In either case, the original error message, with the traceback in string form, will always be included in the exception so that we don't lose any information.

This PR also introduces [`tblib`](https://github.com/ionelmc/python-tblib), a lightweight library that allows parsing traceback from string. The library is included as a source file, with modifications to make it preserve the original line content when the file is not available anymore.

Example of improved traceback as displayed in IPython. Notice that the Python worker frames are concatenated to the exception so that IPython ultratb shows the code around the error line.
```py
---------------------------------------------------------------------------
PythonException                           Traceback (most recent call last)
Cell In[3], line 8
      4 @udf(returnType=StringType())
      5 def foo(value):
      6     1 / 0
----> 8 spark.range(1).toDF("value").select(foo("value")).show()

File ~/personal/test-spark/.venv/lib/python3.9/site-packages/pyspark/sql/classic/dataframe.py:285, in DataFrame.show(self, n, truncate, vertical)
    284 def show(self, n: int = 20, truncate: Union[bool, int] = True, vertical: bool = False) -> None:
--> 285     print(self._show_string(n, truncate, vertical))

...

File ~/personal/test-spark/.venv/lib/python3.9/site-packages/pyspark/errors/exceptions/captured.py:271, in capture_sql_exception.<locals>.deco(*a, **kw)
    267 converted = convert_exception(e.java_exception)
    268 if not isinstance(converted, UnknownException):
    269     # Hide where the exception came from that shows a non-Pythonic
    270     # JVM exception message.
--> 271     raise converted from None
    272 else:
    273     raise

Cell In[3], line 6, in foo()
      4 @udf(returnType=StringType())
      5 def foo(value):
----> 6     1 / 0

PythonException: 
  An exception was thrown from the Python worker. Please see the stack trace below.
Traceback (most recent call last):
  File "/var/folders/jm/2m7c_fjj75v7gqlr5px0j8780000gp/T/ipykernel_6171/1200677507.py", line 6, in foo
ZeroDivisionError: division by zero
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To improve debuggability of Python UDFs (and UDTFs, Data Sources, etc.) by recovering the traceback when calling the UDF using PySpark.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Exceptions converted from JVM will include additional traceback frames if the JVM error message includes a Python traceback.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests and end to end tests in `python/pyspark/errors/tests/test_traceback.py`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No

### What are the risks?

1. This change will break anything that assume that the frames of converted exception don't include UDF frames. This sounds unlikely though.
2. If there's a Python source file that is present on both the worker and the client, but with different content, then the traceback may show wrong line content for frames in that file.
3. If the traceback string format changes in a future Python version, then the parsing will break. A recent example is [PEP 657 in Python 3.11](https://docs.python.org/3/whatsnew/3.11.html#pep-657-fine-grained-error-locations-in-tracebacks) which introduced fine-grained error locations in traceback. If similar changes happen in the future, the unit tests should catch the change. In the worst case the parsing will fail and we will fall back to the original traceback string.
4. If the Python source file name contains a line break then parsing will return an incorrect traceback.

### Why do the worker tracebacks not include the line content?

When Python turns a traceback into string, it looks up the line content from the file and the line number using the `linecache` module. This module contains a in memory cache from file name to lines, and when there's a miss, it reads the file from module globals or from the file system. IPython adds the cell content to the cache when the cell is executed.

When we run a UDF the function is pickled and sent to the driver JVM. The pickle doesn't include the source code nor the line cache so `linecache` will generally not be able to find the source code when it generates the traceback on the Python worker, unless the client code is in a `.py` file on the same host as the worker.

### What alternative solutions did we consider?

This solution may be brittle since it depends on the specific traceback string format. And it also introduces a new 3rd party dependency. Here's some alternatives and why we didn't choose them.

#### Pass linecache to Python worker

If we can pass the linecache content to the worker, then the traceback on the worker will include the line content. To do this, we need to find which files are part of the pickle, and pass the content of these files to the worker. I think this is not feasible because it can potentially cause a lot of overhead when calling UDFs. And the user would still not be able to benefit from rich tracebacks like the one provided by IPython.

#### Send serialized traceback from Python worker to JVM

To avoid the brittle string parsing, we could send the traceback object from the worker to the JVM, then deserialize in Python client. Unfortunately Python tracebacks are not pickleable, so we would still need to use a 3rd party library (`tblib` again) to serialize the traceback. Also, this would require a lot more changes across the codebase.
