### PR TITLE
[SPARK-51664][SQL] Support the TIME data type in the Hash expression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -256,7 +256,7 @@ case class Crc32(child: Expression)
  *                             input with seed.
  *  - binary:                  use murmur3 to hash the bytes with seed.
  *  - string:                  get the bytes of string and hash it.
- *  - time:                    it store long value of `microseconds` since the midnight, use
+ *  - time:                    it stores long value of `microseconds` since the midnight, use
  *                             murmur3 to hash the long input with seed.
  *  - array:                   The `result` starts with seed, then use `result` as seed, recursively
  *                             calculate hash value for each element, and assign the element hash

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -256,6 +256,8 @@ case class Crc32(child: Expression)
  *                             input with seed.
  *  - binary:                  use murmur3 to hash the bytes with seed.
  *  - string:                  get the bytes of string and hash it.
+ *  - time:                    it store long value of `microseconds` since the midnight, use
+ *                             murmur3 to hash the long input with seed.
  *  - array:                   The `result` starts with seed, then use `result` as seed, recursively
  *                             calculate hash value for each element, and assign the element hash
  *                             value to `result`.
@@ -507,7 +509,7 @@ abstract class HashExpression[E] extends Expression {
     case NullType => ""
     case BooleanType => genHashBoolean(input, result)
     case ByteType | ShortType | IntegerType | DateType => genHashInt(input, result)
-    case LongType => genHashLong(input, result)
+    case LongType | _: TimeType => genHashLong(input, result)
     case TimestampType | TimestampNTZType => genHashTimestamp(input, result)
     case FloatType => genHashFloat(input, result)
     case DoubleType => genHashDouble(input, result)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HashExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HashExpressionsSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import java.nio.charset.StandardCharsets
-import java.time.{Duration, Period, ZoneId, ZoneOffset}
+import java.time.{Duration, LocalTime, Period, ZoneId, ZoneOffset}
 
 import scala.collection.mutable.ArrayBuffer
 import scala.language.implicitConversions
@@ -752,6 +752,13 @@ class HashExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
 
     checkResult(Literal.create(-0D, DoubleType), Literal.create(0D, DoubleType))
     checkResult(Literal.create(-0F, FloatType), Literal.create(0F, FloatType))
+  }
+
+  test("Support TimeType") {
+    val time = Literal.create(LocalTime.of(23, 50, 59, 123456000), TimeType())
+    checkEvaluation(Murmur3Hash(Seq(time), 10), 258472763)
+    checkEvaluation(XxHash64(Seq(time), 10), -9197489935839400467L)
+    checkEvaluation(HiveHash(Seq(time)), -40222445)
   }
 
   private def testHash(inputSchema: StructType): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to support the new data type TIME in `HashExpression`, and generate a hash in the same way as for the underlying type `Long.`

### Why are the changes needed?
The affected expressions are used in core components in Spark SQL:
- Murmur3Hash: generating partition ID,
- HiveHash: bucking
- XxHash64: Bloom filter

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
By running the new test:
```
$ build/sbt "test:testOnly *HashExpressionsSuite"
```


### Was this patch authored or co-authored using generative AI tooling?
No.
