### PR TITLE
[SPARK-51860][CONNECT] Disable `spark.connect.grpc.debug.enabled` by default

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -363,7 +363,7 @@ object SparkConnectService extends Logging {
    * Starts the GRPC Service.
    */
   private def startGRPCService(): Unit = {
-    val debugMode = SparkEnv.get.conf.getBoolean("spark.connect.grpc.debug.enabled", true)
+    val debugMode = SparkEnv.get.conf.getBoolean("spark.connect.grpc.debug.enabled", false)
     val bindAddress = SparkEnv.get.conf.get(CONNECT_GRPC_BINDING_ADDRESS)
     val startPort = SparkEnv.get.conf.get(CONNECT_GRPC_BINDING_PORT)
     val sparkConnectService = new SparkConnectService(debugMode)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to disable `spark.connect.grpc.debug.enabled` by default.

### Why are the changes needed?

While checking `Spark Connect` feature of Apache Spark 4.0.0 RC4, I found that Apache Spark 4.0.0 has `spark.connect.grpc.debug.enabled=true` by default.

We had better disable it by default from Apache Spark 4.0.0.

### Does this PR introduce _any_ user-facing change?

No behavior change from user perspective.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.