### PR TITLE
[SPARK-51848][SQL] Fix parsing XML records with defined schema of array/structs/map of Variant

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
@@ -388,7 +388,8 @@ class StaxXmlParser(
                   case st: StructType =>
                     convertObjectWithAttributes(parser, st, field, attributes)
                   case VariantType =>
-                    StaxXmlParser.convertVariant(parser, attributes, options)
+                    val v = StaxXmlParser.convertVariant(parser, attributes, options)
+                    new VariantVal(v.getValue, v.getMetadata)
                   case dt: DataType =>
                     convertField(parser, dt, field)
                 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
@@ -387,6 +387,8 @@ class StaxXmlParser(
                 val newValue = dt match {
                   case st: StructType =>
                     convertObjectWithAttributes(parser, st, field, attributes)
+                  case VariantType =>
+                    StaxXmlParser.convertVariant(parser, attributes, options)
                   case dt: DataType =>
                     convertField(parser, dt, field)
                 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
@@ -202,6 +202,9 @@ class StaxXmlParser(
       case st: StructType => convertObject(parser, st)
       case MapType(StringType, vt, _) => convertMap(parser, vt, attributes)
       case ArrayType(st, _) => convertField(parser, st, startElementName)
+      case VariantType =>
+        val v = StaxXmlParser.convertVariant(parser, attributes, options)
+        new VariantVal(v.getValue, v.getMetadata)
       case _: StringType =>
         convertTo(
           StaxXmlParserUtils.currentStructureAsString(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlVariantSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlVariantSuite.scala
@@ -579,6 +579,7 @@ class XmlVariantSuite extends QueryTest with SharedSparkSession with TestXmlData
         |   </nestedVariantField>
         |   <mapField>
         |     <a><b>7</b></a>
+        |     <c>8</c>
         |   </mapField>
         | </ROW>
         | """.stripMargin.replaceAll("\\s+", "")
@@ -601,9 +602,10 @@ class XmlVariantSuite extends QueryTest with SharedSparkSession with TestXmlData
           variant_get(col("row.structField.c.d"), "$", "int"),
           variant_get(col("row.nestedVariantField"), "$.a", "int"),
           variant_get(col("row.nestedVariantField"), "$.b.c", "int"),
-          variant_get(col("row.mapField.a"), "$.b", "int")
+          variant_get(col("row.mapField.a"), "$.b", "int"),
+          variant_get(col("row.mapField.c"), "$", "int")
         ),
-      Seq(Row("Hello", 1, 2, 3, 4, 5, 6, 7))
+      Seq(Row("Hello", 1, 2, 3, 4, 5, 6, 7, 8))
     )
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
When parsing XML records with a specified schema, which has variant columns inside complex structures like `Array`, `Struct`, or `Map`, those records can't be parsed correctly.

This PR fixes the bug and adds more tests to cover such scenarios.


### Why are the changes needed?
Bug fixes.

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
New UTs


### Was this patch authored or co-authored using generative AI tooling?
N/A