### PR TITLE
[SPARK-51423][SQL] Add the current_time() function for TIME datatype

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -1155,7 +1155,7 @@ datetimeUnit
     ;
 
 primaryExpression
-    : name=(CURRENT_DATE | CURRENT_TIMESTAMP | CURRENT_USER | USER | SESSION_USER)             #currentLike
+    : name=(CURRENT_DATE | CURRENT_TIMESTAMP | CURRENT_USER | USER | SESSION_USER | CURRENT_TIME)             #currentLike
     | name=(TIMESTAMPADD | DATEADD | DATE_ADD) LEFT_PAREN (unit=datetimeUnit | invalidUnit=stringLit) COMMA unitsAmount=valueExpression COMMA timestamp=valueExpression RIGHT_PAREN             #timestampadd
     | name=(TIMESTAMPDIFF | DATEDIFF | DATE_DIFF | TIMEDIFF) LEFT_PAREN (unit=datetimeUnit | invalidUnit=stringLit) COMMA startTimestamp=valueExpression COMMA endTimestamp=valueExpression RIGHT_PAREN    #timestampdiff
     | CASE whenClause+ (ELSE elseExpression=expression)? END                                   #searchedCase

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala
@@ -30,6 +30,7 @@ import org.apache.spark.QueryContext
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.{rebaseGregorianToJulianDays, rebaseGregorianToJulianMicros, rebaseJulianToGregorianDays, rebaseJulianToGregorianMicros}
 import org.apache.spark.sql.errors.ExecutionErrors
+import org.apache.spark.sql.internal.SqlApiConf
 import org.apache.spark.sql.types.{DateType, TimestampType, TimeType}
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.SparkClassUtils
@@ -131,6 +132,32 @@ trait SparkDateTimeUtils {
       val us = Math.multiplyExact(secs, MICROS_PER_SECOND)
       Math.addExact(us, NANOSECONDS.toMicros(instant.getNano))
     }
