### PR TITLE
[SPARK-51598][SQL][TEST] Improve the ExpressionsSchemaSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/ExpressionsSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExpressionsSchemaSuite.scala
@@ -187,8 +187,12 @@ class ExpressionsSchemaSuite extends QueryTest with SharedSparkSession {
       "The number of queries not equals the number of expected queries.")
 
     outputs.zip(expectedOutputs).foreach { case (output, expected) =>
-      assert(expected.sql == output.sql, "SQL query did not match")
-      assert(expected.schema == output.schema, s"Schema did not match for query ${expected.sql}")
+      assert(expected.className == output.className, "The expected class name " +
+        s"${expected.className} does not match the output class name ${output.className}")
+      assert(expected.sql == output.sql, "The expected SQL query " +
+        s"${expected.sql} does not match the output SQL query ${output.sql}")
+      assert(expected.schema == output.schema, "The expected schema " +
+        s"${expected.schema} does not match the output schema ${output.schema}")
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to improve the `ExpressionsSchemaSuite`.


### Why are the changes needed?
As time passes, we can register the expression builders into `FunctionRegistry`, such as: `MinuteExpressionBuilder`.
The change causes `ExpressionsSchemaSuite` works not well due to it just compares the schema and sql. We should add the support to compare expression name.

In addition to, I fix some english grammar errors and make them more clearly.


### Does this PR introduce _any_ user-facing change?
'No'.
Just update tests.


### How was this patch tested?
GA and manual tests.
Without https://github.com/apache/spark/pull/50361, developers could see the error show below.
```
[info] ExpressionsSchemaSuite:
10:51:51.174 WARN org.apache.hadoop.util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
[info] - Check schemas for expression examples *** FAILED *** (1 second, 650 milliseconds)
[info]   "...t.expressions.Minute[]" did not equal "...t.expressions.Minute[ExpressionBuilder]" The expected class name org.apache.spark.sql.catalyst.expressions.Minute does not match the output class name org.apache.spark.sql.catalyst.expressions.MinuteExpressionBuilder (ExpressionsSchemaSuite.scala:190)
[info]   Analysis:
[info]   "...t.expressions.Minute[]" -> "...t.expressions.Minute[ExpressionBuilder]"
[info]   org.scalatest.exceptions.TestFailedException:
[info]   at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
[info]   at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
[info]   at org.scalatest.Assertions$.newAssertionFailedException(Assertions.scala:1231)
[info]   at org.scalatest.Assertions$AssertionsHelper.macroAssert(Assertions.scala:1295)
[info]   at org.apache.spark.sql.ExpressionsSchemaSuite.$anonfun$new$12(ExpressionsSchemaSuite.scala:190)
[info]   at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:619)
[info]   at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:617)
[info]   at scala.collection.AbstractIterable.foreach(Iterable.scala:935)
[info]   at org.apache.spark.sql.ExpressionsSchemaSuite.$anonfun$new$1(ExpressionsSchemaSuite.scala:189)
```


### Was this patch authored or co-authored using generative AI tooling?
'No'.
