### PR TITLE
[SPARK-51062][PYTHON] Fix assertSchemaEqual to compare decimal precision and scale

### DIFF
--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -1803,7 +1803,8 @@ class UtilsTestsMixin:
         self.assertTrue(exception_thrown)
 
     def test_assert_schema_equal_with_decimal_types(self):
-        """Test assertSchemaEqual with decimal types of different precision and scale (SPARK-51062)."""
+        """Test assertSchemaEqual with decimal types of different precision and scale
+        (SPARK-51062)."""
         from pyspark.sql.types import StructType, StructField, DecimalType
 
         # Same precision and scale - should pass

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -1802,6 +1802,31 @@ class UtilsTestsMixin:
 
         self.assertTrue(exception_thrown)
 
+    def test_assert_schema_equal_with_decimal_types(self):
+        """Test assertSchemaEqual with decimal types of different precision and scale (SPARK-51062)."""
+        from pyspark.sql.types import StructType, StructField, DecimalType
+
+        # Same precision and scale - should pass
+        s1 = StructType([
+            StructField("price", DecimalType(10, 2), True),
+        ])
+
+        s1_copy = StructType([
+            StructField("price", DecimalType(10, 2), True),
+        ])
+
+        # This should pass
+        assertSchemaEqual(s1, s1_copy)
+
+        # Different precision and scale - should fail
+        s2 = StructType([
+            StructField("price", DecimalType(12, 4), True),
+        ])
+
+        # This should fail
+        with self.assertRaises(PySparkAssertionError):
+            assertSchemaEqual(s1, s2)
+
 
 class UtilsTests(ReusedSQLTestCase, UtilsTestsMixin):
     pass

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -1807,21 +1807,27 @@ class UtilsTestsMixin:
         from pyspark.sql.types import StructType, StructField, DecimalType
 
         # Same precision and scale - should pass
-        s1 = StructType([
-            StructField("price", DecimalType(10, 2), True),
-        ])
+        s1 = StructType(
+            [
+                StructField("price", DecimalType(10, 2), True),
+            ]
+        )
 
-        s1_copy = StructType([
-            StructField("price", DecimalType(10, 2), True),
-        ])
+        s1_copy = StructType(
+            [
+                StructField("price", DecimalType(10, 2), True),
+            ]
+        )
 
         # This should pass
         assertSchemaEqual(s1, s1_copy)
 
         # Different precision and scale - should fail
-        s2 = StructType([
-            StructField("price", DecimalType(12, 4), True),
-        ])
+        s2 = StructType(
+            [
+                StructField("price", DecimalType(12, 4), True),
+            ]
+        )
 
         # This should fail
         with self.assertRaises(PySparkAssertionError):

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -540,6 +540,9 @@ def assertSchemaEqual(
         if dt1.typeName() == dt2.typeName():
             if dt1.typeName() == "array":
                 return compare_datatypes_ignore_nullable(dt1.elementType, dt2.elementType)
+            elif dt1.typeName() == "decimal":
+                # Fix for SPARK-51062: Compare precision and scale for decimal types
+                return dt1.precision == dt2.precision and dt1.scale == dt2.scale
             elif dt1.typeName() == "struct":
                 return compare_schemas_ignore_nullable(dt1, dt2)
             else:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
 This PR modifies the `compare_datatypes_ignore_nullable` function in `python/pyspark/testing/utils.py` to properly check both precision and scale parameters when comparing
   decimal types. It adds a specific case for "decimal" type that compares precision and scale attributes, instead of just checking the type name.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
 This change is needed because the current implementation incorrectly reports schemas with different decimal parameters as equal. This affects data quality validation
  scenarios where decimal precision and scale are critical, such as financial applications and ETL validation. Without this fix, tests using `assertSchemaEqual` would miss
  important schema differences involving decimal fields.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
 No. This change only affects the internal testing utility `assertSchemaEqual`. It doesn't change any user-facing APIs or behaviors.

<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
 Added a test case to `python/pyspark/sql/tests/test_utils.py` that verifies the correct handling of decimal fields with different precision and scale values. The test
  confirms that:
  1. Schemas with identical decimal parameters are considered equal
  2. Schemas with different decimal parameters are correctly identified as different
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
 Generated-by: Claude by Anthropic
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
