### PR TITLE
[SPARK-51663][SQL][FOLLOWUP] change buildLeft and buildRight to function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -293,14 +293,14 @@ trait JoinSelectionHelper extends Logging {
       join: Join,
       hintOnly: Boolean,
       conf: SQLConf): Option[BuildSide] = {
-    def maybeBuildLeft(): Boolean = {
+    def shouldBuildLeft(): Boolean = {
       if (hintOnly) {
         hintToBroadcastLeft(join.hint)
       } else {
         canBroadcastBySize(join.left, conf) && !hintToNotBroadcastLeft(join.hint)
       }
     }
-    def maybeBuildRight(): Boolean = {
+    def shouldBuildRight(): Boolean = {
       if (hintOnly) {
         hintToBroadcastRight(join.hint)
       } else {
@@ -308,8 +308,8 @@ trait JoinSelectionHelper extends Logging {
       }
     }
     getBuildSide(
-      canBuildBroadcastLeft(join.joinType) && maybeBuildLeft(),
-      canBuildBroadcastRight(join.joinType) && maybeBuildRight(),
+      canBuildBroadcastLeft(join.joinType) && shouldBuildLeft(),
+      canBuildBroadcastRight(join.joinType) && shouldBuildRight(),
       join.left,
       join.right
     )
@@ -319,7 +319,7 @@ trait JoinSelectionHelper extends Logging {
       join: Join,
       hintOnly: Boolean,
       conf: SQLConf): Option[BuildSide] = {
-    def maybeBuildLeft(): Boolean = {
+    def shouldBuildLeft(): Boolean = {
       if (hintOnly) {
         hintToShuffleHashJoinLeft(join.hint)
       } else {
@@ -329,7 +329,7 @@ trait JoinSelectionHelper extends Logging {
           forceApplyShuffledHashJoin(conf)
       }
     }
-    def maybeBuildRight(): Boolean = {
+    def shouldBuildRight(): Boolean = {
       if (hintOnly) {
         hintToShuffleHashJoinRight(join.hint)
       } else {
@@ -340,8 +340,8 @@ trait JoinSelectionHelper extends Logging {
       }
     }
     getBuildSide(
-      canBuildShuffledHashJoinLeft(join.joinType) && maybeBuildLeft(),
-      canBuildShuffledHashJoinRight(join.joinType) && maybeBuildRight(),
+      canBuildShuffledHashJoinLeft(join.joinType) && shouldBuildLeft(),
+      canBuildShuffledHashJoinRight(join.joinType) && shouldBuildRight(),
       join.left,
       join.right
     )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -293,19 +293,19 @@ trait JoinSelectionHelper extends Logging {
       join: Join,
       hintOnly: Boolean,
       conf: SQLConf): Option[BuildSide] = {
-    val buildLeft = if (hintOnly) {
+    lazy val buildLeft = if (hintOnly) {
       hintToBroadcastLeft(join.hint)
     } else {
       canBroadcastBySize(join.left, conf) && !hintToNotBroadcastLeft(join.hint)
     }
-    val buildRight = if (hintOnly) {
+    lazy val buildRight = if (hintOnly) {
       hintToBroadcastRight(join.hint)
     } else {
       canBroadcastBySize(join.right, conf) && !hintToNotBroadcastRight(join.hint)
     }
     getBuildSide(
-      buildLeft && canBuildBroadcastLeft(join.joinType),
-      buildRight && canBuildBroadcastRight(join.joinType),
+      canBuildBroadcastLeft(join.joinType) && buildLeft,
+      canBuildBroadcastRight(join.joinType) && buildRight,
       join.left,
       join.right
     )
@@ -315,7 +315,7 @@ trait JoinSelectionHelper extends Logging {
       join: Join,
       hintOnly: Boolean,
       conf: SQLConf): Option[BuildSide] = {
-    val buildLeft = if (hintOnly) {
+    lazy val buildLeft = if (hintOnly) {
       hintToShuffleHashJoinLeft(join.hint)
     } else {
       hintToPreferShuffleHashJoinLeft(join.hint) ||
@@ -323,7 +323,7 @@ trait JoinSelectionHelper extends Logging {
           muchSmaller(join.left, join.right, conf)) ||
         forceApplyShuffledHashJoin(conf)
     }
-    val buildRight = if (hintOnly) {
+    lazy val buildRight = if (hintOnly) {
       hintToShuffleHashJoinRight(join.hint)
     } else {
       hintToPreferShuffleHashJoinRight(join.hint) ||
@@ -332,8 +332,8 @@ trait JoinSelectionHelper extends Logging {
         forceApplyShuffledHashJoin(conf)
     }
     getBuildSide(
-      buildLeft && canBuildShuffledHashJoinLeft(join.joinType),
-      buildRight && canBuildShuffledHashJoinRight(join.joinType),
+      canBuildShuffledHashJoinLeft(join.joinType) && buildLeft,
+      canBuildShuffledHashJoinRight(join.joinType) && buildRight,
       join.left,
       join.right
     )


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR follows up https://github.com/apache/spark/pull/50455 and improves `JoinSelectionHelper` more.


### Why are the changes needed?
The overhead of `buildLeft`/`buildRight` are more expensive than `canBuildBroadcastLeft`/`canBuildBroadcastRight`.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
