### PR TITLE
[SPARK-51668][SQL] Report metrics for failed writes to V2 data sources

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
@@ -362,8 +362,11 @@ trait V2ExistingTableWriteExec extends V2TableWriteExec {
     }.toMap
 
   override protected def run(): Seq[InternalRow] = {
-    val writtenRows = writeWithV2(write.toBatch)
-    postDriverMetrics()
+    val writtenRows = try {
+      writeWithV2(write.toBatch)
+    } finally {
+      postDriverMetrics()
+    }
     refreshCache()
     writtenRows
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -459,7 +459,9 @@ object QueryTest extends Assertions {
       override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
         capturedQueryExecutions = capturedQueryExecutions :+ qe
       }
-      override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {}
+      override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {
+        capturedQueryExecutions = capturedQueryExecutions :+ qe
+      }
     }
 
     spark.sparkContext.listenerBus.waitUntilEmpty(15000)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Always post driver metrics for data source V2 writes 

### Why are the changes needed?

All metrics that have been collected are otherwise lost in case the command aborts

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added new tests

### Was this patch authored or co-authored using generative AI tooling?

No