### PR TITLE
[SPARK-51739][PYTHON] Validate Arrow schema from mapInArrow & mapInPandas & DataSource

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -20,6 +20,7 @@ Serializers for PyArrow and pandas conversions. See `pyspark.serializers` for mo
 """
 
 from itertools import groupby
+from typing import TYPE_CHECKING, Optional
 
 import pyspark
 from pyspark.errors import PySparkRuntimeError, PySparkTypeError, PySparkValueError
@@ -47,6 +48,10 @@ from pyspark.sql.types import (
     LongType,
     IntegerType,
 )
+
+if TYPE_CHECKING:
+    import pandas as pd
+    import pyarrow as pa
 
 
 class SpecialLengths:
@@ -472,7 +477,12 @@ class ArrowStreamPandasUDFSerializer(ArrowStreamPandasSerializer):
             )
         return s
 
-    def _create_struct_array(self, df, arrow_struct_type, spark_type=None):
+    def _create_struct_array(
+        self,
+        df: "pd.DataFrame",
+        arrow_struct_type: "pa.StructType",
+        spark_type: Optional[StructType] = None,
+    ):
         """
         Create an Arrow StructArray from the given pandas.DataFrame and arrow struct type.
 
@@ -480,7 +490,7 @@ class ArrowStreamPandasUDFSerializer(ArrowStreamPandasSerializer):
         ----------
         df : pandas.DataFrame
             A pandas DataFrame
-        arrow_struct_type : pyarrow.DataType
+        arrow_struct_type : pyarrow.StructType
             pyarrow struct type
 
         Returns
@@ -518,8 +528,7 @@ class ArrowStreamPandasUDFSerializer(ArrowStreamPandasSerializer):
                 for i, field in enumerate(arrow_struct_type)
             ]
 
