### PR TITLE
[SPARK-51590][SQL] Disable TIME in builtin file-based datasources

### DIFF
--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -3087,7 +3087,7 @@ abstract class AvroSuite
     }
   }
 
-  test("SPARK-XXXXX: unsupported the TIME data types in Avro") {
+  test("SPARK-51590: unsupported the TIME data types in Avro") {
     withTempDir { dir =>
       val tempDir = new File(dir, "files").getCanonicalPath
       checkError(

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -3086,6 +3086,22 @@ abstract class AvroSuite
       }
     }
   }
+
+  test("SPARK-XXXXX: unsupported the TIME data types in Avro") {
+    withTempDir { dir =>
+      val tempDir = new File(dir, "files").getCanonicalPath
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("select time'12:01:02' as t")
+            .write.format("avro").mode("overwrite").save(tempDir)
+        },
+        condition = "UNSUPPORTED_DATA_TYPE_FOR_DATASOURCE",
+        parameters = Map(
+          "columnName" -> "`t`",
+          "columnType" -> s"\"${TimeType().sql}\"",
+          "format" -> "Avro"))
+    }
+  }
 }
 
 class AvroV1Suite extends AvroSuite {

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
@@ -83,6 +83,7 @@ private[sql] object AvroUtils extends Logging {
   def supportsDataType(dataType: DataType): Boolean = dataType match {
     case _: VariantType => false
 
+    case _: TimeType => false
     case _: AtomicType => true
 
     case st: StructType => st.forall { f => supportsDataType(f.dataType) }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
@@ -157,6 +157,7 @@ class CSVFileFormat extends TextBasedFileFormat with DataSourceRegister {
   override def supportDataType(dataType: DataType): Boolean = dataType match {
     case _: VariantType => false
 
+    case _: TimeType => false
     case _: AtomicType => true
 
     case udt: UserDefinedType[_] => supportDataType(udt.sqlType)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -135,6 +135,7 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
   override def supportDataType(dataType: DataType): Boolean = dataType match {
     case _: VariantType => true
 
+    case _: TimeType => false
     case _: AtomicType => true
 
     case st: StructType => st.forall { f => supportDataType(f.dataType) }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -246,6 +246,7 @@ class OrcFileFormat
   override def supportDataType(dataType: DataType): Boolean = dataType match {
     case _: VariantType => false
 
+    case _: TimeType => false
     case _: AtomicType => true
 
     case st: StructType => st.forall { f => supportDataType(f.dataType) }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -347,6 +347,7 @@ class ParquetFileFormat
   }
 
   override def supportDataType(dataType: DataType): Boolean = dataType match {
+    case _: TimeType => false
     case _: AtomicType => true
 
     case st: StructType => st.forall { f => supportDataType(f.dataType) }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XmlFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XmlFileFormat.scala
@@ -139,6 +139,7 @@ class XmlFileFormat extends TextBasedFileFormat with DataSourceRegister {
   override def supportDataType(dataType: DataType): Boolean = dataType match {
     case _: VariantType => false
 
+    case _: TimeType => false
     case _: AtomicType => true
 
     case st: StructType => st.forall { f => supportDataType(f.dataType) }

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -1248,7 +1248,7 @@ class FileBasedDataSourceSuite extends QueryTest
     }
   }
 
-  test("SPARK-XXXXX: unsupported the TIME data types in data sources") {
+  test("SPARK-51590: unsupported the TIME data types in data sources") {
     val datasources = allFileBasedDataSources :+ "xml"
     Seq(true, false).foreach { useV1 =>
       val useV1List = if (useV1) {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
@@ -193,7 +193,7 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
     case _: VariantType => false
 
     case _: AnsiIntervalType => false
-
+    case _: TimeType => false
     case _: AtomicType => true
 
     case st: StructType => st.forall { f => supportDataType(f.dataType) }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcQuerySuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.execution.datasources.orc.OrcQueryTest
 import org.apache.spark.sql.hive.{HiveSessionCatalog, HiveUtils}
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.TimeType
 
 class HiveOrcQuerySuite extends OrcQueryTest with TestHiveSingleton {
   import testImplicits._
@@ -420,6 +421,24 @@ class HiveOrcQuerySuite extends OrcQueryTest with TestHiveSingleton {
             .option("ignoreCorruptFiles", value = true)
             .orc(basePath), Row(0L, 1))
         }
+      }
+    }
+  }
+
+  test("SPARK-XXXXX: unsupported the TIME data types in Hive ORC") {
+    withSQLConf(SQLConf.ORC_IMPLEMENTATION.key -> "hive") {
+      withTempDir { dir =>
+        val tempDir = new File(dir, "files").getCanonicalPath
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql("select time'12:01:02' as t")
+              .write.format("orc").mode("overwrite").save(tempDir)
+          },
+          condition = "UNSUPPORTED_DATA_TYPE_FOR_DATASOURCE",
+          parameters = Map(
+            "columnName" -> "`t`",
+            "columnType" -> s"\"${TimeType().sql}\"",
+            "format" -> "ORC"))
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcQuerySuite.scala
@@ -425,7 +425,7 @@ class HiveOrcQuerySuite extends OrcQueryTest with TestHiveSingleton {
     }
   }
 
-  test("SPARK-XXXXX: unsupported the TIME data types in Hive ORC") {
+  test("SPARK-51590: unsupported the TIME data types in Hive ORC") {
     withSQLConf(SQLConf.ORC_IMPLEMENTATION.key -> "hive") {
       withTempDir { dir =>
         val tempDir = new File(dir, "files").getCanonicalPath


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to modify the `supportDataType()` method of builtin file based datasources, and disable the new data type `TIME` till it is fully supported in such datasources. In particular, disable it in the following V1 and V2 datasources:
- Text
- JSON/CSV
- XML
- Parquet
- ORC: native and Hive
- Avro

### Why are the changes needed?
Before the changes if we don't disable the unsupported data type `TIME` in datasources, users might get exceptions from external libs like:

ORC:
```java
java.lang.IllegalArgumentException: Can't parse category at 'time^(6)'
	at org.apache.orc.impl.ParserUtils.parseCategory(ParserUtils.java:67)
```

Avro:
```java
org.apache.spark.sql.avro.IncompatibleSchemaException: Unexpected type TimeType(6).
	at org.apache.spark.sql.avro.SchemaConverters$.toAvroType(SchemaConverters.scala:369)
```


### Does this PR introduce _any_ user-facing change?
Yes. After the changes, users get more friendly `AnalysisException`:
```
[UNSUPPORTED_DATA_TYPE_FOR_DATASOURCE] The ORC datasource doesn't support the column `t` of the type "TIME(6)". SQLSTATE: 0A000
```

### How was this patch tested?
By running the modified test suites:
```
$ build/sbt "test:testOnly *FileBasedDataSourceSuite"
$ build/sbt -Phive "test:testOnle *HiveOrcQuerySuite"
```


### Was this patch authored or co-authored using generative AI tooling?
No.