### PR TITLE
[SPARK-51826][K8S][DOCS] Update `YuniKorn` docs with `1.6.2`

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1988,10 +1988,10 @@ Install Apache YuniKorn:
 ```bash
 helm repo add yunikorn https://apache.github.io/yunikorn-release
 helm repo update
-helm install yunikorn yunikorn/yunikorn --namespace yunikorn --version 1.6.1 --create-namespace --set embedAdmissionController=false
+helm install yunikorn yunikorn/yunikorn --namespace yunikorn --version 1.6.2 --create-namespace --set embedAdmissionController=false
 ```
 
-The above steps will install YuniKorn v1.6.1 on an existing Kubernetes cluster.
+The above steps will install YuniKorn v1.6.2 on an existing Kubernetes cluster.
 
 ##### Get started
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `YuniKorn` docs with v1.6.2 for Apache Spark 4.0.0.

### Why are the changes needed?

Apache YuniKorn v1.6.2 was released on 2025-03-18 with 7 [JIRAs](https://yunikorn.apache.org/release-announce/1.6.2) issues. All users of 1.6.0 and 1.6.1 are urged to upgrade.

  - https://yunikorn.apache.org/release-announce/1.6.2/

I installed YuniKorn v1.6.2 on K8s 1.31 and tested manually.

**K8s v1.32**
```
$ kubectl version
Client Version: v1.32.2
Kustomize Version: v5.5.0
Server Version: v1.32.2
```

**YuniKorn v1.6.2**
```
$ helm list -n yunikorn
NAME    	NAMESPACE	REVISION	UPDATED                             	STATUS  	CHART         	APP VERSION
yunikorn	yunikorn 	1       	2025-04-17 13:44:38.474834 +0900 KST	deployed	yunikorn-1.6.2
```

```
$ build/sbt -Pkubernetes -Pkubernetes-integration-tests -Dspark.kubernetes.test.deployMode=docker-desktop "kubernetes-integration-tests/testOnly *.YuniKornSuite" -Dtest.exclude.tags=minikube,local,decom,r -Dtest.default.exclude.tags=
...
[info] YuniKornSuite:
[info] - SPARK-42190: Run SparkPi with local[*] (8 seconds, 546 milliseconds)
[info] - Run SparkPi with no resources (12 seconds, 633 milliseconds)
[info] - Run SparkPi with no resources & statefulset allocation (11 seconds, 593 milliseconds)
[info] - Run SparkPi with a very long application name. (11 seconds, 607 milliseconds)
...
[info] All tests passed.
[success] Total time: 483 s (08:03), completed Apr 17, 2025, 2:23:09 PM
```

```
Normal  Scheduling         1s    yunikorn  spark-29536dc6abac437ea683063350440259/spark-test-app-d4dc9d4d26dd449c90093a12db319c00-driver is queued and waiting for allocation
```