### PR TITLE
[SPARK-51806][BUILD][4.0] Upgrade kryo-shaded to 4.0.3

### DIFF
--- a/common/unsafe/pom.xml
+++ b/common/unsafe/pom.xml
@@ -80,6 +80,14 @@
       <groupId>com.twitter</groupId>
       <artifactId>chill_${scala.binary.version}</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.esotericsoftware</groupId>
+      <artifactId>kryo-shaded</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.objenesis</groupId>
+      <artifactId>objenesis</artifactId>
+    </dependency>
 
     <!-- Core dependencies -->
     <dependency>

--- a/core/benchmarks/KryoBenchmark-jdk21-results.txt
+++ b/core/benchmarks/KryoBenchmark-jdk21-results.txt
@@ -2,27 +2,27 @@
 Benchmark Kryo Unsafe vs safe Serialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.8.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 Benchmark Kryo Unsafe vs safe Serialization:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-basicTypes: Int with unsafe:true                       168            173           7          5.9         168.2       1.0X
-basicTypes: Long with unsafe:true                      186            191           7          5.4         186.3       0.9X
-basicTypes: Float with unsafe:true                     183            188           6          5.5         183.2       0.9X
-basicTypes: Double with unsafe:true                    187            194           9          5.4         186.8       0.9X
-Array: Int with unsafe:true                              1              1           0        767.7           1.3     129.1X
-Array: Long with unsafe:true                             2              2           0        491.1           2.0      82.6X
-Array: Float with unsafe:true                            1              1           0        759.5           1.3     127.8X
-Array: Double with unsafe:true                           2              2           0        496.6           2.0      83.5X
-Map of string->Double  with unsafe:true                 27             27           1         37.7          26.5       6.3X
-basicTypes: Int with unsafe:false                      231            232           1          4.3         231.3       0.7X
-basicTypes: Long with unsafe:false                     237            241           5          4.2         237.3       0.7X
-basicTypes: Float with unsafe:false                    216            218           2          4.6         216.1       0.8X
-basicTypes: Double with unsafe:false                   233            235           2          4.3         233.2       0.7X
-Array: Int with unsafe:false                            13             13           0         78.8          12.7      13.3X
-Array: Long with unsafe:false                           21             22           0         46.7          21.4       7.9X
-Array: Float with unsafe:false                           8              8           0        125.7           8.0      21.1X
-Array: Double with unsafe:false                         11             11           0         90.2          11.1      15.2X
-Map of string->Double  with unsafe:false                28             28           0         35.8          27.9       6.0X
+basicTypes: Int with unsafe:true                       169            174           8          5.9         169.0       1.0X
+basicTypes: Long with unsafe:true                      178            185           6          5.6         178.0       0.9X
+basicTypes: Float with unsafe:true                     188            194           6          5.3         188.5       0.9X
+basicTypes: Double with unsafe:true                    191            201          10          5.2         190.5       0.9X
+Array: Int with unsafe:true                              1              1           0        767.3           1.3     129.7X
+Array: Long with unsafe:true                             2              2           0        502.3           2.0      84.9X
+Array: Float with unsafe:true                            1              1           0        759.9           1.3     128.4X
+Array: Double with unsafe:true                           2              2           0        489.7           2.0      82.7X
+Map of string->Double  with unsafe:true                 27             28           1         36.8          27.2       6.2X
+basicTypes: Int with unsafe:false                      201            202           1          5.0         201.3       0.8X
+basicTypes: Long with unsafe:false                     218            224           9          4.6         218.0       0.8X
+basicTypes: Float with unsafe:false                    196            197           1          5.1         196.1       0.9X
+basicTypes: Double with unsafe:false                   209            210           1          4.8         209.0       0.8X
+Array: Int with unsafe:false                            13             13           0         79.4          12.6      13.4X
+Array: Long with unsafe:false                           21             22           1         46.7          21.4       7.9X
+Array: Float with unsafe:false                           6              6           0        175.4           5.7      29.6X
+Array: Double with unsafe:false                         11             11           0         89.6          11.2      15.1X
+Map of string->Double  with unsafe:false                28             28           1         36.3          27.6       6.1X
 
 

