### PR TITLE
[SPARK-51673][SQL] Apply default collation to alter view query

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
@@ -115,7 +115,7 @@ object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
    * Transforms the given plan, by transforming all expressions in its operators to use the given
    * new type instead of the default string type.
    */
-  private def transformPlan(plan: LogicalPlan, newType: StringType): LogicalPlan = {
+  def transformPlan(plan: LogicalPlan, newType: StringType): LogicalPlan = {
     val transformedPlan = plan resolveExpressionsUp { expression =>
       transformExpression
         .andThen(_.apply(newType))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
@@ -128,7 +128,7 @@ object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
    * Transforms the given plan, by transforming all expressions in its operators to use the given
    * new type instead of the default string type.
    */
-  def transformPlan(plan: LogicalPlan, newType: StringType): LogicalPlan = {
+  private def transformPlan(plan: LogicalPlan, newType: StringType): LogicalPlan = {
     val transformedPlan = plan resolveExpressionsUp { expression =>
       transformExpression
         .andThen(_.apply(newType))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
@@ -66,6 +66,16 @@ object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
             StringType(defaultCollation)
         }
 
+      case alterViewAs: AlterViewAs =>
+        alterViewAs.child match {
+          case resolvedPersistentView: ResolvedPersistentView =>
+            val collation = resolvedPersistentView.metadata.collation.getOrElse(defaultCollation)
+            StringType(collation)
+          case resolvedTempView: ResolvedTempView =>
+            val collation = resolvedTempView.metadata.collation.getOrElse(defaultCollation)
+            StringType(collation)
+        }
+
       // Check if view has default collation
       case _ if AnalysisContext.get.collation.isDefined =>
         StringType(AnalysisContext.get.collation.get)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDDLCommandStringTypes.scala
@@ -74,6 +74,9 @@ object ResolveDDLCommandStringTypes extends Rule[LogicalPlan] {
           case resolvedTempView: ResolvedTempView =>
             val collation = resolvedTempView.metadata.collation.getOrElse(defaultCollation)
             StringType(collation)
+          case _ =>
+            // As a safeguard, use the default collation for unknown cases.
+            StringType(defaultCollation)
         }
 
       // Check if view has default collation

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -21,12 +21,15 @@ import java.net.URI
 import java.util.Locale
 import java.util.concurrent.{Callable, ExecutionException, TimeUnit}
 import javax.annotation.concurrent.GuardedBy
+
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
+
 import com.google.common.cache.{Cache, CacheBuilder}
 import com.google.common.util.concurrent.UncheckedExecutionException
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.{SparkException, SparkThrowable}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -21,15 +21,12 @@ import java.net.URI
 import java.util.Locale
 import java.util.concurrent.{Callable, ExecutionException, TimeUnit}
 import javax.annotation.concurrent.GuardedBy
-
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
-
 import com.google.common.cache.{Cache, CacheBuilder}
 import com.google.common.util.concurrent.UncheckedExecutionException
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.{SparkException, SparkThrowable}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
@@ -49,7 +46,7 @@ import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAM
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.GLOBAL_TEMP_DATABASE
-import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
+import org.apache.spark.sql.types.{MetadataBuilder, StringType, StructField, StructType}
 import org.apache.spark.sql.util.{CaseInsensitiveStringMap, PartitioningUtils}
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
@@ -987,9 +984,17 @@ class SessionCatalog(
           parser.parseQuery(viewText)
         }
     }
+    // The metadata.viewText contains only the AS query part of CREATE VIEW statement
+    // and does not include the DEFAULT COLLATION part, resulting in a plan without collation.
+    val plan = if (metadata.collation.isDefined) {
+      val newType = StringType(metadata.collation.get)
+      ResolveDDLCommandStringTypes.transformPlan(parsedPlan, newType)
+    } else {
+      parsedPlan
+    }
     val schemaMode = metadata.viewSchemaMode
     if (schemaMode == SchemaEvolution) {
-      View(desc = metadata, isTempView = isTempView, child = parsedPlan)
+      View(desc = metadata, isTempView = isTempView, child = plan)
     } else {
       val projectList = if (!isHiveCreatedView(metadata)) {
         val viewColumnNames = if (metadata.viewQueryColumnNames.isEmpty) {
@@ -1038,7 +1043,7 @@ class SessionCatalog(
           castColToType(col, field, schemaMode)
         }
       }
-      View(desc = metadata, isTempView = isTempView, child = Project(projectList, parsedPlan))
+      View(desc = metadata, isTempView = isTempView, child = Project(projectList, plan))
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -137,7 +137,8 @@ case class CreateViewCommand(
         originalText,
         analyzedPlan,
         aliasedPlan,
-        referredTempFunctions)
+        referredTempFunctions,
+        collation)
       catalog.createTempView(name.table, tableDefinition, overrideIfExists = replace)
     } else if (viewType == GlobalTempView) {
       val db = sparkSession.sessionState.conf.getConf(StaticSQLConf.GLOBAL_TEMP_DATABASE)
@@ -739,8 +740,10 @@ object ViewHelper extends SQLConfHelper with Logging {
       originalText: Option[String],
       analyzedPlan: LogicalPlan,
       aliasedPlan: LogicalPlan,
-      referredTempFunctions: Seq[String]): TemporaryViewRelation = {
-    val uncache = getRawTempView(name.table).map { r =>
+      referredTempFunctions: Seq[String],
+      collation: Option[String] = None): TemporaryViewRelation = {
+    val rawTempView = getRawTempView(name.table)
+    val uncache = rawTempView.map { r =>
       needsToUncache(r, aliasedPlan)
     }.getOrElse(false)
     val storeAnalyzedPlanForView = session.sessionState.conf.storeAnalyzedPlanForView ||
@@ -754,6 +757,16 @@ object ViewHelper extends SQLConfHelper with Logging {
       }
       CommandUtils.uncacheTableOrView(session, name)
     }
+    // When called from CreateViewCommand, this function determines the collation from the
+    // DEFAULT COLLATION clause in the query or assigns None if unspecified.
+    // When called from AlterViewAsCommand, it retrieves the collation from the view's metadata.
+    val defaultCollation = if (collation.isDefined) {
+      collation
+    } else if (rawTempView.isDefined) {
+      rawTempView.get.tableMeta.collation
+    } else {
+      None
+    }
     if (!storeAnalyzedPlanForView) {
       TemporaryViewRelation(
         prepareTemporaryView(
@@ -762,10 +775,11 @@ object ViewHelper extends SQLConfHelper with Logging {
           analyzedPlan,
           aliasedPlan.schema,
           originalText.get,
-          referredTempFunctions))
+          referredTempFunctions,
+          defaultCollation))
     } else {
       TemporaryViewRelation(
-        prepareTemporaryViewStoringAnalyzedPlan(name, aliasedPlan),
+        prepareTemporaryViewStoringAnalyzedPlan(name, aliasedPlan, defaultCollation),
         Some(aliasedPlan))
     }
   }
@@ -795,7 +809,8 @@ object ViewHelper extends SQLConfHelper with Logging {
       analyzedPlan: LogicalPlan,
       viewSchema: StructType,
       originalText: String,
-      tempFunctions: Seq[String]): CatalogTable = {
+      tempFunctions: Seq[String],
+      collation: Option[String]): CatalogTable = {
 
     val tempViews = collectTemporaryViews(analyzedPlan)
     val tempVariables = collectTemporaryVariables(analyzedPlan)
@@ -812,7 +827,8 @@ object ViewHelper extends SQLConfHelper with Logging {
       schema = viewSchema,
       viewText = Some(originalText),
       createVersion = org.apache.spark.SPARK_VERSION,
-      properties = newProperties)
+      properties = newProperties,
+      collation = collation)
   }
 
   /**
@@ -821,12 +837,14 @@ object ViewHelper extends SQLConfHelper with Logging {
    */
   private def prepareTemporaryViewStoringAnalyzedPlan(
       viewName: TableIdentifier,
-      analyzedPlan: LogicalPlan): CatalogTable = {
+      analyzedPlan: LogicalPlan,
+      collation: Option[String]): CatalogTable = {
     CatalogTable(
       identifier = viewName,
       tableType = CatalogTableType.VIEW,
       storage = CatalogStorageFormat.empty,
       schema = analyzedPlan.schema,
-      properties = Map((VIEW_STORING_ANALYZED_PLAN, "true")))
+      properties = Map((VIEW_STORING_ANALYZED_PLAN, "true")),
+      collation = collation)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
@@ -482,12 +482,12 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
         sql(s"CREATE $temporary VIEW $testView DEFAULT COLLATION UTF8_LCASE AS SELECT 1")
         sql(s"ALTER VIEW $testView AS SELECT 'a' AS c1, 'b' AS c2")
         val prefix = "SYSTEM.BUILTIN"
-        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testView"),
+        checkAnswer(sql(s"SELECT COLLATION(c1) FROM $testView"),
           Row(s"$prefix.UTF8_LCASE"))
-        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c2) FROM $testView"),
+        checkAnswer(sql(s"SELECT COLLATION(c2) FROM $testView"),
           Row(s"$prefix.UTF8_LCASE"))
         sql(s"ALTER VIEW $testView AS SELECT 'c' AS c3 WHERE 'a' = 'A'")
-        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c3) FROM $testView"),
+        checkAnswer(sql(s"SELECT COLLATION(c3) FROM $testView"),
           Row(s"$prefix.UTF8_LCASE"))
       }
       withTable(testTable) {
@@ -504,9 +504,9 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
               | WHERE c1 = 'A' AND 'ć' = 'Č'""".stripMargin)
           // scalastyle:on
           val prefix = "SYSTEM.BUILTIN"
-          checkAnswer(sql(s"SELECT DISTINCT COLLATION(c4) FROM $testView"),
+          checkAnswer(sql(s"SELECT COLLATION(c4) FROM $testView"),
             Row(s"$prefix.sr_CI_AI"))
-          checkAnswer(sql(s"SELECT DISTINCT COLLATION(c5) FROM $testView"),
+          checkAnswer(sql(s"SELECT COLLATION(c5) FROM $testView"),
             Row(s"$prefix.sr_CI_AI"))
           checkAnswer(sql(s"SELECT c5 FROM $testView"), Row("d"))
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
@@ -499,10 +499,10 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
             // scalastyle:off
             sql(
               s"""ALTER VIEW $testView AS
-                 | SELECT *, 'c' AS c4,
-                 | (SELECT (SELECT CASE 'š' = 'S' WHEN TRUE THEN 'd' ELSE 'b' END)) AS c5
-                 | FROM $testTable
-                 | WHERE c1 = 'A' AND 'ć' = 'Č'""".stripMargin)
+                | SELECT *, 'c' AS c4,
+                | (SELECT (SELECT CASE 'š' = 'S' WHEN TRUE THEN 'd' ELSE 'b' END)) AS c5
+                | FROM $testTable
+                | WHERE c1 = 'A' AND 'ć' = 'Č'""".stripMargin)
             // scalastyle:on
             val prefix = "SYSTEM.BUILTIN"
             checkAnswer(sql(s"SELECT DISTINCT COLLATION(c4) FROM $testView"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
@@ -477,32 +477,41 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
   }
 
   test("ALTER VIEW check default collation") {
-    withView(testView) {
-      sql(s"CREATE VIEW $testView DEFAULT COLLATION UTF8_LCASE AS SELECT 'a' AS c1, 'b' AS c2")
-      val prefix = "SYSTEM.BUILTIN"
-      checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testView"), Row(s"$prefix.UTF8_LCASE"))
-      checkAnswer(sql(s"SELECT DISTINCT COLLATION(c2) FROM $testView"), Row(s"$prefix.UTF8_LCASE"))
-      sql(s"ALTER VIEW $testView AS SELECT 'c' AS c3 WHERE 'a' = 'A'")
-      checkAnswer(sql(s"SELECT DISTINCT COLLATION(c3) FROM $testView"), Row(s"$prefix.UTF8_LCASE"))
-    }
-    withTable(testTable) {
-      sql(s"CREATE TABLE $testTable (c1 STRING COLLATE UTF8_LCASE, c2 STRING, c3 INT)")
-      sql(s"INSERT INTO $testTable VALUES ('a', 'b', 1)")
-      withView(testView) {
-        sql(s"CREATE VIEW $testView DEFAULT COLLATION sr_AI_CI AS SELECT 'a' AS c1")
-        // scalastyle:off
-        sql(
-          s"""ALTER VIEW $testView AS
-             | SELECT *, 'c' AS c4,
-             | (SELECT (SELECT CASE 'š' = 'S' WHEN TRUE THEN 'd' ELSE 'b' END)) AS c5
-             | FROM $testTable
-             | WHERE c1 = 'A' AND 'ć' = 'Č'""".stripMargin)
-        // scalastyle:on
-        val prefix = "SYSTEM.BUILTIN"
-        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c4) FROM $testView"), Row(s"$prefix.sr_CI_AI"))
-        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c5) FROM $testView"), Row(s"$prefix.sr_CI_AI"))
-        checkAnswer(sql(s"SELECT c5 FROM $testView"), Row("d"))
-      }
+    Seq("", "TEMPORARY").foreach {
+      temporary =>
+        withView(testView) {
+          sql(s"CREATE $temporary VIEW $testView DEFAULT COLLATION UTF8_LCASE AS SELECT 1")
+          sql(s"ALTER VIEW $testView AS SELECT 'a' AS c1, 'b' AS c2")
+          val prefix = "SYSTEM.BUILTIN"
+          checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testView"),
+            Row(s"$prefix.UTF8_LCASE"))
+          checkAnswer(sql(s"SELECT DISTINCT COLLATION(c2) FROM $testView"),
+            Row(s"$prefix.UTF8_LCASE"))
+          sql(s"ALTER VIEW $testView AS SELECT 'c' AS c3 WHERE 'a' = 'A'")
+          checkAnswer(sql(s"SELECT DISTINCT COLLATION(c3) FROM $testView"),
+            Row(s"$prefix.UTF8_LCASE"))
+        }
+        withTable(testTable) {
+          sql(s"CREATE TABLE $testTable (c1 STRING COLLATE UTF8_LCASE, c2 STRING, c3 INT)")
+          sql(s"INSERT INTO $testTable VALUES ('a', 'b', 1)")
+          withView(testView) {
+            sql(s"CREATE $temporary VIEW $testView DEFAULT COLLATION sr_AI_CI AS SELECT 'a' AS c1")
+            // scalastyle:off
+            sql(
+              s"""ALTER VIEW $testView AS
+                 | SELECT *, 'c' AS c4,
+                 | (SELECT (SELECT CASE 'š' = 'S' WHEN TRUE THEN 'd' ELSE 'b' END)) AS c5
+                 | FROM $testTable
+                 | WHERE c1 = 'A' AND 'ć' = 'Č'""".stripMargin)
+            // scalastyle:on
+            val prefix = "SYSTEM.BUILTIN"
+            checkAnswer(sql(s"SELECT DISTINCT COLLATION(c4) FROM $testView"),
+              Row(s"$prefix.sr_CI_AI"))
+            checkAnswer(sql(s"SELECT DISTINCT COLLATION(c5) FROM $testView"),
+              Row(s"$prefix.sr_CI_AI"))
+            checkAnswer(sql(s"SELECT c5 FROM $testView"), Row("d"))
+          }
+        }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
@@ -477,41 +477,40 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
   }
 
   test("ALTER VIEW check default collation") {
-    Seq("", "TEMPORARY").foreach {
-      temporary =>
+    Seq("", "TEMPORARY").foreach { temporary =>
+      withView(testView) {
+        sql(s"CREATE $temporary VIEW $testView DEFAULT COLLATION UTF8_LCASE AS SELECT 1")
+        sql(s"ALTER VIEW $testView AS SELECT 'a' AS c1, 'b' AS c2")
+        val prefix = "SYSTEM.BUILTIN"
+        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testView"),
+          Row(s"$prefix.UTF8_LCASE"))
+        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c2) FROM $testView"),
+          Row(s"$prefix.UTF8_LCASE"))
+        sql(s"ALTER VIEW $testView AS SELECT 'c' AS c3 WHERE 'a' = 'A'")
+        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c3) FROM $testView"),
+          Row(s"$prefix.UTF8_LCASE"))
+      }
+      withTable(testTable) {
+        sql(s"CREATE TABLE $testTable (c1 STRING COLLATE UTF8_LCASE, c2 STRING, c3 INT)")
+        sql(s"INSERT INTO $testTable VALUES ('a', 'b', 1)")
         withView(testView) {
-          sql(s"CREATE $temporary VIEW $testView DEFAULT COLLATION UTF8_LCASE AS SELECT 1")
-          sql(s"ALTER VIEW $testView AS SELECT 'a' AS c1, 'b' AS c2")
+          sql(s"CREATE $temporary VIEW $testView DEFAULT COLLATION sr_AI_CI AS SELECT 'a' AS c1")
+          // scalastyle:off
+          sql(
+            s"""ALTER VIEW $testView AS
+              | SELECT *, 'c' AS c4,
+              | (SELECT (SELECT CASE 'š' = 'S' WHEN TRUE THEN 'd' ELSE 'b' END)) AS c5
+              | FROM $testTable
+              | WHERE c1 = 'A' AND 'ć' = 'Č'""".stripMargin)
+          // scalastyle:on
           val prefix = "SYSTEM.BUILTIN"
-          checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testView"),
-            Row(s"$prefix.UTF8_LCASE"))
-          checkAnswer(sql(s"SELECT DISTINCT COLLATION(c2) FROM $testView"),
-            Row(s"$prefix.UTF8_LCASE"))
-          sql(s"ALTER VIEW $testView AS SELECT 'c' AS c3 WHERE 'a' = 'A'")
-          checkAnswer(sql(s"SELECT DISTINCT COLLATION(c3) FROM $testView"),
-            Row(s"$prefix.UTF8_LCASE"))
+          checkAnswer(sql(s"SELECT DISTINCT COLLATION(c4) FROM $testView"),
+            Row(s"$prefix.sr_CI_AI"))
+          checkAnswer(sql(s"SELECT DISTINCT COLLATION(c5) FROM $testView"),
+            Row(s"$prefix.sr_CI_AI"))
+          checkAnswer(sql(s"SELECT c5 FROM $testView"), Row("d"))
         }
