### PR TITLE
[SPARK-51869][SS] Create classification for user errors within UDFs for Scala TransformWithState

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5235,7 +5235,7 @@
   },
   "TRANSFORM_WITH_STATE_USER_FUNCTION_ERROR" : {
     "message" : [
-      "An error occurred in the handleInputRows function of the StatefulProcessor. Reason: <reason>"
+      "An error occurred in the handleInputRows function of the StatefulProcessor. Function: <function>. Reason: <reason>"
     ],
     "sqlState" : "39000"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5235,7 +5235,7 @@
   },
   "TRANSFORM_WITH_STATE_USER_FUNCTION_ERROR" : {
     "message" : [
-      "An error occurred in the handleInputRows function of the StatefulProcessor. Function: <function>. Reason: <reason>"
+      "An error occurred in the user-defined function <function> of the StatefulProcessor Reason: <reason>"
     ],
     "sqlState" : "39000"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5235,7 +5235,7 @@
   },
   "TRANSFORM_WITH_STATE_USER_FUNCTION_ERROR" : {
     "message" : [
-      "An error occurred in the user-defined function <function> of the StatefulProcessor Reason: <reason>"
+      "An error occurred in the user-defined function <function> of the StatefulProcessor. Reason: <reason>."
     ],
     "sqlState" : "39000"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5233,6 +5233,12 @@
     ],
     "sqlState" : "XXKST"
   },
+  "TRANSFORM_WITH_STATE_USER_FUNCTION_ERROR" : {
+    "message" : [
+      "An error occurred in the handleInputRows function of the StatefulProcessor. Reason: <reason>"
+    ],
+    "sqlState" : "39000"
+  },
   "TRANSPOSE_EXCEED_ROW_LIMIT" : {
     "message" : [
       "Number of rows exceeds the allowed limit of <maxValues> for TRANSPOSE. If this was intended, set <config> to at least the current row count."

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -285,7 +285,7 @@ case class TransformWithStateExec(
       case sparkThrowable: SparkThrowable =>
         throw sparkThrowable
       case e: Exception =>
-        throw TransformWithStateUserFunctionException(e)
+        throw TransformWithStateUserFunctionException(e, "handleInputRows")
     }
   }
 
@@ -314,7 +314,7 @@ case class TransformWithStateExec(
       case sparkThrowable: SparkThrowable =>
         throw sparkThrowable
       case e: Exception =>
-        throw TransformWithStateUserFunctionException(e)
+        throw TransformWithStateUserFunctionException(e, "handleInitialState")
     }
   }
 
@@ -348,7 +348,7 @@ case class TransformWithStateExec(
       case sparkThrowable: SparkThrowable =>
         throw sparkThrowable
       case e: Exception =>
-        throw TransformWithStateUserFunctionException(e)
+        throw TransformWithStateUserFunctionException(e, "handleExpiredTimer")
     }
   }
 