--- a/core/benchmarks/KryoBenchmark-results.txt
+++ b/core/benchmarks/KryoBenchmark-results.txt
@@ -2,27 +2,27 @@
 Benchmark Kryo Unsafe vs safe Serialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.8.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 Benchmark Kryo Unsafe vs safe Serialization:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-basicTypes: Int with unsafe:true                       168            169           1          5.9         168.2       1.0X
-basicTypes: Long with unsafe:true                      194            195           2          5.2         193.6       0.9X
-basicTypes: Float with unsafe:true                     189            190           1          5.3         189.2       0.9X
-basicTypes: Double with unsafe:true                    189            190           1          5.3         188.9       0.9X
-Array: Int with unsafe:true                              1              1           0        761.6           1.3     128.1X
-Array: Long with unsafe:true                             2              2           0        500.3           2.0      84.2X
-Array: Float with unsafe:true                            1              1           0        765.4           1.3     128.8X
-Array: Double with unsafe:true                           2              2           0        492.7           2.0      82.9X
-Map of string->Double  with unsafe:true                 26             27           0         38.0          26.3       6.4X
-basicTypes: Int with unsafe:false                      203            204           1          4.9         203.0       0.8X
-basicTypes: Long with unsafe:false                     231            233           2          4.3         230.6       0.7X
-basicTypes: Float with unsafe:false                    200            202           3          5.0         199.7       0.8X
-basicTypes: Double with unsafe:false                   208            211           5          4.8         207.8       0.8X
-Array: Int with unsafe:false                            15             15           0         65.2          15.3      11.0X
-Array: Long with unsafe:false                           20             21           0         49.0          20.4       8.2X
-Array: Float with unsafe:false                           6              6           0        170.6           5.9      28.7X
-Array: Double with unsafe:false                         10             10           0        103.2           9.7      17.4X
-Map of string->Double  with unsafe:false                28             28           1         35.9          27.9       6.0X
+basicTypes: Int with unsafe:true                       169            171           2          5.9         168.8       1.0X
+basicTypes: Long with unsafe:true                      191            196           8          5.2         191.2       0.9X
+basicTypes: Float with unsafe:true                     189            190           1          5.3         189.0       0.9X
+basicTypes: Double with unsafe:true                    195            197           2          5.1         194.9       0.9X
+Array: Int with unsafe:true                              1              1           0        740.2           1.4     124.9X
+Array: Long with unsafe:true                             2              2           0        491.0           2.0      82.9X
+Array: Float with unsafe:true                            1              1           0        719.8           1.4     121.5X
+Array: Double with unsafe:true                           2              2           0        473.8           2.1      80.0X
+Map of string->Double  with unsafe:true                 27             27           1         36.9          27.1       6.2X
+basicTypes: Int with unsafe:false                      214            215           0          4.7         214.2       0.8X
+basicTypes: Long with unsafe:false                     234            235           1          4.3         233.8       0.7X
+basicTypes: Float with unsafe:false                    209            210           1          4.8         209.0       0.8X
+basicTypes: Double with unsafe:false                   213            217           3          4.7         213.2       0.8X
+Array: Int with unsafe:false                            14             15           0         69.2          14.4      11.7X
+Array: Long with unsafe:false                           21             21           1         48.5          20.6       8.2X
+Array: Float with unsafe:false                           6              6           0        169.0           5.9      28.5X
+Array: Double with unsafe:false                         10             10           0        103.7           9.6      17.5X
+Map of string->Double  with unsafe:false                28             29           1         35.5          28.2       6.0X
 
 

