### PR TITLE
[SPARK-51548][SQL] Provides configuration to decide whether to copy objects before shuffle.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5593,6 +5593,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val NEED_TO_COPY_OBJECT_BEFORE_SHUFFLE =
+    buildConf("spark.sql.needToCopyObjectBeforeShuffle")
+      .internal()
+      .doc("When set to true, we will force copy object before shuffle for non-SortShuffleManager")
+      .version("3.5.1")
+      .booleanConf
+      .createWithDefault(true)
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -6600,6 +6608,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def legacyCodingErrorAction: Boolean = getConf(SQLConf.LEGACY_CODING_ERROR_ACTION)
 
   def legacyEvalCurrentTime: Boolean = getConf(SQLConf.LEGACY_EVAL_CURRENT_TIME)
+
+  def needToCopyObjectsBeforeShuffle: Boolean = getConf(NEED_TO_COPY_OBJECT_BEFORE_SHUFFLE)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -321,8 +321,8 @@ object ShuffleExchangeExec {
         true
       }
     } else {
-      // Catch-all case to safely handle any future ShuffleManager implementations.
-      true
+      // Catch-all case to safely handle any future or third party ShuffleManager implementations.
+      SQLConf.get.needToCopyObjectsBeforeShuffle
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Provides configuration to decide whether to copy objects before shuffle

### Why are the changes needed?

For SparkSQL, We will decide whether to copy the object based on the type of shuffle writer. However, for some third-party shuffle writers, the object will be forced to be copied. However, sometimes it is unnecessary. For example, the shuffle writer in uniffle will directly serialize the record when processing each record, so it is also unnecessary.

### Does this PR introduce _any_ user-facing change?

Add new configuration `spark.sql.needToCopyObjectBeforeShuffle` to enable or disable copy object before shuffle if the ShuffleManager is not SortShuffleManager.

### How was this patch tested?

No need to test.

### Was this patch authored or co-authored using generative AI tooling?

No
