### PR TITLE
[SPARK-51814][SS][PYTHON][FOLLLOW-UP] Uses `list(self)` instead of `StructType.fields` for old version compat

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -1462,7 +1462,7 @@ class TransformWithStateInPySparkRowSerializer(ArrowStreamUDFSerializer):
                     row_as_dict = row.asDict(True)
                     rows_as_dict.append(row_as_dict)
 
-                pdf_schema = pa.schema(pdf_type.fields)
+                pdf_schema = pa.schema(list(pdf_type))
                 record_batch = pa.RecordBatch.from_pylist(rows_as_dict, schema=pdf_schema)
 
                 yield (record_batch, pdf_type)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/50600 that proposes to use `list(self)` instead of `StructType.fields` for old PyArrow version compatibility. This is same as PyArrow implementation: https://github.com/apache/arrow/blob/d2ddee62329eb711572b4d71d6380673d7f7edd1/python/pyarrow/types.pxi#L1086

### Why are the changes needed?

To keep the compatibility with old PyArrow versions. It's currently broken (https://github.com/apache/spark/actions/runs/14591032761/job/40926249530):

```
Caused by: org.apache.spark.api.python.PythonException: Traceback (most recent call last):
  File "/__w/spark/spark/python/lib/pyspark.zip/pyspark/worker.py", line 2178, in main
    process()
  File "/__w/spark/spark/python/lib/pyspark.zip/pyspark/worker.py", line 2170, in process
    serializer.dump_stream(out_iter, outfile)
  File "/__w/spark/spark/python/lib/pyspark.zip/pyspark/sql/pandas/serializers.py", line 1470, in dump_stream
    return ArrowStreamUDFSerializer.dump_stream(self, flatten_iterator(), stream)
  File "/__w/spark/spark/python/lib/pyspark.zip/pyspark/sql/pandas/serializers.py", line 181, in dump_stream
    return super(ArrowStreamUDFSerializer, self).dump_stream(wrap_and_init_stream(), stream)
  File "/__w/spark/spark/python/lib/pyspark.zip/pyspark/sql/pandas/serializers.py", line 120, in dump_stream
    for batch in iterator:
  File "/__w/spark/spark/python/lib/pyspark.zip/pyspark/sql/pandas/serializers.py", line 166, in wrap_and_init_stream
    for batch, _ in iterator:
  File "/__w/spark/spark/python/lib/pyspark.zip/pyspark/sql/pandas/serializers.py", line 1465, in flatten_iterator
    pdf_schema = pa.schema(pdf_type.fields)
AttributeError: 'pyarrow.lib.StructType' object has no attribute 'fields'
```

### Does this PR introduce _any_ user-facing change?

No. The main change has not been released yet.

### How was this patch tested?

Unittests in this PR, and scheduled build.

### Was this patch authored or co-authored using generative AI tooling?

No.