--- a/core/benchmarks/KryoIteratorBenchmark-jdk21-results.txt
+++ b/core/benchmarks/KryoIteratorBenchmark-jdk21-results.txt
@@ -2,27 +2,27 @@
 Benchmark of kryo asIterator on deserialization stream
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.8.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 Benchmark of kryo asIterator on deserialization stream:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------------
-Colletion of int with 1 elements, useIterator: true                        6              6           0          1.6         607.2       1.0X
-Colletion of int with 10 elements, useIterator: true                      13             14           0          0.7        1345.2       0.5X
-Colletion of int with 100 elements, useIterator: true                     82             83           1          0.1        8195.6       0.1X
-Colletion of string with 1 elements, useIterator: true                     8              8           0          1.3         761.4       0.8X
-Colletion of string with 10 elements, useIterator: true                   22             22           0          0.5        2201.7       0.3X
-Colletion of string with 100 elements, useIterator: true                 154            155           1          0.1       15433.3       0.0X
-Colletion of Array[int] with 1 elements, useIterator: true                 7              7           1          1.4         712.7       0.9X
-Colletion of Array[int] with 10 elements, useIterator: true               20             20           0          0.5        1963.0       0.3X
-Colletion of Array[int] with 100 elements, useIterator: true             144            145           1          0.1       14395.8       0.0X
-Colletion of int with 1 elements, useIterator: false                       7              7           0          1.5         654.5       0.9X
-Colletion of int with 10 elements, useIterator: false                     16             16           0          0.6        1587.0       0.4X
-Colletion of int with 100 elements, useIterator: false                   106            107           1          0.1       10568.9       0.1X
-Colletion of string with 1 elements, useIterator: false                    7              8           0          1.4         738.9       0.8X
-Colletion of string with 10 elements, useIterator: false                  21             22           1          0.5        2119.5       0.3X
-Colletion of string with 100 elements, useIterator: false                157            158           1          0.1       15693.2       0.0X
-Colletion of Array[int] with 1 elements, useIterator: false                7              7           0          1.4         695.9       0.9X
-Colletion of Array[int] with 10 elements, useIterator: false              18             19           1          0.6        1817.1       0.3X
-Colletion of Array[int] with 100 elements, useIterator: false            136            137           0          0.1       13612.6       0.0X
+Colletion of int with 1 elements, useIterator: true                        6              6           0          1.7         601.4       1.0X
+Colletion of int with 10 elements, useIterator: true                      13             14           0          0.7        1334.9       0.5X
+Colletion of int with 100 elements, useIterator: true                     83             83           1          0.1        8253.6       0.1X
+Colletion of string with 1 elements, useIterator: true                     8              8           0          1.3         771.0       0.8X
+Colletion of string with 10 elements, useIterator: true                   23             23           1          0.4        2256.5       0.3X
+Colletion of string with 100 elements, useIterator: true                 167            167           0          0.1       16656.6       0.0X
+Colletion of Array[int] with 1 elements, useIterator: true                 7              8           0          1.4         729.6       0.8X
+Colletion of Array[int] with 10 elements, useIterator: true               20             20           0          0.5        1968.9       0.3X
+Colletion of Array[int] with 100 elements, useIterator: true             148            149           0          0.1       14841.9       0.0X
+Colletion of int with 1 elements, useIterator: false                       6              7           0          1.6         621.7       1.0X
+Colletion of int with 10 elements, useIterator: false                     14             14           0          0.7        1358.1       0.4X
+Colletion of int with 100 elements, useIterator: false                    86             87           1          0.1        8573.1       0.1X
+Colletion of string with 1 elements, useIterator: false                    7              7           0          1.4         712.8       0.8X
+Colletion of string with 10 elements, useIterator: false                  21             21           0          0.5        2109.8       0.3X
+Colletion of string with 100 elements, useIterator: false                157            157           0          0.1       15668.4       0.0X
+Colletion of Array[int] with 1 elements, useIterator: false                7              7           0          1.4         691.1       0.9X
+Colletion of Array[int] with 10 elements, useIterator: false              19             19           0          0.5        1857.8       0.3X
+Colletion of Array[int] with 100 elements, useIterator: false            139            140           1          0.1       13894.5       0.0X
 
 

