### PR TITLE
[SPARK-51816][SQL] Simplify `StatFunctions.multipleApproxQuantiles` with dataframe APIs

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -20,9 +20,8 @@ package org.apache.spark.sql.execution.stat
 import java.util.Locale
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{Column, Row}
+import org.apache.spark.sql.Column
 import org.apache.spark.sql.catalyst.expressions.aggregate._
-import org.apache.spark.sql.catalyst.util.QuantileSummaries
 import org.apache.spark.sql.classic.{DataFrame, Dataset}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.functions._
@@ -68,45 +67,35 @@ object StatFunctions extends Logging {
       relativeError: Double): Seq[Seq[Double]] = {
     require(relativeError >= 0,
       s"Relative Error must be non-negative but got $relativeError")
+    require(probabilities.forall(p => p >= 0 && p <= 1.0),
+      "percentile should be in the range [0.0, 1.0]")
     val columns: Seq[Column] = cols.map { colName =>
       val field = df.resolve(colName)
       require(field.dataType.isInstanceOf[NumericType],
         s"Quantile calculation for column $colName with data type ${field.dataType}" +
         " is not supported.")
-      Column(colName).cast(DoubleType)
+      col(colName).cast(DoubleType)
     }
-    val emptySummaries = Array.fill(cols.size)(
-      new QuantileSummaries(QuantileSummaries.defaultCompressThreshold, relativeError))
 
-    // Note that it works more or less by accident as `rdd.aggregate` is not a pure function:
-    // this function returns the same array as given in the input (because `aggregate` reuses
-    // the same argument).
-    def apply(summaries: Array[QuantileSummaries], row: Row): Array[QuantileSummaries] = {
-      var i = 0
-      while (i < summaries.length) {
-        if (!row.isNullAt(i)) {
-          val v = row.getDouble(i)
-          if (!v.isNaN) summaries(i) = summaries(i).insert(v)
-        }
-        i += 1
+    // approx_percentile needs integer accuracy
+    val accuracy = if (relativeError == 0.0) {
+      Int.MaxValue
+    } else {
+      math.min(Int.MaxValue, (1.0 / relativeError).ceil.toLong).toInt
+    }
+
+    val results = Array.fill(cols.size)(Seq.empty[Double])
+    df.select(posexplode(array(columns: _*)).as(Seq("index", "value")))
+      .where(!isnull(col("value")) && !isnan(col("value")))
+      .groupBy("index")
+      .agg(approx_percentile(col("value"), lit(probabilities), lit(accuracy)))
+      .collect()
+      .foreach { row =>
+        val index = row.getInt(0)
+        val quantiles = row.getSeq[Double](1)
+        results(index) = quantiles
       }
-      summaries
-    }
-
-    def merge(
-        sum1: Array[QuantileSummaries],
-        sum2: Array[QuantileSummaries]): Array[QuantileSummaries] = {
-      sum1.zip(sum2).map { case (s1, s2) => s1.compress().merge(s2.compress()) }
-    }
-    val summaries = df.select(columns: _*).materializedRdd
-      .treeAggregate(emptySummaries)(apply, merge)
-
-    summaries.map {
-      summary => summary.query(probabilities) match {
-        case Some(q) => q
-        case None => Seq()
-      }
-    }.toImmutableArraySeq
+    results.toImmutableArraySeq
   }
 
   /** Calculate the Pearson Correlation Coefficient for the given columns */


### PR DESCRIPTION

### What changes were proposed in this pull request?
Simplify `StatFunctions.multipleApproxQuantiles` with dataframe APIs


### Why are the changes needed?
follow up of previous work (e.g. https://github.com/apache/spark/commit/5d3b1e6ed549ce9b6aa1f13ff60bce290c2b5160, 
https://github.com/apache/spark/commit/6a0713a141fa98d83029d8388508cbbc40fd554e, https://github.com/apache/spark/commit/a2f3958a29ad16a1b3e372156d6c6ae4959d5e8c ) that replaces RDD with DataFrame

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
existing tests should cover


### Was this patch authored or co-authored using generative AI tooling?
no
