### PR TITLE
[SPARK-51721][SQL] Change default value of ANALYZER_SINGLE_PASS_RESOLVER_RELATION_BRIDGING_ENABLED flag

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -326,7 +326,7 @@ object SQLConf {
       )
       .version("4.0.0")
       .booleanConf
-      .createWithDefault(Utils.isTesting)
+      .createWithDefault(true)
 
   val MULTI_COMMUTATIVE_OP_OPT_THRESHOLD =
     buildConf("spark.sql.analyzer.canonicalization.multiCommutativeOpMemoryOptThreshold")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change default value of `ANALYZER_SINGLE_PASS_RESOLVER_RELATION_BRIDGING_ENABLED` flag (set it to `true`).

### Why are the changes needed?
To enable users to use dual run analysis bridging by default.

### Does this PR introduce _any_ user-facing change?
Users are going to use dual run analysis with bridging by default.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.