### PR TITLE
[SPARK-51672][SQL] Regenerate golden files with collation aliases in branch-4.0

### DIFF
--- a/sql/core/src/test/resources/sql-tests/analyzer-results/collations.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/collations.sql.out
@@ -3212,8 +3212,8 @@ select lower(`concat_ws(' ' collate UTF8_LCASE, utf8_lcase, utf8_lcase)`) from (
 Project [lower(concat_ws(' ' collate UTF8_LCASE, utf8_lcase, utf8_lcase)#x) AS lower(concat_ws(' ' collate UTF8_LCASE, utf8_lcase, utf8_lcase))#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [concat_ws(' ' collate UTF8_LCASE, utf8_lcase, utf8_lcase)#x]
-      +- Sort [max(concat_ws(' ' collate UTF8_LCASE, utf8_lcase, utf8_lcase))#x ASC NULLS FIRST], true
-         +- Aggregate [concat_ws( , utf8_lcase#x, utf8_lcase#x)], [concat_ws( , utf8_lcase#x, utf8_lcase#x) AS concat_ws(' ' collate UTF8_LCASE, utf8_lcase, utf8_lcase)#x, max(concat_ws( , utf8_lcase#x, utf8_lcase#x)) AS max(concat_ws(' ' collate UTF8_LCASE, utf8_lcase, utf8_lcase))#x]
+      +- Sort [max(concat_ws( , utf8_lcase#x, utf8_lcase#x))#x ASC NULLS FIRST], true
+         +- Aggregate [concat_ws( , utf8_lcase#x, utf8_lcase#x)], [concat_ws( , utf8_lcase#x, utf8_lcase#x) AS concat_ws(' ' collate UTF8_LCASE, utf8_lcase, utf8_lcase)#x, max(concat_ws( , utf8_lcase#x, utf8_lcase#x)) AS max(concat_ws( , utf8_lcase#x, utf8_lcase#x))#x]
             +- SubqueryAlias spark_catalog.default.t5
                +- Relation spark_catalog.default.t5[s#x,utf8_binary#x,utf8_lcase#x] parquet
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Regenerate golden files with collation aliases in branch-4.0

### Why are the changes needed?

Leftover changes to 4.0 from https://github.com/apache/spark/pull/50410, because auto-generated aliases in `Aggregate` are still computed using `Expression.toString` there.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Golden files were regenerated.

### Was this patch authored or co-authored using generative AI tooling?

No.