### PR TITLE
[SPARK-51674][DOCS] Remove unnecessary Spark Connect doc link from Spark website

### DIFF
--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -85,21 +85,13 @@
 
                     <li class="nav-item dropdown">
                         <a href="#" class="nav-link dropdown-toggle" id="navbarAPIDocs" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">API Docs</a>
-                        <ul class="dropdown-menu" aria-labelledby="navbarAPIDocs">
-                            <li><a class="dropdown-item" href="api/python/index.html">Python</a></li>
-                            <li>
-                                <a class="dropdown-item" href="#">Scala &raquo; </a>
-                                <ul class="dropdown-menu dropdown-submenu">
-                                    <li>
-                                        <a class="dropdown-item" href="api/scala/org/apache/spark/index.html">Classic</a>
-                                        <a class="dropdown-item" href="api/connect/scala/org/apache/spark/index.html">Connect</a>
-                                    </li>
-                                </ul>
-                            </li>
-                            <li><a class="dropdown-item" href="api/java/index.html">Java</a></li>
-                            <li><a class="dropdown-item" href="api/R/index.html">R</a></li>
-                            <li><a class="dropdown-item" href="api/sql/index.html">SQL, Built-in Functions</a></li>
-                        </ul>
+                        <div class="dropdown-menu" aria-labelledby="navbarAPIDocs">
+                            <a class="dropdown-item" href="{{ rel_path_to_root }}api/python/index.html">Python</a>
+                            <a class="dropdown-item" href="{{ rel_path_to_root }}api/scala/org/apache/spark/index.html">Scala</a>
+                            <a class="dropdown-item" href="{{ rel_path_to_root }}api/java/index.html">Java</a>
+                            <a class="dropdown-item" href="{{ rel_path_to_root }}api/R/index.html">R</a>
+                            <a class="dropdown-item" href="{{ rel_path_to_root }}api/sql/index.html">SQL, Built-in Functions</a>
+                        </div>
                     </li>
 
                     <li class="nav-item dropdown">

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -61,10 +61,6 @@ links.
     margin-top: 0;
   }
 
-  .navbar .dropdown-menu li {
-    position: relative;
-  }
-
   .navbar .dropdown-menu.fade-down {
     top: 80%;
     transform: none !important;
@@ -80,17 +76,6 @@ links.
     visibility: visible;
     top: 100%;
     font-size: calc(0.51rem + 0.55vw);
-  }
-
-  .navbar .dropdown-menu .dropdown-submenu {
-    display: none;
-    position: absolute;
-    left: 100%;
-    top: -1px !important;
-  }
-
-  .navbar .dropdown-menu li:hover > .dropdown-submenu {
-    display: block;
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This reverts commit 6bf66c75e2b01b66f6c6da852a239fcd9f626ccf (committed by https://github.com/apache/spark/pull/50042).

### Why are the changes needed?

We now have all Classic-only APIs annotated with @ClassicOnly. This tag will be visible in the main Spark API doc. Therefore a separate doc for Spark Connect is not necessary.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Not needed.


### Was this patch authored or co-authored using generative AI tooling?

No.