### PR TITLE
[SPARK-36600] [PYTHON] Minor fix to avoid list creation for generators with schema

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1190,11 +1190,11 @@ class SparkSession(SparkConversionMixin):
         Create an RDD for DataFrame from a list or pandas.DataFrame, returns
         the RDD and schema.
         """
-        # make sure data could consumed multiple times
-        if not isinstance(data, list):
-            data = list(data)
-
         if schema is None or isinstance(schema, (list, tuple)):
+            # make sure data could be consumed multiple times
+            if not isinstance(data, list):
+                data = list(data)
+
             struct = self._inferSchemaFromList(data, names=schema)
             converter = _create_converter(struct)
             tupled_data: Iterable[Tuple] = map(converter, data)


### PR DESCRIPTION
In case of a generator function, we end up creating two lists in the memory. 

We don't have a genuine need to do that if schema is present. This PR aims to fix it.