### PR TITLE
[SPARK-51803][Core] Store external engine JDBC type in the spark schema in the…

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
@@ -51,6 +51,11 @@ class DB2IntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest {
   override val namespaceOpt: Option[String] = Some("DB2INST1")
   override val db = new DB2DatabaseOnDocker
 
+  object ExternalEngineTypeNames {
+    val INTEGER = "INTEGER"
+    val DOUBLE = "DOUBLE"
+  }
+
   override def sparkConf: SparkConf = super.sparkConf
     .set("spark.sql.catalog.db2", classOf[JDBCTableCatalog].getName)
     .set("spark.sql.catalog.db2.url", db.getJdbcUrl(dockerIp, externalPort))
@@ -74,12 +79,12 @@ class DB2IntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest {
     sql(s"CREATE TABLE $tbl (ID INTEGER)")
     var t = spark.table(tbl)
     var expectedSchema = new StructType()
-      .add("ID", IntegerType, true, defaultMetadata(IntegerType))
+      .add("ID", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
     assert(t.schema === expectedSchema)
     sql(s"ALTER TABLE $tbl ALTER COLUMN id TYPE DOUBLE")
     t = spark.table(tbl)
     expectedSchema = new StructType()
-      .add("ID", DoubleType, true, defaultMetadata(DoubleType))
+      .add("ID", DoubleType, true, defaultMetadata(DoubleType, ExternalEngineTypeNames.DOUBLE))
     assert(t.schema === expectedSchema)
     // Update column type from DOUBLE to STRING
     val sql1 = s"ALTER TABLE $tbl ALTER COLUMN id TYPE VARCHAR(10)"
@@ -103,7 +108,7 @@ class DB2IntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest {
       s" TBLPROPERTIES('CCSID'='UNICODE')")
     val t = spark.table(tbl)
     val expectedSchema = new StructType()
-      .add("ID", IntegerType, true, defaultMetadata(IntegerType))
+      .add("ID", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
     assert(t.schema === expectedSchema)
   }
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
@@ -51,7 +51,7 @@ class DB2IntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest {
   override val namespaceOpt: Option[String] = Some("DB2INST1")
   override val db = new DB2DatabaseOnDocker
 
-  object ExternalEngineTypeNames {
+  object JdbcClientTypes {
     val INTEGER = "INTEGER"
     val DOUBLE = "DOUBLE"
   }
@@ -79,12 +79,12 @@ class DB2IntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest {
     sql(s"CREATE TABLE $tbl (ID INTEGER)")
     var t = spark.table(tbl)
     var expectedSchema = new StructType()
-      .add("ID", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
+      .add("ID", IntegerType, true, defaultMetadata(IntegerType, JdbcClientTypes.INTEGER))
     assert(t.schema === expectedSchema)
     sql(s"ALTER TABLE $tbl ALTER COLUMN id TYPE DOUBLE")
     t = spark.table(tbl)
     expectedSchema = new StructType()
-      .add("ID", DoubleType, true, defaultMetadata(DoubleType, ExternalEngineTypeNames.DOUBLE))
+      .add("ID", DoubleType, true, defaultMetadata(DoubleType, JdbcClientTypes.DOUBLE))
     assert(t.schema === expectedSchema)
     // Update column type from DOUBLE to STRING
     val sql1 = s"ALTER TABLE $tbl ALTER COLUMN id TYPE VARCHAR(10)"
@@ -108,7 +108,7 @@ class DB2IntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest {
       s" TBLPROPERTIES('CCSID'='UNICODE')")
     val t = spark.table(tbl)
     val expectedSchema = new StructType()
-      .add("ID", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
+      .add("ID", IntegerType, true, defaultMetadata(IntegerType, JdbcClientTypes.INTEGER))
     assert(t.schema === expectedSchema)
   }
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
@@ -41,6 +41,11 @@ import org.apache.spark.tags.DockerTest
 @DockerTest
 class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest {
 
+  object ExternalEngineTypeNames {
+    val INTEGER = "int"
+    val STRING = "nvarchar"
+  }
+
   def getExternalEngineQuery(executedPlan: SparkPlan): String = {
     getExternalEngineRdd(executedPlan).asInstanceOf[JDBCRDD].getExternalEngineQuery
   }
@@ -97,9 +102,9 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JD
     sql(s"ALTER TABLE $tbl RENAME COLUMN ID TO RENAMED")
     val t = spark.table(s"$tbl")
     val expectedSchema = new StructType()
-      .add("RENAMED", StringType, true, defaultMetadata(StringType, MsSQLRemoteTypes.STRING))
-      .add("ID1", StringType, true, defaultMetadata(StringType, MsSQLRemoteTypes.STRING))
-      .add("ID2", StringType, true, defaultMetadata(StringType, MsSQLRemoteTypes.STRING))
+      .add("RENAMED", StringType, true, defaultMetadata(StringType, ExternalEngineTypeNames.STRING))
+      .add("ID1", StringType, true, defaultMetadata(StringType, ExternalEngineTypeNames.STRING))
+      .add("ID2", StringType, true, defaultMetadata(StringType, ExternalEngineTypeNames.STRING))
     assert(t.schema === expectedSchema)
   }
 
@@ -109,12 +114,12 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JD
     sql(s"CREATE TABLE $tbl (ID INTEGER)")
     var t = spark.table(tbl)
     var expectedSchema = new StructType()
-      .add("ID", IntegerType, true, defaultMetadata(IntegerType, MsSQLRemoteTypes.INTEGER))
+      .add("ID", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
     assert(t.schema === expectedSchema)
     sql(s"ALTER TABLE $tbl ALTER COLUMN id TYPE STRING")
     t = spark.table(tbl)
     expectedSchema = new StructType()
-      .add("ID", StringType, true, defaultMetadata(StringType, MsSQLRemoteTypes.STRING))
+      .add("ID", StringType, true, defaultMetadata(StringType, ExternalEngineTypeNames.STRING))
     assert(t.schema === expectedSchema)
     // Update column type from STRING to INTEGER
     val sql1 = s"ALTER TABLE $tbl ALTER COLUMN id TYPE INTEGER"
@@ -267,9 +272,4 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JD
     assert(rows.length == 1)
     assert(rows(0).getString(0) === "amy")
   }
-}
-
-object MsSQLRemoteTypes {
-  val INTEGER = "int"
-  val STRING = "nvarchar"
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
@@ -41,7 +41,7 @@ import org.apache.spark.tags.DockerTest
 @DockerTest
 class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest {
 
-  object ExternalEngineTypeNames {
+  object JdbcClientTypes {
     val INTEGER = "int"
     val STRING = "nvarchar"
   }
@@ -102,9 +102,9 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JD
     sql(s"ALTER TABLE $tbl RENAME COLUMN ID TO RENAMED")
     val t = spark.table(s"$tbl")
     val expectedSchema = new StructType()
-      .add("RENAMED", StringType, true, defaultMetadata(StringType, ExternalEngineTypeNames.STRING))
-      .add("ID1", StringType, true, defaultMetadata(StringType, ExternalEngineTypeNames.STRING))
-      .add("ID2", StringType, true, defaultMetadata(StringType, ExternalEngineTypeNames.STRING))
+      .add("RENAMED", StringType, true, defaultMetadata(StringType, JdbcClientTypes.STRING))
+      .add("ID1", StringType, true, defaultMetadata(StringType, JdbcClientTypes.STRING))
+      .add("ID2", StringType, true, defaultMetadata(StringType, JdbcClientTypes.STRING))
     assert(t.schema === expectedSchema)
   }
 
@@ -114,12 +114,12 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JD
     sql(s"CREATE TABLE $tbl (ID INTEGER)")
     var t = spark.table(tbl)
     var expectedSchema = new StructType()
-      .add("ID", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
+      .add("ID", IntegerType, true, defaultMetadata(IntegerType, JdbcClientTypes.INTEGER))
     assert(t.schema === expectedSchema)
     sql(s"ALTER TABLE $tbl ALTER COLUMN id TYPE STRING")
     t = spark.table(tbl)
     expectedSchema = new StructType()
-      .add("ID", StringType, true, defaultMetadata(StringType, ExternalEngineTypeNames.STRING))
+      .add("ID", StringType, true, defaultMetadata(StringType, JdbcClientTypes.STRING))
     assert(t.schema === expectedSchema)
     // Update column type from STRING to INTEGER
     val sql1 = s"ALTER TABLE $tbl ALTER COLUMN id TYPE INTEGER"

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -297,7 +297,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
  */
 @DockerTest
 class MySQLOverMariaConnectorIntegrationSuite extends MySQLIntegrationSuite {
-  val externalEngineTypeNames: ExternalEngineTypeNames =
+  override val externalEngineTypeNames: ExternalEngineTypeNames =
     ExternalEngineTypeNames(INTEGER = "INTEGER", STRING = "LONGTEXT")
 
   override def defaultMetadata(

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -59,6 +59,15 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
   override val catalogName: String = "mysql"
   override val db = new MySQLDatabaseOnDocker
 
+  override def defaultMetadata(
+      dataType: DataType = StringType,
+      remoteTypeName: String = MySQLTypeNames.STRING): Metadata = new MetadataBuilder()
+    .putLong("scale", 0)
+    .putBoolean("isTimestampNTZ", false)
+    .putBoolean("isSigned", true)
+    .putString("remoteTypeName", remoteTypeName)
+    .build()
+
   override def sparkConf: SparkConf = super.sparkConf
     .set("spark.sql.catalog.mysql", classOf[JDBCTableCatalog].getName)
     .set("spark.sql.catalog.mysql.url", db.getJdbcUrl(dockerIp, externalPort))
@@ -99,7 +108,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
     sql(s"CREATE TABLE $tbl (ID INTEGER)")
     var t = spark.table(tbl)
     var expectedSchema = new StructType()
-      .add("ID", IntegerType, true, defaultMetadata(IntegerType))
+      .add("ID", IntegerType, true, defaultMetadata(IntegerType, MySQLTypeNames.INTEGER))
     assert(t.schema === expectedSchema)
     sql(s"ALTER TABLE $tbl ALTER COLUMN id TYPE STRING")
     t = spark.table(tbl)
@@ -153,7 +162,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
       s" TBLPROPERTIES('ENGINE'='InnoDB', 'DEFAULT CHARACTER SET'='utf8')")
     val t = spark.table(tbl)
     val expectedSchema = new StructType()
-      .add("ID", IntegerType, true, defaultMetadata(IntegerType))
+      .add("ID", IntegerType, true, defaultMetadata(IntegerType, MySQLTypeNames.INTEGER))
     assert(t.schema === expectedSchema)
   }
 
@@ -282,15 +291,14 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
  */
 @DockerTest
 class MySQLOverMariaConnectorIntegrationSuite extends MySQLIntegrationSuite {
-  override def defaultMetadata(dataType: DataType = StringType): Metadata = new MetadataBuilder()
-    .putLong("scale", 0)
-    .putBoolean("isTimestampNTZ", false)
-    .putBoolean("isSigned", true)
-    .build()
-
   override val db = new MySQLDatabaseOnDocker {
     override def getJdbcUrl(ip: String, port: Int): String =
       s"jdbc:mysql://$ip:$port/mysql?user=root&password=rootpass&allowPublicKeyRetrieval=true" +
         s"&useSSL=false"
   }
+}
+
+object MySQLTypeNames {
+  val INTEGER = "INTEGER"
+  val STRING = "LONGTEXT"
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -70,7 +70,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
     new MetadataBuilder()
       .putLong("scale", 0)
       .putBoolean("isTimestampNTZ", false)
-      .putBoolean("isSigned", , dataType.isInstanceOf[NumericType])
+      .putBoolean("isSigned", dataType.isInstanceOf[NumericType])
       .putString("externalEngineTypeName", externalEngineTypeName)
       .build()
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -59,19 +59,19 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
   override val catalogName: String = "mysql"
   override val db = new MySQLDatabaseOnDocker
 
-  case class ExternalEngineTypeNames(INTEGER: String, STRING: String)
+  case class JdbcClientTypes(INTEGER: String, STRING: String)
 
-  val externalEngineTypeNames: ExternalEngineTypeNames =
-    ExternalEngineTypeNames(INTEGER = "INT", STRING = "LONGTEXT")
+  val jdbcClientTypes: JdbcClientTypes =
+    JdbcClientTypes(INTEGER = "INT", STRING = "LONGTEXT")
 
   override def defaultMetadata(
       dataType: DataType = StringType,
-      externalEngineTypeName: String = externalEngineTypeNames.STRING): Metadata =
+      jdbcClientType: String = jdbcClientTypes.STRING): Metadata =
     new MetadataBuilder()
       .putLong("scale", 0)
       .putBoolean("isTimestampNTZ", false)
       .putBoolean("isSigned", dataType.isInstanceOf[NumericType])
-      .putString("externalEngineTypeName", externalEngineTypeName)
+      .putString("jdbcClientType", jdbcClientType)
       .build()
 
   override def sparkConf: SparkConf = super.sparkConf
@@ -114,7 +114,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
     sql(s"CREATE TABLE $tbl (ID INTEGER)")
     var t = spark.table(tbl)
     var expectedSchema = new StructType()
-      .add("ID", IntegerType, true, defaultMetadata(IntegerType, externalEngineTypeNames.INTEGER))
+      .add("ID", IntegerType, true, defaultMetadata(IntegerType, jdbcClientTypes.INTEGER))
     assert(t.schema === expectedSchema)
     sql(s"ALTER TABLE $tbl ALTER COLUMN id TYPE STRING")
     t = spark.table(tbl)
@@ -168,7 +168,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
       s" TBLPROPERTIES('ENGINE'='InnoDB', 'DEFAULT CHARACTER SET'='utf8')")
     val t = spark.table(tbl)
     val expectedSchema = new StructType()
-      .add("ID", IntegerType, true, defaultMetadata(IntegerType, externalEngineTypeNames.INTEGER))
+      .add("ID", IntegerType, true, defaultMetadata(IntegerType, jdbcClientTypes.INTEGER))
     assert(t.schema === expectedSchema)
   }
 
@@ -297,17 +297,17 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
  */
 @DockerTest
 class MySQLOverMariaConnectorIntegrationSuite extends MySQLIntegrationSuite {
-  override val externalEngineTypeNames: ExternalEngineTypeNames =
-    ExternalEngineTypeNames(INTEGER = "INTEGER", STRING = "LONGTEXT")
+  override val jdbcClientTypes: JdbcClientTypes =
+    JdbcClientTypes(INTEGER = "INTEGER", STRING = "LONGTEXT")
 
   override def defaultMetadata(
       dataType: DataType = StringType,
-      externalEngineTypeName: String = externalEngineTypeNames.STRING): Metadata =
+      jdbcClientType: String = jdbcClientTypes.STRING): Metadata =
     new MetadataBuilder()
       .putLong("scale", 0)
       .putBoolean("isTimestampNTZ", false)
       .putBoolean("isSigned", true)
-      .putString("externalEngineTypeName", externalEngineTypeName)
+      .putString("jdbcClientType", jdbcClientType)
       .build()
 
   override val db = new MySQLDatabaseOnDocker {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -82,13 +82,17 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
 
   override def defaultMetadata(
       dataType: DataType = StringType,
-      externalEngineTypeName: String = ExternalEngineTypeNames.STRING): Metadata = new MetadataBuilder()
-    .putLong("scale", 0)
-    .putBoolean("isTimestampNTZ", false)
-    .putBoolean("isSigned", dataType.isInstanceOf[NumericType] || dataType.isInstanceOf[StringType])
-    .putString(CHAR_VARCHAR_TYPE_STRING_METADATA_KEY, "varchar(255)")
-    .putString("externalEngineTypeName", externalEngineTypeName)
-    .build()
+      externalEngineTypeName: String = ExternalEngineTypeNames.STRING): Metadata =
+    new MetadataBuilder()
+      .putLong("scale", 0)
+      .putBoolean("isTimestampNTZ", false)
+      .putBoolean(
+        "isSigned",
+        dataType.isInstanceOf[NumericType] || dataType.isInstanceOf[StringType])
+      .putString(CHAR_VARCHAR_TYPE_STRING_METADATA_KEY, "varchar(255)")
+      .putString("externalEngineTypeName", externalEngineTypeName)
+      .build()
+
 
   override def sparkConf: SparkConf = super.sparkConf
     .set("spark.sql.catalog.oracle", classOf[JDBCTableCatalog].getName)

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -75,14 +75,14 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
   override val namespaceOpt: Option[String] = Some("SYSTEM")
   override val db = new OracleDatabaseOnDocker
 
-  object ExternalEngineTypeNames {
+  object JdbcClientTypes {
     val NUMBER = "NUMBER"
     val STRING = "VARCHAR2"
   }
 
   override def defaultMetadata(
       dataType: DataType = StringType,
-      externalEngineTypeName: String = ExternalEngineTypeNames.STRING): Metadata =
+      jdbcClientType: String = JdbcClientTypes.STRING): Metadata =
     new MetadataBuilder()
       .putLong("scale", 0)
       .putBoolean("isTimestampNTZ", false)
@@ -90,7 +90,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
         "isSigned",
         dataType.isInstanceOf[NumericType] || dataType.isInstanceOf[StringType])
       .putString(CHAR_VARCHAR_TYPE_STRING_METADATA_KEY, "varchar(255)")
-      .putString("externalEngineTypeName", externalEngineTypeName)
+      .putString("jdbcClientType", jdbcClientType)
       .build()
 
 
@@ -121,7 +121,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
         "ID",
         DecimalType(10, 0),
         true,
-        super.defaultMetadata(DecimalType(10, 0), ExternalEngineTypeNames.NUMBER))
+        super.defaultMetadata(DecimalType(10, 0), JdbcClientTypes.NUMBER))
     assert(t.schema === expectedSchema)
     sql(s"ALTER TABLE $tbl ALTER COLUMN id TYPE LONG")
     t = spark.table(tbl)
@@ -130,7 +130,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
         "ID",
         DecimalType(19, 0),
         true,
-        super.defaultMetadata(DecimalType(19, 0), ExternalEngineTypeNames.NUMBER))
+        super.defaultMetadata(DecimalType(19, 0), JdbcClientTypes.NUMBER))
     assert(t.schema === expectedSchema)
     // Update column type from LONG to INTEGER
     val sql1 = s"ALTER TABLE $tbl ALTER COLUMN id TYPE INTEGER"

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -75,11 +75,14 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
   override val namespaceOpt: Option[String] = Some("SYSTEM")
   override val db = new OracleDatabaseOnDocker
 
-  override def defaultMetadata(dataType: DataType): Metadata = new MetadataBuilder()
+  override def defaultMetadata(
+      dataType: DataType = StringType,
+      remoteTypeName: String = OracleRemoteTypeNames.STRING): Metadata = new MetadataBuilder()
     .putLong("scale", 0)
     .putBoolean("isTimestampNTZ", false)
     .putBoolean("isSigned", dataType.isInstanceOf[NumericType] || dataType.isInstanceOf[StringType])
     .putString(CHAR_VARCHAR_TYPE_STRING_METADATA_KEY, "varchar(255)")
+    .putString("remoteTypeName", remoteTypeName)
     .build()
 
   override def sparkConf: SparkConf = super.sparkConf
@@ -153,4 +156,9 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
       checkAnswer(sql(s"SELECT * FROM $tableName"), Seq(Row("Eason", "Y  ")))
     }
   }
