### PR TITLE
[SPARK-51741][SQL][TESTS] Remove --ONLY_IF spark for subquery tests: PR#1

### DIFF
--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-aggregate.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-aggregate.sql
@@ -4,39 +4,35 @@
 --CONFIG_DIM1 spark.sql.codegen.wholeStage=true
 --CONFIG_DIM1 spark.sql.codegen.wholeStage=false,spark.sql.codegen.factoryMode=CODEGEN_ONLY
 --CONFIG_DIM1 spark.sql.codegen.wholeStage=false,spark.sql.codegen.factoryMode=NO_CODEGEN
---ONLY_IF spark
 
-CREATE TEMPORARY VIEW EMP AS SELECT * FROM VALUES
-  (100, "emp 1", date "2005-01-01", 100.00D, 10),
-  (100, "emp 1", date "2005-01-01", 100.00D, 10),
-  (200, "emp 2", date "2003-01-01", 200.00D, 10),
-  (300, "emp 3", date "2002-01-01", 300.00D, 20),
-  (400, "emp 4", date "2005-01-01", 400.00D, 30),
-  (500, "emp 5", date "2001-01-01", 400.00D, NULL),
-  (600, "emp 6 - no dept", date "2001-01-01", 400.00D, 100),
-  (700, "emp 7", date "2010-01-01", 400.00D, 100),
-  (800, "emp 8", date "2016-01-01", 150.00D, 70)
-AS EMP(id, emp_name, hiredate, salary, dept_id);
+CREATE TEMPORARY VIEW EMP(id, emp_name, hiredate, salary, dept_id) AS VALUES
+  (100, 'emp 1', date '2005-01-01', double(100.00), 10),
+  (100, 'emp 1', date '2005-01-01', double(100.00), 10),
+  (200, 'emp 2', date '2003-01-01', double(200.00), 10),
+  (300, 'emp 3', date '2002-01-01', double(300.00), 20),
+  (400, 'emp 4', date '2005-01-01', double(400.00), 30),
+  (500, 'emp 5', date '2001-01-01', double(400.00), NULL),
+  (600, 'emp 6 - no dept', date '2001-01-01', double(400.00), 100),
+  (700, 'emp 7', date '2010-01-01', double(400.00), 100),
+  (800, 'emp 8', date '2016-01-01', double(150.00), 70);
 
-CREATE TEMPORARY VIEW DEPT AS SELECT * FROM VALUES
-  (10, "dept 1", "CA"),
-  (20, "dept 2", "NY"),
-  (30, "dept 3", "TX"),
-  (40, "dept 4 - unassigned", "OR"),
-  (50, "dept 5 - unassigned", "NJ"),
-  (70, "dept 7", "FL")
-AS DEPT(dept_id, dept_name, state);
+CREATE TEMPORARY VIEW DEPT(dept_id, dept_name, state) AS VALUES
+  (10, 'dept 1', 'CA'),
+  (20, 'dept 2', 'NY'),
+  (30, 'dept 3', 'TX'),
+  (40, 'dept 4 - unassigned', 'OR'),
+  (50, 'dept 5 - unassigned', 'NJ'),
+  (70, 'dept 7', 'FL');
 
-CREATE TEMPORARY VIEW BONUS AS SELECT * FROM VALUES
-  ("emp 1", 10.00D),
-  ("emp 1", 20.00D),
-  ("emp 2", 300.00D),
-  ("emp 2", 100.00D),
-  ("emp 3", 300.00D),
-  ("emp 4", 100.00D),
-  ("emp 5", 1000.00D),
-  ("emp 6 - no dept", 500.00D)
-AS BONUS(emp_name, bonus_amt);
+CREATE TEMPORARY VIEW BONUS(emp_name, bonus_amt) AS VALUES
+  ('emp 1', double(10.00)),
+  ('emp 1', double(20.00)),
+  ('emp 2', double(300.00)),
+  ('emp 2', double(100.00)),
+  ('emp 3', double(300.00)),
+  ('emp 4', double(100.00)),
+  ('emp 5', double(1000.00)),
+  ('emp 6 - no dept', double(500.00));
 
 -- Aggregate in outer query block.
 -- TC.01.01

