### PR TITLE
[SPARK-51680][SQL] Set the logical type for TIME in the parquet writer

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -482,12 +482,14 @@ private[parquet] class ParquetRowConverter(
         }
 
       case _: TimeType
-        if parquetType.asPrimitiveType().getPrimitiveTypeName == INT64 && (
-          parquetType.getLogicalTypeAnnotation == null ||
-          parquetType.getLogicalTypeAnnotation.isInstanceOf[TimeLogicalTypeAnnotation] &&
+        if parquetType.getLogicalTypeAnnotation.isInstanceOf[TimeLogicalTypeAnnotation] &&
           parquetType.getLogicalTypeAnnotation
-            .asInstanceOf[TimeLogicalTypeAnnotation].getUnit == TimeUnit.MICROS) =>
-        new ParquetPrimitiveConverter(updater)
+            .asInstanceOf[TimeLogicalTypeAnnotation].getUnit == TimeUnit.MICROS =>
+        new ParquetPrimitiveConverter(updater) {
+          override def addLong(value: Long): Unit = {
+            this.updater.setLong(value)
+          }
+        }
 
       // A repeated field that is neither contained by a `LIST`- or `MAP`-annotated group nor
       // annotated by `LIST` or `MAP` should be interpreted as a required list of required

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -482,14 +482,12 @@ private[parquet] class ParquetRowConverter(
         }
 
       case _: TimeType
-        if parquetType.getLogicalTypeAnnotation.isInstanceOf[TimeLogicalTypeAnnotation] &&
+        if parquetType.asPrimitiveType().getPrimitiveTypeName == INT64 && (
+          parquetType.getLogicalTypeAnnotation == null ||
+          parquetType.getLogicalTypeAnnotation.isInstanceOf[TimeLogicalTypeAnnotation] &&
           parquetType.getLogicalTypeAnnotation
-            .asInstanceOf[TimeLogicalTypeAnnotation].getUnit == TimeUnit.MICROS =>
-        new ParquetPrimitiveConverter(updater) {
-          override def addLong(value: Long): Unit = {
-            this.updater.setLong(value)
-          }
-        }
+            .asInstanceOf[TimeLogicalTypeAnnotation].getUnit == TimeUnit.MICROS) =>
+        new ParquetPrimitiveConverter(updater)
 
       // A repeated field that is neither contained by a `LIST`- or `MAP`-annotated group nor
       // annotated by `LIST` or `MAP` should be interpreted as a required list of required

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
@@ -565,7 +565,7 @@ class SparkToParquetSchemaConverter(
       case IntegerType | _: YearMonthIntervalType =>
         Types.primitive(INT32, repetition).named(field.name)
 
-      case LongType | _: DayTimeIntervalType | _: TimeType =>
+      case LongType | _: DayTimeIntervalType =>
         Types.primitive(INT64, repetition).named(field.name)
 
       case FloatType =>
@@ -581,6 +581,10 @@ class SparkToParquetSchemaConverter(
       case DateType =>
         Types.primitive(INT32, repetition)
           .as(LogicalTypeAnnotation.dateType()).named(field.name)
+
+      case _: TimeType =>
+        Types.primitive(INT64, repetition)
+          .as(LogicalTypeAnnotation.timeType(false, TimeUnit.MICROS)).named(field.name)
 
       // NOTE: Spark SQL can write timestamp values to Parquet using INT96, TIMESTAMP_MICROS or
       // TIMESTAMP_MILLIS. TIMESTAMP_MICROS is recommended but INT96 is the default to keep the


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to modify the parquet schema converter for the TIME data type, and convert Catalyst's `TimeType(n)` to parquet physical type `INT64` annotated by the logical type:
```
TimeType(isAdjustedToUTC = false, unit = MICROS)
```
in the parquet writer.

### Why are the changes needed?
To fix a failure of non-vectorized reader. The code below portraits the issue:
```scala
scala> spark.conf.set("spark.sql.parquet.enableVectorizedReader", false)
scala> spark.read.parquet("/Users/maxim.gekk/tmp/time_parquet3").show()

org.apache.spark.SparkRuntimeException: [PARQUET_CONVERSION_FAILURE.UNSUPPORTED] Unable to create a Parquet converter for the data type "TIME(6)" whose Parquet type is optional int64 col. Please modify the conversion making sure it is supported. SQLSTATE: 42846
  at org.apache.spark.sql.errors.QueryExecutionErrors$.cannotCreateParquetConverterForDataTypeError(QueryExecutionErrors.scala:2000)
```

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
By running the modified test:
```
$ build/sbt "test:testOnly *ParquetFileFormatV1Suite"
$ build/sbt "test:testOnly *ParquetFileFormatV2Suite"
```


### Was this patch authored or co-authored using generative AI tooling?
No.