### PR TITLE
[SQL][MINOR][TEST] InMemoryTableCatalog should list procedures namespaces

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryCatalog.scala
@@ -30,11 +30,9 @@ class InMemoryCatalog extends InMemoryTableCatalog with FunctionCatalog with Pro
   protected val functions: util.Map[Identifier, UnboundFunction] =
     new ConcurrentHashMap[Identifier, UnboundFunction]()
 
-  override protected def allNamespaces: Seq[Seq[String]] = {
-    (tables.keySet.asScala.map(_.namespace.toSeq) ++
-      functions.keySet.asScala.map(_.namespace.toSeq) ++
-      namespaces.keySet.asScala).toSeq.distinct
-  }
+  override protected def allNamespaces: Seq[Seq[String]] =
+    (super.allNamespaces ++ functions.keySet.asScala.map(_.namespace.toSeq)).distinct
+
 
   override def listFunctions(namespace: Array[String]): Array[Identifier] = {
     if (namespace.isEmpty || namespaceExists(namespace)) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
@@ -190,7 +190,10 @@ class InMemoryTableCatalog extends BasicInMemoryTableCatalog with SupportsNamesp
   protected def allNamespaces: Seq[Seq[String]] = {
     (tables.keySet.asScala.map(_.namespace.toSeq)
       ++ namespaces.keySet.asScala
-      ++ procedures.keySet.asScala.map(_.namespace.toSeq)).toSeq.distinct
+      ++ procedures.keySet.asScala
+      .filter(i => !i.namespace.sameElements(Array("dummy")))
+      .map(_.namespace.toSeq)
+      ).toSeq.distinct
   }
 
   override def namespaceExists(namespace: Array[String]): Boolean = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
@@ -187,22 +187,22 @@ class InMemoryTableCatalog extends BasicInMemoryTableCatalog with SupportsNamesp
     new util.HashMap[Identifier, UnboundProcedure]
   procedures.put(Identifier.of(Array("dummy"), "increment"), UnboundIncrement)
 
-  protected def allNamespaces(): Seq[Seq[String]] = {
+  protected def allNamespaces: Seq[Seq[String]] = {
     (tables.keySet.asScala.map(_.namespace.toSeq)
       ++ namespaces.keySet.asScala
       ++ procedures.keySet.asScala.map(_.namespace.toSeq)).toSeq.distinct
   }
 
   override def namespaceExists(namespace: Array[String]): Boolean = {
-    allNamespaces().exists(_.startsWith(namespace))
+    allNamespaces.exists(_.startsWith(namespace))
   }
 
   override def listNamespaces: Array[Array[String]] = {
-    allNamespaces().map(_.head).distinct.map(Array(_)).toArray
+    allNamespaces.map(_.head).distinct.map(Array(_)).toArray
   }
 
   override def listNamespaces(namespace: Array[String]): Array[Array[String]] = {
-    allNamespaces()
+    allNamespaces
       .filter(_.size > namespace.length)
       .filter(_.startsWith(namespace))
       .map(_.take(namespace.length + 1))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
@@ -187,20 +187,22 @@ class InMemoryTableCatalog extends BasicInMemoryTableCatalog with SupportsNamesp
     new util.HashMap[Identifier, UnboundProcedure]
   procedures.put(Identifier.of(Array("dummy"), "increment"), UnboundIncrement)
 
-  protected def allNamespaces: Seq[Seq[String]] = {
-    (tables.keySet.asScala.map(_.namespace.toSeq) ++ namespaces.keySet.asScala).toSeq.distinct
+  protected def allNamespaces(): Seq[Seq[String]] = {
+    (tables.keySet.asScala.map(_.namespace.toSeq)
+      ++ namespaces.keySet.asScala
+      ++ procedures.keySet.asScala.map(_.namespace.toSeq)).toSeq.distinct
   }
 
   override def namespaceExists(namespace: Array[String]): Boolean = {
-    allNamespaces.exists(_.startsWith(namespace))
+    allNamespaces().exists(_.startsWith(namespace))
   }
 
   override def listNamespaces: Array[Array[String]] = {
-    allNamespaces.map(_.head).distinct.map(Array(_)).toArray
+    allNamespaces().map(_.head).distinct.map(Array(_)).toArray
   }
 
   override def listNamespaces(namespace: Array[String]): Array[Array[String]] = {
-    allNamespaces
+    allNamespaces()
       .filter(_.size > namespace.length)
       .filter(_.startsWith(namespace))
       .map(_.take(namespace.length + 1))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add procedures namespaces to the list of namespaces.

### Why are the changes needed?
This makes the list of namespace more accurate

I found this while adding tests for https://github.com/apache/spark/pull/50109

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing unit test.  I consider to make a test, but it may be overkill as its already a test class.

### Was this patch authored or co-authored using generative AI tooling?
No
