### PR TITLE
[SPARK-51797][SQL] Add table name to TableConstraint and remove parser dependencies

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/constraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/constraints.scala
@@ -59,10 +59,10 @@ trait TableConstraint {
   protected def generateName(tableName: String): String
 
   /**
-   * Gets the constraint name. If no name is specified (null or empty),
-   * generates a name based on the table name using generateConstraintName.
+   * Gets the constraint name. If no name is provided by the user (null or empty),
+   * generates a name based on the table name using generateName.
    *
-   * @return The constraint name (either user-specified or generated)
+   * @return The constraint name (either user-provided or generated)
    */
   final def name: String = {
     if (userProvidedName == null || userProvidedName.isEmpty) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/constraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/constraints.scala
@@ -67,7 +67,7 @@ trait TableConstraint {
    *
    * @return The constraint name (either user-specified or generated)
    */
-  final def getConstraintName: String = {
+  final def constraintName: String = {
     if (name == null || name.isEmpty) {
       generateConstraintName(tableName)
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/constraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/constraints.scala
@@ -56,7 +56,7 @@ trait TableConstraint {
   def withUserProvidedCharacteristic(c: ConstraintCharacteristic): TableConstraint
 
   // Generate a constraint name based on the table name if the name is not specified
-  protected def generateConstraintName(tableName: String): String
+  protected def generateName(tableName: String): String
 
   /**
    * Gets the constraint name. If no name is specified (null or empty),
@@ -64,9 +64,9 @@ trait TableConstraint {
    *
    * @return The constraint name (either user-specified or generated)
    */
-  final def constraintName: String = {
+  final def name: String = {
     if (userProvidedName == null || userProvidedName.isEmpty) {
-      generateConstraintName(tableName)
+      generateName(tableName)
     } else {
       userProvidedName
     }
@@ -115,7 +115,7 @@ case class CheckConstraint(
   override protected def withNewChildInternal(newChild: Expression): Expression =
     copy(child = newChild)
 
-  override protected def generateConstraintName(tableName: String): String = {
+  override protected def generateName(tableName: String): String = {
     s"${tableName}_chk_$randomSuffix"
   }
 
@@ -140,7 +140,7 @@ case class PrimaryKeyConstraint(
   extends TableConstraint {
 // scalastyle:on line.size.limit
 
-  override protected def generateConstraintName(tableName: String): String = s"${tableName}_pk"
+  override protected def generateName(tableName: String): String = s"${tableName}_pk"
 
   override def withUserProvidedName(name: String): TableConstraint = copy(userProvidedName = name)
 
@@ -161,7 +161,7 @@ case class UniqueConstraint(
     extends TableConstraint {
 // scalastyle:on line.size.limit
 
-  override protected def generateConstraintName(tableName: String): String = {
+  override protected def generateName(tableName: String): String = {
     s"${tableName}_uniq_$randomSuffix"
   }
 
@@ -186,7 +186,7 @@ case class ForeignKeyConstraint(
   extends TableConstraint {
 // scalastyle:on line.size.limit
 
-  override protected def generateConstraintName(tableName: String): String =
+  override protected def generateName(tableName: String): String =
     s"${tableName}_${parentTableId.last}_fk_$randomSuffix"
 
   override def withUserProvidedName(name: String): TableConstraint = copy(userProvidedName = name)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -4874,7 +4874,7 @@ class AstBuilder extends DataTypeAstBuilder
     val asSelectPlan = Option(ctx.query).map(plan).toSeq
     withIdentClause(identifierContext, asSelectPlan, (identifiers, otherPlans) => {
       val namedConstraints =
-        constraints.map(c => c.generateConstraintNameIfNeeded(identifiers.last))
+        constraints.map(c => c.withTableName(identifiers.last))
       val tableSpec = UnresolvedTableSpec(properties, provider, options, location, comment,
         collation, serdeInfo, external, namedConstraints)
       val identifier = withOrigin(identifierContext) {
@@ -4953,7 +4953,7 @@ class AstBuilder extends DataTypeAstBuilder
     val asSelectPlan = Option(ctx.query).map(plan).toSeq
     withIdentClause(identifierContext, asSelectPlan, (identifiers, otherPlans) => {
       val namedConstraints =
-        constraints.map(c => c.generateConstraintNameIfNeeded(identifiers.last))
+        constraints.map(c => c.withTableName(identifiers.last))
       val tableSpec = UnresolvedTableSpec(properties, provider, options, location, comment,
         collation, serdeInfo, external = false, namedConstraints)
       val identifier = withOrigin(identifierContext) {
@@ -5465,7 +5465,7 @@ class AstBuilder extends DataTypeAstBuilder
       val tableConstraint = visitTableConstraintDefinition(ctx.tableConstraintDefinition())
       withIdentClause(ctx.identifierReference, identifiers => {
         val table = UnresolvedTable(identifiers, "ALTER TABLE ... ADD CONSTRAINT")
-        val namedConstraint = tableConstraint.generateConstraintNameIfNeeded(identifiers.last)
+        val namedConstraint = tableConstraint.withTableName(identifiers.last)
         AddConstraint(table, namedConstraint)
       })
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3991,7 +3991,7 @@ class AstBuilder extends DataTypeAstBuilder
         visitConstraintCharacteristics(ctx.constraintCharacteristic().asScala.toSeq)
       val expr = visitColumnConstraint(columnName, ctx.columnConstraint())
 
-      expr.withName(name).withCharacteristic(constraintCharacteristic, ctx)
+      expr.withName(name).withCharacteristic(constraintCharacteristic)
     }
   }
 
@@ -5396,7 +5396,7 @@ class AstBuilder extends DataTypeAstBuilder
       val expr =
         visitTableConstraint(ctx.tableConstraint()).asInstanceOf[TableConstraint]
 
-      expr.withName(name).withCharacteristic(constraintCharacteristic, ctx)
+      expr.withName(name).withCharacteristic(constraintCharacteristic)
   }
 
   override def visitCheckConstraint(ctx: CheckConstraintContext): CheckConstraint =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3991,7 +3991,7 @@ class AstBuilder extends DataTypeAstBuilder
         visitConstraintCharacteristics(ctx.constraintCharacteristic().asScala.toSeq)
       val expr = visitColumnConstraint(columnName, ctx.columnConstraint())
 
-      expr.withName(name).withCharacteristic(constraintCharacteristic)
+      expr.withUserProvidedName(name).withUserProvidedCharacteristic(constraintCharacteristic)
     }
   }
 
@@ -5396,7 +5396,7 @@ class AstBuilder extends DataTypeAstBuilder
       val expr =
         visitTableConstraint(ctx.tableConstraint()).asInstanceOf[TableConstraint]
 
-      expr.withName(name).withCharacteristic(constraintCharacteristic)
+      expr.withUserProvidedName(name).withUserProvidedCharacteristic(constraintCharacteristic)
   }
 
   override def visitCheckConstraint(ctx: CheckConstraintContext): CheckConstraint =

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CheckConstraintParseSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CheckConstraintParseSuite.scala
@@ -269,7 +269,7 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
           val tableSpec = c.tableSpec.asInstanceOf[UnresolvedTableSpec]
           assert(tableSpec.constraints.size == 1)
           assert(tableSpec.constraints.head == constraint1.withName(null))
-          assert(tableSpec.constraints.head.getConstraintName.matches("t_chk_[0-9a-f]{7}"))
+          assert(tableSpec.constraints.head.constraintName.matches("t_chk_[0-9a-f]{7}"))
 
         case other =>
           fail(s"Expected CreateTable, but got: $other")
@@ -288,7 +288,7 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
           val tableSpec = c.tableSpec.asInstanceOf[UnresolvedTableSpec]
           assert(tableSpec.constraints.size == 1)
           assert(tableSpec.constraints.head == constraint1.withName(null))
-          assert(tableSpec.constraints.head.getConstraintName.matches("t_chk_[0-9a-f]{7}"))
+          assert(tableSpec.constraints.head.constraintName.matches("t_chk_[0-9a-f]{7}"))
 
         case other =>
           fail(s"Expected ReplaceTable, but got: $other")
@@ -307,7 +307,7 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
         val table = a.table.asInstanceOf[UnresolvedTable]
         assert(table.multipartIdentifier == Seq("a", "b", "t"))
         assert(a.tableConstraint == constraint1.withName(null))
-        assert(a.tableConstraint.getConstraintName.matches("t_chk_[0-9a-f]{7}"))
+        assert(a.tableConstraint.constraintName.matches("t_chk_[0-9a-f]{7}"))
 
       case other =>
         fail(s"Expected AddConstraint, but got: $other")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CheckConstraintParseSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CheckConstraintParseSuite.scala
@@ -31,12 +31,12 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
   val constraint1 = CheckConstraint(
     child = GreaterThan(UnresolvedAttribute("a"), Literal(0)),
     condition = "a > 0",
-    name = "c1",
+    userProvidedName = "c1",
     tableName = "t")
   val constraint2 = CheckConstraint(
     child = EqualTo(UnresolvedAttribute("b"), Literal("foo")),
     condition = "b = 'foo'",
-    name = "c2",
+    userProvidedName = "c2",
     tableName = "t")
 
   test("Create table with one check constraint - table level") {
@@ -56,7 +56,8 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
       case (enforcedStr, relyStr, characteristic) =>
         val sql = s"CREATE TABLE t (a INT, b STRING, CONSTRAINT c1 CHECK (a > 0) " +
           s"$enforcedStr $relyStr) USING parquet"
-        val constraint = constraint1.withName("c1").withCharacteristic(characteristic)
+        val constraint = constraint1.withUserProvidedName("c1")
+          .withUserProvidedCharacteristic(characteristic)
         verifyConstraints(sql, Seq(constraint))
     }
   }
@@ -101,7 +102,8 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
       case (enforcedStr, relyStr, characteristic) =>
         val sql = s"CREATE TABLE t (a INT CONSTRAINT c1 CHECK (a > 0)" +
           s" $enforcedStr $relyStr, b STRING) USING parquet"
-        val constraint = constraint1.withName("c1").withCharacteristic(characteristic)
+        val constraint = constraint1.withUserProvidedName("c1")
+          .withUserProvidedCharacteristic(characteristic)
         verifyConstraints(sql, Seq(constraint))
     }
   }
@@ -149,7 +151,8 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
       case (enforcedStr, relyStr, characteristic) =>
         val sql = s"REPLACE TABLE t (a INT, b STRING, CONSTRAINT c1 CHECK (a > 0) " +
           s"$enforcedStr $relyStr) USING parquet"
-        val constraint = constraint1.withName("c1").withCharacteristic(characteristic)
+        val constraint = constraint1.withUserProvidedName("c1")
+          .withUserProvidedCharacteristic(characteristic)
         verifyConstraints(sql, Seq(constraint), isCreateTable = false)
     }
   }
@@ -229,9 +232,9 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
         CheckConstraint(
           child = GreaterThan(UnresolvedAttribute("d"), Literal(0)),
           condition = "d > 0",
-          name = "c1",
+          userProvidedName = "c1",
           tableName = "t",
-          characteristic = characteristic
+          userProvidedCharacteristic = characteristic
         ))
       comparePlans(parsed, expected)
     }
@@ -268,7 +271,7 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
         case c: CreateTable =>
           val tableSpec = c.tableSpec.asInstanceOf[UnresolvedTableSpec]
           assert(tableSpec.constraints.size == 1)
-          assert(tableSpec.constraints.head == constraint1.withName(null))
+          assert(tableSpec.constraints.head == constraint1.withUserProvidedName(null))
           assert(tableSpec.constraints.head.constraintName.matches("t_chk_[0-9a-f]{7}"))
 
         case other =>
@@ -287,7 +290,7 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
         case c: ReplaceTable =>
           val tableSpec = c.tableSpec.asInstanceOf[UnresolvedTableSpec]
           assert(tableSpec.constraints.size == 1)
-          assert(tableSpec.constraints.head == constraint1.withName(null))
+          assert(tableSpec.constraints.head == constraint1.withUserProvidedName(null))
           assert(tableSpec.constraints.head.constraintName.matches("t_chk_[0-9a-f]{7}"))
 
         case other =>
@@ -306,7 +309,7 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
       case a: AddConstraint =>
         val table = a.table.asInstanceOf[UnresolvedTable]
         assert(table.multipartIdentifier == Seq("a", "b", "t"))
-        assert(a.tableConstraint == constraint1.withName(null))
+        assert(a.tableConstraint == constraint1.withUserProvidedName(null))
         assert(a.tableConstraint.constraintName.matches("t_chk_[0-9a-f]{7}"))
 
       case other =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CheckConstraintParseSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CheckConstraintParseSuite.scala
@@ -56,7 +56,7 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
       case (enforcedStr, relyStr, characteristic) =>
         val sql = s"CREATE TABLE t (a INT, b STRING, CONSTRAINT c1 CHECK (a > 0) " +
           s"$enforcedStr $relyStr) USING parquet"
-        val constraint = constraint1.withName("c1").withCharacteristic(characteristic, null)
+        val constraint = constraint1.withName("c1").withCharacteristic(characteristic)
         verifyConstraints(sql, Seq(constraint))
     }
   }
@@ -101,7 +101,7 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
       case (enforcedStr, relyStr, characteristic) =>
         val sql = s"CREATE TABLE t (a INT CONSTRAINT c1 CHECK (a > 0)" +
           s" $enforcedStr $relyStr, b STRING) USING parquet"
-        val constraint = constraint1.withName("c1").withCharacteristic(characteristic, null)
+        val constraint = constraint1.withName("c1").withCharacteristic(characteristic)
         verifyConstraints(sql, Seq(constraint))
     }
   }
@@ -149,7 +149,7 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
       case (enforcedStr, relyStr, characteristic) =>
         val sql = s"REPLACE TABLE t (a INT, b STRING, CONSTRAINT c1 CHECK (a > 0) " +
           s"$enforcedStr $relyStr) USING parquet"
-        val constraint = constraint1.withName("c1").withCharacteristic(characteristic, null)
+        val constraint = constraint1.withName("c1").withCharacteristic(characteristic)
         verifyConstraints(sql, Seq(constraint), isCreateTable = false)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CheckConstraintParseSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CheckConstraintParseSuite.scala
@@ -272,7 +272,7 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
           val tableSpec = c.tableSpec.asInstanceOf[UnresolvedTableSpec]
           assert(tableSpec.constraints.size == 1)
           assert(tableSpec.constraints.head == constraint1.withUserProvidedName(null))
-          assert(tableSpec.constraints.head.constraintName.matches("t_chk_[0-9a-f]{7}"))
+          assert(tableSpec.constraints.head.name.matches("t_chk_[0-9a-f]{7}"))
 
         case other =>
           fail(s"Expected CreateTable, but got: $other")
@@ -291,7 +291,7 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
           val tableSpec = c.tableSpec.asInstanceOf[UnresolvedTableSpec]
           assert(tableSpec.constraints.size == 1)
           assert(tableSpec.constraints.head == constraint1.withUserProvidedName(null))
-          assert(tableSpec.constraints.head.constraintName.matches("t_chk_[0-9a-f]{7}"))
+          assert(tableSpec.constraints.head.name.matches("t_chk_[0-9a-f]{7}"))
 
         case other =>
           fail(s"Expected ReplaceTable, but got: $other")
@@ -310,7 +310,7 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
         val table = a.table.asInstanceOf[UnresolvedTable]
         assert(table.multipartIdentifier == Seq("a", "b", "t"))
         assert(a.tableConstraint == constraint1.withUserProvidedName(null))
-        assert(a.tableConstraint.constraintName.matches("t_chk_[0-9a-f]{7}"))
+        assert(a.tableConstraint.name.matches("t_chk_[0-9a-f]{7}"))
 
       case other =>
         fail(s"Expected AddConstraint, but got: $other")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ForeignKeyConstraintParseSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ForeignKeyConstraintParseSuite.scala
@@ -75,6 +75,58 @@ class ForeignKeyConstraintParseSuite extends ConstraintParseSuiteBase {
     verifyConstraints(sql, constraints)
   }
 
+  test("Replace table with foreign key - table level") {
+    val sql = "REPLACE TABLE t (a INT, b STRING," +
+      " FOREIGN KEY (a) REFERENCES parent(id)) USING parquet"
+    val constraint = ForeignKeyConstraint(
+      tableName = "t",
+      childColumns = Seq("a"),
+      parentTableId = Seq("parent"),
+      parentColumns = Seq("id")
+    )
+    val constraints = Seq(constraint)
+    verifyConstraints(sql, constraints, isCreateTable = false)
+  }
+
+  test("Replace table with named foreign key - table level") {
+    val sql = "REPLACE TABLE t (a INT, b STRING, CONSTRAINT fk1 FOREIGN KEY (a)" +
+      " REFERENCES parent(id)) USING parquet"
+    val constraint = ForeignKeyConstraint(
+      childColumns = Seq("a"),
+      parentTableId = Seq("parent"),
+      parentColumns = Seq("id"),
+      name = "fk1",
+      tableName = "t"
+    )
+    val constraints = Seq(constraint)
+    verifyConstraints(sql, constraints, isCreateTable = false)
+  }
+
+  test("Replace table with foreign key - column level") {
+    val sql = "REPLACE TABLE t (a INT REFERENCES parent(id), b STRING) USING parquet"
+    val constraint = ForeignKeyConstraint(
+      tableName = "t",
+      childColumns = Seq("a"),
+      parentTableId = Seq("parent"),
+      parentColumns = Seq("id")
+    )
+    val constraints = Seq(constraint)
+    verifyConstraints(sql, constraints, isCreateTable = false)
+  }
+
+  test("Replace table with named foreign key - column level") {
+    val sql = "REPLACE TABLE t (a INT CONSTRAINT fk1 REFERENCES parent(id), b STRING) USING parquet"
+    val constraint = ForeignKeyConstraint(
+      childColumns = Seq("a"),
+      parentTableId = Seq("parent"),
+      parentColumns = Seq("id"),
+      name = "fk1",
+      tableName = "t"
+    )
+    val constraints = Seq(constraint)
+    verifyConstraints(sql, constraints, isCreateTable = false)
+  }
+
   test("Add foreign key constraint") {
     Seq(
       ("", null),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ForeignKeyConstraintParseSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ForeignKeyConstraintParseSuite.scala
@@ -20,23 +20,20 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedTable
 import org.apache.spark.sql.catalyst.expressions.ForeignKeyConstraint
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser.parsePlan
 import org.apache.spark.sql.catalyst.parser.ParseException
-import org.apache.spark.sql.catalyst.plans.logical.{AddConstraint, CreateTable, ReplaceTable, UnresolvedTableSpec}
+import org.apache.spark.sql.catalyst.plans.logical.AddConstraint
 
 class ForeignKeyConstraintParseSuite extends ConstraintParseSuiteBase {
-  test("Create table with unnamed foreign key - table level") {
+  test("Create table with foreign key - table level") {
     val sql = "CREATE TABLE t (a INT, b STRING," +
       " FOREIGN KEY (a) REFERENCES parent(id)) USING parquet"
-    val plan = parsePlan(sql)
-    plan match {
-      case c: CreateTable =>
-        val tableSpec = c.tableSpec.asInstanceOf[UnresolvedTableSpec]
-        assert(tableSpec.constraints.size == 1)
-        assert(tableSpec.constraints.head.isInstanceOf[ForeignKeyConstraint])
-        assert(tableSpec.constraints.head.name.matches("t_parent_fk_[0-9a-f]{7}"))
-
-      case other =>
-        fail(s"Expected CreateTable, but got: $other")
-    }
+    val constraint = ForeignKeyConstraint(
+      tableName = "t",
+      childColumns = Seq("a"),
+      parentTableId = Seq("parent"),
+      parentColumns = Seq("id")
+    )
+    val constraints = Seq(constraint)
+    verifyConstraints(sql, constraints)
   }
 
   test("Create table with named foreign key - table level") {
@@ -46,25 +43,23 @@ class ForeignKeyConstraintParseSuite extends ConstraintParseSuiteBase {
       childColumns = Seq("a"),
       parentTableId = Seq("parent"),
       parentColumns = Seq("id"),
-      name = "fk1"
+      name = "fk1",
+      tableName = "t"
     )
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints)
   }
 
-  test("Create table with unnamed foreign key - column level") {
+  test("Create table with foreign key - column level") {
     val sql = "CREATE TABLE t (a INT REFERENCES parent(id), b STRING) USING parquet"
-    val plan = parsePlan(sql)
-    plan match {
-      case c: CreateTable =>
-        val tableSpec = c.tableSpec.asInstanceOf[UnresolvedTableSpec]
-        assert(tableSpec.constraints.size == 1)
-        assert(tableSpec.constraints.head.isInstanceOf[ForeignKeyConstraint])
-        assert(tableSpec.constraints.head.name.matches("t_parent_fk_[0-9a-f]{7}"))
-
-      case other =>
-        fail(s"Expected CreateTable, but got: $other")
-    }
+    val constraint = ForeignKeyConstraint(
+      tableName = "t",
+      childColumns = Seq("a"),
+      parentTableId = Seq("parent"),
+      parentColumns = Seq("id")
+    )
+    val constraints = Seq(constraint)
+    verifyConstraints(sql, constraints)
   }
 
   test("Create table with named foreign key - column level") {
@@ -73,103 +68,35 @@ class ForeignKeyConstraintParseSuite extends ConstraintParseSuiteBase {
       childColumns = Seq("a"),
       parentTableId = Seq("parent"),
       parentColumns = Seq("id"),
-      name = "fk1"
+      name = "fk1",
+      tableName = "t"
     )
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints)
   }
 
-  test("Replace table with foreign key - table level") {
-    val sql = "REPLACE TABLE t (a INT, b STRING," +
-      " FOREIGN KEY (a) REFERENCES parent(id)) USING parquet"
-    val plan = parsePlan(sql)
-    plan match {
-      case c: ReplaceTable =>
-        val tableSpec = c.tableSpec.asInstanceOf[UnresolvedTableSpec]
-        assert(tableSpec.constraints.size == 1)
-        assert(tableSpec.constraints.head.isInstanceOf[ForeignKeyConstraint])
-        assert(tableSpec.constraints.head.name.matches("t_parent_fk_[0-9a-f]{7}"))
-
-      case other =>
-        fail(s"Expected ReplaceTable, but got: $other")
-    }
-  }
-
-  test("Replace table with named foreign key - table level") {
-    val sql = "REPLACE TABLE t (a INT, b STRING, CONSTRAINT fk1 FOREIGN KEY (a)" +
-      " REFERENCES parent(id)) USING parquet"
-    val constraint = ForeignKeyConstraint(
-      childColumns = Seq("a"),
-      parentTableId = Seq("parent"),
-      parentColumns = Seq("id"),
-      name = "fk1"
-    )
-    val constraints = Seq(constraint)
-    verifyConstraints(sql, constraints, isCreateTable = false)
-  }
-
-  test("Replace table with foreign key - column level") {
-    val sql = "REPLACE TABLE t (a INT REFERENCES parent(id), b STRING) USING parquet"
-    val plan = parsePlan(sql)
-    plan match {
-      case c: ReplaceTable =>
-        val tableSpec = c.tableSpec.asInstanceOf[UnresolvedTableSpec]
-        assert(tableSpec.constraints.size == 1)
-        assert(tableSpec.constraints.head.isInstanceOf[ForeignKeyConstraint])
-        assert(tableSpec.constraints.head.name.matches("t_parent_fk_[0-9a-f]{7}"))
-
-      case other =>
-        fail(s"Expected ReplaceTable, but got: $other")
-    }
-  }
-
-  test("Replace table with named foreign key - column level") {
-    val sql = "REPLACE TABLE t (a INT CONSTRAINT fk1 REFERENCES parent(id), b STRING) USING parquet"
-    val constraint = ForeignKeyConstraint(
-      childColumns = Seq("a"),
-      parentTableId = Seq("parent"),
-      parentColumns = Seq("id"),
-      name = "fk1"
-    )
-    val constraints = Seq(constraint)
-    verifyConstraints(sql, constraints, isCreateTable = false)
-  }
-
   test("Add foreign key constraint") {
-    val sql =
-      """
-        |ALTER TABLE orders ADD CONSTRAINT fk1 FOREIGN KEY (customer_id)
-        |REFERENCES customers (id)
-        |""".stripMargin
-    val parsed = parsePlan(sql)
-    val expected = AddConstraint(
-      UnresolvedTable(
-        Seq("orders"),
-        "ALTER TABLE ... ADD CONSTRAINT"),
-      ForeignKeyConstraint(
-        name = "fk1",
-        childColumns = Seq("customer_id"),
-        parentTableId = Seq("customers"),
-        parentColumns = Seq("id")
-      ))
-    comparePlans(parsed, expected)
-  }
-
-  test("Add foreign key constraint - unnamed") {
-    val sql =
-      """
-        |ALTER TABLE orders ADD FOREIGN KEY (customer_id)
-        |REFERENCES customers (id)
-        |""".stripMargin
-    val parsed = parsePlan(sql)
-    parsed match {
-      case AddConstraint(table, constraint: ForeignKeyConstraint) =>
-        assert(constraint.name.matches("orders_customers_fk_[0-9a-f]{7}"))
-        assert(constraint.childColumns == Seq("customer_id"))
-        assert(constraint.parentTableId == Seq("customers"))
-        assert(constraint.parentColumns == Seq("id"))
-      case other =>
-        fail(s"Expected AddConstraint, but got: $other")
+    Seq(
+      ("", null),
+      ("CONSTRAINT fk1", "fk1")).foreach { case (constraintName, expectedName) =>
+      val sql =
+        s"""
+           |ALTER TABLE orders ADD $constraintName FOREIGN KEY (customer_id)
+           |REFERENCES customers (id)
+           |""".stripMargin
+      val parsed = parsePlan(sql)
+      val expected = AddConstraint(
+        UnresolvedTable(
+          Seq("orders"),
+          "ALTER TABLE ... ADD CONSTRAINT"),
+        ForeignKeyConstraint(
+          name = expectedName,
+          tableName = "orders",
+          childColumns = Seq("customer_id"),
+          parentTableId = Seq("customers"),
+          parentColumns = Seq("id")
+        ))
+      comparePlans(parsed, expected)
     }
   }
 
@@ -211,6 +138,7 @@ class ForeignKeyConstraintParseSuite extends ConstraintParseSuiteBase {
           "ALTER TABLE ... ADD CONSTRAINT"),
         ForeignKeyConstraint(
           name = "fk1",
+          tableName = "orders",
           childColumns = Seq("customer_id"),
           parentTableId = Seq("customers"),
           parentColumns = Seq("id"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ForeignKeyConstraintParseSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ForeignKeyConstraintParseSuite.scala
@@ -43,7 +43,7 @@ class ForeignKeyConstraintParseSuite extends ConstraintParseSuiteBase {
       childColumns = Seq("a"),
       parentTableId = Seq("parent"),
       parentColumns = Seq("id"),
-      name = "fk1",
+      userProvidedName = "fk1",
       tableName = "t"
     )
     val constraints = Seq(constraint)
@@ -68,7 +68,7 @@ class ForeignKeyConstraintParseSuite extends ConstraintParseSuiteBase {
       childColumns = Seq("a"),
       parentTableId = Seq("parent"),
       parentColumns = Seq("id"),
-      name = "fk1",
+      userProvidedName = "fk1",
       tableName = "t"
     )
     val constraints = Seq(constraint)
@@ -95,7 +95,7 @@ class ForeignKeyConstraintParseSuite extends ConstraintParseSuiteBase {
       childColumns = Seq("a"),
       parentTableId = Seq("parent"),
       parentColumns = Seq("id"),
-      name = "fk1",
+      userProvidedName = "fk1",
       tableName = "t"
     )
     val constraints = Seq(constraint)
@@ -120,7 +120,7 @@ class ForeignKeyConstraintParseSuite extends ConstraintParseSuiteBase {
       childColumns = Seq("a"),
       parentTableId = Seq("parent"),
       parentColumns = Seq("id"),
-      name = "fk1",
+      userProvidedName = "fk1",
       tableName = "t"
     )
     val constraints = Seq(constraint)
@@ -142,7 +142,7 @@ class ForeignKeyConstraintParseSuite extends ConstraintParseSuiteBase {
           Seq("orders"),
           "ALTER TABLE ... ADD CONSTRAINT"),
         ForeignKeyConstraint(
-          name = expectedName,
+          userProvidedName = expectedName,
           tableName = "orders",
           childColumns = Seq("customer_id"),
           parentTableId = Seq("customers"),
@@ -189,12 +189,12 @@ class ForeignKeyConstraintParseSuite extends ConstraintParseSuiteBase {
           Seq("orders"),
           "ALTER TABLE ... ADD CONSTRAINT"),
         ForeignKeyConstraint(
-          name = "fk1",
+          userProvidedName = "fk1",
           tableName = "orders",
           childColumns = Seq("customer_id"),
           parentTableId = Seq("customers"),
           parentColumns = Seq("id"),
-          characteristic = characteristic
+          userProvidedCharacteristic = characteristic
         ))
       comparePlans(parsed, expected)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PrimaryKeyConstraintParseSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PrimaryKeyConstraintParseSuite.scala
@@ -27,7 +27,7 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
 
   test("Create table with primary key - table level") {
     val sql = "CREATE TABLE t (a INT, b STRING, PRIMARY KEY (a)) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a"), name = "t_pk")
+    val constraint = PrimaryKeyConstraint(columns = Seq("a"), tableName = "t", name = "t_pk")
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints)
   }
@@ -36,6 +36,7 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
     val sql = "CREATE TABLE t (a INT, b STRING, CONSTRAINT pk1 PRIMARY KEY (a)) USING parquet"
     val constraint = PrimaryKeyConstraint(
       columns = Seq("a"),
+      tableName = "t",
       name = "pk1"
     )
     val constraints = Seq(constraint)
@@ -44,14 +45,14 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
 
   test("Create table with composite primary key - table level") {
     val sql = "CREATE TABLE t (a INT, b STRING, PRIMARY KEY (a, b)) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a", "b"), name = "t_pk")
+    val constraint = PrimaryKeyConstraint(columns = Seq("a", "b"), tableName = "t", name = "t_pk")
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints)
   }
 
   test("Create table with primary key - column level") {
     val sql = "CREATE TABLE t (a INT PRIMARY KEY, b STRING) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a"), name = "t_pk")
+    val constraint = PrimaryKeyConstraint(columns = Seq("a"), tableName = "t", name = "t_pk")
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints)
   }
@@ -60,6 +61,7 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
     val sql = "CREATE TABLE t (a INT CONSTRAINT pk1 PRIMARY KEY, b STRING) USING parquet"
     val constraint = PrimaryKeyConstraint(
       columns = Seq("a"),
+      tableName = "t",
       name = "pk1"
     )
     val constraints = Seq(constraint)
@@ -83,7 +85,7 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
 
   test("Replace table with primary key - table level") {
     val sql = "REPLACE TABLE t (a INT, b STRING, PRIMARY KEY (a)) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a"), name = "t_pk")
+    val constraint = PrimaryKeyConstraint(columns = Seq("a"), tableName = "t", name = "t_pk")
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints, isCreateTable = false)
   }
@@ -92,6 +94,7 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
     val sql = "REPLACE TABLE t (a INT, b STRING, CONSTRAINT pk1 PRIMARY KEY (a)) USING parquet"
     val constraint = PrimaryKeyConstraint(
       columns = Seq("a"),
+      tableName = "t",
       name = "pk1"
     )
     val constraints = Seq(constraint)
@@ -100,14 +103,14 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
 
   test("Replace table with composite primary key - table level") {
     val sql = "REPLACE TABLE t (a INT, b STRING, PRIMARY KEY (a, b)) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a", "b"), name = "t_pk")
