### PR TITLE
[SPARK-51806][BUILD] Upgrade `kryo-shaded` to 4.0.3

### DIFF
--- a/common/unsafe/pom.xml
+++ b/common/unsafe/pom.xml
@@ -80,6 +80,14 @@
       <groupId>com.twitter</groupId>
       <artifactId>chill_${scala.binary.version}</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.esotericsoftware</groupId>
+      <artifactId>kryo-shaded</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.objenesis</groupId>
+      <artifactId>objenesis</artifactId>
+    </dependency>
 
     <!-- Core dependencies -->
     <dependency>

--- a/core/benchmarks/KryoBenchmark-jdk21-results.txt
+++ b/core/benchmarks/KryoBenchmark-jdk21-results.txt
@@ -2,27 +2,27 @@
 Benchmark Kryo Unsafe vs safe Serialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 Benchmark Kryo Unsafe vs safe Serialization:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-basicTypes: Int with unsafe:true                       166            168           3          6.0         165.5       1.0X
-basicTypes: Long with unsafe:true                      178            182           5          5.6         178.2       0.9X
-basicTypes: Float with unsafe:true                     185            189           6          5.4         184.9       0.9X
-basicTypes: Double with unsafe:true                    183            188           9          5.5         183.2       0.9X
-Array: Int with unsafe:true                              1              1           0        763.7           1.3     126.4X
-Array: Long with unsafe:true                             2              2           0        447.3           2.2      74.1X
-Array: Float with unsafe:true                            1              1           0        753.7           1.3     124.8X
-Array: Double with unsafe:true                           2              2           0        457.5           2.2      75.7X
-Map of string->Double  with unsafe:true                 28             28           0         36.2          27.6       6.0X
-basicTypes: Int with unsafe:false                      203            204           1          4.9         203.1       0.8X
-basicTypes: Long with unsafe:false                     223            224           1          4.5         222.8       0.7X
-basicTypes: Float with unsafe:false                    206            207           1          4.9         205.8       0.8X
-basicTypes: Double with unsafe:false                   204            205           1          4.9         204.1       0.8X
-Array: Int with unsafe:false                            13             13           0         79.5          12.6      13.2X
-Array: Long with unsafe:false                           21             22           1         46.6          21.5       7.7X
-Array: Float with unsafe:false                          13             13           0         78.6          12.7      13.0X
-Array: Double with unsafe:false                         15             15           0         67.8          14.8      11.2X
-Map of string->Double  with unsafe:false                28             30           1         35.3          28.3       5.8X
+basicTypes: Int with unsafe:true                       166            169           6          6.0         165.7       1.0X
+basicTypes: Long with unsafe:true                      178            182           4          5.6         177.5       0.9X
+basicTypes: Float with unsafe:true                     183            191           9          5.5         182.7       0.9X
+basicTypes: Double with unsafe:true                    186            193           7          5.4         186.4       0.9X
+Array: Int with unsafe:true                              1              1           0        745.8           1.3     123.5X
+Array: Long with unsafe:true                             2              3           0        451.7           2.2      74.8X
+Array: Float with unsafe:true                            1              1           0        743.0           1.3     123.1X
+Array: Double with unsafe:true                           2              2           0        475.6           2.1      78.8X
+Map of string->Double  with unsafe:true                 27             28           1         37.0          27.0       6.1X
+basicTypes: Int with unsafe:false                      198            199           1          5.1         197.7       0.8X
+basicTypes: Long with unsafe:false                     220            221           1          4.5         219.8       0.8X
+basicTypes: Float with unsafe:false                    206            208           1          4.8         206.3       0.8X
+basicTypes: Double with unsafe:false                   222            225           2          4.5         221.9       0.7X
+Array: Int with unsafe:false                            13             14           1         78.0          12.8      12.9X
+Array: Long with unsafe:false                           21             21           1         48.2          20.8       8.0X
+Array: Float with unsafe:false                           6              6           0        178.9           5.6      29.6X
+Array: Double with unsafe:false                         15             16           0         65.3          15.3      10.8X
+Map of string->Double  with unsafe:false                28             29           2         35.2          28.4       5.8X
 
 

