### PR TITLE
[SPARK-51419][SQL] Get hours of TIME datatype

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -640,7 +640,7 @@ object FunctionRegistry {
     expression[DayOfMonth]("dayofmonth"),
     expression[FromUnixTime]("from_unixtime"),
     expression[FromUTCTimestamp]("from_utc_timestamp"),
-    expression[Hour]("hour"),
+    expressionBuilder("hour", HourExpressionBuilder),
     expression[LastDay]("last_day"),
     expressionBuilder("minute", MinuteExpressionBuilder),
     expression[Month]("month"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -400,15 +400,6 @@ trait GetTimeField extends UnaryExpression
   }
 }
 
-@ExpressionDescription(
-  usage = "_FUNC_(timestamp) - Returns the hour component of the string/timestamp.",
-  examples = """
-    Examples:
-      > SELECT _FUNC_('2009-07-30 12:58:59');
-       12
-  """,
-  group = "datetime_funcs",
-  since = "1.5.0")
 case class Hour(child: Expression, timeZoneId: Option[String] = None) extends GetTimeField {
   def this(child: Expression) = this(child, None)
   override def withTimeZone(timeZoneId: String): Hour = copy(timeZoneId = Option(timeZoneId))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -233,3 +233,75 @@ object MinuteExpressionBuilder extends ExpressionBuilder {
     }
   }
 }
+
+// scalastyle:off line.size.limit
+@ExpressionDescription(
+  usage = """
+    _FUNC_(time_expr) - Returns the hour component of the given time.
+  """,
+  examples = """
+    Examples:
+      > SELECT _FUNC_(TIME'11:35:35.999999');
+       11
+  """,
+  since = "4.1.0",
+  group = "datetime_funcs")
+// scalastyle:on line.size.limit
+case class HoursOfTime(child: Expression)
+  extends RuntimeReplaceable
+    with ExpectsInputTypes {
+
+  override def replacement: Expression = StaticInvoke(
+    classOf[DateTimeUtils.type],
+    IntegerType,
+    "getHoursOfTime",
+    Seq(child),
+    Seq(child.dataType)
+  )
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(TimeType())
+
+  override def children: Seq[Expression] = Seq(child)
+
+  override def prettyName: String = "hour"
+
+  override protected def withNewChildrenInternal(
+    newChildren: IndexedSeq[Expression]): Expression = {
+    copy(child = newChildren.head)
+  }
+}
+
+// scalastyle:off line.size.limit
+@ExpressionDescription(
+  usage = """
+    _FUNC_(expr) - Returns the hour component of the given expression.
+
+    If `expr` is a TIMESTAMP or a string that can be cast to timestamp,
+    it returns the minute of that timestamp.
+    If `expr` is a TIME type (since 4.1.0), it returns the hour of the time-of-day.
+  """,
+  examples = """
+    Examples:
+      > SELECT _FUNC_('2018-02-14 12:58:59');
+       12
+      > SELECT _FUNC_(TIME'13:59:59.999999');
+       13
+  """,
+  since = "1.5.0",
+  group = "datetime_funcs")
+// scalastyle:on line.size.limit
+object HourExpressionBuilder extends ExpressionBuilder {
+  override def build(name: String, expressions: Seq[Expression]): Expression = {
+    if (expressions.isEmpty) {
+      throw QueryCompilationErrors.wrongNumArgsError(name, Seq("> 0"), expressions.length)
+    } else {
+      val child = expressions.head
+      child.dataType match {
+        case _: TimeType =>
+          HoursOfTime(child)
+        case _ =>
+          Hour(child)
+      }
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -277,7 +277,7 @@ case class HoursOfTime(child: Expression)
     _FUNC_(expr) - Returns the hour component of the given expression.
 
     If `expr` is a TIMESTAMP or a string that can be cast to timestamp,
-    it returns the minute of that timestamp.
+    it returns the hour of that timestamp.
     If `expr` is a TIME type (since 4.1.0), it returns the hour of the time-of-day.
   """,
   examples = """

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -270,6 +270,23 @@ case class HoursOfTime(child: Expression)
   }
 }
 
+@ExpressionDescription(
+  usage = """
+    _FUNC_(expr) - Returns the hour component of the given expression.
+
+    If `expr` is a TIMESTAMP or a string that can be cast to timestamp,
+    it returns the hour of that timestamp.
+    If `expr` is a TIME type (since 4.1.0), it returns the hour of the time-of-day.
+  """,
+  examples = """
+    Examples:
+      > SELECT _FUNC_('2018-02-14 12:58:59');
+       12
+      > SELECT _FUNC_(TIME'13:59:59.999999');
+       13
+  """,
+  since = "1.5.0",
+  group = "datetime_funcs")
 // scalastyle:on line.size.limit
 object HourExpressionBuilder extends ExpressionBuilder {
   override def build(name: String, expressions: Seq[Expression]): Expression = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -234,7 +234,6 @@ object MinuteExpressionBuilder extends ExpressionBuilder {
   }
 }
 
-// scalastyle:on line.size.limit
 case class HoursOfTime(child: Expression)
   extends RuntimeReplaceable
     with ExpectsInputTypes {
@@ -276,7 +275,6 @@ case class HoursOfTime(child: Expression)
   """,
   since = "1.5.0",
   group = "datetime_funcs")
-// scalastyle:on line.size.limit
 object HourExpressionBuilder extends ExpressionBuilder {
   override def build(name: String, expressions: Seq[Expression]): Expression = {
     if (expressions.isEmpty) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -234,17 +234,6 @@ object MinuteExpressionBuilder extends ExpressionBuilder {
   }
 }
 
-@ExpressionDescription(
-  usage = """
-    _FUNC_(time_expr) - Returns the hour component of the given time.
-  """,
-  examples = """
-    Examples:
-      > SELECT _FUNC_(TIME'11:35:35.999999');
-       11
-  """,
-  since = "4.1.0",
-  group = "datetime_funcs")
 // scalastyle:on line.size.limit
 case class HoursOfTime(child: Expression)
   extends RuntimeReplaceable

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -270,7 +270,6 @@ case class HoursOfTime(child: Expression)
   }
 }
 
-
 @ExpressionDescription(
   usage = """
     _FUNC_(expr) - Returns the hour component of the given expression.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -270,23 +270,6 @@ case class HoursOfTime(child: Expression)
   }
 }
 
