### PR TITLE
[SPARK-51554][SQL] Add the time_trunc() function for TIME datatype

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/DateTimeConstants.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/DateTimeConstants.java
@@ -45,5 +45,7 @@ public class DateTimeConstants {
   public static final long NANOS_PER_MICROS = 1000L;
   public static final long NANOS_PER_MILLIS = MICROS_PER_MILLIS * NANOS_PER_MICROS;
   public static final long NANOS_PER_SECOND = MILLIS_PER_SECOND * NANOS_PER_MILLIS;
+  public static final long NANOS_PER_MINUTE = SECONDS_PER_MINUTE * NANOS_PER_SECOND;
+  public static final long NANOS_PER_HOUR = MINUTES_PER_HOUR * NANOS_PER_MINUTE;
   public static final long NANOS_PER_DAY = MICROS_PER_DAY * NANOS_PER_MICROS;
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -663,6 +663,7 @@ object FunctionRegistry {
     expressionBuilder("to_timestamp_ltz", ParseToTimestampLTZExpressionBuilder, setAlias = true),
     expression[TruncDate]("trunc"),
     expression[TruncTimestamp]("date_trunc"),
+    expression[TruncateTime]("time_trunc"),
     expression[UnixTimestamp]("unix_timestamp"),
     expression[DayOfWeek]("dayofweek"),
     expression[WeekDay]("weekday"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -635,6 +635,7 @@ case class SubtractTimes(left: Expression, right: Expression)
 }
 
 
+// scalastyle:off line.size.limit
 @ExpressionDescription(
   usage = """
     _FUNC_(unit, expr) - Returns a TIME value representing `expr` truncated to the specified time unit.
@@ -657,6 +658,7 @@ case class SubtractTimes(left: Expression, right: Expression)
   """,
   since = "4.1.0",
   group = "datetime_funcs")
+// scalastyle:on line.size.limit
 case class TruncateTime(unit: Expression, timeExpr: Expression)
   extends BinaryExpression with ImplicitCastInputTypes with RuntimeReplaceable {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -25,8 +25,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{ExpressionBuilder, TypeCheckResult}
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{DataTypeMismatch, TypeCheckSuccess}
 import org.apache.spark.sql.catalyst.expressions.Cast.{toSQLExpr, toSQLId, toSQLType, toSQLValue}
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, CodegenFallback, ExprCode}
-import org.apache.spark.sql.catalyst.expressions.codegen.Block.BlockHelper
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, StaticInvoke}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{CURRENT_LIKE, TreePattern}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -354,8 +353,6 @@ case class SecondsOfTime(child: Expression)
   )
 
   override def inputTypes: Seq[AbstractDataType] = Seq(AnyTimeType)
-  override def inputTypes: Seq[AbstractDataType] =
-    Seq(TypeCollection(TimeType.MIN_PRECISION to TimeType.MAX_PRECISION map TimeType: _*))
 
   override def children: Seq[Expression] = Seq(child)
 
@@ -666,11 +663,7 @@ case class TruncateTime(unit: Expression, timeExpr: Expression)
   override def left: Expression = unit
   override def right: Expression = timeExpr
 
