### PR TITLE
[SPARK-51861][SQL][UI] Remove duplicated/unnecessary info of InMemoryRelation Plan Detail

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -516,4 +516,7 @@ case class InMemoryRelation(
 
   override def simpleString(maxFields: Int): String =
     s"InMemoryRelation [${truncatedString(output, ", ", maxFields)}], ${cacheBuilder.storageLevel}"
+
+  override def stringArgs: Iterator[Any] =
+    Iterator(output, cacheBuilder.storageLevel, outputOrdering)
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove duplicated info in InMemoryRelation Plan Detail

- serializer, a dev-only api
- cachedPlan, duplicated
- logicalPlan, not necessary for the physical detail 


### Why are the changes needed?

These parameters are unnecessary and unformatted, which make the UI hard to read.

### Does this PR introduce _any_ user-facing change?
UI changes

### How was this patch tested?

![image](https://github.com/user-attachments/assets/8184626e-e135-4fd4-9bc8-325b748211d3)



### Was this patch authored or co-authored using generative AI tooling?
no