--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-basic.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-basic.sql
@@ -1,38 +1,34 @@
 -- Tests EXISTS subquery support. Tests basic form 
 -- of EXISTS subquery (both EXISTS and NOT EXISTS)
---ONLY_IF spark
 
-CREATE TEMPORARY VIEW EMP AS SELECT * FROM VALUES
-  (100, "emp 1", date "2005-01-01", 100.00D, 10),
-  (100, "emp 1", date "2005-01-01", 100.00D, 10),
-  (200, "emp 2", date "2003-01-01", 200.00D, 10),
-  (300, "emp 3", date "2002-01-01", 300.00D, 20),
-  (400, "emp 4", date "2005-01-01", 400.00D, 30),
-  (500, "emp 5", date "2001-01-01", 400.00D, NULL),
-  (600, "emp 6 - no dept", date "2001-01-01", 400.00D, 100),
-  (700, "emp 7", date "2010-01-01", 400.00D, 100),
-  (800, "emp 8", date "2016-01-01", 150.00D, 70)
-AS EMP(id, emp_name, hiredate, salary, dept_id);
+CREATE TEMPORARY VIEW EMP(id, emp_name, hiredate, salary, dept_id) AS VALUES
+  (100, 'emp 1', date '2005-01-01', double(100.00), 10),
+  (100, 'emp 1', date '2005-01-01', double(100.00), 10),
+  (200, 'emp 2', date '2003-01-01', double(200.00), 10),
+  (300, 'emp 3', date '2002-01-01', double(300.00), 20),
+  (400, 'emp 4', date '2005-01-01', double(400.00), 30),
+  (500, 'emp 5', date '2001-01-01', double(400.00), NULL),
+  (600, 'emp 6 - no dept', date '2001-01-01', double(400.00), 100),
+  (700, 'emp 7', date '2010-01-01', double(400.00), 100),
+  (800, 'emp 8', date '2016-01-01', double(150.00), 70);
 
-CREATE TEMPORARY VIEW DEPT AS SELECT * FROM VALUES
-  (10, "dept 1", "CA"),
-  (20, "dept 2", "NY"),
-  (30, "dept 3", "TX"),
-  (40, "dept 4 - unassigned", "OR"),
-  (50, "dept 5 - unassigned", "NJ"),
-  (70, "dept 7", "FL")
-AS DEPT(dept_id, dept_name, state);
+CREATE TEMPORARY VIEW DEPT(dept_id, dept_name, state) AS VALUES
+  (10, 'dept 1', 'CA'),
+  (20, 'dept 2', 'NY'),
+  (30, 'dept 3', 'TX'),
+  (40, 'dept 4 - unassigned', 'OR'),
+  (50, 'dept 5 - unassigned', 'NJ'),
+  (70, 'dept 7', 'FL');
 
-CREATE TEMPORARY VIEW BONUS AS SELECT * FROM VALUES
-  ("emp 1", 10.00D),
-  ("emp 1", 20.00D),
-  ("emp 2", 300.00D),
-  ("emp 2", 100.00D),
-  ("emp 3", 300.00D),
-  ("emp 4", 100.00D),
-  ("emp 5", 1000.00D),
-  ("emp 6 - no dept", 500.00D)
-AS BONUS(emp_name, bonus_amt);
+CREATE TEMPORARY VIEW BONUS(emp_name, bonus_amt) AS VALUES
+  ('emp 1', double(10.00)),
+  ('emp 1', double(20.00)),
+  ('emp 2', double(300.00)),
+  ('emp 2', double(100.00)),
+  ('emp 3', double(300.00)),
+  ('emp 4', double(100.00)),
+  ('emp 5', double(1000.00)),
+  ('emp 6 - no dept', double(500.00));
 
 -- uncorrelated exist query 
 -- TC.01.01

--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-cte.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-cte.sql
@@ -1,38 +1,34 @@
 -- Tests EXISTS subquery used along with 
 -- Common Table Expressions(CTE)
---ONLY_IF spark
 
