### PR TITLE
[MINOR][SQL][DOCS] Improve the SQL example for join strategy

### DIFF
--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -240,7 +240,7 @@ head(join(src, hint(records, "broadcast"), src$key == records$key))
 <div data-lang="SQL" markdown="1">
 ```sql
 -- We accept BROADCAST, BROADCASTJOIN and MAPJOIN for broadcast hint
-SELECT /*+ BROADCAST(r) */ * FROM records r JOIN src s ON r.key = s.key
+SELECT /*+ BROADCAST(r) */ * FROM src s JOIN records r ON s.key = r.key
 ```
 </div>
 </div>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to improve the SQL example for join strategy.

### Why are the changes needed?
The SQL example for join strategy confuses users as if the join strategy is related to the join order. This PR makes consistent join order for all the examples.


### Does this PR introduce _any_ user-facing change?
'No'.
Just docs.


### How was this patch tested?
No need.


### Was this patch authored or co-authored using generative AI tooling?
No.
