### PR TITLE
[SPARK-51774][CONNECT][FOLLOW-UP][TESTS] Skip ConnectErrorsTest if grpc is not available

### DIFF
--- a/python/pyspark/errors/tests/test_connect_errors_conversion.py
+++ b/python/pyspark/errors/tests/test_connect_errors_conversion.py
@@ -18,7 +18,6 @@
 
 import unittest
 
-from pyspark.sql.connect.proto import FetchErrorDetailsResponse as pb2
 from pyspark.testing import should_test_connect, connect_requirement_message
 from pyspark.errors.exceptions.connect import (
     convert_exception,
@@ -116,6 +115,7 @@ class ConnectErrorsTest(unittest.TestCase):
     def test_convert_exception_with_stacktrace(self):
         # Mock FetchErrorDetailsResponse with stacktrace
         from google.rpc.error_details_pb2 import ErrorInfo
+        from pyspark.sql.connect.proto import FetchErrorDetailsResponse as pb2
 
         resp = pb2(
             root_error_idx=0,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip `ConnectErrorsTest` if `grpc` is not available.

### Why are the changes needed?

To recover the scheduled build (https://github.com/apache/spark/actions/runs/14579485163)

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI in this PR should verify the change. I will also monitor the scheduled build.

### Was this patch authored or co-authored using generative AI tooling?

No.