### PR TITLE
[SPARK-51836][PYTHON][CONNECT][TESTS] Avoid per-test-function connect session setup

### DIFF
--- a/python/pyspark/ml/tests/connect/test_connect_classification.py
+++ b/python/pyspark/ml/tests/connect/test_connect_classification.py
@@ -17,12 +17,13 @@
 #
 
 import unittest
+import os
 
 from pyspark.util import is_remote_only
+from pyspark.sql import SparkSession
 from pyspark.ml.tests.connect.test_legacy_mode_classification import ClassificationTestsMixin
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 from pyspark.testing.utils import have_torch, torch_requirement_message
-from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 @unittest.skipIf(
@@ -31,12 +32,16 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
     or torch_requirement_message
     or "Requires PySpark core library in Spark Connect server",
 )
-class ClassificationTestsOnConnect(ClassificationTestsMixin, ReusedConnectTestCase):
-    @classmethod
-    def conf(cls):
-        config = super(ClassificationTestsOnConnect, cls).conf()
-        config.set("spark.sql.artifact.copyFromLocalToFs.allowDestLocal", "true")
-        return config
+class ClassificationTestsOnConnect(ClassificationTestsMixin, unittest.TestCase):
+    def setUp(self) -> None:
+        self.spark = (
+            SparkSession.builder.remote(os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[2]"))
+            .config("spark.sql.artifact.copyFromLocalToFs.allowDestLocal", "true")
+            .getOrCreate()
+        )
+
+    def tearDown(self) -> None:
+        self.spark.stop()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/connect/test_connect_classification.py
+++ b/python/pyspark/ml/tests/connect/test_connect_classification.py
@@ -17,13 +17,12 @@
 #
 
 import unittest
-import os
 
 from pyspark.util import is_remote_only
-from pyspark.sql import SparkSession
 from pyspark.ml.tests.connect.test_legacy_mode_classification import ClassificationTestsMixin
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 from pyspark.testing.utils import have_torch, torch_requirement_message
+from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 @unittest.skipIf(
@@ -32,16 +31,12 @@ from pyspark.testing.utils import have_torch, torch_requirement_message
     or torch_requirement_message
     or "Requires PySpark core library in Spark Connect server",
 )
-class ClassificationTestsOnConnect(ClassificationTestsMixin, unittest.TestCase):
-    def setUp(self) -> None:
-        self.spark = (
-            SparkSession.builder.remote(os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[2]"))
-            .config("spark.sql.artifact.copyFromLocalToFs.allowDestLocal", "true")
-            .getOrCreate()
-        )
-
-    def tearDown(self) -> None:
-        self.spark.stop()
+class ClassificationTestsOnConnect(ClassificationTestsMixin, ReusedConnectTestCase):
+    @classmethod
+    def conf(cls):
+        config = super(ReusedConnectTestCase, cls).conf()
+        config.set("spark.sql.artifact.copyFromLocalToFs.allowDestLocal", "true")
+        return config
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/connect/test_connect_classification.py
+++ b/python/pyspark/ml/tests/connect/test_connect_classification.py
@@ -34,7 +34,7 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 class ClassificationTestsOnConnect(ClassificationTestsMixin, ReusedConnectTestCase):
     @classmethod
     def conf(cls):
-        config = super(ReusedConnectTestCase, cls).conf()
+        config = super(ClassificationTestsOnConnect, cls).conf()
         config.set("spark.sql.artifact.copyFromLocalToFs.allowDestLocal", "true")
         return config
 

--- a/python/pyspark/ml/tests/connect/test_connect_evaluation.py
+++ b/python/pyspark/ml/tests/connect/test_connect_evaluation.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import os
 import unittest
 
 from pyspark.testing.connectutils import should_test_connect
@@ -27,7 +28,7 @@ if should_test_connect:
     class EvaluationTestsOnConnect(EvaluationTestsMixin, ReusedConnectTestCase):
         @classmethod
         def master(cls):
-            return "local[2]"
+            return os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[2]")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/connect/test_connect_evaluation.py
+++ b/python/pyspark/ml/tests/connect/test_connect_evaluation.py
@@ -17,7 +17,6 @@
 
 import unittest
 
-from pyspark.sql import SparkSession
 from pyspark.testing.connectutils import should_test_connect
 from pyspark.testing.connectutils import ReusedConnectTestCase
 

--- a/python/pyspark/ml/tests/connect/test_connect_evaluation.py
+++ b/python/pyspark/ml/tests/connect/test_connect_evaluation.py
@@ -25,7 +25,9 @@ if should_test_connect:
 
     @unittest.skip("SPARK-50956: Flaky with RetriesExceeded")
     class EvaluationTestsOnConnect(EvaluationTestsMixin, ReusedConnectTestCase):
-        pass
+        @classmethod
+        def master(cls):
+            return "local[2]"
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/connect/test_connect_evaluation.py
+++ b/python/pyspark/ml/tests/connect/test_connect_evaluation.py
@@ -15,24 +15,18 @@
 # limitations under the License.
 #
 
-import os
 import unittest
 
 from pyspark.sql import SparkSession
 from pyspark.testing.connectutils import should_test_connect
+from pyspark.testing.connectutils import ReusedConnectTestCase
 
 if should_test_connect:
     from pyspark.ml.tests.connect.test_legacy_mode_evaluation import EvaluationTestsMixin
 
     @unittest.skip("SPARK-50956: Flaky with RetriesExceeded")
-    class EvaluationTestsOnConnect(EvaluationTestsMixin, unittest.TestCase):
-        def setUp(self) -> None:
-            self.spark = SparkSession.builder.remote(
-                os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[2]")
-            ).getOrCreate()
-
-        def tearDown(self) -> None:
-            self.spark.stop()
+    class EvaluationTestsOnConnect(EvaluationTestsMixin, ReusedConnectTestCase):
+        pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/connect/test_connect_feature.py
+++ b/python/pyspark/ml/tests/connect/test_connect_feature.py
@@ -29,7 +29,9 @@ if should_test_connect:
         connect_requirement_message or sklearn_requirement_message,
     )
     class FeatureTestsOnConnect(FeatureTestsMixin, ReusedConnectTestCase):
-        pass
+        @classmethod
+        def master(cls):
+            return "local[2]"
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/connect/test_connect_feature.py
+++ b/python/pyspark/ml/tests/connect/test_connect_feature.py
@@ -15,12 +15,11 @@
 # limitations under the License.
 #
 
-import os
 import unittest
 
-from pyspark.sql import SparkSession
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 from pyspark.testing.utils import have_sklearn, sklearn_requirement_message
+from pyspark.testing.connectutils import ReusedConnectTestCase
 
 if should_test_connect:
     from pyspark.ml.tests.connect.test_legacy_mode_feature import FeatureTestsMixin
@@ -29,14 +28,8 @@ if should_test_connect:
         not should_test_connect or not have_sklearn,
         connect_requirement_message or sklearn_requirement_message,
     )
