### PR TITLE
[SPARK-51800][INFRA][FOLLOW-UP] Respect PYSPARK_UDS_MODE environment variable in SparkContext initialization

### DIFF
--- a/python/pyspark/core/context.py
+++ b/python/pyspark/core/context.py
@@ -307,7 +307,11 @@ class SparkContext:
         assert self._gateway is not None
         auth_token = self._gateway.gateway_parameters.auth_token
         is_unix_domain_sock = (
-            self._conf.get("spark.python.unix.domain.socket.enabled", "false").lower() == "true"
+            self._conf.get(
+                "spark.python.unix.domain.socket.enabled",
+                os.environ.get("PYSPARK_UDS_MODE", "false"),
+            ).lower()
+            == "true"
         )
         socket_path = None
         if is_unix_domain_sock:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/50587 that makes the SparkContext initialization to respect `PYSPARK_UDS_MODE` environment variable being used in the scheduled build.

### Why are the changes needed?

To make the scheduled build passing (https://github.com/apache/spark/actions/workflows/build_uds.yml)

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually tested via:

```bash
PYSPARK_UDS_MODE=true ./python/run-tests --python-executables=python3 --testnames "pyspark.sql.tests.test_udf UDFTests.test_same_accumulator_in_udfs"
```

### Was this patch authored or co-authored using generative AI tooling?

No.
