### PR TITLE
[SPARK-51699][BUILD] Upgrade to Apache parent pom 34

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>33</version>
+    <version>34</version>
   </parent>
   <groupId>org.apache.spark</groupId>
   <artifactId>spark-parent_2.13</artifactId>
@@ -2782,7 +2782,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.13.0</version>
+          <version>3.14.0</version>
           <configuration>
             <skipMain>true</skipMain> <!-- skip compile -->
             <skip>true</skip> <!-- skip testCompile -->
@@ -2935,7 +2935,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.4.1</version>
           <configuration>
             <filesets>
               <fileset>
@@ -3035,12 +3035,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.1.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.1.4</version>
           <configuration>
             <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
           </configuration>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade Apache parent pom from version 33 to the latest version 34 along with upgrading few maven plugins versions to match those from the latest parent pom.

- maven-compiler-plugin from 3.13.0 to 3.14.0
- maven-clean-plugin from 3.4.0 to 3.4.1
- maven-install-plugin from 3.1.2 to 3.1.4
- maven-deploy-plugin from 3.1.2 to 3.1.4


### Why are the changes needed?
Apache parent pom version 34 includes several plugin upgrades as well as bug fixes. For the full list please see [release notes](https://github.com/apache/maven-apache-parent/releases/tag/apache-34)

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Local mvn build with the new parent pom succeeds:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  15:08 min
[INFO] Finished at: 2025-04-02T09:07:47-07:00
[INFO] ------------------------------------------------------------------------
```


### Was this patch authored or co-authored using generative AI tooling?
No
