### PR TITLE
[SPARK-51562][SQL] Add the time() function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -464,6 +464,8 @@ object FunctionRegistry {
     expression[TryToBinary]("try_to_binary"),
     expressionBuilder("try_to_timestamp", TryToTimestampExpressionBuilder, setAlias = true),
     expressionBuilder("try_to_time", TryToTimeExpressionBuilder, setAlias = true),
+    expressionBuilder("time", TimeExpressionBuilder, setAlias = true),
+    expressionBuilder("try_time", TryTimeExpressionBuilder, setAlias = true),
     expression[TryAesDecrypt]("try_aes_decrypt"),
     expression[TryReflect]("try_reflect"),
     expression[TryUrlDecode]("try_url_decode"),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -53,6 +53,27 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       parameters = Map("input" -> "'100:50'", "format" -> "'mm:HH'"))
   }
 
+  test("Time Function") {
+    // Test with null inputs
+    checkEvaluation(new Time(Literal(null, StringType)), null)
+
+    // Test with string inputs
+    checkEvaluation(new Time(Literal("00:00:00")), localTime())
+    checkEvaluation(new Time(Literal("23:59:59.999999")), localTime(23, 59, 59, 999999))
+    checkEvaluation(new Time(Literal("12:30:45.123")), localTime(12, 30, 45, 123000))
+    checkEvaluation(new Time(NonFoldableLiteral(" 12:00:00.909 ")), localTime(12, 0, 0, 909000))
+
+    // Test with numeric inputs (seconds)
+    checkEvaluation(new Time(Literal(0)), localTime(0, 0, 0, 0))
+    checkEvaluation(new Time(Literal(123)), localTime(0, 2, 3, 0))
+    checkEvaluation(new Time(Literal(3661.5)), localTime(1, 1, 1, 500000))
+
+    // Test with very large values
+    checkEvaluation(
+      new Time(Literal(86399.999999)),
+      localTime(23, 59, 59, 999999))
+  }
+
   test("HourExpressionBuilder") {
     // Empty expressions list
     checkError(

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -338,6 +338,7 @@
 | org.apache.spark.sql.catalyst.expressions.Subtract | - | SELECT 2 - 1 | struct<(2 - 1):int> |
 | org.apache.spark.sql.catalyst.expressions.Tan | tan | SELECT tan(0) | struct<TAN(0):double> |
 | org.apache.spark.sql.catalyst.expressions.Tanh | tanh | SELECT tanh(0) | struct<TANH(0):double> |
+| org.apache.spark.sql.catalyst.expressions.TimeExpressionBuilder | time | SELECT time('12:25:13.45') | struct<time(12:25:13.45):time(6)> |
 | org.apache.spark.sql.catalyst.expressions.TimeWindow | window | SELECT a, window.start, window.end, count(*) as cnt FROM VALUES ('A1', '2021-01-01 00:00:00'), ('A1', '2021-01-01 00:04:30'), ('A1', '2021-01-01 00:06:00'), ('A2', '2021-01-01 00:01:00') AS tab(a, b) GROUP by a, window(b, '5 minutes') ORDER BY a, start | struct<a:string,start:timestamp,end:timestamp,cnt:bigint> |
 | org.apache.spark.sql.catalyst.expressions.ToBinary | to_binary | SELECT to_binary('abc', 'utf-8') | struct<to_binary(abc, utf-8):binary> |
 | org.apache.spark.sql.catalyst.expressions.ToCharacterBuilder | to_char | SELECT to_char(454, '999') | struct<to_char(454, 999):string> |
@@ -365,6 +366,7 @@
 | org.apache.spark.sql.catalyst.expressions.TryParseUrl | try_parse_url | SELECT try_parse_url('http://spark.apache.org/path?query=1', 'HOST') | struct<try_parse_url(http://spark.apache.org/path?query=1, HOST):string> |
 | org.apache.spark.sql.catalyst.expressions.TryReflect | try_reflect | SELECT try_reflect('java.util.UUID', 'randomUUID') | struct<try_reflect(java.util.UUID, randomUUID):string> |
 | org.apache.spark.sql.catalyst.expressions.TrySubtract | try_subtract | SELECT try_subtract(2, 1) | struct<try_subtract(2, 1):int> |
+| org.apache.spark.sql.catalyst.expressions.TryTimeExpressionBuilder | try_time | SELECT try_time('12:25:13.45') | struct<time(12:25:13.45):time(6)> |
 | org.apache.spark.sql.catalyst.expressions.TryToBinary | try_to_binary | SELECT try_to_binary('abc', 'utf-8') | struct<try_to_binary(abc, utf-8):binary> |
 | org.apache.spark.sql.catalyst.expressions.TryToNumber | try_to_number | SELECT try_to_number('454', '999') | struct<try_to_number(454, 999):decimal(3,0)> |
 | org.apache.spark.sql.catalyst.expressions.TryToTimeExpressionBuilder | try_to_time | SELECT try_to_time('00:12:00.001') | struct<try_to_time(to_time(00:12:00.001)):time(6)> |


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR adds new function time() which should cast an expr to TIME. This function is a synonym for CAST(expr AS TIME)

Examples
```
SELECT time('12:25:13.45');
12:25:13.45
SELECT time(timestamp'2020-04-30 12:25:13.45');
12:25:13.45
SELECT time(123);
00:02:03
```


### Why are the changes needed?
This function is a synonym for CAST(expr AS TIME)


### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?
By running the related test suites:
```
$ build/sbt "test:testOnly *ExpressionInfoSuite"
$ build/sbt "test:testOnly *TimeExpressionsSuite"
$ build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z time.sql"
```
and also with spark-shell
```
scala> spark.sql("select time(123) as col").show()
+--------+
|     col|
+--------+
|00:02:03|
+--------+


scala> spark.sql("select time(timestamp'2020-04-30 00:25:13.45') as col").show()
+-----------+
|        col|
+-----------+
|00:25:13.45|
+-----------+


scala> spark.sql("select time('13:33:13.45') as col").show()
+-----------+
|        col|
+-----------+
|13:33:13.45|
+-----------+
```

### Was this patch authored or co-authored using generative AI tooling?
No
