### PR TITLE
[SPARK-51649][SQL] Dynamic writes/reads of TIME partitions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -534,6 +534,7 @@ object PartitioningUtils extends SQLConfHelper {
     case _: DecimalType => Literal(new JBigDecimal(value)).value
     case DateType =>
       Cast(Literal(value), DateType, Some(zoneId.getId)).eval()
+    case tt: TimeType => Cast(Literal(unescapePathName(value)), tt).eval()
     // Timestamp types
     case dt if AnyTimestampType.acceptsType(dt) =>
       Try {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to support partition values of the TIME type. In particular, if the desired type is `TimeType(n)`, cast partition values by the `Cast` expression to the type.

### Why are the changes needed?
To fix the failure on reading TIME partitions:
```scala
scala> spark.read.schema("t TIME, id INT").parquet("/Users/maxim.gekk/tmp/time_parquet").show(false)
org.apache.spark.SparkRuntimeException: [INVALID_PARTITION_VALUE] Failed to cast value '12%3A00%3A00' to data type "TIME(6)" for partition column `t`. Ensure the value matches the expected data type for this partition column. SQLSTATE: 42846
```


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the new test:
```
$ build/sbt "test:testOnly *PartitionedWriteSuite"
```


### Was this patch authored or co-authored using generative AI tooling?
No.
