### PR TITLE
[SPARK-51845][ML][CONNECT] Add proto messages `CleanCache` and `GetCacheInfo`

### DIFF
--- a/python/pyspark/ml/tests/connect/test_connect_cache.py
+++ b/python/pyspark/ml/tests/connect/test_connect_cache.py
@@ -46,7 +46,6 @@ class MLConnectCacheTests(ReusedConnectTestCase):
 
         # model is cached in python side
         self.assertEqual(len(spark.client.thread_local.ml_caches), 1)
-
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 1)
         self.assertTrue(
@@ -58,7 +57,9 @@ class MLConnectCacheTests(ReusedConnectTestCase):
         del model
 
         # model is removed in python side
-        self.assertFalse(hasattr(spark.client.thread_local, "ml_caches"))
+        self.assertEqual(len(spark.client.thread_local.ml_caches), 0)
+        cache_info = spark.client._get_ml_cache_info()
+        self.assertEqual(len(cache_info), 0)
 
     def test_cleanup_ml(self):
         spark = self.spark
@@ -86,7 +87,6 @@ class MLConnectCacheTests(ReusedConnectTestCase):
 
         # all 3 models are cached in python side
         self.assertEqual(len(spark.client.thread_local.ml_caches), 3)
-
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 3)
         self.assertTrue(
@@ -108,7 +108,7 @@ class MLConnectCacheTests(ReusedConnectTestCase):
         spark.client._cleanup_ml()
 
         # All models are removed in python side
-        self.assertFalse(hasattr(spark.client.thread_local, "ml_caches"))
+        self.assertEqual(len(spark.client.thread_local.ml_caches), 0)
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 0)
 

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -2013,11 +2013,10 @@ class SparkConnectClient(object):
         if not hasattr(self.thread_local, "ml_caches"):
             self.thread_local.ml_caches = set()
 
-        if len(self.thread_local.ml_caches) > 0:
-            try:
-                command = pb2.Command()
-                command.ml_command.clean.SetInParent()
-                self.execute_command(command)
-                self.thread_local.ml_caches.clear()
-            except Exception:
-                pass
+        try:
+            command = pb2.Command()
+            command.ml_command.clean.SetInParent()
+            self.execute_command(command)
+            self.thread_local.ml_caches.clear()
+        except Exception:
+            pass

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -2010,13 +2010,11 @@ class SparkConnectClient(object):
             return []
 
     def _cleanup_ml(self) -> None:
-        if not hasattr(self.thread_local, "ml_caches"):
-            self.thread_local.ml_caches = set()
-
-        try:
-            command = pb2.Command()
-            command.ml_command.clean.SetInParent()
-            self.execute_command(command)
-            self.thread_local.ml_caches.clear()
-        except Exception:
-            pass
+        if hasattr(self.thread_local, "ml_caches") and len(self.thread_local.ml_caches) > 0:
+            try:
+                command = pb2.Command()
+                command.ml_command.clean.SetInParent()
+                self.execute_command(command)
+                self.thread_local.ml_caches.clear()
+            except Exception:
+                pass

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1987,9 +1987,6 @@ class SparkConnectClient(object):
                 for obj_id in deleted:
                     self.thread_local.ml_caches.remove(obj_id)
 
-            if len(self.thread_local.ml_caches) == 0:
-                del self.thread_local.ml_caches
-
     def _delete_ml_cache(self, cache_ids: List[str]) -> List[str]:
         # try best to delete the cache
         try:
@@ -2017,7 +2014,6 @@ class SparkConnectClient(object):
                 command.ml_command.clean_cache.SetInParent()
                 self.execute_command(command)
                 self.thread_local.ml_caches.clear()
-                del self.thread_local.ml_caches
             except Exception:
                 pass
 

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -2013,7 +2013,11 @@ class SparkConnectClient(object):
         if not hasattr(self.thread_local, "ml_caches"):
             self.thread_local.ml_caches = set()
 
-        self.disable_reattachable_execute()
-        deleted = self._delete_ml_cache(list(self.thread_local.ml_caches))
-        for obj_id in deleted:
-            self.thread_local.ml_caches.remove(obj_id)
+        if len(self.thread_local.ml_caches) > 0:
+            try:
+                command = pb2.Command()
+                command.ml_command.clean.SetInParent()
+                self.execute_command(command)
+                self.thread_local.ml_caches.clear()
+            except Exception:
+                pass