+}
+
+object OracleRemoteTypeNames {
+  val INTEGER = "NUMBER"
+  val STRING = "VARCHAR2"
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -121,7 +121,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
         "ID",
         DecimalType(10, 0),
         true,
-        self.defaultMetadata(DecimalType(10, 0), ExternalEngineTypeNames.NUMBER))
+        super.defaultMetadata(DecimalType(10, 0), ExternalEngineTypeNames.NUMBER))
     assert(t.schema === expectedSchema)
     sql(s"ALTER TABLE $tbl ALTER COLUMN id TYPE LONG")
     t = spark.table(tbl)
@@ -130,7 +130,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
         "ID",
         DecimalType(19, 0),
         true,
-        self.defaultMetadata(DecimalType(19, 0), ExternalEngineTypeNames.NUMBER))
+        super.defaultMetadata(DecimalType(19, 0), ExternalEngineTypeNames.NUMBER))
     assert(t.schema === expectedSchema)
     // Update column type from LONG to INTEGER
     val sql1 = s"ALTER TABLE $tbl ALTER COLUMN id TYPE INTEGER"

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -121,7 +121,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
         "ID",
         DecimalType(10, 0),
         true,
-        defaultMetadata(DecimalType(10, 0), ExternalEngineTypeNames.NUMBER))
+        self.defaultMetadata(DecimalType(10, 0), ExternalEngineTypeNames.NUMBER))
     assert(t.schema === expectedSchema)
     sql(s"ALTER TABLE $tbl ALTER COLUMN id TYPE LONG")
     t = spark.table(tbl)