-CREATE TEMPORARY VIEW EMP AS SELECT * FROM VALUES
-  (100, "emp 1", date "2005-01-01", 100.00D, 10),
-  (100, "emp 1", date "2005-01-01", 100.00D, 10),
-  (200, "emp 2", date "2003-01-01", 200.00D, 10),
-  (300, "emp 3", date "2002-01-01", 300.00D, 20),
-  (400, "emp 4", date "2005-01-01", 400.00D, 30),
-  (500, "emp 5", date "2001-01-01", 400.00D, NULL),
-  (600, "emp 6 - no dept", date "2001-01-01", 400.00D, 100),
-  (700, "emp 7", date "2010-01-01", 400.00D, 100),
-  (800, "emp 8", date "2016-01-01", 150.00D, 70)
-AS EMP(id, emp_name, hiredate, salary, dept_id);
+CREATE TEMPORARY VIEW EMP(id, emp_name, hiredate, salary, dept_id) AS VALUES
+  (100, 'emp 1', date '2005-01-01', double(100.00), 10),
+  (100, 'emp 1', date '2005-01-01', double(100.00), 10),
+  (200, 'emp 2', date '2003-01-01', double(200.00), 10),
+  (300, 'emp 3', date '2002-01-01', double(300.00), 20),
+  (400, 'emp 4', date '2005-01-01', double(400.00), 30),
+  (500, 'emp 5', date '2001-01-01', double(400.00), NULL),
+  (600, 'emp 6 - no dept', date '2001-01-01', double(400.00), 100),
+  (700, 'emp 7', date '2010-01-01', double(400.00), 100),
+  (800, 'emp 8', date '2016-01-01', double(150.00), 70);
 
-CREATE TEMPORARY VIEW DEPT AS SELECT * FROM VALUES
-  (10, "dept 1", "CA"),
-  (20, "dept 2", "NY"),
-  (30, "dept 3", "TX"),
-  (40, "dept 4 - unassigned", "OR"),
-  (50, "dept 5 - unassigned", "NJ"),
-  (70, "dept 7", "FL")
-AS DEPT(dept_id, dept_name, state);
+CREATE TEMPORARY VIEW DEPT(dept_id, dept_name, state) AS VALUES
+  (10, 'dept 1', 'CA'),
+  (20, 'dept 2', 'NY'),
+  (30, 'dept 3', 'TX'),
+  (40, 'dept 4 - unassigned', 'OR'),
+  (50, 'dept 5 - unassigned', 'NJ'),
+  (70, 'dept 7', 'FL');
 
-CREATE TEMPORARY VIEW BONUS AS SELECT * FROM VALUES
-  ("emp 1", 10.00D),
-  ("emp 1", 20.00D),
-  ("emp 2", 300.00D),
-  ("emp 2", 100.00D),
-  ("emp 3", 300.00D),
-  ("emp 4", 100.00D),
-  ("emp 5", 1000.00D),
-  ("emp 6 - no dept", 500.00D)
-AS BONUS(emp_name, bonus_amt);
+CREATE TEMPORARY VIEW BONUS(emp_name, bonus_amt) AS VALUES
+  ('emp 1', double(10.00)),
+  ('emp 1', double(20.00)),
+  ('emp 2', double(300.00)),
+  ('emp 2', double(100.00)),
+  ('emp 3', double(300.00)),
+  ('emp 4', double(100.00)),
+  ('emp 5', double(1000.00)),
+  ('emp 6 - no dept', double(500.00));
 
 -- CTE used inside subquery with correlated condition 
 -- TC.01.01 

--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-in-join-condition.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-in-join-condition.sql
@@ -6,7 +6,6 @@
 -- 3. Join type: inner / left outer / right outer / full outer / left semi / left anti
 -- 4. AND or OR for the join condition
 
---ONLY_IF spark
 CREATE TEMP VIEW x(x1, x2) AS VALUES
     (2, 1),
     (1, 1),
