### PR TITLE
[SPARK-49858][SQL] Fix Spark JSON reader incorrectly considers a string of digits a timestamp

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -120,12 +120,15 @@ class JSONOptions(
       Some(parameters.getOrElse(TIMESTAMP_FORMAT,
         s"${DateFormatter.defaultPattern}'T'HH:mm:ss.SSSXXX"))
     } else {
-      parameters.get(TIMESTAMP_FORMAT)
+      Some(parameters.getOrElse(TIMESTAMP_FORMAT,
+        s"${DateFormatter.defaultPattern}'T'${TimeFormatter.defaultPattern}[.SSS][XXX]"))
     }
   val timestampFormatInWrite: String =
     parameters.getOrElse(TIMESTAMP_FORMAT, commonTimestampFormat)
 
-  val timestampNTZFormatInRead: Option[String] = parameters.get(TIMESTAMP_NTZ_FORMAT)
+  val timestampNTZFormatInRead: Option[String] = Some(parameters.getOrElse(TIMESTAMP_NTZ_FORMAT,
+    s"${DateFormatter.defaultPattern}'T'${TimeFormatter.defaultPattern}[.SSS]"
+  ))
   val timestampNTZFormatInWrite: String =
     parameters.getOrElse(TIMESTAMP_NTZ_FORMAT, s"${DateFormatter.defaultPattern}'T'HH:mm:ss[.SSS]")
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
@@ -44,13 +44,13 @@ class JsonInferSchema(options: JSONOptions) extends Serializable with Logging {
   private val decimalParser = ExprUtils.getDecimalParser(options.locale)
 
   private val timestampFormatter = TimestampFormatter(
-    options.timestampFormatInRead.getOrElse(defaultTimestampPattern()),
+    options.timestampFormatInRead,
     options.zoneId,
     options.locale,
     legacyFormat = FAST_DATE_FORMAT,
     isParsing = true)
   private val timestampNTZFormatter = TimestampFormatter(
-    options.timestampNTZFormatInRead.getOrElse(defaultTimestampNTZPattern()),
+    options.timestampNTZFormatInRead,
     options.zoneId,
     legacyFormat = FAST_DATE_FORMAT,
     isParsing = true,
@@ -60,12 +60,6 @@ class JsonInferSchema(options: JSONOptions) extends Serializable with Logging {
   private val ignoreMissingFiles = options.ignoreMissingFiles
   private val isDefaultNTZ = SQLConf.get.timestampType == TimestampNTZType
   private val legacyMode = SQLConf.get.legacyTimeParserPolicy == LegacyBehaviorPolicy.LEGACY
-
-  private def defaultTimestampPattern(): String =
-    s"${DateFormatter.defaultPattern}'T'${TimeFormatter.defaultPattern}[.SSS][XXX]"
-
-  private def defaultTimestampNTZPattern(): String =
-    s"${DateFormatter.defaultPattern}'T'${TimeFormatter.defaultPattern}[.SSS]"
 
   private def handleJsonErrorsByParseMode(parseMode: ParseMode,
       columnNameOfCorruptRecord: String, e: Throwable): Option[StructType] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
@@ -44,13 +44,13 @@ class JsonInferSchema(options: JSONOptions) extends Serializable with Logging {
   private val decimalParser = ExprUtils.getDecimalParser(options.locale)
 
   private val timestampFormatter = TimestampFormatter(
-    options.timestampFormatInRead,
+    options.timestampFormatInRead.getOrElse(defaultTimestampPattern()),
     options.zoneId,
     options.locale,
     legacyFormat = FAST_DATE_FORMAT,
     isParsing = true)
   private val timestampNTZFormatter = TimestampFormatter(
-    options.timestampNTZFormatInRead,
+    options.timestampNTZFormatInRead.getOrElse(defaultTimestampNTZPattern()),
     options.zoneId,
     legacyFormat = FAST_DATE_FORMAT,
     isParsing = true,
@@ -60,6 +60,12 @@ class JsonInferSchema(options: JSONOptions) extends Serializable with Logging {
   private val ignoreMissingFiles = options.ignoreMissingFiles
   private val isDefaultNTZ = SQLConf.get.timestampType == TimestampNTZType
   private val legacyMode = SQLConf.get.legacyTimeParserPolicy == LegacyBehaviorPolicy.LEGACY
+
+  private def defaultTimestampPattern(): String =
+    s"${DateFormatter.defaultPattern}'T'${TimeFormatter.defaultPattern}[.SSS][XXX]"
+
+  private def defaultTimestampNTZPattern(): String =
+    s"${DateFormatter.defaultPattern}'T'${TimeFormatter.defaultPattern}[.SSS]"
 
   private def handleJsonErrorsByParseMode(parseMode: ParseMode,
       columnNameOfCorruptRecord: String, e: Throwable): Option[StructType] = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JsonInferSchemaSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JsonInferSchemaSuite.scala
@@ -120,4 +120,23 @@ class JsonInferSchemaSuite extends SparkFunSuite with SQLHelper {
       """{"a": "2884-06-24T02:45:51.138"}""",
       StringType)
   }
+
+  test("SPARK-49858: inferring the schema with default timestampFormat") {
+    checkType(
+      Map("inferTimestamp" -> "true"), """{"a": "23456"}""", StringType)
+    checkType(Map("inferTimestamp" -> "true"), """{"a": "23456-01"}""", StringType)
+    checkType(Map("inferTimestamp" -> "true"), """{"a": "2025-01-01"}""", StringType)
+    checkType(
+      Map("inferTimestamp" -> "true"),
+      """{"a": "2025-01-01T00:00:00.123+01:00"}""",
+      TimestampType)
+    checkType(
+      Map("inferTimestamp" -> "true"),
+      """{"a": "2025-01-01T00:00:00.123"}""",
+      TimestampType)
+    checkType(
+      Map("inferTimestamp" -> "true"),
+      """{"a": "2025-01-01T00:00:00.123456+01:00"}""",
+      StringType)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Previously, Spark JSON reader used `DefaultTimestampFormatter` and function `def parseTimestampString` for inferring timestamps from strings if the user does not specify any timestamp patterns, which can confuse in case the string only has Year or  Year + Month segments in the string with regular strings. Eg. "23456", "23456-01",...

This change is to add a default value for `timestampFormat` and `timestampNTZFormat` to align with the documentation https://spark.apache.org/docs/3.5.3/sql-data-sources-json.html

### Why are the changes needed?

To avoid confusion between regular strings and strings that are in the formats having only Year or Year + Month segments, as reported in this issue: https://issues.apache.org/jira/browse/SPARK-49858

### Does this PR introduce _any_ user-facing change?

Yes

- Previous behavior: 

Spark tried to use `def parseTimestampString` for parsing the string to timestamp within the JSON, it allows a maximum of 6 digits for the Year segment

```scala
package org.apache.spark.sql.catalyst.util

/*
...
*/

def parseTimestampString(s: UTF8String): (Array[Int], Option[ZoneId], Boolean) = {
    def isValidDigits(segment: Int, digits: Int): Boolean = {
      // A Long is able to represent a timestamp within [+-]200 thousand years
      val maxDigitsYear = 6
      // For the nanosecond part, more than 6 digits is allowed, but will be truncated.
      segment == 6 || (segment == 0 && digits >= 4 && digits <= maxDigitsYear) ||
      // For the zoneId segment(7), it's could be zero digits when it's a region-based zone ID
      (segment == 7 && digits <= 2) ||
      (segment != 0 && segment != 6 && segment != 7 && digits > 0 && digits <= 2)
    }
/*
...
*/
}
```

Hence, `"23456"` string is considered as a Timestamp, which is in user business, indeed a regular string, below is captured from Spark Scala

<img width="783" alt="image" src="https://github.com/user-attachments/assets/9f9b82ef-1004-4761-bc22-2dcfd15affcc" />

The issue is even worse when is in PySpark when pulling result from JVM to a Python datetime, and Python datetime cannot handle Year part that is greater than 9999

<img width="879" alt="image" src="https://github.com/user-attachments/assets/0f7ecf4b-c434-48fc-acb5-dd5d02a26d13" />

### How was this patch tested?

Unit tests are provided for the above cases.

### Was this patch authored or co-authored using generative AI tooling?

No