### PR TITLE
[SPARK-51584][SQL] Add rule that pushes Project through Offset and Suite that tests it

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -402,6 +402,8 @@ package object dsl {
 
       def localLimit(limitExpr: Expression): LogicalPlan = LocalLimit(limitExpr, logicalPlan)
 
+      def globalLimit(limitExpr: Expression): LogicalPlan = GlobalLimit(limitExpr, logicalPlan)
+
       def offset(offsetExpr: Expression): LogicalPlan = Offset(offsetExpr, logicalPlan)
 
       def join(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -101,6 +101,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
         // Operator push down
         PushProjectionThroughUnion,
         PushProjectionThroughLimit,
+        PushProjectionThroughOffset,
         ReorderJoin,
         EliminateOuterJoin,
         PushDownPredicates,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushProjectionThroughOffset.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushProjectionThroughOffset.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Offset, Project}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.{OFFSET, PROJECT}
+
+/**
+ * Pushes Project operator through Offset operator.
+ */
+object PushProjectionThroughOffset extends Rule[LogicalPlan] {
+  def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
+    _.containsAllPatterns(PROJECT, OFFSET)) {
+
+    case p @ Project(projectList, offset @ Offset(_, child))
+      if projectList.forall(_.deterministic) =>
+      offset.copy(child = p.copy(projectList, child))
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1399,6 +1399,8 @@ case class Offset(offsetExpr: Expression, child: LogicalPlan) extends OrderPrese
   }
   override protected def withNewChildInternal(newChild: LogicalPlan): Offset =
     copy(child = newChild)
+
+  override val nodePatterns: Seq[TreePattern] = Seq(OFFSET)
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -131,6 +131,7 @@ object TreePattern extends Enumeration  {
   val LOCAL_RELATION: Value = Value
   val LOGICAL_QUERY_STAGE: Value = Value
   val NATURAL_LIKE_JOIN: Value = Value
+  val OFFSET: Value = Value
   val OUTER_JOIN: Value = Value
   val PROJECT: Value = Value
   val PYTHON_DATA_SOURCE: Value = Value

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushProjectionThroughOffsetSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushProjectionThroughOffsetSuite.scala
@@ -26,15 +26,8 @@ import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 
 class PushProjectionThroughOffsetSuite extends PlanTest {
-  object Optimize1 extends RuleExecutor[LogicalPlan] {
-    val batches = Batch("Optimizer Batch",
-      FixedPoint(100),
-      PushProjectionThroughLimit,
-      PushProjectionThroughOffset,
-      EliminateLimits) :: Nil
-  }
 
-  object Optimize2 extends RuleExecutor[LogicalPlan] {
+  object Optimize extends RuleExecutor[LogicalPlan] {
     val batches = Batch("Optimizer Batch",
       FixedPoint(100),
       PushProjectionThroughLimit,
@@ -52,31 +45,64 @@ class PushProjectionThroughOffsetSuite extends PlanTest {
       .offset(5)
       .select(Symbol("a"), Symbol("b"), 'c')
       .analyze
-    val optimized1 = Optimize1.execute(query1)
+    val optimized1 = Optimize.execute(query1)
     val expected1 = testRelation
       .select(Symbol("a"), Symbol("b"), 'c')
       .offset(5).analyze
     comparePlans(optimized1, expected1)
 
     val query2 = testRelation
-      .offset(5).limit(15)
+      .limit(15).offset(5)
       .select(Symbol("a"), Symbol("b"), 'c')
       .analyze
-    val optimized2 = Optimize1.execute(query2)
+    val optimized2 = Optimize.execute(query2)
     val expected2 = testRelation
       .select(Symbol("a"), Symbol("b"), 'c')
-      .offset(5).limit(15).analyze
+      .limit(15).offset(5).analyze
     comparePlans(optimized2, expected2)
 
     val query3 = testRelation
       .offset(5).limit(15)
       .select(Symbol("a"), Symbol("b"), 'c')
       .analyze
-    val optimized3 = Optimize2.execute(query3)
+    val optimized3 = Optimize.execute(query3)
     val expected3 = testRelation
       .select(Symbol("a"), Symbol("b"), 'c')
       .localLimit(Add(15, 5)).offset(5).globalLimit(15)
       .analyze
     comparePlans(optimized3, expected3)
+
+    val query4 = testRelation
+      .offset(5).limit(15)
+      .select(Symbol("a"), Symbol("b"), 'c')
+      .limit(10).analyze
+    val optimized4 = Optimize.execute(query4)
+    val expected4 = testRelation
+      .select(Symbol("a"), Symbol("b"), 'c')
+      .localLimit(Add(10, 5)).offset(5).globalLimit(10)
+      .analyze
+    comparePlans(optimized4, expected4)
+
+    val query5 = testRelation
+      .localLimit(10)
+      .select(Symbol("a"), Symbol("b"), 'c')
+      .offset(5).limit(10).analyze
+    val optimized5 = Optimize.execute(query5)
+    val expected5 = testRelation
+      .select(Symbol("a"), Symbol("b"), 'c')
+      .localLimit(10).offset(5).globalLimit(10)
+      .analyze
+    comparePlans(optimized5, expected5)
+
+    val query6 = testRelation
+      .localLimit(20)
+      .select(Symbol("a"), Symbol("b"), 'c')
+      .offset(5).limit(10).analyze
+    val optimized6 = Optimize.execute(query6)
+    val expected6 = testRelation
+      .select(Symbol("a"), Symbol("b"), 'c')
+      .localLimit(15).offset(5).globalLimit(10)
+      .analyze
+    comparePlans(optimized6, expected6)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushProjectionThroughOffsetSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushProjectionThroughOffsetSuite.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.Add
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+
+class PushProjectionThroughOffsetSuite extends PlanTest {
+  object Optimize1 extends RuleExecutor[LogicalPlan] {
+    val batches = Batch("Optimizer Batch",
+      FixedPoint(100),
+      PushProjectionThroughLimit,
+      PushProjectionThroughOffset,
+      EliminateLimits) :: Nil
+  }
+
+  object Optimize2 extends RuleExecutor[LogicalPlan] {
+    val batches = Batch("Optimizer Batch",
+      FixedPoint(100),
+      PushProjectionThroughLimit,
+      PushProjectionThroughOffset,
+      EliminateLimits,
+      LimitPushDown) :: Nil
+  }
+
+  test("push projection through offset") {
+    val testRelation = LocalRelation.fromExternalRows(
+      Seq("a".attr.int, "b".attr.int, "c".attr.int),
+      1.to(30).map(_ => Row(1, 2, 3)))
+
+    val query1 = testRelation
+      .offset(5)
+      .select(Symbol("a"), Symbol("b"), 'c')
+      .analyze
+    val optimized1 = Optimize1.execute(query1)
+    val expected1 = testRelation
+      .select(Symbol("a"), Symbol("b"), 'c')
+      .offset(5).analyze
+    comparePlans(optimized1, expected1)
+
+    val query2 = testRelation
+      .offset(5).limit(15)
+      .select(Symbol("a"), Symbol("b"), 'c')
+      .analyze
+    val optimized2 = Optimize1.execute(query2)
+    val expected2 = testRelation
+      .select(Symbol("a"), Symbol("b"), 'c')
+      .offset(5).limit(15).analyze
+    comparePlans(optimized2, expected2)
+
+    val query3 = testRelation
+      .offset(5).limit(15)
+      .select(Symbol("a"), Symbol("b"), 'c')
+      .analyze
+    val optimized3 = Optimize2.execute(query3)
+    val expected3 = testRelation
+      .select(Symbol("a"), Symbol("b"), 'c')
+      .localLimit(Add(15, 5)).offset(5).globalLimit(15)
+      .analyze
+    comparePlans(optimized3, expected3)
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushProjectionThroughOffsetSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushProjectionThroughOffsetSuite.scala
@@ -43,64 +43,64 @@ class PushProjectionThroughOffsetSuite extends PlanTest {
 
     val query1 = testRelation
       .offset(5)
-      .select(Symbol("a"), Symbol("b"), 'c')
+      .select($"a", $"b", $"c")
       .analyze
     val optimized1 = Optimize.execute(query1)
     val expected1 = testRelation
-      .select(Symbol("a"), Symbol("b"), 'c')
+      .select($"a", $"b", $"c")
       .offset(5).analyze
     comparePlans(optimized1, expected1)
 
     val query2 = testRelation
       .limit(15).offset(5)
-      .select(Symbol("a"), Symbol("b"), 'c')
+      .select($"a", $"b", $"c")
       .analyze
     val optimized2 = Optimize.execute(query2)
     val expected2 = testRelation
-      .select(Symbol("a"), Symbol("b"), 'c')
+      .select($"a", $"b", $"c")
       .limit(15).offset(5).analyze
     comparePlans(optimized2, expected2)
 
     val query3 = testRelation
       .offset(5).limit(15)
-      .select(Symbol("a"), Symbol("b"), 'c')
+      .select($"a", $"b", $"c")
       .analyze
     val optimized3 = Optimize.execute(query3)
     val expected3 = testRelation
-      .select(Symbol("a"), Symbol("b"), 'c')
+      .select($"a", $"b", $"c")
       .localLimit(Add(15, 5)).offset(5).globalLimit(15)
       .analyze
     comparePlans(optimized3, expected3)
 
     val query4 = testRelation
       .offset(5).limit(15)
-      .select(Symbol("a"), Symbol("b"), 'c')
+      .select($"a", $"b", $"c")
       .limit(10).analyze
     val optimized4 = Optimize.execute(query4)
     val expected4 = testRelation
-      .select(Symbol("a"), Symbol("b"), 'c')
+      .select($"a", $"b", $"c")
       .localLimit(Add(10, 5)).offset(5).globalLimit(10)
       .analyze
     comparePlans(optimized4, expected4)
 
     val query5 = testRelation
       .localLimit(10)
-      .select(Symbol("a"), Symbol("b"), 'c')
+      .select($"a", $"b", $"c")
       .offset(5).limit(10).analyze
     val optimized5 = Optimize.execute(query5)
     val expected5 = testRelation
-      .select(Symbol("a"), Symbol("b"), 'c')
+      .select($"a", $"b", $"c")
       .localLimit(10).offset(5).globalLimit(10)
       .analyze
     comparePlans(optimized5, expected5)
 
     val query6 = testRelation
       .localLimit(20)
-      .select(Symbol("a"), Symbol("b"), 'c')
+      .select($"a", $"b", $"c")
       .offset(5).limit(10).analyze
     val optimized6 = Optimize.execute(query6)
     val expected6 = testRelation
-      .select(Symbol("a"), Symbol("b"), 'c')
+      .select($"a", $"b", $"c")
       .localLimit(15).offset(5).globalLimit(10)
       .analyze
     comparePlans(optimized6, expected6)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Add a new rule PushProjectionThroughOffset analogous to PushProjectionThroughLimit, that pushes projection nodes beneath Offset nodes.


### Why are the changes needed?

Currently, if a Project node is above a Offset and Limit node, the Project will get pushed through the Limit node, but not the Offset node, and then the Offset and LocalLimit nodes won't get swapped, eliminating the optimization LocalLimit nets in this case. 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Created PushProjectionThroughOffsetSuite to test this new rule.

### Was this patch authored or co-authored using generative AI tooling?

No.