--- a/core/benchmarks/KryoBenchmark-results.txt
+++ b/core/benchmarks/KryoBenchmark-results.txt
@@ -2,27 +2,27 @@
 Benchmark Kryo Unsafe vs safe Serialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 Benchmark Kryo Unsafe vs safe Serialization:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-basicTypes: Int with unsafe:true                       177            180           3          5.7         176.9       1.0X
-basicTypes: Long with unsafe:true                      188            190           1          5.3         188.1       0.9X
-basicTypes: Float with unsafe:true                     190            192           2          5.3         190.2       0.9X
-basicTypes: Double with unsafe:true                    199            201           4          5.0         199.0       0.9X
-Array: Int with unsafe:true                              1              1           0        783.6           1.3     138.6X
-Array: Long with unsafe:true                             2              2           0        491.6           2.0      87.0X
-Array: Float with unsafe:true                            1              1           0        757.8           1.3     134.1X
-Array: Double with unsafe:true                           2              2           0        497.5           2.0      88.0X
-Map of string->Double  with unsafe:true                 26             27           3         37.9          26.4       6.7X
-basicTypes: Int with unsafe:false                      230            232           1          4.3         230.1       0.8X
-basicTypes: Long with unsafe:false                     267            268           1          3.7         267.0       0.7X
-basicTypes: Float with unsafe:false                    229            230           1          4.4         229.2       0.8X
-basicTypes: Double with unsafe:false                   216            217           1          4.6         216.3       0.8X
-Array: Int with unsafe:false                            15             15           0         68.8          14.5      12.2X
-Array: Long with unsafe:false                           22             22           0         46.1          21.7       8.2X
-Array: Float with unsafe:false                           6              6           0        169.6           5.9      30.0X
-Array: Double with unsafe:false                          9              9           0        108.1           9.3      19.1X
-Map of string->Double  with unsafe:false                28             28           1         36.3          27.5       6.4X
+basicTypes: Int with unsafe:true                       172            174           1          5.8         171.9       1.0X
+basicTypes: Long with unsafe:true                      196            197           0          5.1         196.2       0.9X
+basicTypes: Float with unsafe:true                     193            195           2          5.2         192.7       0.9X
+basicTypes: Double with unsafe:true                    193            194           1          5.2         193.2       0.9X
+Array: Int with unsafe:true                              1              1           0        715.2           1.4     122.9X
+Array: Long with unsafe:true                             2              2           0        474.2           2.1      81.5X
+Array: Float with unsafe:true                            1              1           0        718.2           1.4     123.5X
+Array: Double with unsafe:true                           2              2           0        475.8           2.1      81.8X
+Map of string->Double  with unsafe:true                 27             28           0         36.7          27.2       6.3X
+basicTypes: Int with unsafe:false                      207            209           5          4.8         207.3       0.8X
+basicTypes: Long with unsafe:false                     239            241           2          4.2         238.9       0.7X
+basicTypes: Float with unsafe:false                    215            217           2          4.6         215.4       0.8X
+basicTypes: Double with unsafe:false                   220            225           7          4.5         220.2       0.8X
+Array: Int with unsafe:false                            16             20           7         63.4          15.8      10.9X
+Array: Long with unsafe:false                           22             22           0         45.9          21.8       7.9X
+Array: Float with unsafe:false                           6              6           1        170.0           5.9      29.2X
+Array: Double with unsafe:false                         10             10           0         98.6          10.1      16.9X
+Map of string->Double  with unsafe:false                28             29           1         35.9          27.9       6.2X
 
 

