### PR TITLE
[SPARK-51581][CORE][SQL] Use `nonEmpty`/`isEmpty` for empty check for explicit `Iterable`

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Distribution.scala
+++ b/core/src/main/scala/org/apache/spark/util/Distribution.scala
@@ -74,7 +74,7 @@ private[spark] class Distribution(val data: Array[Double], val startIdx: Int, va
 private[spark] object Distribution {
 
   def apply(data: Iterable[Double]): Option[Distribution] = {
-    if (data.size > 0) {
+    if (data.nonEmpty) {
       Some(new Distribution(data))
     } else {
       None

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -787,7 +787,7 @@ object QueryPlan extends PredicateHelper {
    * ""                     -> <fieldName>: None
    */
   def generateFieldString(fieldName: String, values: Any): String = values match {
-    case iter: Iterable[_] if (iter.size == 0) => s"${fieldName}: []"
+    case iter: Iterable[_] if iter.isEmpty => s"${fieldName}: []"
     case iter: Iterable[_] => s"${fieldName} [${iter.size}]: ${iter.mkString("[", ", ", "]")}"
     case str: String if (str == null || str.isEmpty) => s"${fieldName}: None"
     case str: String => s"${fieldName}: ${str}"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr changes the explicit `Iterable` types in Spark code to use `nonEmpty`/`isEmpty` for empty checks, replacing `Iterable.size > 0`/`Iterable.size == 0`.

### Why are the changes needed?
For data structures that can only be confirmed as `Iterable`, since their specific data structure cannot be determined, using `Iterable.size > 0`/`Iterable.size == 0` for empty checks may trigger an iteration over the collection:

https://github.com/scala/scala/blob/3f6bdaeafde17d790023cc3f299b81eaaf876ca3/src/library/scala/collection/IterableOnce.scala#L969-L982

```scala
  /** The size of this $coll.
   *
   *  $willNotTerminateInf
   *
   *  @return    the number of elements in this $coll.
   */
  def size: Int =
    if (knownSize >= 0) knownSize
    else {
      val it = iterator
      var len = 0
      while (it.hasNext) { len += 1; it.next() }
      len
    }
```

Therefore, it is best to use `nonEmpty`/`isEmpty` for empty checks to avoid potential performance issues:

https://github.com/scala/scala/blob/3f6bdaeafde17d790023cc3f299b81eaaf876ca3/src/library/scala/collection/IterableOnce.scala#L946-L960

```scala
  /** Tests whether the $coll is empty.
   *
   *  Note: The default implementation creates and discards an iterator.
   *
   *  Note: Implementations in subclasses that are not repeatedly iterable must take
   *  care not to consume any elements when `isEmpty` is called.
   *
   *  @return    `true` if the $coll contains no elements, `false` otherwise.
   */
  def isEmpty: Boolean =
    knownSize match {
      case -1 => !iterator.hasNext
      case  0 => true
      case  _ => false
    }
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No