### PR TITLE
[SPARK-51455][SQL][TESTS] Improve test coverage of the TIME data type

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -1468,6 +1468,9 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
     ).foreach { case (time, expectedStr) =>
       checkEvaluation(Cast(Literal(time), StringType), expectedStr)
     }
+
+    checkConsistencyBetweenInterpretedAndCodegen(
+      (child: Expression) => Cast(child, StringType), TimeType())
   }
 
   test("cast string to time") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralGenerator.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import java.sql.{Date, Timestamp}
-import java.time.{Duration, Instant, LocalDate, Period}
+import java.time.{Duration, Instant, LocalDate, LocalTime, Period}
 import java.util.concurrent.TimeUnit
 
 import org.scalacheck.{Arbitrary, Gen}
@@ -123,6 +123,14 @@ object LiteralGenerator {
       yield Literal.create(new Date(day * MILLIS_PER_DAY), DateType)
   }
 
+  lazy val timeLiteralGen: Gen[Literal] = {
+    // Valid range for TimeType is [00:00:00, 23:59:59.999999]
+    val minTime = DateTimeUtils.localTimeToMicros(LocalTime.MIN)
+    val maxTime = DateTimeUtils.localTimeToMicros(LocalTime.MAX)
+    for { t <- Gen.choose(minTime, maxTime) }
+      yield Literal(t, TimeType())
+  }
+
   private def millisGen = {
     // Catalyst's Timestamp type stores number of microseconds since epoch in
     // a variable of Long type. To prevent arithmetic overflow of Long on
@@ -196,6 +204,7 @@ object LiteralGenerator {
       case DoubleType => doubleLiteralGen
       case FloatType => floatLiteralGen
       case DateType => dateLiteralGen
+      case _: TimeType => timeLiteralGen
       case TimestampType => timestampLiteralGen
       case TimestampNTZType => timestampNTZLiteralGen
       case BooleanType => booleanLiteralGen

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -106,6 +106,9 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       HoursOfTime(Literal.create(null, TimeType(TimeType.MICROS_PRECISION))),
       null
     )
+
+    checkConsistencyBetweenInterpretedAndCodegen(
+      (child: Expression) => HoursOfTime(child).replacement, TimeType())
   }
 
   test("MinuteExpressionBuilder") {
@@ -161,5 +164,8 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       MinutesOfTime(Literal.create(null, TimeType(TimeType.MICROS_PRECISION))),
       null
     )
+
+    checkConsistencyBetweenInterpretedAndCodegen(
+      (child: Expression) => MinutesOfTime(child).replacement, TimeType())
   }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -801,6 +801,14 @@ public class JavaDatasetSuite implements Serializable {
     Assertions.assertEquals(data, ds.collectAsList());
   }
 
+  @Test
+  public void testLocalTimeEncoder() {
+    Encoder<LocalTime> encoder = Encoders.LOCALTIME();
+    List<LocalTime> data = Arrays.asList(LocalTime.NOON, LocalTime.MIDNIGHT);
+    Dataset<LocalTime> ds = spark.createDataset(data, encoder);
+    Assertions.assertEquals(data, ds.collectAsList());
+  }
+
   public static class KryoSerializable {
     String value;
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources.parquet
 
 import java.io.File
 import java.math.BigDecimal
-import java.time.{Duration, LocalDateTime, Period, ZoneOffset}
+import java.time.{Duration, LocalDateTime, LocalTime, Period, ZoneOffset}
 import java.util.concurrent.TimeUnit
 
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -1166,6 +1166,18 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
       val df = sql("select cast(value as struct<f1:array<double>,f2:array<int>>) AS value from tbl")
       val expected = Row(Row(Array(1.0d, 2.0d, 3.0d), Array(1, 1, 2))) :: Nil
       checkAnswer(df, expected)
+    }
+  }
+
+  test("create table with TIME") {
+    withTable("tbl") {
+      sql("create table tbl (c1 time(6), c2 time) using parquet")
+      sql("insert into tbl values (time'12:13:14.001001', time'23:59:59')")
+      sql("insert into tbl values (null, null)")
+      val expected = Seq(
+        (LocalTime.parse("12:13:14.001001"), LocalTime.parse("23:59:59")),
+        (null, null)).toDF()
+      checkAnswer(sql("select * from tbl"), expected)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose new tests:
- Create a Dataset with TIME values via Java API.
- Create a table with TIME columns using parquet
- Random time literal generator + tests for comparing codegen and non-codegen outputs.

### Why are the changes needed?
To improve test coverage of the new data type TIME.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the modified test suites:
```
$ build/sbt "test:testOnly *CastWithAnsiOnSuite"
$ build/sbt "test:testOnly *ParquetV1QuerySuite"
$ build/sbt "test:testOnly *ParquetV2QuerySuite"
```


### Was this patch authored or co-authored using generative AI tooling?
No.
