### PR TITLE
[SPARK-51665][BUILD] Truncate the lists in dev/test-jars.txt and dev/test-classes.txt during release process

### DIFF
--- a/dev/create-release/release-tag.sh
+++ b/dev/create-release/release-tag.sh
@@ -73,9 +73,11 @@ cd spark
 git config user.name "$GIT_NAME"
 git config user.email "$GIT_EMAIL"
 
-# Remove test jars that do not belong to source releases.
+# Remove test jars and classes that do not belong to source releases.
 rm $(<dev/test-jars.txt)
+:> dev/test-jars.txt
 rm $(<dev/test-classes.txt)
+:> dev/test-classes.txt
 git commit -a -m "Removing test jars and class files"
 JAR_RM_REF=$(git rev-parse HEAD)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a sort of a followup of https://github.com/apache/spark/pull/50422 and https://github.com/apache/spark/pull/50378 that empty the list itself during the CI.

### Why are the changes needed?

Otherwise, the CI on the specific revert commit would fail (although the released commit itself would pass though)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

I will work together with the release manager.

### Was this patch authored or co-authored using generative AI tooling?

No.