### PR TITLE
[SPARK-51840][SQL] Restore Partition columns in HiveExternalCatalog#alterTable

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -668,7 +668,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
 
       val (newSchema, partitionColumnNames) = if (oldTableDef.schema == EMPTY_DATA_SCHEMA) {
         val restoredOldTable = restoreTableMetadata(oldTableDef)
-        (StructType(EMPTY_DATA_SCHEMA ++ restoreTableMetadata(oldTableDef).partitionSchema),
+        (StructType(EMPTY_DATA_SCHEMA ++ restoredOldTable.partitionSchema),
           restoredOldTable.partitionColumnNames)
       } else {
         (oldTableDef.schema, oldTableDef.partitionColumnNames)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -671,7 +671,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       val newDef = tableDefinition.copy(
         storage = newStorage,
         schema = oldTableDef.schema,
-        partitionColumnNames = oldTableDef.partitionColumnNames,
         bucketSpec = oldTableDef.bucketSpec,
         properties = newTableProps,
         owner = owner)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.hive.execution
 
 import java.io.File
 import java.net.URI
+import java.time.LocalDateTime
 import java.util.Locale
 
 import org.apache.hadoop.fs.Path
@@ -608,6 +609,19 @@ class HiveDDLSuite
       parameters = Map(
         "details" -> "The spec ([partCol1=]) contains an empty partition column value")
     )
+  }
+
+  test("SPARK-51840: Restore Partition columns in HiveExternalCatalog#alterTable") {
+    withTable("t") {
+      sql(
+        """
+          |CREATE TABLE t USING json
+          |  PARTITIONED BY (A) AS
+          |    SELECT 'APACHE' A, TIMESTAMP_NTZ '2018-11-17 13:33:33' B
+          |""".stripMargin)
+      sql("MSCK REPAIR TABLE t")
+      checkAnswer(spark.table("t"), Row(LocalDateTime.of(2018, 11, 17, 13, 33, 33), "APACHE"))
+    }
   }
 
   test("add/drop partitions - external table") {


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR restores the partition columns information in HiveExternalCatalog#alterTable API. Otherwise, many of the commands involved will fail, such as CTAS, MSCK on Spark-specific metastore schemas, etc.

### Why are the changes needed?
improvement for partitioned non-hive compatible tables,

```
[info]   Cause: org.apache.hadoop.hive.ql.metadata.HiveException: Unable to alter table. partition keys can not be changed.
[info]   at org.apache.hadoop.hive.ql.metadata.Hive.alterTable(Hive.java:634)
[info]   at org.apache.hadoop.hive.ql.metadata.Hive.alterTable(Hive.java:612)
[info]   at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[info]   at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[info]   at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[info]   at java.base/java.lang.reflect.Method.invoke(Method.java:569)
```

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
new test


### Was this patch authored or co-authored using generative AI tooling?
no