--- a/core/benchmarks/KryoIteratorBenchmark-jdk21-results.txt
+++ b/core/benchmarks/KryoIteratorBenchmark-jdk21-results.txt
@@ -2,27 +2,27 @@
 Benchmark of kryo asIterator on deserialization stream
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 Benchmark of kryo asIterator on deserialization stream:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------------
-Colletion of int with 1 elements, useIterator: true                        6              6           0          1.7         584.3       1.0X
-Colletion of int with 10 elements, useIterator: true                      13             14           0          0.8        1330.3       0.4X
-Colletion of int with 100 elements, useIterator: true                     83             84           0          0.1        8310.8       0.1X
-Colletion of string with 1 elements, useIterator: true                     8              8           0          1.3         763.6       0.8X
-Colletion of string with 10 elements, useIterator: true                   22             23           0          0.5        2209.8       0.3X
-Colletion of string with 100 elements, useIterator: true                 163            164           2          0.1       16262.3       0.0X
-Colletion of Array[int] with 1 elements, useIterator: true                 7              8           0          1.4         730.9       0.8X
-Colletion of Array[int] with 10 elements, useIterator: true               20             20           0          0.5        1990.1       0.3X
-Colletion of Array[int] with 100 elements, useIterator: true             155            156           1          0.1       15527.8       0.0X
-Colletion of int with 1 elements, useIterator: false                       6              6           0          1.7         599.4       1.0X
-Colletion of int with 10 elements, useIterator: false                     13             14           0          0.7        1337.3       0.4X
-Colletion of int with 100 elements, useIterator: false                    83             84           1          0.1        8320.9       0.1X
-Colletion of string with 1 elements, useIterator: false                    7              8           0          1.4         731.4       0.8X
-Colletion of string with 10 elements, useIterator: false                  22             22           0          0.5        2160.9       0.3X
-Colletion of string with 100 elements, useIterator: false                170            171           0          0.1       17015.3       0.0X
-Colletion of Array[int] with 1 elements, useIterator: false                7              8           1          1.4         710.4       0.8X
-Colletion of Array[int] with 10 elements, useIterator: false              19             20           0          0.5        1925.0       0.3X
-Colletion of Array[int] with 100 elements, useIterator: false            143            144           2          0.1       14267.3       0.0X
+Colletion of int with 1 elements, useIterator: true                        6              7           0          1.5         645.9       1.0X
+Colletion of int with 10 elements, useIterator: true                      13             14           0          0.8        1330.8       0.5X
+Colletion of int with 100 elements, useIterator: true                     80             81           1          0.1        7987.1       0.1X
+Colletion of string with 1 elements, useIterator: true                     8              8           0          1.3         787.4       0.8X
+Colletion of string with 10 elements, useIterator: true                   21             21           0          0.5        2113.7       0.3X
+Colletion of string with 100 elements, useIterator: true                 161            162           1          0.1       16108.9       0.0X
+Colletion of Array[int] with 1 elements, useIterator: true                 7              8           0          1.3         747.8       0.9X
+Colletion of Array[int] with 10 elements, useIterator: true               19             19           0          0.5        1879.8       0.3X
+Colletion of Array[int] with 100 elements, useIterator: true             140            141           1          0.1       14008.3       0.0X
+Colletion of int with 1 elements, useIterator: false                       6              7           0          1.6         642.6       1.0X
+Colletion of int with 10 elements, useIterator: false                     14             15           1          0.7        1414.6       0.5X
+Colletion of int with 100 elements, useIterator: false                    87             88           1          0.1        8699.0       0.1X
+Colletion of string with 1 elements, useIterator: false                    7              8           0          1.3         746.5       0.9X
+Colletion of string with 10 elements, useIterator: false                  22             22           0          0.5        2192.3       0.3X
+Colletion of string with 100 elements, useIterator: false                161            162           2          0.1       16091.2       0.0X
+Colletion of Array[int] with 1 elements, useIterator: false                7              8           0          1.4         719.6       0.9X
+Colletion of Array[int] with 10 elements, useIterator: false              19             19           0          0.5        1869.6       0.3X
+Colletion of Array[int] with 100 elements, useIterator: false            138            139           1          0.1       13766.1       0.0X
 
 