@@ -470,7 +470,7 @@ case class TransformWithStateExec(
       case sparkThrowable: SparkThrowable =>
         throw sparkThrowable
       case e: Exception =>
-        throw TransformWithStateUserFunctionException(e)
+        throw TransformWithStateUserFunctionException(e, "close")
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -261,6 +261,7 @@ case class TransformWithStateExec(
 
   private def handleInputRows(keyRow: UnsafeRow, valueRowIter: Iterator[InternalRow]):
     Iterator[InternalRow] = {
+
     val getOutputRow = ObjectOperator.wrapObjectToRow(outputObjectType)
 
     val keyObj = getKeyObj(keyRow) // convert key to objects

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -592,8 +592,8 @@ case class TransformWithStateExec(
     try {
       block
     } catch {
-      case sparkThrowable: SparkThrowable =>
-        throw sparkThrowable
+      case st: Exception with SparkThrowable if st.getCondition != null =>
+        throw st
       case e: Exception =>
         throw TransformWithStateUserFunctionException(e, functionName)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
@@ -370,6 +370,12 @@ class TWSSchemaMustBeNullable(
       "columnFamilyName" -> columnFamilyName,
       "schema" -> schema))
 
+private[sql] case class TransformWithStateUserFunctionException(cause: Throwable)
+  extends SparkException(
+    errorClass = "TRANSFORM_WITH_STATE_USER_FUNCTION_ERROR",
+    messageParameters = Map("reason" -> Option(cause.getMessage).getOrElse("")),
+    cause = cause)
+
 class StateStoreInvalidValueSchemaEvolution(
     oldValueSchema: String,
     newValueSchema: String)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
@@ -370,10 +370,14 @@ class TWSSchemaMustBeNullable(
       "columnFamilyName" -> columnFamilyName,
       "schema" -> schema))
 
-private[sql] case class TransformWithStateUserFunctionException(cause: Throwable)
+private[sql] case class TransformWithStateUserFunctionException(
+    cause: Throwable,
+    functionName: String)
   extends SparkException(
     errorClass = "TRANSFORM_WITH_STATE_USER_FUNCTION_ERROR",
-    messageParameters = Map("reason" -> Option(cause.getMessage).getOrElse("")),
+    messageParameters = Map(
+      "reason" -> Option(cause.getMessage).getOrElse(""),
+      "function" -> functionName),
     cause = cause)
 
 class StateStoreInvalidValueSchemaEvolution(

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -73,6 +73,119 @@ case class EvolvedState(
     score: Double           // Should default to 0.0
 )
 
+class ClassifiedTimerErrorProcessor
+  extends StatefulProcessor[String, String, (String, BasicState)] {
+
+  @transient var state: ValueState[BasicState] = _
+
+  override def init(outputMode: OutputMode, timeMode: TimeMode): Unit = {
+    state = getHandle.getValueState[BasicState](
+      "testState",
+      Encoders.product[BasicState],
+      TTLConfig.NONE)
+  }
+
+  override def handleInputRows(
+      key: String,
+      rows: Iterator[String],
+      timerValues: TimerValues): Iterator[(String, BasicState)] = {
+    getHandle.registerTimer(timerValues.getCurrentProcessingTimeInMs() + 1000)
+    Seq.empty.iterator
+  }
+
+  override def handleExpiredTimer(
+      key: String,
+      timerValues: TimerValues,
+      expiredTimerInfo: ExpiredTimerInfo): Iterator[(String, BasicState)] = {
+    throw StateStoreErrors.multipleColumnFamiliesNotSupported("dummy val")
+  }
+}
+
+class UnclassifiedTimerErrorProcessor
+  extends StatefulProcessor[String, String, (String, BasicState)] {
+
+  @transient var state: ValueState[BasicState] = _
+
+  override def init(outputMode: OutputMode, timeMode: TimeMode): Unit = {
+    state = getHandle.getValueState[BasicState](
+      "testState",
+      Encoders.product[BasicState],
+      TTLConfig.NONE)
+  }
+
+  override def handleInputRows(
+      key: String,
+      rows: Iterator[String],
+      timerValues: TimerValues): Iterator[(String, BasicState)] = {
+    getHandle.registerTimer(timerValues.getCurrentProcessingTimeInMs() + 1000)
+    Seq.empty.iterator
+  }
+
+  override def handleExpiredTimer(
+      key: String,
+      timerValues: TimerValues,
+      expiredTimerInfo: ExpiredTimerInfo): Iterator[(String, BasicState)] = {
+    null.asInstanceOf[ValueState[BasicState]].get()
+    Seq.empty.iterator
+  }
+}
+
+
+class ClassifiedErrorInitialStateProcessor
+  extends StatefulProcessorWithInitialState[String, String, (String, BasicState), String] {
+
+  @transient var state: ValueState[BasicState] = _
+
+  override def init(outputMode: OutputMode, timeMode: TimeMode): Unit = {
+    state = getHandle.getValueState[BasicState](
+      "testState",
+      Encoders.product[BasicState],
+      TTLConfig.NONE)
+  }
+
+  override def handleInitialState(
+      key: String,
+      initialState: String,
+      timerValues: TimerValues): Unit = {
+    throw StateStoreErrors.multipleColumnFamiliesNotSupported("dummy val")
+  }
+
+  override def handleInputRows(
+      key: String,
+      rows: Iterator[String],
+      timerValues: TimerValues): Iterator[(String, BasicState)] = {
+    Seq.empty.iterator
+  }
+}
+
+
+class UnclassifiedErrorInitialStateProcessor
+  extends StatefulProcessorWithInitialState[String, String, (String, BasicState), String] {
+
+  @transient var state: ValueState[BasicState] = _
+
+  override def init(outputMode: OutputMode, timeMode: TimeMode): Unit = {
+    state = getHandle.getValueState[BasicState](
+      "testState",
+      Encoders.product[BasicState],
+      TTLConfig.NONE)
+  }
+
+  override def handleInitialState(
+      key: String,
+      initialState: String,
+      timerValues: TimerValues): Unit = {
+    null.asInstanceOf[ValueState[BasicState]].get()
+  }
+
+  override def handleInputRows(
+      key: String,
+      rows: Iterator[String],
+      timerValues: TimerValues): Iterator[(String, BasicState)] = {
+    Seq.empty.iterator
+  }
+}
+
 // Processor with initial schema
 class DefaultValueInitialProcessor
   extends StatefulProcessor[String, String, (String, BasicState)] {
@@ -2484,6 +2597,120 @@ class TransformWithStateValidationSuite extends StateStoreMetricsTest {
 
       testStream(result, OutputMode.Update())(
         AddData(inputData, "a"),
+        ExpectFailure[StateStoreMultipleColumnFamiliesNotSupportedException] { error =>
+          assert(error.getMessage.contains("not supported"))
+        }
+      )
+    }
+  }
+
+  test("transformWithState - check that error within handleInitialState is classified") {
+    withSQLConf(
+      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName,
+      SQLConf.SHUFFLE_PARTITIONS.key ->
+        TransformWithStateSuiteUtils.NUM_SHUFFLE_PARTITIONS.toString) {
+
+      val inputData = MemoryStream[String]
+      val initDf = Seq("init_1").toDS().groupByKey(x => x)
+      val result = inputData.toDS()
+        .groupByKey(x => x)
+        .transformWithState(new UnclassifiedErrorInitialStateProcessor(),
+          TimeMode.None(),
+          OutputMode.Update(),
+          initDf)
+
+      testStream(result, OutputMode.Update())(
+        AddData(inputData, "a"),
+        ExpectFailure[TransformWithStateUserFunctionException] { error =>
+          checkError(
+            error.asInstanceOf[SparkException],
+            condition = "TRANSFORM_WITH_STATE_USER_FUNCTION_ERROR",
+            parameters = Map("reason" ->
+              ("Cannot invoke \"org.apache.spark.sql.streaming.ValueState." +
+                "get()\" because \"null\" is null"))
+          )
+        }
+      )
+    }
+  }
+
+  test("transformWithState - check that classified error is thrown from handleInitialState") {
+    withSQLConf(
+      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName,
+      SQLConf.SHUFFLE_PARTITIONS.key ->
+        TransformWithStateSuiteUtils.NUM_SHUFFLE_PARTITIONS.toString) {
+
+      val inputData = MemoryStream[String]
+      val initDf = Seq("init_1").toDS().groupByKey(x => x)
+      val result = inputData.toDS()
+        .groupByKey(x => x)
+        .transformWithState(new ClassifiedErrorInitialStateProcessor(),
+          TimeMode.None(),
+          OutputMode.Update(),
+          initDf)
+
+      testStream(result, OutputMode.Update())(
+        AddData(inputData, "a"),
+        ExpectFailure[StateStoreMultipleColumnFamiliesNotSupportedException] { error =>
+          assert(error.getMessage.contains("not supported"))
+        }
+      )
+    }
+  }
+
+  test("transformWithState - check that error within handleExpiredTimer is classified") {
+    withSQLConf(
+      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName,
+      SQLConf.SHUFFLE_PARTITIONS.key ->
+        TransformWithStateSuiteUtils.NUM_SHUFFLE_PARTITIONS.toString) {
+
+      val clock = new StreamManualClock
+      val inputData = MemoryStream[String]
+      val result = inputData.toDS()
+        .groupByKey(x => x)
+        .transformWithState(new UnclassifiedTimerErrorProcessor(),
+          TimeMode.ProcessingTime(),
+          OutputMode.Update())
+
+      testStream(result, OutputMode.Update())(
+        StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock),
+        AddData(inputData, "a"),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(),
+        AdvanceManualClock(2 * 1000),
+        ExpectFailure[TransformWithStateUserFunctionException] { error =>
+          checkError(
+            error.asInstanceOf[SparkException],
+            condition = "TRANSFORM_WITH_STATE_USER_FUNCTION_ERROR",
+            parameters = Map("reason" ->
+              ("Cannot invoke \"org.apache.spark.sql.streaming.ValueState." +
+                "get()\" because \"null\" is null"))
+          )
+        }
+      )
+    }
+  }
+
+  test("transformWithState - check that classified error is thrown from handleExpiredTimer") {
+    withSQLConf(
+      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName,
+      SQLConf.SHUFFLE_PARTITIONS.key ->
+        TransformWithStateSuiteUtils.NUM_SHUFFLE_PARTITIONS.toString) {
+
+      val clock = new StreamManualClock
+      val inputData = MemoryStream[String]
+      val result = inputData.toDS()
+        .groupByKey(x => x)
+        .transformWithState(new ClassifiedTimerErrorProcessor(),
+          TimeMode.ProcessingTime(),
+          OutputMode.Update())
+
+      testStream(result, OutputMode.Update())(
+        StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock),
+        AddData(inputData, "a"),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(),
+        AdvanceManualClock(2 * 1000),
         ExpectFailure[StateStoreMultipleColumnFamiliesNotSupportedException] { error =>
           assert(error.getMessage.contains("not supported"))
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -2575,7 +2575,8 @@ class TransformWithStateValidationSuite extends StateStoreMetricsTest {
             condition = "TRANSFORM_WITH_STATE_USER_FUNCTION_ERROR",
             parameters = Map("reason" ->
               ("Cannot invoke \"org.apache.spark.sql.streaming.ValueState." +
-                "get()\" because \"null\" is null"))
+                "get()\" because \"null\" is null"),
+            "function" -> "handleInputRows")
           )
         }
       )
@@ -2627,7 +2628,8 @@ class TransformWithStateValidationSuite extends StateStoreMetricsTest {
             condition = "TRANSFORM_WITH_STATE_USER_FUNCTION_ERROR",
             parameters = Map("reason" ->
               ("Cannot invoke \"org.apache.spark.sql.streaming.ValueState." +
-                "get()\" because \"null\" is null"))
+                "get()\" because \"null\" is null"),
+            "function" -> "handleInitialState")
           )
         }
       )
