### PR TITLE
[SPARK-51252][SS][TESTS] Make tests more consistent for StateStoreInstanceMetricSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreInstanceMetricSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreInstanceMetricSuite.scala
@@ -88,6 +88,8 @@ class StateStoreInstanceMetricSuite extends StreamTest with AlsoTestWithRocksDBF
               ProcessAllAvailable(),
               AddData(inputData, "b"),
               ProcessAllAvailable(),
+              AddData(inputData, "b"),
+              ProcessAllAvailable(),
               CheckNewAnswer("a", "b"),
               Execute { q =>
                 // Make sure only smallest K active metrics are published
@@ -104,7 +106,7 @@ class StateStoreInstanceMetricSuite extends StreamTest with AlsoTestWithRocksDBF
                       .get(SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT)
                   )
                   // All state store instances should have uploaded a version
-                  assert(instanceMetrics.forall(_._2 == 2))
+                  assert(instanceMetrics.forall(_._2 >= 0))
                 }
               },
               StopStream
@@ -150,6 +152,8 @@ class StateStoreInstanceMetricSuite extends StreamTest with AlsoTestWithRocksDBF
               ProcessAllAvailable(),
               AddData(inputData, "b"),
               ProcessAllAvailable(),
+              AddData(inputData, "b"),
+              ProcessAllAvailable(),
               CheckNewAnswer("a", "b"),
               Execute { q =>
                 // Partitions getting skipped (id 0 and 1) do not have an uploaded version, leaving
@@ -179,10 +183,10 @@ class StateStoreInstanceMetricSuite extends StreamTest with AlsoTestWithRocksDBF
                     instanceMetrics.size == q.sparkSession.conf
                       .get(SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT)
                   )
-                  // Two metrics published are -1, the remainder should all be set to version 2
-                  // as they uploaded properly.
+                  // Two metrics published are -1, but the remainder should all be set to a
+                  // non-negative version as they uploaded properly.
                   assert(
-                    instanceMetrics.count(_._2 == 2) == q.sparkSession.conf
+                    instanceMetrics.count(_._2 >= 0) == q.sparkSession.conf
                       .get(SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT) - 2
                   )
                 }
@@ -209,7 +213,8 @@ class StateStoreInstanceMetricSuite extends StreamTest with AlsoTestWithRocksDBF
           SQLConf.STREAMING_NO_DATA_PROGRESS_EVENT_INTERVAL.key -> "10",
           SQLConf.STATE_STORE_MAINTENANCE_SHUTDOWN_TIMEOUT.key -> "3",
           SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.key -> "1",
-          SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT.key -> "10"
+          SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT.key -> "10",
+          SQLConf.SHUFFLE_PARTITIONS.key -> "3"
         ) {
           withTempDir { checkpointDir =>
             val input1 = MemoryStream[Int]
@@ -229,7 +234,12 @@ class StateStoreInstanceMetricSuite extends StreamTest with AlsoTestWithRocksDBF
               ProcessAllAvailable(),
               AddData(input1, 2, 3),
               ProcessAllAvailable(),
-              CheckNewAnswer((1, 2, 1, 3), (5, 10, 5, 15)),
+              AddData(input1, 2),
+              ProcessAllAvailable(),
+              AddData(input2, 3),
+              ProcessAllAvailable(),
+              AddData(input1, 4),
+              ProcessAllAvailable(),
               Execute { q =>
                 eventually(timeout(10.seconds)) {
                   // Make sure only smallest K active metrics are published.
@@ -247,7 +257,7 @@ class StateStoreInstanceMetricSuite extends StreamTest with AlsoTestWithRocksDBF
                       .get(SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT)
                   )
                   // All state store instances should have uploaded a version
-                  assert(instanceMetrics.forall(_._2 == 2))
+                  assert(instanceMetrics.forall(_._2 >= 0))
                 }
               },
               StopStream
@@ -300,7 +310,12 @@ class StateStoreInstanceMetricSuite extends StreamTest with AlsoTestWithRocksDBF
               ProcessAllAvailable(),
               AddData(input1, 2, 3),
               ProcessAllAvailable(),
-              CheckNewAnswer((1, 2, 1, 3), (5, 10, 5, 15)),
+              AddData(input1, 2),
+              ProcessAllAvailable(),
+              AddData(input2, 3),
+              ProcessAllAvailable(),
+              AddData(input1, 4),
+              ProcessAllAvailable(),
               Execute { q =>
                 eventually(timeout(10.seconds)) {
                   // Make sure only smallest K active metrics are published.
@@ -326,7 +341,7 @@ class StateStoreInstanceMetricSuite extends StreamTest with AlsoTestWithRocksDBF
                   assert(badInstanceMetrics.count(_._2 == -1) == 2 * 4)
                   // The rest should have uploaded a version
                   assert(
-                    allInstanceMetrics.count(_._2 == 2) == q.sparkSession.conf
+                    allInstanceMetrics.count(_._2 >= 0) == q.sparkSession.conf
                       .get(SQLConf.STATE_STORE_INSTANCE_METRICS_REPORT_LIMIT) - 2 * 4
                   )
                 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreInstanceMetricSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreInstanceMetricSuite.scala
@@ -243,7 +243,7 @@ class StateStoreInstanceMetricSuite extends StreamTest with AlsoTestWithRocksDBF
               Execute { q =>
                 eventually(timeout(10.seconds)) {
                   // Make sure only smallest K active metrics are published.
-                  // There are 5 * 4 = 20 metrics in total because of join, but only 10
+                  // There are 3 * 4 = 12 metrics in total because of join, but only 10
                   // are published.
                   val instanceMetrics = q.lastProgress
                     .stateOperators(0)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

SPARK-51252

Fix for flaky tests described in #50030. 

This PR relaxes the version check in the tests and processes more data in queries to force more batches.

I also reduced the number of shuffle partitions for one of the join queries because there used to be 5 * 4 state stores that would need a snapshot to upload in a short time span. Now there's only 3 * 4 stores to deal with.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The tests previously introduced in #50030 are quite flaky depending on the environment, resulting in CI gates failing some tests in the suite.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Re-ran and verified the tests multiple times locally, but primarily using the current merge gates to see if these pass properly.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.