### PR TITLE
[SPARK-51619][PYTHON] Support UDT input / output in Arrow-optimized Python UDF

### DIFF
--- a/python/docs/source/migration_guide/pyspark_upgrade.rst
+++ b/python/docs/source/migration_guide/pyspark_upgrade.rst
@@ -19,6 +19,11 @@
 Upgrading PySpark
 ==================
 
+Upgrading from PySpark 4.0 to 4.1
+---------------------------------
+
+* In Spark 4.1, Arrow-optimized Python UDF supports UDT input / output instead of falling back to the regular UDF. To restore the legacy behavior, set ``spark.sql.execution.pythonUDF.arrow.legacy.fallbackOnUDT`` to ``true``.
+
 Upgrading from PySpark 3.5 to 4.0
 ---------------------------------
 

--- a/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
@@ -214,6 +214,13 @@ class ArrowPythonUDFTestsMixin(BaseUDFTestsMixin):
         with self.assertRaises(PythonException):
             self.spark.sql("SELECT test_udf(id, a => id * 10) FROM range(2)").show()
 
+    def test_udf_with_udt(self):
+        for fallback in [False, True]:
+            with self.subTest(fallback=fallback), self.sql_conf(
+                {"spark.sql.execution.pythonUDF.arrow.legacy.fallbackOnUDT": fallback}
+            ):
+                super().test_udf_with_udt()
+
 
 class ArrowPythonUDFTests(ArrowPythonUDFTestsMixin, ReusedSQLTestCase):
     @classmethod

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3567,6 +3567,15 @@ object SQLConf {
           " must be more than one.")
       .createOptional
 
+  val PYTHON_UDF_ARROW_FALLBACK_ON_UDT =
+    buildConf("spark.sql.execution.pythonUDF.arrow.legacy.fallbackOnUDT")
+      .internal()
+      .doc("When true, Arrow-optimized Python UDF will fallback to the regular UDF when " +
+        "its input or output is UDT.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val PYTHON_TABLE_UDF_ARROW_ENABLED =
     buildConf("spark.sql.execution.pythonUDTF.arrow.enabled")
       .doc("Enable Arrow optimization for Python UDTFs.")
@@ -6401,6 +6410,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def pythonUDFWorkerKillOnIdleTimeout: Boolean = getConf(PYTHON_UDF_WORKER_KILL_ON_IDLE_TIMEOUT)
 
   def pythonUDFArrowConcurrencyLevel: Option[Int] = getConf(PYTHON_UDF_ARROW_CONCURRENCY_LEVEL)
+
+  def pythonUDFArrowFallbackOnUDT: Boolean = getConf(PYTHON_UDF_ARROW_FALLBACK_ON_UDT)
 
   def pysparkPlotMaxRows: Int = getConf(PYSPARK_PLOT_MAX_ROWS)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{StructType, UserDefinedType}
 
 /**
  * Grouped a iterator into batches.
@@ -107,7 +107,9 @@ class ArrowEvalPythonEvaluatorFactory(
       schema: StructType,
       context: TaskContext): Iterator[InternalRow] = {
 
-    val outputTypes = output.drop(childOutput.length).map(_.dataType)
+    val outputTypes = output.drop(childOutput.length).map(_.dataType.transformRecursively {
+      case udt: UserDefinedType[_] => udt.sqlType
+    })
 
     val batchIter = Iterator(iter)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowPythonRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowPythonRunner.scala
@@ -107,8 +107,12 @@ class ArrowPythonWithNamedArgumentRunner(
     funcs, evalType, argMetas.map(_.map(_.offset)), _schema, _timeZoneId, largeVarTypes, workerConf,
     pythonMetrics, jobArtifactUUID) {
 
-  override protected def writeUDF(dataOut: DataOutputStream): Unit =
+  override protected def writeUDF(dataOut: DataOutputStream): Unit = {
+    if (evalType == PythonEvalType.SQL_ARROW_BATCHED_UDF) {
+      PythonWorkerUtils.writeUTF(schema.json, dataOut)
+    }
     PythonUDFRunner.writeUDFs(dataOut, funcs, argMetas, profiler)
+  }
 }
 
 object ArrowPythonRunner {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
@@ -237,7 +237,8 @@ object ExtractPythonUDFs extends Rule[LogicalPlan] with Logging {
 
   private def correctEvalType(udf: PythonUDF): Int = {
     if (udf.evalType == PythonEvalType.SQL_ARROW_BATCHED_UDF) {
-      if (containsUDT(udf.dataType) || udf.children.exists(expr => containsUDT(expr.dataType))) {
+      if (conf.pythonUDFArrowFallbackOnUDT &&
+        (containsUDT(udf.dataType) || udf.children.exists(expr => containsUDT(expr.dataType)))) {
         PythonEvalType.SQL_BATCHED_UDF
       } else {
         PythonEvalType.SQL_ARROW_BATCHED_UDF


### PR DESCRIPTION
### What changes were proposed in this pull request?

Supports UDT input / output in Arrow-optimized Python UDF.

### Why are the changes needed?

Currently Arrow-optimized Python UDF will fallback to the regular UDF when its input or output is UDT.

### Does this PR introduce _any_ user-facing change?

Yes, the type coercion rule on the UDF input / output may be different.

To restore the legacy behavior, set `spark.sql.execution.pythonUDF.arrow.legacy.fallbackOnUDT` to `true`.

### How was this patch tested?

Modified the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.