--- a/core/benchmarks/KryoIteratorBenchmark-results.txt
+++ b/core/benchmarks/KryoIteratorBenchmark-results.txt
@@ -2,27 +2,27 @@
 Benchmark of kryo asIterator on deserialization stream
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.8.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 Benchmark of kryo asIterator on deserialization stream:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------------
-Colletion of int with 1 elements, useIterator: true                        6              7           0          1.6         625.0       1.0X
-Colletion of int with 10 elements, useIterator: true                      14             14           0          0.7        1381.4       0.5X
-Colletion of int with 100 elements, useIterator: true                     83             84           1          0.1        8314.5       0.1X
-Colletion of string with 1 elements, useIterator: true                     8              8           0          1.3         779.9       0.8X
-Colletion of string with 10 elements, useIterator: true                   23             23           0          0.4        2259.0       0.3X
-Colletion of string with 100 elements, useIterator: true                 165            165           1          0.1       16478.7       0.0X
-Colletion of Array[int] with 1 elements, useIterator: true                 8              8           0          1.3         752.2       0.8X
-Colletion of Array[int] with 10 elements, useIterator: true               20             20           0          0.5        2006.2       0.3X
-Colletion of Array[int] with 100 elements, useIterator: true             151            152           0          0.1       15114.7       0.0X
-Colletion of int with 1 elements, useIterator: false                       6              6           0          1.6         606.5       1.0X
-Colletion of int with 10 elements, useIterator: false                     13             14           0          0.8        1329.7       0.5X
-Colletion of int with 100 elements, useIterator: false                    82             84           4          0.1        8169.8       0.1X
-Colletion of string with 1 elements, useIterator: false                    7              8           0          1.4         732.7       0.9X
-Colletion of string with 10 elements, useIterator: false                  22             22           0          0.5        2174.1       0.3X
-Colletion of string with 100 elements, useIterator: false                173            174           1          0.1       17251.5       0.0X
-Colletion of Array[int] with 1 elements, useIterator: false                7              7           0          1.4         694.7       0.9X
-Colletion of Array[int] with 10 elements, useIterator: false              19             19           0          0.5        1871.3       0.3X
-Colletion of Array[int] with 100 elements, useIterator: false            138            139           1          0.1       13794.5       0.0X
+Colletion of int with 1 elements, useIterator: true                        6              7           0          1.6         634.7       1.0X
+Colletion of int with 10 elements, useIterator: true                      13             14           0          0.7        1339.1       0.5X
+Colletion of int with 100 elements, useIterator: true                     81             81           1          0.1        8050.8       0.1X
+Colletion of string with 1 elements, useIterator: true                     8              8           0          1.3         778.0       0.8X
+Colletion of string with 10 elements, useIterator: true                   22             22           0          0.5        2217.0       0.3X
+Colletion of string with 100 elements, useIterator: true                 164            164           1          0.1       16355.3       0.0X
+Colletion of Array[int] with 1 elements, useIterator: true                 7              7           0          1.4         724.7       0.9X
+Colletion of Array[int] with 10 elements, useIterator: true               19             20           0          0.5        1937.4       0.3X
+Colletion of Array[int] with 100 elements, useIterator: true             139            140           1          0.1       13937.4       0.0X
+Colletion of int with 1 elements, useIterator: false                       6              7           0          1.6         626.2       1.0X
+Colletion of int with 10 elements, useIterator: false                     13             14           0          0.7        1348.9       0.5X
+Colletion of int with 100 elements, useIterator: false                    82             83           1          0.1        8203.8       0.1X
+Colletion of string with 1 elements, useIterator: false                    7              8           0          1.4         735.7       0.9X
+Colletion of string with 10 elements, useIterator: false                  21             22           0          0.5        2139.6       0.3X
+Colletion of string with 100 elements, useIterator: false                162            163           2          0.1       16179.3       0.0X
+Colletion of Array[int] with 1 elements, useIterator: false                7              7           0          1.4         705.7       0.9X
+Colletion of Array[int] with 10 elements, useIterator: false              19             20           0          0.5        1923.1       0.3X
+Colletion of Array[int] with 100 elements, useIterator: false            142            143           2          0.1       14181.4       0.0X
 
 

