### PR TITLE
[SPARK-51842][SQL] Remove unnecessary judgement from fillDefaultValue

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowFunctionFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowFunctionFrame.scala
@@ -123,10 +123,7 @@ abstract class OffsetWindowFunctionFrameBase(
   protected val fillDefaultValue = {
     // Collect the expressions and bind them.
     val boundExpressions = Seq.fill(ordinal)(NoOp) ++ expressions.toImmutableArraySeq.map { e =>
-      if (e.default == null) {
-        // The default value is null.
-        Literal.create(null, e.dataType)
-      } else if (e.default.foldable) {
+      if (e.default.foldable) {
         // The default value is foldable.
         Literal.create(e.default.eval(), e.dataType)
       } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to remove unnecessary judgement from `fillDefaultValue`.

### Why are the changes needed?
Currently, there is a judgement `e.default == null` while declaring `fillDefaultValue`.
After an investigation, there should not be a value of primitive type here. It might be a literal null even if users specify null as the default value.

### Does this PR introduce _any_ user-facing change?
 'No'.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
