### PR TITLE
[SPARK-51707][CONNECT][TESTS] Handling of `IllegalStateException` with `Memory leaked` message in the `afterAll` of `RemoteSparkSession`

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/RemoteSparkSession.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/RemoteSparkSession.scala
@@ -225,6 +225,8 @@ trait RemoteSparkSession
     try {
       if (spark != null) spark.stop()
     } catch {
+      case e: IllegalStateException if Option(e.getMessage).exists(_.contains("Memory leaked")) =>
+        throw e
       case e: Throwable => debug(e)
     }
     spark = null


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr improves the `afterAll` method of `RemoteSparkSession`. When it catches an `IllegalStateException` containing the message "Memory leaked", the method now throws the exception directly instead of just logging it. This adjustment enhances the exception detection capability of the `SparkSession#close` method during the execution of the `RootAllocator#close` operation, enabling relevant test cases to capture potential memory leak issues more promptly.

### Why are the changes needed?
Automatically check for potential Arrow-related memory leaks in test cases related to `RemoteSparkSession`



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Locally test：revert fix of SPARK-51677 and run test with this pr

```
git revert ad0bc93fe6abb2d1a302f77741e41a6e754e428c
build/sbt "connect-client-jvm/test" -Phive 
```


```
...
[info] org.apache.spark.sql.connect.SparkSessionE2ESuite *** ABORTED *** (3 seconds, 225 milliseconds)
[info]   java.lang.IllegalStateException: Memory was leaked by query. Memory leaked: (128000)
[info] Allocator(ROOT) 0/128000/128032/9223372036854775807 (res/actual/peak/limit)
[info]   at org.apache.arrow.memory.BaseAllocator.close(BaseAllocator.java:504)
[info]   at org.apache.arrow.memory.RootAllocator.close(RootAllocator.java:27)
[info]   at org.apache.spark.sql.connect.SparkSession.close(SparkSession.scala:632)
[info]   at org.apache.spark.sql.SparkSession.stop(SparkSession.scala:783)
[info]   at org.apache.spark.sql.connect.test.RemoteSparkSession.afterAll(RemoteSparkSession.scala:226)
[info]   at org.apache.spark.sql.connect.test.RemoteSparkSession.afterAll$(RemoteSparkSession.scala:224)
[info]   at org.apache.spark.sql.connect.SparkSessionE2ESuite.afterAll(SparkSessionE2ESuite.scala:38)
[info]   at org.scalatest.BeforeAndAfterAll.$anonfun$run$1(BeforeAndAfterAll.scala:225)
[info]   at org.scalatest.Status.$anonfun$withAfterEffect$1(Status.scala:377)
[info]   at org.scalatest.Status.$anonfun$withAfterEffect$1$adapted(Status.scala:373)
[info]   at org.scalatest.CompositeStatus.whenCompleted(Status.scala:962)
[info]   at org.scalatest.Status.withAfterEffect(Status.scala:373)
[info]   at org.scalatest.Status.withAfterEffect$(Status.scala:371)
[info]   at org.scalatest.CompositeStatus.withAfterEffect(Status.scala:863)
[info]   at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:224)
[info]   at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
[info]   at org.apache.spark.sql.connect.SparkSessionE2ESuite.run(SparkSessionE2ESuite.scala:38)
[info]   at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:321)
[info]   at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:517)
[info]   at sbt.ForkMain$Run.lambda$runTest$1(ForkMain.java:414)
[info]   at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[info]   at java.base/java.lang.Thread.run(Thread.java:840)
...
[info] org.apache.spark.sql.connect.ClientE2ETestSuite *** ABORTED *** (41 seconds, 54 milliseconds)
[info]   java.lang.IllegalStateException: Memory was leaked by query. Memory leaked: (12192)
[info] Allocator(ROOT) 0/12192/6325056/9223372036854775807 (res/actual/peak/limit)
[info]   at org.apache.arrow.memory.BaseAllocator.close(BaseAllocator.java:504)
[info]   at org.apache.arrow.memory.RootAllocator.close(RootAllocator.java:27)
[info]   at org.apache.spark.sql.connect.SparkSession.close(SparkSession.scala:632)
[info]   at org.apache.spark.sql.SparkSession.stop(SparkSession.scala:783)
[info]   at org.apache.spark.sql.connect.test.RemoteSparkSession.afterAll(RemoteSparkSession.scala:226)
[info]   at org.apache.spark.sql.connect.test.RemoteSparkSession.afterAll$(RemoteSparkSession.scala:224)
[info]   at org.apache.spark.sql.connect.ClientE2ETestSuite.afterAll(ClientE2ETestSuite.scala:51)
[info]   at org.scalatest.BeforeAndAfterAll.$anonfun$run$1(BeforeAndAfterAll.scala:225)
[info]   at org.scalatest.Status.$anonfun$withAfterEffect$1(Status.scala:377)
[info]   at org.scalatest.Status.$anonfun$withAfterEffect$1$adapted(Status.scala:373)
[info]   at org.scalatest.CompositeStatus.whenCompleted(Status.scala:962)
[info]   at org.scalatest.Status.withAfterEffect(Status.scala:373)
[info]   at org.scalatest.Status.withAfterEffect$(Status.scala:371)
[info]   at org.scalatest.CompositeStatus.withAfterEffect(Status.scala:863)
[info]   at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:224)
[info]   at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
[info]   at org.apache.spark.sql.connect.ClientE2ETestSuite.run(ClientE2ETestSuite.scala:51)
[info]   at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:321)
[info]   at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:517)
[info]   at sbt.ForkMain$Run.lambda$runTest$1(ForkMain.java:414)
[info]   at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[info]   at java.base/java.lang.Thread.run(Thread.java:840)
...
[info] Run completed in 3 minutes, 8 seconds.
[info] Total number of tests run: 1475
[info] Suites: completed 33, aborted 2
[info] Tests: succeeded 1475, failed 0, canceled 1, ignored 6, pending 0
[info] *** 2 SUITES ABORTED ***
[error] Error: Total 1479, Failed 0, Errors 2, Passed 1477, Ignored 6, Canceled 1
[error] Error during tests:
[error] 	org.apache.spark.sql.connect.ClientE2ETestSuite
[error] 	org.apache.spark.sql.connect.SparkSessionE2ESuite
```

It can be observed that after revert the relevant fixes for SPARK-51677, applying the current pr can expose memory leak issues during the testing process.


### Was this patch authored or co-authored using generative AI tooling?
No