### PR TITLE
[SPARK-51421][SQL] Get seconds of TIME datatype

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -648,7 +648,7 @@ object FunctionRegistry {
     expression[NextDay]("next_day"),
     expression[Now]("now"),
     expression[Quarter]("quarter"),
-    expression[Second]("second"),
+    expressionBuilder("second", SecondExpressionBuilder),
     expression[ParseToTimestamp]("to_timestamp"),
     expression[ParseToDate]("to_date"),
     expression[ToTime]("to_time"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -290,3 +290,61 @@ object HourExpressionBuilder extends ExpressionBuilder {
     }
   }
 }
+
+case class SecondsOfTime(child: Expression)
+  extends RuntimeReplaceable
+    with ExpectsInputTypes {
+
+  override def replacement: Expression = StaticInvoke(
+    classOf[DateTimeUtils.type],
+    IntegerType,
+    "getSecondsOfTime",
+    Seq(child),
+    Seq(child.dataType)
+  )
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(TimeType())
+
+  override def children: Seq[Expression] = Seq(child)
+
+  override def prettyName: String = "second"
+
+  override protected def withNewChildrenInternal(
+    newChildren: IndexedSeq[Expression]): Expression = {
+      copy(child = newChildren.head)
+  }
+}
+
+@ExpressionDescription(
+  usage = """
+    _FUNC_(expr) - Returns the second component of the given expression.
+
+    If `expr` is a TIMESTAMP or a string that can be cast to timestamp,
+    it returns the second of that timestamp.
+    If `expr` is a TIME type (since 4.1.0), it returns the second of the time-of-day.
+  """,
+  examples = """
+    Examples:
+      > SELECT _FUNC_('2018-02-14 12:58:59');
+       59
+      > SELECT _FUNC_(TIME'13:59:59.999999');
+       59
+  """,
+  since = "1.5.0",
+  group = "datetime_funcs")
+object SecondExpressionBuilder extends ExpressionBuilder {
+  override def build(name: String, expressions: Seq[Expression]): Expression = {
+    if (expressions.isEmpty) {
+      throw QueryCompilationErrors.wrongNumArgsError(name, Seq("> 0"), expressions.length)
+    } else {
+      val child = expressions.head
+      child.dataType match {
+        case _: TimeType =>
+          SecondsOfTime(child)
+        case _ =>
+          Second(child)
+      }
+    }
+  }
+}
+

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.catalyst.util.TimeFormatter
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.types.StringTypeWithCollation
-import org.apache.spark.sql.types.{AbstractDataType, IntegerType, ObjectType, TimeType}
+import org.apache.spark.sql.types.{AbstractDataType, IntegerType, ObjectType, TimeType, TypeCollection}
 import org.apache.spark.unsafe.types.UTF8String
 
 /**
@@ -303,7 +303,8 @@ case class SecondsOfTime(child: Expression)
     Seq(child.dataType)
   )
 
-  override def inputTypes: Seq[AbstractDataType] = Seq(TimeType())
+  override def inputTypes: Seq[AbstractDataType] =
+    Seq(TypeCollection(TimeType.MIN_PRECISION to TimeType.MAX_PRECISION map TimeType: _*))
 
   override def children: Seq[Expression] = Seq(child)
 
@@ -327,7 +328,7 @@ case class SecondsOfTime(child: Expression)
     Examples:
       > SELECT _FUNC_('2018-02-14 12:58:59');
        59
-      > SELECT _FUNC_(TIME'13:59:59.999999');
+      > SELECT _FUNC_(TIME'13:25:59.999999');
        59
   """,
   since = "1.5.0",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -136,6 +136,12 @@ object DateTimeUtils extends SparkDateTimeUtils {
   }
 
   /**
+   * Returns the second value of a given TIME (TimeType) value.
+   */
+  def getSecondsOfTime(micros: Long): Int = {
+    microsToLocalTime(micros).getSecond
+  }
+  /**
    * Returns the seconds part and its fractional part with microseconds.
    */
   def getSecondsWithFraction(micros: Long, zoneId: ZoneId): Decimal = {

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -286,7 +286,7 @@
 | org.apache.spark.sql.catalyst.expressions.SchemaOfJson | schema_of_json | SELECT schema_of_json('[{"col":0}]') | struct<schema_of_json([{"col":0}]):string> |
 | org.apache.spark.sql.catalyst.expressions.SchemaOfXml | schema_of_xml | SELECT schema_of_xml('<p><a>1</a></p>') | struct<schema_of_xml(<p><a>1</a></p>):string> |
 | org.apache.spark.sql.catalyst.expressions.Sec | sec | SELECT sec(0) | struct<SEC(0):double> |
-| org.apache.spark.sql.catalyst.expressions.Second | second | SELECT second('2009-07-30 12:58:59') | struct<second(2009-07-30 12:58:59):int> |
+| org.apache.spark.sql.catalyst.expressions.SecondExpressionBuilder | second | SELECT second('2018-02-14 12:58:59') | struct<second(2018-02-14 12:58:59):int> |
 | org.apache.spark.sql.catalyst.expressions.SecondsToTimestamp | timestamp_seconds | SELECT timestamp_seconds(1230219000) | struct<timestamp_seconds(1230219000):timestamp> |
 | org.apache.spark.sql.catalyst.expressions.Sentences | sentences | SELECT sentences('Hi there! Good morning.') | struct<sentences(Hi there! Good morning., , ):array<array<string>>> |
 | org.apache.spark.sql.catalyst.expressions.Sequence | sequence | SELECT sequence(1, 5) | struct<sequence(1, 5):array<int>> |

--- a/sql/core/src/test/resources/sql-tests/results/hll.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/hll.sql.out
@@ -18,27 +18,30 @@ struct<>
 -- !query
 SELECT hll_sketch_estimate(hll_sketch_agg(col)) AS result FROM t1
 -- !query schema
-struct<result:bigint>
+struct<>
 -- !query output
-5
+java.lang.NoClassDefFoundError
+Could not initialize class org.apache.datasketches.memory.internal.BaseWritableMemoryImpl
 
 
 -- !query
 SELECT hll_sketch_estimate(hll_sketch_agg(col, 12))
 FROM VALUES (50), (60), (60), (60), (75), (100) tab(col)
 -- !query schema
-struct<hll_sketch_estimate(hll_sketch_agg(col, 12)):bigint>
+struct<>
 -- !query output
-4
+java.lang.NoClassDefFoundError
+Could not initialize class org.apache.datasketches.memory.internal.BaseWritableMemoryImpl
 
 
 -- !query
 SELECT hll_sketch_estimate(hll_sketch_agg(col))
 FROM VALUES ('abc'), ('def'), ('abc'), ('ghi'), ('abc') tab(col)
 -- !query schema
-struct<hll_sketch_estimate(hll_sketch_agg(col, 12)):bigint>
+struct<>
 -- !query output
-3
+java.lang.NoClassDefFoundError
+Could not initialize class org.apache.datasketches.memory.internal.BaseWritableMemoryImpl
 
 
 -- !query
@@ -53,9 +56,10 @@ SELECT hll_sketch_estimate(
     (2, 5),
     (3, 6) AS tab(col1, col2)
 -- !query schema
-struct<hll_sketch_estimate(hll_union(hll_sketch_agg(col1, 12), hll_sketch_agg(col2, 12), false)):bigint>
+struct<>
 -- !query output
-6
+java.lang.NoClassDefFoundError
+Could not initialize class org.apache.datasketches.memory.internal.BaseWritableMemoryImpl
 
 
 -- !query
@@ -66,9 +70,10 @@ SELECT hll_sketch_estimate(hll_union_agg(sketch, true))
           SELECT hll_sketch_agg(col, 20) as sketch
             FROM VALUES (1) AS tab(col))
 -- !query schema
-struct<hll_sketch_estimate(hll_union_agg(sketch, true)):bigint>
+struct<>
 -- !query output
-1
+java.lang.NoClassDefFoundError
+Could not initialize class org.apache.datasketches.memory.internal.BaseWritableMemoryImpl
 
 
 -- !query
@@ -149,16 +154,8 @@ SELECT hll_union(
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkRuntimeException
-{
-  "errorClass" : "HLL_UNION_DIFFERENT_LG_K",
-  "sqlState" : "22000",
-  "messageParameters" : {
-    "function" : "`hll_union`",
-    "left" : "12",
-    "right" : "13"
-  }
-}
+java.lang.NoClassDefFoundError
+Could not initialize class org.apache.datasketches.memory.internal.BaseWritableMemoryImpl
 
 
 -- !query
@@ -171,16 +168,8 @@ FROM (SELECT hll_sketch_agg(col, 12) as sketch
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkRuntimeException
-{
-  "errorClass" : "HLL_UNION_DIFFERENT_LG_K",
-  "sqlState" : "22000",
-  "messageParameters" : {
-    "function" : "`hll_union_agg`",
-    "left" : "12",
-    "right" : "20"
-  }
-}
+java.lang.NoClassDefFoundError
+Could not initialize class org.apache.datasketches.memory.internal.BaseWritableMemoryImpl
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/hll.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/hll.sql.out
@@ -18,30 +18,27 @@ struct<>
 -- !query
 SELECT hll_sketch_estimate(hll_sketch_agg(col)) AS result FROM t1
 -- !query schema
-struct<>
+struct<result:bigint>
 -- !query output
-java.lang.NoClassDefFoundError
-Could not initialize class org.apache.datasketches.memory.internal.BaseWritableMemoryImpl
+5
 
 
 -- !query
 SELECT hll_sketch_estimate(hll_sketch_agg(col, 12))
 FROM VALUES (50), (60), (60), (60), (75), (100) tab(col)
 -- !query schema
-struct<>
+struct<hll_sketch_estimate(hll_sketch_agg(col, 12)):bigint>
 -- !query output
-java.lang.NoClassDefFoundError
-Could not initialize class org.apache.datasketches.memory.internal.BaseWritableMemoryImpl
+4
 
 
 -- !query
 SELECT hll_sketch_estimate(hll_sketch_agg(col))
 FROM VALUES ('abc'), ('def'), ('abc'), ('ghi'), ('abc') tab(col)
 -- !query schema
-struct<>
+struct<hll_sketch_estimate(hll_sketch_agg(col, 12)):bigint>
 -- !query output
-java.lang.NoClassDefFoundError
-Could not initialize class org.apache.datasketches.memory.internal.BaseWritableMemoryImpl
+3
 
 
 -- !query
@@ -56,10 +53,9 @@ SELECT hll_sketch_estimate(
     (2, 5),
     (3, 6) AS tab(col1, col2)
 -- !query schema
-struct<>
+struct<hll_sketch_estimate(hll_union(hll_sketch_agg(col1, 12), hll_sketch_agg(col2, 12), false)):bigint>
 -- !query output
-java.lang.NoClassDefFoundError
-Could not initialize class org.apache.datasketches.memory.internal.BaseWritableMemoryImpl
+6
 
 
 -- !query
@@ -70,10 +66,9 @@ SELECT hll_sketch_estimate(hll_union_agg(sketch, true))
           SELECT hll_sketch_agg(col, 20) as sketch
             FROM VALUES (1) AS tab(col))
 -- !query schema
-struct<>
+struct<hll_sketch_estimate(hll_union_agg(sketch, true)):bigint>
 -- !query output
-java.lang.NoClassDefFoundError
-Could not initialize class org.apache.datasketches.memory.internal.BaseWritableMemoryImpl
+1
 
 
 -- !query
@@ -154,8 +149,16 @@ SELECT hll_union(
 -- !query schema
 struct<>
 -- !query output
-java.lang.NoClassDefFoundError
-Could not initialize class org.apache.datasketches.memory.internal.BaseWritableMemoryImpl
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "HLL_UNION_DIFFERENT_LG_K",
+  "sqlState" : "22000",
+  "messageParameters" : {
+    "function" : "`hll_union`",
+    "left" : "12",
+    "right" : "13"
+  }
+}
 
 
 -- !query
@@ -168,8 +171,16 @@ FROM (SELECT hll_sketch_agg(col, 12) as sketch
 -- !query schema
 struct<>
 -- !query output
-java.lang.NoClassDefFoundError
-Could not initialize class org.apache.datasketches.memory.internal.BaseWritableMemoryImpl
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "HLL_UNION_DIFFERENT_LG_K",
+  "sqlState" : "22000",
+  "messageParameters" : {
+    "function" : "`hll_union_agg`",
+    "left" : "12",
+    "right" : "20"
+  }
+}
 
 
 -- !query


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR adds support for extracting the second component from TIME (TimeType) values in Spark SQL. For example:
```
scala> spark.sql("SELECT SECOND(TIME'13:59:45.99')").show()
+--------------------------+
|second(TIME '13:59:45.99')|
+--------------------------+
|                        45|
+--------------------------+


scala> spark.sql("select second(cast('12:00:01.123' as time(4)))").show(false)
+-------------------------------------+
|second(CAST(12:00:01.123 AS TIME(4)))|
+-------------------------------------+
|1                                    |
+-------------------------------------+
```

### Why are the changes needed?
Spark previously supported second() for only TIMESTAMP type values. TIME support was missing, leading to implicit casting attempt to TIMESTAMP, which was incorrect. This PR ensures that second(TIME'HH:MM:SS.######') behaves correctly without unnecessary type coercion.


### Does this PR introduce _any_ user-facing change?
Yes

- Before this PR, calling second(TIME'HH:MM:SS.######') resulted in a type mismatch error or an implicit cast attempt to TIMESTAMP, which was incorrect.
- With this PR, second(TIME'HH:MM:SS.######') now works correctly for TIME values without implicit casting.
- Users can now extract the second component from TIME values natively.



### How was this patch tested?
By running new tests:

```$ build/sbt "test:testOnly *TimeExpressionsSuite"```


### Was this patch authored or co-authored using generative AI tooling?
No

