### PR TITLE
[SPARK-51333][ML][PYTHON][CONNECT] Unwrap `InvocationTargetException` thrown in `MLUtils.loadOperator`

### DIFF
--- a/python/pyspark/ml/tests/test_classification.py
+++ b/python/pyspark/ml/tests/test_classification.py
@@ -979,7 +979,6 @@ class ClassificationTestsMixin:
             model2 = MultilayerPerceptronClassificationModel.load(d)
             self.assertEqual(str(model), str(model2))
 
-
     def test_invalid_load_location(self):
         spark = self.spark
         with self.assertRaisesRegex(PySparkException, "Path does not exist"):

--- a/python/pyspark/ml/tests/test_classification.py
+++ b/python/pyspark/ml/tests/test_classification.py
@@ -21,6 +21,7 @@ from shutil import rmtree
 
 import numpy as np
 
+from pyspark.errors import PySparkException
 from pyspark.ml.linalg import Vectors, Matrices
 from pyspark.sql import DataFrame, Row
 from pyspark.ml.classification import (
@@ -977,6 +978,12 @@ class ClassificationTestsMixin:
             model.write().overwrite().save(d)
             model2 = MultilayerPerceptronClassificationModel.load(d)
             self.assertEqual(str(model), str(model2))
+
+
+    def test_invalid_load_location(self):
+        spark = self.spark
+        with self.assertRaisesRegex(PySparkException, "Path does not exist"):
+            LogisticRegression.load("invalid_location")
 
 
 class ClassificationTests(ClassificationTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/ml/tests/test_classification.py
+++ b/python/pyspark/ml/tests/test_classification.py
@@ -980,7 +980,6 @@ class ClassificationTestsMixin:
             self.assertEqual(str(model), str(model2))
 
     def test_invalid_load_location(self):
-        spark = self.spark
         with self.assertRaisesRegex(PySparkException, "Path does not exist"):
             LogisticRegression.load("invalid_location")
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -416,10 +416,15 @@ private[ml] object MLUtils {
     if (operators.isEmpty || !operators.contains(name)) {
       throw MlUnsupportedException(s"Unsupported read for $name")
     }
-    operators(name)
-      .getMethod("load", classOf[String])
-      .invoke(null, path)
-      .asInstanceOf[T]
+    try {
+      operators(name)
+        .getMethod("load", classOf[String])
+        .invoke(null, path)
+        .asInstanceOf[T]
+    } catch {
+      case e: InvocationTargetException if e.getCause != null =>
+        throw e.getCause
+    }
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, if model loading fails in `MLUtils.loadOperator`, it throws an [InvocationTargetException](https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/InvocationTargetException.html), which wraps an exception thrown by the method invoked.

As a followup of https://github.com/apache/spark/pull/50098, this PR unwraps InvocationTargetException thrown in `MLUtils.loadOperator`, to make it throws the correct exception.

### Why are the changes needed?

Existing error message is useless in debug.


### Does this PR introduce _any_ user-facing change?

Yes. For example,

```
from pyspark.ml.classification import LogisticRegression
LogisticRegression.load("invalid_location")
```

Before the PR, this codes throws
```
java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.apache.spark.sql.connect.ml.MLUtils$.loadOperator(MLUtils.scala:417)
	at org.apache.spark.sql.connect.ml.MLUtils$.loadTransformer(MLUtils.scala:438)
	at org.apache.spark.sql.connect.ml.MLHandler$.handleMlCommand(MLHandler.scala:247)
```

With this PR, it will throw the correct exception:
```
java.io.FileNotFoundException: File invalid_location/metadata does not exist
	at org.apache.hadoop.fs.RawLocalFileSystem.deprecatedGetFileStatus(RawLocalFileSystem.java:917)
	at org.apache.hadoop.fs.RawLocalFileSystem.getFileLinkStatusInternal(RawLocalFileSystem.java:1238)
	at org.apache.hadoop.fs.RawLocalFileSystem.getFileStatus(RawLocalFileSystem.java:907)
	at org.apache.hadoop.fs.FilterFileSystem.getFileStatus(FilterFileSystem.java:462)
	at org.apache.spark.sql.execution.streaming.FileStreamSink$.hasMetadata(FileStreamSink.scala:56)
	at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:381)
```

### How was this patch tested?

New test.

### Was this patch authored or co-authored using generative AI tooling?

No.
