### PR TITLE
[SPARK-51669][SQL][TESTS] Generate random TIME values in tests

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 
 import java.math.MathContext
 import java.sql.{Date, Timestamp}
-import java.time.{Duration, Instant, LocalDate, LocalDateTime, Period, ZoneId}
+import java.time.{Duration, Instant, LocalDate, LocalDateTime, LocalTime, Period, ZoneId}
 import java.time.temporal.ChronoUnit
 
 import scala.collection.mutable
@@ -283,6 +283,18 @@ object RandomDataGenerator {
             DateTimeUtils.microsToLocalDateTime(uniformMicrosRand(rand))
           },
           specialTs.map { s => LocalDateTime.parse(s.replace(" ", "T")) }
+        )
+      case _: TimeType =>
+        val specialTimes = Seq(
+          "00:00:00",
+          "23:59:59.999999"
+        )
+        randomNumeric[LocalTime](
+          rand,
+          (rand: Random) => {
+            DateTimeUtils.microsToLocalTime(rand.between(0, 24 * 60 * 60 * 1000 * 1000L))
+          },
+          specialTimes.map(LocalTime.parse)
         )
       case CalendarIntervalType => Some(() => {
         val months = rand.nextInt(1000)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
@@ -117,7 +117,7 @@ object DataTypeTestUtils {
     DateType,
     StringType,
     TimestampType,
-    TimestampNTZType) ++ dayTimeIntervalTypes ++ yearMonthIntervalTypes
+    TimestampNTZType) ++ dayTimeIntervalTypes ++ yearMonthIntervalTypes ++ timeTypes
 
   /**
    * Instances of [[ArrayType]] for all [[AtomicType]]s. Arrays of these types may contain null.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
@@ -101,7 +101,7 @@ object DataTypeTestUtils {
     TimestampNTZType,
     DateType,
     StringType,
-    BinaryType) ++ dayTimeIntervalTypes ++ yearMonthIntervalTypes
+    BinaryType) ++ dayTimeIntervalTypes ++ yearMonthIntervalTypes ++ timeTypes
 
   /**
    * All the types that we can use in a property check

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.types.DataTypeTestUtils.{dayTimeIntervalTypes, unsafeRowMutableFieldTypes}
+import org.apache.spark.sql.types.DataTypeTestUtils.{dayTimeIntervalTypes, timeTypes, unsafeRowMutableFieldTypes}
 import org.apache.spark.tags.SlowHiveTest
 import org.apache.spark.unsafe.UnsafeAlignedOffset
 
@@ -897,7 +897,8 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
       FloatType, DoubleType, DecimalType(25, 5), DecimalType(6, 5),
       DateType, TimestampType,
       ArrayType(IntegerType), MapType(StringType, LongType), struct,
-      new TestUDT.MyDenseVectorUDT()) ++ dayTimeIntervalTypes ++ unsafeRowMutableFieldTypes
+      new TestUDT.MyDenseVectorUDT()) ++ dayTimeIntervalTypes ++ unsafeRowMutableFieldTypes ++
+      timeTypes
     // Right now, we will use SortAggregate to handle UDAFs.
     // UnsafeRow.mutableFieldTypes.asScala.toSeq will trigger SortAggregate to use
     // UnsafeRow as the aggregation buffer. While, dataTypes will trigger


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to extend `RandomDataGenerator` to support new data type `TIME`. More precisely, extend the method `forType` to generate uniformly distributed random values of the `TIME` type. Also add two types `TimeType(0)` and `TimeType(6)` to the sequence of atomic types in `DataTypeTestUtils`. The last vals `atomicTypes`, `propertyCheckSupported`, `ordered` are used in some tests, see the list at the section `How was this patch tested?`.  

### Why are the changes needed?
To extend test coverage of the new data type TIME.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the affected test suites:
```
$ build/sbt "test:testOnly *RandomDataGeneratorSuite"
$ build/sbt "test:testOnly *AggregationQuerySuite"
$ build/sbt "test:testOnly *CastWithAnsiOnSuite"
$ build/sbt "test:testOnly *OrderingSuite"
$ build/sbt "test:testOnly *PredicateSuite"
```


### Was this patch authored or co-authored using generative AI tooling?
No.