-        withTable(testTable) {
-          sql(s"CREATE TABLE $testTable (c1 STRING COLLATE UTF8_LCASE, c2 STRING, c3 INT)")
-          sql(s"INSERT INTO $testTable VALUES ('a', 'b', 1)")
-          withView(testView) {
-            sql(s"CREATE $temporary VIEW $testView DEFAULT COLLATION sr_AI_CI AS SELECT 'a' AS c1")
-            // scalastyle:off
-            sql(
-              s"""ALTER VIEW $testView AS
-                | SELECT *, 'c' AS c4,
-                | (SELECT (SELECT CASE 'š' = 'S' WHEN TRUE THEN 'd' ELSE 'b' END)) AS c5
-                | FROM $testTable
-                | WHERE c1 = 'A' AND 'ć' = 'Č'""".stripMargin)
-            // scalastyle:on
-            val prefix = "SYSTEM.BUILTIN"
-            checkAnswer(sql(s"SELECT DISTINCT COLLATION(c4) FROM $testView"),
-              Row(s"$prefix.sr_CI_AI"))
-            checkAnswer(sql(s"SELECT DISTINCT COLLATION(c5) FROM $testView"),
-              Row(s"$prefix.sr_CI_AI"))
-            checkAnswer(sql(s"SELECT c5 FROM $testView"), Row("d"))
-          }
-        }
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
@@ -475,6 +475,36 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
       checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c2 = 'b'"), Seq(Row(0)))
     }
   }
