### PR TITLE
[SPARK-51634][SQL] Support TIME in off-heap column vectors

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -619,7 +619,8 @@ public final class OffHeapColumnVector extends WritableColumnVector {
       this.data = Platform.reallocateMemory(data, oldCapacity * 4L, newCapacity * 4L);
     } else if (type instanceof LongType || type instanceof DoubleType ||
         DecimalType.is64BitDecimalType(type) || type instanceof TimestampType ||
-        type instanceof TimestampNTZType || type instanceof DayTimeIntervalType) {
+        type instanceof TimestampNTZType || type instanceof DayTimeIntervalType ||
+        type instanceof TimeType) {
       this.data = Platform.reallocateMemory(data, oldCapacity * 8L, newCapacity * 8L);
     } else if (childColumns != null) {
       // Nothing to store.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -1628,16 +1628,6 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
       }
     }
   }
-
-  test("Write TimeType") {
-    withTempPath { dir =>
-      val data = Seq(LocalTime.parse("01:12:30.999999")).toDF("col")
-      data.write.parquet(dir.getCanonicalPath)
-      val readback = spark.read.parquet(dir.getCanonicalPath)
-      assertResult(readback.schema) { new StructType().add("col", TimeType()) }
-      checkAnswer(readback, data)
-    }
-  }
 }
 
 class JobCommitFailureParquetOutputCommitter(outputPath: Path, context: TaskAttemptContext)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to modify `OffHeapColumnVector.java` to support the new data type `TIME`, and move a test from `ParquetIOSuite` to `ParquetFileFormatSuite` to test read/write `TIME` value in parquet for both V1 and V2 versions.

### Why are the changes needed?
To fix the failure:
```scala
scala> spark.conf.set("spark.sql.columnVector.offheap.enabled", true)
scala> spark.read.parquet("/Users/maxim.gekk/tmp/test5").show()
org.apache.spark.SparkException: [FAILED_READ_FILE.NO_HINT] Encountered error while reading file file:///Users/maxim.gekk/tmp/test5/part-00000-855fbee0-1e15-460e-99ea-edf614e2415b-c000.snappy.parquet.  SQLSTATE: KD001
```

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the modified test suite:
```
$ build/sbt "test:testOnly *ParquetFileFormatV1Suite"
$ build/sbt "test:testOnly *ParquetFileFormatV2Suite"
```


### Was this patch authored or co-authored using generative AI tooling?
No.