### PR TITLE
[SPARK-51612][SQL] Display Spark confs set at view creation in Desc As Json

### DIFF
--- a/docs/sql-ref-syntax-aux-describe-table.md
+++ b/docs/sql-ref-syntax-aux-describe-table.md
@@ -106,7 +106,7 @@ to return the metadata pertaining to a partition or column respectively.
       "view_catalog_and_namespace": "<view_catalog_and_namespace>",
       "view_query_output_columns": ["col1", "col2"],
       // Spark SQL configurations captured at the time of permanent view creation
-      "view_creation_confs": {
+      "view_creation_spark_configuration": {
         "conf1": "<value1>",
         "conf2": "<value2>"
       },

--- a/docs/sql-ref-syntax-aux-describe-table.md
+++ b/docs/sql-ref-syntax-aux-describe-table.md
@@ -105,6 +105,11 @@ to return the metadata pertaining to a partition or column respectively.
       "view_schema_mode": "<view_schema_mode>",
       "view_catalog_and_namespace": "<view_catalog_and_namespace>",
       "view_query_output_columns": ["col1", "col2"],
+      // Spark SQL configurations captured at the time of permanent view creation
+      "view_creation_confs": {
+        "conf1": "<value1>",
+        "conf2": "<value2>"
+      },
       "comment": "<comment>",
       "table_properties": {
         "property1": "<property1>",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DescribeRelationJsonCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DescribeRelationJsonCommand.scala
@@ -74,6 +74,7 @@ case class DescribeRelationJsonCommand(
         describeIdentifier(v.identifier.toQualifiedNameParts(v.catalog), jsonMap)
         describeColsJson(v.metadata.schema, jsonMap)
         describeFormattedTableInfoJson(v.metadata, jsonMap)
+        describeViewSqlConfsJson(v.metadata, jsonMap)
 
       case ResolvedTable(catalog, identifier, V1Table(metadata), _) =>
         describeIdentifier(identifier.toQualifiedNameParts(catalog), jsonMap)
@@ -240,6 +241,17 @@ case class DescribeRelationJsonCommand(
     val columnsJson = jsonType(StructType(schema.fields))
       .asInstanceOf[JObject].find(_.isInstanceOf[JArray]).get
     addKeyValueToMap("columns", columnsJson, jsonMap)
+  }
+
+  /** Display SQL confs set at time of view creation */
+  private def describeViewSqlConfsJson(
+      table: CatalogTable,
+      jsonMap: mutable.LinkedHashMap[String, JValue]): Unit = {
+    val viewConfigs: Map[String, String] = table.viewSQLConfigs
+    val viewConfigsJson: JValue = JObject(viewConfigs.map { case (key, value) =>
+      key -> JString(value)
+    }.toList)
+    addKeyValueToMap("view_creation_confs", viewConfigsJson, jsonMap)
   }
 
   private def describeClusteringInfoJson(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DescribeRelationJsonCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DescribeRelationJsonCommand.scala
@@ -251,7 +251,7 @@ case class DescribeRelationJsonCommand(
     val viewConfigsJson: JValue = JObject(viewConfigs.map { case (key, value) =>
       key -> JString(value)
     }.toList)
-    addKeyValueToMap("view_creation_confs", viewConfigsJson, jsonMap)
+    addKeyValueToMap("view_creation_spark_configuration", viewConfigsJson, jsonMap)
   }
 
   private def describeClusteringInfoJson(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DescribeTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DescribeTableSuiteBase.scala
@@ -350,7 +350,7 @@ case class DescribeTableJson(
     view_schema_mode: Option[String] = None,
     view_catalog_and_namespace: Option[String] = None,
     view_query_output_columns: Option[List[String]] = None,
-    view_creation_confs: Option[Map[String, String]] = None
+    view_creation_spark_configuration: Option[Map[String, String]] = None
 )
 
 /** Used for columns field of DescribeTableJson */

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DescribeTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DescribeTableSuiteBase.scala
@@ -349,7 +349,8 @@ case class DescribeTableJson(
     view_original_text: Option[String] = None,
     view_schema_mode: Option[String] = None,
     view_catalog_and_namespace: Option[String] = None,
-    view_query_output_columns: Option[List[String]] = None
+    view_query_output_columns: Option[List[String]] = None,
+    view_creation_confs: Option[Map[String, String]] = None
 )
 
 /** Used for columns field of DescribeTableJson */

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
@@ -583,14 +583,15 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
             table_properties = None,
             storage_properties = None,
             serde_library = None,
-            view_creation_confs = None
+            view_creation_spark_configuration = None
           ))
           // assert output contains Spark confs set at view creation
           if (!isTemp) {
-            assert(parsedOutput.view_creation_confs.get("spark.sql.ansi.enabled") == "false")
-            assert(parsedOutput.view_creation_confs
+            assert(parsedOutput.view_creation_spark_configuration
+              .get("spark.sql.ansi.enabled") == "false")
+            assert(parsedOutput.view_creation_spark_configuration
               .get("spark.sql.parquet.enableVectorizedReader") == "true")
-            assert(parsedOutput.view_creation_confs
+            assert(parsedOutput.view_creation_spark_configuration
               .get("spark.sql.sources.fileCompressionFactor") == "2.0")
           }
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Include Spark confs captured at the time of view creation in `Desc As Json` output.

Example output (new field `view_creation_confs` at bottom):
```
{
  "table_name": "view",
  "catalog_name": "spark_catalog",
  "namespace": [
    "default"
  ],
  "schema_name": "default",
  "columns": [
    {
      "name": "id",
      "type": {
        "name": "int"
      },
      "nullable": true
    },
    {
      "name": "name",
      "type": {
        "name": "string",
        "collation": "UTF8_BINARY"
      },
      "nullable": true
    },
    {
      "name": "created_at",
      "type": {
        "name": "timestamp_ltz"
      },
      "nullable": true
    }
  ],
  "created_time": "2025-03-26T17:12:34Z",
  "last_access": "UNKNOWN",
  "created_by": "Spark 4.1.0-SNAPSHOT",
  "type": "VIEW",
  "view_text": "SELECT * FROM spark_catalog.ns.table",
  "view_original_text": "SELECT * FROM spark_catalog.ns.table",
  "view_schema_mode": "COMPENSATION",
  "view_catalog_and_namespace": "spark_catalog.default",
  "view_query_output_columns": [
    "id",
    "name",
    "created_at"
  ],
  // NEW
  "view_creation_confs": {
    "spark.sql.ansi.enabled": "true",
    "spark.sql.session.timeZone": "America/Los_Angeles",
    "spark.sql.legacy.useV1Command": "false",
    "spark.sql.parquet.fieldId.read.enabled": "true"
  }
}
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Add a new field which uses the existing CatalogTable `viewSQLConfigs` to surface information about Spark conf settings at view creation to users

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, adds a new field to Desc As Json

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added test for desc view as json

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