@@ -2684,7 +2686,8 @@ class TransformWithStateValidationSuite extends StateStoreMetricsTest {
             condition = "TRANSFORM_WITH_STATE_USER_FUNCTION_ERROR",
             parameters = Map("reason" ->
               ("Cannot invoke \"org.apache.spark.sql.streaming.ValueState." +
-                "get()\" because \"null\" is null"))
+                "get()\" because \"null\" is null"),
+              "function" -> "handleExpiredTimer")
           )
         }
       )

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -125,11 +125,10 @@ class UnclassifiedTimerErrorProcessor
       key: String,
       timerValues: TimerValues,
       expiredTimerInfo: ExpiredTimerInfo): Iterator[(String, BasicState)] = {
-    null.asInstanceOf[ValueState[BasicState]].get()
+    throw new IllegalStateException("dummy unclassified error")
     Seq.empty.iterator
   }
 }
-
 
 class ClassifiedErrorInitialStateProcessor
   extends StatefulProcessorWithInitialState[String, String, (String, BasicState), String] {
@@ -158,7 +157,6 @@ class ClassifiedErrorInitialStateProcessor
   }
 }
 
-
 class UnclassifiedErrorInitialStateProcessor
   extends StatefulProcessorWithInitialState[String, String, (String, BasicState), String] {
 
@@ -175,7 +173,7 @@ class UnclassifiedErrorInitialStateProcessor
       key: String,
       initialState: String,
       timerValues: TimerValues): Unit = {
-    null.asInstanceOf[ValueState[BasicState]].get()
+    throw new IllegalStateException("dummy unclassified error")
   }
 
   override def handleInputRows(
@@ -228,7 +226,7 @@ class UnclassifiedErrorProcessor
       key: String,
       rows: Iterator[String],
       timerValues: TimerValues): Iterator[(String, BasicState)] = {
-    null.asInstanceOf[ValueState[BasicState]].get()
+    throw new IllegalStateException("dummy unclassified error")
     Seq.empty.iterator
   }
 }
