### PR TITLE
[SPARK-51655][SQL] Fix metric collection in UnionLoopExec and add test

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -107,6 +107,24 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
     }
   }
 
+  test("Recursive CTEs metrics") {
+    val df = sql("""WITH RECURSIVE t(n) AS(
+                          | VALUES 1, 2
+                          | UNION ALL
+                          | SELECT n+1 FROM t WHERE n < 20
+                          | )
+                          | SELECT * FROM t""".stripMargin)
+    val unionLoopExec = df.queryExecution.executedPlan.collect {
+      case ule: UnionLoopExec => ule
+    }
+    sparkContext.listenerBus.waitUntilEmpty()
+    assert(unionLoopExec.size == 1)
+    val expected = Map("number of output rows" -> 39L, "number of recursive iterations" -> 20L,
+      "number of anchor output rows" -> 2L)
+    testSparkPlanMetrics(df, 22, Map(
+      2L -> (("UnionLoop", expected))))
+  }
+
   test("Filter metrics") {
     // Assume the execution plan is
     // PhysicalRDD(nodeId = 1) -> Filter(nodeId = 0)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix metrics collection method for Recursive CTEs. Also, add new metric which tracks the number of rows that the anchor returns.

### Why are the changes needed?

Current way of collecting metrics for recursive CTEs is incorrect.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New test in SQLMetricsSuite.

### Was this patch authored or co-authored using generative AI tooling?

No.
