### PR TITLE
[SPARK-51670][SQL] Refactor Intersect and Except to follow Union example to reuse in single-pass Analyzer

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -418,8 +418,14 @@ case class Intersect(
   private lazy val lazyOutput: Seq[Attribute] = computeOutput()
 
   /** We don't use right.output because those rows get excluded from the set. */
-  private def computeOutput(): Seq[Attribute] =
-    left.output.zip(right.output).map { case (leftAttr, rightAttr) =>
+  private def computeOutput(): Seq[Attribute] = Intersect.mergeChildOutputs(children.map(_.output))
+}
+
+/** Factory methods for `Intersect` nodes. */
+object Intersect {
+  /** We don't use right.output because those rows get excluded from the set. */
+  def mergeChildOutputs(childOutputs: Seq[Seq[Attribute]]): Seq[Attribute] =
+    childOutputs.head.zip(childOutputs.tail.head).map { case (leftAttr, rightAttr) =>
       leftAttr.withNullability(leftAttr.nullable && rightAttr.nullable)
     }
 }
@@ -452,10 +458,16 @@ case class Except(
   private lazy val lazyOutput: Seq[Attribute] = computeOutput()
 
   /** We don't use right.output because those rows get excluded from the set. */
-  private def computeOutput(): Seq[Attribute] = left.output
+  private def computeOutput(): Seq[Attribute] = Except.mergeChildOutputs(children.map(_.output))
 }
 
-/** Factory for constructing new `Union` nodes. */
+/** Factory methods for `Except` nodes. */
+object Except {
+  /** We don't use right.output because those rows get excluded from the set. */
+  def mergeChildOutputs(childOutputs: Seq[Seq[Attribute]]): Seq[Attribute] = childOutputs.head
+}
+
+/** Factory methods for `Union` nodes. */
 object Union {
   def apply(left: LogicalPlan, right: LogicalPlan): Union = {
     Union (left :: right :: Nil)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -416,7 +416,7 @@ case class Intersect(
     newLeft: LogicalPlan, newRight: LogicalPlan): Intersect = copy(left = newLeft, right = newRight)
 
   private lazy val lazyOutput: Seq[Attribute] = computeOutput()
-  
+
   private def computeOutput(): Seq[Attribute] = Intersect.mergeChildOutputs(children.map(_.output))
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -416,8 +416,7 @@ case class Intersect(
     newLeft: LogicalPlan, newRight: LogicalPlan): Intersect = copy(left = newLeft, right = newRight)
 
   private lazy val lazyOutput: Seq[Attribute] = computeOutput()
-
-  /** We don't use right.output because those rows get excluded from the set. */
+  
   private def computeOutput(): Seq[Attribute] = Intersect.mergeChildOutputs(children.map(_.output))
 }
 
@@ -457,7 +456,6 @@ case class Except(
 
   private lazy val lazyOutput: Seq[Attribute] = computeOutput()
 
-  /** We don't use right.output because those rows get excluded from the set. */
   private def computeOutput(): Seq[Attribute] = Except.mergeChildOutputs(children.map(_.output))
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add mergeChildOutputs method to  Intersect/Except objects.


### Why are the changes needed?
To improve the code health and to reuse those in the single-pass Analyzer.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Refactor.


### Was this patch authored or co-authored using generative AI tooling?
No.
