### PR TITLE
[SPARK-51118][PYTHON] Fix ExtractPythonUDFs to check the chained UDF input types for fallback

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
@@ -21,14 +21,17 @@ from pyspark.errors import AnalysisException, PythonException, PySparkNotImpleme
 from pyspark.sql import Row
 from pyspark.sql.functions import udf
 from pyspark.sql.tests.test_udf import BaseUDFTestsMixin
-from pyspark.sql.types import VarcharType
+from pyspark.sql.types import ArrayType, DoubleType, VarcharType
 from pyspark.testing.sqlutils import (
+    ExamplePoint,
+    ExamplePointUDT,
     have_pandas,
     have_pyarrow,
     pandas_requirement_message,
     pyarrow_requirement_message,
     ReusedSQLTestCase,
 )
+from pyspark.testing.utils import assertDataFrameEqual
 from pyspark.util import PythonEvalType
 
 
@@ -213,6 +216,103 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
 
         with self.assertRaises(PythonException):
             self.spark.sql("SELECT test_udf(id, a => id * 10) FROM range(2)").show()
+
+    def test_udf_with_udt(self):
+        row = Row(
+            label=1.0,
+            point=ExamplePoint(1.0, 2.0),
+            points=[ExamplePoint(4.0, 5.0), ExamplePoint(6.0, 7.0)],
+        )
+        df = self.spark.createDataFrame([row])
+
+        for use_arrow in [False, True]:
+            with self.subTest(use_arrow=use_arrow):
+
+                @udf(returnType=ExamplePointUDT(), useArrow=use_arrow)
+                def doubleInUDTOut(d):
+                    return ExamplePoint(d, 10 * d)
+
+                @udf(returnType=DoubleType(), useArrow=use_arrow)
+                def udtInDoubleOut(e):
+                    return e.y
+
+                @udf(returnType=ArrayType(ExamplePointUDT()), useArrow=use_arrow)
+                def doubleInUDTArrayOut(d):
+                    return [ExamplePoint(d + i, 10 * d + i) for i in range(2)]
+
+                @udf(returnType=DoubleType(), useArrow=use_arrow)
+                def udtArrayInDoubleOut(es):
+                    return es[-1].y
+
+                @udf(returnType=ExamplePointUDT(), useArrow=use_arrow)
+                def udtInUDTOut(e):
+                    return ExamplePoint(e.x * 10.0, e.y * 10.0)
+
+                @udf(returnType=DoubleType(), useArrow=use_arrow)
+                def doubleInDoubleOut(d):
+                    return d * 100.0
+
+                queries = [
+                    (
+                        "double -> UDT",
+                        df.select(doubleInUDTOut(df.label)),
+                        [Row(ExamplePoint(1.0, 10.0))],
+                    ),
+                    (
+                        "UDT -> double",
+                        df.select(udtInDoubleOut(df.point)),
+                        [Row(2.0)],
+                    ),
+                    (
+                        "double -> array of UDT",
+                        df.select(doubleInUDTArrayOut(df.label)),
+                        [Row([ExamplePoint(1.0, 10.0), ExamplePoint(2.0, 11.0)])],
+                    ),
+                    (
+                        "array of UDT -> double",
+                        df.select(udtArrayInDoubleOut(df.points)),
+                        [Row(7.0)],
+                    ),
+                    (
+                        "double -> UDT -> double",
+                        df.select(udtInDoubleOut(doubleInUDTOut(df.label))),
+                        [Row(10.0)],
+                    ),
+                    (
+                        "double -> UDT -> UDT",
+                        df.select(udtInUDTOut(doubleInUDTOut(df.label))),
+                        [Row(ExamplePoint(10.0, 100.0))],
+                    ),
+                    (
+                        "double -> double -> UDT",
+                        df.select(doubleInUDTOut(doubleInDoubleOut(df.label))),
+                        [Row(ExamplePoint(100.0, 1000.0))],
+                    ),
+                    (
+                        "UDT -> UDT -> double",
+                        df.select(udtInDoubleOut(udtInUDTOut(df.point))),
+                        [Row(20.0)],
+                    ),
+                    (
+                        "UDT -> UDT -> UDT",
+                        df.select(udtInUDTOut(udtInUDTOut(df.point))),
+                        [Row(ExamplePoint(100.0, 200.0))],
+                    ),
+                    (
+                        "UDT -> double -> double",
+                        df.select(doubleInDoubleOut(udtInDoubleOut(df.point))),
+                        [Row(200.0)],
+                    ),
+                    (
+                        "UDT -> double -> UDT",
+                        df.select(doubleInUDTOut(udtInDoubleOut(df.point))),
+                        [Row(ExamplePoint(2.0, 20.0))],
+                    ),
+                ]
+
+                for chain, actual, expected in queries:
+                    with self.subTest(chain=chain):
+                        assertDataFrameEqual(actual=actual, expected=expected)
 
 
 class PythonUDFArrowTests(PythonUDFArrowTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -1077,7 +1077,7 @@ class TypesTestsMixin:
         udf = F.udf(lambda p: p.y, DoubleType())
         self.assertEqual(2.0, df.select(udf(df.point)).first()[0])
         arrow_udf = F.udf(lambda p: p.y, DoubleType(), useArrow=True)
-        self.assertEqual(2.0, df.select(udf(df.point)).first()[0])
+        self.assertEqual(2.0, df.select(arrow_udf(df.point)).first()[0])
 
         udf2 = F.udf(lambda p: PythonOnlyPoint(p.x + 1, p.y + 1), PythonOnlyUDT())
         self.assertEqual(PythonOnlyPoint(2.0, 3.0), df.select(udf2(df.point)).first()[0])

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -46,8 +46,6 @@ from pyspark.sql.types import (
 )
 from pyspark.errors import AnalysisException, PythonException, PySparkTypeError
 from pyspark.testing.sqlutils import (
-    ExamplePoint,
-    ExamplePointUDT,
     ReusedSQLTestCase,
     test_compiled,
     test_not_compiled_message,
@@ -1260,103 +1258,6 @@ class BaseUDFTestsMixin(object):
             errorClass="NOT_INT",
             messageParameters={"arg_name": "evalType", "arg_type": "str"},
         )
-
-    def test_udf_with_udt(self):
-        row = Row(
-            label=1.0,
-            point=ExamplePoint(1.0, 2.0),
-            points=[ExamplePoint(4.0, 5.0), ExamplePoint(6.0, 7.0)],
-        )
-        df = self.spark.createDataFrame([row])
-
-        for use_arrow in [False, True]:
-            with self.subTest(use_arrow=use_arrow):
-
-                @udf(returnType=ExamplePointUDT(), useArrow=use_arrow)
-                def doubleInUDTOut(d):
-                    return ExamplePoint(d, 10 * d)
-
-                @udf(returnType=DoubleType(), useArrow=use_arrow)
-                def udtInDoubleOut(e):
-                    return e.y
-
-                @udf(returnType=ArrayType(ExamplePointUDT()), useArrow=use_arrow)
-                def doubleInUDTArrayOut(d):
-                    return [ExamplePoint(d + i, 10 * d + i) for i in range(2)]
-
-                @udf(returnType=DoubleType(), useArrow=use_arrow)
-                def udtArrayInDoubleOut(es):
-                    return es[-1].y
-
-                @udf(returnType=ExamplePointUDT(), useArrow=use_arrow)
-                def udtInUDTOut(e):
-                    return ExamplePoint(e.x * 10.0, e.y * 10.0)
-
-                @udf(returnType=DoubleType(), useArrow=use_arrow)
-                def doubleInDoubleOut(d):
-                    return d * 100.0
-
-                queries = [
-                    (
-                        "double -> UDT",
-                        df.select(doubleInUDTOut(df.label)),
-                        [Row(ExamplePoint(1.0, 10.0))],
-                    ),
-                    (
-                        "UDT -> double",
-                        df.select(udtInDoubleOut(df.point)),
-                        [Row(2.0)],
-                    ),
-                    (
-                        "double -> array of UDT",
-                        df.select(doubleInUDTArrayOut(df.label)),
-                        [Row([ExamplePoint(1.0, 10.0), ExamplePoint(2.0, 11.0)])],
-                    ),
-                    (
-                        "array of UDT -> double",
-                        df.select(udtArrayInDoubleOut(df.points)),
-                        [Row(7.0)],
-                    ),
-                    (
-                        "double -> UDT -> double",
-                        df.select(udtInDoubleOut(doubleInUDTOut(df.label))),
-                        [Row(10.0)],
-                    ),
-                    (
-                        "double -> UDT -> UDT",
-                        df.select(udtInUDTOut(doubleInUDTOut(df.label))),
-                        [Row(ExamplePoint(10.0, 100.0))],
-                    ),
-                    (
-                        "double -> double -> UDT",
-                        df.select(doubleInUDTOut(doubleInDoubleOut(df.label))),
-                        [Row(ExamplePoint(100.0, 1000.0))],
-                    ),
-                    (
-                        "UDT -> UDT -> double",
-                        df.select(udtInDoubleOut(udtInUDTOut(df.point))),
-                        [Row(20.0)],
-                    ),
-                    (
-                        "UDT -> UDT -> UDT",
-                        df.select(udtInUDTOut(udtInUDTOut(df.point))),
-                        [Row(ExamplePoint(100.0, 200.0))],
-                    ),
-                    (
-                        "UDT -> double -> double",
-                        df.select(doubleInDoubleOut(udtInDoubleOut(df.point))),
-                        [Row(200.0)],
-                    ),
-                    (
-                        "UDT -> double -> UDT",
-                        df.select(doubleInUDTOut(udtInDoubleOut(df.point))),
-                        [Row(ExamplePoint(2.0, 20.0))],
-                    ),
-                ]
-
-                for chain, actual, expected in queries:
-                    with self.subTest(chain=chain):
-                        assertDataFrameEqual(actual=actual, expected=expected)
 
 
 class UDFTests(BaseUDFTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -46,6 +46,8 @@ from pyspark.sql.types import (
 )
 from pyspark.errors import AnalysisException, PythonException, PySparkTypeError
 from pyspark.testing.sqlutils import (
+    ExamplePoint,
+    ExamplePointUDT,
     ReusedSQLTestCase,
     test_compiled,
     test_not_compiled_message,
@@ -1258,6 +1260,97 @@ class BaseUDFTestsMixin(object):
             errorClass="NOT_INT",
             messageParameters={"arg_name": "evalType", "arg_type": "str"},
         )
+
+    def test_udf_with_udt(self):
+        row = Row(
+            label=1.0,
+            point=ExamplePoint(1.0, 2.0),
+            points=[ExamplePoint(4.0, 5.0), ExamplePoint(6.0, 7.0)],
+        )
+        df = self.spark.createDataFrame([row])
+
+        for use_arrow in [False, True]:
+            with self.subTest(use_arrow=use_arrow):
+
+                @udf(returnType=ExamplePointUDT(), useArrow=use_arrow)
+                def doubleInUDTOut(d):
+                    return ExamplePoint(d, 10 * d)
+
+                @udf(returnType=DoubleType(), useArrow=use_arrow)
+                def udtInDoubleOut(e):
+                    return e.y
+
+                @udf(returnType=ArrayType(ExamplePointUDT()), useArrow=use_arrow)
+                def doubleInUDTArrayOut(d):
+                    return [ExamplePoint(d + i, 10 * d + i) for i in range(2)]
+
+                @udf(returnType=DoubleType(), useArrow=use_arrow)
+                def udtArrayInDoubleOut(es):
+                    return es[-1].y
+
+                @udf(returnType=ExamplePointUDT(), useArrow=use_arrow)
+                def udtInUDTOut(e):
+                    return ExamplePoint(e.x * 10.0, e.y * 10.0)
+
+                @udf(returnType=DoubleType(), useArrow=use_arrow)
+                def doubleInDoubleOut(d):
+                    return d * 100.0
+
+                # double -> UDT
+                assertDataFrameEqual(
+                    df.select(doubleInUDTOut(df.label)),
+                    [Row(ExamplePoint(1.0, 10.0))],
+                )
+                # UDT -> double
+                assertDataFrameEqual(
+                    df.select(udtInDoubleOut(df.point)),
+                    [Row(2.0)],
+                )
+                # double -> array of UDT
+                assertDataFrameEqual(
+                    df.select(doubleInUDTArrayOut(df.label)),
+                    [Row([ExamplePoint(1.0, 10.0), ExamplePoint(2.0, 11.0)])],
+                )
+                # array of UDT -> double
+                assertDataFrameEqual(
+                    df.select(udtArrayInDoubleOut(df.points)),
+                    [Row(7.0)],
+                )
+                # double -> UDT -> double
+                assertDataFrameEqual(
+                    df.select(udtInDoubleOut(doubleInUDTOut(df.label))),
+                    [Row(10.0)],
+                )
+                # double -> UDT -> UDT
+                assertDataFrameEqual(
+                    df.select(udtInUDTOut(doubleInUDTOut(df.label))),
+                    [Row(ExamplePoint(10.0, 100.0))],
+                )
+                # double -> double -> UDT
+                assertDataFrameEqual(
+                    df.select(doubleInUDTOut(doubleInDoubleOut(df.label))),
+                    [Row(ExamplePoint(100.0, 1000.0))],
+                )
+                # UDT -> UDT -> double
+                assertDataFrameEqual(
+                    df.select(udtInDoubleOut(udtInUDTOut(df.point))),
+                    [Row(20.0)],
+                )
+                # UDT -> UDT -> UDT
+                assertDataFrameEqual(
+                    df.select(udtInUDTOut(udtInUDTOut(df.point))),
+                    [Row(ExamplePoint(100.0, 200.0))],
+                )
+                # UDT -> double -> double
+                assertDataFrameEqual(
+                    df.select(doubleInDoubleOut(udtInDoubleOut(df.point))),
+                    [Row(200.0)],
+                )
+                # UDT -> double -> UDT
+                assertDataFrameEqual(
+                    df.select(doubleInUDTOut(udtInDoubleOut(df.point))),
+                    [Row(ExamplePoint(2.0, 20.0))],
+                )
 
 
 class UDFTests(BaseUDFTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -1296,61 +1296,67 @@ class BaseUDFTestsMixin(object):
                 def doubleInDoubleOut(d):
                     return d * 100.0
 
-                # double -> UDT
-                assertDataFrameEqual(
-                    df.select(doubleInUDTOut(df.label)),
-                    [Row(ExamplePoint(1.0, 10.0))],
-                )
-                # UDT -> double
-                assertDataFrameEqual(
-                    df.select(udtInDoubleOut(df.point)),
-                    [Row(2.0)],
-                )
-                # double -> array of UDT
-                assertDataFrameEqual(
-                    df.select(doubleInUDTArrayOut(df.label)),
-                    [Row([ExamplePoint(1.0, 10.0), ExamplePoint(2.0, 11.0)])],
-                )
-                # array of UDT -> double
-                assertDataFrameEqual(
-                    df.select(udtArrayInDoubleOut(df.points)),
-                    [Row(7.0)],
-                )
-                # double -> UDT -> double
-                assertDataFrameEqual(
-                    df.select(udtInDoubleOut(doubleInUDTOut(df.label))),
-                    [Row(10.0)],
-                )
-                # double -> UDT -> UDT
-                assertDataFrameEqual(
-                    df.select(udtInUDTOut(doubleInUDTOut(df.label))),
-                    [Row(ExamplePoint(10.0, 100.0))],
-                )
-                # double -> double -> UDT
-                assertDataFrameEqual(
-                    df.select(doubleInUDTOut(doubleInDoubleOut(df.label))),
-                    [Row(ExamplePoint(100.0, 1000.0))],
-                )
-                # UDT -> UDT -> double
-                assertDataFrameEqual(
-                    df.select(udtInDoubleOut(udtInUDTOut(df.point))),
-                    [Row(20.0)],
-                )
-                # UDT -> UDT -> UDT
-                assertDataFrameEqual(
-                    df.select(udtInUDTOut(udtInUDTOut(df.point))),
-                    [Row(ExamplePoint(100.0, 200.0))],
-                )
-                # UDT -> double -> double
-                assertDataFrameEqual(
-                    df.select(doubleInDoubleOut(udtInDoubleOut(df.point))),
-                    [Row(200.0)],
-                )
-                # UDT -> double -> UDT
-                assertDataFrameEqual(
-                    df.select(doubleInUDTOut(udtInDoubleOut(df.point))),
-                    [Row(ExamplePoint(2.0, 20.0))],
-                )
+                queries = [
+                    (
+                        "double -> UDT",
+                        df.select(doubleInUDTOut(df.label)),
+                        [Row(ExamplePoint(1.0, 10.0))],
+                    ),
+                    (
+                        "UDT -> double",
+                        df.select(udtInDoubleOut(df.point)),
+                        [Row(2.0)],
+                    ),
+                    (
+                        "double -> array of UDT",
+                        df.select(doubleInUDTArrayOut(df.label)),
+                        [Row([ExamplePoint(1.0, 10.0), ExamplePoint(2.0, 11.0)])],
+                    ),
+                    (
+                        "array of UDT -> double",
+                        df.select(udtArrayInDoubleOut(df.points)),
+                        [Row(7.0)],
+                    ),
+                    (
+                        "double -> UDT -> double",
+                        df.select(udtInDoubleOut(doubleInUDTOut(df.label))),
+                        [Row(10.0)],
+                    ),
+                    (
+                        "double -> UDT -> UDT",
+                        df.select(udtInUDTOut(doubleInUDTOut(df.label))),
+                        [Row(ExamplePoint(10.0, 100.0))],
+                    ),
+                    (
+                        "double -> double -> UDT",
+                        df.select(doubleInUDTOut(doubleInDoubleOut(df.label))),
+                        [Row(ExamplePoint(100.0, 1000.0))],
+                    ),
+                    (
+                        "UDT -> UDT -> double",
+                        df.select(udtInDoubleOut(udtInUDTOut(df.point))),
+                        [Row(20.0)],
+                    ),
+                    (
+                        "UDT -> UDT -> UDT",
+                        df.select(udtInUDTOut(udtInUDTOut(df.point))),
+                        [Row(ExamplePoint(100.0, 200.0))],
+                    ),
+                    (
+                        "UDT -> double -> double",
+                        df.select(doubleInDoubleOut(udtInDoubleOut(df.point))),
+                        [Row(200.0)],
+                    ),
+                    (
+                        "UDT -> double -> UDT",
+                        df.select(doubleInUDTOut(udtInDoubleOut(df.point))),
+                        [Row(ExamplePoint(2.0, 20.0))],
+                    ),
+                ]
+
+                for chain, actual, expected in queries:
+                    with self.subTest(chain=chain):
+                        assertDataFrameEqual(actual=actual, expected=expected)
 
 
 class UDFTests(BaseUDFTestsMixin, ReusedSQLTestCase):

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
@@ -173,7 +173,7 @@ object ExtractPythonUDFs extends Rule[LogicalPlan] with Logging {
   private def canEvaluateInPython(e: PythonUDF): Boolean = {
     e.children match {
       // single PythonUDF child could be chained and evaluated in Python
-      case Seq(u: PythonUDF) => e.evalType == u.evalType && canEvaluateInPython(u)
+      case Seq(u: PythonUDF) => correctEvalType(e) == correctEvalType(u) && canEvaluateInPython(u)
       // Python UDF can't be evaluated directly in JVM
       case children => !children.exists(hasScalarPythonUDF)
     }
@@ -197,10 +197,10 @@ object ExtractPythonUDFs extends Rule[LogicalPlan] with Logging {
     def collectEvaluableUDFs(expr: Expression): Seq[PythonUDF] = expr match {
       case udf: PythonUDF if PythonUDF.isScalarPythonUDF(udf) && canEvaluateInPython(udf)
         && firstVisitedScalarUDFEvalType.isEmpty =>
-        firstVisitedScalarUDFEvalType = Some(udf.evalType)
+        firstVisitedScalarUDFEvalType = Some(correctEvalType(udf))
         Seq(udf)
       case udf: PythonUDF if PythonUDF.isScalarPythonUDF(udf) && canEvaluateInPython(udf)
-        && canChainUDF(udf.evalType) =>
+        && canChainUDF(correctEvalType(udf)) =>
         Seq(udf)
       case e => e.children.flatMap(collectEvaluableUDFs)
     }
@@ -235,19 +235,24 @@ object ExtractPythonUDFs extends Rule[LogicalPlan] with Logging {
     }
   }
 
+  private def correctEvalType(udf: PythonUDF): Int = {
+    if (udf.evalType == PythonEvalType.SQL_ARROW_BATCHED_UDF) {
+      if (containsUDT(udf.dataType) || udf.children.exists(expr => containsUDT(expr.dataType))) {
+        PythonEvalType.SQL_BATCHED_UDF
+      } else {
+        PythonEvalType.SQL_ARROW_BATCHED_UDF
+      }
+    } else {
+      udf.evalType
+    }
+  }
+
   private def containsUDT(dataType: DataType): Boolean = dataType match {
     case _: UserDefinedType[_] => true
     case ArrayType(elementType, _) => containsUDT(elementType)
     case StructType(fields) => fields.exists(field => containsUDT(field.dataType))
     case MapType(keyType, valueType, _) => containsUDT(keyType) || containsUDT(valueType)
     case _ => false
-  }
-
-  private def findInputs(udf: PythonUDF): Seq[Expression] = {
-    udf.children.flatMap {
-      case u: PythonUDF => findInputs(u)
-      case expr => Seq(expr)
-    }
   }
 
   /**
@@ -279,7 +284,7 @@ object ExtractPythonUDFs extends Rule[LogicalPlan] with Logging {
             AttributeReference(s"pythonUDF$i", u.dataType)()
           }
 
-          val evalTypes = validUdfs.map(_.evalType).toSet
+          val evalTypes = validUdfs.map(correctEvalType).toSet
           if (evalTypes.size != 1) {
             throw SparkException.internalError(
               "Expected udfs have the same evalType but got different evalTypes: " +
@@ -288,24 +293,16 @@ object ExtractPythonUDFs extends Rule[LogicalPlan] with Logging {
           val evalType = evalTypes.head
           val evaluation = evalType match {
             case PythonEvalType.SQL_BATCHED_UDF =>
-              BatchEvalPython(validUdfs, resultAttrs, child)
-            case PythonEvalType.SQL_SCALAR_PANDAS_UDF | PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF =>
-              ArrowEvalPython(validUdfs, resultAttrs, child, evalType)
-            case PythonEvalType.SQL_ARROW_BATCHED_UDF =>
-
-              val hasUDTInput = validUdfs.flatMap(findInputs)
-                .exists(expr => containsUDT(expr.dataType))
-              val hasUDTReturn = validUdfs.exists(udf => containsUDT(udf.dataType))
-
-              if (hasUDTInput || hasUDTReturn) {
+              if (validUdfs.exists(_.evalType != PythonEvalType.SQL_BATCHED_UDF)) {
                 // Use BatchEvalPython if UDT is detected
                 logWarning(log"Arrow optimization disabled due to " +
                   log"${MDC(REASON, "UDT input or return type")}. " +
                   log"Falling back to non-Arrow-optimized UDF execution.")
-                BatchEvalPython(validUdfs, resultAttrs, child)
-              } else {
-                ArrowEvalPython(validUdfs, resultAttrs, child, evalType)
               }
+              BatchEvalPython(validUdfs, resultAttrs, child)
+            case PythonEvalType.SQL_SCALAR_PANDAS_UDF | PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF
+                 | PythonEvalType.SQL_ARROW_BATCHED_UDF =>
+              ArrowEvalPython(validUdfs, resultAttrs, child, evalType)
             case _ =>
               throw SparkException.internalError("Unexpected UDF evalType")
           }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `ExtractPythonUDFs` to check the chained UDF input types for fallback.

### Why are the changes needed?

Currently the fallback of Arrow-optimized Python UDF to non Arrow for the case the UDF has UDT input/output only works with not chained UDFs because it checks only the last UDFs.

For example:

```py
from pyspark.sql.functions import udf
from pyspark.sql.types import *
from pyspark.testing.sqlutils import ExamplePoint, ExamplePointUDT

row = Row(
    label=1.0,
    point=ExamplePoint(1.0, 2.0),
)

df = spark.createDataFrame([row])

@udf(returnType=DoubleType(), useArrow=True)
def udtInDoubleOut(e):
    return e.y

@udf(returnType=DoubleType(), useArrow=True)
def doubleInDoubleOut(d):
    return d * 100.0

df.select(doubleInDoubleOut(udtInDoubleOut(df.point))).show()
```

This doesn't fallback to non Arrow because `doubleInDoubleOut` looks like no UDT input/output and fails with:

```
pyspark.errors.exceptions.captured.PythonException:
  An exception was thrown from the Python worker. Please see the stack trace below.
Traceback (most recent call last):
  ...
AttributeError: 'list' object has no attribute 'y'
```

### Does this PR introduce _any_ user-facing change?

Yes, the fallback will work with chained UDFs, too.

### How was this patch tested?

Added the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