@@ -130,7 +130,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
         "ID",
         DecimalType(19, 0),
         true,
-        defaultMetadata(DecimalType(19, 0), ExternalEngineTypeNames.NUMBER))
+        self.defaultMetadata(DecimalType(19, 0), ExternalEngineTypeNames.NUMBER))
     assert(t.schema === expectedSchema)
     // Update column type from LONG to INTEGER
     val sql1 = s"ALTER TABLE $tbl ALTER COLUMN id TYPE INTEGER"

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
@@ -39,14 +39,19 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
   override val catalogName: String = "postgresql"
   override val db = new PostgresDatabaseOnDocker
 
+  object ExternalEngineTypeNames {
+    val INTEGER = "int4"
+    val STRING = "text"
+  }
+
   override def defaultMetadata(
       dataType: DataType = StringType,
-      remoteTypeName: String = PostgresRemoteTypeNames.STRING): Metadata =
+      externalEngineTypeName: String = ExternalEngineTypeNames.STRING): Metadata =
     new MetadataBuilder()
       .putLong("scale", 0)
       .putBoolean("isTimestampNTZ", false)
       .putBoolean("isSigned", dataType.isInstanceOf[NumericType])
-      .putString("remoteTypeName", remoteTypeName)
+      .putString("externalEngineTypeName", externalEngineTypeName)
       .build()
 
   override def sparkConf: SparkConf = super.sparkConf
@@ -204,7 +209,7 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
     sql(s"CREATE TABLE $tbl (ID INTEGER)")
     var t = spark.table(tbl)
     var expectedSchema = new StructType()
-      .add("ID", IntegerType, true, defaultMetadata(IntegerType, PostgresRemoteTypeNames.INTEGER))
+      .add("ID", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
     assert(t.schema === expectedSchema)
     sql(s"ALTER TABLE $tbl ALTER COLUMN id TYPE STRING")
     t = spark.table(tbl)
@@ -233,7 +238,7 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
       s" TBLPROPERTIES('TABLESPACE'='pg_default')")
     val t = spark.table(tbl)
     val expectedSchema = new StructType()
-      .add("ID", IntegerType, true, defaultMetadata(IntegerType, PostgresRemoteTypeNames.INTEGER))
+      .add("ID", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
     assert(t.schema === expectedSchema)
   }
 
@@ -408,9 +413,4 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
     assert(rows.length === 1)
     assert(rows(0).getString(0) === "amy")
   }
