### PR TITLE
[SPARK-51583] [SQL] Improve error message when to_timestamp function has arguments of wrong type

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1107,6 +1107,11 @@
           "class <className> not found."
         ]
       },
+      "UNEXPECTED_FUNCTION_ARGUMENT_TYPE" : {
+        "message" : [
+          "Argument type must be a <requiredType>, but it's <argumentType>."
+        ]
+      },
       "UNEXPECTED_INPUT_TYPE" : {
         "message" : [
           "The <paramIndex> parameter requires the <requiredType> type, however <inputSql> has the type <inputType>."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -422,6 +422,13 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
                 e.invalidFormat(checkRes)
             }
 
+          case parseToTimestamp: ParseToTimestamp if parseToTimestamp.left.dataType != StringType =>
+            throw QueryCompilationErrors.unexpectedFunctionArgumentDatatype(
+              expression = parseToTimestamp,
+              requiredType = StringType,
+              argumentType = parseToTimestamp.left.dataType
+            )
+
           case c: Cast if !c.resolved =>
             throw SparkException.internalError(
               msg = s"Found the unresolved Cast: ${c.simpleString(SQLConf.get.maxToStringFields)}",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -4334,4 +4334,18 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       origin = origin
     )
   }
+
+  def unexpectedFunctionArgumentDatatype(
+      expression: Expression,
+      requiredType: DataType,
+      argumentType: DataType): Throwable = {
+    new AnalysisException(
+      errorClass = "DATATYPE_MISMATCH.UNEXPECTED_FUNCTION_ARGUMENT_TYPE",
+      messageParameters = Map(
+        "sqlExpr" -> toSQLExpr(expression),
+        "requiredType" -> toSQLType(requiredType),
+        "argumentType" -> toSQLType(argumentType)
+      )
+    )
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
I propose that we fix error message when to_timestamp function is called with improper argument types.

### Why are the changes needed?
Users are provided with more user facing error instead of an internal one, which is more correct.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added test.

### Was this patch authored or co-authored using generative AI tooling?
No.