### PR TITLE
[SPARK-51824][ML][CONNECT][TESTS] Force to clean up the ML cache after each test

### DIFF
--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -16,7 +16,6 @@
 #
 import shutil
 import tempfile
-import typing
 import os
 import functools
 import unittest
@@ -187,6 +186,10 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
     def tearDownClass(cls):
         shutil.rmtree(cls.tempdir.name, ignore_errors=True)
         cls.spark.stop()
+
+    def tearDown(self) -> None:
+        # force to clean up the ML cache after each test
+        self.spark.client._cleanup_ml()
 
     def test_assert_remote_mode(self):
         from pyspark.sql import is_remote

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -16,6 +16,7 @@
 #
 import shutil
 import tempfile
+import typing
 import os
 import functools
 import unittest
@@ -189,7 +190,12 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
 
     def tearDown(self) -> None:
         # force to clean up the ML cache after each test
-        self.spark.client._cleanup_ml()
+        try:
+            # in some tests (e.g. test_connect_basic),
+            # both connect session (self.connect) and classic session (self.spark) are used.
+            self.spark.client._cleanup_ml()
+        except Exception:
+            pass
 
     def test_assert_remote_mode(self):
         from pyspark.sql import is_remote


### PR DESCRIPTION
Revert "Revert "[SPARK-51824][ML][CONNECT][TESTS] Force to clean up the ML cache after each test""

and fix tests issue

second PR for https://github.com/apache/spark/pull/50614

manually test with `python/run-tests -k --python-executables python3 --testnames 'pyspark.sql.tests.connect.test_connect_basic'`

before:
```
======================================================================
ERROR [0.071s]: test_garbage_collection_checkpoint (pyspark.sql.tests.connect.test_connect_basic.SparkConnectGCTests.test_garbage_collection_checkpoint)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ruifeng.zheng/Dev/spark/python/pyspark/testing/connectutils.py", line 192, in tearDown
    self.spark.client._cleanup_ml()
    ^^^^^^^^^^^^^^^^^
  File "/Users/ruifeng.zheng/Dev/spark/python/pyspark/sql/session.py", line 2105, in client
    raise PySparkRuntimeError(
    ...<2 lines>...
    )
pyspark.errors.exceptions.base.PySparkRuntimeError: [ONLY_SUPPORTED_WITH_SPARK_CONNECT] SparkSession.client is only supported with Spark Connect; however, the current Spark session does not use Spark Connect
```

after
```
(spark_313) ➜  spark git:(ml_test_cleanup_2) python/run-tests -k --python-executables python3 --testnames 'pyspark.sql.tests.connect.test_connect_basic'
Running PySpark tests. Output is in /Users/ruifeng.zheng/Dev/spark/python/unit-tests.log
Will test against the following Python executables: ['python3']
Will test the following Python tests: ['pyspark.sql.tests.connect.test_connect_basic']
python3 python_implementation is CPython
python3 version is: Python 3.13.3
Starting test(python3): pyspark.sql.tests.connect.test_connect_basic (temp output: /Users/ruifeng.zheng/Dev/spark/python/target/6227399e-3316-431d-92e8-1ac3c658c0fc/python3__pyspark.sql.tests.connect.test_connect_basic___j4sz49d.log)
Finished test(python3): pyspark.sql.tests.connect.test_connect_basic (30s)
Tests passed in 30 seconds

```