@@ -2573,10 +2571,9 @@ class TransformWithStateValidationSuite extends StateStoreMetricsTest {
           checkError(
             error.asInstanceOf[SparkException],
             condition = "TRANSFORM_WITH_STATE_USER_FUNCTION_ERROR",
-            parameters = Map("reason" ->
-              ("Cannot invoke \"org.apache.spark.sql.streaming.ValueState." +
-                "get()\" because \"null\" is null"),
-            "function" -> "handleInputRows")
+            parameters = Map(
+              "reason" -> "dummy unclassified error",
+              "function" -> "handleInputRows")
           )
         }
       )
@@ -2626,10 +2623,9 @@ class TransformWithStateValidationSuite extends StateStoreMetricsTest {
           checkError(
             error.asInstanceOf[SparkException],
             condition = "TRANSFORM_WITH_STATE_USER_FUNCTION_ERROR",
-            parameters = Map("reason" ->
-              ("Cannot invoke \"org.apache.spark.sql.streaming.ValueState." +
-                "get()\" because \"null\" is null"),
-            "function" -> "handleInitialState")
+            parameters = Map(
+              "reason" -> "dummy unclassified error",
+              "function" -> "handleInitialState")
           )
         }
       )
@@ -2684,9 +2680,8 @@ class TransformWithStateValidationSuite extends StateStoreMetricsTest {
           checkError(
             error.asInstanceOf[SparkException],
             condition = "TRANSFORM_WITH_STATE_USER_FUNCTION_ERROR",
-            parameters = Map("reason" ->
-              ("Cannot invoke \"org.apache.spark.sql.streaming.ValueState." +
-                "get()\" because \"null\" is null"),
+            parameters = Map(
+              "reason" -> "dummy unclassified error",
               "function" -> "handleExpiredTimer")
           )
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds proper error handling to the handleInputRows method in TransformWithState

### Why are the changes needed?
The changes improve error handling and reporting when users implement custom stateful processors. Without this change, when an error occurs within the handleInputRows function, users would receive a generic exception without clear indication that the error originated from their implementation. The new approach provides more descriptive error messages that pinpoint the source of the problem.

### Does this PR introduce any user-facing change?
Yes, this PR introduces a user-facing change in the form of a new error message format for errors occurring within the StatefulProcessor's handleInputRows function. Users will now receive more descriptive error messages when their stateful processing logic fails.

### How was this patch tested?
The patch was tested by adding two new test cases to TransformWithStateSuite:

"transformWithState - check that error within handleInputRows is classified" - tests that unclassified errors within the handleInputRows method are properly wrapped in a TransformWithStateUserFunctionException
"transformWithState - check that classified error is thrown from handleInputRows" - tests that already classified SparkThrowable exceptions are passed through correctly

### Was this patch authored or co-authored using generative AI tooling?
No