### PR TITLE
[SPARK-51829][PYTHON][ML] Client side should update `client.thread_local.ml_caches` after deletion

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -1117,6 +1117,7 @@ pyspark_ml_connect = Module(
         # ml doctests
         "pyspark.ml.connect.functions",
         # ml unittests
+        "pyspark.ml.tests.connect.test_connect_cache",
         "pyspark.ml.tests.connect.test_connect_function",
         "pyspark.ml.tests.connect.test_parity_torch_distributor",
         "pyspark.ml.tests.connect.test_parity_torch_data_loader",

--- a/python/pyspark/ml/tests/connect/test_connect_cache.py
+++ b/python/pyspark/ml/tests/connect/test_connect_cache.py
@@ -17,9 +17,7 @@
 
 import unittest
 
-from pyspark.errors import PySparkException
-from pyspark.ml.linalg import Vectors, Matrices
-from pyspark.sql import DataFrame, Row
+from pyspark.ml.linalg import Vectors
 from pyspark.ml.classification import LinearSVC
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
@@ -77,6 +75,7 @@ class MLConnectCacheTests(ReusedConnectTestCase):
         model1 = svc.fit(df)
         model2 = svc.fit(df)
         model3 = svc.fit(df)
+        self.assertEqual(len([model1, model2, model3]), 3)
 
         # all 3 models are cached in python side
         self.assertEqual(len(spark.client.thread_local.ml_caches), 3)

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1998,8 +1998,12 @@ class SparkConnectClient(object):
                     [pb2.ObjectRef(id=cache_id) for cache_id in cache_ids]
                 )
                 (_, properties, _) = self.execute_command(command)
+
+                assert properties is not None
+
                 if properties is not None and "ml_command_result" in properties:
-                    deleted = properties["ml_command_result"].param.string.split(",")
+                    ml_command_result = properties["ml_command_result"]
+                    deleted = ml_command_result.operator_info.obj_ref.id.split(",")
                     return cast(List[str], deleted)
             return []
         except Exception:

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
@@ -104,8 +104,10 @@ private[connect] class MLCache(sessionHolder: SessionHolder) extends Logging {
    * @param refId
    *   the key used to look up the corresponding object
    */
-  def remove(refId: String): Unit = {
-    cachedModel.remove(refId)
+  def remove(refId: String): Boolean = {
+    val removed = cachedModel.remove(refId)
+    // remove returns null if the key is not present
+    removed != null
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Client side should update `client.thread_local.ml_caches` after deletion:

- server side returns the list of ids of objects which have been successfully deleted from ml cache;
- client side also remove them from `client.thread_local.ml_caches`

### Why are the changes needed?
`client.thread_local.ml_caches` should not keep deleted objects, but

```
In [1]: from pyspark.ml.linalg import Vectors
   ...: from pyspark.ml.classification import *
   ...: from pyspark.ml.regression import *
   ...:
   ...: df = spark.createDataFrame([
   ...:     (1.0, 2.0, Vectors.dense(1.0)),
   ...:     (0.0, 2.0, Vectors.sparse(1, [], []))], ["label", "weight", "features"])
   ...:
   ...: lr = LinearRegression(regParam=0.0, solver="normal")
   ...: model = lr.fit(df)
25/04/17 13:23:16 WARN Instrumentation: [15c70922] regParam is zero, which might cause numerical instability and overfitting.
[--------------------------------------------------------------------------------] 0.00% Complete (0 Tasks running, 2s, Scanned 0.0[--------------------------------------------------------------------------------] 0.00% Complete (0 Tasks running, 2s, Scanned 0.025/04/17 13:23:18 WARN InstanceBuilder: Failed to load implementation from:dev.ludovic.netlib.lapack.JNILAPACK
[********************************************************************************] 100.00% Complete (0 Tasks running, 2s, Scanned 0[********************************************************************************] 100.00% Complete (0 Tasks running, 2s, Scanned 0
In [2]: spark.client.thread_local.ml_caches
Out[2]: {'e531e646-6f41-42ad-a9b1-1ce78e35c79c'}

In [3]: del model

In [4]: spark.client.thread_local.ml_caches
Out[4]: {'e531e646-6f41-42ad-a9b1-1ce78e35c79c'}
```

### Does this PR introduce _any_ user-facing change?
no



### How was this patch tested?
added test


### Was this patch authored or co-authored using generative AI tooling?
no