--- a/python/pyspark/sql/connect/proto/ml_pb2.py
+++ b/python/pyspark/sql/connect/proto/ml_pb2.py
@@ -40,7 +40,7 @@ from pyspark.sql.connect.proto import ml_common_pb2 as spark_dot_connect_dot_ml_
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x16spark/connect/ml.proto\x12\rspark.connect\x1a\x1dspark/connect/relations.proto\x1a\x1fspark/connect/expressions.proto\x1a\x1dspark/connect/ml_common.proto"\xfd\t\n\tMlCommand\x12\x30\n\x03\x66it\x18\x01 \x01(\x0b\x32\x1c.spark.connect.MlCommand.FitH\x00R\x03\x66it\x12,\n\x05\x66\x65tch\x18\x02 \x01(\x0b\x32\x14.spark.connect.FetchH\x00R\x05\x66\x65tch\x12\x39\n\x06\x64\x65lete\x18\x03 \x01(\x0b\x32\x1f.spark.connect.MlCommand.DeleteH\x00R\x06\x64\x65lete\x12\x36\n\x05write\x18\x04 \x01(\x0b\x32\x1e.spark.connect.MlCommand.WriteH\x00R\x05write\x12\x33\n\x04read\x18\x05 \x01(\x0b\x32\x1d.spark.connect.MlCommand.ReadH\x00R\x04read\x12?\n\x08\x65valuate\x18\x06 \x01(\x0b\x32!.spark.connect.MlCommand.EvaluateH\x00R\x08\x65valuate\x1a\xb2\x01\n\x03\x46it\x12\x37\n\testimator\x18\x01 \x01(\x0b\x32\x19.spark.connect.MlOperatorR\testimator\x12\x34\n\x06params\x18\x02 \x01(\x0b\x32\x17.spark.connect.MlParamsH\x00R\x06params\x88\x01\x01\x12\x31\n\x07\x64\x61taset\x18\x03 \x01(\x0b\x32\x17.spark.connect.RelationR\x07\x64\x61tasetB\t\n\x07_params\x1a=\n\x06\x44\x65lete\x12\x33\n\x08obj_refs\x18\x01 \x03(\x0b\x32\x18.spark.connect.ObjectRefR\x07objRefs\x1a\x9a\x03\n\x05Write\x12\x37\n\x08operator\x18\x01 \x01(\x0b\x32\x19.spark.connect.MlOperatorH\x00R\x08operator\x12\x33\n\x07obj_ref\x18\x02 \x01(\x0b\x32\x18.spark.connect.ObjectRefH\x00R\x06objRef\x12\x34\n\x06params\x18\x03 \x01(\x0b\x32\x17.spark.connect.MlParamsH\x01R\x06params\x88\x01\x01\x12\x12\n\x04path\x18\x04 \x01(\tR\x04path\x12.\n\x10should_overwrite\x18\x05 \x01(\x08H\x02R\x0fshouldOverwrite\x88\x01\x01\x12\x45\n\x07options\x18\x06 \x03(\x0b\x32+.spark.connect.MlCommand.Write.OptionsEntryR\x07options\x1a:\n\x0cOptionsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x06\n\x04typeB\t\n\x07_paramsB\x13\n\x11_should_overwrite\x1aQ\n\x04Read\x12\x35\n\x08operator\x18\x01 \x01(\x0b\x32\x19.spark.connect.MlOperatorR\x08operator\x12\x12\n\x04path\x18\x02 \x01(\tR\x04path\x1a\xb7\x01\n\x08\x45valuate\x12\x37\n\tevaluator\x18\x01 \x01(\x0b\x32\x19.spark.connect.MlOperatorR\tevaluator\x12\x34\n\x06params\x18\x02 \x01(\x0b\x32\x17.spark.connect.MlParamsH\x00R\x06params\x88\x01\x01\x12\x31\n\x07\x64\x61taset\x18\x03 \x01(\x0b\x32\x17.spark.connect.RelationR\x07\x64\x61tasetB\t\n\x07_paramsB\t\n\x07\x63ommand"\x93\x03\n\x0fMlCommandResult\x12\x39\n\x05param\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralH\x00R\x05param\x12\x1a\n\x07summary\x18\x02 \x01(\tH\x00R\x07summary\x12T\n\roperator_info\x18\x03 \x01(\x0b\x32-.spark.connect.MlCommandResult.MlOperatorInfoH\x00R\x0coperatorInfo\x1a\xc3\x01\n\x0eMlOperatorInfo\x12\x33\n\x07obj_ref\x18\x01 \x01(\x0b\x32\x18.spark.connect.ObjectRefH\x00R\x06objRef\x12\x14\n\x04name\x18\x02 \x01(\tH\x00R\x04name\x12\x15\n\x03uid\x18\x03 \x01(\tH\x01R\x03uid\x88\x01\x01\x12\x34\n\x06params\x18\x04 \x01(\x0b\x32\x17.spark.connect.MlParamsH\x02R\x06params\x88\x01\x01\x42\x06\n\x04typeB\x06\n\x04_uidB\t\n\x07_paramsB\r\n\x0bresult_typeB6\n\x1eorg.apache.spark.connect.protoP\x01Z\x12internal/generatedb\x06proto3'
+    b'\n\x16spark/connect/ml.proto\x12\rspark.connect\x1a\x1dspark/connect/relations.proto\x1a\x1fspark/connect/expressions.proto\x1a\x1dspark/connect/ml_common.proto"\xbe\n\n\tMlCommand\x12\x30\n\x03\x66it\x18\x01 \x01(\x0b\x32\x1c.spark.connect.MlCommand.FitH\x00R\x03\x66it\x12,\n\x05\x66\x65tch\x18\x02 \x01(\x0b\x32\x14.spark.connect.FetchH\x00R\x05\x66\x65tch\x12\x39\n\x06\x64\x65lete\x18\x03 \x01(\x0b\x32\x1f.spark.connect.MlCommand.DeleteH\x00R\x06\x64\x65lete\x12\x36\n\x05write\x18\x04 \x01(\x0b\x32\x1e.spark.connect.MlCommand.WriteH\x00R\x05write\x12\x33\n\x04read\x18\x05 \x01(\x0b\x32\x1d.spark.connect.MlCommand.ReadH\x00R\x04read\x12?\n\x08\x65valuate\x18\x06 \x01(\x0b\x32!.spark.connect.MlCommand.EvaluateH\x00R\x08\x65valuate\x12\x36\n\x05\x63lean\x18\x07 \x01(\x0b\x32\x1e.spark.connect.MlCommand.CleanH\x00R\x05\x63lean\x1a\xb2\x01\n\x03\x46it\x12\x37\n\testimator\x18\x01 \x01(\x0b\x32\x19.spark.connect.MlOperatorR\testimator\x12\x34\n\x06params\x18\x02 \x01(\x0b\x32\x17.spark.connect.MlParamsH\x00R\x06params\x88\x01\x01\x12\x31\n\x07\x64\x61taset\x18\x03 \x01(\x0b\x32\x17.spark.connect.RelationR\x07\x64\x61tasetB\t\n\x07_params\x1a=\n\x06\x44\x65lete\x12\x33\n\x08obj_refs\x18\x01 \x03(\x0b\x32\x18.spark.connect.ObjectRefR\x07objRefs\x1a\x07\n\x05\x43lean\x1a\x9a\x03\n\x05Write\x12\x37\n\x08operator\x18\x01 \x01(\x0b\x32\x19.spark.connect.MlOperatorH\x00R\x08operator\x12\x33\n\x07obj_ref\x18\x02 \x01(\x0b\x32\x18.spark.connect.ObjectRefH\x00R\x06objRef\x12\x34\n\x06params\x18\x03 \x01(\x0b\x32\x17.spark.connect.MlParamsH\x01R\x06params\x88\x01\x01\x12\x12\n\x04path\x18\x04 \x01(\tR\x04path\x12.\n\x10should_overwrite\x18\x05 \x01(\x08H\x02R\x0fshouldOverwrite\x88\x01\x01\x12\x45\n\x07options\x18\x06 \x03(\x0b\x32+.spark.connect.MlCommand.Write.OptionsEntryR\x07options\x1a:\n\x0cOptionsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x06\n\x04typeB\t\n\x07_paramsB\x13\n\x11_should_overwrite\x1aQ\n\x04Read\x12\x35\n\x08operator\x18\x01 \x01(\x0b\x32\x19.spark.connect.MlOperatorR\x08operator\x12\x12\n\x04path\x18\x02 \x01(\tR\x04path\x1a\xb7\x01\n\x08\x45valuate\x12\x37\n\tevaluator\x18\x01 \x01(\x0b\x32\x19.spark.connect.MlOperatorR\tevaluator\x12\x34\n\x06params\x18\x02 \x01(\x0b\x32\x17.spark.connect.MlParamsH\x00R\x06params\x88\x01\x01\x12\x31\n\x07\x64\x61taset\x18\x03 \x01(\x0b\x32\x17.spark.connect.RelationR\x07\x64\x61tasetB\t\n\x07_paramsB\t\n\x07\x63ommand"\x93\x03\n\x0fMlCommandResult\x12\x39\n\x05param\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralH\x00R\x05param\x12\x1a\n\x07summary\x18\x02 \x01(\tH\x00R\x07summary\x12T\n\roperator_info\x18\x03 \x01(\x0b\x32-.spark.connect.MlCommandResult.MlOperatorInfoH\x00R\x0coperatorInfo\x1a\xc3\x01\n\x0eMlOperatorInfo\x12\x33\n\x07obj_ref\x18\x01 \x01(\x0b\x32\x18.spark.connect.ObjectRefH\x00R\x06objRef\x12\x14\n\x04name\x18\x02 \x01(\tH\x00R\x04name\x12\x15\n\x03uid\x18\x03 \x01(\tH\x01R\x03uid\x88\x01\x01\x12\x34\n\x06params\x18\x04 \x01(\x0b\x32\x17.spark.connect.MlParamsH\x02R\x06params\x88\x01\x01\x42\x06\n\x04typeB\x06\n\x04_uidB\t\n\x07_paramsB\r\n\x0bresult_typeB6\n\x1eorg.apache.spark.connect.protoP\x01Z\x12internal/generatedb\x06proto3'
 )
 
 _globals = globals()
@@ -54,21 +54,23 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["_MLCOMMAND_WRITE_OPTIONSENTRY"]._loaded_options = None
     _globals["_MLCOMMAND_WRITE_OPTIONSENTRY"]._serialized_options = b"8\001"
     _globals["_MLCOMMAND"]._serialized_start = 137
-    _globals["_MLCOMMAND"]._serialized_end = 1414
-    _globals["_MLCOMMAND_FIT"]._serialized_start = 480
-    _globals["_MLCOMMAND_FIT"]._serialized_end = 658
-    _globals["_MLCOMMAND_DELETE"]._serialized_start = 660
-    _globals["_MLCOMMAND_DELETE"]._serialized_end = 721
-    _globals["_MLCOMMAND_WRITE"]._serialized_start = 724
-    _globals["_MLCOMMAND_WRITE"]._serialized_end = 1134
-    _globals["_MLCOMMAND_WRITE_OPTIONSENTRY"]._serialized_start = 1036
-    _globals["_MLCOMMAND_WRITE_OPTIONSENTRY"]._serialized_end = 1094
-    _globals["_MLCOMMAND_READ"]._serialized_start = 1136
-    _globals["_MLCOMMAND_READ"]._serialized_end = 1217
-    _globals["_MLCOMMAND_EVALUATE"]._serialized_start = 1220
-    _globals["_MLCOMMAND_EVALUATE"]._serialized_end = 1403
-    _globals["_MLCOMMANDRESULT"]._serialized_start = 1417
-    _globals["_MLCOMMANDRESULT"]._serialized_end = 1820
-    _globals["_MLCOMMANDRESULT_MLOPERATORINFO"]._serialized_start = 1610
-    _globals["_MLCOMMANDRESULT_MLOPERATORINFO"]._serialized_end = 1805
+    _globals["_MLCOMMAND"]._serialized_end = 1479
+    _globals["_MLCOMMAND_FIT"]._serialized_start = 536
+    _globals["_MLCOMMAND_FIT"]._serialized_end = 714
+    _globals["_MLCOMMAND_DELETE"]._serialized_start = 716
+    _globals["_MLCOMMAND_DELETE"]._serialized_end = 777
+    _globals["_MLCOMMAND_CLEAN"]._serialized_start = 779
+    _globals["_MLCOMMAND_CLEAN"]._serialized_end = 786
+    _globals["_MLCOMMAND_WRITE"]._serialized_start = 789
+    _globals["_MLCOMMAND_WRITE"]._serialized_end = 1199
+    _globals["_MLCOMMAND_WRITE_OPTIONSENTRY"]._serialized_start = 1101
+    _globals["_MLCOMMAND_WRITE_OPTIONSENTRY"]._serialized_end = 1159
+    _globals["_MLCOMMAND_READ"]._serialized_start = 1201
+    _globals["_MLCOMMAND_READ"]._serialized_end = 1282
+    _globals["_MLCOMMAND_EVALUATE"]._serialized_start = 1285
+    _globals["_MLCOMMAND_EVALUATE"]._serialized_end = 1468
+    _globals["_MLCOMMANDRESULT"]._serialized_start = 1482
+    _globals["_MLCOMMANDRESULT"]._serialized_end = 1885
+    _globals["_MLCOMMANDRESULT_MLOPERATORINFO"]._serialized_start = 1675
+    _globals["_MLCOMMANDRESULT_MLOPERATORINFO"]._serialized_end = 1870
 # @@protoc_insertion_point(module_scope)

--- a/python/pyspark/sql/connect/proto/ml_pb2.py
+++ b/python/pyspark/sql/connect/proto/ml_pb2.py
@@ -40,7 +40,7 @@ from pyspark.sql.connect.proto import ml_common_pb2 as spark_dot_connect_dot_ml_
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x16spark/connect/ml.proto\x12\rspark.connect\x1a\x1dspark/connect/relations.proto\x1a\x1fspark/connect/expressions.proto\x1a\x1dspark/connect/ml_common.proto"\xbe\n\n\tMlCommand\x12\x30\n\x03\x66it\x18\x01 \x01(\x0b\x32\x1c.spark.connect.MlCommand.FitH\x00R\x03\x66it\x12,\n\x05\x66\x65tch\x18\x02 \x01(\x0b\x32\x14.spark.connect.FetchH\x00R\x05\x66\x65tch\x12\x39\n\x06\x64\x65lete\x18\x03 \x01(\x0b\x32\x1f.spark.connect.MlCommand.DeleteH\x00R\x06\x64\x65lete\x12\x36\n\x05write\x18\x04 \x01(\x0b\x32\x1e.spark.connect.MlCommand.WriteH\x00R\x05write\x12\x33\n\x04read\x18\x05 \x01(\x0b\x32\x1d.spark.connect.MlCommand.ReadH\x00R\x04read\x12?\n\x08\x65valuate\x18\x06 \x01(\x0b\x32!.spark.connect.MlCommand.EvaluateH\x00R\x08\x65valuate\x12\x36\n\x05\x63lean\x18\x07 \x01(\x0b\x32\x1e.spark.connect.MlCommand.CleanH\x00R\x05\x63lean\x1a\xb2\x01\n\x03\x46it\x12\x37\n\testimator\x18\x01 \x01(\x0b\x32\x19.spark.connect.MlOperatorR\testimator\x12\x34\n\x06params\x18\x02 \x01(\x0b\x32\x17.spark.connect.MlParamsH\x00R\x06params\x88\x01\x01\x12\x31\n\x07\x64\x61taset\x18\x03 \x01(\x0b\x32\x17.spark.connect.RelationR\x07\x64\x61tasetB\t\n\x07_params\x1a=\n\x06\x44\x65lete\x12\x33\n\x08obj_refs\x18\x01 \x03(\x0b\x32\x18.spark.connect.ObjectRefR\x07objRefs\x1a\x07\n\x05\x43lean\x1a\x9a\x03\n\x05Write\x12\x37\n\x08operator\x18\x01 \x01(\x0b\x32\x19.spark.connect.MlOperatorH\x00R\x08operator\x12\x33\n\x07obj_ref\x18\x02 \x01(\x0b\x32\x18.spark.connect.ObjectRefH\x00R\x06objRef\x12\x34\n\x06params\x18\x03 \x01(\x0b\x32\x17.spark.connect.MlParamsH\x01R\x06params\x88\x01\x01\x12\x12\n\x04path\x18\x04 \x01(\tR\x04path\x12.\n\x10should_overwrite\x18\x05 \x01(\x08H\x02R\x0fshouldOverwrite\x88\x01\x01\x12\x45\n\x07options\x18\x06 \x03(\x0b\x32+.spark.connect.MlCommand.Write.OptionsEntryR\x07options\x1a:\n\x0cOptionsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x06\n\x04typeB\t\n\x07_paramsB\x13\n\x11_should_overwrite\x1aQ\n\x04Read\x12\x35\n\x08operator\x18\x01 \x01(\x0b\x32\x19.spark.connect.MlOperatorR\x08operator\x12\x12\n\x04path\x18\x02 \x01(\tR\x04path\x1a\xb7\x01\n\x08\x45valuate\x12\x37\n\tevaluator\x18\x01 \x01(\x0b\x32\x19.spark.connect.MlOperatorR\tevaluator\x12\x34\n\x06params\x18\x02 \x01(\x0b\x32\x17.spark.connect.MlParamsH\x00R\x06params\x88\x01\x01\x12\x31\n\x07\x64\x61taset\x18\x03 \x01(\x0b\x32\x17.spark.connect.RelationR\x07\x64\x61tasetB\t\n\x07_paramsB\t\n\x07\x63ommand"\x93\x03\n\x0fMlCommandResult\x12\x39\n\x05param\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralH\x00R\x05param\x12\x1a\n\x07summary\x18\x02 \x01(\tH\x00R\x07summary\x12T\n\roperator_info\x18\x03 \x01(\x0b\x32-.spark.connect.MlCommandResult.MlOperatorInfoH\x00R\x0coperatorInfo\x1a\xc3\x01\n\x0eMlOperatorInfo\x12\x33\n\x07obj_ref\x18\x01 \x01(\x0b\x32\x18.spark.connect.ObjectRefH\x00R\x06objRef\x12\x14\n\x04name\x18\x02 \x01(\tH\x00R\x04name\x12\x15\n\x03uid\x18\x03 \x01(\tH\x01R\x03uid\x88\x01\x01\x12\x34\n\x06params\x18\x04 \x01(\x0b\x32\x17.spark.connect.MlParamsH\x02R\x06params\x88\x01\x01\x42\x06\n\x04typeB\x06\n\x04_uidB\t\n\x07_paramsB\r\n\x0bresult_typeB6\n\x1eorg.apache.spark.connect.protoP\x01Z\x12internal/generatedb\x06proto3'
+    b'\n\x16spark/connect/ml.proto\x12\rspark.connect\x1a\x1dspark/connect/relations.proto\x1a\x1fspark/connect/expressions.proto\x1a\x1dspark/connect/ml_common.proto"\xb2\x0b\n\tMlCommand\x12\x30\n\x03\x66it\x18\x01 \x01(\x0b\x32\x1c.spark.connect.MlCommand.FitH\x00R\x03\x66it\x12,\n\x05\x66\x65tch\x18\x02 \x01(\x0b\x32\x14.spark.connect.FetchH\x00R\x05\x66\x65tch\x12\x39\n\x06\x64\x65lete\x18\x03 \x01(\x0b\x32\x1f.spark.connect.MlCommand.DeleteH\x00R\x06\x64\x65lete\x12\x36\n\x05write\x18\x04 \x01(\x0b\x32\x1e.spark.connect.MlCommand.WriteH\x00R\x05write\x12\x33\n\x04read\x18\x05 \x01(\x0b\x32\x1d.spark.connect.MlCommand.ReadH\x00R\x04read\x12?\n\x08\x65valuate\x18\x06 \x01(\x0b\x32!.spark.connect.MlCommand.EvaluateH\x00R\x08\x65valuate\x12\x46\n\x0b\x63lean_cache\x18\x07 \x01(\x0b\x32#.spark.connect.MlCommand.CleanCacheH\x00R\ncleanCache\x12M\n\x0eget_cache_info\x18\x08 \x01(\x0b\x32%.spark.connect.MlCommand.GetCacheInfoH\x00R\x0cgetCacheInfo\x1a\xb2\x01\n\x03\x46it\x12\x37\n\testimator\x18\x01 \x01(\x0b\x32\x19.spark.connect.MlOperatorR\testimator\x12\x34\n\x06params\x18\x02 \x01(\x0b\x32\x17.spark.connect.MlParamsH\x00R\x06params\x88\x01\x01\x12\x31\n\x07\x64\x61taset\x18\x03 \x01(\x0b\x32\x17.spark.connect.RelationR\x07\x64\x61tasetB\t\n\x07_params\x1a=\n\x06\x44\x65lete\x12\x33\n\x08obj_refs\x18\x01 \x03(\x0b\x32\x18.spark.connect.ObjectRefR\x07objRefs\x1a\x0c\n\nCleanCache\x1a\x0e\n\x0cGetCacheInfo\x1a\x9a\x03\n\x05Write\x12\x37\n\x08operator\x18\x01 \x01(\x0b\x32\x19.spark.connect.MlOperatorH\x00R\x08operator\x12\x33\n\x07obj_ref\x18\x02 \x01(\x0b\x32\x18.spark.connect.ObjectRefH\x00R\x06objRef\x12\x34\n\x06params\x18\x03 \x01(\x0b\x32\x17.spark.connect.MlParamsH\x01R\x06params\x88\x01\x01\x12\x12\n\x04path\x18\x04 \x01(\tR\x04path\x12.\n\x10should_overwrite\x18\x05 \x01(\x08H\x02R\x0fshouldOverwrite\x88\x01\x01\x12\x45\n\x07options\x18\x06 \x03(\x0b\x32+.spark.connect.MlCommand.Write.OptionsEntryR\x07options\x1a:\n\x0cOptionsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x06\n\x04typeB\t\n\x07_paramsB\x13\n\x11_should_overwrite\x1aQ\n\x04Read\x12\x35\n\x08operator\x18\x01 \x01(\x0b\x32\x19.spark.connect.MlOperatorR\x08operator\x12\x12\n\x04path\x18\x02 \x01(\tR\x04path\x1a\xb7\x01\n\x08\x45valuate\x12\x37\n\tevaluator\x18\x01 \x01(\x0b\x32\x19.spark.connect.MlOperatorR\tevaluator\x12\x34\n\x06params\x18\x02 \x01(\x0b\x32\x17.spark.connect.MlParamsH\x00R\x06params\x88\x01\x01\x12\x31\n\x07\x64\x61taset\x18\x03 \x01(\x0b\x32\x17.spark.connect.RelationR\x07\x64\x61tasetB\t\n\x07_paramsB\t\n\x07\x63ommand"\x93\x03\n\x0fMlCommandResult\x12\x39\n\x05param\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralH\x00R\x05param\x12\x1a\n\x07summary\x18\x02 \x01(\tH\x00R\x07summary\x12T\n\roperator_info\x18\x03 \x01(\x0b\x32-.spark.connect.MlCommandResult.MlOperatorInfoH\x00R\x0coperatorInfo\x1a\xc3\x01\n\x0eMlOperatorInfo\x12\x33\n\x07obj_ref\x18\x01 \x01(\x0b\x32\x18.spark.connect.ObjectRefH\x00R\x06objRef\x12\x14\n\x04name\x18\x02 \x01(\tH\x00R\x04name\x12\x15\n\x03uid\x18\x03 \x01(\tH\x01R\x03uid\x88\x01\x01\x12\x34\n\x06params\x18\x04 \x01(\x0b\x32\x17.spark.connect.MlParamsH\x02R\x06params\x88\x01\x01\x42\x06\n\x04typeB\x06\n\x04_uidB\t\n\x07_paramsB\r\n\x0bresult_typeB6\n\x1eorg.apache.spark.connect.protoP\x01Z\x12internal/generatedb\x06proto3'
 )
 
 _globals = globals()
@@ -54,23 +54,25 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["_MLCOMMAND_WRITE_OPTIONSENTRY"]._loaded_options = None
     _globals["_MLCOMMAND_WRITE_OPTIONSENTRY"]._serialized_options = b"8\001"
     _globals["_MLCOMMAND"]._serialized_start = 137
-    _globals["_MLCOMMAND"]._serialized_end = 1479
-    _globals["_MLCOMMAND_FIT"]._serialized_start = 536
-    _globals["_MLCOMMAND_FIT"]._serialized_end = 714
-    _globals["_MLCOMMAND_DELETE"]._serialized_start = 716
-    _globals["_MLCOMMAND_DELETE"]._serialized_end = 777
-    _globals["_MLCOMMAND_CLEAN"]._serialized_start = 779
-    _globals["_MLCOMMAND_CLEAN"]._serialized_end = 786
-    _globals["_MLCOMMAND_WRITE"]._serialized_start = 789
-    _globals["_MLCOMMAND_WRITE"]._serialized_end = 1199
-    _globals["_MLCOMMAND_WRITE_OPTIONSENTRY"]._serialized_start = 1101
-    _globals["_MLCOMMAND_WRITE_OPTIONSENTRY"]._serialized_end = 1159
-    _globals["_MLCOMMAND_READ"]._serialized_start = 1201
-    _globals["_MLCOMMAND_READ"]._serialized_end = 1282
-    _globals["_MLCOMMAND_EVALUATE"]._serialized_start = 1285
-    _globals["_MLCOMMAND_EVALUATE"]._serialized_end = 1468
-    _globals["_MLCOMMANDRESULT"]._serialized_start = 1482
-    _globals["_MLCOMMANDRESULT"]._serialized_end = 1885
-    _globals["_MLCOMMANDRESULT_MLOPERATORINFO"]._serialized_start = 1675
-    _globals["_MLCOMMANDRESULT_MLOPERATORINFO"]._serialized_end = 1870
+    _globals["_MLCOMMAND"]._serialized_end = 1595
+    _globals["_MLCOMMAND_FIT"]._serialized_start = 631
+    _globals["_MLCOMMAND_FIT"]._serialized_end = 809
+    _globals["_MLCOMMAND_DELETE"]._serialized_start = 811
+    _globals["_MLCOMMAND_DELETE"]._serialized_end = 872
+    _globals["_MLCOMMAND_CLEANCACHE"]._serialized_start = 874
+    _globals["_MLCOMMAND_CLEANCACHE"]._serialized_end = 886
+    _globals["_MLCOMMAND_GETCACHEINFO"]._serialized_start = 888
+    _globals["_MLCOMMAND_GETCACHEINFO"]._serialized_end = 902
+    _globals["_MLCOMMAND_WRITE"]._serialized_start = 905
+    _globals["_MLCOMMAND_WRITE"]._serialized_end = 1315
+    _globals["_MLCOMMAND_WRITE_OPTIONSENTRY"]._serialized_start = 1217
+    _globals["_MLCOMMAND_WRITE_OPTIONSENTRY"]._serialized_end = 1275
+    _globals["_MLCOMMAND_READ"]._serialized_start = 1317
+    _globals["_MLCOMMAND_READ"]._serialized_end = 1398
+    _globals["_MLCOMMAND_EVALUATE"]._serialized_start = 1401
+    _globals["_MLCOMMAND_EVALUATE"]._serialized_end = 1584
+    _globals["_MLCOMMANDRESULT"]._serialized_start = 1598
+    _globals["_MLCOMMANDRESULT"]._serialized_end = 2001
+    _globals["_MLCOMMANDRESULT_MLOPERATORINFO"]._serialized_start = 1791
+    _globals["_MLCOMMANDRESULT_MLOPERATORINFO"]._serialized_end = 1986
 # @@protoc_insertion_point(module_scope)

--- a/python/pyspark/sql/connect/proto/ml_pb2.pyi
+++ b/python/pyspark/sql/connect/proto/ml_pb2.pyi
@@ -134,6 +134,15 @@ class MlCommand(google.protobuf.message.Message):
             self, field_name: typing_extensions.Literal["obj_refs", b"obj_refs"]
         ) -> None: ...
 
+    class Clean(google.protobuf.message.Message):
+        """Force to clean up all the ML cached objects"""
+
+        DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+        def __init__(
+            self,
+        ) -> None: ...
+
     class Write(google.protobuf.message.Message):
         """Command to write ML operator"""
 
@@ -330,6 +339,7 @@ class MlCommand(google.protobuf.message.Message):
     WRITE_FIELD_NUMBER: builtins.int
     READ_FIELD_NUMBER: builtins.int
     EVALUATE_FIELD_NUMBER: builtins.int
+    CLEAN_FIELD_NUMBER: builtins.int
     @property
     def fit(self) -> global___MlCommand.Fit: ...
     @property
@@ -342,6 +352,8 @@ class MlCommand(google.protobuf.message.Message):
     def read(self) -> global___MlCommand.Read: ...
     @property
     def evaluate(self) -> global___MlCommand.Evaluate: ...
+    @property
+    def clean(self) -> global___MlCommand.Clean: ...
     def __init__(
         self,
         *,
@@ -351,10 +363,13 @@ class MlCommand(google.protobuf.message.Message):
         write: global___MlCommand.Write | None = ...,
         read: global___MlCommand.Read | None = ...,
         evaluate: global___MlCommand.Evaluate | None = ...,
+        clean: global___MlCommand.Clean | None = ...,
     ) -> None: ...
     def HasField(
         self,
         field_name: typing_extensions.Literal[
+            "clean",
+            b"clean",
             "command",
             b"command",
             "delete",
@@ -374,6 +389,8 @@ class MlCommand(google.protobuf.message.Message):
     def ClearField(
         self,
         field_name: typing_extensions.Literal[
+            "clean",
+            b"clean",
             "command",
             b"command",
             "delete",
@@ -393,7 +410,8 @@ class MlCommand(google.protobuf.message.Message):
     def WhichOneof(
         self, oneof_group: typing_extensions.Literal["command", b"command"]
     ) -> (
-        typing_extensions.Literal["fit", "fetch", "delete", "write", "read", "evaluate"] | None
+        typing_extensions.Literal["fit", "fetch", "delete", "write", "read", "evaluate", "clean"]
+        | None
     ): ...
 
 global___MlCommand = MlCommand

--- a/python/pyspark/sql/connect/proto/ml_pb2.pyi
+++ b/python/pyspark/sql/connect/proto/ml_pb2.pyi
@@ -134,8 +134,17 @@ class MlCommand(google.protobuf.message.Message):
             self, field_name: typing_extensions.Literal["obj_refs", b"obj_refs"]
         ) -> None: ...
 
-    class Clean(google.protobuf.message.Message):
+    class CleanCache(google.protobuf.message.Message):
         """Force to clean up all the ML cached objects"""
+
+        DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+        def __init__(
+            self,
+        ) -> None: ...
+
+    class GetCacheInfo(google.protobuf.message.Message):
+        """Get the information of all the ML cached objects"""
 
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -339,7 +348,8 @@ class MlCommand(google.protobuf.message.Message):
     WRITE_FIELD_NUMBER: builtins.int
     READ_FIELD_NUMBER: builtins.int
     EVALUATE_FIELD_NUMBER: builtins.int
-    CLEAN_FIELD_NUMBER: builtins.int
+    CLEAN_CACHE_FIELD_NUMBER: builtins.int
+    GET_CACHE_INFO_FIELD_NUMBER: builtins.int
     @property
     def fit(self) -> global___MlCommand.Fit: ...
     @property
@@ -353,7 +363,9 @@ class MlCommand(google.protobuf.message.Message):
     @property
     def evaluate(self) -> global___MlCommand.Evaluate: ...
     @property
-    def clean(self) -> global___MlCommand.Clean: ...
+    def clean_cache(self) -> global___MlCommand.CleanCache: ...
+    @property
+    def get_cache_info(self) -> global___MlCommand.GetCacheInfo: ...
     def __init__(
         self,
         *,
@@ -363,13 +375,14 @@ class MlCommand(google.protobuf.message.Message):
         write: global___MlCommand.Write | None = ...,
         read: global___MlCommand.Read | None = ...,
         evaluate: global___MlCommand.Evaluate | None = ...,
-        clean: global___MlCommand.Clean | None = ...,
+        clean_cache: global___MlCommand.CleanCache | None = ...,
+        get_cache_info: global___MlCommand.GetCacheInfo | None = ...,
     ) -> None: ...
     def HasField(
         self,
         field_name: typing_extensions.Literal[
-            "clean",
-            b"clean",
+            "clean_cache",
+            b"clean_cache",
             "command",
             b"command",
             "delete",
@@ -380,6 +393,8 @@ class MlCommand(google.protobuf.message.Message):
             b"fetch",
             "fit",
             b"fit",
+            "get_cache_info",
+            b"get_cache_info",
             "read",
             b"read",
             "write",
@@ -389,8 +404,8 @@ class MlCommand(google.protobuf.message.Message):
     def ClearField(
         self,
         field_name: typing_extensions.Literal[
-            "clean",
-            b"clean",
+            "clean_cache",
+            b"clean_cache",
             "command",
             b"command",
             "delete",
@@ -401,6 +416,8 @@ class MlCommand(google.protobuf.message.Message):
             b"fetch",
             "fit",
             b"fit",
+            "get_cache_info",
+            b"get_cache_info",
             "read",
             b"read",
             "write",
@@ -410,7 +427,9 @@ class MlCommand(google.protobuf.message.Message):
     def WhichOneof(
         self, oneof_group: typing_extensions.Literal["command", b"command"]
     ) -> (
-        typing_extensions.Literal["fit", "fetch", "delete", "write", "read", "evaluate", "clean"]
+        typing_extensions.Literal[
+            "fit", "fetch", "delete", "write", "read", "evaluate", "clean_cache", "get_cache_info"
+        ]
         | None
     ): ...
 

--- a/sql/connect/common/src/main/protobuf/spark/connect/ml.proto
+++ b/sql/connect/common/src/main/protobuf/spark/connect/ml.proto
@@ -36,7 +36,8 @@ message MlCommand {
     Write write = 4;
     Read read = 5;
     Evaluate evaluate = 6;
-    Clean clean = 7;
+    CleanCache clean_cache = 7;
+    GetCacheInfo get_cache_info = 8;
   }
 
   // Command for estimator.fit(dataset)
@@ -56,7 +57,10 @@ message MlCommand {
   }
 
   // Force to clean up all the ML cached objects
-  message Clean { }
+  message CleanCache { }
+
+  // Get the information of all the ML cached objects
+  message GetCacheInfo { }
 
   // Command to write ML operator
   message Write {

--- a/sql/connect/common/src/main/protobuf/spark/connect/ml.proto
+++ b/sql/connect/common/src/main/protobuf/spark/connect/ml.proto
@@ -36,6 +36,7 @@ message MlCommand {
     Write write = 4;
     Read read = 5;
     Evaluate evaluate = 6;
+    Clean clean = 7;
   }
 
   // Command for estimator.fit(dataset)
@@ -53,6 +54,9 @@ message MlCommand {
   message Delete {
     repeated ObjectRef obj_refs = 1;
   }
+
+  // Force to clean up all the ML cached objects
+  message Clean { }
 
   // Command to write ML operator
   message Write {

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
@@ -20,6 +20,8 @@ import java.util.UUID
 import java.util.concurrent.{ConcurrentMap, TimeUnit}
 import java.util.concurrent.atomic.AtomicLong
 
+import scala.collection.mutable
+
 import com.google.common.cache.{CacheBuilder, RemovalNotification}
 
 import org.apache.spark.internal.Logging
@@ -117,5 +119,13 @@ private[connect] class MLCache(sessionHolder: SessionHolder) extends Logging {
     val size = cachedModel.size()
     cachedModel.clear()
     size
+  }
+
+  def getInfo(): Array[String] = {
+    val info = mutable.ArrayBuilder.make[String]
+    cachedModel.forEach { case (key, value) =>
+      info += s"id: $key, obj: ${value.obj.getClass}, size: ${value.sizeBytes}"
+    }
+    info.result()
   }
 }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
@@ -113,7 +113,9 @@ private[connect] class MLCache(sessionHolder: SessionHolder) extends Logging {
   /**
    * Clear all the caches
    */
-  def clear(): Unit = {
+  def clear(): Int = {
+    val size = cachedModel.size()
     cachedModel.clear()
+    size
   }
 }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
@@ -186,11 +186,17 @@ private[connect] object MLHandler extends Logging {
               .setObjRef(proto.ObjectRef.newBuilder().setId(ids.result().mkString(","))))
           .build()
 
-      case proto.MlCommand.CommandCase.CLEAN =>
+      case proto.MlCommand.CommandCase.CLEAN_CACHE =>
         val size = mlCache.clear()
         proto.MlCommandResult
           .newBuilder()
           .setParam(LiteralValueProtoConverter.toLiteralProto(size))
+          .build()
+
+      case proto.MlCommand.CommandCase.GET_CACHE_INFO =>
+        proto.MlCommandResult
+          .newBuilder()
+          .setParam(LiteralValueProtoConverter.toLiteralProto(mlCache.getInfo()))
           .build()
 
       case proto.MlCommand.CommandCase.WRITE =>

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
@@ -186,6 +186,13 @@ private[connect] object MLHandler extends Logging {
               .setObjRef(proto.ObjectRef.newBuilder().setId(ids.result().mkString(","))))
           .build()
 
+      case proto.MlCommand.CommandCase.CLEAN =>
+        val size = mlCache.clear()
+        proto.MlCommandResult
+          .newBuilder()
+          .setParam(LiteralValueProtoConverter.toLiteralProto(size))
+          .build()
+
       case proto.MlCommand.CommandCase.WRITE =>
         mlCommand.getWrite.getTypeCase match {
           case proto.MlCommand.Write.TypeCase.OBJ_REF => // save a model


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
 Add proto message `CleanCache` and `GetCacheInfo`


### Why are the changes needed?
to improve debuggability


### Does this PR introduce _any_ user-facing change?
no, the new protos are only used internally

```
In [1]: from pyspark.ml.linalg import Vectors
   ...: from pyspark.ml.classification import *
   ...: from pyspark.ml.regression import *
   ...:
   ...: df = spark.createDataFrame([
   ...:     (1.0, 2.0, Vectors.dense(1.0)),
   ...:     (0.0, 2.0, Vectors.sparse(1, [], []))], ["label", "weight", "features"])
   ...:
   ...: lr = LinearRegression(regParam=0.0, solver="normal")
   ...: model = lr.fit(df)
25/04/21 11:12:36 WARN Instrumentation: [91fb6f9e] regParam is zero, which might cause numerical instability and overfitting.
25/04/21 11:12:37 WARN InstanceBuilder: Failed to load implementation from:dev.ludovic.netlib.lapack.JNILAPACK
[********************************************************************************] 100.00% Complete (0 Tasks running, 2s, Sca[********************************************************************************] 100.00% Complete (0 Tasks running, 2s, Sca[********************************************************************************] 100.00% Complete (0 Tasks running, 2s, Sca[********************************************************************************] 100.00% Complete (0 Tasks running, 2s, Sca
In [2]: spark.client.thread_local.ml_caches
Out[2]: {'7c7505a7-9a9a-4716-a485-d735c48608cc'}

In [3]: spark.client._get_ml_cache_info()
Out[3]: ['id: 7c7505a7-9a9a-4716-a485-d735c48608cc, obj: class org.apache.spark.ml.regression.LinearRegressionModel, size: 5924']

In [4]: del model

In [5]: spark.client.thread_local.ml_caches
Out[5]: set()

In [6]: spark.client._get_ml_cache_info()
Out[6]: []
```

### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no