+
+  test("ALTER VIEW check default collation") {
+    withView(testView) {
+      sql(s"CREATE VIEW $testView DEFAULT COLLATION UTF8_LCASE AS SELECT 'a' AS c1, 'b' AS c2")
+      val prefix = "SYSTEM.BUILTIN"
+      checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testView"), Row(s"$prefix.UTF8_LCASE"))
+      checkAnswer(sql(s"SELECT DISTINCT COLLATION(c2) FROM $testView"), Row(s"$prefix.UTF8_LCASE"))
+      sql(s"ALTER VIEW $testView AS SELECT 'c' AS c3 WHERE 'a' = 'A'")
+      checkAnswer(sql(s"SELECT DISTINCT COLLATION(c3) FROM $testView"), Row(s"$prefix.UTF8_LCASE"))
+    }
+    withTable(testTable) {
+      sql(s"CREATE TABLE $testTable (c1 STRING COLLATE UTF8_LCASE, c2 STRING, c3 INT)")
+      sql(s"INSERT INTO $testTable VALUES ('a', 'b', 1)")
+      withView(testView) {
+        sql(s"CREATE VIEW $testView DEFAULT COLLATION sr_AI_CI AS SELECT 'a' AS c1")
+        // scalastyle:off
+        sql(
+          s"""ALTER VIEW $testView AS
+             | SELECT *, 'c' AS c4,
+             | (SELECT (SELECT CASE 'š' = 'S' WHEN TRUE THEN 'd' ELSE 'b' END)) AS c5
+             | FROM $testTable
+             | WHERE c1 = 'A' AND 'ć' = 'Č'""".stripMargin)
+        // scalastyle:on
+        val prefix = "SYSTEM.BUILTIN"
+        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c4) FROM $testView"), Row(s"$prefix.sr_CI_AI"))
+        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c5) FROM $testView"), Row(s"$prefix.sr_CI_AI"))
+        checkAnswer(sql(s"SELECT c5 FROM $testView"), Row("d"))
+      }
+    }
+  }
 }
 
 class DefaultCollationTestSuiteV2 extends DefaultCollationTestSuite with DatasourceV2SQLBase {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fixed the application of default collation in `ALTER VIEW` queries. For example, if a view has a default collation and we execute `ALTER VIEW v AS SELECT 'a' AS c1`, the default collation was not being applied to the literal `a`.


### Why are the changes needed?
Bug fix.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Tests added to `DefaultCollationTestSuite.scala`


### Was this patch authored or co-authored using generative AI tooling?
No.
