### PR TITLE
[SPARK-40353][SPARK-51599][PS][FOLLOW-UP] Fix failure in Python PS with old dependencies

### DIFF
--- a/python/pyspark/pandas/tests/io/test_dataframe_spark_io.py
+++ b/python/pyspark/pandas/tests/io/test_dataframe_spark_io.py
@@ -23,6 +23,7 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
+from pyspark.testing.utils import have_openpyxl, openpyxl_requirement_message
 
 
 class DataFrameSparkIOTestsMixin:
@@ -253,7 +254,7 @@ class DataFrameSparkIOTestsMixin:
                 expected_idx.sort_values(by="f").to_spark().toPandas(),
             )
 
-    @unittest.skip("openpyxl")
+    @unittest.skipIf(not have_openpyxl, openpyxl_requirement_message)
     def test_read_excel(self):
         with self.temp_dir() as tmp:
             path1 = "{}/file1.xlsx".format(tmp)
@@ -345,7 +346,7 @@ class DataFrameSparkIOTestsMixin:
                     pd.concat([pdfs1["Sheet_name_2"], pdfs2["Sheet_name_2"]]).sort_index(),
                 )
 
-    @unittest.skip("openpyxl")
+    @unittest.skipIf(not have_openpyxl, openpyxl_requirement_message)
     def test_read_large_excel(self):
         n = 20000
         pdf = pd.DataFrame(

--- a/python/pyspark/pandas/tests/io/test_dataframe_spark_io.py
+++ b/python/pyspark/pandas/tests/io/test_dataframe_spark_io.py
@@ -253,6 +253,7 @@ class DataFrameSparkIOTestsMixin:
                 expected_idx.sort_values(by="f").to_spark().toPandas(),
             )
 
+    @unittest.skip("openpyxl")
     def test_read_excel(self):
         with self.temp_dir() as tmp:
             path1 = "{}/file1.xlsx".format(tmp)
@@ -344,6 +345,7 @@ class DataFrameSparkIOTestsMixin:
                     pd.concat([pdfs1["Sheet_name_2"], pdfs2["Sheet_name_2"]]).sort_index(),
                 )
 
+    @unittest.skip("openpyxl")
     def test_read_large_excel(self):
         n = 20000
         pdf = pd.DataFrame(


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fix failure in Python PS with old dependencies

https://github.com/apache/spark/actions/runs/14103817104/job/39506718320


### Why are the changes needed?
excel tests requires `openpyxl`, when not installed, should skip the tests


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
