### PR TITLE
[SPARK-51652][SQL] Refactor SetOperation computation out to reuse it in the single-pass Analyzer

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -876,20 +876,12 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
           // used in equality comparison, remove this type check once we support it.
           case o if mapColumnInSetOperation(o).isDefined =>
             val mapCol = mapColumnInSetOperation(o).get
-            o.failAnalysis(
-              errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE",
-              messageParameters = Map(
-                "colName" -> toSQLId(mapCol.name),
-                "dataType" -> toSQLType(mapCol.dataType)))
+            throw QueryCompilationErrors.unsupportedSetOperationOnMapType(mapCol)
 
           // TODO: Remove this type check once we support Variant ordering
           case o if variantColumnInSetOperation(o).isDefined =>
             val variantCol = variantColumnInSetOperation(o).get
-            o.failAnalysis(
-              errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_VARIANT_TYPE",
-              messageParameters = Map(
-                "colName" -> toSQLId(variantCol.name),
-                "dataType" -> toSQLType(variantCol.dataType)))
+            throw QueryCompilationErrors.unsupportedSetOperationOnVariantType(variantCol)
 
           case o if variantExprInPartitionExpression(o).isDefined =>
             val variantExpr = variantExprInPartitionExpression(o).get

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -876,12 +876,18 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
           // used in equality comparison, remove this type check once we support it.
           case o if mapColumnInSetOperation(o).isDefined =>
             val mapCol = mapColumnInSetOperation(o).get
-            throw QueryCompilationErrors.unsupportedSetOperationOnMapType(mapCol)
+            throw QueryCompilationErrors.unsupportedSetOperationOnMapType(
+              mapCol = mapCol,
+              origin = operator.origin
+            )
 
           // TODO: Remove this type check once we support Variant ordering
           case o if variantColumnInSetOperation(o).isDefined =>
             val variantCol = variantColumnInSetOperation(o).get
-            throw QueryCompilationErrors.unsupportedSetOperationOnVariantType(variantCol)
+            throw QueryCompilationErrors.unsupportedSetOperationOnVariantType(
+              variantCol = variantCol,
+              origin = operator.origin
+            )
 
           case o if variantExprInPartitionExpression(o).isDefined =>
             val variantExpr = variantExprInPartitionExpression(o).get

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -294,6 +294,26 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("tableName" -> toSQLId(tableName)))
   }
 
+  def unsupportedSetOperationOnMapType(mapCol: Attribute): Throwable = {
+    new AnalysisException(
+      errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE",
+      messageParameters = Map(
+        "colName" -> toSQLId(mapCol.name),
+        "dataType" -> toSQLType(mapCol.dataType)
+      )
+    )
+  }
+
+  def unsupportedSetOperationOnVariantType(variantCol: Attribute): Throwable = {
+    new AnalysisException(
+      errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_VARIANT_TYPE",
+      messageParameters = Map(
+        "colName" -> toSQLId(variantCol.name),
+        "dataType" -> toSQLType(variantCol.dataType)
+      )
+    )
+  }
+
   def nonPartitionColError(partitionName: String): Throwable = {
     new AnalysisException(
       errorClass = "NON_PARTITION_COLUMN",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -294,23 +294,25 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("tableName" -> toSQLId(tableName)))
   }
 
-  def unsupportedSetOperationOnMapType(mapCol: Attribute): Throwable = {
+  def unsupportedSetOperationOnMapType(mapCol: Attribute, origin: Origin): Throwable = {
     new AnalysisException(
       errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE",
       messageParameters = Map(
         "colName" -> toSQLId(mapCol.name),
         "dataType" -> toSQLType(mapCol.dataType)
-      )
+      ),
+      origin = origin
     )
   }
 
-  def unsupportedSetOperationOnVariantType(variantCol: Attribute): Throwable = {
+  def unsupportedSetOperationOnVariantType(variantCol: Attribute, origin: Origin): Throwable = {
     new AnalysisException(
       errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_VARIANT_TYPE",
       messageParameters = Map(
         "colName" -> toSQLId(variantCol.name),
         "dataType" -> toSQLType(variantCol.dataType)
-      )
+      ),
+      origin = origin
     )
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Move SetOperation-related `UNSUPPORTED_FEATURE` errors to QueryCompilationErrors.


### Why are the changes needed?
To improve the code health and to reuse those in the single-pass Analyzer.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Refactor.


### Was this patch authored or co-authored using generative AI tooling?
No.
