### PR TITLE
[SPARK-51814][SS][PYTHON][FOLLOW-UP] Add pyspark.sql.tests.pandas.helper for testing pyspark-client

### DIFF
--- a/python/packaging/client/setup.py
+++ b/python/packaging/client/setup.py
@@ -80,6 +80,7 @@ if "SPARK_TESTING" in os.environ:
         "pyspark.sql.tests.connect.pandas",
         "pyspark.sql.tests.connect.shell",
         "pyspark.sql.tests.pandas",
+        "pyspark.sql.tests.pandas.helper",
         "pyspark.sql.tests.plot",
         "pyspark.sql.tests.streaming",
         "pyspark.ml.tests",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/50600 that adds `pyspark.sql.tests.pandas.helper` for testing `pyspark-client`. This is used when running pure Python build (but not included in the actual release just to be clear).

### Why are the changes needed?

To recover the scheduled build at https://github.com/apache/spark/actions/runs/14562462764/job/40847455092.

It fails as below:

```
Starting test(python3): pyspark.sql.tests.connect.pandas.test_parity_pandas_transform_with_state (temp output: /home/runner/work/spark/spark/python/target/b1c33a00-c967-4156-a866-6c78a4b754c4/python3__pyspark.sql.tests.connect.pandas.test_parity_pandas_transform_with_state__kwppfpzy.log)
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/hostedtoolcache/Python/3.11.12/x64/lib/python3.11/site-packages/pyspark/sql/tests/connect/pandas/test_parity_pandas_transform_with_state.py", line 19, in <module>
    from pyspark.sql.tests.pandas.test_pandas_transform_with_state import (
  File "/opt/hostedtoolcache/Python/3.11.12/x64/lib/python3.11/site-packages/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py", line 48, in <module>
    from pyspark.sql.tests.pandas.helper.helper_pandas_transform_with_state import (
ModuleNotFoundError: No module named 'pyspark.sql.tests.pandas.helper'
```

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Will monitor the scheduled builds.

### Was this patch authored or co-authored using generative AI tooling?

No.