### PR TITLE
[SPARK-51648][UI] Move inlined javascript in ExecutionPage to spark-sql-viz.js

### DIFF
--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -22,13 +22,10 @@ var PlanVizConstants = {
   svgMarginY: 16
 };
 
-/* eslint-disable no-unused-vars */
 function shouldRenderPlanViz() {
   return planVizContainer().selectAll("svg").empty();
 }
-/* eslint-enable no-unused-vars */
 
-/* eslint-disable no-unused-vars */
 function renderPlanViz() {
   var svg = planVizContainer().append("svg");
   var metadata = d3.select("#plan-viz-metadata");
@@ -52,7 +49,6 @@ function renderPlanViz() {
   resizeSvg(svg);
   postprocessForAdditionalMetrics();
 }
-/* eslint-enable no-unused-vars */
 
 /* -------------------- *
  * | Helper functions | *
@@ -344,4 +340,17 @@ document.getElementById("plan-viz-download-btn").addEventListener("click", async
     return;
   }
   downloadPlanBlob(blob, format);
+});
+
+/* eslint-disable no-unused-vars */
+function clickPhysicalPlanDetails() {
+/* eslint-enable no-unused-vars */
+  $('#physical-plan-details').toggle();
+  $('#physical-plan-details-arrow').toggleClass('arrow-open').toggleClass('arrow-closed');
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+  if (shouldRenderPlanViz()) {
+    renderPlanViz();
+  }
 });

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
@@ -144,7 +144,6 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
         </div>
       </div>
       {planVisualizationResources(request)}
-      <script>$(function() {{ if (shouldRenderPlanViz()) {{ renderPlanViz(); }} }})</script>
     </div>
   }
 
@@ -163,12 +162,6 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
     <div id="physical-plan-details" style="display: none;">
       <pre>{physicalPlanDescription}</pre>
     </div>
-    <script>
-      function clickPhysicalPlanDetails() {{
-        $('#physical-plan-details').toggle();
-        $('#physical-plan-details-arrow').toggleClass('arrow-open').toggleClass('arrow-closed');
-      }}
-    </script>
   }
 
   private def modifiedConfigs(modifiedConfigs: Map[String, String]): Seq[Node] = {


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR moves the inlined javascript in ExecutionPage to spark-sql-viz.js


### Why are the changes needed?

- Improve the debugbility of Spark UI
- Simply the development progress as the js code can be updated to the jar archive w/o compiling the full maven module.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?

Locally verified the ExecutionPage


### Was this patch authored or co-authored using generative AI tooling?
no
