### PR TITLE
[SPARK-51660][CORE] Gracefully handle when MDC is not supported

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -113,7 +113,10 @@ private[spark] class Executor(
   private lazy val mdcIsSupported = {
     try {
       // This tests if any class initialization error is thrown
-      MDC.clear()
+      val testKey = System.nanoTime().toString
+      MDC.put(testKey, "testValue")
+      MDC.remove(testKey)
+
       true
     } catch {
       case t: Throwable =>

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -109,7 +109,7 @@ private[spark] class Executor(
   // so that tasks can exit quickly if they are interrupted while waiting on another task to
   // finish downloading dependencies.
   private val updateDependenciesLock = new ReentrantLock()
-  
+
   private lazy val mdcIsSupported = {
     try {
       // This tests if any class initialization error is thrown


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This improves the handling when MDC is not supported. The previous handling only works when one task runs on an executor. After this fix multiple tasks can run on an executor when MDC is not supported.


### Why are the changes needed?
In https://github.com/apache/spark/pull/35141 it added handling to gracefully handle when MDC is not available. It catches NoSuchFieldError, which is thrown during MDC initialization. This will work for the first task. If a second task runs it will not throw a NoSuchFieldError. Instead it throws NoClassDefFoundError. Then the job will hang indefinitely. This improves the fix so it works for all tasks instead of just the first one.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, it fixes a bug. It also changes a log message to include the exception for easier debugging.


### How was this patch tested?
I tested it manually in spark-shell by manually throwing `NoSuchFieldError`. It logs this message and does not hang.
```
25/03/28 14:11:48 INFO Executor: MDC is not supported.
java.lang.NoSuchFieldError: this is a test
    at org.apache.spark.executor.Executor.liftedTree1$1(Executor.scala:118)
    at org.apache.spark.executor.Executor.mdcIsSupported$lzycompute(Executor.scala:114)
    at org.apache.spark.executor.Executor.mdcIsSupported(Executor.scala:113)
    at org.apache.spark.executor.Executor.org$apache$spark$executor$Executor$$setMDCForTask(Executor.scala:948)
    at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:584)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
    at java.base/java.lang.Thread.run(Thread.java:833)
```


### Was this patch authored or co-authored using generative AI tooling?
No
