### PR TITLE
[SPARK-51688][PYTHON][FOLLOW-UP] Log string instead of option instance

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -745,11 +745,12 @@ private[spark] class PythonAccumulatorV2(
     if (socket == null || !socket.isOpen) {
       if (isUnixDomainSock) {
         socket = SocketChannel.open(UnixDomainSocketAddress.of(socketPath.get))
-        logInfo(log"Connected to AccumulatorServer at socket: ${MDC(SOCKET_ADDRESS, serverHost)}")
+        logInfo(
+          log"Connected to AccumulatorServer at socket: ${MDC(SOCKET_ADDRESS, serverHost.get)}")
       } else {
         socket = SocketChannel.open(new InetSocketAddress(serverHost.get, serverPort.get))
-        logInfo(log"Connected to AccumulatorServer at host: ${MDC(HOST, serverHost)}" +
-          log" port: ${MDC(PORT, serverPort)}")
+        logInfo(log"Connected to AccumulatorServer at host: ${MDC(HOST, serverHost.get)}" +
+          log" port: ${MDC(PORT, serverPort.get)}")
       }
       // send the secret just for the initial authentication when opening a new connection
       secretToken.foreach { token =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/50587 that logs strings properly instead of `Option`s

### Why are the changes needed?

To log strings properly instead of option instances.

### Does this PR introduce _any_ user-facing change?

No the main change has not been released yet.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.