-  override def inputTypes: Seq[AbstractDataType] =
-    Seq(
-      StringType,
-      TypeCollection(TimeType.MIN_PRECISION to TimeType.MAX_PRECISION map TimeType: _*)
-    )
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType, AnyTimeType)
 
   override def dataType: DataType = timeExpr.dataType
   override def prettyName: String = "time_trunc"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -535,11 +535,11 @@ object DateTimeUtils extends SparkDateTimeUtils {
   }
 
   /**
-   * Truncate a TIME‑of‑day value given as microseconds from midnight.
+   * Truncate a TIME-of-day value given as microseconds from midnight.
    *
-   * @param unitUtf8  the requested unit ('HOUR', 'MINUTE', …) or null
+   * @param unitUtf8  the requested unit ('HOUR', 'MINUTE', ...) or null
    * @param micros microseconds since 00:00:00
-   * @return truncated value as microseconds‑of‑day, or -1L if the unit is invalid
+   * @return truncated value as microseconds-of-day, or -1L if the unit is invalid
    */
   def truncateTime(unitUtf8: UTF8String, micros: Long): Long = {
     val level = parseTruncLevelForTime(unitUtf8)
@@ -569,7 +569,7 @@ object DateTimeUtils extends SparkDateTimeUtils {
 
   /**
    * Truncates a time-of-day (represented in microseconds from midnight) to the specified level.
-   * Returns TRUNC_INVALID (–1) if the level is out of range or unrecognized.
+   * Returns TRUNC_INVALID (-1) if the level is out of range or unrecognized.
    */
   def truncTime(microsOfDay: Long, level: Int): Long = {
     if (level < MIN_LEVEL_OF_TIME_TRUNC || level > MAX_LEVEL_OF_TIME_TRUNC) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -535,6 +535,23 @@ object DateTimeUtils extends SparkDateTimeUtils {
   }
 
   /**
+   * Truncate a TIME‑of‑day value given as microseconds from midnight.
+   *
+   * @param unitUtf8  the requested unit ('HOUR', 'MINUTE', …) or null
+   * @param micros microseconds since 00:00:00
+   * @return truncated value as microseconds‑of‑day, or -1L if the unit is invalid
+   */
+  def truncateTime(unitUtf8: UTF8String, micros: Long): Long = {
+    val level = parseTruncLevelForTime(unitUtf8)
+    if (level < MIN_LEVEL_OF_TIME_TRUNC) {  // unknown unit
+      -1L
+    } else {
+      val out = truncTime(micros, level)         // may still return -1L on error
+      if (out < 0) -1L else out
+    }
+  }
+
+  /**
    * Returns the truncate level, could be from TRUNC_TO_MICROSECOND to TRUNC_TO_HOUR,
    * or TRUNC_INVALID, TRUNC_INVALID means unsupported truncate level.
    */

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -418,4 +418,58 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       }
     }
   }
+
+  test("TruncateTime") {
+    val fullTime = Literal(localTime(12, 34, 56, 789123), TimeType())
+
+    // foldable, invalid/null units
+    checkEvaluation(
+      TruncateTime(Literal("FOO"), fullTime),
+      null)
+
+    checkEvaluation(
+      TruncateTime(Literal.create(null, StringType), fullTime),
+      null)
+
+    // foldable, valid units
+    checkEvaluation(
+      TruncateTime(Literal("hour"), fullTime),
+      localTime(12))
+
+    checkEvaluation(
+      TruncateTime(Literal("minute"), fullTime),
+      localTime(12, 34))
+
+    checkEvaluation(
+      TruncateTime(Literal("second"), fullTime),
+      localTime(12, 34, 56))
+
+    checkEvaluation(
+      TruncateTime(Literal("millisecond"), fullTime),
+      localTime(12, 34, 56, 789000))
+
+    checkEvaluation(
+      TruncateTime(Literal("microsecond"), fullTime),
+      localTime(12, 34, 56, 789123))
+
+    // non-foldable, invalid/null units
+    checkEvaluation(
+      TruncateTime(NonFoldableLiteral("NULL"), fullTime),
+      null)
+
+    checkEvaluation(
+      TruncateTime(NonFoldableLiteral("BAR"), fullTime),
+      null)
+
+    // non-foldable, valid unit
+    checkEvaluation(
+      TruncateTime(NonFoldableLiteral("minute"), fullTime),
+      localTime(12, 34))
+
+    // test precision preservation
+    val millisTime = Literal(localTime(23, 59, 0, 123456), TimeType(3))
+    checkEvaluation(
+      TruncateTime(Literal("hour"), millisTime),
+      localTime(23))
+  }
 }

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -355,6 +355,7 @@
 | org.apache.spark.sql.catalyst.expressions.TransformValues | transform_values | SELECT transform_values(map_from_arrays(array(1, 2, 3), array(1, 2, 3)), (k, v) -> v + 1) | struct<transform_values(map_from_arrays(array(1, 2, 3), array(1, 2, 3)), lambdafunction((namedlambdavariable() + 1), namedlambdavariable(), namedlambdavariable())):map<int,int>> |
 | org.apache.spark.sql.catalyst.expressions.TruncDate | trunc | SELECT trunc('2019-08-04', 'week') | struct<trunc(2019-08-04, week):date> |
 | org.apache.spark.sql.catalyst.expressions.TruncTimestamp | date_trunc | SELECT date_trunc('YEAR', '2015-03-05T09:32:05.359') | struct<date_trunc(YEAR, 2015-03-05T09:32:05.359):timestamp> |
