### PR TITLE
[SPARK-51646][SQL] Fix propagating collation in views with default collation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -158,6 +158,7 @@ case class AnalysisContext(
     referredTempVariableNames: Seq[Seq[String]] = Seq.empty,
     outerPlan: Option[LogicalPlan] = None,
     isExecuteImmediate: Boolean = false,
+    collation: Option[String] = None,
 
     /**
      * This is a bridge state between this fixed-point [[Analyzer]] and a single-pass [[Resolver]].
@@ -213,7 +214,8 @@ object AnalysisContext {
       viewDesc.viewReferredTempViewNames,
       mutable.Set(viewDesc.viewReferredTempFunctionNames: _*),
       viewDesc.viewReferredTempVariableNames,
-      isExecuteImmediate = originContext.isExecuteImmediate)
+      isExecuteImmediate = originContext.isExecuteImmediate,
+      collation = viewDesc.collation)
     set(context)
     try f finally { set(originContext) }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
@@ -133,7 +133,7 @@ object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
       newType => columnDef.copy(dataType = replaceDefaultStringType(columnDef.dataType, newType))
 
     case cast: Cast if hasDefaultStringType(cast.dataType) &&
-      cast.getTagValue(Cast.USER_SPECIFIED_CAST).isEmpty =>
+      cast.getTagValue(Cast.USER_SPECIFIED_CAST).isDefined =>
       newType => cast.copy(dataType = replaceDefaultStringType(cast.dataType, newType))
 
     case Literal(value, dt) if hasDefaultStringType(dt) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
@@ -109,7 +109,7 @@ object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
    * Transforms the given plan, by transforming all expressions in its operators to use the given
    * new type instead of the default string type.
    */
-  private def transformPlan(plan: LogicalPlan, newType: StringType): LogicalPlan = {
+  def transformPlan(plan: LogicalPlan, newType: StringType): LogicalPlan = {
     val transformedPlan = plan resolveExpressionsUp { expression =>
       transformExpression
         .andThen(_.apply(newType))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.catalyst.expressions.{Cast, DefaultStringProducingExpression, Expression, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Cast, DefaultStringProducingExpression, Expression, Literal, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.logical.{AddColumns, AlterColumns, AlterColumnSpec, AlterTableCommand, AlterViewAs, ColumnDefinition, CreateTable, CreateView, LogicalPlan, QualifiedColType, ReplaceColumns, ReplaceTable, V2CreateTablePlan}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.catalog.TableCatalog

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
@@ -115,7 +115,7 @@ object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
    * Transforms the given plan, by transforming all expressions in its operators to use the given
    * new type instead of the default string type.
    */
-  def transformPlan(plan: LogicalPlan, newType: StringType): LogicalPlan = {
+  private def transformPlan(plan: LogicalPlan, newType: StringType): LogicalPlan = {
     val transformedPlan = plan resolveExpressionsUp { expression =>
       transformExpression
         .andThen(_.apply(newType))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
@@ -131,6 +131,16 @@ object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
 
     case Literal(value, dt) if hasDefaultStringType(dt) =>
       newType => Literal(value, replaceDefaultStringType(dt, newType))
+
+    case subquery: SubqueryExpression =>
+      val plan = subquery.plan
+      newType =>
+        val newPlan = plan resolveExpressionsUp { expression =>
+          transformExpression
+            .andThen(_.apply(newType))
+            .applyOrElse(expression, identity[Expression])
+        }
+        subquery.withNewPlan(newPlan)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -21,12 +21,15 @@ import java.net.URI
 import java.util.Locale
 import java.util.concurrent.{Callable, ExecutionException, TimeUnit}
 import javax.annotation.concurrent.GuardedBy
+
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
+
 import com.google.common.cache.{Cache, CacheBuilder}
 import com.google.common.util.concurrent.UncheckedExecutionException
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.{SparkException, SparkThrowable}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -21,15 +21,12 @@ import java.net.URI
 import java.util.Locale
 import java.util.concurrent.{Callable, ExecutionException, TimeUnit}
 import javax.annotation.concurrent.GuardedBy
-
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
-
 import com.google.common.cache.{Cache, CacheBuilder}
 import com.google.common.util.concurrent.UncheckedExecutionException
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.{SparkException, SparkThrowable}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
@@ -49,7 +46,7 @@ import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAM
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.GLOBAL_TEMP_DATABASE
-import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
+import org.apache.spark.sql.types.{MetadataBuilder, StringType, StructField, StructType}
 import org.apache.spark.sql.util.{CaseInsensitiveStringMap, PartitioningUtils}
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
@@ -987,9 +984,17 @@ class SessionCatalog(
           parser.parseQuery(viewText)
         }
     }
+    // The metadata.viewText contains only the AS query part of CREATE VIEW statement
+    // and does not include the DEFAULT COLLATION part, resulting in a plan without collation.
+    val plan = if (metadata.collation.isDefined) {
+      val newType = StringType(metadata.collation.get)
+      ResolveDDLCommandStringTypes.transformPlan(parsedPlan, newType)
+    } else {
+      parsedPlan
+    }
     val schemaMode = metadata.viewSchemaMode
     if (schemaMode == SchemaEvolution) {
-      View(desc = metadata, isTempView = isTempView, child = parsedPlan)
+      View(desc = metadata, isTempView = isTempView, child = plan)
     } else {
       val projectList = if (!isHiveCreatedView(metadata)) {
         val viewColumnNames = if (metadata.viewQueryColumnNames.isEmpty) {
@@ -1038,7 +1043,7 @@ class SessionCatalog(
           castColToType(col, field, schemaMode)
         }
       }
-      View(desc = metadata, isTempView = isTempView, child = Project(projectList, parsedPlan))
+      View(desc = metadata, isTempView = isTempView, child = Project(projectList, plan))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
@@ -452,7 +452,8 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
       sql(
         s"""CREATE VIEW $testView DEFAULT COLLATION UTF8_LCASE
            | AS SELECT 'a' AS c1,
-           | (SELECT (SELECT CASE 'a' = 'A' WHEN TRUE THEN 'a' ELSE 'b' END)) AS c2
+           | (SELECT (SELECT CASE 'a' = 'A' WHEN TRUE THEN 'a' ELSE 'b' END)
+           |  WHERE (SELECT 'b' WHERE 'c' = 'C') = 'B') AS c2
            |""".stripMargin)
       checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'A'"), Seq(Row(1)))
       checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c2 = 'a'"), Seq(Row(1)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
@@ -397,9 +397,9 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
         // scalastyle:off
         sql(
           s"""CREATE OR REPLACE VIEW $testView
-             | DEFAULT COLLATION sr_ci_ai
-             | AS SELECT *, 'ć' AS c3 FROM $testTable
-             |""".stripMargin)
+            | DEFAULT COLLATION sr_ci_ai
+            | AS SELECT *, 'ć' AS c3 FROM $testTable
+            |""".stripMargin)
         val prefix = "SYSTEM.BUILTIN"
         checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testView"), Row(s"$prefix.UTF8_BINARY"))
         checkAnswer(sql(s"SELECT DISTINCT COLLATION(c2) FROM $testView"), Row(s"$prefix.UTF8_LCASE"))
@@ -414,10 +414,10 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
       // scalastyle:off
       sql(
         s"""CREATE OR REPLACE VIEW $testView
-           | (c1)
-           | DEFAULT COLLATION sr_ai
-           | AS SELECT 'Ć' as c1 WHERE 'Ć' = 'C'
-           |""".stripMargin)
+          | (c1)
+          | DEFAULT COLLATION sr_ai
+          | AS SELECT 'Ć' as c1 WHERE 'Ć' = 'C'
+          |""".stripMargin)
       checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'Č'"), Row(1))
       // scalastyle:on
     }
@@ -427,8 +427,8 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
     withView(testView) {
       sql(
         s"""CREATE VIEW $testView DEFAULT COLLATION UTF8_LCASE
-           | as SELECT 'a' as c1
-           |""".stripMargin)
+          | as SELECT 'a' as c1
+          |""".stripMargin)
       checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'A'"), Seq(Row(1)))
     }
     withTable(testTable) {
@@ -439,9 +439,9 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
           // scalastyle:off
           sql(
             s"""CREATE VIEW $testView DEFAULT COLLATION SR_AI_CI
-               | AS SELECT c1 FROM $testTable
-               | WHERE 'ć' = 'č'
-               |""".stripMargin)
+              | AS SELECT c1 FROM $testTable
+              | WHERE 'ć' = 'č'
+              |""".stripMargin)
           // scalastyle:on
           checkAnswer(sql(s"SELECT COUNT(*) FROM $testView"), Seq(Row(2)))
           checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'A'"), Seq(Row(2)))
@@ -456,8 +456,8 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
       withView(testView) {
         sql(
           s"""CREATE VIEW $testView DEFAULT COLLATION UNICODE
-             | AS SELECT CAST(c1 AS STRING COLLATE SR_AI) FROM $testTable
-             |""".stripMargin)
+            | AS SELECT CAST(c1 AS STRING COLLATE SR_AI) FROM $testTable
+            |""".stripMargin)
         val prefix = "SYSTEM.BUILTIN"
         checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testView"), Row(s"$prefix.sr_AI"))
         checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'c'"), Row(2))
@@ -466,10 +466,10 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
     withView(testView) {
       sql(
         s"""CREATE VIEW $testView DEFAULT COLLATION UTF8_LCASE
-           | AS SELECT 'a' AS c1,
-           | (SELECT (SELECT CASE 'a' = 'A' WHEN TRUE THEN 'a' ELSE 'b' END)
-           |  WHERE (SELECT 'b' WHERE 'c' = 'C') = 'B') AS c2
-           |""".stripMargin)
+          | AS SELECT 'a' AS c1,
+          | (SELECT (SELECT CASE 'a' = 'A' WHEN TRUE THEN 'a' ELSE 'b' END)
+          |  WHERE (SELECT 'b' WHERE 'c' = 'C') = 'B') AS c2
+          |""".stripMargin)
       checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'A'"), Seq(Row(1)))
       checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c2 = 'a'"), Seq(Row(1)))
       checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c2 = 'b'"), Seq(Row(0)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
@@ -397,9 +397,9 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
         // scalastyle:off
         sql(
           s"""CREATE OR REPLACE VIEW $testView
-            | DEFAULT COLLATION sr_ci_ai
-            | AS SELECT *, 'ć' AS c3 FROM $testTable
-            |""".stripMargin)
+             | DEFAULT COLLATION sr_ci_ai
+             | AS SELECT *, 'ć' AS c3 FROM $testTable
+             |""".stripMargin)
         val prefix = "SYSTEM.BUILTIN"
         checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testView"), Row(s"$prefix.UTF8_BINARY"))
         checkAnswer(sql(s"SELECT DISTINCT COLLATION(c2) FROM $testView"), Row(s"$prefix.UTF8_LCASE"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
@@ -474,13 +474,6 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
       checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c2 = 'a'"), Seq(Row(1)))
       checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c2 = 'b'"), Seq(Row(0)))
     }
-    withView(testView) {
-      sql(
-        s"""CREATE VIEW $testView DEFAULT COLLATION UTF8_LCASE
-           |  AS WITH t (SELECT 'a' AS c) SELECT c as c1 FROM t
-           |""".stripMargin)
-      checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'A'"), Seq(Row(1)))
-    }
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fixed propagating default collation to literals, subqueries, etc., in `CREATE VIEW ... DEFAULT COLLATION ...` query.
The issue was that the saved string used to construct the view did not include the `DEFAULT COLLATION` ... clause, resulting in the view being created without collation information.

### Why are the changes needed?
Bug fix.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Tests added to `DefaultCollationTestSuite`.


### Was this patch authored or co-authored using generative AI tooling?
No.