+    val constraint = PrimaryKeyConstraint(columns = Seq("a", "b"), tableName = "t", name = "t_pk")
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints, isCreateTable = false)
   }
 
   test("Replace table with primary key - column level") {
     val sql = "REPLACE TABLE t (a INT PRIMARY KEY, b STRING) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a"), name = "t_pk")
+    val constraint = PrimaryKeyConstraint(columns = Seq("a"), tableName = "t", name = "t_pk")
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints, isCreateTable = false)
   }
@@ -116,6 +119,7 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
     val sql = "REPLACE TABLE t (a INT CONSTRAINT pk1 PRIMARY KEY, b STRING) USING parquet"
     val constraint = PrimaryKeyConstraint(
       columns = Seq("a"),
+      tableName = "t",
       name = "pk1"
     )
     val constraints = Seq(constraint)
@@ -150,6 +154,7 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
           "ALTER TABLE ... ADD CONSTRAINT"),
         PrimaryKeyConstraint(
           name = expectedName,
+          tableName = "c",
           columns = Seq("id", "name")
         ))
       comparePlans(parsed, expected)
@@ -192,6 +197,7 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
         PrimaryKeyConstraint(
           name = "pk1",
           columns = Seq("id"),
+          tableName = "c",
           characteristic = characteristic
         ))
       comparePlans(parsed, expected)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PrimaryKeyConstraintParseSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PrimaryKeyConstraintParseSuite.scala
