### PR TITLE
[SPARK-51350][SQL][FOLLOW-UP] Allow query for all namespaces

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -304,7 +304,7 @@ statement
     | SHOW PARTITIONS identifierReference partitionSpec?               #showPartitions
     | SHOW identifier? FUNCTIONS ((FROM | IN) ns=identifierReference)?
         (LIKE? (legacy=multipartIdentifier | pattern=stringLit))?      #showFunctions
-    | SHOW PROCEDURES ((FROM | IN) identifierReference)?               #showProcedures
+    | SHOW PROCEDURES ((FROM | IN) multipartIdentifier)?               #showProcedures
     | SHOW CREATE TABLE identifierReference (AS SERDE)?                #showCreateTable
     | SHOW CURRENT namespace                                           #showCurrentNamespace
     | SHOW CATALOGS (LIKE? pattern=stringLit)?                            #showCatalogs

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/ProcedureCatalog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/ProcedureCatalog.java
@@ -36,6 +36,12 @@ public interface ProcedureCatalog extends CatalogPlugin {
   UnboundProcedure loadProcedure(Identifier ident);
 
   /**
+   * List all procedures.
+   *
+   */
+  Identifier[] listProcedures();
+
+  /**
    * List all procedures in the specified namespace.
    *
    */

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
@@ -277,6 +277,11 @@ class InMemoryTableCatalog extends BasicInMemoryTableCatalog with SupportsNamesp
     procedure
   }
 
+  override def listProcedures(): Array[Identifier] = {
+    val result = procedures.keySet.asScala
+    result.filter(!_.namespace.sameElements(Array("dummy"))).toArray
+  }
+
   override def listProcedures(namespace: Array[String]): Array[Identifier] = {
     val result =
       if (namespaceExists(namespace)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -27,7 +27,7 @@ import org.antlr.v4.runtime.tree.TerminalNode
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
-import org.apache.spark.sql.catalyst.analysis.{CurrentNamespace, GlobalTempView, LocalTempView, PersistedView, PlanWithUnresolvedIdentifier, SchemaEvolution, SchemaTypeEvolution, UnresolvedAttribute, UnresolvedFunctionName, UnresolvedIdentifier, UnresolvedNamespace}
+import org.apache.spark.sql.catalyst.analysis.{GlobalTempView, LocalTempView, PersistedView, PlanWithUnresolvedIdentifier, SchemaEvolution, SchemaTypeEvolution, UnresolvedAttribute, UnresolvedFunctionName, UnresolvedIdentifier, UnresolvedNamespace}
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
 import org.apache.spark.sql.catalyst.parser._
@@ -1181,11 +1181,7 @@ class SparkSqlAstBuilder extends AstBuilder {
   }
 
   override def visitShowProcedures(ctx: ShowProceduresContext): LogicalPlan = withOrigin(ctx) {
-    val ns = if (ctx.identifierReference != null) {
-      withIdentClause(ctx.identifierReference, UnresolvedNamespace(_))
-    } else {
-      CurrentNamespace
-    }
-    ShowProceduresCommand(ns)
+    val multiPart = Option(ctx.multipartIdentifier).map(visitMultipartIdentifier)
+    ShowProceduresCommand(UnresolvedNamespace(multiPart.getOrElse(Seq.empty[String])))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ShowProceduresCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ShowProceduresCommand.scala
@@ -45,7 +45,11 @@ case class ShowProceduresCommand(
     child match {
       case ResolvedNamespace(catalog, ns, _) =>
         val procedureCatalog = catalog.asProcedureCatalog
-        val procedures = procedureCatalog.listProcedures(ns.toArray)
+        val procedures = if (ns.isEmpty) {
+          procedureCatalog.listProcedures()
+        } else {
+          procedureCatalog.listProcedures(ns.toArray)
+        }
 
         procedures.toSeq.map{ p =>
           val schema = if (p.namespace() != null && p.namespace().nonEmpty) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ProcedureSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ProcedureSuite.scala
@@ -382,9 +382,12 @@ class ProcedureSuite extends QueryTest with SharedSparkSession with BeforeAndAft
         UnboundMultiResultProcedure)
 
       checkAnswer(
-        // uses default catalog and ns
+        // uses default catalog
         sql("SHOW PROCEDURES"),
-        Row("cat", ArraySeq(), null, "xxx") :: Nil)
+        Row("cat", ArraySeq(""), "", "xyz") ::
+        Row("cat", ArraySeq(), null, "xxx") ::
+        Row("cat", ArraySeq("ns"), "ns", "abc") ::
+        Row("cat", ArraySeq("ns"), "ns", "foo") :: Nil)
 
       checkAnswer(
         sql("SHOW PROCEDURES IN ns"),
@@ -423,9 +426,12 @@ class ProcedureSuite extends QueryTest with SharedSparkSession with BeforeAndAft
           Row("cat", Array("ns"), "ns", "foo") :: Nil)
 
       checkAnswer(
-        // uses default catalog and ns
+        // uses default catalog
         sql("SHOW PROCEDURES"),
-        Row("cat2", ArraySeq(), null, "bar") :: Nil)
+        Row("cat2", ArraySeq(""), "", "foo") ::
+        Row("cat2", ArraySeq(), null, "bar") ::
+          Row("cat2", ArraySeq("ns_1", "db_1"), "db_1", "foo") ::
+          Row("cat2", ArraySeq("ns_1", "db_1"), "db_1", "bar") :: Nil)
 
       checkAnswer(
         sql("SHOW PROCEDURES FROM ns_1.db_1"),


### PR DESCRIPTION


### What changes were proposed in this pull request?
Make some changes to SHOW PROCEDURES to allow showing procedures across all namespaces.  Previously, not specifying a namespace would default to the current namespace.  Make a separate API in ProcedureCatalog for this.


### Why are the changes needed?
Better UX, to allow user to list all procedures of a ProcedureCatalog.

This is more in line with SHOW NAMESPACES and SupportsNamespaces catalog API.


### Does this PR introduce _any_ user-facing change?
No, the command is not released yet.


### How was this patch tested?
ProcedureSuite


### Was this patch authored or co-authored using generative AI tooling?
