### PR TITLE
[SPARK-51796] [SQL] Disallow Sort order expressions under non-Sort operators

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/PlanHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/PlanHelper.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.plans.logical
 
-import org.apache.spark.sql.catalyst.expressions.{Expression, Generator, WindowExpression}
+import org.apache.spark.sql.catalyst.expressions.{Expression, Generator, SortOrder, WindowExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 
 /**
@@ -31,6 +31,7 @@ object PlanHelper {
    * - A WindowExpression but the plan is not Window
    * - An AggregateExpression but the plan is not Aggregate or Window
    * - A Generator but the plan is not Generate
+   * - A SortOrder but the plan is not Sort
    * Returns the list of invalid expressions that this operator hosts. This can happen when
    * 1. The input query from users contain invalid expressions.
    *    Example : SELECT * FROM tab WHERE max(c1) > 0
@@ -50,6 +51,8 @@ object PlanHelper {
         case e: Generator
           if !(plan.isInstanceOf[Generate] ||
                plan.isInstanceOf[BaseEvalPythonUDTF]) => e
+        case sortOrder: SortOrder if !plan.isInstanceOf[Sort] && !plan.isInstanceOf[Window] =>
+          sortOrder
       }
     }
     invalidExpressions

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4934,6 +4934,17 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
 
     checkAnswer(df, Row("a"))
   }
+
+  test("SPARK-51796: SortOrder expressions are not allowed under non-Sort operators") {
+    val df = sql("SELECT 1 AS name")
+    checkError(
+      exception = intercept[AnalysisException] {
+        df.select(desc("name"))
+      },
+      condition = "UNSUPPORTED_EXPR_FOR_OPERATOR",
+      parameters = Map("invalidExprSqls" -> "\"name DESC NULLS LAST\""),
+    )
+  }
 }
 
 case class Foo(bar: Option[String])


### PR DESCRIPTION
### What changes were proposed in this pull request?
I propose that we disallow `SortOrder` expressions under non-`Sort` operators.

### Why are the changes needed?
Following Dataframe program throw an internal error:
```
val df = sql("SELECT 1 AS name")
df.select(desc("name"))
```
In this PR we fix is so we throw a more user friendly one.

### Does this PR introduce _any_ user-facing change?
Different (more user friendly) error is thrown.

### How was this patch tested?
Added test.

### Was this patch authored or co-authored using generative AI tooling?
No.