### PR TITLE
[SPARK-51758][SS][FOLLOWUP][TESTS] Fix flaky test around watermark due to additional batch causing empty df

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
@@ -612,11 +612,14 @@ class TransformWithStateInPandasTestsMixin:
                 assert set(batch_df.sort("id").collect()) == {
                     Row(id="a", timestamp="4"),
                 }
-            else:
+            elif batch_id == 2:
                 # watermark for late event = 10 and min event = 2 with no filtering
                 assert set(batch_df.sort("id").collect()) == {
                     Row(id="a", timestamp="2"),
                 }
+            else:
+                for q in self.spark.streams.active:
+                    q.stop()
 
         self._test_transform_with_state_in_pandas_event_time(
             MinEventTimeStatefulProcessor(), check_results, "None"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix flaky test around watermark due to additional batch causing empty df


### Why are the changes needed?
Without the changes, sometimes we would see the test fail because the extra batch with empty df case was not accounted for.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Test only change

```
Will test the following Python tests: ['pyspark.sql.tests.pandas.test_pandas_transform_with_state TransformWithStateInPandasTests.test_transform_with_state_with_wmark_and_non_event_time']
python3.9 python_implementation is CPython
python3.9 version is: Python 3.9.20
Starting test(python3.9): pyspark.sql.tests.pandas.test_pandas_transform_with_state TransformWithStateInPandasTests.test_transform_with_state_with_wmark_and_non_event_time (temp output: /Users/anish.shrigondekar/spark/spark/python/target/ad6814cf-2fcb-4f6c-a6c3-d63ce94013d4/python3.9__pyspark.sql.tests.pandas.test_pandas_transform_with_state_TransformWithStateInPandasTests.test_transform_with_state_with_wmark_and_non_event_time__7nb2vczb.log)
Finished test(python3.9): pyspark.sql.tests.pandas.test_pandas_transform_with_state TransformWithStateInPandasTests.test_transform_with_state_with_wmark_and_non_event_time (40s)
Tests passed in 40 seconds
```


### Was this patch authored or co-authored using generative AI tooling?
No