--- a/core/benchmarks/KryoSerializerBenchmark-jdk21-results.txt
+++ b/core/benchmarks/KryoSerializerBenchmark-jdk21-results.txt
@@ -2,11 +2,11 @@
 Benchmark KryoPool vs old"pool of 1" implementation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.8.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 Benchmark KryoPool vs old"pool of 1" implementation:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-KryoPool:true                                                 3510           5106        1647          0.0     7019615.4       1.0X
-KryoPool:false                                                5795           7573        1370          0.0    11590855.1       0.6X
+KryoPool:true                                                 3561           5499        1885          0.0     7122219.0       1.0X
+KryoPool:false                                                5568           7543        1424          0.0    11135651.8       0.6X
 
 

--- a/core/benchmarks/KryoSerializerBenchmark-results.txt
+++ b/core/benchmarks/KryoSerializerBenchmark-results.txt
@@ -2,11 +2,11 @@
 Benchmark KryoPool vs old"pool of 1" implementation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.8.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 Benchmark KryoPool vs old"pool of 1" implementation:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-KryoPool:true                                                 3719           5368        2041          0.0     7437642.4       1.0X
-KryoPool:false                                                6032           7509        1286          0.0    12063237.4       0.6X
+KryoPool:true                                                 3566           5426        1989          0.0     7131530.8       1.0X
+KryoPool:false                                                5514           7642        1298          0.0    11027056.3       0.6X
 
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -60,6 +60,14 @@
       <artifactId>chill-java</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.esotericsoftware</groupId>
+      <artifactId>kryo-shaded</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.objenesis</groupId>
+      <artifactId>objenesis</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
       <scope>test</scope>

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -158,7 +158,7 @@ json4s-scalap_2.13/4.0.7//json4s-scalap_2.13-4.0.7.jar
 jsr305/3.0.0//jsr305-3.0.0.jar
 jta/1.1//jta-1.1.jar
 jul-to-slf4j/2.0.16//jul-to-slf4j-2.0.16.jar
-kryo-shaded/4.0.2//kryo-shaded-4.0.2.jar
+kryo-shaded/4.0.3//kryo-shaded-4.0.3.jar
 kubernetes-client-api/7.1.0//kubernetes-client-api-7.1.0.jar
 kubernetes-client/7.1.0//kubernetes-client-7.1.0.jar
 kubernetes-httpclient-vertx/7.1.0//kubernetes-httpclient-vertx-7.1.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
     <!-- SPARK-46938: Required by Hive / LibThrift libs -->
     <javaxservlet.version>4.0.1</javaxservlet.version>
     <chill.version>0.10.0</chill.version>
+    <kryo.version>4.0.3</kryo.version>
     <ivy.version>2.5.3</ivy.version>
     <oro.version>2.0.8</oro.version>
     <!--
@@ -477,12 +478,42 @@
             <groupId>org.apache.xbean</groupId>
             <artifactId>xbean-asm7-shaded</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.esotericsoftware</groupId>
+            <artifactId>kryo-shaded</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
         <groupId>com.twitter</groupId>
         <artifactId>chill-java</artifactId>
         <version>${chill.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.esotericsoftware</groupId>
+            <artifactId>kryo-shaded</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.esotericsoftware</groupId>
+        <artifactId>kryo-shaded</artifactId>
+        <version>${kryo.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <!--
+        SPARK-51806: Kryo 4.0.x depends on objenesis 2.5.1, while Spark currently
+        depends on objenesis 3.3. Here, it is uniformly defined as version 3.3.
+        -->
+      <dependency>
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <version>3.3</version>
       </dependency>
       <dependency>
         <groupId>com.github.jnr</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade `kryo-shaded` from 4.0.2 to 4.0.3.

### Why are the changes needed?
This version brings some bug fixes and performance improvements related to chunked encoding:
- mproved filling InputChunked buffer: https://github.com/EsotericSoftware/kryo/issues/651
- Support skipping input chunks after a buffer underflow https://github.com/EsotericSoftware/kryo/issues/850
- Avoid flush repeatedly when has finished flushing https://github.com/EsotericSoftware/kryo/issues/978

full changes as follows:

- https://github.com/EsotericSoftware/kryo/compare/kryo-parent-4.0.2...kryo-parent-4.0.3


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
