### PR TITLE
[SPARK-51703][BUILD] Upgrade jetty to 11.0.25 

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -139,8 +139,8 @@ jersey-container-servlet/3.0.17//jersey-container-servlet-3.0.17.jar
 jersey-hk2/3.0.17//jersey-hk2-3.0.17.jar
 jersey-server/3.0.17//jersey-server-3.0.17.jar
 jettison/1.5.4//jettison-1.5.4.jar
-jetty-util-ajax/11.0.24//jetty-util-ajax-11.0.24.jar
-jetty-util/11.0.24//jetty-util-11.0.24.jar
+jetty-util-ajax/11.0.25//jetty-util-ajax-11.0.25.jar
+jetty-util/11.0.25//jetty-util-11.0.25.jar
 jjwt-api/0.12.6//jjwt-api-0.12.6.jar
 jjwt-impl/0.12.6//jjwt-impl-0.12.6.jar
 jjwt-jackson/0.12.6//jjwt-jackson-0.12.6.jar

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
     <parquet.version>1.15.1</parquet.version>
     <orc.version>2.1.1</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
-    <jetty.version>11.0.24</jetty.version>
+    <jetty.version>11.0.25</jetty.version>
     <jakartaservlet.version>5.0.0</jakartaservlet.version>
     <!-- SPARK-46938: Required by Hive / LibThrift libs -->
     <javaxservlet.version>4.0.1</javaxservlet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade jetty from 11.0.24 to 11.0.25 .

### Why are the changes needed?
The new version includes the following [changes](https://github.com/jetty/jetty.project/releases/tag/jetty-11.0.25):

- https://github.com/jetty/jetty.project/pull/12874 - Introduce UriCompliance.USER_INFO to Jetty 10.0.x
- https://github.com/jetty/jetty.project/issues/12869 - XmlConfiguration shouldn't treat non-XML command line options as XML
- https://github.com/jetty/jetty.project/issues/12776 - ByteBufferPool - all ongoing requests fail when single request is cancelled on HTTP/2
- https://github.com/jetty/jetty.project/issues/12821 - Better document ContextHandler.setCompactPath(boolean) deprecation
- https://github.com/jetty/jetty.project/issues/12268 - IteratingCallback may iterate too much when process() returns Action.IDLE


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