+| org.apache.spark.sql.catalyst.expressions.TruncateTime | time_trunc | SELECT time_trunc('HOUR', '09:32:05.359') | struct<time_trunc(HOUR, 09:32:05.359):time(0)> |
 | org.apache.spark.sql.catalyst.expressions.TryAdd | try_add | SELECT try_add(1, 2) | struct<try_add(1, 2):int> |
 | org.apache.spark.sql.catalyst.expressions.TryAesDecrypt | try_aes_decrypt | SELECT try_aes_decrypt(unhex('6E7CA17BBB468D3084B5744BCA729FB7B2B7BCB8E4472847D02670489D95FA97DBBA7D3210'), '0000111122223333', 'GCM') | struct<try_aes_decrypt(unhex(6E7CA17BBB468D3084B5744BCA729FB7B2B7BCB8E4472847D02670489D95FA97DBBA7D3210), 0000111122223333, GCM, DEFAULT, ):binary> |
 | org.apache.spark.sql.catalyst.expressions.TryDivide | try_divide | SELECT try_divide(3, 2) | struct<try_divide(3, 2):double> |


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Added a new built-in function `time_trunc(unit, expr)` that returns a `TIME` value truncated to the specified unit.
- Allowed input for expr to be either a `TIME` type ~~(or a string that can be cast to TIME.)~~
  - Recent addition of the AnyTimeType which is used here, doesn't allow cast from string. Hence this behavior change. However simply allowing anytimetype to be casted from a valid string, this change would automatically be able handle valid input time strings as well.
- Supported truncation units are `HOUR`, `MINUTE`, `SECOND`, `MILLISECOND`, and `MICROSECOND`.
- Handles both foldable and non-foldable inputs


### Why are the changes needed?
- Spark currently lacks a built-in function for truncating TIME values in a similar way as `truncTimestamp`.

### Does this PR introduce _any_ user-facing change?
Yes. A new built-in function `time_trunc` is added. Users can call the function to truncate TIME values to one of the above mentioned supported units.


### How was this patch tested?
By running newly added UTs:
```bash
$ build/sbt "test:testOnly *TimeExpressionsSuite.scala"
```

By manual tests:

