### PR TITLE
[SPARK-51592][SQL] Avoid logging makes Driver OOM in AdaptiveSparkPlanExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -352,8 +352,9 @@ case class AdaptiveSparkPlanExec(
           val newCost = costEvaluator.evaluateCost(newPhysicalPlan)
           if (newCost < origCost ||
             (newCost == origCost && currentPhysicalPlan != newPhysicalPlan)) {
-            logOnLevel("Plan changed:\n" +
-              sideBySide(currentPhysicalPlan.treeString, newPhysicalPlan.treeString).mkString("\n"))
+            lazy val plans = sideBySide(
+              currentPhysicalPlan.treeString, newPhysicalPlan.treeString).mkString("\n")
+            logOnLevel("Plan changed:\n" + plans)
             cleanUpTempTags(newPhysicalPlan)
             currentPhysicalPlan = newPhysicalPlan
             currentLogicalPlan = newLogicalPlan


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a lazy evaluation of the side-by-side comparison of the current and new physical plans.

### Why are the changes needed?

Avoid Driver OOM:
```
25/03/24 00:30:34 INFO ApplicationMaster: Final app status: FAILED, exitCode: 15, (reason: User class threw exception: java.lang.OutOfMemoryError: Required array length 2147483639 + 957 is too large
	at java.base/jdk.internal.util.ArraysSupport.hugeLength(ArraysSupport.java:649)
	at java.base/jdk.internal.util.ArraysSupport.newLength(ArraysSupport.java:642)
	at java.base/java.lang.AbstractStringBuilder.newCapacity(AbstractStringBuilder.java:257)
	at java.base/java.lang.AbstractStringBuilder.ensureCapacityInternal(AbstractStringBuilder.java:229)
	at java.base/java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:582)
	at java.base/java.lang.StringBuilder.append(StringBuilder.java:179)
	at scala.collection.mutable.StringBuilder.append(StringBuilder.scala:203)
	at scala.collection.TraversableOnce$appender$1.apply(TraversableOnce.scala:419)
	at scala.collection.TraversableOnce$appender$1.apply(TraversableOnce.scala:410)
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
	at scala.collection.TraversableOnce.addString(TraversableOnce.scala:424)
	at scala.collection.TraversableOnce.addString$(TraversableOnce.scala:407)
	at scala.collection.AbstractTraversable.addString(Traversable.scala:108)
	at scala.collection.TraversableOnce.mkString(TraversableOnce.scala:377)
	at scala.collection.TraversableOnce.mkString$(TraversableOnce.scala:376)
	at scala.collection.AbstractTraversable.mkString(Traversable.scala:108)
	at scala.collection.TraversableOnce.mkString(TraversableOnce.scala:379)
	at scala.collection.TraversableOnce.mkString$(TraversableOnce.scala:379)
	at scala.collection.AbstractTraversable.mkString(Traversable.scala:108)
	at org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec.$anonfun$getFinalPhysicalPlan$8(AdaptiveSparkPlanExec.scala:364)
	at org.apache.spark.internal.Logging.logDebug(Logging.scala:64)
	at org.apache.spark.internal.Logging.logDebug$(Logging.scala:63)
	at org.apache.spark.sql.execution.SparkPlan.logDebug(SparkPlan.scala:65)
	at org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec.$anonfun$logOnLevel$2(AdaptiveSparkPlanExec.scala:82)
	at org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec.$anonfun$logOnLevel$2$adapted(AdaptiveSparkPlanExec.scala:82)
	at org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec.$anonfun$getFinalPhysicalPlan$1(AdaptiveSparkPlanExec.scala:363)
```


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.

### Was this patch authored or co-authored using generative AI tooling?

No.