### PR TITLE
[SPARK-51118][TESTS][FOLLOWUP][4.0] Move test_udf_with_udt to BaseUDFTestsMixin

### DIFF
--- a/python/pyspark/sql/tests/connect/arrow/test_parity_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/connect/arrow/test_parity_arrow_python_udf.py
@@ -16,10 +16,10 @@
 #
 
 from pyspark.sql.tests.connect.test_parity_udf import UDFParityTests
-from pyspark.sql.tests.arrow.test_arrow_python_udf import PythonUDFArrowTestsMixin
+from pyspark.sql.tests.arrow.test_arrow_python_udf import ArrowPythonUDFTestsMixin
 
 
-class ArrowPythonUDFParityTests(UDFParityTests, PythonUDFArrowTestsMixin):
+class ArrowPythonUDFParityTests(UDFParityTests, ArrowPythonUDFTestsMixin):
     @classmethod
     def setUpClass(cls):
         super(ArrowPythonUDFParityTests, cls).setUpClass()

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -45,6 +45,8 @@ from pyspark.sql.types import (
 )
 from pyspark.errors import AnalysisException, PythonException, PySparkTypeError
 from pyspark.testing.sqlutils import (
+    ExamplePoint,
+    ExamplePointUDT,
     ReusedSQLTestCase,
     test_compiled,
     test_not_compiled_message,
@@ -1241,6 +1243,115 @@ class BaseUDFTestsMixin(object):
             errorClass="NOT_INT",
             messageParameters={"arg_name": "evalType", "arg_type": "str"},
         )
+
+    def test_timeout_util_with_udf(self):
+        @udf
+        def f(x):
+            time.sleep(10)
+            return str(x)
+
+        @timeout(1)
+        def timeout_func():
+            self.spark.range(1).select(f("id")).show()
+
+        # causing a py4j.protocol.Py4JNetworkError in pyspark classic
+        # causing a TimeoutError in pyspark connect
+        with self.assertRaises(Exception):
+            timeout_func()
+
+    def test_udf_with_udt(self):
+        row = Row(
+            label=1.0,
+            point=ExamplePoint(1.0, 2.0),
+            points=[ExamplePoint(4.0, 5.0), ExamplePoint(6.0, 7.0)],
+        )
+        df = self.spark.createDataFrame([row])
+
+        @udf(returnType=ExamplePointUDT())
+        def doubleInUDTOut(d):
+            return ExamplePoint(d, 10 * d)
+
+        @udf(returnType=DoubleType())
+        def udtInDoubleOut(e):
+            return e.y
+
+        @udf(returnType=ArrayType(ExamplePointUDT()))
+        def doubleInUDTArrayOut(d):
+            return [ExamplePoint(d + i, 10 * d + i) for i in range(2)]
+
+        @udf(returnType=DoubleType())
+        def udtArrayInDoubleOut(es):
+            return es[-1].y
+
+        @udf(returnType=ExamplePointUDT())
+        def udtInUDTOut(e):
+            return ExamplePoint(e.x * 10.0, e.y * 10.0)
+
+        @udf(returnType=DoubleType())
+        def doubleInDoubleOut(d):
+            return d * 100.0
+
+        queries = [
+            (
+                "double -> UDT",
+                df.select(doubleInUDTOut(df.label)),
+                [Row(ExamplePoint(1.0, 10.0))],
+            ),
+            (
+                "UDT -> double",
+                df.select(udtInDoubleOut(df.point)),
+                [Row(2.0)],
+            ),
+            (
+                "double -> array of UDT",
+                df.select(doubleInUDTArrayOut(df.label)),
+                [Row([ExamplePoint(1.0, 10.0), ExamplePoint(2.0, 11.0)])],
+            ),
+            (
+                "array of UDT -> double",
+                df.select(udtArrayInDoubleOut(df.points)),
+                [Row(7.0)],
+            ),
+            (
+                "double -> UDT -> double",
+                df.select(udtInDoubleOut(doubleInUDTOut(df.label))),
+                [Row(10.0)],
+            ),
+            (
+                "double -> UDT -> UDT",
+                df.select(udtInUDTOut(doubleInUDTOut(df.label))),
+                [Row(ExamplePoint(10.0, 100.0))],
+            ),
+            (
+                "double -> double -> UDT",
+                df.select(doubleInUDTOut(doubleInDoubleOut(df.label))),
+                [Row(ExamplePoint(100.0, 1000.0))],
+            ),
+            (
+                "UDT -> UDT -> double",
+                df.select(udtInDoubleOut(udtInUDTOut(df.point))),
+                [Row(20.0)],
+            ),
+            (
+                "UDT -> UDT -> UDT",
+                df.select(udtInUDTOut(udtInUDTOut(df.point))),
+                [Row(ExamplePoint(100.0, 200.0))],
+            ),
+            (
+                "UDT -> double -> double",
+                df.select(doubleInDoubleOut(udtInDoubleOut(df.point))),
+                [Row(200.0)],
+            ),
+            (
+                "UDT -> double -> UDT",
+                df.select(doubleInUDTOut(udtInDoubleOut(df.point))),
+                [Row(ExamplePoint(2.0, 20.0))],
+            ),
+        ]
+
+        for chain, actual, expected in queries:
+            with self.subTest(chain=chain):
+                assertDataFrameEqual(actual=actual, expected=expected)
 
 
 class UDFTests(BaseUDFTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -1244,21 +1244,6 @@ class BaseUDFTestsMixin(object):
             messageParameters={"arg_name": "evalType", "arg_type": "str"},
         )
 
-    def test_timeout_util_with_udf(self):
-        @udf
-        def f(x):
-            time.sleep(10)
-            return str(x)
-
-        @timeout(1)
-        def timeout_func():
-            self.spark.range(1).select(f("id")).show()
-
-        # causing a py4j.protocol.Py4JNetworkError in pyspark classic
-        # causing a TimeoutError in pyspark connect
-        with self.assertRaises(Exception):
-            timeout_func()
-
     def test_udf_with_udt(self):
         row = Row(
             label=1.0,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a backport of #50392.

Move `test_udf_with_udt` to `BaseUDFTestsMixin`.

### Why are the changes needed?

These tests should be shared properly.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The moved tests should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.
