### PR TITLE
[MINOR][SPARK-51525][FOLLOWUP][SQL] Desc As JSON test for top-level default collation field

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DescribeTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DescribeTableSuiteBase.scala
@@ -319,3 +319,67 @@ trait DescribeTableSuiteBase extends QueryTest with DDLCommandTestUtils {
     }
   }
 }
+
+/** Represents JSON output of DESCRIBE TABLE AS JSON */
+case class DescribeTableJson(
+    table_name: Option[String] = None,
+    catalog_name: Option[String] = None,
+    namespace: Option[List[String]] = Some(Nil),
+    schema_name: Option[String] = None,
+    columns: Option[List[TableColumn]] = Some(Nil),
+    created_time: Option[String] = None,
+    last_access: Option[String] = None,
+    created_by: Option[String] = None,
+    `type`: Option[String] = None,
+    collation: Option[String] = None,
+    provider: Option[String] = None,
+    bucket_columns: Option[List[String]] = Some(Nil),
+    sort_columns: Option[List[String]] = Some(Nil),
+    comment: Option[String] = None,
+    table_properties: Option[Map[String, String]] = None,
+    location: Option[String] = None,
+    serde_library: Option[String] = None,
+    storage_properties: Option[Map[String, String]] = None,
+    partition_provider: Option[String] = None,
+    partition_columns: Option[List[String]] = Some(Nil),
+    partition_values: Option[Map[String, String]] = None,
+    clustering_columns: Option[List[String]] = None,
+    statistics: Option[Map[String, Any]] = None,
+    view_text: Option[String] = None,
+    view_original_text: Option[String] = None,
+    view_schema_mode: Option[String] = None,
+    view_catalog_and_namespace: Option[String] = None,
+    view_query_output_columns: Option[List[String]] = None
+)
+
+/** Used for columns field of DescribeTableJson */
+case class TableColumn(
+    name: String,
+    `type`: Type,
+    element_nullable: Boolean = true,
+    comment: Option[String] = None,
+    default: Option[String] = None
+)
+
+case class Type(
+    name: String,
+    collation: Option[String] = None,
+    fields: Option[List[Field]] = None,
+    `type`: Option[Type] = None,
+    element_type: Option[Type] = None,
+    key_type: Option[Type] = None,
+    value_type: Option[Type] = None,
+    comment: Option[String] = None,
+    default: Option[String] = None,
+    element_nullable: Option[Boolean] = Some(true),
+    value_nullable: Option[Boolean] = Some(true),
+    nullable: Option[Boolean] = Some(true)
+)
+
+case class Field(
+    name: String,
+    `type`: Type,
+    element_nullable: Boolean = true,
+    comment: Option[String] = None,
+    default: Option[String] = None
+)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.SPARK_VERSION
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.execution.command
+import org.apache.spark.sql.execution.command.{DescribeTableJson, Field, TableColumn, Type}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StringType
 
@@ -850,67 +851,3 @@ class DescribeTableSuite extends DescribeTableSuiteBase with CommandSuiteBase {
     }
   }
 }
-
-/** Represents JSON output of DESCRIBE TABLE AS JSON */
-case class DescribeTableJson(
-    table_name: Option[String] = None,
-    catalog_name: Option[String] = None,
-    namespace: Option[List[String]] = Some(Nil),
-    schema_name: Option[String] = None,
-    columns: Option[List[TableColumn]] = Some(Nil),
-    created_time: Option[String] = None,
-    last_access: Option[String] = None,
-    created_by: Option[String] = None,
-    `type`: Option[String] = None,
-    collation: Option[String] = None,
-    provider: Option[String] = None,
-    bucket_columns: Option[List[String]] = Some(Nil),
-    sort_columns: Option[List[String]] = Some(Nil),
-    comment: Option[String] = None,
-    table_properties: Option[Map[String, String]] = None,
-    location: Option[String] = None,
-    serde_library: Option[String] = None,
-    storage_properties: Option[Map[String, String]] = None,
-    partition_provider: Option[String] = None,
-    partition_columns: Option[List[String]] = Some(Nil),
-    partition_values: Option[Map[String, String]] = None,
-    clustering_columns: Option[List[String]] = None,
-    statistics: Option[Map[String, Any]] = None,
-    view_text: Option[String] = None,
-    view_original_text: Option[String] = None,
-    view_schema_mode: Option[String] = None,
-    view_catalog_and_namespace: Option[String] = None,
-    view_query_output_columns: Option[List[String]] = None
-  )
-
-/** Used for columns field of DescribeTableJson */
-case class TableColumn(
-  name: String,
-  `type`: Type,
-  element_nullable: Boolean = true,
-  comment: Option[String] = None,
-  default: Option[String] = None
-)
-
-case class Type(
-   name: String,
-   collation: Option[String] = None,
-   fields: Option[List[Field]] = None,
-   `type`: Option[Type] = None,
-   element_type: Option[Type] = None,
-   key_type: Option[Type] = None,
-   value_type: Option[Type] = None,
-   comment: Option[String] = None,
-   default: Option[String] = None,
-   element_nullable: Option[Boolean] = Some(true),
-   value_nullable: Option[Boolean] = Some(true),
-   nullable: Option[Boolean] = Some(true)
-)
-
-case class Field(
-  name: String,
-  `type`: Type,
-  element_nullable: Boolean = true,
-  comment: Option[String] = None,
-  default: Option[String] = None
-)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Follow-up to https://github.com/apache/spark/pull/50290. Add a test that Desc As JSON includes a top-level field `collation` when a default table collation is specified. 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Test that Desc As JSON supports default table collation in addition to column collations.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added test in DescribeTableSuite


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No