### PR TITLE
[SPARK-51420][SQL][TESTS][FOLLOWUP] Re-generate `sql-expression-schema.md`

### DIFF
--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -223,7 +223,7 @@
 | org.apache.spark.sql.catalyst.expressions.Md5 | md5 | SELECT md5('Spark') | struct<md5(Spark):string> |
 | org.apache.spark.sql.catalyst.expressions.MicrosToTimestamp | timestamp_micros | SELECT timestamp_micros(1230219000123123) | struct<timestamp_micros(1230219000123123):timestamp> |
 | org.apache.spark.sql.catalyst.expressions.MillisToTimestamp | timestamp_millis | SELECT timestamp_millis(1230219000123) | struct<timestamp_millis(1230219000123):timestamp> |
-| org.apache.spark.sql.catalyst.expressions.Minute | minute | SELECT minute('2009-07-30 12:58:59') | struct<minute(2009-07-30 12:58:59):int> |
+| org.apache.spark.sql.catalyst.expressions.MinuteExpressionBuilder | minute | SELECT minute('2009-07-30 12:58:59') | struct<minute(2009-07-30 12:58:59):int> |
 | org.apache.spark.sql.catalyst.expressions.MonotonicallyIncreasingID | monotonically_increasing_id | SELECT monotonically_increasing_id() | struct<monotonically_increasing_id():bigint> |
 | org.apache.spark.sql.catalyst.expressions.Month | month | SELECT month('2016-07-30') | struct<month(2016-07-30):int> |
 | org.apache.spark.sql.catalyst.expressions.MonthName | monthname | SELECT monthname('2008-02-20') | struct<monthname(2008-02-20):string> |


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to regenerate `sql-expression-schema.md` via:
```
$ SPARK_GENERATE_GOLDEN_FILES=1 build/sbt "test:testOnly *ExpressionsSchemaSuite"
```

### Why are the changes needed?
To have `sql-expression-schema.md` up-to-date, and avoid unrelated changes in other PRs.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
By running the related test:
```
$ build/sbt "test:testOnly *ExpressionsSchemaSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.
