### PR TITLE
[SPARK-51838][PYTHON][TESTS][FOLLOW-UP] Skip `test_wildcard_import` in Python 3.10 and below

### DIFF
--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -23,6 +23,7 @@ import io
 from itertools import chain
 import math
 import re
+import sys
 import unittest
 
 from pyspark.errors import PySparkTypeError, PySparkValueError, SparkRuntimeException
@@ -90,6 +91,7 @@ class FunctionsTestsMixin:
             expected_missing_in_py, missing_in_py, "Missing functions in pyspark not as expected"
         )
 
+    @unittest.skipIf(sys.version_info < (3, 11))
     def test_wildcard_import(self):
         all_set = set(F.__all__)
 

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -91,7 +91,7 @@ class FunctionsTestsMixin:
             expected_missing_in_py, missing_in_py, "Missing functions in pyspark not as expected"
         )
 
-    @unittest.skipIf(sys.version_info < (3, 11))
+    @unittest.skipIf(sys.version_info < (3, 11), "Only works with Python 3.11+")
     def test_wildcard_import(self):
         all_set = set(F.__all__)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Retry of https://github.com/apache/spark/pull/50650.

### Why are the changes needed?

To make the build passing.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.