--- a/core/benchmarks/KryoIteratorBenchmark-results.txt
+++ b/core/benchmarks/KryoIteratorBenchmark-results.txt
@@ -2,27 +2,27 @@
 Benchmark of kryo asIterator on deserialization stream
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 Benchmark of kryo asIterator on deserialization stream:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------------
-Colletion of int with 1 elements, useIterator: true                        6              7           0          1.6         641.0       1.0X
-Colletion of int with 10 elements, useIterator: true                      13             14           0          0.7        1334.5       0.5X
-Colletion of int with 100 elements, useIterator: true                     81             82           0          0.1        8144.5       0.1X
-Colletion of string with 1 elements, useIterator: true                     8              8           0          1.3         760.7       0.8X
-Colletion of string with 10 elements, useIterator: true                   22             23           0          0.4        2227.9       0.3X
-Colletion of string with 100 elements, useIterator: true                 165            165           1          0.1       16461.8       0.0X
-Colletion of Array[int] with 1 elements, useIterator: true                 7              8           0          1.3         747.8       0.9X
-Colletion of Array[int] with 10 elements, useIterator: true               20             20           0          0.5        1980.0       0.3X
-Colletion of Array[int] with 100 elements, useIterator: true             149            151           1          0.1       14910.6       0.0X
-Colletion of int with 1 elements, useIterator: false                       6              7           0          1.6         618.9       1.0X
-Colletion of int with 10 elements, useIterator: false                     13             14           0          0.8        1329.3       0.5X
-Colletion of int with 100 elements, useIterator: false                    82             83           1          0.1        8176.8       0.1X
-Colletion of string with 1 elements, useIterator: false                    7              8           0          1.3         743.4       0.9X
-Colletion of string with 10 elements, useIterator: false                  21             22           0          0.5        2137.1       0.3X
-Colletion of string with 100 elements, useIterator: false                161            162           1          0.1       16131.4       0.0X
-Colletion of Array[int] with 1 elements, useIterator: false                7              8           0          1.4         713.0       0.9X
-Colletion of Array[int] with 10 elements, useIterator: false              19             20           0          0.5        1910.7       0.3X
-Colletion of Array[int] with 100 elements, useIterator: false            140            142           1          0.1       14021.4       0.0X
+Colletion of int with 1 elements, useIterator: true                        6              6           0          1.6         629.3       1.0X
+Colletion of int with 10 elements, useIterator: true                      14             14           0          0.7        1350.0       0.5X
+Colletion of int with 100 elements, useIterator: true                     83             83           1          0.1        8255.8       0.1X
+Colletion of string with 1 elements, useIterator: true                     8              8           0          1.3         750.8       0.8X
+Colletion of string with 10 elements, useIterator: true                   21             21           1          0.5        2116.4       0.3X
+Colletion of string with 100 elements, useIterator: true                 162            163           1          0.1       16191.1       0.0X
+Colletion of Array[int] with 1 elements, useIterator: true                 7              8           0          1.4         732.3       0.9X
+Colletion of Array[int] with 10 elements, useIterator: true               19             19           0          0.5        1906.4       0.3X
+Colletion of Array[int] with 100 elements, useIterator: true             142            143           0          0.1       14222.9       0.0X
+Colletion of int with 1 elements, useIterator: false                       6              6           0          1.7         604.6       1.0X
+Colletion of int with 10 elements, useIterator: false                     13             13           0          0.8        1325.8       0.5X
+Colletion of int with 100 elements, useIterator: false                    83             83           0          0.1        8261.2       0.1X
+Colletion of string with 1 elements, useIterator: false                    7              8           1          1.4         719.2       0.9X
+Colletion of string with 10 elements, useIterator: false                  22             22           0          0.5        2203.0       0.3X
+Colletion of string with 100 elements, useIterator: false                163            163           1          0.1       16294.8       0.0X
+Colletion of Array[int] with 1 elements, useIterator: false                7              7           0          1.5         674.8       0.9X
+Colletion of Array[int] with 10 elements, useIterator: false              18             19           0          0.6        1808.7       0.3X
+Colletion of Array[int] with 100 elements, useIterator: false            135            135           0          0.1       13481.7       0.0X
 
 

--- a/core/benchmarks/KryoSerializerBenchmark-jdk21-results.txt
+++ b/core/benchmarks/KryoSerializerBenchmark-jdk21-results.txt
@@ -2,11 +2,11 @@
 Benchmark KryoPool vs old"pool of 1" implementation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 Benchmark KryoPool vs old"pool of 1" implementation:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-KryoPool:true                                                 3586           4906        1321          0.0     7171228.8       1.0X
-KryoPool:false                                                5722           7623        1380          0.0    11444024.2       0.6X
+KryoPool:true                                                 3610           5082        1510          0.0     7219633.5       1.0X
+KryoPool:false                                                5886           7699        1454          0.0    11772046.4       0.6X
 
 

--- a/core/benchmarks/KryoSerializerBenchmark-results.txt
+++ b/core/benchmarks/KryoSerializerBenchmark-results.txt
@@ -2,11 +2,11 @@
 Benchmark KryoPool vs old"pool of 1" implementation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 Benchmark KryoPool vs old"pool of 1" implementation:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-KryoPool:true                                                 3517           5031        1861          0.0     7033673.5       1.0X
