### PR TITLE
[SPARK-51722][SQL] Remove "stop" origin from ParseException

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/parsers.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/parsers.scala
@@ -205,10 +205,7 @@ class ParseException private (
       messageParameters)
 
   def this(errorClass: String, ctx: ParserRuleContext) =
-    this(
-      errorClass = errorClass,
-      messageParameters = Map.empty,
-      ctx = ctx)
+    this(errorClass = errorClass, messageParameters = Map.empty, ctx = ctx)
 
   /** Compose the message through SparkThrowableHelper given errorClass and messageParameters. */
   def this(

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/parsers.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/parsers.scala
@@ -99,7 +99,6 @@ abstract class AbstractParser extends DataTypeParserInterface with Logging {
         throw new ParseException(
           command = Option(command),
           start = e.origin,
-          stop = e.origin,
           errorClass = e.getCondition,
           messageParameters = e.getMessageParameters.asScala.toMap,
           queryContext = e.getQueryContext)
@@ -158,24 +157,19 @@ case object ParseErrorListener extends BaseErrorListener {
       charPositionInLine: Int,
       msg: String,
       e: RecognitionException): Unit = {
-    val (start, stop) = offendingSymbol match {
+    val start = offendingSymbol match {
       case token: CommonToken =>
-        val start = Origin(Some(line), Some(token.getCharPositionInLine))
-        val length = token.getStopIndex - token.getStartIndex + 1
-        val stop = Origin(Some(line), Some(token.getCharPositionInLine + length))
-        (start, stop)
+        Origin(Some(line), Some(token.getCharPositionInLine))
       case _ =>
-        val start = Origin(Some(line), Some(charPositionInLine))
-        (start, start)
+        Origin(Some(line), Some(charPositionInLine))
     }
     e match {
       case sre: SparkRecognitionException if sre.errorClass.isDefined =>
-        throw new ParseException(None, start, stop, sre.errorClass.get, sre.messageParameters)
+        throw new ParseException(None, start, sre.errorClass.get, sre.messageParameters)
       case _ =>
         throw new ParseException(
           command = None,
           start = start,
-          stop = stop,
           errorClass = "PARSE_SYNTAX_ERROR",
           messageParameters = Map("error" -> msg, "hint" -> ""))
     }
@@ -190,7 +184,6 @@ class ParseException private (
     val command: Option[String],
     message: String,
     val start: Origin,
-    val stop: Origin,
     errorClass: Option[String] = None,
     messageParameters: Map[String, String] = Map.empty,
     queryContext: Array[QueryContext] = ParseException.getQueryContext())
@@ -208,24 +201,25 @@ class ParseException private (
       Option(SparkParserUtils.command(ctx)),
       SparkThrowableHelper.getMessage(errorClass, messageParameters),
       SparkParserUtils.position(ctx.getStart),
-      SparkParserUtils.position(ctx.getStop),
       Some(errorClass),
       messageParameters)
 
-  def this(errorClass: String, ctx: ParserRuleContext) = this(errorClass, Map.empty, ctx)
+  def this(errorClass: String, ctx: ParserRuleContext) =
+    this(
+      errorClass = errorClass,
+      messageParameters = Map.empty,
+      ctx = ctx)
 
   /** Compose the message through SparkThrowableHelper given errorClass and messageParameters. */
   def this(
       command: Option[String],
       start: Origin,
-      stop: Origin,
       errorClass: String,
       messageParameters: Map[String, String]) =
     this(
       command,
       SparkThrowableHelper.getMessage(errorClass, messageParameters),
       start,
-      stop,
       Some(errorClass),
       messageParameters,
       queryContext = ParseException.getQueryContext())
@@ -233,7 +227,6 @@ class ParseException private (
   def this(
       command: Option[String],
       start: Origin,
-      stop: Origin,
       errorClass: String,
       messageParameters: Map[String, String],
       queryContext: Array[QueryContext]) =
@@ -241,7 +234,6 @@ class ParseException private (
       command,
       SparkThrowableHelper.getMessage(errorClass, messageParameters),
       start,
-      stop,
       Some(errorClass),
       messageParameters,
       queryContext)
@@ -282,7 +274,7 @@ class ParseException private (
     } else {
       (cl, messageParameters)
     }
-    new ParseException(Option(cmd), start, stop, newCl, params, queryContext)
+    new ParseException(Option(cmd), start, newCl, params, queryContext)
   }
 
   override def getQueryContext: Array[QueryContext] = queryContext

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -500,7 +500,6 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
     new ParseException(
       command = Option(sqlText),
       start = position,
-      stop = position,
       errorClass = "INVALID_SQL_SYNTAX.UNSUPPORTED_SQL_STATEMENT",
       messageParameters = Map("sqlText" -> sqlText))
   }
@@ -632,7 +631,6 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
     new ParseException(
       command = origin.sqlText,
       start = origin,
-      stop = origin,
       errorClass = "UNSUPPORTED_FEATURE.PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT",
       messageParameters = Map("statement" -> statement))
   }
@@ -690,7 +688,6 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
     new ParseException(
       command = Some(command),
       start = start,
-      stop = stop,
       errorClass = "UNCLOSED_BRACKETED_COMMENT",
       messageParameters = Map.empty)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1800,7 +1800,6 @@ class AstBuilder extends DataTypeAstBuilder
             throw new ParseException(
               command = Some(SparkParserUtils.command(n)),
               start = Origin(),
-              stop = Origin(),
               errorClass = "PARSE_SYNTAX_ERROR",
               messageParameters = Map(
                 "error" -> s"'$error'",

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
@@ -192,7 +192,6 @@ private[client] object GrpcExceptionConverter {
       new ParseException(
         None,
         Origin(),
-        Origin(),
         errorClass = params.errorClass.orNull,
         messageParameters = params.messageParameters,
         queryContext = params.queryContext)),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

The "stop" origin from ParseException is not used. We should remove it to simplify code.
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Code clean up

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing UT
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No