### PR TITLE
[SPARK-51589][SQL] Fix small bug failing to check for aggregate functions in |> SELECT

### DIFF
--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -677,6 +677,65 @@ org.apache.spark.sql.AnalysisException
 
 
 -- !query
+from t
+|> select sum(x)
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "PIPE_OPERATOR_CONTAINS_AGGREGATE_FUNCTION",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "clause" : "SELECT",
+    "expr" : "sum(x#x)"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 18,
+    "stopIndex" : 23,
+    "fragment" : "sum(x)"
+  } ]
+}
+
+
+-- !query
+from t as t_alias
+|> select y, sum(x)
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "PIPE_OPERATOR_CONTAINS_AGGREGATE_FUNCTION",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "clause" : "SELECT",
+    "expr" : "sum(x#x)"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 32,
+    "stopIndex" : 37,
+    "fragment" : "sum(x)"
+  } ]
+}
+
+
+-- !query
+from t as t_alias
+|> select y, sum(x) group by y
+-- !query analysis
+org.apache.spark.sql.catalyst.parser.ParseException
+{
+  "errorClass" : "PARSE_SYNTAX_ERROR",
+  "sqlState" : "42601",
+  "messageParameters" : {
+    "error" : "'group'",
+    "hint" : ""
+  }
+}
+
+
+-- !query
 table t
 |> extend 1 as z
 -- !query analysis

--- a/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
@@ -225,6 +225,15 @@ table t
 table t
 |> select y, length(y) + sum(x) as result;
 
+from t
+|> select sum(x);
+
+from t as t_alias
+|> select y, sum(x);
+
+from t as t_alias
+|> select y, sum(x) group by y;
+
 -- EXTEND operators: positive tests.
 ------------------------------------
 

--- a/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
@@ -628,6 +628,71 @@ org.apache.spark.sql.AnalysisException
 
 
 -- !query
+from t
+|> select sum(x)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "PIPE_OPERATOR_CONTAINS_AGGREGATE_FUNCTION",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "clause" : "SELECT",
+    "expr" : "sum(x#x)"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 18,
+    "stopIndex" : 23,
+    "fragment" : "sum(x)"
+  } ]
+}
+
+
+-- !query
+from t as t_alias
+|> select y, sum(x)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "PIPE_OPERATOR_CONTAINS_AGGREGATE_FUNCTION",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "clause" : "SELECT",
+    "expr" : "sum(x#x)"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 32,
+    "stopIndex" : 37,
+    "fragment" : "sum(x)"
+  } ]
+}
+
+
+-- !query
+from t as t_alias
+|> select y, sum(x) group by y
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.parser.ParseException
+{
+  "errorClass" : "PARSE_SYNTAX_ERROR",
+  "sqlState" : "42601",
+  "messageParameters" : {
+    "error" : "'group'",
+    "hint" : ""
+  }
+}
+
+
+-- !query
 table t
 |> extend 1 as z
 -- !query schema


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a small bug with `|> SELECT` with aggregate functions without aliases. In such cases, we should be returning an error instructing the user to use `|> AGGREGATE` instead, but we do not.

This bug only happens when the aggregate function does not have any alias.

For example:

```
VALUES (0), (1) tab(col)
|> SELECT SUM(col)
```

Before this PR, the above query returned a result of 1. After this PR, the above query instead returns an error instructing the user to switch to `|> AGGREGATE` to perform the sum operation instead.

### Why are the changes needed?

The documented behavior of `|> SELECT` is that the expression list must not contain any aggregate functions, and the user receives an error otherwise.

### Does this PR introduce _any_ user-facing change?

Yes, see above.

### How was this patch tested?

This PR adds golden file based test coverage.

### Was this patch authored or co-authored using generative AI tooling?

No.