### PR TITLE
[SPARK-51699][BUILD] Upgrade to Apache parent pom 34

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>18</version>
+    <version>34</version>
   </parent>
   <groupId>org.apache.spark</groupId>
   <artifactId>spark-parent_2.12</artifactId>
@@ -112,9 +112,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.version>1.8</java.version>
+    <java.version>8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
+    <maven.compiler.release/>
     <maven.version>3.9.6</maven.version>
     <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
@@ -2855,7 +2856,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.5.0</version>
           <executions>
             <execution>
               <id>enforce-versions</id>
@@ -3019,7 +3020,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.14.0</version>
           <configuration>
             <source>${java.version}</source>
             <target>${java.version}</target>
@@ -3036,7 +3037,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.5.2</version>
           <!-- Note config is repeated in scalatest config -->
           <configuration>
             <includes>
@@ -3145,7 +3146,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -3155,7 +3156,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
           <configuration>
             <attach>true</attach>
           </configuration>
@@ -3172,7 +3173,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.4.1</version>
           <configuration>
             <filesets>
               <fileset>
@@ -3199,7 +3200,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.11.2</version>
           <configuration>
             <additionalJOptions>
               <additionalJOption>-Xdoclint:all</additionalJOption>
@@ -3247,7 +3248,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.7.1</version>
           <configuration>
             <tarLongFileMode>posix</tarLongFileMode>
           </configuration>
@@ -3255,7 +3256,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.0</version>
           <dependencies>
             <dependency>
               <groupId>org.ow2.asm</groupId>
@@ -3272,17 +3273,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.8.1</version>
           <executions>
             <execution>
               <id>default-cli</id>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade Apache parent pom from version 18 to the latest version 34 along with upgrading few maven plugins versions to match those from the latest parent pom.

- maven-enforcer-plugin from 3.3.0 to 3.5.0
- maven-compiler-plugin from 3.11.0 to 3.14.0
- maven-surefire-plugin from 3.1.2 to 3.5.2
- maven-jar-plugin from 3.3.0 to 3.4.2
- maven-source-plugin from 3.3.0 to 3.3.1
- maven-clean-plugin from 3.3.1 to 3.4.1
- maven-javadoc-plugin from 3.5.0 to 3.11.2
- maven-assembly-plugin from 3.6.0 to 3.7.1
- maven-shade-plugin from 3.5.0 to 3.6.0
- maven-install-plugin from 3.1.1 to 3.1.4
- maven-deploy-plugin from 3.1.1 to 3.1.4
- maven-dependency-plugin from 3.6.0 to 3.8.1

### Why are the changes needed?
Apache parent pom version 18 is 15 years old.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
maven build with Java 8 and Java 17


### Was this patch authored or co-authored using generative AI tooling?
No