### PR TITLE
[SPARK-49488][SQL][FOLLOWUP] Do not push down extract expression if extracted field is second

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -270,7 +270,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
       assert(rows(0).getString(0) === "tom")
     }
 
-    withClue("minute") {
+    withClue("second") {
       val df = sql(s"SELECT name FROM $tbl WHERE second(time1) = 0 AND month(date1) = 5")
       checkFilterPushed(df, false)
       val rows = df.collect()

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -203,7 +203,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
     assert(rows2(0).getString(0) === "amy")
     assert(rows2(1).getString(0) === "alex")
 
-    val df3 = sql(s"SELECT name FROM $tbl WHERE second(time1) = 0 AND month(date1) = 5")
+    val df3 = sql(s"SELECT name FROM $tbl WHERE month(date1) = 5")
     checkFilterPushed(df3)
     val rows3 = df3.collect()
     assert(rows3.length === 2)
@@ -268,6 +268,15 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
       val rows = df.collect()
       assert(rows.length === 1)
       assert(rows(0).getString(0) === "tom")
+    }
+
+    withClue("minute") {
+      val df = sql(s"SELECT name FROM $tbl WHERE second(time1) = 0 AND month(date1) = 5")
+      checkFilterPushed(df, false)
+      val rows = df.collect()
+      assert(rows.length === 2)
+      assert(rows(0).getString(0) === "amy")
+      assert(rows(1).getString(0) === "alex")
     }
 
     val df9 = sql(s"SELECT name FROM $tbl WHERE " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -57,8 +57,11 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
       field match {
         case "DAY_OF_YEAR" => s"DAYOFYEAR(${build(extract.source())})"
         case "WEEK" => s"WEEKOFYEAR(${build(extract.source())})"
-        case "YEAR_OF_WEEK" => visitUnexpectedExpr(extract)
-        case "SECOND" => visitUnexpectedExpr(extract)
+        // MySQL does not support the date field YEAR_OF_WEEK.
+        // We can't push down SECOND due to the difference in result types between Spark and
+        // MySQL. Spark returns decimal(8, 6), but MySQL returns integer.
+        case "YEAR_OF_WEEK" | "SECOND" =>
+          visitUnexpectedExpr(extract)
         // WEEKDAY uses Monday = 0, Tuesday = 1, ... and ISO standard is Monday = 1, ...,
         // so we use the formula (WEEKDAY + 1) to follow the ISO standard.
         case "DAY_OF_WEEK" => s"(WEEKDAY(${build(extract.source())}) + 1)"

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -58,10 +58,11 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
         case "DAY_OF_YEAR" => s"DAYOFYEAR(${build(extract.source())})"
         case "WEEK" => s"WEEKOFYEAR(${build(extract.source())})"
         case "YEAR_OF_WEEK" => visitUnexpectedExpr(extract)
+        case "SECOND" => visitUnexpectedExpr(extract)
         // WEEKDAY uses Monday = 0, Tuesday = 1, ... and ISO standard is Monday = 1, ...,
         // so we use the formula (WEEKDAY + 1) to follow the ISO standard.
         case "DAY_OF_WEEK" => s"(WEEKDAY(${build(extract.source())}) + 1)"
-        // SECOND, MINUTE, HOUR, DAY, MONTH, QUARTER, YEAR are identical on MySQL and Spark for
+        // MINUTE, HOUR, DAY, MONTH, QUARTER, YEAR are identical on MySQL and Spark for
         // both datetime and interval types.
         case _ => super.visitExtract(field, build(extract.source()))
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to forbid the pushdown while extract `second` from date or interval.


### Why are the changes needed?
Currently, Spark supports extract second from date or interval and it returns result with `decimal(8, 6)`.
But extract second from date or interval returns integer in MySQL.
So we should forbid the pushdown.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
