### PR TITLE
[SPARK-51838][PYTHON][TESTS][FOLLWO-UP] Ignore typing module in `test_wildcard_import`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,7 +41,7 @@ on:
         description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false
         type: string
-        default: '{"PYSPARK_IMAGE_TO_TEST": "python-310", "PYTHON_TO_TEST": "python3.10"}'
+        default: '{"PYSPARK_IMAGE_TO_TEST": "python-309", "PYTHON_TO_TEST": "python3.9"}'
       jobs:
         description: >-
           Jobs to run, and should be in JSON format. The values should be matched with the job's key defined

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,7 +41,7 @@ on:
         description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false
         type: string
-        default: '{"PYSPARK_IMAGE_TO_TEST": "python-309", "PYTHON_TO_TEST": "python3.9"}'
+        default: '{"PYSPARK_IMAGE_TO_TEST": "python-311", "PYTHON_TO_TEST": "python3.11"}'
       jobs:
         description: >-
           Jobs to run, and should be in JSON format. The values should be matched with the job's key defined

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,7 +41,7 @@ on:
         description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false
         type: string
-        default: '{"PYSPARK_IMAGE_TO_TEST": "python-311", "PYTHON_TO_TEST": "python3.11"}'
+        default: '{"PYSPARK_IMAGE_TO_TEST": "python-310", "PYTHON_TO_TEST": "python3.10"}'
       jobs:
         description: >-
           Jobs to run, and should be in JSON format. The values should be matched with the job's key defined

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -23,7 +23,6 @@ import io
 from itertools import chain
 import math
 import re
-import sys
 import unittest
 
 from pyspark.errors import PySparkTypeError, PySparkValueError, SparkRuntimeException
@@ -91,7 +90,6 @@ class FunctionsTestsMixin:
             expected_missing_in_py, missing_in_py, "Missing functions in pyspark not as expected"
         )
 
-    @unittest.skipIf(sys.version_info < (3, 11), "Only works with Python 3.11+")
     def test_wildcard_import(self):
         all_set = set(F.__all__)
 

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -104,14 +104,16 @@ class FunctionsTestsMixin:
         #     "aes_encrypt",
         #     ...,
         # }
-        fn_set = {name for (name, value) in getmembers(F, isfunction) if name[0] != "_"}
+        fn_set = {
+            name
+            for (name, value) in getmembers(F, isfunction)
+            if name[0] != "_" and value.__module__ != "typing"
+        }
 
         expected_fn_all_diff = {
             "approxCountDistinct",  # deprecated
             "bitwiseNOT",  # deprecated
-            "cast",  # typing
             "countDistinct",  # deprecated
-            "overload",  # typing
             "quote",  # new function in 4.1
             "shiftLeft",  # deprecated
             "shiftRight",  # deprecated
@@ -134,10 +136,13 @@ class FunctionsTestsMixin:
         #     "UserDefinedFunction",
         #     "UserDefinedTableFunction",
         # }
-        clz_set = {name for (name, value) in getmembers(F, isclass) if name[0] != "_"}
+        clz_set = {
+            name
+            for (name, value) in getmembers(F, isclass)
+            if name[0] != "_" and value.__module__ != "typing"
+        }
 
         expected_clz_all_diff = {
-            "Any",  # typing
             "ArrayType",  # should be imported from pyspark.sql.types
             "ByteType",  # should be imported from pyspark.sql.types
             "Column",  # should be imported from pyspark.sql


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Ignore typing module in `test_wildcard_import`


### Why are the changes needed?
to improve test coverage

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
PR builder with

1, python 3.9
```
default: '{"PYSPARK_IMAGE_TO_TEST": "python-309", "PYTHON_TO_TEST": "python3.9"}'
```
https://github.com/zhengruifeng/spark/actions/runs/14570259237/job/40866184319

2, python 3.10
```
default: '{"PYSPARK_IMAGE_TO_TEST": "python-310", "PYTHON_TO_TEST": "python3.10"}'
```

https://github.com/zhengruifeng/spark/actions/runs/14568395419/job/40861267656


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
