### PR TITLE
[SPARK-51865][CONNECT][TESTS] Print stacktrace message when `o.a.arrow.memory.BaseAllocator` fails to close

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -840,6 +840,8 @@ object SparkConnectClient {
 
     testOnly := ((Test / testOnly) dependsOn (buildTestDeps)).evaluated,
 
+    (Test / javaOptions) += "-Darrow.memory.debug.allocator=true",
+
     (assembly / test) := { },
 
     (assembly / logLevel) := Level.Info,

--- a/sql/connect/client/jvm/pom.xml
+++ b/sql/connect/client/jvm/pom.xml
@@ -138,6 +138,13 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+        <configuration>
+          <argLine>-ea -Xmx4g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraJavaTestArgs} -Darrow.memory.debug.allocator=true</argLine>
+        </configuration>
+      </plugin>
       <!-- Shade all Guava / Protobuf / Netty dependencies of this build -->
       <!-- TODO (SPARK-42449): Ensure shading rules are handled correctly in `native-image.properties` and support GraalVM   -->
       <plugin>

--- a/sql/connect/client/jvm/src/test/resources/log4j2.properties
+++ b/sql/connect/client/jvm/src/test/resources/log4j2.properties
@@ -37,3 +37,6 @@ appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %maxLen{%m}{512}%n%ex{
 # Ignore messages below warning level from Jetty, because it's a bit verbose
 logger.jetty.name = org.sparkproject.jetty
 logger.jetty.level = warn
+
+logger.allocator.name =org.apache.arrow.memory.BaseAllocator
+logger.allocator.level = trace

--- a/sql/connect/client/jvm/src/test/resources/log4j2.properties
+++ b/sql/connect/client/jvm/src/test/resources/log4j2.properties
@@ -38,5 +38,5 @@ appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %maxLen{%m}{512}%n%ex{
 logger.jetty.name = org.sparkproject.jetty
 logger.jetty.level = warn
 
-logger.allocator.name =org.apache.arrow.memory.BaseAllocator
+logger.allocator.name = org.apache.arrow.memory.BaseAllocator
 logger.allocator.level = trace

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/arrow/ArrowEncoderSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/arrow/ArrowEncoderSuite.scala
@@ -99,40 +99,49 @@ class ArrowEncoderSuite extends ConnectFunSuite with BeforeAndAfterAll {
     val serializerAllocator = newAllocator("serialization")
     val deserializerAllocator = newAllocator("deserialization")
 
-    val arrowIterator = ArrowSerializer.serialize(
-      input = iterator,
-      enc = inputEncoder,
-      allocator = serializerAllocator,
-      maxRecordsPerBatch = maxRecordsPerBatch,
-      maxBatchSize = maxBatchSize,
-      batchSizeCheckInterval = batchSizeCheckInterval,
-      timeZoneId = "UTC",
-      largeVarTypes = false)
+    try {
+      val arrowIterator = ArrowSerializer.serialize(
+        input = iterator,
+        enc = inputEncoder,
+        allocator = serializerAllocator,
+        maxRecordsPerBatch = maxRecordsPerBatch,
+        maxBatchSize = maxBatchSize,
+        batchSizeCheckInterval = batchSizeCheckInterval,
+        timeZoneId = "UTC",
+        largeVarTypes = false)
 
-    val inspectedIterator = if (inspectBatch != null) {
-      arrowIterator.map { batch =>
-        inspectBatch(batch)
-        batch
+      val inspectedIterator = if (inspectBatch != null) {
+        arrowIterator.map { batch =>
+          inspectBatch(batch)
+          batch
+        }
+      } else {
+        arrowIterator
       }
-    } else {
-      arrowIterator
-    }
 
-    val resultIterator =
-      ArrowDeserializers.deserializeFromArrow(
-        inspectedIterator,
-        outputEncoder,
-        deserializerAllocator,
-        timeZoneId = "UTC")
-    new CloseableIterator[O] {
-      override def close(): Unit = {
-        arrowIterator.close()
-        resultIterator.close()
+      val resultIterator =
+        ArrowDeserializers.deserializeFromArrow(
+          inspectedIterator,
+          outputEncoder,
+          deserializerAllocator,
+          timeZoneId = "UTC")
+      new CloseableIterator[O] {
+        override def close(): Unit = {
+          arrowIterator.close()
+          resultIterator.close()
+          serializerAllocator.close()
+          deserializerAllocator.close()
+        }
+
+        override def hasNext: Boolean = resultIterator.hasNext
+
+        override def next(): O = resultIterator.next()
+      }
+    } catch {
+      case e: Throwable =>
         serializerAllocator.close()
         deserializerAllocator.close()
-      }
-      override def hasNext: Boolean = resultIterator.hasNext
-      override def next(): O = resultIterator.next()
+        throw e
     }
   }
 

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/arrow/ArrowEncoderSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/arrow/ArrowEncoderSuite.scala
@@ -827,8 +827,7 @@ class ArrowEncoderSuite extends ConnectFunSuite with BeforeAndAfterAll {
     }
   }
 
-  // TODO(SPARK-51866): Re-enable this test.
-  ignore("kryo serialization") {
+  test("kryo serialization") {
     val e = intercept[SparkRuntimeException] {
       val encoder = agnosticEncoderFor(Encoders.kryo[(Int, String)])
       roundTripAndCheckIdentical(encoder) { () =>

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/RemoteSparkSession.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/RemoteSparkSession.scala
@@ -222,10 +222,14 @@ trait RemoteSparkSession
   }
 
   override def afterAll(): Unit = {
+    def isArrowAllocatorIssue(message: String): Boolean = {
+      Option(message).exists(m => m.contains("closed with outstanding") ||
+        m.contains("Memory leaked"))
+    }
     try {
       if (spark != null) spark.stop()
     } catch {
-      case e: IllegalStateException if Option(e.getMessage).exists(_.contains("Memory leaked")) =>
+      case e: IllegalStateException if isArrowAllocatorIssue(e.getMessage) =>
         throw e
       case e: Throwable => debug(e)
     }

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/RemoteSparkSession.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/RemoteSparkSession.scala
@@ -223,8 +223,9 @@ trait RemoteSparkSession
 
   override def afterAll(): Unit = {
     def isArrowAllocatorIssue(message: String): Boolean = {
-      Option(message).exists(m => m.contains("closed with outstanding") ||
-        m.contains("Memory leaked"))
+      Option(message).exists(m =>
+        m.contains("closed with outstanding") ||
+          m.contains("Memory leaked"))
     }
     try {
       if (spark != null) spark.stop()


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pull request (PR) includes the following modifications to enable `BaseAllocator` to print stacktrace information upon failure during testing:
1. Set the logging level of `org.apache.arrow.memory.BaseAllocator` to `trace`, so that information at the `Verbosity.LOG_WITH_STACKTRACE` level will be inlined into the error message of exceptions.
2. Added a test option for the `connect-client-jvm` module: `(Test / javaOptions) += "-Darrow.memory.debug.allocator=true"`. This enables `RootAllocator` to print memory allocation events.
3. Optimized the logic for matching and handling failure scenarios when closing `BaseAllocator` in the `RemoteSparkSession#afterAll` function.


### Why are the changes needed?
Print more detailed stacktrace information after a failure in closing `BaseAllocator` to facilitate troubleshooting. An example is as follows:

```
[info]     ledger[762] allocator: ROOT), isOwning: , size: , references: 2, life: 684012591764208..0, allocatorManager: [, life: ] holds 3 buffers. 
[info]         ArrowBuf[2286], address:5912689792, capacity:2
[info]      event log for: ArrowBuf[2286]
[info]        684012592054541 create()
[info]               at org.apache.arrow.memory.util.HistoricalLog$Event.<init>(HistoricalLog.java:174)
[info]               at org.apache.arrow.memory.util.HistoricalLog.recordEvent(HistoricalLog.java:86)
[info]               at org.apache.arrow.memory.ArrowBuf.<init>(ArrowBuf.java:93)
[info]               at org.apache.arrow.memory.BufferLedger.deriveBuffer(BufferLedger.java:219)
[info]               at org.apache.arrow.memory.ArrowBuf.slice(ArrowBuf.java:194)
[info]               at org.apache.arrow.vector.ipc.message.MessageSerializer.deserializeRecordBatch(MessageSerializer.java:429)
[info]               at org.apache.arrow.vector.ipc.message.MessageSerializer.deserializeRecordBatch(MessageSerializer.java:343)
[info]               at org.apache.spark.sql.connect.client.arrow.MessageIterator.next(ConcatenatingArrowStreamReader.scala:170)
[info]               at org.apache.spark.sql.connect.client.SparkResult.org$apache$spark$sql$connect$client$SparkResult$$processResponses(SparkResult.scala:184)
[info]               at org.apache.spark.sql.connect.client.SparkResult.length(SparkResult.scala:221)
[info]               at org.apache.spark.sql.connect.SparkSessionE2ESuite.$anonfun$new$33(SparkSessionE2ESuite.scala:315)
[info]               at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]               at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
[info]               at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]               at org.scalatest.Transformer.apply(Transformer.scala:22)
[info]               at org.scalatest.Transformer.apply(Transformer.scala:20)
[info]               at org.scalatest.funsuite.AnyFunSuiteLike$$anon$1.apply(AnyFunSuiteLike.scala:226)
[info]               at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
[info]               at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
[info]               at org.scalatest.funsuite.AnyFunSuite.withFixture(AnyFunSuite.scala:1564)
[info]               at org.scalatest.funsuite.AnyFunSuiteLike.invokeWithFixture$1(AnyFunSuiteLike.scala:224)
[info]               at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$runTest$1(AnyFunSuiteLike.scala:236)
[info]               at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
[info]               at org.scalatest.funsuite.AnyFunSuiteLike.runTest(AnyFunSuiteLike.scala:236)
[info]               at org.scalatest.funsuite.AnyFunSuiteLike.runTest$(AnyFunSuiteLike.scala:218)
[info]               at org.scalatest.funsuite.AnyFunSuite.runTest(AnyFunSuite.scala:1564)
[info]               at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$runTests$1(AnyFunSuiteLike.scala:269)
[info]               at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:413)
[info]               at scala.collection.immutable.List.foreach(List.scala:334)
[info]               at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
[info]               at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:396)
[info]               at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
[info]               at org.scalatest.funsuite.AnyFunSuiteLike.runTests(AnyFunSuiteLike.scala:269)
[info]               at org.scalatest.funsuite.AnyFunSuiteLike.runTests$(AnyFunSuiteLike.scala:268)
[info]               at org.scalatest.funsuite.AnyFunSuite.runTests(AnyFunSuite.scala:1564)
[info]               at org.scalatest.Suite.run(Suite.scala:1114)
[info]               at org.scalatest.Suite.run$(Suite.scala:1096)
[info]               at org.scalatest.funsuite.AnyFunSuite.org$scalatest$funsuite$AnyFunSuiteLike$$super$run(AnyFunSuite.scala:1564)
[info]               at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$run$1(AnyFunSuiteLike.scala:273)
[info]               at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
[info]               at org.scalatest.funsuite.AnyFunSuiteLike.run(AnyFunSuiteLike.scala:273)
[info]               at org.scalatest.funsuite.AnyFunSuiteLike.run$(AnyFunSuiteLike.scala:272)
[info]               at org.apache.spark.sql.connect.SparkSessionE2ESuite.org$scalatest$BeforeAndAfterAll$$super$run(SparkSessionE2ESuite.scala:38)
[info]               at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
[info]               at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
[info]               at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
[info]               at org.apache.spark.sql.connect.SparkSessionE2ESuite.run(SparkSessionE2ESuite.scala:38)
[info]               at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:321)
[info]               at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:517)
[info]               at sbt.ForkMain$Run.lambda$runTest$1(ForkMain.java:414)
[info]               at java.util.concurrent.FutureTask.run(FutureTask.java:264)
[info]               at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[info]               at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[info]               at java.lang.Thread.run(Thread.java:840)
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Action
- Locally confirmed that modifying the logging level of `org.apache.arrow.memory.BaseAllocator` has no adverse effects: the size of `unit-tests.log` was 285K before this pr and 315K after this pr.

### Was this patch authored or co-authored using generative AI tooling?
No