+  }
+
+  /**
+   * Gets the number of microseconds since midnight using the session time zone.
+   */
+  def instantToMicrosOfDay(instant: Instant): Long = {
+    val zoneId = getZoneId(SqlApiConf.get.sessionLocalTimeZone)
+    val localDateTime = LocalDateTime.ofInstant(instant, zoneId)
+    localDateTime.toLocalTime.toNanoOfDay / 1000
+  }
+
+  /**
+   * Truncates a time value (in microseconds) to the specified fractional precision `p`.
+   *
+   * For example, if `p = 3`, we keep millisecond resolution and discard any digits beyond
+   * the thousand-microsecond place. So a value like `123456` microseconds (12:34:56.123456)
+   * becomes `123000` microseconds (12:34:56.123).
+   *
+   * @param micros The original time in microseconds.
+   * @param p      The fractional second precision (range 0 to 6).
+   * @return       The truncated microsecond value, preserving only `p` fractional digits.
+   */
+  def truncateTimeMicrosToPrecision(micros: Long, p: Int): Long = {
+    val scale = TimeType.MICROS_PRECISION - p
+    val factor = math.pow(10, scale).toLong
+    (micros / factor) * factor
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -627,7 +627,7 @@ object FunctionRegistry {
     expression[CurrentDate]("current_date"),
     expressionBuilder("curdate", CurDateExpressionBuilder, setAlias = true),
     expression[CurrentTimestamp]("current_timestamp"),
-    expressionBuilder("current_time", CurrentTimeExpressionBuilder),
+    expression[CurrentTime]("current_time"),
     expression[CurrentTimeZone]("current_timezone"),
     expression[LocalTimestamp]("localtimestamp"),
     expression[DateDiff]("datediff"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -627,6 +627,7 @@ object FunctionRegistry {
     expression[CurrentDate]("current_date"),
     expressionBuilder("curdate", CurDateExpressionBuilder, setAlias = true),
     expression[CurrentTimestamp]("current_timestamp"),
+    expressionBuilder("current_time", CurrentTimeExpressionBuilder),
     expression[CurrentTimeZone]("current_timezone"),
     expression[LocalTimestamp]("localtimestamp"),
     expression[DateDiff]("datediff"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/LiteralFunctionResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/LiteralFunctionResolution.scala
@@ -17,16 +17,7 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.catalyst.expressions.{
-  Alias,
-  CurrentDate,
-  CurrentTimestamp,
-  CurrentUser,
-  Expression,
-  GroupingID,
-  NamedExpression,
-  VirtualColumn
-}
+import org.apache.spark.sql.catalyst.expressions.{Alias, CurrentDate, CurrentTime, CurrentTimestamp, CurrentUser, Expression, GroupingID, NamedExpression, VirtualColumn}
 import org.apache.spark.sql.catalyst.util.toPrettySQL
 
 /**
@@ -47,10 +38,12 @@ object LiteralFunctionResolution {
     }
   }
 
-  // support CURRENT_DATE, CURRENT_TIMESTAMP, CURRENT_USER, USER, SESSION_USER and grouping__id
+  // support CURRENT_DATE, CURRENT_TIMESTAMP, CURRENT_TIME,
+  //  CURRENT_USER, USER, SESSION_USER and grouping__id
   private val literalFunctions: Seq[(String, () => Expression, Expression => String)] = Seq(
     (CurrentDate().prettyName, () => CurrentDate(), toPrettySQL(_)),
     (CurrentTimestamp().prettyName, () => CurrentTimestamp(), toPrettySQL(_)),
+    (CurrentTime().prettyName, () => CurrentTime(), toPrettySQL(_)),
     (CurrentUser().prettyName, () => CurrentUser(), toPrettySQL),
     ("user", () => CurrentUser(), toPrettySQL),
     ("session_user", () => CurrentUser(), toPrettySQL),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -365,6 +365,11 @@ object SecondExpressionBuilder extends ExpressionBuilder {
 
     _FUNC_ - Returns the current time at the start of query evaluation.
   """,
+  arguments = """
+    Arguments:
+      * precision - An optional integer literal in the range [${TimeType.MIN_PRECISION}..${TimeType.MICROS_PRECISION}], indicating how many
+                    fractional digits of seconds to include. If omitted, the default is ${TimeType.MICROS_PRECISION}.
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_();

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -367,8 +367,8 @@ object SecondExpressionBuilder extends ExpressionBuilder {
   """,
   arguments = """
     Arguments:
-      * precision - An optional integer literal in the range [${TimeType.MIN_PRECISION}..${TimeType.MICROS_PRECISION}], indicating how many
-                    fractional digits of seconds to include. If omitted, the default is ${TimeType.MICROS_PRECISION}.
+      * precision - An optional integer literal in the range [0..6], indicating how many
+                    fractional digits of seconds to include. If omitted, the default is 6.
   """,
   examples = """
     Examples:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.trees.TreePatternBits
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{convertSpecialDate, convertSpecialTimestamp, convertSpecialTimestampNTZ, instantToMicros, localDateTimeToMicros}
+import org.apache.spark.sql.catalyst.util.SparkDateTimeUtils.{instantToMicrosOfDay, truncateTimeMicrosToPrecision}
 import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLExpr
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.types._
@@ -112,6 +113,7 @@ object ComputeCurrentTime extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = {
     val instant = Instant.now()
     val currentTimestampMicros = instantToMicros(instant)
+    val currentTimeOfDayMicros = instantToMicrosOfDay(instant)
     val currentTime = Literal.create(currentTimestampMicros, TimestampType)
     val timezone = Literal.create(conf.sessionLocalTimeZone, StringType)
     val currentDates = collection.mutable.HashMap.empty[ZoneId, Literal]
@@ -129,6 +131,11 @@ object ComputeCurrentTime extends Rule[LogicalPlan] {
               Literal.create(
                 DateTimeUtils.microsToDays(currentTimestampMicros, cd.zoneId), DateType)
             })
+          case currentTimeType : CurrentTime =>
+            // scalastyle:off line.size.limit
+            val truncatedTime = truncateTimeMicrosToPrecision(currentTimeOfDayMicros, currentTimeType.precision)
+            Literal.create(truncatedTime, TimeType(currentTimeType.precision))
+          // scalastyle:on line.size.limit
           case CurrentTimestamp() | Now() => currentTime
           case CurrentTimeZone() => timezone
           case localTimestamp: LocalTimestamp =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2888,12 +2888,14 @@ class AstBuilder extends DataTypeAstBuilder
           CurrentDate()
         case SqlBaseParser.CURRENT_TIMESTAMP =>
           CurrentTimestamp()
+        case SqlBaseParser.CURRENT_TIME =>
+          CurrentTime()
         case SqlBaseParser.CURRENT_USER | SqlBaseParser.USER | SqlBaseParser.SESSION_USER =>
           CurrentUser()
       }
     } else {
       // If the parser is not in ansi mode, we should return `UnresolvedAttribute`, in case there
-      // are columns named `CURRENT_DATE` or `CURRENT_TIMESTAMP`.
+      // are columns named `CURRENT_DATE` or `CURRENT_TIMESTAMP` or `CURRENT_TIME`
       UnresolvedAttribute.quoted(ctx.name.getText)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2148,21 +2148,6 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       ))
   }
 
-  // scalastyle:off line.size.limit
-  def nonFoldableInputError(argumentName: String, expression: Expression, requiredType: DataType): Throwable = {
-    new AnalysisException(
-      errorClass = "DATATYPE_MISMATCH.NON_FOLDABLE_INPUT",
-      messageParameters = Map(
-        "sqlExpr" -> toSQLExpr(expression),
-        "inputName" -> toSQLId(argumentName),
-        "inputType" -> toSQLType(requiredType),
-        "inputExpr" -> toSQLExpr(expression)
-      )
-    )
-  }
-  // scalastyle:on line.size.limit
-
-
   def streamJoinStreamWithoutEqualityPredicateUnsupportedError(plan: LogicalPlan): Throwable = {
     new ExtendedAnalysisException(
       new AnalysisException(errorClass = "_LEGACY_ERROR_TEMP_1181", messageParameters = Map.empty),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2148,6 +2148,21 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       ))
   }
 
+  // scalastyle:off line.size.limit
+  def nonFoldableInputError(argumentName: String, expression: Expression, requiredType: DataType): Throwable = {
+    new AnalysisException(
+      errorClass = "DATATYPE_MISMATCH.NON_FOLDABLE_INPUT",
+      messageParameters = Map(
+        "sqlExpr" -> toSQLExpr(expression),
+        "inputName" -> toSQLId(argumentName),
+        "inputType" -> toSQLType(requiredType),
+        "inputExpr" -> toSQLExpr(expression)
+      )
+    )
+  }
+  // scalastyle:on line.size.limit
+
+
   def streamJoinStreamWithoutEqualityPredicateUnsupportedError(plan: LogicalPlan): Throwable = {
     new ExtendedAnalysisException(
       new AnalysisException(errorClass = "_LEGACY_ERROR_TEMP_1181", messageParameters = Map.empty),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -819,6 +819,25 @@ class AnalysisSuite extends AnalysisTest with Matchers {
     }
   }
 
+  test("CURRENT_TIME should be case insensitive") {
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+      val input = Project(Seq(
+        // The user references "current_time" or "CURRENT_TIME" in the query
+        UnresolvedAttribute("current_time"),
+        UnresolvedAttribute("CURRENT_TIME")
+      ), testRelation)
+
+      // The analyzer should resolve both to the same expression: CurrentTime()
+      val expected = Project(Seq(
+        Alias(CurrentTime(), toPrettySQL(CurrentTime()))(),
+        Alias(CurrentTime(), toPrettySQL(CurrentTime()))()
+      ), testRelation).analyze
+
+      checkAnalysis(input, expected)
+    }
+  }
+
+
   test("CTE with non-existing column alias") {
     assertAnalysisErrorCondition(parsePlan("WITH t(x) AS (SELECT 1) SELECT * FROM t WHERE y = 1"),
       "UNRESOLVED_COLUMN.WITH_SUGGESTION",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ComputeCurrentTimeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ComputeCurrentTimeSuite.scala
@@ -24,12 +24,13 @@ import scala.concurrent.duration._
 import scala.jdk.CollectionConverters.MapHasAsScala
 
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.expressions.{Alias, CurrentDate, CurrentTime, CurrentTimestamp, CurrentTimeZone, Expression, InSubquery, ListQuery, Literal, LocalTimestamp, Now}
+import org.apache.spark.sql.catalyst.expressions.{Add, Alias, Cast, CurrentDate, CurrentTime, CurrentTimestamp, CurrentTimeZone, Expression, InSubquery, ListQuery, Literal, LocalTimestamp, Now}
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LocalRelation, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.unsafe.types.UTF8String
 
 class ComputeCurrentTimeSuite extends PlanTest {
@@ -56,8 +57,8 @@ class ComputeCurrentTimeSuite extends PlanTest {
     // logical plan that calls current_time() twice in the Project
     val planInput = Project(
       Seq(
-        Alias(CurrentTime(3), "a")(),
-        Alias(CurrentTime(3), "b")()
+        Alias(CurrentTime(Literal(3)), "a")(),
+        Alias(CurrentTime(Literal(3)), "b")()
       ),
       LocalRelation()
     )
@@ -76,6 +77,58 @@ class ComputeCurrentTimeSuite extends PlanTest {
         s"but got ${lits(0)} vs ${lits(1)}")
   }
 
+  test("analyzer should replace current_time with foldable child expressions") {
+    // We build a plan that calls current_time(2 + 1) twice
+    val foldableExpr = Add(Literal(2), Literal(1))  // a foldable arithmetic expression => 3
+    val planInput = Project(
+      Seq(
+        Alias(CurrentTime(foldableExpr), "a")(),
+        Alias(CurrentTime(foldableExpr), "b")()
+      ),
+      LocalRelation()
+    )
+
+    val analyzed = planInput.analyze
+    val optimized = Optimize.execute(analyzed).asInstanceOf[Project]
+
+    // We expect the optimizer to replace current_time(2 + 1) with a literal time value,
+    // so let's extract those literal values.
+    val lits = literals[Long](optimized)
+    assert(lits.size == 2, s"Expected two literal values, found ${lits.size}")
+
+    // Both references to current_time(2 + 1) should be replaced by the same microsecond-of-day
+    assert(lits(0) == lits(1),
+      s"Expected both current_time(2 + 1) calls to yield the same literal, " +
+        s"but got ${lits(0)} vs. ${lits(1)}"
+    )
+  }
+
+  test("analyzer should replace current_time with foldable casted string-literal") {
+    // We'll build a foldable cast expression: CAST(' 0005 ' AS INT) => 5
+    val castExpr = Cast(Literal(" 0005 "), IntegerType)
+
+    // Two references to current_time(castExpr) => so we can check they're replaced consistently
+    val planInput = Project(
+      Seq(
+        Alias(CurrentTime(castExpr), "a")(),
+        Alias(CurrentTime(castExpr), "b")()
+      ),
+      LocalRelation()
+    )
+
+    val analyzed = planInput.analyze
+    val optimized = Optimize.execute(analyzed).asInstanceOf[Project]
+
+    val lits = literals[Long](optimized)
+    assert(lits.size == 2, s"Expected two literal values, found ${lits.size}")
+
+    // Both references to current_time(CAST(' 0005 ' AS INT)) in the same query
+    // should produce the same microsecond-of-day literal.
+    assert(lits(0) == lits(1),
+      s"Expected both references to yield the same literal, but got ${lits(0)} vs. ${lits(1)}"
+    )
+  }
+
 
   test("analyzer should respect time flow in current timestamp calls") {
     val in = Project(Alias(CurrentTimestamp(), "t1")() :: Nil, LocalRelation())
@@ -91,7 +144,7 @@ class ComputeCurrentTimeSuite extends PlanTest {
   }
 
   test("analyzer should respect time flow in current_time calls") {
-    val in = Project(Alias(CurrentTime(4), "t1")() :: Nil, LocalRelation())
+    val in = Project(Alias(CurrentTime(Literal(4)), "t1")() :: Nil, LocalRelation())
 
     val planT1 = Optimize.execute(in.analyze).asInstanceOf[Project]
     sleep(5)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -1194,16 +1194,18 @@ class ExpressionParserSuite extends AnalysisTest {
     }
   }
 
-  test("current date/timestamp braceless expressions") {
+  test("current date/timestamp/time braceless expressions") {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "true",
       SQLConf.ENFORCE_RESERVED_KEYWORDS.key -> "true") {
       assertEqual("current_date", CurrentDate())
       assertEqual("current_timestamp", CurrentTimestamp())
+      assertEqual("current_time", CurrentTime())
     }
 
     def testNonAnsiBehavior(): Unit = {
       assertEqual("current_date", UnresolvedAttribute.quoted("current_date"))
       assertEqual("current_timestamp", UnresolvedAttribute.quoted("current_timestamp"))
+      assertEqual("current_time", UnresolvedAttribute.quoted("current_time"))
     }
     withSQLConf(
       SQLConf.ANSI_ENABLED.key -> "false",

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -104,6 +104,7 @@
 | org.apache.spark.sql.catalyst.expressions.CurrentDatabase | current_database | SELECT current_database() | struct<current_schema():string> |
 | org.apache.spark.sql.catalyst.expressions.CurrentDatabase | current_schema | SELECT current_schema() | struct<current_schema():string> |
 | org.apache.spark.sql.catalyst.expressions.CurrentDate | current_date | SELECT current_date() | struct<current_date():date> |
+| org.apache.spark.sql.catalyst.expressions.CurrentTime | current_time | SELECT current_time() | struct<current_time(6):time(6)> |
 | org.apache.spark.sql.catalyst.expressions.CurrentTimeZone | current_timezone | SELECT current_timezone() | struct<current_timezone():string> |
 | org.apache.spark.sql.catalyst.expressions.CurrentTimestamp | current_timestamp | SELECT current_timestamp() | struct<current_timestamp():timestamp> |
 | org.apache.spark.sql.catalyst.expressions.CurrentUser | current_user | SELECT current_user() | struct<current_user():string> |

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelper.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelper.scala
@@ -27,7 +27,7 @@ import org.apache.spark.ErrorMessageFormat.MINIMAL
 import org.apache.spark.SparkThrowableHelper.getMessage
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.IntegratedUDFTestUtils.{TestUDF, TestUDTFSet}
-import org.apache.spark.sql.catalyst.expressions.{CurrentDate, CurrentTimestampLike, CurrentUser, Literal}
+import org.apache.spark.sql.catalyst.expressions.{CurrentDate, CurrentTime, CurrentTimestampLike, CurrentUser, Literal}
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.fileToString
@@ -99,6 +99,9 @@ trait SQLQueryTestHelper extends Logging {
         deterministic = false
         expr
       case expr: CurrentTimestampLike =>
+        deterministic = false
+        expr
+      case expr: CurrentTime =>
         deterministic = false
         expr
       case expr: CurrentUser =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
@@ -209,6 +209,7 @@ class ExpressionInfoSuite extends SparkFunSuite with SharedSparkSession {
       "org.apache.spark.sql.catalyst.expressions.CurrentTimeZone",
       "org.apache.spark.sql.catalyst.expressions.Now",
       "org.apache.spark.sql.catalyst.expressions.LocalTimestamp",
+      "org.apache.spark.sql.catalyst.expressions.CurrentTime",
       // Random output without a seed
       "org.apache.spark.sql.catalyst.expressions.Rand",
       "org.apache.spark.sql.catalyst.expressions.Randn",


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds support for a new function current_time() which returns the current time at the start of query evaluation.

```bash
# happy cases
scala> spark.sql("SELECT current_time(0);").show()
+---------------+
|current_time(0)|
+---------------+
|       17:11:26|
+---------------+

scala> spark.sql("SELECT current_time(3);").show()
+---------------+
|current_time(3)|
+---------------+
|   17:11:50.225|
+---------------+

scala> spark.sql("SELECT current_time(6);").show()
+---------------+
|current_time(6)|
+---------------+
|17:12:00.734735|
+---------------+

# No braces and Empty braces
scala> spark.sql("SELECT current_time;").show()
+---------------+
|current_time(6)|
+---------------+
|17:12:23.132088|
+---------------+


scala> spark.sql("SELECT current_time();").show()
+---------------+
|current_time(6)|
+---------------+
|17:12:26.718602|
+---------------+

# foldability
## Nested Arithmetic
scala> spark.sql("SELECT current_time((4 - 2) * (1 + 1));").show()
+---------------------------------+
|current_time(((4 - 2) * (1 + 1)))|
+---------------------------------+
|                    17:13:04.4647|
+---------------------------------+

## Casting String literals
scala> spark.sql("SELECT current_time(CAST(' 0005 ' AS INT));").show()
+---------------------------------+
|current_time(CAST( 0005  AS INT))|
+---------------------------------+
|                   17:13:26.28039|
+---------------------------------+

scala> spark.sql("SELECT current_time('5');").show()
+---------------+
|current_time(5)|
+---------------+
| 22:34:07.65007|
+---------------+


## Combine Cast and Arithmetic
scala> spark.sql("SELECT current_time(CAST('4' AS INT) * CAST('1' AS INT));").show()
+-----------------------------------------------+
|current_time((CAST(4 AS INT) * CAST(1 AS INT)))|
+-----------------------------------------------+
|                                  17:14:06.7151|
+-----------------------------------------------+

# failure cases
scala> spark.sql("SELECT current_time(-1);").show()
org.apache.spark.sql.catalyst.ExtendedAnalysisException: [DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE] Cannot resolve "current_time(-1)" due to data type mismatch: The `precision` must be between [0, 6] (current value = -1). SQLSTATE: 42K09; line 1 pos 7;
'Project [unresolvedalias(current_time(-1))]
+- OneRowRelation'

scala> spark.sql("SELECT current_time('foo');").show()
org.apache.spark.SparkNumberFormatException: [CAST_INVALID_INPUT] The value 'foo' of the type "STRING" cannot be cast to "INT" because it is malformed. Correct the value as per the syntax, or change its target type. Use `try_cast` to tolerate malformed input and return NULL instead. SQLSTATE: 22018
== SQL (line 1, position 8) ==
SELECT current_time('foo');

scala> spark.sql("SELECT current_time(2,2);").show()
org.apache.spark.sql.AnalysisException: [WRONG_NUM_ARGS.WITHOUT_SUGGESTION] The `current_time` requires [0, 1] parameters but the actual number is 2. Please, refer to 'https://spark.apache.org/docs/latest/sql-ref-functions.html' for a fix. SQLSTATE: 42605; line 1 pos 7


# All calls of current_time within the same query should return the same value.
scala> val df = spark.sql("""
     |   SELECT
     |     current_time AS col1,
     |     current_time() AS col2,
     |  current_time(0) AS col3,
     |  current_time(1) AS col4,
     |  current_time(2) AS col5,
     |  current_time(3) AS col6,
     |  current_time(4) AS col7,
     |  current_time(5) AS col8,
     |  current_time(6) AS col9,
     |     current_time AS col10
     | """)
val df: org.apache.spark.sql.DataFrame = [col1: time(6), col2: time(6) ... 8 more fields]

scala> df.show()
+---------------+---------------+--------+----------+-----------+-----------+-------------+--------------+---------------+---------------+
|           col1|           col2|    col3|      col4|       col5|       col6|         col7|          col8|           col9|          col10|
+---------------+---------------+--------+----------+-----------+-----------+-------------+--------------+---------------+---------------+
|17:15:47.680648|17:15:47.680648|17:15:47|17:15:47.6|17:15:47.68|17:15:47.68|17:15:47.6806|17:15:47.68064|17:15:47.680648|17:15:47.680648|
+---------------+---------------+--------+----------+-----------+-----------+-------------+--------------+---------------+---------------+

```

### Why are the changes needed?
Adds a built-in current_time([n]) function returning just the time portion (in a TIME(n) type). This aligns Spark with other SQL systems offering a native time function, improves convenience for time-only queries, and complements existing functions like current_date and current_timestamp.


### Does this PR introduce _any_ user-facing change?
Yes, adds a new function. Users can now get the current time using this function.

### How was this patch tested?
Manual testing as shown above and running UTs added:

```bash
$ build/sbt "test:testOnly *TimeExpressionsSuite.scala"
$ build/sbt "test:testOnly *ComputeCurrentTimeSuite.scala"
$ build/sbt "test:testOnly *ResolveInlineTablesSuite.scala
$ build/sbt "test:testOnly *AnalysisSuite.scala
```


### Was this patch authored or co-authored using generative AI tooling?
No
