### PR TITLE
[SPARK-40353][PS][CONNECT] Fix index nullable mismatch in `ps.read_excel`

### DIFF
--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -65,6 +65,7 @@ from pyspark.sql.types import (
     StringType,
     DateType,
     StructType,
+    StructField,
     DataType,
 )
 from pyspark.sql.dataframe import DataFrame as PySparkDataFrame
@@ -85,6 +86,7 @@ from pyspark.pandas.utils import (
 from pyspark.pandas.frame import DataFrame, _reduce_spark_multi
 from pyspark.pandas.internal import (
     InternalFrame,
+    InternalField,
     DEFAULT_SERIES_NAME,
     HIDDEN_COLUMNS,
     SPARK_INDEX_NAME_FORMAT,
@@ -1186,9 +1188,29 @@ def read_excel(
                 pdf = pdf_or_pser
 
             psdf = cast(DataFrame, from_pandas(pdf))
-            return_schema = force_decimal_precision_scale(
-                as_nullable_spark_type(psdf._internal.spark_frame.drop(*HIDDEN_COLUMNS).schema)
-            )
+
+            index_scol_names = psdf._internal.index_spark_column_names
+            raw_schema = psdf._internal.spark_frame.drop(*HIDDEN_COLUMNS).schema
+            nullable_fields = []
+            for field in raw_schema.fields:
+                if field.name in index_scol_names:
+                    print(field)
+                    nullable_fields.append(field)
+                else:
+                    nullable_fields.append(
+                        StructField(
+                            field.name,
+                            as_nullable_spark_type(field.dataType),
+                            nullable=True,
+                            metadata=field.metadata,
+                        )
+                    )
+            nullable_schema = StructType(nullable_fields)
+            return_schema = force_decimal_precision_scale(nullable_schema)
+
+            return_data_fields: Optional[List[InternalField]] = None
+            if psdf._internal.data_fields is not None:
+                return_data_fields = [f.normalize_spark_type() for f in psdf._internal.data_fields]
 
             def output_func(pdf: pd.DataFrame) -> pd.DataFrame:
                 pdf = pd.concat([pd_read_excel(bin, sn=sn) for bin in pdf[pdf.columns[0]]])
@@ -1211,8 +1233,7 @@ def read_excel(
                 .select("content")
                 .mapInPandas(lambda iterator: map(output_func, iterator), schema=return_schema)
             )
-
-            return DataFrame(psdf._internal.with_new_sdf(sdf))
+            return DataFrame(psdf._internal.with_new_sdf(sdf, data_fields=return_data_fields))
 
         if isinstance(pdf_or_psers, dict):
             return {

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -1189,12 +1189,11 @@ def read_excel(
 
             psdf = cast(DataFrame, from_pandas(pdf))
 
-            index_scol_names = psdf._internal.index_spark_column_names
             raw_schema = psdf._internal.spark_frame.drop(*HIDDEN_COLUMNS).schema
+            index_scol_names = psdf._internal.index_spark_column_names
             nullable_fields = []
             for field in raw_schema.fields:
                 if field.name in index_scol_names:
-                    print(field)
                     nullable_fields.append(field)
                 else:
                     nullable_fields.append(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix nullable mismatch in `ps.read_excel`


### Why are the changes needed?
to re-enable the tests


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
updated ut


### Was this patch authored or co-authored using generative AI tooling?
no