### PR TITLE
[SPARK-51761][INFRA] Add a daily test using the Ubuntu Arm Runner

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1290,3 +1290,12 @@ jobs:
           cd ui-test
           npm install --save-dev
           node --experimental-vm-modules node_modules/.bin/jest
+
+  maven-test:
+    name: "Run Maven Test ARM"
+    permissions:
+      packages: write
+    uses: ./.github/workflows/maven_test.yml
+    with:
+      java: 21
+      os: ubuntu-24.04-arm

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1290,13 +1290,3 @@ jobs:
           cd ui-test
           npm install --save-dev
           node --experimental-vm-modules node_modules/.bin/jest
-
-  maven-test:
-    name: "Run Maven Test ARM"
-    permissions:
-      packages: write
-    uses: ./.github/workflows/maven_test.yml
-    with:
-      java: 21
-      os: ubuntu-24.04-arm
-      architecture: arm64

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1299,3 +1299,4 @@ jobs:
     with:
       java: 21
       os: ubuntu-24.04-arm
+      architecture: arm64

--- a/.github/workflows/build_maven_java21_arm.yml
+++ b/.github/workflows/build_maven_java21_arm.yml
@@ -34,3 +34,4 @@ jobs:
     with:
       java: 21
       os: ubuntu-24.04-arm
+      architecture: arm64

--- a/.github/workflows/build_maven_java21_arm.yml
+++ b/.github/workflows/build_maven_java21_arm.yml
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Build / Maven (master, Scala 2.13, Hadoop 3, JDK 21, ARM)"
+
+on:
+  schedule:
+    - cron: '0 15 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-build:
+    permissions:
+      packages: write
+    name: Run
+    uses: ./.github/workflows/maven_test.yml
+    if: github.repository == 'apache/spark'
+    with:
+      java: 21
+      os: ubuntu-24.04-arm

--- a/.github/workflows/build_maven_java21_arm.yml
+++ b/.github/workflows/build_maven_java21_arm.yml
@@ -34,4 +34,4 @@ jobs:
     with:
       java: 21
       os: ubuntu-24.04-arm
-      architecture: arm64
+      arch: arm64

--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -41,7 +41,7 @@ on:
         required: false
         type: string
         default: ubuntu-latest
-      architecture:
+      arch:
         description: The target architecture (x86, x64, arm64) of the Python or PyPy interpreter.
         required: false
         type: string
@@ -177,7 +177,7 @@ jobs:
         if: contains(matrix.modules, 'resource-managers#yarn') || (contains(matrix.modules, 'sql#core')) || contains(matrix.modules, 'connect')
         with:
           python-version: '3.11'
-          architecture: ${{ inputs.architecture }}
+          architecture: ${{ inputs.arch }}
       - name: Install Python packages (Python 3.11)
         if: contains(matrix.modules, 'resource-managers#yarn') || (contains(matrix.modules, 'sql#core')) || contains(matrix.modules, 'connect')
         run: |

--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -41,6 +41,11 @@ on:
         required: false
         type: string
         default: ubuntu-latest
+      architecture:
+        description: The target architecture (x86, x64, arm64) of the Python or PyPy interpreter.
+        required: false
+        type: string
+        default: x64
       envs:
         description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false
@@ -172,7 +177,7 @@ jobs:
         if: contains(matrix.modules, 'resource-managers#yarn') || (contains(matrix.modules, 'sql#core')) || contains(matrix.modules, 'connect')
         with:
           python-version: '3.11'
-          architecture: x64
+          architecture: ${{ inputs.architecture }}
       - name: Install Python packages (Python 3.11)
         if: contains(matrix.modules, 'resource-managers#yarn') || (contains(matrix.modules, 'sql#core')) || contains(matrix.modules, 'connect')
         run: |


### PR DESCRIPTION
### What changes were proposed in this pull request?
Standard GitHub-hosted runners have added the combination of `Linux + Arm64`. This pull request adds a daily test for this scenario.

- https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners
- https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-24-image.md

![image](https://github.com/user-attachments/assets/70ac8cf2-2b98-45b7-8a91-b7ecdbb4f9cd)


### Why are the changes needed?
Check the availability of Spark on `Linux + Arm64`.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Monitor Daily test after merged.


### Was this patch authored or co-authored using generative AI tooling?
No