### PR TITLE
[SPARK-51607][CONNECT][BUILD] Set `combine.self = "override"` to configuration of `maven-shade-plugin` in `connect` modules

### DIFF
--- a/sql/connect/client/jvm/pom.xml
+++ b/sql/connect/client/jvm/pom.xml
@@ -143,7 +143,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <configuration>
+        <configuration combine.self = "override">
           <shadedArtifactAttached>false</shadedArtifactAttached>
           <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
           <artifactSet>

--- a/sql/connect/common/pom.xml
+++ b/sql/connect/common/pom.xml
@@ -136,7 +136,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <configuration>
+                <configuration combine.self = "override">
                     <shadedArtifactAttached>false</shadedArtifactAttached>
                     <artifactSet>
                         <includes>

--- a/sql/connect/server/pom.xml
+++ b/sql/connect/server/pom.xml
@@ -306,7 +306,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <configuration>
+        <configuration combine.self = "override">
           <shadedArtifactAttached>false</shadedArtifactAttached>
           <artifactSet>
             <includes>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Similar to the situation in SPARK-50166, for modules that have independently configured shading and relocation rules, the `configuration` tag of `maven-shade-plugin` should be set with `combine.self = "override"`. This pull request makes similar modifications to three modules related to connect.

### Why are the changes needed?
Avoid the `maven-shade-plugin` configuration in connect-related modules from being affected by the default configuration in the parent `pom.xml`. 

For example, before this pull request, the `com.google.common.cache.{CacheBuilder, CacheLoader}` referenced in `org.apache.spark.sql.connect.SparkSession` was relocated to `org/sparkproject/guava` (as configured in the parent `pom.xml`) instead of the desired `org/sparkproject/connect/guava`. We can verify this by unpacking the resulting jar and using the `grep` command:

```
grep -R "org/sparkproject/guava" *
Binary file tmp/org/apache/spark/connect/proto/SparkConnectServiceGrpc$SparkConnectServiceFutureStub.class matches
Binary file tmp/org/apache/spark/sql/connect/SparkSession$Builder.class matches
Binary file tmp/org/apache/spark/sql/connect/SparkSession$.class matches
Binary file tmp/org/apache/spark/sql/connect/SparkSession$$anon$1.class matches
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Git Hub Acitons
- build a client using dev/make-distribution.sh --tgz -Phive with this pr, checked `bin/spark-shell --remote local`

### Was this patch authored or co-authored using generative AI tooling?
No