@@ -27,7 +27,7 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
 
   test("Create table with primary key - table level") {
     val sql = "CREATE TABLE t (a INT, b STRING, PRIMARY KEY (a)) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a"), tableName = "t", name = "t_pk")
+    val constraint = PrimaryKeyConstraint(columns = Seq("a"), tableName = "t", name = null)
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints)
   }
@@ -45,14 +45,14 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
 
   test("Create table with composite primary key - table level") {
     val sql = "CREATE TABLE t (a INT, b STRING, PRIMARY KEY (a, b)) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a", "b"), tableName = "t", name = "t_pk")
+    val constraint = PrimaryKeyConstraint(columns = Seq("a", "b"), tableName = "t", name = null)
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints)
   }
 
   test("Create table with primary key - column level") {
     val sql = "CREATE TABLE t (a INT PRIMARY KEY, b STRING) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a"), tableName = "t", name = "t_pk")
+    val constraint = PrimaryKeyConstraint(columns = Seq("a"), tableName = "t", name = null)
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints)
   }
@@ -85,7 +85,7 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
 
   test("Replace table with primary key - table level") {
     val sql = "REPLACE TABLE t (a INT, b STRING, PRIMARY KEY (a)) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a"), tableName = "t", name = "t_pk")
+    val constraint = PrimaryKeyConstraint(columns = Seq("a"), tableName = "t", name = null)
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints, isCreateTable = false)
   }
