### PR TITLE
[SPARK-51700][SS] Fix incorrect logging when no files are eligible for deletion in RocksDBFileManager

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -516,7 +516,12 @@ class RocksDBFileManager(
         logInfo(log"Estimated maximum version is " +
           log"${MDC(LogKeys.MAX_SEEN_VERSION, maxSeenVersion.get)}" +
           log" and minimum version is ${MDC(LogKeys.MIN_SEEN_VERSION, minSeenVersion)}")
-        val versionsToDelete = maxSeenVersion.get - minSeenVersion + 1 - numVersionsToRetain
+        var versionsToDelete = maxSeenVersion.get - minSeenVersion + 1 - numVersionsToRetain
+        // If the number of versions to delete is negative, that means that none of the versions
+        // are eligible for deletion and we reset the variable to 0
+        if (versionsToDelete < 0) {
+          versionsToDelete = 0
+        }
         if (versionsToDelete < minVersionsToDelete) {
           logInfo(log"Skipping deleting files." +
             log" Need at least ${MDC(LogKeys.MIN_VERSIONS_TO_DELETE, minVersionsToDelete)}" +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -24,6 +24,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import scala.collection.{mutable, Map}
+import scala.math._
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
@@ -516,12 +517,9 @@ class RocksDBFileManager(
         logInfo(log"Estimated maximum version is " +
           log"${MDC(LogKeys.MAX_SEEN_VERSION, maxSeenVersion.get)}" +
           log" and minimum version is ${MDC(LogKeys.MIN_SEEN_VERSION, minSeenVersion)}")
-        var versionsToDelete = maxSeenVersion.get - minSeenVersion + 1 - numVersionsToRetain
         // If the number of versions to delete is negative, that means that none of the versions
-        // are eligible for deletion and we reset the variable to 0
-        if (versionsToDelete < 0) {
-          versionsToDelete = 0
-        }
+        // are eligible for deletion and we set the variable to 0
+        val versionsToDelete = max(maxSeenVersion.get - minSeenVersion + 1 - numVersionsToRetain, 0)
         if (versionsToDelete < minVersionsToDelete) {
           logInfo(log"Skipping deleting files." +
             log" Need at least ${MDC(LogKeys.MIN_VERSIONS_TO_DELETE, minVersionsToDelete)}" +


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix incorrect logging when no files are eligible for deletion in RocksDBFileManager

### Why are the changes needed?
Without this, when no files are eligible, we are logging the wrong(negative) value in the logs

```
25/04/01 20:16:23 INFO RocksDBFileManager StateStoreId(opId=0,partId=138,name=default): Skipping deleting files. Need at least 30 stale versions for batch deletion but found only -90.
```


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing unit tests


### Was this patch authored or co-authored using generative AI tooling?
No