```bash
# Happy test cases
scala> spark.sql("SELECT time_trunc('HOUR', TIME'09:32:05.123456');").show()
+---------------------------------+
|time_trunc(HOUR, 09:32:05.123456)|
+---------------------------------+
|                         09:00:00                 |
+---------------------------------+

scala> spark.sql("SELECT time_trunc('MINUTE', TIME'09:32:05.123456');").show()
+------------------------------------------+
|time_trunc(MINUTE, TIME '09:32:05.123456')|
+------------------------------------------+
|                                  09:32:00|
+------------------------------------------+

scala> spark.sql("SELECT time_trunc('second', TIME'09:32:05.123456');").show()
+-----------------------------------+
|time_trunc(second, 09:32:05.123456)|
+-----------------------------------+
|                           09:32:05|
+-----------------------------------+

scala> spark.sql("SELECT time_trunc(concat('milli','second'), TIME'09:32:05.123456');").show()
+--------------------------------------------------+
|time_trunc(concat(milli, second), 09:32:05.123456)|
+--------------------------------------------------+
|                                      09:32:05.123|
+--------------------------------------------------+

scala> spark.sql("SELECT time_trunc('MICROSECOND', TIME'09:32:05.123456');").show()
+----------------------------------------+
|time_trunc(MICROSECOND, 09:32:05.123456)|
+----------------------------------------+
|                         09:32:05.123456|
+----------------------------------------+

scala> spark.sql("SELECT time_trunc('MICROSECOND', TIME'09:32:05.1234');").show()
+--------------------------------------+
|time_trunc(MICROSECOND, 09:32:05.1234)|
+--------------------------------------+
|                         09:32:05.1234|
+--------------------------------------+

# Invalid inputs
scala> spark.sql("SELECT time_trunc('MICROSECOND', '09:32:05.1234');").show()
org.apache.spark.sql.catalyst.ExtendedAnalysisException: [DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE] Cannot resolve "time_trunc(MICROSECOND, 09:32:05.1234)" due to data type mismatch: The second parameter requires the "TIME" type, however "09:32:05.1234" has the type "STRING". SQLSTATE: 42K09; line 1 pos 7;
'Project [unresolvedalias(time_trunc(MICROSECOND, 09:32:05.1234))]
+- OneRowRelation

scala> spark.sql("SELECT time_trunc('MS', TIME'09:32:05.123456');").show()
+-------------------------------+
|time_trunc(MS, 09:32:05.123456)|
+-------------------------------+
|                           NULL|
+-------------------------------+

scala> spark.sql("SELECT time_trunc('MICROSECOND', TIME'29:32:05.123456');").show()
org.apache.spark.sql.catalyst.parser.ParseException:
[INVALID_TYPED_LITERAL] The value of the typed literal "TIME" is invalid: '29:32:05.123456'. SQLSTATE: 42604
== SQL (line 1, position 34) ==
...ELECT time_trunc('MICROSECOND', TIME'29:32:05.123456');
                                   ^^^^^^^^^^^^^^^^^^^^^
  at org.apache.spark.sql.errors.QueryParsingErrors$.cannotParseValueTypeError(QueryParsingErrors.scala:250)'

# unfoldable inputs
scala> val df = Seq(
     |   ("HOUR",       "09:32:05.123456"),
     |   ("MINUTE",     "10:20:15.123456"),
     |   ("second",     "11:59:59.999999"),
     |   ("MILLISECOND","00:00:00.123000"),
     |   ("MICROSECOND","00:00:00.123000"),
     |   ("MICROSECOND","00:00:00.123456"),
     |   ("MS","00:00:00.123456"),
     |   ("NULL","00:00:00.123456")
     | ).toDF("unitcol", "timecol")
val df: org.apache.spark.sql.DataFrame = [unitcol: string, timecol: string]

scala> val timeDf = df.selectExpr("unitcol", "CAST(timecol AS TIME(6)) as timeval")
val timeDf: org.apache.spark.sql.DataFrame = [unitcol: string, timeval: time(6)]

scala> timeDf.createOrReplaceTempView("tmp")

scala> spark.sql("""
     |   SELECT
     |     unitcol,
     |     timeval,
     |     time_trunc(unitcol, timeval) as truncated
     |   FROM tmp
     | """).show(false)
+-----------+---------------+---------------+
|unitcol    |timeval        |truncated      |
+-----------+---------------+---------------+
|HOUR       |09:32:05.123456|09:00:00       |
|MINUTE     |10:20:15.123456|10:20:00       |
|second     |11:59:59.999999|11:59:59       |
|MILLISECOND|00:00:00.123   |00:00:00.123   |
|MICROSECOND|00:00:00.123   |00:00:00.123   |
|MICROSECOND|00:00:00.123456|00:00:00.123456|
|MS         |00:00:00.123456|NULL           |
|NULL       |00:00:00.123456|NULL           |
+-----------+---------------+---------------+
```


### Was this patch authored or co-authored using generative AI tooling?
No.
