### PR TITLE
[SPARK-51420][SQL][FOLLOWUP] Support all valid TIME precisions in the minute function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -187,7 +187,8 @@ case class MinutesOfTime(child: Expression)
     Seq(child.dataType)
   )
 
-  override def inputTypes: Seq[AbstractDataType] = Seq(TimeType())
+  override def inputTypes: Seq[AbstractDataType] =
+    Seq(TypeCollection(TimeType.MIN_PRECISION to TimeType.MAX_PRECISION map TimeType: _*))
 
   override def children: Seq[Expression] = Seq(child)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -125,11 +125,22 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
         "docroot" -> SPARK_DOC_ROOT)
     )
 
-    // test TIME-typed child should build MinutesOfTime
+    // test TIME-typed child should build MinutesOfTime for default precision value
     val timeExpr = Literal(localTime(12, 58, 59), TimeType())
     val builtExprForTime = MinuteExpressionBuilder.build("minute", Seq(timeExpr))
     assert(builtExprForTime.isInstanceOf[MinutesOfTime])
     assert(builtExprForTime.asInstanceOf[MinutesOfTime].child eq timeExpr)
+    assert(builtExprForTime.checkInputDataTypes().isSuccess)
+
+    // test TIME-typed child should build MinutesOfTime for all allowed custom precision values
+    (TimeType.MIN_PRECISION to TimeType.MICROS_PRECISION).foreach { precision =>
+      val timeExpr = Literal(localTime(12, 58, 59), TimeType(precision))
+      val builtExpr = MinuteExpressionBuilder.build("minute", Seq(timeExpr))
+
+      assert(builtExpr.isInstanceOf[MinutesOfTime])
+      assert(builtExpr.asInstanceOf[MinutesOfTime].child eq timeExpr)
+      assert(builtExpr.checkInputDataTypes().isSuccess)
+    }
 
     // test non TIME-typed child should build Minute
     val tsExpr = Literal("2009-07-30 12:58:59")


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Followup to the original PR: https://github.com/apache/spark/pull/50296
- Extend the minute(...) function (MinutesOfTime) to handle TIME types of any precision from 0 to 6.
- Add tests verifying that minute(...) works for all valid TIME precisions.


### Why are the changes needed?
- Previously, minute(...) did not consistently support TIME type inputs with arbitrary precision.
- Users need the minute function to handle TIME(0) through TIME(6).

### Does this PR introduce _any_ user-facing change?
- Yes. Users can now call minute(...) on TIME(p) columns or literals with any valid precision.

### How was this patch tested?
By running new tests:
```
$ build/sbt "test:testOnly *TimeExpressionsSuite.scala"
```

By manual tests:
```
scala> spark.sql("select minute(cast('12:30' as time(0)));").show()
+------------------------------+
|minute(CAST(12:30 AS TIME(0)))|
+------------------------------+
|                            30|
+------------------------------+


scala> spark.sql("select minute(cast('12:30' as time(2)));").show()
+------------------------------+
|minute(CAST(12:30 AS TIME(2)))|
+------------------------------+
|                            30|
+------------------------------+


scala> spark.sql("select minute(cast('12:30' as time(5)));").show()
+------------------------------+
|minute(CAST(12:30 AS TIME(5)))|
+------------------------------+
|                            30|
+------------------------------+
```



### Was this patch authored or co-authored using generative AI tooling?
No
