### PR TITLE
Revert "[SPARK-47895][SQL] group by alias should be idempotent"

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveReferencesInAggregate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveReferencesInAggregate.scala
@@ -116,19 +116,7 @@ class ResolveReferencesInAggregate(val catalogManager: CatalogManager) extends S
       groupExprs.map { g =>
         g.transformWithPruning(_.containsPattern(UNRESOLVED_ATTRIBUTE)) {
           case u: UnresolvedAttribute =>
-            val (result, index) =
-              selectList.zipWithIndex.find(ne => conf.resolver(ne._1.name, u.name))
-                .getOrElse((u, -1))
-
-            trimAliases(result) match {
-              // HACK ALERT: If the expanded grouping expression is an integer literal, don't use it
-              //             but use an integer literal of the index. The reason is we may
-              //             repeatedly analyze the plan, and the original integer literal may cause
-              //             failures with a later GROUP BY ordinal resolution. GROUP BY constant is
-              //             meaningless so whatever value does not matter here.
-              case IntegerLiteral(_) => Literal(index + 1)
-              case _ => result
-            }
+            selectList.find(ne => conf.resolver(ne.name, u.name)).getOrElse(u)
         }
       }
     } else {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/SubstituteUnresolvedOrdinalsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/SubstituteUnresolvedOrdinalsSuite.scala
@@ -104,22 +104,4 @@ class SubstituteUnresolvedOrdinalsSuite extends AnalysisTest {
       testRelationWithData.groupBy(Literal(1))(Literal(100).as("a"))
     )
   }
-
-  test("SPARK-47895: group by alias repeated analysis") {
-    val plan = testRelation.groupBy($"b")(Literal(100).as("b")).analyze
-    comparePlans(
-      plan,
-      testRelation.groupBy(Literal(1))(Literal(100).as("b"))
-    )
-
-    val testRelationWithData = testRelation.copy(data = Seq(new GenericInternalRow(Array(1: Any))))
-    // Copy the plan to reset its `analyzed` flag, so that analyzer rules will re-apply.
-    val copiedPlan = plan.transform {
-      case _: LocalRelation => testRelationWithData
-    }
-    comparePlans(
-      copiedPlan.analyze, // repeated analysis
-      testRelationWithData.groupBy(Literal(1))(Literal(100).as("b"))
-    )
-  }
 }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/group-by-alias.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/group-by-alias.sql.out
@@ -332,6 +332,13 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 
 
 -- !query
+SELECT MAX(col1), 3 as abc FROM VALUES(1),(2),(3),(4) GROUP BY col1 % abc
+-- !query analysis
+Aggregate [(col1#x % 3)], [max(col1#x) AS max(col1)#x, 3 AS abc#x]
++- LocalRelation [col1#x]
+
+
+-- !query
 set spark.sql.groupByAliases=false
 -- !query analysis
 SetCommand (spark.sql.groupByAliases,Some(false))

--- a/sql/core/src/test/resources/sql-tests/inputs/group-by-alias.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/group-by-alias.sql
@@ -43,6 +43,9 @@ SELECT a AS k, COUNT(non_existing) FROM testData GROUP BY k;
 -- Aggregate functions cannot be used in GROUP BY
 SELECT COUNT(b) AS k FROM testData GROUP BY k;
 
+-- Ordinal is replaced correctly when grouping by alias of a literal
+SELECT MAX(col1), 3 as abc FROM VALUES(1),(2),(3),(4) GROUP BY col1 % abc;
+
 -- turn off group by aliases
 set spark.sql.groupByAliases=false;
 

--- a/sql/core/src/test/resources/sql-tests/results/group-by-alias.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-alias.sql.out
@@ -278,6 +278,16 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 
 
 -- !query
+SELECT MAX(col1), 3 as abc FROM VALUES(1),(2),(3),(4) GROUP BY col1 % abc
+-- !query schema
+struct<max(col1):int,abc:int>
+-- !query output
+2	3
+3	3
+4	3
+
+
+-- !query
 set spark.sql.groupByAliases=false
 -- !query schema
 struct<key:string,value:string>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR reverts https://github.com/apache/spark/pull/50461 because it introduces a correctness issue by replacing an `Alias` with incorrect literal. A followup will be made with a different way to fix this issue.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
In the below example, alias `abc` is replaced with `2` resulting in 2 rows instead of correct 3.
Before erronous PR:
![image](https://github.com/user-attachments/assets/dcc98323-369d-4f5e-b0ad-de5b76ffc5c3)


After erronous PR:
![image](https://github.com/user-attachments/assets/31c24125-6654-48f8-9b55-40a6a667ed23)

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
User now sees an error message instead of an incorrect result. 
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Added a test case to check for this behavior in the future 
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