-@ExpressionDescription(
-  usage = """
-    _FUNC_(expr) - Returns the hour component of the given expression.
-
-    If `expr` is a TIMESTAMP or a string that can be cast to timestamp,
-    it returns the hour of that timestamp.
-    If `expr` is a TIME type (since 4.1.0), it returns the hour of the time-of-day.
-  """,
-  examples = """
-    Examples:
-      > SELECT _FUNC_('2018-02-14 12:58:59');
-       12
-      > SELECT _FUNC_(TIME'13:59:59.999999');
-       13
-  """,
-  since = "1.5.0",
-  group = "datetime_funcs")
 // scalastyle:on line.size.limit
 object HourExpressionBuilder extends ExpressionBuilder {
   override def build(name: String, expressions: Seq[Expression]): Expression = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -234,7 +234,6 @@ object MinuteExpressionBuilder extends ExpressionBuilder {
   }
 }
 
-// scalastyle:off line.size.limit
 @ExpressionDescription(
   usage = """
     _FUNC_(time_expr) - Returns the hour component of the given time.
@@ -271,7 +270,7 @@ case class HoursOfTime(child: Expression)
   }
 }
 
-// scalastyle:off line.size.limit
+
 @ExpressionDescription(
   usage = """
     _FUNC_(expr) - Returns the hour component of the given expression.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -106,6 +106,13 @@ object DateTimeUtils extends SparkDateTimeUtils {
   }
 
   /**
+   * Returns the hour value of a given TIME (TimeType) value.
+   */
+  def getHoursOfTime(micros: Long): Int = {
+    microsToLocalTime(micros).getHour
+  }
+
+  /**
    * Returns the minute value of a given timestamp value. The timestamp is expressed in
    * microseconds since the epoch.
    */

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -82,7 +82,7 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   test("Hour with TIME type") {
     // A few test times in microseconds since midnight:
-    //   time in microseconds -> expected minute
+    //   time in microseconds -> expected hour
     val testTimes = Seq(
       localTime() -> 0,
       localTime(1) -> 1,
@@ -94,7 +94,7 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     )
 
     // Create a literal with TimeType() for each test microsecond value
-    // evaluate MinutesOfTime(...), and check that the result matches the expected minute.
+    // evaluate HoursOfTime(...), and check that the result matches the expected hour.
     testTimes.foreach { case (micros, expectedHour) =>
       checkEvaluation(
         HoursOfTime(Literal(micros, TimeType())),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -53,6 +53,61 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       parameters = Map("input" -> "'100:50'", "format" -> "'mm:HH'"))
   }
 
+  test("HourExpressionBuilder") {
+    // Empty expressions list
+    checkError(
+      exception = intercept[AnalysisException] {
+        MinuteExpressionBuilder.build("hour", Seq.empty)
+      },
+      condition = "WRONG_NUM_ARGS.WITHOUT_SUGGESTION",
+      parameters = Map(
+        "functionName" -> "`hour`",
+        "expectedNum" -> "> 0",
+        "actualNum" -> "0",
+        "docroot" -> SPARK_DOC_ROOT)
+    )
+
+    // test TIME-typed child should build MinutesOfTime
+    val timeExpr = Literal(localTime(12, 58, 59), TimeType())
+    val builtExprForTime = HourExpressionBuilder.build("hour", Seq(timeExpr))
+    assert(builtExprForTime.isInstanceOf[HoursOfTime])
+    assert(builtExprForTime.asInstanceOf[HoursOfTime].child eq timeExpr)
+
+    // test non TIME-typed child should build hour
+    val tsExpr = Literal("2007-09-03 10:45:23")
+    val builtExprForTs = MinuteExpressionBuilder.build("hour", Seq(tsExpr))
+    assert(builtExprForTs.isInstanceOf[Hour])
+    assert(builtExprForTs.asInstanceOf[Hour].child eq tsExpr)
+  }
+
+  test("Hour with TIME type") {
+    // A few test times in microseconds since midnight:
+    //   time in microseconds -> expected minute
+    val testTimes = Seq(
+      localTime() -> 0,
+      localTime(1) -> 1,
+      localTime(0, 59) -> 0,
+      localTime(14, 30) -> 14,
+      localTime(12, 58, 59) -> 12,
+      localTime(23, 0, 1) -> 23,
+      localTime(23, 59, 59, 999999) -> 23
+    )
+
+    // Create a literal with TimeType() for each test microsecond value
+    // evaluate MinutesOfTime(...), and check that the result matches the expected minute.
+    testTimes.foreach { case (micros, expectedHour) =>
+      checkEvaluation(
+        HoursOfTime(Literal(micros, TimeType())),
+        expectedHour)
+    }
+
+    // Verify NULL handling
+    checkEvaluation(
+      HoursOfTime(Literal.create(null, TimeType(TimeType.MICROS_PRECISION))),
+      null
+    )
+  }
+
   test("MinuteExpressionBuilder") {
     // Empty expressions list
     checkError(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -67,7 +67,7 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
         "docroot" -> SPARK_DOC_ROOT)
     )
 
-    // test TIME-typed child should build MinutesOfTime
+    // test TIME-typed child should build HoursOfTime
     val timeExpr = Literal(localTime(12, 58, 59), TimeType())
     val builtExprForTime = HourExpressionBuilder.build("hour", Seq(timeExpr))
     assert(builtExprForTime.isInstanceOf[HoursOfTime])

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -57,7 +57,7 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     // Empty expressions list
     checkError(
       exception = intercept[AnalysisException] {
-        MinuteExpressionBuilder.build("hour", Seq.empty)
+        HourExpressionBuilder.build("hour", Seq.empty)
       },
       condition = "WRONG_NUM_ARGS.WITHOUT_SUGGESTION",
       parameters = Map(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -75,7 +75,7 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
 
     // test non TIME-typed child should build hour
     val tsExpr = Literal("2007-09-03 10:45:23")
-    val builtExprForTs = MinuteExpressionBuilder.build("hour", Seq(tsExpr))
+    val builtExprForTs = HourExpressionBuilder.build("hour", Seq(tsExpr))
     assert(builtExprForTs.isInstanceOf[Hour])
     assert(builtExprForTs.asInstanceOf[Hour].child eq tsExpr)
   }

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -159,7 +159,7 @@
 | org.apache.spark.sql.catalyst.expressions.Hex | hex | SELECT hex(17) | struct<hex(17):string> |
 | org.apache.spark.sql.catalyst.expressions.HllSketchEstimate | hll_sketch_estimate | SELECT hll_sketch_estimate(hll_sketch_agg(col)) FROM VALUES (1), (1), (2), (2), (3) tab(col) | struct<hll_sketch_estimate(hll_sketch_agg(col, 12)):bigint> |
 | org.apache.spark.sql.catalyst.expressions.HllUnion | hll_union | SELECT hll_sketch_estimate(hll_union(hll_sketch_agg(col1), hll_sketch_agg(col2))) FROM VALUES (1, 4), (1, 4), (2, 5), (2, 5), (3, 6) tab(col1, col2) | struct<hll_sketch_estimate(hll_union(hll_sketch_agg(col1, 12), hll_sketch_agg(col2, 12), false)):bigint> |
-| org.apache.spark.sql.catalyst.expressions.Hour | hour | SELECT hour('2009-07-30 12:58:59') | struct<hour(2009-07-30 12:58:59):int> |
+| org.apache.spark.sql.catalyst.expressions.HourExpressionBuilder | hour | SELECT hour('2018-02-14 12:58:59') | struct<hour(2018-02-14 12:58:59):int> |
 | org.apache.spark.sql.catalyst.expressions.Hypot | hypot | SELECT hypot(3, 4) | struct<HYPOT(3, 4):double> |
 | org.apache.spark.sql.catalyst.expressions.ILike | ilike | SELECT ilike('Spark', '_Park') | struct<ilike(Spark, _Park):boolean> |
 | org.apache.spark.sql.catalyst.expressions.If | if | SELECT if(1 < 2, 'a', 'b') | struct<(IF((1 < 2), a, b)):string> |


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR adds support for extracting the hour component from TIME (TimeType) values in Spark SQL.

```
scala> spark.sql("SELECT hour(TIME'07:01:09.12312321231232');").show()
+----------------------------+
|hour(TIME '07:01:09.123123')|
+----------------------------+
|                           7|
+----------------------------+

scala> spark.sql("SELECT hour('2009-07-30 12:58:59')").show()
+-------------------------+
|hour(2009-07-30 12:58:59)|
+-------------------------+
|                       12|
+-------------------------+

```


### Why are the changes needed?
Spark previously supported hour() for only TIMESTAMP type values. TIME support was missing, leading to implicit casting attempt to TIMESTAMP, which was incorrect. This PR ensures that `hour(TIME'HH:MM:SS.######')` behaves correctly without unnecessary type coercion.



### Does this PR introduce _any_ user-facing change?
Yes

- Before this PR, calling hour(TIME'HH:MM:SS.######') resulted in a type mismatch error or an implicit cast attempt to TIMESTAMP, which was incorrect.
- With this PR, hour(TIME'HH:MM:SS.######') now works correctly for TIME values without implicit casting.
- Users can now extract the hour component from TIME values natively.



### How was this patch tested?
By running new tests:

```$ build/sbt "test:testOnly *TimeExpressionsSuite"```


### Was this patch authored or co-authored using generative AI tooling?
No
