### PR TITLE
revert '[SPARK-51333][ML][PYTHON][CONNECT] Unwrap InvocationTargetException thrown in MLUtils.loadOperator' from 4.0

### DIFF
--- a/python/pyspark/ml/tests/test_classification.py
+++ b/python/pyspark/ml/tests/test_classification.py
@@ -21,7 +21,6 @@ from shutil import rmtree
 
 import numpy as np
 
-from pyspark.errors import PySparkException
 from pyspark.ml.linalg import Vectors, Matrices
 from pyspark.sql import DataFrame, Row
 from pyspark.ml.classification import (
@@ -978,10 +977,6 @@ class ClassificationTestsMixin:
             model.write().overwrite().save(d)
             model2 = MultilayerPerceptronClassificationModel.load(d)
             self.assertEqual(str(model), str(model2))
-
-    def test_invalid_load_location(self):
-        with self.assertRaisesRegex(PySparkException, "Path does not exist"):
-            LogisticRegression.load("invalid_location")
 
 
 class ClassificationTests(ClassificationTestsMixin, ReusedSQLTestCase):

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -415,15 +415,10 @@ private[ml] object MLUtils {
     if (operators.isEmpty || !operators.contains(name)) {
       throw MlUnsupportedException(s"Unsupported read for $name")
     }
-    try {
-      operators(name)
-        .getMethod("load", classOf[String])
-        .invoke(null, path)
-        .asInstanceOf[T]
-    } catch {
-      case e: InvocationTargetException if e.getCause != null =>
-        throw e.getCause
-    }
+    operators(name)
+      .getMethod("load", classOf[String])
+      .invoke(null, path)
+      .asInstanceOf[T]
   }
 
   /**


### PR DESCRIPTION
revert https://github.com/apache/spark/pull/50478 from 4.0 due to compilation error