### PR TITLE
[SPARK-51404][SQL] Parse the `time(n)` type as `TimeType(n)`

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -174,7 +174,7 @@ object DataType {
   def fromJson(json: String): DataType = parseDataType(parse(json))
 
   private val otherTypes = {
-    Seq(
+    (Seq(
       NullType,
       DateType,
       TimestampType,
@@ -202,7 +202,8 @@ object DataType {
       YearMonthIntervalType(MONTH),
       YearMonthIntervalType(YEAR, MONTH),
       TimestampNTZType,
-      VariantType)
+      VariantType) ++
+      (TimeType.MIN_PRECISION to TimeType.MAX_PRECISION).map(TimeType(_)))
       .map(t => t.typeName -> t)
       .toMap
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support parsing `time(n)` as `TimeType(n)` in schema JSON or DDL string. It also add tests for parsing "time(n)" in JSON/DDL.

### Why are the changes needed?
The changes is required by other parts of Spark SQL to support new data type.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
By running the modified test suite:
```
$ build/sbt "test:testOnly *DataTypeSuite"
```


### Was this patch authored or co-authored using generative AI tooling?
No.
