### PR TITLE
[SPARK-51641][SQL] Fixed CREATE OR REPLACE TABLE ... DEFAULT COLLATION and views with default collation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.catalyst.expressions.{Cast, DefaultStringProducingExpression, Expression, Literal}
-import org.apache.spark.sql.catalyst.plans.logical.{AddColumns, AlterColumns, AlterColumnSpec, AlterTableCommand, AlterViewAs, ColumnDefinition, CreateTable, CreateView, LogicalPlan, QualifiedColType, ReplaceColumns, V2CreateTablePlan}
+import org.apache.spark.sql.catalyst.expressions.{Cast, DefaultStringProducingExpression, Expression, Literal, SubqueryExpression}
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumns, AlterColumnSpec, AlterColumns, AlterTableCommand, AlterViewAs, ColumnDefinition, CreateTable, CreateView, LogicalPlan, QualifiedColType, ReplaceColumns, ReplaceTable, V2CreateTablePlan}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.catalog.TableCatalog
 import org.apache.spark.sql.types.{DataType, StringType}
@@ -45,6 +45,9 @@ object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
     table match {
       case createTable: CreateTable if createTable.tableSpec.collation.isDefined =>
         StringType(createTable.tableSpec.collation.get)
+
+      case replaceTable: ReplaceTable if replaceTable.tableSpec.collation.isDefined =>
+        StringType(replaceTable.tableSpec.collation.get)
 
       case createView: CreateView if createView.collation.isDefined =>
         StringType(createView.collation.get)
@@ -73,7 +76,7 @@ object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
   private def isCreateOrAlterPlan(plan: LogicalPlan): Boolean = plan match {
     // For CREATE TABLE, only v2 CREATE TABLE command is supported.
     // Also, table DEFAULT COLLATION cannot be specified through CREATE TABLE AS SELECT command.
-    case _: V2CreateTablePlan | _: CreateView | _: AlterViewAs => true
+    case _: V2CreateTablePlan | _: ReplaceTable | _: CreateView | _: AlterViewAs => true
     case _ => false
   }
 
@@ -104,7 +107,7 @@ object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
    * Transforms the given plan, by transforming all expressions in its operators to use the given
    * new type instead of the default string type.
    */
-  private def transformPlan(plan: LogicalPlan, newType: StringType): LogicalPlan = {
+  def transformPlan(plan: LogicalPlan, newType: StringType): LogicalPlan = {
     val transformedPlan = plan resolveExpressionsUp { expression =>
       transformExpression
         .andThen(_.apply(newType))
@@ -126,6 +129,16 @@ object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
 
     case Literal(value, dt) if hasDefaultStringType(dt) =>
       newType => Literal(value, replaceDefaultStringType(dt, newType))
+
+    case subquery: SubqueryExpression =>
+      val plan = subquery.plan
+      newType =>
+        val newPlan = plan resolveExpressionsUp { expression =>
+          transformExpression
+            .andThen(_.apply(newType))
+            .applyOrElse(expression, identity[Expression])
+        }
+        subquery.withNewPlan(newPlan)
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fixed `CREATE OR REPLACE TABLE ... DEFAULT COLLATION`. Problem was that `ReplaceTable` wasn't applicable to `ResolveDDLCommandStringTypes` rule, so creating table using this method wasn't propagating collation to columns.
Fixed views with default collation to properly propagate collation to its literals, subqueries, etc.


### Why are the changes needed?
Bug fix.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Tests added to `DefaultCollationTestSuite`.


### Was this patch authored or co-authored using generative AI tooling?
No.