-    class FeatureTestsOnConnect(FeatureTestsMixin, unittest.TestCase):
-        def setUp(self) -> None:
-            self.spark = SparkSession.builder.remote(
-                os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[2]")
-            ).getOrCreate()
-
-        def tearDown(self) -> None:
-            self.spark.stop()
+    class FeatureTestsOnConnect(FeatureTestsMixin, ReusedConnectTestCase):
+        pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/connect/test_connect_feature.py
+++ b/python/pyspark/ml/tests/connect/test_connect_feature.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import os
 import unittest
 
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
@@ -31,7 +32,7 @@ if should_test_connect:
     class FeatureTestsOnConnect(FeatureTestsMixin, ReusedConnectTestCase):
         @classmethod
         def master(cls):
-            return "local[2]"
+            return os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[2]")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/connect/test_connect_pipeline.py
+++ b/python/pyspark/ml/tests/connect/test_connect_pipeline.py
@@ -34,9 +34,13 @@ if should_test_connect:
     class PipelineTestsOnConnect(PipelineTestsMixin, ReusedConnectTestCase):
         @classmethod
         def conf(cls):
-            c = super(PipelineTestsOnConnect, cls).conf()
-            c.set("spark.sql.artifact.copyFromLocalToFs.allowDestLocal", "true")
-            return c
+            config = super(PipelineTestsOnConnect, cls).conf()
+            config.set("spark.sql.artifact.copyFromLocalToFs.allowDestLocal", "true")
+            return config
+
+        @classmethod
+        def master(cls):
+            return "local[2]"
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/connect/test_connect_pipeline.py
+++ b/python/pyspark/ml/tests/connect/test_connect_pipeline.py
@@ -15,14 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import unittest
 
 from pyspark.util import is_remote_only
-from pyspark.sql import SparkSession
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 from pyspark.testing.utils import have_torch, torch_requirement_message
-
+from pyspark.testing.connectutils import ReusedConnectTestCase
 
 if should_test_connect:
     from pyspark.ml.tests.connect.test_legacy_mode_pipeline import PipelineTestsMixin
@@ -33,18 +31,12 @@ if should_test_connect:
         or torch_requirement_message
         or "Requires PySpark core library in Spark Connect server",
     )
-    class PipelineTestsOnConnect(PipelineTestsMixin, unittest.TestCase):
-        def setUp(self) -> None:
-            self.spark = (
-                SparkSession.builder.remote(
-                    os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[2]")
-                )
-                .config("spark.sql.artifact.copyFromLocalToFs.allowDestLocal", "true")
-                .getOrCreate()
-            )
-
-        def tearDown(self) -> None:
-            self.spark.stop()
+    class PipelineTestsOnConnect(PipelineTestsMixin, ReusedConnectTestCase):
+        @classmethod
+        def conf(cls):
+            c = super(ReusedConnectTestCase, cls).conf()
+            c.set("spark.sql.artifact.copyFromLocalToFs.allowDestLocal", "true")
+            return c
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/connect/test_connect_pipeline.py
+++ b/python/pyspark/ml/tests/connect/test_connect_pipeline.py
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+import os
 import unittest
 
 from pyspark.util import is_remote_only
