### PR TITLE
[SPARK-51824][ML][CONNECT][TESTS] Force to clean up the ML cache after each test

### DIFF
--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -16,7 +16,6 @@
 #
 import shutil
 import tempfile
-import typing
 import os
 import functools
 import unittest
@@ -187,6 +186,10 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
     def tearDownClass(cls):
         shutil.rmtree(cls.tempdir.name, ignore_errors=True)
         cls.spark.stop()
+
+    def tearDown(self) -> None:
+        # force to clean up the ML cache after each test
+        self.spark.client._cleanup_ml()
 
     def test_assert_remote_mode(self):
         from pyspark.sql import is_remote


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Force to clean up the ML cache after each test

### Why are the changes needed?
to make sure ml cache is clean for next test


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
manually check with

```
In [1]: from pyspark.ml.linalg import Vectors
   ...: from pyspark.ml.classification import *
   ...: from pyspark.ml.regression import *
   ...:
   ...: df = spark.createDataFrame([
   ...:     (1.0, 2.0, Vectors.dense(1.0)),
   ...:     (0.0, 2.0, Vectors.sparse(1, [], []))], ["label", "weight", "features"])
   ...:
   ...: lr = LinearRegression(regParam=0.0, solver="normal")
   ...: model = lr.fit(df)
25/04/17 09:18:02 WARN Instrumentation: [a5693be2] regParam is zero, which might cause numerical instability and overfitting.
[--------------------------------------------------------------------------------] 0.00% Complete (0 Tasks running, 2s, Scanned 0.0 [--------------------------------------------------------------------------------] 0.00% Complete (0 Tasks running, 2s, Scanned 0.0 25/04/17 09:18:03 WARN InstanceBuilder: Failed to load implementation from:dev.ludovic.netlib.lapack.JNILAPACK
[********************************************************************************] 100.00% Complete (0 Tasks running, 2s, Scanned 0.[********************************************************************************] 100.00% Complete (0 Tasks running, 2s, Scanned 0.
In [2]: spark.client
Out[2]: <pyspark.sql.connect.client.core.SparkConnectClient at 0x11854e510>

In [3]: model
LinearRegressionModel: uid=LinearRegression_a03f0711070f, numFeatures=1

In [4]: spark.client._cleanup_ml()

In [5]: model
---------------------------------------------------------------------------
SparkException                            Traceback (most recent call last)

...

SparkException: [CONNECT_ML.CACHE_INVALID] Generic Spark Connect ML error. Cannot retrieve object c34300da-302f-4ec4-afd3-c82bba321eff from the ML cache. It is probably because the entry has been evicted. SQLSTATE: XX000

```

### Was this patch authored or co-authored using generative AI tooling?
no
