### PR TITLE
[Core]Convert shuffleWriteTime from Nanoseconds to Milliseconds for Consistency with Other Metrics

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.channels.FileChannel;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.Checksum;
 import javax.annotation.Nullable;
 
@@ -232,7 +233,8 @@ final class BypassMergeSortShuffleWriter<K, V>
           }
         }
       } finally {
-        writeMetrics.incWriteTime(System.nanoTime() - writeStartTime);
+        long writeTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - writeStartTime);
+        writeMetrics.incWriteTime(writeTime);
       }
       partitionWriters = null;
     }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
@@ -25,6 +25,7 @@ import java.io.*;
 import java.nio.channels.FileChannel;
 import java.nio.channels.WritableByteChannel;
 import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
 
 import scala.Option;
 import scala.Product2;
@@ -472,7 +473,8 @@ public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
                 partitionLengthInSpill);
             copyThrewException = false;
             spillInputChannelPositions[i] += partitionLengthInSpill;
-            writeMetrics.incWriteTime(System.nanoTime() - writeStartTime);
+            long writeTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - writeStartTime);
+            writeMetrics.incWriteTime(writeTime);
           }
         } finally {
           Closeables.close(resolvedChannel, copyThrewException);

--- a/core/src/main/java/org/apache/spark/storage/TimeTrackingOutputStream.java
+++ b/core/src/main/java/org/apache/spark/storage/TimeTrackingOutputStream.java
@@ -19,6 +19,7 @@ package org.apache.spark.storage;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.spark.annotation.Private;
 import org.apache.spark.shuffle.ShuffleWriteMetricsReporter;
@@ -43,34 +44,39 @@ public final class TimeTrackingOutputStream extends OutputStream {
   public void write(int b) throws IOException {
     final long startTime = System.nanoTime();
     outputStream.write(b);
-    writeMetrics.incWriteTime(System.nanoTime() - startTime);
+    long writeTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+    writeMetrics.incWriteTime(writeTime);
   }
 
   @Override
   public void write(byte[] b) throws IOException {
     final long startTime = System.nanoTime();
     outputStream.write(b);
-    writeMetrics.incWriteTime(System.nanoTime() - startTime);
+    long writeTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+    writeMetrics.incWriteTime(writeTime);
   }
 
   @Override
   public void write(byte[] b, int off, int len) throws IOException {
     final long startTime = System.nanoTime();
     outputStream.write(b, off, len);
-    writeMetrics.incWriteTime(System.nanoTime() - startTime);
+    long writeTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+    writeMetrics.incWriteTime(writeTime);
   }
 
   @Override
   public void flush() throws IOException {
     final long startTime = System.nanoTime();
     outputStream.flush();
-    writeMetrics.incWriteTime(System.nanoTime() - startTime);
+    long writeTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+    writeMetrics.incWriteTime(writeTime);
   }
 
   @Override
   public void close() throws IOException {
     final long startTime = System.nanoTime();
     outputStream.close();
-    writeMetrics.incWriteTime(System.nanoTime() - startTime);
+    long writeTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+    writeMetrics.incWriteTime(writeTime);
   }
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
@@ -18,12 +18,14 @@
 package org.apache.spark.shuffle.sort
 
 import org.apache.spark._
-import org.apache.spark.internal.{config, Logging}
+import org.apache.spark.internal.{Logging, config}
 import org.apache.spark.scheduler.MapStatus
 import org.apache.spark.shuffle.{BaseShuffleHandle, ShuffleWriter}
 import org.apache.spark.shuffle.ShuffleWriteMetricsReporter
 import org.apache.spark.shuffle.api.ShuffleExecutorComponents
 import org.apache.spark.util.collection.ExternalSorter
+
+import java.util.concurrent.TimeUnit
 
 private[spark] class SortShuffleWriter[K, V, C](
     handle: BaseShuffleHandle[K, V, C],
@@ -89,7 +91,8 @@ private[spark] class SortShuffleWriter[K, V, C](
       if (sorter != null) {
         val startTime = System.nanoTime()
         sorter.stop()
-        writeMetrics.incWriteTime(System.nanoTime - startTime)
+        val writeTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime - startTime)
+        writeMetrics.incWriteTime(writeTime)
         sorter = null
       }
     }

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
@@ -21,7 +21,6 @@ import java.io.{BufferedOutputStream, File, FileOutputStream, IOException, Outpu
 import java.nio.channels.{ClosedByInterruptException, FileChannel}
 import java.nio.file.Files
 import java.util.zip.Checksum
-
 import org.apache.spark.SparkException
 import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.internal.{Logging, MDC}
@@ -31,6 +30,8 @@ import org.apache.spark.serializer.{SerializationStream, SerializerInstance, Ser
 import org.apache.spark.shuffle.ShuffleWriteMetricsReporter
 import org.apache.spark.util.Utils
 import org.apache.spark.util.collection.PairsWriter
+
+import java.util.concurrent.TimeUnit
 
 /**
  * A class for writing JVM objects directly to a file on disk. This class allows data to be appended
@@ -246,7 +247,8 @@ private[spark] class DiskBlockObjectWriter(
         // Force outstanding writes to disk and track how long it takes
         val start = System.nanoTime()
         fos.getFD.sync()
-        writeMetrics.incWriteTime(System.nanoTime() - start)
+        val writeTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime - start)
+        writeMetrics.incWriteTime(writeTime)
       }
 
       val pos = channel.position()


### PR DESCRIPTION
### What changes were proposed in this pull request?
• Convert shuffleWriteTime from nanoseconds to milliseconds by dividing its value by 1,000,000.
• Ensure that shuffleWriteTime now uses the same unit as other related metrics (fetchReadTime, jvmGCTime, SerializationTime, and DeserializeTime) to provide better consistency and reduce potential confusion.