-}
-
-object PostgresRemoteTypeNames {
-  val INTEGER = "int4"
-  val STRING = "text"
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
@@ -39,19 +39,19 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
   override val catalogName: String = "postgresql"
   override val db = new PostgresDatabaseOnDocker
 
-  object ExternalEngineTypeNames {
+  object JdbcClientTypes {
     val INTEGER = "int4"
     val STRING = "text"
   }
 
   override def defaultMetadata(
       dataType: DataType = StringType,
-      externalEngineTypeName: String = ExternalEngineTypeNames.STRING): Metadata =
+      jdbcClientType: String = JdbcClientTypes.STRING): Metadata =
     new MetadataBuilder()
       .putLong("scale", 0)
       .putBoolean("isTimestampNTZ", false)
       .putBoolean("isSigned", dataType.isInstanceOf[NumericType])
-      .putString("externalEngineTypeName", externalEngineTypeName)
+      .putString("jdbcClientType", jdbcClientType)
       .build()
 
   override def sparkConf: SparkConf = super.sparkConf
@@ -209,7 +209,7 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
     sql(s"CREATE TABLE $tbl (ID INTEGER)")
     var t = spark.table(tbl)
     var expectedSchema = new StructType()
-      .add("ID", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
+      .add("ID", IntegerType, true, defaultMetadata(IntegerType, JdbcClientTypes.INTEGER))
     assert(t.schema === expectedSchema)
     sql(s"ALTER TABLE $tbl ALTER COLUMN id TYPE STRING")
     t = spark.table(tbl)
@@ -238,7 +238,7 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
       s" TBLPROPERTIES('TABLESPACE'='pg_default')")
     val t = spark.table(tbl)
     val expectedSchema = new StructType()
-      .add("ID", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
+      .add("ID", IntegerType, true, defaultMetadata(IntegerType, JdbcClientTypes.INTEGER))
     assert(t.schema === expectedSchema)
   }
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -78,15 +78,20 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
     // nullable is true in the expectedSchema because Spark always sets nullable to true
     // regardless of the JDBC metadata https://github.com/apache/spark/pull/18445
     var expectedSchema = new StructType().add("ID", StringType, true, defaultMetadata())
-    assert(t.schema === expectedSchema)
+    // If function is not overriden we don't want to compare external engine types
+    var expectedSchemaWithoutExternalEngineTypeName =
+      removeMetadataFromAllFields(expectedSchema, "externalEngineTypeName")
+    var schemaWithoutExternalEngineTypeName =
+      removeMetadataFromAllFields(t.schema, "externalEngineTypeName")
+    assert(schemaWithoutExternalEngineTypeName === expectedSchemaWithoutExternalEngineTypeName)
     sql(s"ALTER TABLE $catalogName.alt_table ALTER COLUMN ID DROP NOT NULL")
     t = spark.table(s"$catalogName.alt_table")
     expectedSchema = new StructType().add("ID", StringType, true, defaultMetadata())
 
     // If function is not overriden we don't want to compare external engine types
-    val expectedSchemaWithoutExternalEngineTypeName =
+    expectedSchemaWithoutExternalEngineTypeName =
       removeMetadataFromAllFields(expectedSchema, "externalEngineTypeName")
-    val schemaWithoutExternalEngineTypeName =
+    schemaWithoutExternalEngineTypeName =
       removeMetadataFromAllFields(t.schema, "externalEngineTypeName")
     assert(schemaWithoutExternalEngineTypeName === expectedSchemaWithoutExternalEngineTypeName)
     // Update nullability of not existing column

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -50,11 +50,11 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
 
   def defaultMetadata(
       dataType: DataType = StringType,
-      externalEngineTypeName: String = "STRING"): Metadata = new MetadataBuilder()
+      jdbcClientType: String = "STRING"): Metadata = new MetadataBuilder()
     .putLong("scale", 0)
     .putBoolean("isTimestampNTZ", false)
     .putBoolean("isSigned", dataType.isInstanceOf[NumericType])
