### PR TITLE
[SPARK-51419][SQL][FOLLOWUP] Making hour function to accept any precision of TIME type

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -246,7 +246,8 @@ case class HoursOfTime(child: Expression)
     Seq(child.dataType)
   )
 
-  override def inputTypes: Seq[AbstractDataType] = Seq(TimeType())
+  override def inputTypes: Seq[AbstractDataType] =
+    Seq(TypeCollection(TimeType.MIN_PRECISION to TimeType.MAX_PRECISION map TimeType: _*))
 
   override def children: Seq[Expression] = Seq(child)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -73,6 +73,18 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     assert(builtExprForTime.isInstanceOf[HoursOfTime])
     assert(builtExprForTime.asInstanceOf[HoursOfTime].child eq timeExpr)
 
+    assert(builtExprForTime.checkInputDataTypes().isSuccess)
+
+    // test TIME-typed child should build HoursOfTime for all allowed custom precision values
+    (TimeType.MIN_PRECISION to TimeType.MICROS_PRECISION).foreach { precision =>
+      val timeExpr = Literal(localTime(12, 58, 59), TimeType(precision))
+      val builtExpr = HourExpressionBuilder.build("hour", Seq(timeExpr))
+
+      assert(builtExpr.isInstanceOf[HoursOfTime])
+      assert(builtExpr.asInstanceOf[HoursOfTime].child eq timeExpr)
+      assert(builtExpr.checkInputDataTypes().isSuccess)
+    }
+
     // test non TIME-typed child should build hour
     val tsExpr = Literal("2007-09-03 10:45:23")
     val builtExprForTs = HourExpressionBuilder.build("hour", Seq(tsExpr))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This is followup PR of [SPARK-51419 ](https://github.com/apache/spark/pull/50355)


### Why are the changes needed?
This Followup PR allows any precision in the range of [0,6] for the hour function


### Does this PR introduce _any_ user-facing change?
Yes. This changes allows User to execute below query

```
spark.sql("select hour(cast('12:00:01.123' as time(3)))").show(false)
```


### How was this patch tested?
We tested by running sample query as below

```
spark.sql("select hour(cast('12:00:01.123' as time(3)))").show(false)
```

Output:

```
+-----------------------------------+
|hour(CAST(12:00:01.123 AS TIME(3)))|
+-----------------------------------+
|12                                                        |
+-----------------------------------+

```


### Was this patch authored or co-authored using generative AI tooling?
No