@@ -103,14 +103,14 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
 
   test("Replace table with composite primary key - table level") {
     val sql = "REPLACE TABLE t (a INT, b STRING, PRIMARY KEY (a, b)) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a", "b"), tableName = "t", name = "t_pk")
+    val constraint = PrimaryKeyConstraint(columns = Seq("a", "b"), tableName = "t", name = null)
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints, isCreateTable = false)
   }
 
   test("Replace table with primary key - column level") {
     val sql = "REPLACE TABLE t (a INT PRIMARY KEY, b STRING) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a"), tableName = "t", name = "t_pk")
+    val constraint = PrimaryKeyConstraint(columns = Seq("a"), tableName = "t", name = null)
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints, isCreateTable = false)
   }
@@ -142,7 +142,7 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
   }
 
   test("Add primary key constraint") {
-    Seq(("", "c_pk"), ("CONSTRAINT pk1", "pk1")).foreach { case (constraintName, expectedName) =>
+    Seq(("", null), ("CONSTRAINT pk1", "pk1")).foreach { case (constraintName, expectedName) =>
       val sql =
         s"""
            |ALTER TABLE a.b.c ADD $constraintName PRIMARY KEY (id, name)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PrimaryKeyConstraintParseSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PrimaryKeyConstraintParseSuite.scala
@@ -27,7 +27,10 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
 
   test("Create table with primary key - table level") {
     val sql = "CREATE TABLE t (a INT, b STRING, PRIMARY KEY (a)) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a"), tableName = "t", name = null)
+    val constraint = PrimaryKeyConstraint(
+      columns = Seq("a"),
+      tableName = "t",
+      userProvidedName = null)
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints)
   }
@@ -37,7 +40,7 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
     val constraint = PrimaryKeyConstraint(
       columns = Seq("a"),
       tableName = "t",
-      name = "pk1"
+      userProvidedName = "pk1"
     )
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints)
@@ -45,14 +48,20 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
 
   test("Create table with composite primary key - table level") {
     val sql = "CREATE TABLE t (a INT, b STRING, PRIMARY KEY (a, b)) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a", "b"), tableName = "t", name = null)
+    val constraint = PrimaryKeyConstraint(
+      columns = Seq("a", "b"),
+      tableName = "t",
+      userProvidedName = null)
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints)
   }
 
   test("Create table with primary key - column level") {
     val sql = "CREATE TABLE t (a INT PRIMARY KEY, b STRING) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a"), tableName = "t", name = null)
+    val constraint = PrimaryKeyConstraint(
+      columns = Seq("a"),
+      tableName = "t",
+      userProvidedName = null)
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints)
   }
@@ -62,7 +71,7 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
     val constraint = PrimaryKeyConstraint(
       columns = Seq("a"),
       tableName = "t",
-      name = "pk1"
+      userProvidedName = "pk1"
     )
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints)
@@ -85,7 +94,10 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
 
   test("Replace table with primary key - table level") {
     val sql = "REPLACE TABLE t (a INT, b STRING, PRIMARY KEY (a)) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a"), tableName = "t", name = null)
+    val constraint = PrimaryKeyConstraint(
+      columns = Seq("a"),
+      tableName = "t",
+      userProvidedName = null)
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints, isCreateTable = false)
   }
@@ -95,7 +107,7 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
     val constraint = PrimaryKeyConstraint(
       columns = Seq("a"),
       tableName = "t",
-      name = "pk1"
+      userProvidedName = "pk1"
     )
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints, isCreateTable = false)
@@ -103,14 +115,20 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
 
   test("Replace table with composite primary key - table level") {
     val sql = "REPLACE TABLE t (a INT, b STRING, PRIMARY KEY (a, b)) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a", "b"), tableName = "t", name = null)
+    val constraint = PrimaryKeyConstraint(
+      columns = Seq("a", "b"),
+      tableName = "t",
+      userProvidedName = null)
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints, isCreateTable = false)
   }
 
   test("Replace table with primary key - column level") {
     val sql = "REPLACE TABLE t (a INT PRIMARY KEY, b STRING) USING parquet"
-    val constraint = PrimaryKeyConstraint(columns = Seq("a"), tableName = "t", name = null)
+    val constraint = PrimaryKeyConstraint(
+      columns = Seq("a"),
+      tableName = "t",
+      userProvidedName = null)
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints, isCreateTable = false)
   }
@@ -120,7 +138,7 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
     val constraint = PrimaryKeyConstraint(
       columns = Seq("a"),
       tableName = "t",
-      name = "pk1"
+      userProvidedName = "pk1"
     )
     val constraints = Seq(constraint)
     verifyConstraints(sql, constraints, isCreateTable = false)
@@ -153,7 +171,7 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
           Seq("a", "b", "c"),
           "ALTER TABLE ... ADD CONSTRAINT"),
         PrimaryKeyConstraint(
-          name = expectedName,
+          userProvidedName = expectedName,
           tableName = "c",
           columns = Seq("id", "name")
         ))
@@ -195,10 +213,10 @@ class PrimaryKeyConstraintParseSuite extends ConstraintParseSuiteBase {
           Seq("a", "b", "c"),
           "ALTER TABLE ... ADD CONSTRAINT"),
         PrimaryKeyConstraint(
-          name = "pk1",
+          userProvidedName = "pk1",
           columns = Seq("id"),
           tableName = "c",
-          characteristic = characteristic
+          userProvidedCharacteristic = characteristic
         ))
       comparePlans(parsed, expected)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/UniqueConstraintParseSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/UniqueConstraintParseSuite.scala
@@ -62,7 +62,7 @@ class UniqueConstraintParseSuite extends ConstraintParseSuiteBase {
     val sql = "CREATE TABLE t (a INT, b STRING, CONSTRAINT uk1 UNIQUE (a)) USING parquet"
     val constraint = UniqueConstraint(
       columns = Seq("a"),
-      name = "uk1",
+      userProvidedName = "uk1",
       tableName = "t"
     )
     val constraints = Seq(constraint)
@@ -124,7 +124,7 @@ class UniqueConstraintParseSuite extends ConstraintParseSuiteBase {
     val sql = "REPLACE TABLE t (a INT, b STRING, CONSTRAINT uk1 UNIQUE (a)) USING parquet"
     val constraint = UniqueConstraint(
       columns = Seq("a"),
-      name = "uk1",
+      userProvidedName = "uk1",
       tableName = "t"
     )
     val constraints = Seq(constraint)
@@ -145,7 +145,7 @@ class UniqueConstraintParseSuite extends ConstraintParseSuiteBase {
     val sql = "CREATE TABLE t (a INT CONSTRAINT uk1 UNIQUE, b STRING) USING parquet"
     val constraint = UniqueConstraint(
       columns = Seq("a"),
-      name = "uk1",
+      userProvidedName = "uk1",
       tableName = "t"
     )
     val constraints = Seq(constraint)
@@ -164,7 +164,7 @@ class UniqueConstraintParseSuite extends ConstraintParseSuiteBase {
           Seq("a", "b", "c"),
           "ALTER TABLE ... ADD CONSTRAINT"),
         UniqueConstraint(
-          name = expectedName,
+          userProvidedName = expectedName,
           tableName = "c",
           columns = Seq("email", "username")
         ))
@@ -206,10 +206,10 @@ class UniqueConstraintParseSuite extends ConstraintParseSuiteBase {
           Seq("a", "b", "c"),
           "ALTER TABLE ... ADD CONSTRAINT"),
         UniqueConstraint(
-          name = "uk1",
+          userProvidedName = "uk1",
           columns = Seq("email"),
           tableName = "c",
-          characteristic = characteristic
+          userProvidedCharacteristic = characteristic
         ))
       comparePlans(parsed, expected)
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

1. Made `tableName` a class member of `TableConstraint` trait and its implementations
   - Added `tableName` as a required field in constraint case classes
   - Implemented `withTableName` method to support table name updates
   - This change helps ensure consistent constraint naming and better logical plan comparison

2. Simplified constraint parsing
   - Removed dependency on ANTLR `ParserRuleContext` from constraint APIs
   - This change reduces coupling between parsing and constraint implementation



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The changes simplify constraint handling and make the code more maintainable by reducing parser dependencies and standardizing constraint naming.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No