### PR TITLE
[SPARK-51688][PYTHON][FOLLOW-UP] Use `socketPath.get` for logging instead of `socketHost.get`

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -746,7 +746,7 @@ private[spark] class PythonAccumulatorV2(
       if (isUnixDomainSock) {
         socket = SocketChannel.open(UnixDomainSocketAddress.of(socketPath.get))
         logInfo(
-          log"Connected to AccumulatorServer at socket: ${MDC(SOCKET_ADDRESS, serverHost.get)}")
+          log"Connected to AccumulatorServer at socket: ${MDC(SOCKET_ADDRESS, socketPath.get)}")
       } else {
         socket = SocketChannel.open(new InetSocketAddress(serverHost.get, serverPort.get))
         logInfo(log"Connected to AccumulatorServer at host: ${MDC(HOST, serverHost.get)}" +


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/50648 that uses `socketPath.get` for logging instead of `socketHost.get`

### Why are the changes needed?

To recover the build (https://github.com/apache/spark/actions/runs/14584778652). Now it fails as it's always `None`.

### Does this PR introduce _any_ user-facing change?

No the main change has not been released yet.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.