@@ -47,10 +46,10 @@ select * from x right join y on x1 = y1 and exists (select * from z where z2 = y
 select * from x right join y on x1 = y1 and not exists (select * from z where z2 = y2) order by x1, x2, y1, y2;
 
 -- Same as above, but for full outer join
-select * from x right join y on x1 = y1 and exists (select * from z where z2 = x2) order by x1, x2, y1, y2;
-select * from x right join y on x1 = y1 and not exists (select * from z where z2 = x2) order by x1, x2, y1, y2;
-select * from x right join y on x1 = y1 and exists (select * from z where z2 = y2) order by x1, x2, y1, y2;
-select * from x right join y on x1 = y1 and not exists (select * from z where z2 = y2) order by x1, x2, y1, y2;
+select * from x full outer join y on x1 = y1 and exists (select * from z where z2 = x2) order by x1, x2, y1, y2;
+select * from x full outer join y on x1 = y1 and not exists (select * from z where z2 = x2) order by x1, x2, y1, y2;
+select * from x full outer join y on x1 = y1 and exists (select * from z where z2 = y2) order by x1, x2, y1, y2;
+select * from x full outer join y on x1 = y1 and not exists (select * from z where z2 = y2) order by x1, x2, y1, y2;
 
 -- Same as above, but for left semi join
 select * from x left semi join y on x1 = y1 and exists (select * from z where z2 = x2) order by x1, x2;

--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-joins-and-set-ops.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-joins-and-set-ops.sql
@@ -13,38 +13,34 @@
 --CONFIG_DIM2 spark.sql.codegen.wholeStage=false,spark.sql.codegen.factoryMode=CODEGEN_ONLY
 --CONFIG_DIM2 spark.sql.codegen.wholeStage=false,spark.sql.codegen.factoryMode=NO_CODEGEN
 
---ONLY_IF spark
-CREATE TEMPORARY VIEW EMP AS SELECT * FROM VALUES
-  (100, "emp 1", date "2005-01-01", 100.00D, 10),
-  (100, "emp 1", date "2005-01-01", 100.00D, 10),
-  (200, "emp 2", date "2003-01-01", 200.00D, 10),
-  (300, "emp 3", date "2002-01-01", 300.00D, 20),
-  (400, "emp 4", date "2005-01-01", 400.00D, 30),
-  (500, "emp 5", date "2001-01-01", 400.00D, NULL),
-  (600, "emp 6 - no dept", date "2001-01-01", 400.00D, 100),
-  (700, "emp 7", date "2010-01-01", 400.00D, 100),
-  (800, "emp 8", date "2016-01-01", 150.00D, 70)
-AS EMP(id, emp_name, hiredate, salary, dept_id);
+CREATE TEMPORARY VIEW EMP(id, emp_name, hiredate, salary, dept_id) AS VALUES
+  (100, 'emp 1', date '2005-01-01', double(100.00), 10),
+  (100, 'emp 1', date '2005-01-01', double(100.00), 10),
+  (200, 'emp 2', date '2003-01-01', double(200.00), 10),
+  (300, 'emp 3', date '2002-01-01', double(300.00), 20),
+  (400, 'emp 4', date '2005-01-01', double(400.00), 30),
+  (500, 'emp 5', date '2001-01-01', double(400.00), NULL),
+  (600, 'emp 6 - no dept', date '2001-01-01', double(400.00), 100),
+  (700, 'emp 7', date '2010-01-01', double(400.00), 100),
+  (800, 'emp 8', date '2016-01-01', double(150.00), 70);
 
-CREATE TEMPORARY VIEW DEPT AS SELECT * FROM VALUES
-  (10, "dept 1", "CA"),
-  (20, "dept 2", "NY"),
-  (30, "dept 3", "TX"),
-  (40, "dept 4 - unassigned", "OR"),
-  (50, "dept 5 - unassigned", "NJ"),
-  (70, "dept 7", "FL")
-AS DEPT(dept_id, dept_name, state);
+CREATE TEMPORARY VIEW DEPT(dept_id, dept_name, state) AS VALUES
+  (10, 'dept 1', 'CA'),
+  (20, 'dept 2', 'NY'),
+  (30, 'dept 3', 'TX'),
+  (40, 'dept 4 - unassigned', 'OR'),
+  (50, 'dept 5 - unassigned', 'NJ'),
+  (70, 'dept 7', 'FL');
 
-CREATE TEMPORARY VIEW BONUS AS SELECT * FROM VALUES
-  ("emp 1", 10.00D),
-  ("emp 1", 20.00D),
-  ("emp 2", 300.00D),
-  ("emp 2", 100.00D),
-  ("emp 3", 300.00D),
-  ("emp 4", 100.00D),
-  ("emp 5", 1000.00D),
-  ("emp 6 - no dept", 500.00D)
-AS BONUS(emp_name, bonus_amt);
+CREATE TEMPORARY VIEW BONUS(emp_name, bonus_amt) AS VALUES
+  ('emp 1', double(10.00)),
+  ('emp 1', double(20.00)),
+  ('emp 2', double(300.00)),
+  ('emp 2', double(100.00)),
+  ('emp 3', double(300.00)),
+  ('emp 4', double(100.00)),
+  ('emp 5', double(1000.00)),
+  ('emp 6 - no dept', double(500.00));
 
 -- Join in outer query block
 -- TC.01.01

--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-orderby-limit.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-orderby-limit.sql
@@ -5,38 +5,34 @@
 --CONFIG_DIM1 spark.sql.codegen.wholeStage=false,spark.sql.codegen.factoryMode=CODEGEN_ONLY
 --CONFIG_DIM1 spark.sql.codegen.wholeStage=false,spark.sql.codegen.factoryMode=NO_CODEGEN
 
---ONLY_IF spark
-CREATE TEMPORARY VIEW EMP AS SELECT * FROM VALUES
-  (100, "emp 1", date "2005-01-01", 100.00D, 10),
-  (100, "emp 1", date "2005-01-01", 100.00D, 10),
-  (200, "emp 2", date "2003-01-01", 200.00D, 10),
-  (300, "emp 3", date "2002-01-01", 300.00D, 20),
-  (400, "emp 4", date "2005-01-01", 400.00D, 30),
-  (500, "emp 5", date "2001-01-01", 400.00D, NULL),
-  (600, "emp 6 - no dept", date "2001-01-01", 400.00D, 100),
-  (700, "emp 7", date "2010-01-01", 400.00D, 100),
-  (800, "emp 8", date "2016-01-01", 150.00D, 70)
-AS EMP(id, emp_name, hiredate, salary, dept_id);
+CREATE TEMPORARY VIEW EMP(id, emp_name, hiredate, salary, dept_id) AS VALUES
+  (100, 'emp 1', date '2005-01-01', double(100.00), 10),
+  (100, 'emp 1', date '2005-01-01', double(100.00), 10),
+  (200, 'emp 2', date '2003-01-01', double(200.00), 10),
+  (300, 'emp 3', date '2002-01-01', double(300.00), 20),
+  (400, 'emp 4', date '2005-01-01', double(400.00), 30),
+  (500, 'emp 5', date '2001-01-01', double(400.00), NULL),
+  (600, 'emp 6 - no dept', date '2001-01-01', double(400.00), 100),
+  (700, 'emp 7', date '2010-01-01', double(400.00), 100),
+  (800, 'emp 8', date '2016-01-01', double(150.00), 70);
 
-CREATE TEMPORARY VIEW DEPT AS SELECT * FROM VALUES
-  (10, "dept 1", "CA"),
-  (20, "dept 2", "NY"),
-  (30, "dept 3", "TX"),
-  (40, "dept 4 - unassigned", "OR"),
-  (50, "dept 5 - unassigned", "NJ"),
-  (70, "dept 7", "FL")
-AS DEPT(dept_id, dept_name, state);
+CREATE TEMPORARY VIEW DEPT(dept_id, dept_name, state) AS VALUES
+  (10, 'dept 1', 'CA'),
+  (20, 'dept 2', 'NY'),
+  (30, 'dept 3', 'TX'),
+  (40, 'dept 4 - unassigned', 'OR'),
+  (50, 'dept 5 - unassigned', 'NJ'),
+  (70, 'dept 7', 'FL');
 
-CREATE TEMPORARY VIEW BONUS AS SELECT * FROM VALUES
-  ("emp 1", 10.00D),
-  ("emp 1", 20.00D),
-  ("emp 2", 300.00D),
-  ("emp 2", 100.00D),
-  ("emp 3", 300.00D),
-  ("emp 4", 100.00D),
-  ("emp 5", 1000.00D),
-  ("emp 6 - no dept", 500.00D)
-AS BONUS(emp_name, bonus_amt);
+CREATE TEMPORARY VIEW BONUS(emp_name, bonus_amt) AS VALUES
+  ('emp 1', double(10.00)),
+  ('emp 1', double(20.00)),
+  ('emp 2', double(300.00)),
+  ('emp 2', double(100.00)),
+  ('emp 3', double(300.00)),
+  ('emp 4', double(100.00)),
+  ('emp 5', double(1000.00)),
+  ('emp 6 - no dept', double(500.00));
 
 -- order by in both outer and/or inner query block
 -- TC.01.01

--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-outside-filter.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-outside-filter.sql
@@ -1,38 +1,33 @@
 -- Tests EXISTS subquery support where the subquery is used outside the WHERE clause.
 
---ONLY_IF spark
+CREATE TEMPORARY VIEW EMP(id, emp_name, hiredate, salary, dept_id) AS VALUES
+  (100, 'emp 1', date '2005-01-01', double(100.00), 10),
+  (100, 'emp 1', date '2005-01-01', double(100.00), 10),
+  (200, 'emp 2', date '2003-01-01', double(200.00), 10),
+  (300, 'emp 3', date '2002-01-01', double(300.00), 20),
+  (400, 'emp 4', date '2005-01-01', double(400.00), 30),
+  (500, 'emp 5', date '2001-01-01', double(400.00), NULL),
+  (600, 'emp 6 - no dept', date '2001-01-01', double(400.00), 100),
+  (700, 'emp 7', date '2010-01-01', double(400.00), 100),
+  (800, 'emp 8', date '2016-01-01', double(150.00), 70);
 
-CREATE TEMPORARY VIEW EMP AS SELECT * FROM VALUES
-  (100, "emp 1", date "2005-01-01", 100.00D, 10),
-  (100, "emp 1", date "2005-01-01", 100.00D, 10),
-  (200, "emp 2", date "2003-01-01", 200.00D, 10),
-  (300, "emp 3", date "2002-01-01", 300.00D, 20),
-  (400, "emp 4", date "2005-01-01", 400.00D, 30),
-  (500, "emp 5", date "2001-01-01", 400.00D, NULL),
-  (600, "emp 6 - no dept", date "2001-01-01", 400.00D, 100),
-  (700, "emp 7", date "2010-01-01", 400.00D, 100),
-  (800, "emp 8", date "2016-01-01", 150.00D, 70)
-AS EMP(id, emp_name, hiredate, salary, dept_id);
+CREATE TEMPORARY VIEW DEPT(dept_id, dept_name, state) AS VALUES
+  (10, 'dept 1', 'CA'),
+  (20, 'dept 2', 'NY'),
+  (30, 'dept 3', 'TX'),
+  (40, 'dept 4 - unassigned', 'OR'),
+  (50, 'dept 5 - unassigned', 'NJ'),
+  (70, 'dept 7', 'FL');
 
-CREATE TEMPORARY VIEW DEPT AS SELECT * FROM VALUES
-  (10, "dept 1", "CA"),
-  (20, "dept 2", "NY"),
-  (30, "dept 3", "TX"),
-  (40, "dept 4 - unassigned", "OR"),
-  (50, "dept 5 - unassigned", "NJ"),
-  (70, "dept 7", "FL")
-AS DEPT(dept_id, dept_name, state);
-
-CREATE TEMPORARY VIEW BONUS AS SELECT * FROM VALUES
-  ("emp 1", 10.00D),
-  ("emp 1", 20.00D),
-  ("emp 2", 300.00D),
-  ("emp 2", 100.00D),
-  ("emp 3", 300.00D),
-  ("emp 4", 100.00D),
-  ("emp 5", 1000.00D),
-  ("emp 6 - no dept", 500.00D)
-AS BONUS(emp_name, bonus_amt);
+CREATE TEMPORARY VIEW BONUS(emp_name, bonus_amt) AS VALUES
+  ('emp 1', double(10.00)),
+  ('emp 1', double(20.00)),
+  ('emp 2', double(300.00)),
+  ('emp 2', double(100.00)),
+  ('emp 3', double(300.00)),
+  ('emp 4', double(100.00)),
+  ('emp 5', double(1000.00)),
+  ('emp 6 - no dept', double(500.00));
 
 -- uncorrelated select exist
 -- TC.01.01

--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-within-and-or.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-within-and-or.sql
@@ -1,38 +1,34 @@
 -- Tests EXISTS subquery support. Tests EXISTS 
 -- subquery within a AND or OR expression.
 
---ONLY_IF spark
-CREATE TEMPORARY VIEW EMP AS SELECT * FROM VALUES
-  (100, "emp 1", date "2005-01-01", 100.00D, 10),
-  (100, "emp 1", date "2005-01-01", 100.00D, 10),
-  (200, "emp 2", date "2003-01-01", 200.00D, 10),
-  (300, "emp 3", date "2002-01-01", 300.00D, 20),
-  (400, "emp 4", date "2005-01-01", 400.00D, 30),
-  (500, "emp 5", date "2001-01-01", 400.00D, NULL),
-  (600, "emp 6 - no dept", date "2001-01-01", 400.00D, 100),
-  (700, "emp 7", date "2010-01-01", 400.00D, 100),
-  (800, "emp 8", date "2016-01-01", 150.00D, 70)
-AS EMP(id, emp_name, hiredate, salary, dept_id);
+CREATE TEMPORARY VIEW EMP(id, emp_name, hiredate, salary, dept_id) AS VALUES
+  (100, 'emp 1', date '2005-01-01', double(100.00), 10),
+  (100, 'emp 1', date '2005-01-01', double(100.00), 10),
+  (200, 'emp 2', date '2003-01-01', double(200.00), 10),
+  (300, 'emp 3', date '2002-01-01', double(300.00), 20),
+  (400, 'emp 4', date '2005-01-01', double(400.00), 30),
+  (500, 'emp 5', date '2001-01-01', double(400.00), NULL),
+  (600, 'emp 6 - no dept', date '2001-01-01', double(400.00), 100),
+  (700, 'emp 7', date '2010-01-01', double(400.00), 100),
+  (800, 'emp 8', date '2016-01-01', double(150.00), 70);
 
-CREATE TEMPORARY VIEW DEPT AS SELECT * FROM VALUES
-  (10, "dept 1", "CA"),
-  (20, "dept 2", "NY"),
-  (30, "dept 3", "TX"),
-  (40, "dept 4 - unassigned", "OR"),
-  (50, "dept 5 - unassigned", "NJ"),
-  (70, "dept 7", "FL")
-AS DEPT(dept_id, dept_name, state);
+CREATE TEMPORARY VIEW DEPT(dept_id, dept_name, state) AS VALUES
+  (10, 'dept 1', 'CA'),
+  (20, 'dept 2', 'NY'),
+  (30, 'dept 3', 'TX'),
+  (40, 'dept 4 - unassigned', 'OR'),
+  (50, 'dept 5 - unassigned', 'NJ'),
+  (70, 'dept 7', 'FL');
 
-CREATE TEMPORARY VIEW BONUS AS SELECT * FROM VALUES
-  ("emp 1", 10.00D),
-  ("emp 1", 20.00D),
-  ("emp 2", 300.00D),
-  ("emp 2", 100.00D),
-  ("emp 3", 300.00D),
-  ("emp 4", 100.00D),
-  ("emp 5", 1000.00D),
-  ("emp 6 - no dept", 500.00D)
-AS BONUS(emp_name, bonus_amt);
+CREATE TEMPORARY VIEW BONUS(emp_name, bonus_amt) AS VALUES
+  ('emp 1', double(10.00)),
+  ('emp 1', double(20.00)),
+  ('emp 2', double(300.00)),
+  ('emp 2', double(100.00)),
+  ('emp 3', double(300.00)),
+  ('emp 4', double(100.00)),
+  ('emp 5', double(1000.00)),
+  ('emp 6 - no dept', double(500.00));
 
 
 -- Or used in conjunction with exists - ExistenceJoin

--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/nested-not-in.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/nested-not-in.sql
@@ -1,52 +1,49 @@
 -- Tests NOT-IN subqueries nested inside OR expression(s).
---ONLY_IF spark
 
 --CONFIG_DIM1 spark.sql.optimizeNullAwareAntiJoin=true
 --CONFIG_DIM1 spark.sql.optimizeNullAwareAntiJoin=false
 
-CREATE TEMPORARY VIEW EMP AS SELECT * FROM VALUES
-  (100, "emp 1", 10),
-  (200, "emp 2", NULL),
-  (300, "emp 3", 20),
-  (400, "emp 4", 30),
-  (500, "emp 5", NULL),
-  (600, "emp 6", 100),
-  (800, "emp 8", 70)
-AS EMP(id, emp_name, dept_id);
+CREATE TEMPORARY VIEW EMP(id, emp_name, hiredate, salary, dept_id) AS VALUES
+  (100, 'emp 1', date '2005-01-01', double(100.00), 10),
+  (100, 'emp 1', date '2005-01-01', double(100.00), 10),
+  (200, 'emp 2', date '2003-01-01', double(200.00), 10),
+  (300, 'emp 3', date '2002-01-01', double(300.00), 20),
+  (400, 'emp 4', date '2005-01-01', double(400.00), 30),
+  (500, 'emp 5', date '2001-01-01', double(400.00), NULL),
+  (600, 'emp 6 - no dept', date '2001-01-01', double(400.00), 100),
+  (700, 'emp 7', date '2010-01-01', double(400.00), 100),
+  (800, 'emp 8', date '2016-01-01', double(150.00), 70);
 
-CREATE TEMPORARY VIEW DEPT AS SELECT * FROM VALUES
-  (10, "dept 1", "CA"),
-  (20, "dept 2", "NY"),
-  (30, "dept 3", "TX"),
-  (40, "dept 4 - unassigned", "OR"),
-  (50, "dept 5 - unassigned", "NJ"),
-  (70, "dept 7", "FL")
-AS DEPT(dept_id, dept_name, state);
+CREATE TEMPORARY VIEW DEPT(dept_id, dept_name, state) AS VALUES
+  (10, 'dept 1', 'CA'),
+  (20, 'dept 2', 'NY'),
+  (30, 'dept 3', 'TX'),
+  (40, 'dept 4 - unassigned', 'OR'),
+  (50, 'dept 5 - unassigned', 'NJ'),
+  (70, 'dept 7', 'FL');
 
-CREATE TEMPORARY VIEW BONUS AS SELECT * FROM VALUES
-  ("emp 1", 10.00D),
-  ("emp 1", 20.00D),
-  ("emp 2", 300.00D),
-  ("emp 2", 100.00D),
-  ("emp 3", 300.00D),
-  ("emp 4", 100.00D),
-  ("emp 5", 1000.00D),
-  ("emp 6 - no dept", 500.00D)
-AS BONUS(emp_name, bonus_amt);
+CREATE TEMPORARY VIEW BONUS(emp_name, bonus_amt) AS VALUES
+  ('emp 1', double(10.00)),
+  ('emp 1', double(20.00)),
+  ('emp 2', double(300.00)),
+  ('emp 2', double(100.00)),
+  ('emp 3', double(300.00)),
+  ('emp 4', double(100.00)),
+  ('emp 5', double(1000.00)),
+  ('emp 6 - no dept', double(500.00));
 
-CREATE TEMPORARY VIEW ADDRESS AS SELECT * FROM VALUES
+CREATE TEMPORARY VIEW ADDRESS(id, emp_name, address) AS VALUES
   (100, "emp 1", "addr1"),
   (200, null, "addr2"),
   (null, "emp 3", "addr3"),
   (null, null, "addr4"),
   (600, "emp 6", "addr6"),
-  (800, "emp 8", "addr8")
-AS ADDRESS(id, emp_name, address);
+  (800, "emp 8", "addr8");
 
-CREATE TEMPORARY VIEW S1 AS SELECT * FROM VALUES
-  (null, null), (5, 5), (8, 8), (11, 11) AS s1(a, b);
-CREATE TEMPORARY VIEW S2 AS SELECT * FROM VALUES
-  (7, 7), (8, 8), (11, 11), (null, null) AS s2(c, d);
+CREATE TEMPORARY VIEW S1(a, b) AS VALUES
+  (null, null), (5, 5), (8, 8), (11, 11);
+CREATE TEMPORARY VIEW S2(c, d) AS VALUES
+  (7, 7), (8, 8), (11, 11), (null, null);
 
 -- null produced from both sides.
 -- TC.01.01


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Remove --ONLY_IF spark for some subquery tests so that they are covered by PostgresSQLQueryTestSuite. This requires changing some SQL syntax, mostly that of view creation for these files.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To increase coverage of cross-DBMS correctness testing. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
NA - test only change.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.