-    .putString("externalEngineTypeName", externalEngineTypeName)
+    .putString("jdbcClientType", jdbcClientType)
     .build()
 
   /**
@@ -79,21 +79,21 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
     // regardless of the JDBC metadata https://github.com/apache/spark/pull/18445
     var expectedSchema = new StructType().add("ID", StringType, true, defaultMetadata())
     // If function is not overriden we don't want to compare external engine types
-    var expectedSchemaWithoutExternalEngineTypeName =
-      removeMetadataFromAllFields(expectedSchema, "externalEngineTypeName")
-    var schemaWithoutExternalEngineTypeName =
-      removeMetadataFromAllFields(t.schema, "externalEngineTypeName")
-    assert(schemaWithoutExternalEngineTypeName === expectedSchemaWithoutExternalEngineTypeName)
+    var expectedSchemaWithoutJdbcClientType =
+      removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
+    var schemaWithoutJdbcClientType =
+      removeMetadataFromAllFields(t.schema, "jdbcClientType")
+    assert(schemaWithoutJdbcClientType === expectedSchemaWithoutJdbcClientType)
     sql(s"ALTER TABLE $catalogName.alt_table ALTER COLUMN ID DROP NOT NULL")
     t = spark.table(s"$catalogName.alt_table")
     expectedSchema = new StructType().add("ID", StringType, true, defaultMetadata())
 
     // If function is not overriden we don't want to compare external engine types
-    expectedSchemaWithoutExternalEngineTypeName =
-      removeMetadataFromAllFields(expectedSchema, "externalEngineTypeName")
-    schemaWithoutExternalEngineTypeName =
-      removeMetadataFromAllFields(t.schema, "externalEngineTypeName")
-    assert(schemaWithoutExternalEngineTypeName === expectedSchemaWithoutExternalEngineTypeName)
+    expectedSchemaWithoutJdbcClientType =
+      removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
+    schemaWithoutJdbcClientType =
+      removeMetadataFromAllFields(t.schema, "jdbcClientType")
+    assert(schemaWithoutJdbcClientType === expectedSchemaWithoutJdbcClientType)
     // Update nullability of not existing column
     val sqlText = s"ALTER TABLE $catalogName.alt_table ALTER COLUMN bad_column DROP NOT NULL"
     checkError(
@@ -116,11 +116,11 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
       .add("ID2", StringType, true, defaultMetadata())
 
     // If function is not overriden we don't want to compare external engine types
-    val expectedSchemaWithoutExternalEngineTypeName =
-      removeMetadataFromAllFields(expectedSchema, "externalEngineTypeName")
-    val schemaWithoutExternalEngineTypeName =
-      removeMetadataFromAllFields(t.schema, "externalEngineTypeName")
-    assert(schemaWithoutExternalEngineTypeName === expectedSchemaWithoutExternalEngineTypeName)
+    val expectedSchemaWithoutJdbcClientType =
+      removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
+    val schemaWithoutJdbcClientType =
+      removeMetadataFromAllFields(t.schema, "jdbcClientType")
+    assert(schemaWithoutJdbcClientType === expectedSchemaWithoutJdbcClientType)
   }
 
   def testCreateTableWithProperty(tbl: String): Unit = {}
@@ -144,30 +144,30 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
       var t = spark.table(s"$catalogName.alt_table")
       var expectedSchema = new StructType()
         .add("ID", StringType, true, defaultMetadata())
-      var expectedSchemaWithoutExternalEngineTypeName =
-        removeMetadataFromAllFields(expectedSchema, "externalEngineTypeName")
-      var schemaWithoutExternalEngineTypeName =
-        removeMetadataFromAllFields(t.schema, "externalEngineTypeName")
-      assert(schemaWithoutExternalEngineTypeName === expectedSchemaWithoutExternalEngineTypeName)
+      var expectedSchemaWithoutJdbcClientType =
+        removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
+      var schemaWithoutJdbcClientType =
+        removeMetadataFromAllFields(t.schema, "jdbcClientType")
+      assert(schemaWithoutJdbcClientType === expectedSchemaWithoutJdbcClientType)
       sql(s"ALTER TABLE $catalogName.alt_table ADD COLUMNS (C1 STRING, C2 STRING)")
       t = spark.table(s"$catalogName.alt_table")
       expectedSchema = expectedSchema
         .add("C1", StringType, true, defaultMetadata())
         .add("C2", StringType, true, defaultMetadata())
-      expectedSchemaWithoutExternalEngineTypeName =
-        removeMetadataFromAllFields(expectedSchema, "externalEngineTypeName")
-      schemaWithoutExternalEngineTypeName =
-        removeMetadataFromAllFields(t.schema, "externalEngineTypeName")
-      assert(schemaWithoutExternalEngineTypeName === expectedSchemaWithoutExternalEngineTypeName)
+      expectedSchemaWithoutJdbcClientType =
+        removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
+      schemaWithoutJdbcClientType =
+        removeMetadataFromAllFields(t.schema, "jdbcClientType")
+      assert(schemaWithoutJdbcClientType === expectedSchemaWithoutJdbcClientType)
       sql(s"ALTER TABLE $catalogName.alt_table ADD COLUMNS (C3 STRING)")
       t = spark.table(s"$catalogName.alt_table")
       expectedSchema = expectedSchema
         .add("C3", StringType, true, defaultMetadata())
-      expectedSchemaWithoutExternalEngineTypeName =
-        removeMetadataFromAllFields(expectedSchema, "externalEngineTypeName")
-      schemaWithoutExternalEngineTypeName =
-        removeMetadataFromAllFields(t.schema, "externalEngineTypeName")
-      assert(schemaWithoutExternalEngineTypeName === expectedSchemaWithoutExternalEngineTypeName)
+      expectedSchemaWithoutJdbcClientType =
+        removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
+      schemaWithoutJdbcClientType =
+        removeMetadataFromAllFields(t.schema, "jdbcClientType")
+      assert(schemaWithoutJdbcClientType === expectedSchemaWithoutJdbcClientType)
       // Add already existing column
       checkError(
         exception = intercept[AnalysisException] {
@@ -199,11 +199,11 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
       val t = spark.table(s"$catalogName.alt_table")
       val expectedSchema = new StructType()
         .add("C2", StringType, true, defaultMetadata())
-      val expectedSchemaWithoutExternalEngineTypeName =
-        removeMetadataFromAllFields(expectedSchema, "externalEngineTypeName")
-      val schemaWithoutExternalEngineTypeName =
-        removeMetadataFromAllFields(t.schema, "externalEngineTypeName")
-      assert(schemaWithoutExternalEngineTypeName === expectedSchemaWithoutExternalEngineTypeName)
+      val expectedSchemaWithoutJdbcClientType =
+        removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
+      val schemaWithoutJdbcClientType =
+        removeMetadataFromAllFields(t.schema, "jdbcClientType")
+      assert(schemaWithoutJdbcClientType === expectedSchemaWithoutJdbcClientType)
       // Drop not existing column
       val sqlText = s"ALTER TABLE $catalogName.alt_table DROP COLUMN bad_column"
       checkError(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -314,7 +314,7 @@ object JdbcUtils extends Logging with SQLConfHelper {
       metadata.putBoolean("isSigned", isSigned)
       metadata.putBoolean("isTimestampNTZ", isTimestampNTZ)
       metadata.putLong("scale", fieldScale)
-      metadata.putString("externalEngineTypeName", typeName)
+      metadata.putString("jdbcClientType", typeName)
       dialect.updateExtraColumnMeta(conn, rsmd, i + 1, metadata)
 
       val columnType =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -314,6 +314,7 @@ object JdbcUtils extends Logging with SQLConfHelper {
       metadata.putBoolean("isSigned", isSigned)
       metadata.putBoolean("isTimestampNTZ", isTimestampNTZ)
       metadata.putLong("scale", fieldScale)
+      metadata.putString("remoteTypeName", typeName)
       dialect.updateExtraColumnMeta(conn, rsmd, i + 1, metadata)
 
       val columnType =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -314,7 +314,7 @@ object JdbcUtils extends Logging with SQLConfHelper {
       metadata.putBoolean("isSigned", isSigned)
       metadata.putBoolean("isTimestampNTZ", isTimestampNTZ)
       metadata.putLong("scale", fieldScale)
-      metadata.putString("remoteTypeName", typeName)
+      metadata.putString("externalEngineTypeName", typeName)
       dialect.updateExtraColumnMeta(conn, rsmd, i + 1, metadata)
 
       val columnType =

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -38,10 +38,11 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   val tempDir = Utils.createTempDir()
   val url = s"jdbc:h2:${tempDir.getCanonicalPath};user=testUser;password=testPass"
 
-  def defaultMetadata(dataType: DataType): Metadata = new MetadataBuilder()
+  def defaultMetadata(dataType: DataType, remoteTypeName: String): Metadata = new MetadataBuilder()
     .putLong("scale", 0)
     .putBoolean("isTimestampNTZ", false)
     .putBoolean("isSigned", dataType.isInstanceOf[NumericType])
+    .putString("remoteTypeName", remoteTypeName)
     .build()
 
   override def sparkConf: SparkConf = super.sparkConf
@@ -144,8 +145,12 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   test("load a table") {
     val t = spark.table("h2.test.people")
     val expectedSchema = new StructType()
-      .add("NAME", VarcharType(32), true, defaultMetadata(VarcharType(32)))
-      .add("ID", IntegerType, true, defaultMetadata(IntegerType))
+      .add(
+        "NAME",
+        VarcharType(32),
+        true,
+        defaultMetadata(VarcharType(32), H2RemoteTypeNames.STRING))
+      .add("ID", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
     assert(t.schema === CharVarcharUtils.replaceCharVarcharWithStringInSchema(expectedSchema))
     Seq(
       "h2.test.not_existing_table" -> "`h2`.`test`.`not_existing_table`",
@@ -187,13 +192,17 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       sql(s"ALTER TABLE $tableName ADD COLUMNS (C1 INTEGER, C2 STRING)")
       var t = spark.table(tableName)
       var expectedSchema = new StructType()
-        .add("ID", IntegerType, true, defaultMetadata(IntegerType))
-        .add("C1", IntegerType, true, defaultMetadata(IntegerType))
-        .add("C2", StringType, true, defaultMetadata(StringType))
+        .add("ID", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
+        .add("C1", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
+        .add("C2", StringType, true, defaultMetadata(StringType, H2RemoteTypeNames.CLOB))
       assert(t.schema === expectedSchema)
       sql(s"ALTER TABLE $tableName ADD COLUMNS (c3 DOUBLE)")
       t = spark.table(tableName)
-      expectedSchema = expectedSchema.add("c3", DoubleType, true, defaultMetadata(DoubleType))
+      expectedSchema = expectedSchema.add(
+        "c3",
+        DoubleType,
+        true,
+        defaultMetadata(DoubleType, H2RemoteTypeNames.DOUBLE))
       assert(t.schema === expectedSchema)
       // Add already existing column
       checkError(
@@ -231,8 +240,8 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       sql(s"ALTER TABLE $tableName RENAME COLUMN id TO C")
       val t = spark.table(tableName)
       val expectedSchema = new StructType()
-        .add("C", IntegerType, true, defaultMetadata(IntegerType))
-        .add("C0", IntegerType, true, defaultMetadata(IntegerType))
+        .add("C", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
+        .add("C0", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
       assert(t.schema === expectedSchema)
       // Rename to already existing column
       checkError(
@@ -271,7 +280,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       sql(s"ALTER TABLE $tableName DROP COLUMN c3")
       val t = spark.table(tableName)
       val expectedSchema = new StructType()
-        .add("C2", IntegerType, true, defaultMetadata(IntegerType))
+        .add("C2", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
       assert(t.schema === expectedSchema)
       // Drop not existing column
       val sqlText = s"ALTER TABLE $tableName DROP COLUMN bad_column"
@@ -307,8 +316,8 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       sql(s"ALTER TABLE $tableName ALTER COLUMN deptno TYPE DOUBLE")
       val t = spark.table(tableName)
       val expectedSchema = new StructType()
-        .add("ID", DoubleType, true, defaultMetadata(DoubleType))
-        .add("deptno", DoubleType, true, defaultMetadata(DoubleType))
+        .add("ID", DoubleType, true, defaultMetadata(DoubleType, H2RemoteTypeNames.DOUBLE))
+        .add("deptno", DoubleType, true, defaultMetadata(DoubleType, H2RemoteTypeNames.DOUBLE))
       assert(t.schema === expectedSchema)
       // Update not existing column
       val sqlText = s"ALTER TABLE $tableName ALTER COLUMN bad_column TYPE DOUBLE"
@@ -352,8 +361,8 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       sql(s"ALTER TABLE $tableName ALTER COLUMN deptno DROP NOT NULL")
       val t = spark.table(tableName)
       val expectedSchema = new StructType()
-        .add("ID", IntegerType, true, defaultMetadata(IntegerType))
-        .add("deptno", IntegerType, true, defaultMetadata(IntegerType))
+        .add("ID", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
+        .add("deptno", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
       assert(t.schema === expectedSchema)
       // Update nullability of not existing column
       val sqlText = s"ALTER TABLE $tableName ALTER COLUMN bad_column DROP NOT NULL"
@@ -482,8 +491,8 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       sql(s"CREATE TABLE $tableName (c1 INTEGER NOT NULL, c2 INTEGER)")
       var t = spark.table(tableName)
       var expectedSchema = new StructType()
-        .add("c1", IntegerType, true, defaultMetadata(IntegerType))
-        .add("c2", IntegerType, true, defaultMetadata(IntegerType))
+        .add("c1", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
+        .add("c2", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
       assert(t.schema === expectedSchema)
 
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
@@ -503,8 +512,8 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
         sql(s"ALTER TABLE $tableName RENAME COLUMN C2 TO c3")
         expectedSchema = new StructType()
-          .add("c1", IntegerType, true, defaultMetadata(IntegerType))
-          .add("c3", IntegerType, true, defaultMetadata(IntegerType))
+          .add("c1", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
+          .add("c2", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
         t = spark.table(tableName)
         assert(t.schema === expectedSchema)
       }
@@ -526,7 +535,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
         sql(s"ALTER TABLE $tableName DROP COLUMN C3")
         expectedSchema = new StructType()
-          .add("c1", IntegerType, true, defaultMetadata(IntegerType))
+          .add("c1", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
         t = spark.table(tableName)
         assert(t.schema === expectedSchema)
       }
@@ -548,7 +557,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
         sql(s"ALTER TABLE $tableName ALTER COLUMN C1 TYPE DOUBLE")
         expectedSchema = new StructType()
-          .add("c1", DoubleType, true, defaultMetadata(DoubleType))
+          .add("c1", DoubleType, true, defaultMetadata(DoubleType, H2RemoteTypeNames.DOUBLE))
         t = spark.table(tableName)
         assert(t.schema === expectedSchema)
       }
@@ -570,7 +579,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
         sql(s"ALTER TABLE $tableName ALTER COLUMN C1 DROP NOT NULL")
         expectedSchema = new StructType()
-          .add("c1", DoubleType, true, defaultMetadata(IntegerType))
+          .add("c1", DoubleType, true, defaultMetadata(DoubleType, H2RemoteTypeNames.DOUBLE))
         t = spark.table(tableName)
         assert(t.schema === expectedSchema)
       }
@@ -640,8 +649,12 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       sql(s"ALTER TABLE $tableName ALTER COLUMN deptno TYPE VARCHAR(30)")
       val t = spark.table(tableName)
       val expected = new StructType()
-        .add("ID", CharType(10), true, defaultMetadata(CharType(10)))
-        .add("deptno", VarcharType(30), true, defaultMetadata(VarcharType(30)))
+        .add("ID", CharType(10), true, defaultMetadata(CharType(10), H2RemoteTypeNames.CHAR))
+        .add(
+          "deptno",
+          VarcharType(30),
+          true,
+          defaultMetadata(VarcharType(30), H2RemoteTypeNames.STRING))
       val replaced = CharVarcharUtils.replaceCharVarcharWithStringInSchema(expected)
       assert(t.schema === replaced)
     }
@@ -654,13 +667,18 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
         .executeUpdate())
       withSQLConf(SQLConf.LEGACY_CHAR_VARCHAR_AS_STRING.key -> "true") {
         val expected = new StructType()
-          .add("ID", StringType, true, defaultMetadata(StringType))
-          .add("DEPTNO", StringType, true, defaultMetadata(StringType))
+          // We are not changing the remote type name so it remains CHAR
+          .add("ID", StringType, true, defaultMetadata(StringType, H2RemoteTypeNames.CHAR))
+          .add("DEPTNO", StringType, true, defaultMetadata(StringType, H2RemoteTypeNames.STRING))
         assert(sql(s"SELECT * FROM h2.test.char_tbl").schema === expected)
       }
       val expected = new StructType()
-        .add("ID", CharType(5), true, defaultMetadata(CharType(5)))
-        .add("DEPTNO", VarcharType(10), true, defaultMetadata(VarcharType(10)))
+        .add("ID", CharType(5), true, defaultMetadata(CharType(5), H2RemoteTypeNames.CHAR))
+        .add(
+          "DEPTNO",
+          VarcharType(10),
+          true,
+          defaultMetadata(VarcharType(10), H2RemoteTypeNames.STRING))
       val replaced = CharVarcharUtils.replaceCharVarcharWithStringInSchema(expected)
       assert(sql(s"SELECT * FROM h2.test.char_tbl").schema === replaced)
     } finally {
@@ -682,4 +700,12 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       assert(plan.isInstanceOf[InMemoryTableScanExec])
     }
   }
+}
+
+object H2RemoteTypeNames {
+  val CHAR = "CHARACTER"
+  val CLOB = "CHARACTER LARGE OBJECT"
+  val DOUBLE = "DOUBLE PRECISION"
+  val INTEGER = "INTEGER"
+  val STRING = "CHARACTER VARYING"
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -536,7 +536,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
             true,
             defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
           .add(
-            "c2",
+            "c3",
             IntegerType,
             true,
             defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -38,11 +38,21 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   val tempDir = Utils.createTempDir()
   val url = s"jdbc:h2:${tempDir.getCanonicalPath};user=testUser;password=testPass"
 
-  def defaultMetadata(dataType: DataType, remoteTypeName: String): Metadata = new MetadataBuilder()
+  object ExternalEngineTypeNames {
+    val CHAR = "CHARACTER"
+    val CLOB = "CHARACTER LARGE OBJECT"
+    val DOUBLE = "DOUBLE PRECISION"
+    val INTEGER = "INTEGER"
+    val STRING = "CHARACTER VARYING"
+  }
+
+  def defaultMetadata(
+      dataType: DataType,
+      externalEngineTypeName: String): Metadata = new MetadataBuilder()
     .putLong("scale", 0)
     .putBoolean("isTimestampNTZ", false)
     .putBoolean("isSigned", dataType.isInstanceOf[NumericType])
-    .putString("remoteTypeName", remoteTypeName)
+    .putString("externalEngineTypeName", externalEngineTypeName)
     .build()
 
   override def sparkConf: SparkConf = super.sparkConf
@@ -149,8 +159,8 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
         "NAME",
         VarcharType(32),
         true,
-        defaultMetadata(VarcharType(32), H2RemoteTypeNames.STRING))
-      .add("ID", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
+        defaultMetadata(VarcharType(32), ExternalEngineTypeNames.STRING))
+      .add("ID", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
     assert(t.schema === CharVarcharUtils.replaceCharVarcharWithStringInSchema(expectedSchema))
     Seq(
       "h2.test.not_existing_table" -> "`h2`.`test`.`not_existing_table`",
@@ -192,9 +202,9 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       sql(s"ALTER TABLE $tableName ADD COLUMNS (C1 INTEGER, C2 STRING)")
       var t = spark.table(tableName)
       var expectedSchema = new StructType()
-        .add("ID", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
-        .add("C1", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
-        .add("C2", StringType, true, defaultMetadata(StringType, H2RemoteTypeNames.CLOB))
+        .add("ID", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
+        .add("C1", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
+        .add("C2", StringType, true, defaultMetadata(StringType, ExternalEngineTypeNames.CLOB))
       assert(t.schema === expectedSchema)
       sql(s"ALTER TABLE $tableName ADD COLUMNS (c3 DOUBLE)")
       t = spark.table(tableName)
@@ -202,7 +212,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
         "c3",
         DoubleType,
         true,
-        defaultMetadata(DoubleType, H2RemoteTypeNames.DOUBLE))
+        defaultMetadata(DoubleType, ExternalEngineTypeNames.DOUBLE))
       assert(t.schema === expectedSchema)
       // Add already existing column
       checkError(
@@ -240,8 +250,8 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       sql(s"ALTER TABLE $tableName RENAME COLUMN id TO C")
       val t = spark.table(tableName)
       val expectedSchema = new StructType()
-        .add("C", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
-        .add("C0", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
+        .add("C", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
+        .add("C0", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
       assert(t.schema === expectedSchema)
       // Rename to already existing column
       checkError(
@@ -280,7 +290,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       sql(s"ALTER TABLE $tableName DROP COLUMN c3")
       val t = spark.table(tableName)
       val expectedSchema = new StructType()
-        .add("C2", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
+        .add("C2", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
       assert(t.schema === expectedSchema)
       // Drop not existing column
       val sqlText = s"ALTER TABLE $tableName DROP COLUMN bad_column"
@@ -316,8 +326,12 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       sql(s"ALTER TABLE $tableName ALTER COLUMN deptno TYPE DOUBLE")
       val t = spark.table(tableName)
       val expectedSchema = new StructType()
-        .add("ID", DoubleType, true, defaultMetadata(DoubleType, H2RemoteTypeNames.DOUBLE))
-        .add("deptno", DoubleType, true, defaultMetadata(DoubleType, H2RemoteTypeNames.DOUBLE))
+        .add("ID", DoubleType, true, defaultMetadata(DoubleType, ExternalEngineTypeNames.DOUBLE))
+        .add(
+          "deptno",
+          DoubleType,
+          true,
+          defaultMetadata(DoubleType, ExternalEngineTypeNames.DOUBLE))
       assert(t.schema === expectedSchema)
       // Update not existing column
       val sqlText = s"ALTER TABLE $tableName ALTER COLUMN bad_column TYPE DOUBLE"
@@ -361,8 +375,12 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       sql(s"ALTER TABLE $tableName ALTER COLUMN deptno DROP NOT NULL")
       val t = spark.table(tableName)
       val expectedSchema = new StructType()
-        .add("ID", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
-        .add("deptno", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
+        .add("ID", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
+        .add(
+          "deptno",
+          IntegerType,
+          true,
+          defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
       assert(t.schema === expectedSchema)
       // Update nullability of not existing column
       val sqlText = s"ALTER TABLE $tableName ALTER COLUMN bad_column DROP NOT NULL"
@@ -491,8 +509,8 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       sql(s"CREATE TABLE $tableName (c1 INTEGER NOT NULL, c2 INTEGER)")
       var t = spark.table(tableName)
       var expectedSchema = new StructType()
-        .add("c1", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
-        .add("c2", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
+        .add("c1", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
+        .add("c2", IntegerType, true, defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
       assert(t.schema === expectedSchema)
 
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
@@ -512,8 +530,16 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
         sql(s"ALTER TABLE $tableName RENAME COLUMN C2 TO c3")
         expectedSchema = new StructType()
-          .add("c1", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
-          .add("c2", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
+          .add(
+            "c1",
+            IntegerType,
+            true,
+            defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
+          .add(
+            "c2",
+            IntegerType,
+            true,
+            defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
         t = spark.table(tableName)
         assert(t.schema === expectedSchema)
       }
@@ -535,7 +561,11 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
         sql(s"ALTER TABLE $tableName DROP COLUMN C3")
         expectedSchema = new StructType()
-          .add("c1", IntegerType, true, defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
+          .add(
+            "c1",
+            IntegerType,
+            true,
+            defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
         t = spark.table(tableName)
         assert(t.schema === expectedSchema)
       }
@@ -557,7 +587,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
         sql(s"ALTER TABLE $tableName ALTER COLUMN C1 TYPE DOUBLE")
         expectedSchema = new StructType()
-          .add("c1", DoubleType, true, defaultMetadata(DoubleType, H2RemoteTypeNames.DOUBLE))
+          .add("c1", DoubleType, true, defaultMetadata(DoubleType, ExternalEngineTypeNames.DOUBLE))
         t = spark.table(tableName)
         assert(t.schema === expectedSchema)
       }
@@ -579,7 +609,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
         sql(s"ALTER TABLE $tableName ALTER COLUMN C1 DROP NOT NULL")
         expectedSchema = new StructType()
-          .add("c1", DoubleType, true, defaultMetadata(DoubleType, H2RemoteTypeNames.DOUBLE))
+          .add("c1", DoubleType, true, defaultMetadata(DoubleType, ExternalEngineTypeNames.DOUBLE))
         t = spark.table(tableName)
         assert(t.schema === expectedSchema)
       }
@@ -649,12 +679,12 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       sql(s"ALTER TABLE $tableName ALTER COLUMN deptno TYPE VARCHAR(30)")
       val t = spark.table(tableName)
       val expected = new StructType()
-        .add("ID", CharType(10), true, defaultMetadata(CharType(10), H2RemoteTypeNames.CHAR))
+        .add("ID", CharType(10), true, defaultMetadata(CharType(10), ExternalEngineTypeNames.CHAR))
         .add(
           "deptno",
           VarcharType(30),
           true,
-          defaultMetadata(VarcharType(30), H2RemoteTypeNames.STRING))
+          defaultMetadata(VarcharType(30), ExternalEngineTypeNames.STRING))
       val replaced = CharVarcharUtils.replaceCharVarcharWithStringInSchema(expected)
       assert(t.schema === replaced)
     }
@@ -668,17 +698,21 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       withSQLConf(SQLConf.LEGACY_CHAR_VARCHAR_AS_STRING.key -> "true") {
         val expected = new StructType()
           // We are not changing the remote type name so it remains CHAR
-          .add("ID", StringType, true, defaultMetadata(StringType, H2RemoteTypeNames.CHAR))
-          .add("DEPTNO", StringType, true, defaultMetadata(StringType, H2RemoteTypeNames.STRING))
+          .add("ID", StringType, true, defaultMetadata(StringType, ExternalEngineTypeNames.CHAR))
+          .add(
+            "DEPTNO",
+            StringType,
+            true,
+            defaultMetadata(StringType, ExternalEngineTypeNames.STRING))
         assert(sql(s"SELECT * FROM h2.test.char_tbl").schema === expected)
       }
       val expected = new StructType()
-        .add("ID", CharType(5), true, defaultMetadata(CharType(5), H2RemoteTypeNames.CHAR))
+        .add("ID", CharType(5), true, defaultMetadata(CharType(5), ExternalEngineTypeNames.CHAR))
         .add(
           "DEPTNO",
           VarcharType(10),
           true,
-          defaultMetadata(VarcharType(10), H2RemoteTypeNames.STRING))
+          defaultMetadata(VarcharType(10), ExternalEngineTypeNames.STRING))
       val replaced = CharVarcharUtils.replaceCharVarcharWithStringInSchema(expected)
       assert(sql(s"SELECT * FROM h2.test.char_tbl").schema === replaced)
     } finally {
@@ -700,12 +734,4 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       assert(plan.isInstanceOf[InMemoryTableScanExec])
     }
   }
-}
-
-object H2RemoteTypeNames {
-  val CHAR = "CHARACTER"
-  val CLOB = "CHARACTER LARGE OBJECT"
-  val DOUBLE = "DOUBLE PRECISION"
-  val INTEGER = "INTEGER"
-  val STRING = "CHARACTER VARYING"
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -78,10 +78,11 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  def defaultMetadata(dataType: DataType): Metadata = new MetadataBuilder()
+  def defaultMetadata(dataType: DataType, remoteTypeName: String): Metadata = new MetadataBuilder()
     .putLong("scale", 0)
     .putBoolean("isTimestampNTZ", false)
     .putBoolean("isSigned", dataType.isInstanceOf[NumericType])
+    .putString("remoteTypeName", remoteTypeName)
     .build()
 
   override def beforeAll(): Unit = {
@@ -1429,8 +1430,14 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-16848: jdbc API throws an exception for user specified schema") {
-    val schema = StructType(Seq(StructField("name", StringType, false, defaultMetadata(StringType)),
-      StructField("theid", IntegerType, false, defaultMetadata(IntegerType))))
+    val schema = StructType(Seq(
+      StructField("name", StringType, false, defaultMetadata(StringType, H2RemoteTypeNames.STRING)),
+      StructField(
+        "theid",
+        IntegerType,
+        false,
+        defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))
+    ))
     val parts = Array[String]("THEID < 2", "THEID >= 2")
     val e1 = intercept[AnalysisException] {
       spark.read.schema(schema).jdbc(urlWithUserAndPass, "TEST.PEOPLE", parts, new Properties())
@@ -1451,8 +1458,17 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     val df = spark.read.jdbc(urlWithUserAndPass, "TEST.PEOPLE", parts, props)
     assert(df.schema.size === 2)
     val structType = CatalystSqlParser.parseTableSchema(customSchema)
+    val sparkToRemoteDataType: Map[DataType, String] = Map(
+      IntegerType -> H2RemoteTypeNames.INTEGER,
+      StringType -> H2RemoteTypeNames.STRING,
+      VarcharType(32) -> H2RemoteTypeNames.STRING)
     val expectedSchema = new StructType(structType.map(
-      f => StructField(f.name, f.dataType, f.nullable, defaultMetadata(f.dataType))).toArray)
+      f => StructField(
+        f.name,
+        f.dataType,
+        f.nullable,
+        defaultMetadata(f.dataType, sparkToRemoteDataType(f.dataType)))
+    ).toArray)
     assert(df.schema === CharVarcharUtils.replaceCharVarcharWithStringInSchema(expectedSchema))
     assert(df.count() === 3)
   }
@@ -1469,8 +1485,17 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
         """.stripMargin.replaceAll("\n", " "))
       val df = sql("select * from people_view")
       assert(df.schema.length === 2)
+      val sparkToRemoteDataType: Map[DataType, String] = Map(
+        IntegerType -> H2RemoteTypeNames.INTEGER,
+        StringType -> H2RemoteTypeNames.STRING,
+        VarcharType(32) -> H2RemoteTypeNames.STRING)
       val expectedSchema = new StructType(CatalystSqlParser.parseTableSchema(customSchema)
-        .map(f => StructField(f.name, f.dataType, f.nullable, defaultMetadata(f.dataType))).toArray)
+        .map(f => StructField(
+          f.name,
+          f.dataType,
+          f.nullable,
+          defaultMetadata(f.dataType, sparkToRemoteDataType(f.dataType)))
+        ).toArray)
 
       assert(df.schema === CharVarcharUtils.replaceCharVarcharWithStringInSchema(expectedSchema))
       assert(df.count() === 3)
@@ -1616,9 +1641,16 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     }
 
   test("jdbc data source shouldn't have unnecessary metadata in its schema") {
-    var schema = StructType(
-      Seq(StructField("NAME", VarcharType(32), true, defaultMetadata(VarcharType(32))),
-      StructField("THEID", IntegerType, true, defaultMetadata(IntegerType))))
+    var schema = StructType(Seq(
+      StructField(
+        "NAME",
+        VarcharType(32),
+        true,
+        defaultMetadata(VarcharType(32), H2RemoteTypeNames.STRING)),
+      StructField("THEID",
+        IntegerType,
+        true,
+        defaultMetadata(IntegerType, H2RemoteTypeNames.INTEGER))))
     schema = CharVarcharUtils.replaceCharVarcharWithStringInSchema(schema)
     val df = spark.read.format("jdbc")
       .option("Url", urlWithUserAndPass)
@@ -2247,4 +2279,9 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
         parameters = Map("jdbcDialect" -> dialect.getClass.getSimpleName))
     }
   }
+}
+
+object H2RemoteTypeNames {
+  val INTEGER = "INTEGER"
+  val STRING = "CHARACTER VARYING"
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -78,18 +78,18 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  object ExternalEngineTypeNames {
+  object JdbcClientTypes {
     val INTEGER = "INTEGER"
     val STRING = "CHARACTER VARYING"
   }
 
   def defaultMetadata(
       dataType: DataType,
-      externalEngineTypeName: String): Metadata = new MetadataBuilder()
+      jdbcClientType: String): Metadata = new MetadataBuilder()
     .putLong("scale", 0)
     .putBoolean("isTimestampNTZ", false)
     .putBoolean("isSigned", dataType.isInstanceOf[NumericType])
-    .putString("externalEngineTypeName", externalEngineTypeName)
+    .putString("jdbcClientType", jdbcClientType)
     .build()
 
   override def beforeAll(): Unit = {
@@ -1442,12 +1442,12 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
         "name",
         StringType,
         false,
-        defaultMetadata(StringType, ExternalEngineTypeNames.STRING)),
+        defaultMetadata(StringType, JdbcClientTypes.STRING)),
       StructField(
         "theid",
         IntegerType,
         false,
-        defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))
+        defaultMetadata(IntegerType, JdbcClientTypes.INTEGER))
     ))
     val parts = Array[String]("THEID < 2", "THEID >= 2")
     val e1 = intercept[AnalysisException] {
@@ -1470,9 +1470,9 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     assert(df.schema.size === 2)
     val structType = CatalystSqlParser.parseTableSchema(customSchema)
     val sparkToRemoteDataType: Map[DataType, String] = Map(
-      IntegerType -> ExternalEngineTypeNames.INTEGER,
-      StringType -> ExternalEngineTypeNames.STRING,
-      VarcharType(32) -> ExternalEngineTypeNames.STRING)
+      IntegerType -> JdbcClientTypes.INTEGER,
+      StringType -> JdbcClientTypes.STRING,
+      VarcharType(32) -> JdbcClientTypes.STRING)
     val expectedSchema = new StructType(structType.map(
       f => StructField(
         f.name,
@@ -1497,9 +1497,9 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       val df = sql("select * from people_view")
       assert(df.schema.length === 2)
       val sparkToRemoteDataType: Map[DataType, String] = Map(
-        IntegerType -> ExternalEngineTypeNames.INTEGER,
-        StringType -> ExternalEngineTypeNames.STRING,
-        VarcharType(32) -> ExternalEngineTypeNames.STRING)
+        IntegerType -> JdbcClientTypes.INTEGER,
+        StringType -> JdbcClientTypes.STRING,
+        VarcharType(32) -> JdbcClientTypes.STRING)
       val expectedSchema = new StructType(CatalystSqlParser.parseTableSchema(customSchema)
         .map(f => StructField(
           f.name,
@@ -1657,11 +1657,11 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
         "NAME",
         VarcharType(32),
         true,
-        defaultMetadata(VarcharType(32), ExternalEngineTypeNames.STRING)),
+        defaultMetadata(VarcharType(32), JdbcClientTypes.STRING)),
       StructField("THEID",
         IntegerType,
         true,
-        defaultMetadata(IntegerType, ExternalEngineTypeNames.INTEGER))))
+        defaultMetadata(IntegerType, JdbcClientTypes.INTEGER))))
     schema = CharVarcharUtils.replaceCharVarcharWithStringInSchema(schema)
     val df = spark.read.format("jdbc")
       .option("Url", urlWithUserAndPass)


### PR DESCRIPTION
… metadata of StructField

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Store in the metadata of each StructField in JDBC connections the external engine data type.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
it can be useful when looking at analyzed plan to know how the external engine data types are mapped to Spark types.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

By extending existing unit tests to verify the new funcitonality.
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
