### PR TITLE
[SPARK-51832][BUILD] Use -q option to simplify maven version evaluation

### DIFF
--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -148,18 +148,9 @@ if [ "$SBT_ENABLED" == "true" ]; then
   SCALA_VERSION=$("$SBT" -no-colors "show scalaBinaryVersion" | awk '/\[info\]/{ver=$2} END{print ver}')
   SPARK_HADOOP_VERSION=$("$SBT" -no-colors "show hadoopVersion" | awk '/\[info\]/{ver=$2} END{print ver}')
 else
-  VERSION=$("$MVN" help:evaluate -Dexpression=project.version $@ \
-      | grep -v "INFO"\
-      | grep -v "WARNING"\
-      | tail -n 1)
-  SCALA_VERSION=$("$MVN" help:evaluate -Dexpression=scala.binary.version $@ \
-      | grep -v "INFO"\
-      | grep -v "WARNING"\
-      | tail -n 1)
-  SPARK_HADOOP_VERSION=$("$MVN" help:evaluate -Dexpression=hadoop.version $@ \
-      | grep -v "INFO"\
-      | grep -v "WARNING"\
-      | tail -n 1)
+  VERSION=$("$MVN" help:evaluate -Dexpression=project.version "$@" -q -DforceStdout)
+  SCALA_VERSION=$("$MVN" help:evaluate -Dexpression=scala.binary.version "$@" -q -DforceStdout)
+  SPARK_HADOOP_VERSION=$("$MVN" help:evaluate -Dexpression=hadoop.version "$@" -q -DforceStdout)
 fi
 
 if [ "$NAME" == "none" ]; then


### PR DESCRIPTION


### What changes were proposed in this pull request?

Use `-q` option to simplify Maven version evaluation


### Why are the changes needed?

code simplification
### Does this PR introduce _any_ user-facing change?
no, dev only


### How was this patch tested?
```
++ command -v /Users/hzyaoqin/spark/build/mvn
+ '[' '!' /Users/hzyaoqin/spark/build/mvn ']'
+ '[' false == true ']'
++ /Users/hzyaoqin/spark/build/mvn help:evaluate -Dexpression=project.version -Phive -Phive-thriftserver -Pyarn -Pkubernetes -q -DforceStdout
Using `mvn` from path: /Users/hzyaoqin/spark/build/apache-maven-3.9.9/bin/mvn
+ VERSION=4.1.0-SNAPSHOT
++ /Users/hzyaoqin/spark/build/mvn help:evaluate -Dexpression=scala.binary.version -Phive -Phive-thriftserver -Pyarn -Pkubernetes -q -DforceStdout
Using `mvn` from path: /Users/hzyaoqin/spark/build/apache-maven-3.9.9/bin/mvn
+ SCALA_VERSION=2.13
++ /Users/hzyaoqin/spark/build/mvn help:evaluate -Dexpression=hadoop.version -Phive -Phive-thriftserver -Pyarn -Pkubernetes -q -DforceStdout
Using `mvn` from path: /Users/hzyaoqin/spark/build/apache-maven-3.9.9/bin/mvn
+ SPARK_HADOOP_VERSION=3.4.1
```


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no