@@ -40,7 +42,7 @@ if should_test_connect:
 
         @classmethod
         def master(cls):
-            return "local[2]"
+            return os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[2]")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/connect/test_connect_pipeline.py
+++ b/python/pyspark/ml/tests/connect/test_connect_pipeline.py
@@ -34,7 +34,7 @@ if should_test_connect:
     class PipelineTestsOnConnect(PipelineTestsMixin, ReusedConnectTestCase):
         @classmethod
         def conf(cls):
-            c = super(ReusedConnectTestCase, cls).conf()
+            c = super(PipelineTestsOnConnect, cls).conf()
             c.set("spark.sql.artifact.copyFromLocalToFs.allowDestLocal", "true")
             return c
 

--- a/python/pyspark/ml/tests/connect/test_connect_summarizer.py
+++ b/python/pyspark/ml/tests/connect/test_connect_summarizer.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import os
 import unittest
 
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
@@ -27,7 +28,7 @@ if should_test_connect:
     class SummarizerTestsOnConnect(SummarizerTestsMixin, ReusedConnectTestCase):
         @classmethod
         def master(cls):
-            return "local[2]"
+            return os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[2]")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/connect/test_connect_summarizer.py
+++ b/python/pyspark/ml/tests/connect/test_connect_summarizer.py
@@ -16,23 +16,16 @@
 #
 
 import unittest
-import os
 
-from pyspark.sql import SparkSession
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+from pyspark.testing.connectutils import ReusedConnectTestCase
 
 if should_test_connect:
     from pyspark.ml.tests.connect.test_legacy_mode_summarizer import SummarizerTestsMixin
 
     @unittest.skipIf(not should_test_connect, connect_requirement_message)
-    class SummarizerTestsOnConnect(SummarizerTestsMixin, unittest.TestCase):
-        def setUp(self) -> None:
-            self.spark = SparkSession.builder.remote(
-                os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[2]")
-            ).getOrCreate()
-
-        def tearDown(self) -> None:
-            self.spark.stop()
+    class SummarizerTestsOnConnect(SummarizerTestsMixin, ReusedConnectTestCase):
+        pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/connect/test_connect_summarizer.py
+++ b/python/pyspark/ml/tests/connect/test_connect_summarizer.py
@@ -25,7 +25,9 @@ if should_test_connect:
 
     @unittest.skipIf(not should_test_connect, connect_requirement_message)
     class SummarizerTestsOnConnect(SummarizerTestsMixin, ReusedConnectTestCase):
-        pass
+        @classmethod
+        def master(cls):
+            return "local[2]"
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/connect/test_connect_tuning.py
+++ b/python/pyspark/ml/tests/connect/test_connect_tuning.py
@@ -35,7 +35,7 @@ if should_test_connect:
     class CrossValidatorTestsOnConnect(CrossValidatorTestsMixin, ReusedConnectTestCase):
         @classmethod
         def conf(cls):
-            c = super(ReusedConnectTestCase, cls).conf()
+            c = super(CrossValidatorTestsOnConnect, cls).conf()
             c.set("spark.sql.artifact.copyFromLocalToFs.allowDestLocal", "true")
             return c
 

--- a/python/pyspark/ml/tests/connect/test_connect_tuning.py
+++ b/python/pyspark/ml/tests/connect/test_connect_tuning.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+import os
 import unittest
 
 from pyspark.util import is_remote_only
@@ -41,7 +42,7 @@ if should_test_connect:
 
         @classmethod
         def master(cls):
-            return "local[2]"
+            return os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[2]")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/connect/test_connect_tuning.py
+++ b/python/pyspark/ml/tests/connect/test_connect_tuning.py
@@ -35,9 +35,13 @@ if should_test_connect:
     class CrossValidatorTestsOnConnect(CrossValidatorTestsMixin, ReusedConnectTestCase):
         @classmethod
         def conf(cls):
-            c = super(CrossValidatorTestsOnConnect, cls).conf()
-            c.set("spark.sql.artifact.copyFromLocalToFs.allowDestLocal", "true")
-            return c
+            config = super(CrossValidatorTestsOnConnect, cls).conf()
+            config.set("spark.sql.artifact.copyFromLocalToFs.allowDestLocal", "true")
+            return config
+
+        @classmethod
+        def master(cls):
+            return "local[2]"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Avoid per-test-function session setup

### Why are the changes needed?
To make test stable and fast
these `python/pyspark/ml/tests/connect/test_connect_xxx` are known to be kind of flaky, I notice that they setup/teardown spark session for each test function, this seems unnecessary and costly.

There are still some similar places, but such change cause test failure, will revisit them later.

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
