### PR TITLE
[SPARK-51395][SQL][TESTS][FOLLOW-UP] Explicitly sets failOnError in Abs at tests

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
@@ -400,7 +400,7 @@ class DataSourceV2StrategySuite extends PlanTest with SharedSparkSession {
       v2Expr = new GeneralScalarExpression("RAND", Array(LiteralValue(17L, LongType))))
 
     checkRoundTripConversion(
-      catalystExpr = Abs(Literal(-5)),
+      catalystExpr = Abs(Literal(-5), failOnError = true),
       v2Expr = new GeneralScalarExpression("ABS", Array(LiteralValue(-5, IntegerType))))
 
     checkRoundTripConversion(
@@ -582,7 +582,7 @@ class DataSourceV2StrategySuite extends PlanTest with SharedSparkSession {
           LiteralValue(5, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = Sqrt(Pow(Abs(Literal(-3)), Literal(2))),
+      catalystExpr = Sqrt(Pow(Abs(Literal(-3), failOnError = true), Literal(2))),
       v2Expr = new GeneralScalarExpression(
         "SQRT",
         Array(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/50197 that fixes the tests to pass when ANSI is off.

### Why are the changes needed?

The non-ANSI scheduled build is broken at https://github.com/apache/spark/actions/runs/14424930354/job/40452472736

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Ran the unittests:

```bash
SPARK_ANSI_SQL_MODE=false ./build/sbt "sql/testOnly org.apache.spark.sql.execution.datasources.v2.DataSourceV2StrategySuite -- -z round
```

### Was this patch authored or co-authored using generative AI tooling?

No.