### PR TITLE
[SPARK-51714][SS] Add Failure Ingestion test to test state store checkpoint format V2

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -136,7 +136,7 @@ class RocksDB(
 
   private val workingDir = createTempDir("workingDir")
 
-  protected def CreateFileManager(
+  protected def createFileManager(
       dfsRootDir: String,
       localTempDir: File,
       hadoopConf: Configuration,
@@ -151,7 +151,7 @@ class RocksDB(
     )
   }
 
-  private val fileManager = CreateFileManager(dfsRootDir, createTempDir("fileManager"),
+  private val fileManager = createFileManager(dfsRootDir, createTempDir("fileManager"),
     hadoopConf, conf.compressionCodec, loggingId = loggingId)
   private val byteArrayPair = new ByteArrayPair()
   private val commitLatencyMs = new mutable.HashMap[String, Long]()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -135,7 +135,23 @@ class RocksDB(
   private val nativeStats = rocksDbOptions.statistics()
 
   private val workingDir = createTempDir("workingDir")
-  private val fileManager = new RocksDBFileManager(dfsRootDir, createTempDir("fileManager"),
+
+  protected def CreateFileManager(
+      dfsRootDir: String,
+      localTempDir: File,
+      hadoopConf: Configuration,
+      codecName: String,
+      loggingId: String): RocksDBFileManager = {
+    new RocksDBFileManager(
+      dfsRootDir,
+      localTempDir,
+      hadoopConf,
+      codecName,
+      loggingId = loggingId
+    )
+  }
+
+  private val fileManager = CreateFileManager(dfsRootDir, createTempDir("fileManager"),
     hadoopConf, conf.compressionCodec, loggingId = loggingId)
   private val byteArrayPair = new ByteArrayPair()
   private val commitLatencyMs = new mutable.HashMap[String, Long]()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
 import org.apache.commons.io.{FilenameUtils, IOUtils}
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FileStatus, Path, PathFilter}
+import org.apache.hadoop.fs.{FileStatus, FileSystem, Path, PathFilter}
 import org.json4s.{Formats, NoTypeHints}
 import org.json4s.jackson.Serialization
 
@@ -132,8 +132,12 @@ class RocksDBFileManager(
 
   import RocksDBImmutableFile._
 
+  protected def GetFileSystem(myDfsRootDir: String, myHadoopConf: Configuration) : FileSystem = {
+    new Path(myDfsRootDir).getFileSystem(myHadoopConf)
+  }
+
   private lazy val fm = CheckpointFileManager.create(new Path(dfsRootDir), hadoopConf)
-  private val fs = new Path(dfsRootDir).getFileSystem(hadoopConf)
+  private val fs = GetFileSystem(dfsRootDir, hadoopConf)
   private val onlyZipFiles = new PathFilter {
     override def accept(path: Path): Boolean = path.toString.endsWith(".zip")
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -132,12 +132,12 @@ class RocksDBFileManager(
 
   import RocksDBImmutableFile._
 
-  protected def GetFileSystem(myDfsRootDir: String, myHadoopConf: Configuration) : FileSystem = {
+  protected def getFileSystem(myDfsRootDir: String, myHadoopConf: Configuration) : FileSystem = {
     new Path(myDfsRootDir).getFileSystem(myHadoopConf)
   }
 
   private lazy val fm = CheckpointFileManager.create(new Path(dfsRootDir), hadoopConf)
-  private val fs = GetFileSystem(dfsRootDir, hadoopConf)
+  private val fs = getFileSystem(dfsRootDir, hadoopConf)
   private val onlyZipFiles = new PathFilter {
     override def accept(path: Path): Boolean = path.toString.endsWith(".zip")
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -524,7 +524,7 @@ private[sql] class RocksDBStateStoreProvider
   @volatile private var stateStoreEncoding: String = _
   @volatile private var stateSchemaProvider: Option[StateSchemaProvider] = _
 
-  protected def CreateRocksDB(
+  protected def createRocksDB(
       dfsRootDir: String,
       conf: RocksDBConf,
       localRootDir: File,
@@ -550,7 +550,7 @@ private[sql] class RocksDBStateStoreProvider
       s"partId=${stateStoreId.partitionId},name=${stateStoreId.storeName})"
     val sparkConf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf)
     val localRootDir = Utils.createTempDir(Utils.getLocalDir(sparkConf), storeIdStr)
-    CreateRocksDB(dfsRootDir, RocksDBConf(storeConf), localRootDir, hadoopConf, storeIdStr,
+    createRocksDB(dfsRootDir, RocksDBConf(storeConf), localRootDir, hadoopConf, storeIdStr,
       useColumnFamilies, storeConf.enableStateStoreCheckpointIds, stateStoreId.partitionId)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -524,13 +524,33 @@ private[sql] class RocksDBStateStoreProvider
   @volatile private var stateStoreEncoding: String = _
   @volatile private var stateSchemaProvider: Option[StateSchemaProvider] = _
 
+  protected def CreateRocksDB(
+      dfsRootDir: String,
+      conf: RocksDBConf,
+      localRootDir: File,
+      hadoopConf: Configuration,
+      loggingId: String,
+      useColumnFamilies: Boolean,
+      enableStateStoreCheckpointIds: Boolean,
+      partitionId: Int = 0): RocksDB = {
+    new RocksDB(
+      dfsRootDir,
+      conf,
+      localRootDir,
+      hadoopConf,
+      loggingId,
+      useColumnFamilies,
+      enableStateStoreCheckpointIds,
+      partitionId)
+  }
+
   private[sql] lazy val rocksDB = {
     val dfsRootDir = stateStoreId.storeCheckpointLocation().toString
     val storeIdStr = s"StateStoreId(opId=${stateStoreId.operatorId}," +
       s"partId=${stateStoreId.partitionId},name=${stateStoreId.storeName})"
     val sparkConf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf)
     val localRootDir = Utils.createTempDir(Utils.getLocalDir(sparkConf), storeIdStr)
-    new RocksDB(dfsRootDir, RocksDBConf(storeConf), localRootDir, hadoopConf, storeIdStr,
+    CreateRocksDB(dfsRootDir, RocksDBConf(storeConf), localRootDir, hadoopConf, storeIdStr,
       useColumnFamilies, storeConf.enableStateStoreCheckpointIds, stateStoreId.partitionId)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -988,12 +988,14 @@ object StateStore extends Logging {
 
   /** Stop maintenance thread and reset the maintenance task */
   def stopMaintenanceTask(): Unit = loadedProviders.synchronized {
-    stopMaintenanceTaskNoLock()
+    stopMaintenanceTaskWithoutLock()
   }
 
-  /** Only used for unit tests. The function doesn't hold lockloadedProviders. Calling
-   * it can work-around a deadlock condition where a maintenance task is waiting for the lock */
-  private[streaming] def stopMaintenanceTaskNoLock(): Unit = {
+  /**
+   * Only used for unit tests. The function doesn't hold loadedProviders lock. Calling
+   * it can work-around a deadlock condition where a maintenance task is waiting for the lock
+   * */
+  private[streaming] def stopMaintenanceTaskWithoutLock(): Unit = {
     if (maintenanceThreadPool != null) {
       maintenanceThreadPoolLock.synchronized {
         maintenancePartitions.clear()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -988,6 +988,12 @@ object StateStore extends Logging {
 
   /** Stop maintenance thread and reset the maintenance task */
   def stopMaintenanceTask(): Unit = loadedProviders.synchronized {
+    stopMaintenanceTaskNoLock()
+  }
+
+  /** Only used for unit tests. The function doesn't hold lockloadedProviders. Calling
+   * it can work-around a deadlock condition where a maintenance task is waiting for the lock */
+  private[streaming] def stopMaintenanceTaskNoLock(): Unit = {
     if (maintenanceThreadPool != null) {
       maintenanceThreadPoolLock.synchronized {
         maintenancePartitions.clear()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
@@ -119,7 +119,7 @@ class FailureInjectionState {
   // File names matching this regex will cause the copyFromLocalFile to fail
   @volatile
   var failPreCopyFromLocalFileNameRegex: Seq[String] = Seq.empty
-  // File names matching this regex will cause the createAtomic to fail and put the streams in
+  // File names matching this regex will cause the close() to fail and put the streams in
   // `delayedStreams`
   @volatile
   var createAtomicDelayCloseRegex: Seq[String] = Seq.empty

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
@@ -108,7 +108,12 @@ class FailureInjectionCheckpointFileManager(path: Path, hadoopConf: Configuratio
   }
 }
 
-/** Contains a list of variables for failure ingestion conditions */
+/**
+ * Contains a list of variables for failure ingestion conditions.
+ * These are singleton instances accessed by all instances of FailureInjectionCheckpointFileManager
+ * and FailureInjectionFileSystem. This allows a unit test to have a global control of failure
+ * and access to the delayed streams.
+ */
 object FailureInjectionFileSystem {
   // File names matching this regex will cause the copyFromLocalFile to fail
   var failPreCopyFromLocalFileNameRegex: Seq[String] = Seq.empty
@@ -144,13 +149,13 @@ class FailureInjectionFileSystem(innerFs: FileSystem) extends FileSystem {
   override def open(f: Path, bufferSize: Int): FSDataInputStream = innerFs.open(f, bufferSize)
 
   override def create(
-                       f: Path,
-                       permission: FsPermission,
-                       overwrite: Boolean,
-                       bufferSize: Int,
-                       replication: Short,
-                       blockSize: Long,
-                       progress: Progressable): FSDataOutputStream =
+      f: Path,
+      permission: FsPermission,
+      overwrite: Boolean,
+      bufferSize: Int,
+      replication: Short,
+      blockSize: Long,
+      progress: Progressable): FSDataOutputStream =
     innerFs.create(f, permission, overwrite, bufferSize, replication, blockSize, progress)
 
   override def append(f: Path, bufferSize: Int, progress: Progressable): FSDataOutputStream =
@@ -158,9 +163,7 @@ class FailureInjectionFileSystem(innerFs: FileSystem) extends FileSystem {
 
   override def delete(f: Path, recursive: Boolean): Boolean = innerFs.delete(f, recursive)
 
-  override def listStatus(f: Path): Array[FileStatus] = {
-    innerFs.listStatus(f)
-  }
+  override def listStatus(f: Path): Array[FileStatus] = innerFs.listStatus(f)
 
   override def setWorkingDirectory(new_dir: Path): Unit = innerFs.setWorkingDirectory(new_dir)
 
@@ -180,7 +183,7 @@ class FailureInjectionFileSystem(innerFs: FileSystem) extends FileSystem {
 }
 
 /**
- * A rapper RocksDB State Store Provider that replaces FileSystem used in RocksDBFileManager
+ * A wrapper RocksDB State Store Provider that replaces FileSystem used in RocksDBFileManager
  * to FailureInjectionFileSystem.
  */
 class FailureInjectionRocksDBStateStoreProvider extends RocksDBStateStoreProvider {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.streaming.state
+
+import java.io._
+import java.net.URI
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs._
+import org.apache.hadoop.fs.permission.FsPermission
+import org.apache.hadoop.util.Progressable
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.streaming.CheckpointFileManager.{CancellableFSDataOutputStream, RenameBasedFSDataOutputStream}
+import org.apache.spark.sql.execution.streaming.FileSystemBasedCheckpointFileManager
+
+/** A wrapper file output stream that will throw exception in close() and put the underlying
+ * stream to FailureInjectionFileSystem.delayedStreams  */
+class DelayCloseFSDataOutputStreamWrapper(stream: CancellableFSDataOutputStream)
+  extends CancellableFSDataOutputStream(stream.getWrappedStream) with Logging {
+  val originalStream: CancellableFSDataOutputStream = stream
+
+  var closed: Boolean = false
+
+  override def close(): Unit = {
+    if (!closed) {
+      closed = true
+      FailureInjectionFileSystem.delayedStreams =
+        FailureInjectionFileSystem.delayedStreams :+ originalStream
+      throw new IOException("Fake File Stream Close Failure")
+    }
+  }
+
+  /** Cancel is not needed in unit tests */
+  override def cancel(): Unit = {}
+}
+
+/** A wrapper checkpoint file manager that might inject functions in some function calls.
+ * Used in unit tests to simulate failure scenarios.
+ * This can be put into SQLConf.STREAMING_CHECKPOINT_FILE_MANAGER_CLASS to provide failure
+ * injection behavior.
+ */
+class FailureInjectionCheckpointFileManager(path: Path, hadoopConf: Configuration)
+  extends FileSystemBasedCheckpointFileManager(path, hadoopConf) with Logging {
+
+  override def createAtomic(path: Path,
+                            overwriteIfPossible: Boolean): CancellableFSDataOutputStream = {
+    FailureInjectionFileSystem.failureCreateAtomicRegex.foreach { pattern =>
+      if (path.toString.matches(pattern)) {
+        throw new IOException("Fake File System Create Atomic Failure")
+      }
+    }
+
+    var shouldDelay = false
+    FailureInjectionFileSystem.createAtomicDelayCloseRegex.foreach { pattern =>
+      if (path.toString.matches(pattern)) {
+        shouldDelay = true
+      }
+    }
+    val ret = new RenameBasedFSDataOutputStream(this, path, overwriteIfPossible)
+    if (shouldDelay) {
+      new DelayCloseFSDataOutputStreamWrapper(ret)
+    } else {
+      ret
+    }
+
+  }
+
+  override def renameTempFile(srcPath: Path, dstPath: Path,
+                              overwriteIfPossible: Boolean): Unit = {
+    if (FailureInjectionFileSystem.allowOverwriteInRename || !fs.exists(dstPath)) {
+      super.renameTempFile(srcPath, dstPath, overwriteIfPossible)
+    } else {
+      logWarning(s"Skip renaming temp file $srcPath to $dstPath because it already exists.")
+    }
+  }
+
+  override def list(path: Path, filter: PathFilter): Array[FileStatus] = {
+    super.list(path, filter)
+  }
+
+  override def exists(path: Path): Boolean = {
+    if (FailureInjectionFileSystem.shouldFailExist) {
+      throw new IOException("Fake File Exists Failure")
+    }
+    super.exists(path)
+  }
+}
+
+/** Contains a list of variables for failure ingestion conditions */
+object FailureInjectionFileSystem {
+  // File names matching this regex will cause the copyFromLocalFile to fail
+  var failPreCopyFromLocalFileNameRegex: Seq[String] = Seq.empty
+  // File names matching this regex will cause the createAtomic to fail and put the streams in
+  // `delayedStreams`
+  var createAtomicDelayCloseRegex: Seq[String] = Seq.empty
+  // File names matching this regex will cause the createAtomic() to fail
+  var failureCreateAtomicRegex: Seq[String] = Seq.empty
+  // If true, Exists() call will fail
+  var shouldFailExist: Boolean = false
+  // If true, simulate a case where rename() will not overwrite an existing file.
+  var allowOverwriteInRename: Boolean = true
+
+  // List of streams that are delayed in close() based on `createAtomicDelayCloseRegex`
+  var delayedStreams: Seq[CancellableFSDataOutputStream] = Seq.empty
+}
+
+/** A wrapper FileSystem that inject some failures. This class can used to replace the
+ * FileSystem in RocksDBFileManager. */
+class FailureInjectionFileSystem(innerFs: FileSystem) extends FileSystem {
+
+  override def getConf: Configuration = innerFs.getConf
+
+  override def mkdirs(f: Path, permission: FsPermission): Boolean = innerFs.mkdirs(f, permission)
+
+  override def rename(src: Path, dst: Path): Boolean = innerFs.rename(src, dst)
+
+  override def getUri: URI = innerFs.getUri
+
+  override def open(f: Path, bufferSize: Int): FSDataInputStream = innerFs.open(f, bufferSize)
+
+  override def create(
+                       f: Path,
+                       permission: FsPermission,
+                       overwrite: Boolean,
+                       bufferSize: Int,
+                       replication: Short,
+                       blockSize: Long,
+                       progress: Progressable): FSDataOutputStream =
+    innerFs.create(f, permission, overwrite, bufferSize, replication, blockSize, progress)
+
+  override def append(f: Path, bufferSize: Int, progress: Progressable): FSDataOutputStream =
+    innerFs.append(f, bufferSize, progress)
+
+  override def delete(f: Path, recursive: Boolean): Boolean = innerFs.delete(f, recursive)
+
+  override def listStatus(f: Path): Array[FileStatus] = {
+    innerFs.listStatus(f)
+  }
+
+  override def setWorkingDirectory(new_dir: Path): Unit = innerFs.setWorkingDirectory(new_dir)
+
+  override def getWorkingDirectory: Path = innerFs.getWorkingDirectory
+
+  override def getFileStatus(f: Path): FileStatus = innerFs.getFileStatus(f)
+
+  override def copyFromLocalFile(src: Path, dst: Path): Unit = {
+    FailureInjectionFileSystem.failPreCopyFromLocalFileNameRegex.foreach { pattern =>
+      if (src.toString.matches(pattern)) {
+        throw new IOException(s"Injected failure due to source path matching pattern: $pattern")
+      }
+    }
+
+    innerFs.copyFromLocalFile(src, dst)
+  }
+}
+
+/** A rapper RocksDB State Store Provider that replaces FileSystem used in RocksDBFileManager
+ * to FailureInjectionFileSystem. */
+class FailureInjectionRocksDBStateStoreProvider extends RocksDBStateStoreProvider {
+  override def CreateRocksDB(
+                              dfsRootDir: String,
+                              conf: RocksDBConf,
+                              localRootDir: File,
+                              hadoopConf: Configuration,
+                              loggingId: String,
+                              useColumnFamilies: Boolean,
+                              enableStateStoreCheckpointIds: Boolean,
+                              partitionId: Int): RocksDB = {
+    FailureInjectionRocksDBStateStoreProvider.createRocksDBWithFaultInjection(
+      dfsRootDir,
+      conf,
+      localRootDir,
+      hadoopConf,
+      loggingId,
+      useColumnFamilies,
+      enableStateStoreCheckpointIds,
+      partitionId)
+  }
+}
+
+object FailureInjectionRocksDBStateStoreProvider {
+  /** RocksDBFieManager is created by RocksDB class where it creates a default FileSystem.
+   * we made RocksDB create a RocksDBFileManager but a different FileSystem here. */
+  def createRocksDBWithFaultInjection(
+                                       dfsRootDir: String,
+                                       conf: RocksDBConf,
+                                       localRootDir: File,
+                                       hadoopConf: Configuration,
+                                       loggingId: String,
+                                       useColumnFamilies: Boolean,
+                                       enableStateStoreCheckpointIds: Boolean,
+                                       partitionId: Int): RocksDB = {
+    new RocksDB(
+      dfsRootDir,
+      conf = conf,
+      localRootDir = localRootDir,
+      hadoopConf = hadoopConf,
+      loggingId = loggingId,
+      useColumnFamilies = useColumnFamilies,
+      enableStateStoreCheckpointIds = enableStateStoreCheckpointIds,
+      partitionId = partitionId
+    ) {
+      override def CreateFileManager(
+                                      dfsRootDir: String,
+                                      localTempDir: File,
+                                      hadoopConf: Configuration,
+                                      codecName: String,
+                                      loggingId: String): RocksDBFileManager = {
+        new RocksDBFileManager(
+          dfsRootDir,
+          localTempDir,
+          hadoopConf,
+          codecName,
+          loggingId = loggingId
+        ) {
+          override def GetFileSystem(
+                                      myDfsRootDir: String,
+                                      myHadoopConf: Configuration): FileSystem = {
+            new FailureInjectionFileSystem(new Path(myDfsRootDir).getFileSystem(myHadoopConf))
+          }
+        }
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
@@ -209,7 +209,7 @@ class FailureInjectionRocksDBStateStoreProvider extends RocksDBStateStoreProvide
 object FailureInjectionRocksDBStateStoreProvider {
   /**
    * RocksDBFieManager is created by RocksDB class where it creates a default FileSystem.
-   * we made RocksDB create a RocksDBFileManager but a different FileSystem here.
+   * We make RocksDB create a RocksDBFileManager that uses a different FileSystem here.
    * */
   def createRocksDBWithFaultInjection(
       dfsRootDir: String,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
@@ -53,13 +53,13 @@ class DelayCloseFSDataOutputStreamWrapper(stream: CancellableFSDataOutputStream)
 }
 
 /**
- * A wrapper checkpoint file manager that might inject functions in some function calls.
+ * A wrapper checkpoint file manager that might inject failures in some function calls.
  * Used in unit tests to simulate failure scenarios.
  * This can be put into SQLConf.STREAMING_CHECKPOINT_FILE_MANAGER_CLASS to provide failure
  * injection behavior.
  *
- * @param path
- * @param hadoopConf
+ * @param path The path to the checkpoint directory, passing to the parent class
+ * @param hadoopConf  hadoop conf that will be passed to the parent class
  */
 class FailureInjectionCheckpointFileManager(path: Path, hadoopConf: Configuration)
   extends FileSystemBasedCheckpointFileManager(path, hadoopConf) with Logging {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
@@ -243,8 +243,8 @@ object FailureInjectionRocksDBStateStoreProvider {
           codecName,
           loggingId = loggingId) {
           override def getFileSystem(
-                                      myDfsRootDir: String,
-                                      myHadoopConf: Configuration): FileSystem = {
+              myDfsRootDir: String,
+              myHadoopConf: Configuration): FileSystem = {
             new FailureInjectionFileSystem(new Path(myDfsRootDir).getFileSystem(myHadoopConf))
           }
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
@@ -112,21 +112,29 @@ class FailureInjectionCheckpointFileManager(path: Path, hadoopConf: Configuratio
 
 /**
  * A class that contains the failure injection state for a path.
+ * Variables in this class cannot be updated concurrently by two threads, but can have multiple
+ * readers
  */
 class FailureInjectionState {
   // File names matching this regex will cause the copyFromLocalFile to fail
+  @volatile
   var failPreCopyFromLocalFileNameRegex: Seq[String] = Seq.empty
   // File names matching this regex will cause the createAtomic to fail and put the streams in
   // `delayedStreams`
+  @volatile
   var createAtomicDelayCloseRegex: Seq[String] = Seq.empty
   // File names matching this regex will cause the createAtomic() to fail
+  @volatile
   var failureCreateAtomicRegex: Seq[String] = Seq.empty
   // If true, Exists() call will fail
+  @volatile
   var shouldFailExist: Boolean = false
   // If true, simulate a case where rename() will not overwrite an existing file.
+  @volatile
   var allowOverwriteInRename: Boolean = true
 
   // List of streams that are delayed in close() based on `createAtomicDelayCloseRegex`
+  @volatile
   var delayedStreams: Seq[CancellableFSDataOutputStream] = Seq.empty
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
@@ -84,7 +84,6 @@ class FailureInjectionCheckpointFileManager(path: Path, hadoopConf: Configuratio
     } else {
       ret
     }
-
   }
 
   override def renameTempFile(srcPath: Path, dstPath: Path,
@@ -188,14 +187,14 @@ class FailureInjectionFileSystem(innerFs: FileSystem) extends FileSystem {
  */
 class FailureInjectionRocksDBStateStoreProvider extends RocksDBStateStoreProvider {
   override def createRocksDB(
-                              dfsRootDir: String,
-                              conf: RocksDBConf,
-                              localRootDir: File,
-                              hadoopConf: Configuration,
-                              loggingId: String,
-                              useColumnFamilies: Boolean,
-                              enableStateStoreCheckpointIds: Boolean,
-                              partitionId: Int): RocksDB = {
+      dfsRootDir: String,
+      conf: RocksDBConf,
+      localRootDir: File,
+      hadoopConf: Configuration,
+      loggingId: String,
+      useColumnFamilies: Boolean,
+      enableStateStoreCheckpointIds: Boolean,
+      partitionId: Int): RocksDB = {
     FailureInjectionRocksDBStateStoreProvider.createRocksDBWithFaultInjection(
       dfsRootDir,
       conf,
@@ -214,14 +213,14 @@ object FailureInjectionRocksDBStateStoreProvider {
    * we made RocksDB create a RocksDBFileManager but a different FileSystem here.
    * */
   def createRocksDBWithFaultInjection(
-                                       dfsRootDir: String,
-                                       conf: RocksDBConf,
-                                       localRootDir: File,
-                                       hadoopConf: Configuration,
-                                       loggingId: String,
-                                       useColumnFamilies: Boolean,
-                                       enableStateStoreCheckpointIds: Boolean,
-                                       partitionId: Int): RocksDB = {
+      dfsRootDir: String,
+      conf: RocksDBConf,
+      localRootDir: File,
+      hadoopConf: Configuration,
+      loggingId: String,
+      useColumnFamilies: Boolean,
+      enableStateStoreCheckpointIds: Boolean,
+      partitionId: Int): RocksDB = {
     new RocksDB(
       dfsRootDir,
       conf = conf,
@@ -233,18 +232,17 @@ object FailureInjectionRocksDBStateStoreProvider {
       partitionId = partitionId
     ) {
       override def createFileManager(
-                                      dfsRootDir: String,
-                                      localTempDir: File,
-                                      hadoopConf: Configuration,
-                                      codecName: String,
-                                      loggingId: String): RocksDBFileManager = {
+          dfsRootDir: String,
+          localTempDir: File,
+          hadoopConf: Configuration,
+          codecName: String,
+          loggingId: String): RocksDBFileManager = {
         new RocksDBFileManager(
           dfsRootDir,
           localTempDir,
           hadoopConf,
           codecName,
-          loggingId = loggingId
-        ) {
+          loggingId = loggingId) {
           override def getFileSystem(
                                       myDfsRootDir: String,
                                       myHadoopConf: Configuration): FileSystem = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
@@ -86,8 +86,7 @@ class FailureInjectionCheckpointFileManager(path: Path, hadoopConf: Configuratio
     }
   }
 
-  override def renameTempFile(srcPath: Path, dstPath: Path,
-                              overwriteIfPossible: Boolean): Unit = {
+  override def renameTempFile(srcPath: Path, dstPath: Path, overwriteIfPossible: Boolean): Unit = {
     if (FailureInjectionFileSystem.allowOverwriteInRename || !fs.exists(dstPath)) {
       super.renameTempFile(srcPath, dstPath, overwriteIfPossible)
     } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBCheckpointFailureInjectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBCheckpointFailureInjectionSuite.scala
@@ -245,7 +245,7 @@ class RocksDBCheckpointFailureInjectionSuite extends StreamTest
 
   /**
    * This test is to simulate the case where a previous task had connectivity problem that couldn't
-   * be killed or write changelog file. Only after the later one is successfully committed, it come
+   * be killed or write changelog file. Only after the later one is successfully committed, it comes
    * back and write the changelog file.
    *  */
   Seq(false, true).foreach { ifEnableStateStoreCheckpointIds =>
@@ -443,7 +443,7 @@ class RocksDBCheckpointFailureInjectionSuite extends StreamTest
   }
 
   /**
-   * An integreated test to cover this scenario:
+   * An integrated test to cover this scenario:
    * 1. A batch is running and a snapshot checkpoint is scheduled
    * 2. The batch fails
    * 3. The query restarts

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBCheckpointFailureInjectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBCheckpointFailureInjectionSuite.scala
@@ -1,0 +1,637 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming.state
+
+import java.io._
+
+import scala.language.implicitConversions
+
+import org.apache.hadoop.conf.Configuration
+
+import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.functions.count
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.SQLConf.STREAMING_CHECKPOINT_FILE_MANAGER_CLASS
+import org.apache.spark.sql.streaming._
+import org.apache.spark.sql.streaming.OutputMode.Update
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.tags.SlowSQLTest
+import org.apache.spark.util.Utils
+
+
+@SlowSQLTest
+/**
+ * Test suite to ingest some failures in RocksDB checkpoint */
+class RocksDBCheckpointFailureInjectionSuite extends StreamTest
+  with SharedSparkSession {
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set(SQLConf.STATE_STORE_PROVIDER_CLASS, classOf[RocksDBStateStoreProvider].getName)
+
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    FailureInjectionFileSystem.failPreCopyFromLocalFileNameRegex = Seq.empty
+    FailureInjectionFileSystem.failureCreateAtomicRegex = Seq.empty
+    FailureInjectionFileSystem.shouldFailExist = false
+  }
+
+  implicit def toArray(str: String): Array[Byte] = if (str != null) str.getBytes else null
+
+  test("Basic RocksDB SST File Upload Failure Handling") {
+    val fmClass = "org.apache.spark.sql.execution.streaming.state." +
+      "FailureInjectionCheckpointFileManager"
+    val hadoopConf = new Configuration()
+    hadoopConf.set(STREAMING_CHECKPOINT_FILE_MANAGER_CLASS.parent.key, fmClass)
+    withTempDir { remoteDir =>
+      withSQLConf(
+        RocksDBConf.ROCKSDB_SQL_CONF_NAME_PREFIX + ".changelogCheckpointing.enabled" -> "false") {
+        val conf = RocksDBConf(StateStoreConf(SQLConf.get))
+        withDB(
+          remoteDir.getAbsolutePath,
+          version = 0,
+          conf = conf,
+          hadoopConf = hadoopConf
+        ) { db =>
+          db.put("version", "1.1")
+          commitAndGetCheckpointId(db)
+
+          FailureInjectionFileSystem.failPreCopyFromLocalFileNameRegex = Seq(".*sst")
+          db.put("version", "2.1")
+          intercept[IOException] {
+            commitAndGetCheckpointId(db)
+          }
+
+          db.load(1)
+
+          FailureInjectionFileSystem.failPreCopyFromLocalFileNameRegex = Seq.empty
+          var ex = intercept[SparkException] {
+            db.load(2)
+          }
+          checkError(
+            ex,
+            condition = "CANNOT_LOAD_STATE_STORE.CANNOT_READ_STREAMING_STATE_FILE",
+            parameters = Map(
+              "fileToRead" -> s"$remoteDir/2.changelog"
+            )
+          )
+
+          db.load(0)
+            FailureInjectionFileSystem.shouldFailExist = true
+          var ex2 = intercept[IOException] {
+            db.load(1)
+          }
+        }
+      }
+    }
+  }
+
+  test("Basic RocksDB Zip File Upload Failure Handling") {
+    val fmClass = "org.apache.spark.sql.execution.streaming.state." +
+      "FailureInjectionCheckpointFileManager"
+    val hadoopConf = new Configuration()
+    hadoopConf.set(STREAMING_CHECKPOINT_FILE_MANAGER_CLASS.parent.key, fmClass)
+    withTempDir { remoteDir =>
+      withSQLConf(
+        RocksDBConf.ROCKSDB_SQL_CONF_NAME_PREFIX + ".changelogCheckpointing.enabled" -> "false") {
+        val conf = RocksDBConf(StateStoreConf(SQLConf.get))
+        withDB(
+          remoteDir.getAbsolutePath,
+          version = 0,
+          conf = conf,
+          hadoopConf = hadoopConf
+        ) { db =>
+          db.put("version", "1.1")
+          commitAndGetCheckpointId(db)
+
+          db.load(1)
+          FailureInjectionFileSystem.failureCreateAtomicRegex = Seq(".*zip")
+          db.put("version", "2.1")
+          intercept[IOException] {
+            commitAndGetCheckpointId(db)
+          }
+
+          db.load(1)
+
+          FailureInjectionFileSystem.failureCreateAtomicRegex = Seq.empty
+          var ex = intercept[SparkException] {
+            db.load(2)
+          }
+          checkError(
+            ex,
+            condition = "CANNOT_LOAD_STATE_STORE.CANNOT_READ_STREAMING_STATE_FILE",
+            parameters = Map(
+              "fileToRead" -> s"$remoteDir/2.changelog"
+            )
+          )
+
+          db.load(0)
+          FailureInjectionFileSystem.shouldFailExist = true
+          var ex2 = intercept[IOException] {
+            db.load(1)
+          }
+        }
+      }
+    }
+  }
+
+
+  /**
+   * This test is to simulate the case where a previous task had connectivity problem that couldn't
+   * be killed or write zip file. Only after the later one is successfully committed, it come back
+   * and write the zip file.
+   * The final validation isn't necessary for V1 but we just would like to make sure
+   * FailureInjectionCheckpointFileManager has correct behavior --  allows zip files to be delayed
+   * to be written, so that the test for V1 is valid.
+   */
+  test("Zip File Overwritten by Previous Task Checkpoint V1") {
+    val fmClass = "org.apache.spark.sql.execution.streaming.state." +
+      "FailureInjectionCheckpointFileManager"
+    val hadoopConf = new Configuration()
+    hadoopConf.set(STREAMING_CHECKPOINT_FILE_MANAGER_CLASS.parent.key, fmClass)
+    withTempDir { remoteDir =>
+      withSQLConf(
+        RocksDBConf.ROCKSDB_SQL_CONF_NAME_PREFIX + ".changelogCheckpointing.enabled" -> "false") {
+        val conf = RocksDBConf(StateStoreConf(SQLConf.get))
+        withDB(
+          remoteDir.getAbsolutePath,
+          version = 0,
+          conf = conf,
+          hadoopConf = hadoopConf
+        ) { db =>
+          db.put("version", "1.1")
+          commitAndGetCheckpointId(db)
+
+          db.load(1)
+          FailureInjectionFileSystem.createAtomicDelayCloseRegex = Seq(".*zip")
+          db.put("version", "2.1")
+          intercept[IOException] {
+            commitAndGetCheckpointId(db)
+          }
+
+          FailureInjectionFileSystem.createAtomicDelayCloseRegex = Seq.empty
+
+          db.load(1)
+
+          db.put("version", "2.2")
+          commitAndGetCheckpointId(db)
+
+          assert(FailureInjectionFileSystem.delayedStreams.size == 1)
+          FailureInjectionFileSystem.delayedStreams.foreach(_.close())
+        }
+        withDB(
+          remoteDir.getAbsolutePath,
+          version = 2,
+          conf = conf,
+          hadoopConf = hadoopConf
+        ) { db =>
+          // Assuming previous 2.zip overwrites, we should see the previous value.
+          assert(new String(db.get("version"), "UTF-8") == "2.1")
+        }
+      }
+    }
+   }
+
+  /**
+   * This test is to simulate the case where a previous task had connectivity problem that couldn't
+   *  be killed or write zip file. Only after the later one is successfully committed, it comes back
+   *  and write the zip file.
+   *  */
+  test("Zip File Overwritten by Previous Task Checkpoint V2") {
+    val fmClass = "org.apache.spark.sql.execution.streaming.state." +
+      "FailureInjectionCheckpointFileManager"
+    val hadoopConf = new Configuration()
+    hadoopConf.set(STREAMING_CHECKPOINT_FILE_MANAGER_CLASS.parent.key, fmClass)
+    withTempDir { remoteDir =>
+      withSQLConf(
+        RocksDBConf.ROCKSDB_SQL_CONF_NAME_PREFIX + ".changelogCheckpointing.enabled" -> "false") {
+        val conf = RocksDBConf(StateStoreConf(SQLConf.get))
+        var checkpointId2: Option[String] = None
+        withDB(
+          remoteDir.getAbsolutePath,
+          version = 0,
+          conf = conf,
+          hadoopConf = hadoopConf,
+          enableStateStoreCheckpointIds = true
+        ) { db =>
+          db.put("version", "1.1")
+          val checkpointId1 = commitAndGetCheckpointId(db)
+
+          FailureInjectionFileSystem.createAtomicDelayCloseRegex = Seq(".*zip")
+          db.load(1, checkpointId1)
+          db.put("version", "2.1")
+          intercept[IOException] {
+            commitAndGetCheckpointId(db)
+          }
+
+          FailureInjectionFileSystem.createAtomicDelayCloseRegex = Seq.empty
+
+          db.load(1, checkpointId1)
+
+          db.put("version", "2.2")
+          checkpointId2 = commitAndGetCheckpointId(db)
+
+          assert(FailureInjectionFileSystem.delayedStreams.nonEmpty)
+          FailureInjectionFileSystem.delayedStreams.foreach(_.close())
+        }
+        withDB(
+          remoteDir.getAbsolutePath,
+          version = 2,
+          conf = conf,
+          hadoopConf = hadoopConf,
+          enableStateStoreCheckpointIds = true,
+          checkpointId = checkpointId2
+        ) { db =>
+          assert(new String(db.get("version"), "UTF-8") == "2.2")
+        }
+      }
+    }
+  }
+
+  /**
+   * This test is to simulate the case where a previous task had connectivity problem that couldn't
+   * be killed or write changelog file. Only after the later one is successfully committed, it comes
+   * back and write the changelog file.
+   * In the end, the test validates that the state store has the value of the old overwriting
+   * changelog. This change is not necessary but we would like to be here to ensure that the failure
+   * Injection code works properly so that the v2 test result is valid.
+   */
+  test("Changelog File Overwritten by Previous Task With Changelog Checkpoint V1") {
+    val fmClass = "org.apache.spark.sql.execution.streaming.state." +
+      "FailureInjectionCheckpointFileManager"
+    val hadoopConf = new Configuration()
+    hadoopConf.set(STREAMING_CHECKPOINT_FILE_MANAGER_CLASS.parent.key, fmClass)
+    withTempDir { remoteDir =>
+      withSQLConf(
+        RocksDBConf.ROCKSDB_SQL_CONF_NAME_PREFIX + ".changelogCheckpointing.enabled" -> "true",
+        SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.key -> "5") {
+        val conf = RocksDBConf(StateStoreConf(SQLConf.get))
+        withDB(
+          remoteDir.getAbsolutePath,
+          version = 0,
+          conf = conf,
+          hadoopConf = hadoopConf,
+          enableStateStoreCheckpointIds = false
+        ) { db =>
+          db.put("version", "1.1")
+          commitAndGetCheckpointId(db)
+
+          FailureInjectionFileSystem.createAtomicDelayCloseRegex = Seq(".*/2\\.changelog")
+
+          db.load(1)
+          db.put("version", "2.1")
+          intercept[IOException] {
+            commitAndGetCheckpointId(db)
+          }
+
+          FailureInjectionFileSystem.createAtomicDelayCloseRegex = Seq.empty
+
+          db.load(1)
+
+          db.put("version", "2.2")
+          commitAndGetCheckpointId(db)
+
+          assert(FailureInjectionFileSystem.delayedStreams.nonEmpty)
+          FailureInjectionFileSystem.delayedStreams.foreach(_.close())
+
+        }
+        withDB(
+          remoteDir.getAbsolutePath,
+          version = 2,
+          conf = conf,
+          hadoopConf = hadoopConf,
+          enableStateStoreCheckpointIds = false
+        ) { db =>
+
+          assert(new String(db.get("version"), "UTF-8") == "2.1")
+        }
+      }
+    }
+  }
+
+  /**
+   * This test is to simulate the case where a previous task had connectivity problem that couldn't
+   * be killed or write changelog file. Only after the later one is successfully committed, it come
+   * back and write the changelog file.
+   *  */
+  test("Changelog File Overwritten by Previous Task With Changelog Checkpoint V2") {
+    val fmClass = "org.apache.spark.sql.execution.streaming.state." +
+      "FailureInjectionCheckpointFileManager"
+    val hadoopConf = new Configuration()
+    hadoopConf.set(STREAMING_CHECKPOINT_FILE_MANAGER_CLASS.parent.key, fmClass)
+    withTempDir { remoteDir =>
+      withSQLConf(
+        RocksDBConf.ROCKSDB_SQL_CONF_NAME_PREFIX + ".changelogCheckpointing.enabled" -> "true",
+        SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.key -> "5") {
+        val conf = RocksDBConf(StateStoreConf(SQLConf.get))
+
+        var checkpointId2: Option[String] = None
+        withDB(
+          remoteDir.getAbsolutePath,
+          version = 0,
+          conf = conf,
+          hadoopConf = hadoopConf,
+          enableStateStoreCheckpointIds = true
+        ) { db =>
+          db.put("version", "1.1")
+          val checkpointId1 = commitAndGetCheckpointId(db)
+
+          FailureInjectionFileSystem.createAtomicDelayCloseRegex = Seq(".*/2_.*changelog")
+
+          db.load(1, checkpointId1)
+          db.put("version", "2.1")
+          intercept[IOException] {
+            commitAndGetCheckpointId(db)
+          }
+
+          FailureInjectionFileSystem.createAtomicDelayCloseRegex = Seq.empty
+
+          db.load(1, checkpointId1)
+
+          db.put("version", "2.2")
+          checkpointId2 = commitAndGetCheckpointId(db)
+
+          assert(FailureInjectionFileSystem.delayedStreams.nonEmpty)
+          FailureInjectionFileSystem.delayedStreams.foreach(_.close())
+
+          db.load(1, checkpointId1)
+          db.load(2, checkpointId2)
+        }
+
+        withDB(
+          remoteDir.getAbsolutePath,
+          version = 2,
+          conf = conf,
+          hadoopConf = hadoopConf,
+          enableStateStoreCheckpointIds = true,
+          checkpointId = checkpointId2
+        ) { db =>
+          assert(new String(db.get("version"), "UTF-8") == "2.2")
+        }
+      }
+    }
+  }
+
+  /**
+   * This test is to simulate the case where
+   * 1. There is a snapshot checkpoint scheduled
+   * 2. The batch eventually failed
+   * 3. Query is retried and moved forward
+   * 4. The snapshot checkpoint succeeded
+   * In checkpoint V2, this snapshot shouldn't take effective. Otherwise, it will break the strong
+   * consistency guaranteed by V2.
+   */
+  test("Delay Snapshot V2") {
+    val fmClass = "org.apache.spark.sql.execution.streaming.state." +
+      "FailureInjectionCheckpointFileManager"
+    val hadoopConf = new Configuration()
+    hadoopConf.set(STREAMING_CHECKPOINT_FILE_MANAGER_CLASS.parent.key, fmClass)
+    withTempDir { remoteDir =>
+      withSQLConf(
+        RocksDBConf.ROCKSDB_SQL_CONF_NAME_PREFIX + ".changelogCheckpointing.enabled" -> "true",
+        SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.key -> "2") {
+        val conf = RocksDBConf(StateStoreConf(SQLConf.get))
+        var checkpointId3: Option[String] = None
+        withDB(
+          remoteDir.getAbsolutePath,
+          version = 0,
+          conf = conf,
+          hadoopConf = hadoopConf,
+          enableStateStoreCheckpointIds = true
+        ) { db =>
+          db.put("version", "1.1")
+          val checkpointId1 = commitAndGetCheckpointId(db)
+
+          withDB(
+            remoteDir.getAbsolutePath,
+            version = 1,
+            conf = conf,
+            hadoopConf = hadoopConf,
+            enableStateStoreCheckpointIds = true,
+            checkpointId = checkpointId1
+          ) { db2 =>
+            db2.put("version", "2.1")
+            db2.commit()
+
+            db.load(1, checkpointId1)
+            db.put("version", "2.2")
+            val checkpointId2 = commitAndGetCheckpointId(db)
+
+            db.load(2, checkpointId2)
+            db.put("foo", "bar")
+            checkpointId3 = commitAndGetCheckpointId(db)
+
+            db2.doMaintenance()
+          }
+        }
+        withDB(
+          remoteDir.getAbsolutePath,
+          version = 3,
+          conf = conf,
+          hadoopConf = hadoopConf,
+          enableStateStoreCheckpointIds = true,
+          checkpointId = checkpointId3
+        ) { db =>
+          assert(new String(db.get("version"), "UTF-8") == "2.2")
+          assert(new String(db.get("foo"), "UTF-8") == "bar")
+        }
+      }
+    }
+  }
+
+  import testImplicits._
+
+  /**
+   * An integrated test where a previous changelog from a failed batch come back and finish
+   * writing. In checkpoint V2, this changelog should be ignored.
+   * Test it with both file renaming overwrite and not renaming overwrite.
+   */
+  Seq(false, true).foreach { ifAllowRenameOverwrite =>
+    test(s"Job failure with changelog shows up ifAllowRenameOverwrite = $ifAllowRenameOverwrite") {
+      val fmClass = "org.apache.spark.sql.execution.streaming.state." +
+        "FailureInjectionCheckpointFileManager"
+      val hadoopConf = new Configuration()
+      hadoopConf.set(STREAMING_CHECKPOINT_FILE_MANAGER_CLASS.parent.key, fmClass)
+      val rocksdbChangelogCheckpointingConfKey =
+        RocksDBConf.ROCKSDB_SQL_CONF_NAME_PREFIX + ".changelogCheckpointing.enabled"
+      FailureInjectionFileSystem.allowOverwriteInRename = ifAllowRenameOverwrite
+      withTempDir { checkpointDir =>
+        withSQLConf(
+          rocksdbChangelogCheckpointingConfKey -> "true",
+          SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.key -> "2") {
+          val inputData = MemoryStream[Int]
+          val aggregated =
+            inputData.toDF()
+              .groupBy($"value")
+              .agg(count("*"))
+              .as[(Int, Long)]
+
+          FailureInjectionFileSystem.createAtomicDelayCloseRegex = Seq(".*/2_.*changelog")
+
+          testStream(aggregated, Update)(
+            StartStream(checkpointLocation = checkpointDir.getAbsolutePath,
+              additionalConfs = Map(
+                rocksdbChangelogCheckpointingConfKey -> "true",
+                SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "2",
+                STREAMING_CHECKPOINT_FILE_MANAGER_CLASS.parent.key -> fmClass)),
+            AddData(inputData, 3),
+            CheckLastBatch((3, 1)),
+            AddData(inputData, 3, 2),
+            ExpectFailure[SparkException] { ex =>
+              ex.getCause.getMessage.contains("CANNOT_WRITE_STATE_STORE.CANNOT_COMMIT")
+            },
+            AddData(inputData, 3, 1)
+          )
+          assert(FailureInjectionFileSystem.delayedStreams.nonEmpty)
+          FailureInjectionFileSystem.delayedStreams.foreach(_.close())
+          FailureInjectionFileSystem.delayedStreams = Seq.empty
+          FailureInjectionFileSystem.createAtomicDelayCloseRegex = Seq.empty
+
+          testStream(aggregated, Update)(
+            StartStream(checkpointLocation = checkpointDir.getAbsolutePath,
+              additionalConfs = Map(
+                rocksdbChangelogCheckpointingConfKey -> "true",
+                SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "2",
+                STREAMING_CHECKPOINT_FILE_MANAGER_CLASS.parent.key -> fmClass)),
+            AddData(inputData, 4),
+            CheckLastBatch((3, 3), (1, 1), (4, 1)),
+            StopStream
+          )
+        }
+      }
+    }
+  }
+
+  /**
+   * An integreated test to cover this scenario:
+   * 1. A batch is running and a snapshot checkpoint is scheduled
+   * 2. The batch fails
+   * 3. The query restarts
+   * 4. The snapshot checkpoint succeeded
+   * and validate that the snapshot checkpoint is not used in subsequent query restart.
+   */
+  test("Previous Maintenance Snapshot Checkpoint Overwrite") {
+    val fmClass = "org.apache.spark.sql.execution.streaming.state." +
+      "FailureInjectionCheckpointFileManager"
+    val hadoopConf = new Configuration()
+    hadoopConf.set(STREAMING_CHECKPOINT_FILE_MANAGER_CLASS.parent.key, fmClass)
+    val rocksdbChangelogCheckpointingConfKey =
+      RocksDBConf.ROCKSDB_SQL_CONF_NAME_PREFIX + ".changelogCheckpointing.enabled"
+    withTempDir { checkpointDir =>
+      withSQLConf(
+        rocksdbChangelogCheckpointingConfKey -> "true",
+        SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.key -> "2") {
+        val inputData = MemoryStream[Int]
+        val aggregated =
+          inputData.toDF()
+            .groupBy($"value")
+            .agg(count("*"))
+            .as[(Int, Long)]
+
+        FailureInjectionFileSystem.createAtomicDelayCloseRegex = Seq(".*/*zip")
+
+        testStream(aggregated, Update)(
+          StartStream(checkpointLocation = checkpointDir.getAbsolutePath,
+            additionalConfs = Map(
+              rocksdbChangelogCheckpointingConfKey -> "true",
+              SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "2",
+              SQLConf.STREAMING_MAINTENANCE_INTERVAL.key -> "20",
+              STREAMING_CHECKPOINT_FILE_MANAGER_CLASS.parent.key -> fmClass)),
+          AddData(inputData, 3),
+          CheckAnswer((3, 1)),
+          AddData(inputData, 3, 2),
+          AddData(inputData, 3, 1),
+          CheckAnswer((3, 1), (3, 3), (2, 1), (1, 1)),
+          AddData(inputData, 1),
+          CheckAnswer((3, 1), (3, 3), (2, 1), (1, 1), (1, 2)),
+          Execute { _ =>
+            while (FailureInjectionFileSystem.delayedStreams.isEmpty) {
+              Thread.sleep(1)
+            }
+            // If we call StoreStore.stop(), or let testStream() call it implicitly, it will
+            // cause deadlock. This is a work-around here before we make StateStore.stop() not
+            // deadlock.
+            StateStore.stopMaintenanceTaskNoLock()
+          },
+          StopStream
+        )
+        FailureInjectionFileSystem.createAtomicDelayCloseRegex = Seq.empty
+
+        testStream(aggregated, Update)(
+          StartStream(checkpointLocation = checkpointDir.getAbsolutePath,
+            additionalConfs = Map(
+              rocksdbChangelogCheckpointingConfKey -> "true",
+              SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "2",
+              STREAMING_CHECKPOINT_FILE_MANAGER_CLASS.parent.key -> fmClass)),
+          AddData(inputData, 1),
+          CheckAnswer((1, 3)),
+          StopStream
+        )
+        assert(FailureInjectionFileSystem.delayedStreams.nonEmpty)
+        FailureInjectionFileSystem.delayedStreams.foreach(_.close())
+        FailureInjectionFileSystem.delayedStreams = Seq.empty
+
+        testStream(aggregated, Update)(
+          StartStream(checkpointLocation = checkpointDir.getAbsolutePath,
+            additionalConfs = Map(
+              rocksdbChangelogCheckpointingConfKey -> "true",
+              SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "2",
+              STREAMING_CHECKPOINT_FILE_MANAGER_CLASS.parent.key -> fmClass)),
+          AddData(inputData, 3, 1, 4),
+          CheckAnswer((3, 4), (1, 4), (4, 1)),
+          StopStream
+        )
+      }
+    }
+  }
+
+  def commitAndGetCheckpointId(db: RocksDB): Option[String] = {
+    val (v, ci) = db.commit()
+    ci.stateStoreCkptId
+  }
+
+  def withDB[T](
+      remoteDir: String,
+      version: Int,
+      conf: RocksDBConf,
+      hadoopConf: Configuration = new Configuration(),
+      enableStateStoreCheckpointIds: Boolean = false,
+      checkpointId: Option[String] = None)(
+      func: RocksDB => T): T = {
+    var db: RocksDB = null
+    try {
+      db = FailureInjectionRocksDBStateStoreProvider.createRocksDBWithFaultInjection(
+        remoteDir,
+        conf = conf,
+        localRootDir = Utils.createTempDir(),
+        hadoopConf = hadoopConf,
+        loggingId = s"[Thread-${Thread.currentThread.getId}]",
+        useColumnFamilies = true,
+        enableStateStoreCheckpointIds = enableStateStoreCheckpointIds,
+        partitionId = 0)
+      db.load(version, checkpointId)
+      func(db)
+    } finally {
+      if (db != null) {
+        db.close()
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBCheckpointFailureInjectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBCheckpointFailureInjectionSuite.scala
@@ -568,7 +568,7 @@ class RocksDBCheckpointFailureInjectionSuite extends StreamTest
             // If we call StoreStore.stop(), or let testStream() call it implicitly, it will
             // cause deadlock. This is a work-around here before we make StateStore.stop() not
             // deadlock.
-            StateStore.stopMaintenanceTaskNoLock()
+            StateStore.stopMaintenanceTaskWithoutLock()
           },
           StopStream
         )

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBCheckpointFailureInjectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBCheckpointFailureInjectionSuite.scala
@@ -68,8 +68,7 @@ class RocksDBCheckpointFailureInjectionSuite extends StreamTest
           remoteDir.getAbsolutePath,
           version = 0,
           conf = conf,
-          hadoopConf = hadoopConf
-        ) { db =>
+          hadoopConf = hadoopConf) { db =>
           db.put("version", "1.1")
           commitAndGetCheckpointId(db)
 
@@ -116,8 +115,7 @@ class RocksDBCheckpointFailureInjectionSuite extends StreamTest
           remoteDir.getAbsolutePath,
           version = 0,
           conf = conf,
-          hadoopConf = hadoopConf
-        ) { db =>
+          hadoopConf = hadoopConf) { db =>
           db.put("version", "1.1")
           commitAndGetCheckpointId(db)
 
@@ -174,8 +172,7 @@ class RocksDBCheckpointFailureInjectionSuite extends StreamTest
           remoteDir.getAbsolutePath,
           version = 0,
           conf = conf,
-          hadoopConf = hadoopConf
-        ) { db =>
+          hadoopConf = hadoopConf) { db =>
           db.put("version", "1.1")
           commitAndGetCheckpointId(db)
 
@@ -200,8 +197,7 @@ class RocksDBCheckpointFailureInjectionSuite extends StreamTest
           remoteDir.getAbsolutePath,
           version = 2,
           conf = conf,
-          hadoopConf = hadoopConf
-        ) { db =>
+          hadoopConf = hadoopConf) { db =>
           // Assuming previous 2.zip overwrites, we should see the previous value.
           assert(new String(db.get("version"), "UTF-8") == "2.1")
         }
@@ -229,8 +225,7 @@ class RocksDBCheckpointFailureInjectionSuite extends StreamTest
           version = 0,
           conf = conf,
           hadoopConf = hadoopConf,
-          enableStateStoreCheckpointIds = true
-        ) { db =>
+          enableStateStoreCheckpointIds = true) { db =>
           db.put("version", "1.1")
           val checkpointId1 = commitAndGetCheckpointId(db)
 
@@ -257,8 +252,7 @@ class RocksDBCheckpointFailureInjectionSuite extends StreamTest
           conf = conf,
           hadoopConf = hadoopConf,
           enableStateStoreCheckpointIds = true,
-          checkpointId = checkpointId2
-        ) { db =>
+          checkpointId = checkpointId2 ) { db =>
           assert(new String(db.get("version"), "UTF-8") == "2.2")
         }
       }
@@ -288,8 +282,7 @@ class RocksDBCheckpointFailureInjectionSuite extends StreamTest
           version = 0,
           conf = conf,
           hadoopConf = hadoopConf,
-          enableStateStoreCheckpointIds = false
-        ) { db =>
+          enableStateStoreCheckpointIds = false) { db =>
           db.put("version", "1.1")
           commitAndGetCheckpointId(db)
 
@@ -317,8 +310,7 @@ class RocksDBCheckpointFailureInjectionSuite extends StreamTest
           version = 2,
           conf = conf,
           hadoopConf = hadoopConf,
-          enableStateStoreCheckpointIds = false
-        ) { db =>
+          enableStateStoreCheckpointIds = false ) { db =>
 
           assert(new String(db.get("version"), "UTF-8") == "2.1")
         }
@@ -348,8 +340,7 @@ class RocksDBCheckpointFailureInjectionSuite extends StreamTest
           version = 0,
           conf = conf,
           hadoopConf = hadoopConf,
-          enableStateStoreCheckpointIds = true
-        ) { db =>
+          enableStateStoreCheckpointIds = true) { db =>
           db.put("version", "1.1")
           val checkpointId1 = commitAndGetCheckpointId(db)
 
@@ -381,8 +372,7 @@ class RocksDBCheckpointFailureInjectionSuite extends StreamTest
           conf = conf,
           hadoopConf = hadoopConf,
           enableStateStoreCheckpointIds = true,
-          checkpointId = checkpointId2
-        ) { db =>
+          checkpointId = checkpointId2) { db =>
           assert(new String(db.get("version"), "UTF-8") == "2.2")
         }
       }
@@ -414,8 +404,7 @@ class RocksDBCheckpointFailureInjectionSuite extends StreamTest
           version = 0,
           conf = conf,
           hadoopConf = hadoopConf,
-          enableStateStoreCheckpointIds = true
-        ) { db =>
+          enableStateStoreCheckpointIds = true) { db =>
           db.put("version", "1.1")
           val checkpointId1 = commitAndGetCheckpointId(db)
 
@@ -425,8 +414,7 @@ class RocksDBCheckpointFailureInjectionSuite extends StreamTest
             conf = conf,
             hadoopConf = hadoopConf,
             enableStateStoreCheckpointIds = true,
-            checkpointId = checkpointId1
-          ) { db2 =>
+            checkpointId = checkpointId1) { db2 =>
             db2.put("version", "2.1")
             db2.commit()
 
@@ -447,8 +435,7 @@ class RocksDBCheckpointFailureInjectionSuite extends StreamTest
           conf = conf,
           hadoopConf = hadoopConf,
           enableStateStoreCheckpointIds = true,
-          checkpointId = checkpointId3
-        ) { db =>
+          checkpointId = checkpointId3) { db =>
           assert(new String(db.get("version"), "UTF-8") == "2.2")
           assert(new String(db.get("foo"), "UTF-8") == "bar")
         }


### PR DESCRIPTION
### Why are the changes needed?
The new state store checkpoint format needs failure tolerance tests to make sure the implementation is correct and delivers the behavior we would like.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
It is test code itself


### Was this patch authored or co-authored using generative AI tooling?
No.