-KryoPool:false                                                5802           7614        1293          0.0    11604325.7       0.6X
+KryoPool:true                                                 3682           5317        1787          0.0     7363182.2       1.0X
+KryoPool:false                                                5853           7922        1339          0.0    11705848.9       0.6X
 
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -60,6 +60,14 @@
       <artifactId>chill-java</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.esotericsoftware</groupId>
+      <artifactId>kryo-shaded</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.objenesis</groupId>
+      <artifactId>objenesis</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
       <scope>test</scope>

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -158,7 +158,7 @@ json4s-scalap_2.13/4.0.7//json4s-scalap_2.13-4.0.7.jar
 jsr305/3.0.0//jsr305-3.0.0.jar
 jta/1.1//jta-1.1.jar
 jul-to-slf4j/2.0.17//jul-to-slf4j-2.0.17.jar
-kryo-shaded/4.0.2//kryo-shaded-4.0.2.jar
+kryo-shaded/4.0.3//kryo-shaded-4.0.3.jar
 kubernetes-client-api/7.1.0//kubernetes-client-api-7.1.0.jar
 kubernetes-client/7.1.0//kubernetes-client-7.1.0.jar
 kubernetes-httpclient-vertx/7.1.0//kubernetes-httpclient-vertx-7.1.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -498,6 +498,12 @@
         <groupId>com.esotericsoftware</groupId>
         <artifactId>kryo-shaded</artifactId>
         <version>${kryo.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <!--
         SPARK-51806: Kryo 4.0.x depends on objenesis 2.5.1, while Spark currently

--- a/pom.xml
+++ b/pom.xml
@@ -487,12 +487,22 @@
             <groupId>org.apache.xbean</groupId>
             <artifactId>xbean-asm7-shaded</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.esotericsoftware</groupId>
+            <artifactId>kryo-shaded</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
         <groupId>com.twitter</groupId>
         <artifactId>chill-java</artifactId>
         <version>${chill.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.esotericsoftware</groupId>
+            <artifactId>kryo-shaded</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.esotericsoftware</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
     <!-- SPARK-46938: Required by Hive / LibThrift libs -->
     <javaxservlet.version>4.0.1</javaxservlet.version>
     <chill.version>0.10.0</chill.version>
+    <kryo.version>4.0.3</kryo.version>
     <ivy.version>2.5.3</ivy.version>
     <oro.version>2.0.8</oro.version>
     <!--
@@ -492,6 +493,16 @@
         <groupId>com.twitter</groupId>
         <artifactId>chill-java</artifactId>
         <version>${chill.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.esotericsoftware</groupId>
+        <artifactId>kryo-shaded</artifactId>
+        <version>${kryo.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <version>3.3</version>
       </dependency>
       <dependency>
         <groupId>com.github.jnr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -500,7 +500,7 @@
         <version>${kryo.version}</version>
       </dependency>
       <!--
-        SPARK-51806: Kryo 4.0.x depends on version objenesis 2.5.1, while Spark currently
+        SPARK-51806: Kryo 4.0.x depends on objenesis 2.5.1, while Spark currently
         depends on objenesis 3.3. Here, it is uniformly defined as version 3.3.
         -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -499,6 +499,10 @@
         <artifactId>kryo-shaded</artifactId>
         <version>${kryo.version}</version>
       </dependency>
+      <!--
+        SPARK-51806: Kryo 4.0.x depends on version objenesis 2.5.1, while Spark currently
+        depends on objenesis 3.3. Here, it is uniformly defined as version 3.3.
+        -->
       <dependency>
         <groupId>org.objenesis</groupId>
         <artifactId>objenesis</artifactId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade `kryo-shaded` from 4.0.2 to 4.0.3.

### Why are the changes needed?
This version brings some bug fixes and performance improvements related to chunked encoding:
- mproved filling InputChunked buffer: https://github.com/EsotericSoftware/kryo/issues/651
- Support skipping input chunks after a buffer underflow https://github.com/EsotericSoftware/kryo/issues/850
- Avoid flush repeatedly when has finished flushing https://github.com/EsotericSoftware/kryo/issues/978

full changes as follows:

- https://github.com/EsotericSoftware/kryo/compare/kryo-parent-4.0.2...kryo-parent-4.0.3


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
