### PR TITLE
[SPARK-51760][BUILD] Upgrade ASM to 9.8

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -279,7 +279,7 @@ vertx-core/4.5.12//vertx-core-4.5.12.jar
 vertx-web-client/4.5.12//vertx-web-client-4.5.12.jar
 vertx-web-common/4.5.12//vertx-web-common-4.5.12.jar
 wildfly-openssl/2.2.5.Final//wildfly-openssl-2.2.5.Final.jar
-xbean-asm9-shaded/4.26//xbean-asm9-shaded-4.26.jar
+xbean-asm9-shaded/4.27//xbean-asm9-shaded-4.27.jar
 xmlschema-core/2.3.1//xmlschema-core-2.3.1.jar
 xz/1.10//xz-1.10.jar
 zjsonpatch/7.1.0//zjsonpatch-7.1.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <maven.version>3.9.9</maven.version>
     <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
-    <asm.version>9.7.1</asm.version>
+    <asm.version>9.8</asm.version>
     <slf4j.version>2.0.17</slf4j.version>
     <log4j.version>2.24.3</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
@@ -505,7 +505,7 @@
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-asm9-shaded</artifactId>
-        <version>4.26</version>
+        <version>4.27</version>
       </dependency>
 
       <!-- Shaded deps marked as provided. These are promoted to compile scope

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -33,9 +33,9 @@ addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
 
-libraryDependencies += "org.ow2.asm"  % "asm" % "9.7.1"
+libraryDependencies += "org.ow2.asm"  % "asm" % "9.8"
 
-libraryDependencies += "org.ow2.asm"  % "asm-commons" % "9.7.1"
+libraryDependencies += "org.ow2.asm"  % "asm-commons" % "9.8"
 
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade ASM from 9.7.1 to 9.8.


### Why are the changes needed?
The new version is intended to support Java 25:

- new Opcodes.V25 constant for Java 25
- bug fixes
   - Fix one more copy operation on DUP2
   - 318015: Valid bytecode for jvm, but failed to pass the CheckClassAdapter.
   - `ASMifier` should print calls to `valueOf` instead of deprecated constructors of primitive wrappers


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
