### PR TITLE
[SPARK-51838][PYTHON][TESTS][FOLLWO-UP] Skip `test_wildcard_import` in low python versions

### DIFF
--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -23,6 +23,7 @@ import io
 from itertools import chain
 import math
 import re
+import sys
 import unittest
 
 from pyspark.errors import PySparkTypeError, PySparkValueError, SparkRuntimeException
@@ -90,6 +91,7 @@ class FunctionsTestsMixin:
             expected_missing_in_py, missing_in_py, "Missing functions in pyspark not as expected"
         )
 
+    @unittest.skipIf(sys.version_info < (3, 11))
     def test_wildcard_import(self):
         all_set = set(F.__all__)
 


### PR DESCRIPTION
Skip `test_wildcard_import` in low python versions, to address https://github.com/apache/spark/pull/50634

There seems to be a behavior change in different python versions