### PR TITLE
[Spark-50873][SQL] Prune column after RewriteSubquery rule for DSV2

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.execution.datasources.{PruneFileSourcePartitions, PushVariantIntoScan, SchemaPruning, V1Writes}
-import org.apache.spark.sql.execution.datasources.v2.{GroupBasedRowLevelOperationScanPlanning, OptimizeMetadataOnlyDeleteFromTable, V2ScanPartitioningAndOrdering, V2ScanRelationPushDown, V2Writes}
+import org.apache.spark.sql.execution.datasources.v2.{GroupBasedRowLevelOperationScanPlanning, OptimizeMetadataOnlyDeleteFromTable, V2PruneColumnAfterRewriteSubquery, V2ScanPartitioningAndOrdering, V2ScanRelationPushDown, V2Writes}
 import org.apache.spark.sql.execution.dynamicpruning.{CleanupDynamicPruningFilters, PartitionPruning, RowLevelOperationRuntimeGroupFiltering}
 import org.apache.spark.sql.execution.python.{ExtractGroupingPythonUDFFromAggregate, ExtractPythonUDFFromAggregate, ExtractPythonUDFs, ExtractPythonUDTFs}
 
@@ -95,6 +95,8 @@ class SparkOptimizer(
       LimitPushDownThroughWindow,
       EliminateLimits,
       ConstantFolding),
+    Batch("Prune column after RewriteSubquery for DSV2", Once,
+      V2PruneColumnAfterRewriteSubquery),
     Batch("User Provided Optimizers", fixedPoint, experimentalMethods.extraOptimizations: _*),
     Batch("Replace CTE with Repartition", Once, ReplaceCTERefWithRepartition)))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2PruneColumnAfterRewriteSubquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2PruneColumnAfterRewriteSubquery.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additiosnal information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.planning.ScanOperation
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project, V2WriteCommand}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.datasources.DataSourceStrategy
+import org.apache.spark.sql.util.SchemaUtils.restoreOriginalOutputNames
+
+object V2PruneColumnAfterRewriteSubquery extends Rule[LogicalPlan] with Logging {
+  import DataSourceV2Implicits._
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    if (plan.isInstanceOf[V2WriteCommand]) return plan
+    plan.transform {
+      case ScanOperation(project, filtersStayUp, filtersPushDown, dssr: DataSourceV2ScanRelation)
+        if needPrune(project, filtersStayUp, filtersPushDown, dssr) =>
+        val r = dssr.relation;
+        val sHolder = ScanBuilderHolder(r.output, r, r.table.asReadable.newScanBuilder(r.options))
+        val normalizedProjects = DataSourceStrategy
+          .normalizeExprs(project, sHolder.output)
+          .asInstanceOf[Seq[NamedExpression]]
+        val allFilters = filtersPushDown.reduceOption(And).toSeq ++ filtersStayUp
+
+        val normalizedFilters = DataSourceStrategy.normalizeExprs(allFilters, sHolder.output)
+        val (scan, output) = PushDownUtils.pruneColumns(
+          sHolder.builder, sHolder.relation, normalizedProjects, normalizedFilters)
+
+        val scanRelation = if (scan.readSchema().equals(dssr.scan.readSchema())) {
+          dssr
+        } else {
+          DataSourceV2ScanRelation(sHolder.relation, scan, output)
+        }
+
+        val projectionOverSchema =
+          ProjectionOverSchema(output.toStructType, AttributeSet(output))
+        val projectionFunc = (expr: Expression) => expr transformDown {
+          case projectionOverSchema(newExpr) => newExpr
+        }
+
+        val finalFilters = normalizedFilters.map(projectionFunc)
+        val withFilter = finalFilters.foldLeft[LogicalPlan](scanRelation)((plan, cond) => {
+          Filter(cond, plan)
+        })
+
+        if (withFilter.output != project) {
+          val newProjects = normalizedProjects
+            .map(projectionFunc)
+            .asInstanceOf[Seq[NamedExpression]]
+          Project(restoreOriginalOutputNames(newProjects, project.map(_.name)), withFilter)
+        } else {
+          withFilter
+        }
+    }
+  }
+
+  private def needPrune(
+      projects: Seq[NamedExpression],
+      filtersStayUp: Seq[Expression],
+      filtersPushDown: Seq[Expression],
+      dssr: DataSourceV2ScanRelation): Boolean = {
+    dssr.scan match {
+      case v1: V1ScanWrapper if v1.pushedDownOperators.aggregation.isDefined =>
+        false
+      case _ =>
+        val allFilters = filtersPushDown.reduceOption(And).toSeq ++ filtersStayUp
+        val exprs = projects ++ allFilters
+        val requiredColumns = AttributeSet(exprs.flatMap(_.references))
+        requiredColumns.nonEmpty && !AttributeSet(dssr.output).equals(requiredColumns)
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2PruneColumnAfterRewriteSubquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2PruneColumnAfterRewriteSubquery.scala
@@ -1,7 +1,7 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additiosnal information regarding copyright ownership.
+ * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
@@ -27,6 +27,7 @@ import org.apache.spark.sql.util.SchemaUtils.restoreOriginalOutputNames
 
 object V2PruneColumnAfterRewriteSubquery extends Rule[LogicalPlan] with Logging {
   import DataSourceV2Implicits._
+
   override def apply(plan: LogicalPlan): LogicalPlan = {
     if (plan.isInstanceOf[V2WriteCommand]) return plan
     plan.transform {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR offers an optimize rule for SparkOptimizer to prune unnecessary column for DataSourceV2 (DSV2) after RewriteSubquery. 
Spark 3 use V2ScanRelationPushDown rule to prune column for DSV2. However, if there are subquerys in the qeuery sql, RewriteSubery rule will be generated new predicates which can be use to prune column after executed V2ScanRelationPushDown, but Spark does not prune column again which cause lower performance.
See the issue for more detail description : [SPARK-50873](https://issues.apache.org/jira/browse/SPARK-50873)

### Why are the changes needed?
A better performance for Spark DSV2. 
For example, in 10T TPCDS test, the query16 execution time will be reduced by 50% from 2.5min to 1.3min in my cluster. 


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
 GitHub Actions.

### Was this patch authored or co-authored using generative AI tooling?
No.
