### PR TITLE
[SPARK-51862][ML][CONNECT][TESTS] Clean up ml cache before ReusedConnectTestCase and ReusedMixedTestCase

### DIFF
--- a/python/pyspark/ml/tests/connect/test_connect_cache.py
+++ b/python/pyspark/ml/tests/connect/test_connect_cache.py
@@ -59,7 +59,7 @@ class MLConnectCacheTests(ReusedConnectTestCase):
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 0)
 
-    def test_cleanup_ml(self):
+    def test_cleanup_ml_cache(self):
         spark = self.spark
         df = (
             spark.createDataFrame(
@@ -101,7 +101,7 @@ class MLConnectCacheTests(ReusedConnectTestCase):
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 2)
 
-        spark.client._cleanup_ml()
+        spark.client._cleanup_ml_cache()
 
         # All models are removed in python side
         self.assertEqual(len(spark.client.thread_local.ml_caches), 0)

--- a/python/pyspark/ml/tests/connect/test_connect_cache.py
+++ b/python/pyspark/ml/tests/connect/test_connect_cache.py
@@ -25,8 +25,6 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 class MLConnectCacheTests(ReusedConnectTestCase):
     def test_delete_model(self):
         spark = self.spark
-        spark.client._cleanup_ml()
-
         df = (
             spark.createDataFrame(
                 [
@@ -63,8 +61,6 @@ class MLConnectCacheTests(ReusedConnectTestCase):
 
     def test_cleanup_ml(self):
         spark = self.spark
-        spark.client._cleanup_ml()
-
         df = (
             spark.createDataFrame(
                 [

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -2007,7 +2007,7 @@ class SparkConnectClient(object):
         except Exception:
             return []
 
-    def _cleanup_ml(self) -> None:
+    def _cleanup_ml_cache(self) -> None:
         if hasattr(self.thread_local, "ml_caches"):
             try:
                 command = pb2.Command()

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -686,7 +686,7 @@ class SparkConnectClient(object):
         self._progress_handlers: List[ProgressHandler] = []
 
         # cleanup ml cache if possible
-        atexit.register(self._cleanup_ml)
+        atexit.register(self._cleanup_ml_cache)
 
     @property
     def _stub(self) -> grpc_lib.SparkConnectServiceStub:

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -188,14 +188,9 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
         shutil.rmtree(cls.tempdir.name, ignore_errors=True)
         cls.spark.stop()
 
-    def tearDown(self) -> None:
-        # force to clean up the ML cache after each test
-        try:
-            # in some tests (e.g. test_connect_basic),
-            # both connect session (self.connect) and classic session (self.spark) are used.
-            self.spark.client._cleanup_ml()
-        except Exception:
-            pass
+    def setUp(self) -> None:
+        # force to clean up the ML cache before each test
+        self.spark.client._cleanup_ml()
 
     def test_assert_remote_mode(self):
         from pyspark.sql import is_remote
@@ -235,6 +230,10 @@ class ReusedMixedTestCase(ReusedConnectTestCase, SQLTestUtils):
             del os.environ["PYSPARK_NO_NAMESPACE_SHARE"]
         finally:
             super(ReusedMixedTestCase, cls).tearDownClass()
+
+    def setUp(self) -> None:
+        # force to clean up the ML cache before each test
+        self.connect.client._cleanup_ml()
 
     def compare_by_show(self, df1, df2, n: int = 20, truncate: int = 20):
         from pyspark.sql.classic.dataframe import DataFrame as SDF

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -190,7 +190,7 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
 
     def setUp(self) -> None:
         # force to clean up the ML cache before each test
-        self.spark.client._cleanup_ml()
+        self.spark.client._cleanup_ml_cache()
 
     def test_assert_remote_mode(self):
         from pyspark.sql import is_remote
@@ -233,7 +233,7 @@ class ReusedMixedTestCase(ReusedConnectTestCase, SQLTestUtils):
 
     def setUp(self) -> None:
         # force to clean up the ML cache before each test
-        self.connect.client._cleanup_ml()
+        self.connect.client._cleanup_ml_cache()
 
     def compare_by_show(self, df1, df2, n: int = 20, truncate: int = 20):
         from pyspark.sql.classic.dataframe import DataFrame as SDF


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Clean up ml cache before ReusedConnectTestCase and ReusedMixedTestCase


### Why are the changes needed?
to make sure the cache is clean before each test


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
