### PR TITLE
[MINOR][SQL][TESTS] Ignore messages below error level from `HadoopFSUtils` for sql module tests

### DIFF
--- a/core/src/test/resources/log4j2.properties
+++ b/core/src/test/resources/log4j2.properties
@@ -37,7 +37,3 @@ appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %maxLen{%m}{512}%n%ex{
 # Ignore messages below warning level from Jetty, because it's a bit verbose
 logger.jetty.name = org.sparkproject.jetty
 logger.jetty.level = warn
-
-# Ignore messages below error level from HadoopFSUtils, because it's a bit verbose
-logger.hadoopfsutils.name = org.apache.spark.util.HadoopFSUtils
-logger.hadoopfsutils.level = error

--- a/core/src/test/resources/log4j2.properties
+++ b/core/src/test/resources/log4j2.properties
@@ -37,3 +37,7 @@ appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %maxLen{%m}{512}%n%ex{
 # Ignore messages below warning level from Jetty, because it's a bit verbose
 logger.jetty.name = org.sparkproject.jetty
 logger.jetty.level = warn
+
+# Ignore messages below error level from HadoopFSUtils, because it's a bit verbose
+logger.hadoopfsutils.name = org.apache.spark.util.HadoopFSUtils
+logger.hadoopfsutils.level = error

--- a/sql/core/src/test/resources/log4j2.properties
+++ b/sql/core/src/test/resources/log4j2.properties
@@ -84,3 +84,7 @@ logger.structured.name = org.apache.spark.sql.LogQuerySuite
 logger.structured.level = trace
 logger.structured.appenderRefs = structured
 logger.structured.appenderRef.structured.ref = structured
+
+# Ignore messages below error level from HadoopFSUtils, because it's a bit verbose
+logger.hadoopfsutils.name = org.apache.spark.util.HadoopFSUtils
+logger.hadoopfsutils.level = error


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr ignore messages below error level from `HadoopFSUtils` for sql module tests.


### Why are the changes needed?
From the test logs of Github Actions, there are a large number of logs from `HadoopFSUtils`. For example, in the pipeline named `sql-other tests`, there are approximately 40,000 similar logs like the following:

- https://github.com/apache/spark/actions/runs/13915102741/job/38936641387

```
04:22:51.192 WARN org.apache.spark.util.HadoopFSUtils: The directory /home/runner/work/spark/spark/target/tmp/spark-e3d8a446-2dd8-42fd-a64f-b96504d8cd69/deleted was not found. Was it deleted very recently?

04:22:51.193 WARN org.apache.spark.util.HadoopFSUtils: The directory /home/runner/work/spark/spark/target/tmp/spark-e3d8a446-2dd8-42fd-a64f-b96504d8cd69/deleted was not found. Was it deleted very recently?

[info] - InMemoryFileIndex: root folders that don't exist don't throw exceptions (6 milliseconds)
04:22:51.244 WARN org.apache.spark.util.HadoopFSUtils: The directory mockFs:/rootDir/subDir was not found. Was it deleted very recently?

04:22:51.271 WARN org.apache.spark.util.HadoopFSUtils: The directory mockFs:/rootDir/subDir was not found. Was it deleted very recently?

04:22:51.280 WARN org.apache.spark.util.HadoopFSUtils: The directory mockFs:/rootDir/subDir was not found. Was it deleted very recently?

04:22:51.281 WARN org.apache.spark.util.HadoopFSUtils: The directory mockFs:/rootDir/subDir was not found. Was it deleted very recently?

04:22:51.307 WARN org.apache.spark.util.HadoopFSUtils: The directory mockFs:/rootDir/subDir was not found. Was it deleted very recently?

04:22:51.332 WARN org.apache.spark.util.HadoopFSUtils: The directory mockFs:/rootDir/subDir was not found. Was it deleted very recently?

04:22:51.334 WARN org.apache.spark.util.HadoopFSUtils: The directory mockFs:/rootDir/subDir was not found. Was it deleted very recently?

04:22:51.334 WARN org.apache.spark.util.HadoopFSUtils: The directory mockFs:/rootDir/subDir was not found. Was it deleted very recently?
```

Similar logs are more like noise, so the current pr makes `HadoopFSUtils` only print error-level logs during SQL module testing.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions
- Manual inspection shows that the new tests in the SQL module no longer print similar logs as mentioned above.


### Was this patch authored or co-authored using generative AI tooling?
No
