### PR TITLE
[SPARK-51801][BUILD] Upgrade ORC Format to 1.1.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -236,7 +236,7 @@ opentracing-api/0.33.0//opentracing-api-0.33.0.jar
 opentracing-noop/0.33.0//opentracing-noop-0.33.0.jar
 opentracing-util/0.33.0//opentracing-util-0.33.0.jar
 orc-core/2.1.1/shaded-protobuf/orc-core-2.1.1-shaded-protobuf.jar
-orc-format/1.0.0/shaded-protobuf/orc-format-1.0.0-shaded-protobuf.jar
+orc-format/1.1.0/shaded-protobuf/orc-format-1.1.0-shaded-protobuf.jar
 orc-mapreduce/2.1.1/shaded-protobuf/orc-mapreduce-2.1.1-shaded-protobuf.jar
 orc-shims/2.1.1//orc-shims-2.1.1.jar
 oro/2.0.8//oro-2.0.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -2319,7 +2319,7 @@
       <dependency>
         <groupId>org.apache.orc</groupId>
         <artifactId>orc-format</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
         <classifier>${orc.classifier}</classifier>
         <scope>${orc.deps.scope}</scope>
       </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache ORC Format to 1.1.0 from 1.1.0 for Apache Spark 4.1.0.

### Why are the changes needed?

Apache ORC Format v1.1.0 is released on 2025-04-18.
- https://github.com/apache/orc-format/releases/tag/v1.1.0

To bring the latest feature and bug fixes.
- https://github.com/apache/orc-format/milestone/2?closed=1
  - https://github.com/apache/orc-format/pull/18
  - https://github.com/apache/orc-format/pull/19

### Does this PR introduce _any_ user-facing change?

No, there is no behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.