### PR TITLE
[SPARK-51372][SQL][FOLLOW-UP] Retain the property map for DataSourceV2 TableInfo

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableInfo.java
@@ -38,7 +38,7 @@ public class TableInfo {
    */
   private TableInfo(Builder builder) {
     this.columns = builder.columns;
-    this.properties = Collections.unmodifiableMap(builder.properties);
+    this.properties = builder.properties;
     this.partitions = builder.partitions;
     this.constraints = builder.constraints;
   }
@@ -73,8 +73,7 @@ public class TableInfo {
     }
 
     public Builder withProperties(Map<String, String> properties) {
-      this.properties = Maps.newHashMap();
-      this.properties.putAll(properties);
+      this.properties = properties;
       return this;
     }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableInfo.java
@@ -22,7 +22,6 @@ import org.apache.spark.sql.connector.catalog.constraints.Constraint;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.types.StructType;
 
-import java.util.Collections;
 import java.util.Map;
 
 public class TableInfo {


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `DataSourceV2`, we introduced a new `TableInfo` structure as part of https://github.com/apache/spark/pull/50137. This PR makes the changes such that we use the same property map from Spark instead of creating a new one.

### Why are the changes needed?
Retain the existing behavior, since the original PR was a refactoring change.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No