-        struct_names = [field.name for field in arrow_struct_type]
-        return pa.StructArray.from_arrays(struct_arrs, struct_names)
+        return pa.StructArray.from_arrays(struct_arrs, fields=list(arrow_struct_type))
 
     def _create_batch(self, series):
         """

--- a/python/pyspark/sql/tests/arrow/test_arrow_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_map.py
@@ -124,7 +124,7 @@ class MapInArrowTestsMixin(object):
         def empty_rows(_):
             return iter([pa.RecordBatch.from_pandas(pd.DataFrame({"a": []}))])
 
-        self.assertEqual(self.spark.range(10).mapInArrow(empty_rows, "a int").count(), 0)
+        self.assertEqual(self.spark.range(10).mapInArrow(empty_rows, "a double").count(), 0)
 
     def test_chain_map_in_arrow(self):
         def func(iterator):
@@ -174,6 +174,33 @@ class MapInArrowTestsMixin(object):
         for batch_size in [0, -1]:
             with self.sql_conf({"spark.sql.execution.arrow.maxRecordsPerBatch": batch_size}):
                 MapInArrowTests.test_map_in_arrow(self)
+
+    def test_nested_extraneous_field(self):
+        def func(iterator):
+            for _ in iterator:
+                struct_arr = pa.StructArray.from_arrays([[1, 2], [3, 4]], names=["a", "b"])
+                yield pa.RecordBatch.from_arrays([struct_arr], ["x"])
+
+        df = self.spark.range(1)
+        with self.assertRaisesRegex(Exception, r"ARROW_TYPE_MISMATCH"):
+            df.mapInArrow(func, "x struct<b:int>").collect()
+
+    def test_top_level_wrong_order(self):
+        def func(iterator):
+            for _ in iterator:
+                yield pa.RecordBatch.from_arrays([[1], [2]], ["b", "a"])
+
+        df = self.spark.range(1)
+        with self.assertRaisesRegex(Exception, r"ARROW_TYPE_MISMATCH"):
+            df.mapInArrow(func, "a int, b int").collect()
+
+    def test_different_nullability(self):
+        def func(iterator):
+            for _ in iterator:
+                yield pa.RecordBatch.from_arrays([[1]], ["a"])
+
+        df = self.spark.range(1)
+        self.assertEqual(df.mapInArrow(func, "a long not null").collect(), [(1,)])
 
 
 class MapInArrowTests(MapInArrowTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/arrow/test_arrow_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_map.py
@@ -182,7 +182,7 @@ class MapInArrowTestsMixin(object):
                 yield pa.RecordBatch.from_arrays([struct_arr], ["x"])
 
         df = self.spark.range(1)
-        with self.assertRaisesRegex(Exception, r"ARROW_TYPE_MISMATCH"):
+        with self.assertRaisesRegex(Exception, r"ARROW_TYPE_MISMATCH.*SQL_MAP_ARROW_ITER_UDF"):
             df.mapInArrow(func, "x struct<b:int>").collect()
 
     def test_top_level_wrong_order(self):
@@ -191,7 +191,7 @@ class MapInArrowTestsMixin(object):
                 yield pa.RecordBatch.from_arrays([[1], [2]], ["b", "a"])
 
         df = self.spark.range(1)
-        with self.assertRaisesRegex(Exception, r"ARROW_TYPE_MISMATCH"):
+        with self.assertRaisesRegex(Exception, r"ARROW_TYPE_MISMATCH.*SQL_MAP_ARROW_ITER_UDF"):
             df.mapInArrow(func, "a int, b int").collect()
 
     def test_different_nullability(self):

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -732,45 +732,6 @@ class BasePythonDataSourceTestsMixin:
         ):
             df.write.format("test").mode("append").saveAsTable("test_table")
 
-    def test_data_source_nested_extraneous_field(self):
-        import pyarrow as pa
-
-        class TestDataSource(DataSource):
-            def reader(self, schema):
-                return TestReader()
-
-        class TestReader(DataSourceReader):
-            def read(self, partition):
-                struct_array = pa.StructArray.from_arrays([[1, 2], [3, 4]], names=["a", "b"])
-                yield pa.record_batch([struct_array], names=["x"])
-
-        self.spark.dataSource.register(TestDataSource)
-
-        with self.assertRaisesRegex(
-            Exception,
-            r"ARROW_TYPE_MISMATCH",
-        ):
-            self.spark.read.format("TestDataSource").schema("x struct<b:int>").load().show()
-
-    def test_data_source_top_level_wrong_order(self):
-        import pyarrow as pa
-
-        class TestDataSource(DataSource):
-            def reader(self, schema):
-                return TestReader()
-
-        class TestReader(DataSourceReader):
-            def read(self, partition):
-                yield pa.record_batch([[1], [2]], names=["b", "a"])
-
-        self.spark.dataSource.register(TestDataSource)
-
-        with self.assertRaisesRegex(
-            Exception,
-            r"ARROW_TYPE_MISMATCH",
-        ):
-            self.spark.read.format("TestDataSource").schema("a int, b int").load().show()
-
     @unittest.skipIf(
         "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
     )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3548,6 +3548,15 @@ object SQLConf {
       // show full stacktrace in tests but hide in production by default.
       .createWithDefault(!Utils.isTesting)
 
+  val PYSPARK_ARROW_VALIDATE_SCHEMA =
+    buildConf("spark.sql.execution.arrow.pyspark.validateSchema.enabled")
+      .doc(
+        "When true, validate the schema of Arrow batches returned by mapInArrow, mapInPandas " +
+        "and DataSource against the expected schema to ensure that they are compatible.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val PYTHON_UDF_ARROW_ENABLED =
     buildConf("spark.sql.execution.pythonUDF.arrow.enabled")
       .doc("Enable Arrow optimization in regular Python UDFs. This optimization " +
@@ -6447,6 +6456,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def pysparkHideTraceback: Boolean = getConf(PYSPARK_HIDE_TRACEBACK)
 
   def pysparkSimplifiedTraceback: Boolean = getConf(PYSPARK_SIMPLIFIED_TRACEBACK)
+
+  def pysparkArrowValidateSchema: Boolean = getConf(PYSPARK_ARROW_VALIDATE_SCHEMA)
 
   def pandasGroupedMapAssignColumnsByName: Boolean =
     getConf(SQLConf.PANDAS_GROUPED_MAP_ASSIGN_COLUMNS_BY_NAME)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/UserDefinedPythonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/UserDefinedPythonDataSource.scala
@@ -163,6 +163,7 @@ case class UserDefinedPythonDataSource(dataSourceCls: PythonFunction) {
       toAttributes(outputSchema),
       Seq((ChainedPythonFunctions(Seq(pythonUDF.func)), pythonUDF.resultId.id)),
       inputSchema,
+      outputSchema,
       conf.arrowMaxRecordsPerBatch,
       pythonEvalType,
       conf.sessionLocalTimeZone,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
@@ -80,9 +80,9 @@ class MapInBatchEvaluatorFactory(
         // Scalar Iterator UDF returns a StructType column in ColumnarBatch, select
         // the children here
         val actualSchema = batch.column(0).dataType()
-        if (outputSchema != actualSchema) {
+        if (!outputSchema.sameType(actualSchema)) {
           throw QueryExecutionErrors.arrowDataTypeMismatchError(
-            "pandas_udf()", Seq(outputSchema), Seq(actualSchema))
+            "DataSource", Seq(outputSchema), Seq(actualSchema))
         }
         val structVector = batch.column(0).asInstanceOf[ArrowColumnVector]
         val outputVectors = output.indices.map(structVector.getChild)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
@@ -79,8 +79,8 @@ class MapInBatchEvaluatorFactory(
 
       columnarBatchIter.flatMap { batch =>
         if (SQLConf.get.pysparkArrowValidateSchema) {
-          // Ensure the schema matches the expected schema, but allowing nullable fields to become
-          // non-nullable.
+          // Ensure the schema matches the expected schema, but allowing nullable fields in the
+          // output schema to become non-nullable in the actual schema.
           val actualSchema = batch.column(0).dataType()
           val isCompatible =
             DataType.equalsIgnoreCompatibleNullability(from = actualSchema, to = outputSchema)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.python
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.{PartitionEvaluator, PartitionEvaluatorFactory, TaskContext}
-import org.apache.spark.api.python.ChainedPythonFunctions
+import org.apache.spark.api.python.{ChainedPythonFunctions, PythonEvalType}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -81,7 +81,7 @@ class MapInBatchEvaluatorFactory(
         val actualSchema = batch.column(0).dataType()
         if (!outputSchema.sameType(actualSchema)) {  // Ignore nullability mismatch for now
           throw QueryExecutionErrors.arrowDataTypeMismatchError(
-            "DataSource", Seq(outputSchema), Seq(actualSchema))
+            PythonEvalType.toString(pythonEvalType), Seq(outputSchema), Seq(actualSchema))
         }
         // Scalar Iterator UDF returns a StructType column in ColumnarBatch, select
         // the children here

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
@@ -77,13 +77,14 @@ class MapInBatchEvaluatorFactory(
       val unsafeProj = UnsafeProjection.create(output, output)
 
       columnarBatchIter.flatMap { batch =>
-        // Scalar Iterator UDF returns a StructType column in ColumnarBatch, select
-        // the children here
+        // Ensure the schema matches the expected schema
         val actualSchema = batch.column(0).dataType()
-        if (!outputSchema.sameType(actualSchema)) {
+        if (!outputSchema.sameType(actualSchema)) {  // Ignore nullability mismatch for now
           throw QueryExecutionErrors.arrowDataTypeMismatchError(
             "DataSource", Seq(outputSchema), Seq(actualSchema))
         }
+        // Scalar Iterator UDF returns a StructType column in ColumnarBatch, select
+        // the children here
         val structVector = batch.column(0).asInstanceOf[ArrowColumnVector]
         val outputVectors = output.indices.map(structVector.getChild)
         val flattenedBatch = new ColumnarBatch(outputVectors.toArray)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
@@ -79,9 +79,11 @@ class MapInBatchEvaluatorFactory(
 
       columnarBatchIter.flatMap { batch =>
         if (SQLConf.get.pysparkArrowValidateSchema) {
-          // Ensure the schema matches the expected schema
+          // Ensure the schema matches the expected schema, but allowing nullable fields to become
+          // non-nullable.
           val actualSchema = batch.column(0).dataType()
-          val isCompatible = DataType.equalsIgnoreCompatibleNullability(actualSchema, outputSchema)
+          val isCompatible =
+            DataType.equalsIgnoreCompatibleNullability(from = actualSchema, to = outputSchema)
           if (!isCompatible) {
             throw QueryExecutionErrors.arrowDataTypeMismatchError(
               PythonEvalType.toString(pythonEvalType), Seq(outputSchema), Seq(actualSchema))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchExec.scala
@@ -56,6 +56,7 @@ trait MapInBatchExec extends UnaryExecNode with PythonSQLMetrics {
       output,
       chainedFunc,
       child.schema,
+      pythonUDF.dataType,
       conf.arrowMaxRecordsPerBatch,
       pythonEvalType,
       conf.sessionLocalTimeZone,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Check the actual Arrow batch schema against the declared schema in `MapInBatchEvaluator`, throwing error if they don't match.

Also fix Pandas to Arrow conversion in `ArrowStreamPandasUDFSerializer` to respect nullability of output schema fields.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To improve error message and reject suspicious usage.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes.

#### Behaviour change

1. Some previously suspicious but accepted schema mismatches are now no longer valid.

    This includes:
    - extraneous fields (previously ignored)
    - wrong order of fields of the same type (previously accepted but in wrong order)
    - expected non-nullable field is actually nullable (previously ignored)

    Example:
    ```py
    from pyspark.sql.datasource import DataSource, DataSourceReader
    from pyspark.sql.pandas.types import to_arrow_schema
    import pyarrow as pa

    expected = StructType.fromDDL("a int, b int")
    actual = StructType.fromDDL("b int, a int")  # wrong order of fields

    class TestDataSource(DataSource):
        def schema(self):
            return expected
        def reader(self, schema):
            return TestReader()

    class TestReader(DataSourceReader):
        def read(self, partition):
            schema = to_arrow_schema(actual)
            yield pa.record_batch([[1], [2]], schema=schema)

    spark.dataSource.register(TestDataSource)
    spark.read.format("TestDataSource").load().show()
    ```
    Before:
    ```
    +---+---+
    |  a|  b|
    +---+---+
    |  1|  2|
    +---+---+
    ```
    Now:
    ```
    org.apache.spark.SparkException: [ARROW_TYPE_MISMATCH] Invalid schema from pandas_udf(): expected StructType(StructField(a,IntegerType,true),StructField(b,IntegerType,true)), got StructType(StructField(b,LongType,true),StructField(a,LongType,true)). SQLSTATE: 42K0G
    ```

2. For other schema mismatches, the error changed from internal error to a clearer `ARROW_TYPE_MISMATCH` error.

    This includes
    - wrong field types
    - less than expected number of fields

    Example:
    ```py
    from pyspark.sql.pandas.types import to_arrow_schema
    from pyspark.sql.types import StructType, StructField, IntegerType
    import pyarrow as pa

    expected = StructType([StructField("a", IntegerType()), StructField("b", IntegerType())])
    actual = StructType([StructField("a", IntegerType())])  # missing a column

    def fun(iterator):
        for batch in iterator:
            schema = to_arrow_schema(actual)
            yield pa.record_batch([[1]], schema=schema)

    spark.range(2).mapInArrow(fun, expected).show()
    ```
    Before:
    ```
    java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
        at org.apache.spark.sql.vectorized.ArrowColumnVector.getChild(ArrowColumnVector.java:134)
        at org.apache.spark.sql.execution.python.MapInBatchEvaluatorFactory$MapInBatchEvaluator.$anonfun$eval$3(MapInBatchEvaluatorFactory.scala:82)
        ...
    ```
    Now:
    ```
    org.apache.spark.SparkException: [ARROW_TYPE_MISMATCH] Invalid schema from pandas_udf(): expected StructType(StructField(a,IntegerType,true),StructField(b,IntegerType,true)), got StructType(StructField(a,IntegerType,true)). SQLSTATE: 42K0G
    ```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

End-to-end tests in `python/pyspark/sql/tests/arrow/test_arrow_map.py`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
