### PR TITLE
[SPARK-51586][SS] initialize input partitions independent of columnar support in continuous mode

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -170,6 +170,8 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
 
       val continuousStream = r.stream.asInstanceOf[ContinuousStream]
       val scanExec = ContinuousScanExec(r.output, r.scan, continuousStream, r.startOffset.get)
+      // initialize partitions
+      scanExec.inputPartitions
 
       // Add a Project here to make sure we produce unsafe rows.
       DataSourceV2Strategy.withProjectAndFilter(p, f, scanExec, !scanExec.supportsColumnar) :: Nil


### PR DESCRIPTION
### What changes were proposed in this pull request?
Initialize input partitions independent of columnar support in `ContinuousScanExec`

### Why are the changes needed?
After [SPARK-45080](https://issues.apache.org/jira/browse/SPARK-45080) and [PR 42823](https://github.com/apache/spark/pull/42823) Kafka continuous stream may go into infinite loop of reconfiguring. As `KafkaScan` columnar support mode is hardcoded to `UNSUPPORTED` `ContinuousScanExec` does not initialize `inputPartitions` in `supportsColumnar` as it did prior to the above PR. So, there is no call to `KafkaContinuousStream.planInputPartitions` during query planning. It leaves `KafkaContinuousStream.knownPartitions` uninitialized, so call to `needsReconfiguration` returns `true`. Now `epochUpdateThread` in `ContinuousExecution` requests interruption of `queryExecutionThread`, so that thread also can't initialize `knownPartitions` as it checks for interrupts in `KafkaOffsetReaderAdmin.withRetries` and exits before `knownPartitions` is assigned.


### Does this PR introduce _any_ user-facing change?
Yes, it fixes bug that may prevent kafka continuous stream from working properly


### How was this patch tested?
Using existing Kafka tests. Those tests should complete faster.


### Was this patch authored or co-authored using generative AI tooling?
No
