### PR TITLE
[SPARK-51886][SQL]Part2.a Adds support for decorrelating nested correlated subqueries in Optimizer

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2345,18 +2345,18 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
      */
     private def resolveSubQueries(plan: LogicalPlan, outer: LogicalPlan): LogicalPlan = {
       plan.transformAllExpressionsWithPruning(_.containsPattern(PLAN_EXPRESSION), ruleId) {
-        case s @ ScalarSubquery(sub, _, exprId, _, _, _, _) if !sub.resolved =>
-          resolveSubQuery(s, outer)(ScalarSubquery(_, _, exprId))
-        case e @ Exists(sub, _, exprId, _, _) if !sub.resolved =>
-          resolveSubQuery(e, outer)(Exists(_, _, exprId))
-        case InSubquery(values, l @ ListQuery(_, _, exprId, _, _, _))
+        case s @ ScalarSubquery(sub, _, _, exprId, _, _, _, _) if !sub.resolved =>
+          resolveSubQuery(s, outer)(ScalarSubquery(_, _, Seq.empty, exprId))
+        case e @ Exists(sub, _, _, exprId, _, _) if !sub.resolved =>
+          resolveSubQuery(e, outer)(Exists(_, _, Seq.empty, exprId))
+        case InSubquery(values, l @ ListQuery(_, _, _, exprId, _, _, _))
             if values.forall(_.resolved) && !l.resolved =>
           val expr = resolveSubQuery(l, outer)((plan, exprs) => {
-            ListQuery(plan, exprs, exprId, plan.output.length)
+            ListQuery(plan, exprs, Seq.empty, exprId, plan.output.length)
           })
           InSubquery(values, expr.asInstanceOf[ListQuery])
-        case s @ LateralSubquery(sub, _, exprId, _, _) if !sub.resolved =>
-          resolveSubQuery(s, outer)(LateralSubquery(_, _, exprId))
+        case s @ LateralSubquery(sub, _, _, exprId, _, _) if !sub.resolved =>
+          resolveSubQuery(s, outer)(LateralSubquery(_, _, Seq.empty, exprId))
         case a: FunctionTableSubqueryArgumentExpression if !a.plan.resolved =>
           resolveSubQuery(a, outer)(
             (plan, outerAttrs) => a.copy(plan = plan, outerAttrs = outerAttrs))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ValidateSubqueryExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ValidateSubqueryExpression.scala
@@ -129,7 +129,7 @@ object ValidateSubqueryExpression
     checkOuterReference(plan, expr)
 
     expr match {
-      case ScalarSubquery(query, outerAttrs, _, _, _, _, _) =>
+      case ScalarSubquery(query, outerAttrs, _, _, _, _, _, _) =>
         // Scalar subquery must return one column as output.
         if (query.output.size != 1) {
           throw QueryCompilationErrors.subqueryReturnMoreThanOneColumn(query.output.size,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SQLFunction.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SQLFunction.scala
@@ -85,8 +85,8 @@ case class SQLFunction(
       case (None, Some(Project(expr :: Nil, _: OneRowRelation)))
         if !isTableFunc =>
         (Some(expr), None)
-      case (Some(ScalarSubquery(Project(expr :: Nil, _: OneRowRelation), _, _, _, _, _, _)), None)
-        if !isTableFunc =>
+      case (Some(ScalarSubquery(Project(expr :: Nil, _: OneRowRelation),
+        _, _, _, _, _, _, _)), None) if !isTableFunc =>
         (Some(expr), None)
       case (_, _) =>
         (parsedExpression, parsedQuery)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
@@ -46,6 +46,10 @@ import org.apache.spark.sql.types.DataType
  *             relation or as a more complex logical plan in the event of a table subquery.
  * @param outerAttrs outer references of this subquery plan, generally empty since these table
  *                   arguments do not allow correlated references currently
+ * @param outerScopeAttrs outer references of the subquery plan that cannot be resolved by the
+ *                        direct containing query of the subquery. They have to be the subset of
+ *                        outerAttrs and are generally empty since these table arguments do not
+ *                        allow correlated references currently
  * @param exprId expression ID of this subquery expression, generally generated afresh each time
  * @param partitionByExpressions if non-empty, the TABLE argument included the PARTITION BY clause
  *                               to indicate that the input relation should be repartitioned by the
@@ -67,30 +71,53 @@ import org.apache.spark.sql.types.DataType
 case class FunctionTableSubqueryArgumentExpression(
     plan: LogicalPlan,
     outerAttrs: Seq[Expression] = Seq.empty,
+    outerScopeAttrs: Seq[Expression] = Seq.empty,
     exprId: ExprId = NamedExpression.newExprId,
     partitionByExpressions: Seq[Expression] = Seq.empty,
     withSinglePartition: Boolean = false,
     orderByExpressions: Seq[SortOrder] = Seq.empty,
     selectedInputExpressions: Seq[PythonUDTFSelectedExpression] = Seq.empty)
-  extends SubqueryExpression(plan, outerAttrs, exprId, Seq.empty, None) with Unevaluable {
+  extends SubqueryExpression(
+      plan,
+      outerAttrs,
+      outerScopeAttrs,
+      exprId,
+      Seq.empty,
+      None
+    ) with Unevaluable {
 
   assert(!(withSinglePartition && partitionByExpressions.nonEmpty),
     "WITH SINGLE PARTITION is mutually exclusive with PARTITION BY")
 
   override def dataType: DataType = plan.schema
+
   override def nullable: Boolean = false
+
   override def withNewPlan(plan: LogicalPlan): FunctionTableSubqueryArgumentExpression =
     copy(plan = plan)
+
   override def withNewOuterAttrs(outerAttrs: Seq[Expression])
   : FunctionTableSubqueryArgumentExpression = copy(outerAttrs = outerAttrs)
+
   override def hint: Option[HintInfo] = None
+
   override def withNewHint(hint: Option[HintInfo]): FunctionTableSubqueryArgumentExpression =
     copy()
+
+  override def withNewOuterScopeAttrs(
+    outerScopeAttrs: Seq[Expression]
+  ): FunctionTableSubqueryArgumentExpression = {
+    validateOuterScopeAttrs()
+    copy(outerScopeAttrs = outerScopeAttrs)
+  }
+
   override def toString: String = s"table-argument#${exprId.id} $conditionString"
+
   override lazy val canonicalized: Expression = {
     FunctionTableSubqueryArgumentExpression(
       plan.canonicalized,
       outerAttrs.map(_.canonicalized),
+      outerScopeAttrs.map(_.canonicalized),
       ExprId(0),
       partitionByExpressions,
       withSinglePartition,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -638,7 +638,13 @@ case class ScalarSubquery(
       outerAttrs = newChildren.take(outerAttrs.size),
       joinCond = newChildren.drop(outerAttrs.size))
 
-  final override def nodePatternsInternal(): Seq[TreePattern] = Seq(SCALAR_SUBQUERY)
+  final override def nodePatternsInternal(): Seq[TreePattern] = {
+    if (outerScopeAttrs.isEmpty) {
+      Seq(SCALAR_SUBQUERY)
+    } else {
+      Seq(NESTED_CORRELATED_SUBQUERY, SCALAR_SUBQUERY)
+    }
+  }
 }
 
 object ScalarSubquery {
@@ -726,7 +732,17 @@ case class LateralSubquery(
       outerAttrs = newChildren.take(outerAttrs.size),
       joinCond = newChildren.drop(outerAttrs.size))
 
-  final override def nodePatternsInternal(): Seq[TreePattern] = Seq(LATERAL_SUBQUERY)
+  final override def nodePatternsInternal(): Seq[TreePattern] = {
+    if (outerScopeAttrs.isEmpty) {
+      Seq(LATERAL_SUBQUERY)
+    } else {
+      // Currently we don't support lateral subqueries with
+      // nested outer references.
+      assert(false, "Nested outer references are not supported in lateral subqueries." +
+        " Please file a bug if you see this error.")
+      Seq(NESTED_CORRELATED_SUBQUERY, LATERAL_SUBQUERY)
+    }
+  }
 }
 
 /**
@@ -803,7 +819,13 @@ case class ListQuery(
       outerAttrs = newChildren.take(outerAttrs.size),
       joinCond = newChildren.drop(outerAttrs.size))
 
-  final override def nodePatternsInternal(): Seq[TreePattern] = Seq(LIST_SUBQUERY)
+  final override def nodePatternsInternal(): Seq[TreePattern] = {
+    if (outerScopeAttrs.isEmpty) {
+      Seq(LIST_SUBQUERY)
+    } else {
+      Seq(NESTED_CORRELATED_SUBQUERY, LIST_SUBQUERY)
+    }
+  }
 }
 
 /**
@@ -873,7 +895,13 @@ case class Exists(
       outerAttrs = newChildren.take(outerAttrs.size),
       joinCond = newChildren.drop(outerAttrs.size))
 
-  final override def nodePatternsInternal(): Seq[TreePattern] = Seq(EXISTS_SUBQUERY)
+  final override def nodePatternsInternal(): Seq[TreePattern] = {
+    if (outerScopeAttrs.isEmpty) {
+      Seq(EXISTS_SUBQUERY)
+    } else {
+      Seq(NESTED_CORRELATED_SUBQUERY, EXISTS_SUBQUERY)
+    }
+  }
 }
 
 case class UnresolvedExistsPlanId(planId: Long)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -18,13 +18,14 @@
 package org.apache.spark.sql.catalyst.optimizer
 
 import scala.collection.mutable
+
 import org.apache.spark.SparkException
 import org.apache.spark.internal.{LogKeys, MDC}
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.SubqueryExpression.{hasCorrelatedSubquery, hasSubquery}
+import org.apache.spark.sql.catalyst.expressions.SubqueryExpression.hasCorrelatedSubquery
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans._
@@ -205,8 +206,8 @@ abstract class Optimizer(catalogManager: CatalogManager)
       PullOutNestedDataOuterRefExpressions,
       PullupCorrelatedPredicates),
     Batch("Rewrite Nested Correlated Subqueries", Once,
-      RewriteDomainJoinsInSubqueries,
-    )
+      RewriteDomainJoinsInOnePass,
+    ),
     // Subquery batch applies the optimizer rules recursively. Therefore, it makes no sense
     // to enforce idempotence on it and we change this batch from Once to FixedPoint(1).
     Batch("Subquery", FixedPoint(1),
@@ -297,7 +298,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
       RewriteIntersectAll.ruleName,
       ReplaceDistinctWithAggregate.ruleName,
       PullupCorrelatedPredicates.ruleName,
-      RewriteDomainJoinsInSubqueries.ruleName,
+      RewriteDomainJoinsInOnePass.ruleName,
       RewriteCorrelatedScalarSubquery.ruleName,
       RewritePredicateSubquery.ruleName,
       NormalizeFloatingNumbers.ruleName,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -364,7 +364,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
       case d: DynamicPruningSubquery => d
       case s @ ScalarSubquery(
         PhysicalOperation(projections, predicates, a @ Aggregate(group, _, child, _)),
-        _, _, _, _, mayHaveCountBug, _)
+        _, _, _, _, _, mayHaveCountBug, _)
         if conf.getConf(SQLConf.DECORRELATE_SUBQUERY_PREVENT_CONSTANT_FOLDING_FOR_COUNT_BUG) &&
           mayHaveCountBug.nonEmpty && mayHaveCountBug.get =>
         // This is a subquery with an aggregate that may suffer from a COUNT bug.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -205,8 +205,12 @@ abstract class Optimizer(catalogManager: CatalogManager)
       OptimizeOneRowRelationSubquery,
       PullOutNestedDataOuterRefExpressions,
       PullupCorrelatedPredicates),
+    // This batch rewrites all correlated subqueries along with any domain joins inside.
+    // Each rule in the batch is only effective when there are nested correlated subqueries
+    // in the plan.
     Batch("Rewrite Nested Correlated Subqueries", Once,
       RewriteDomainJoinsInOnePass,
+      RewriteCorrelatedSubqueriesInOnePass
     ),
     // Subquery batch applies the optimizer rules recursively. Therefore, it makes no sense
     // to enforce idempotence on it and we change this batch from Once to FixedPoint(1).

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -91,7 +91,7 @@ object ConstantFolding extends Rule[LogicalPlan] {
       }
 
     // Don't replace ScalarSubquery if its plan is an aggregate that may suffer from a COUNT bug.
-    case s @ ScalarSubquery(_, _, _, _, _, mayHaveCountBug, _)
+    case s @ ScalarSubquery(_, _, _, _, _, _, mayHaveCountBug, _)
       if conf.getConf(SQLConf.DECORRELATE_SUBQUERY_PREVENT_CONSTANT_FOLDING_FOR_COUNT_BUG) &&
         mayHaveCountBug.nonEmpty && mayHaveCountBug.get =>
       s
@@ -892,7 +892,7 @@ object NullPropagation extends Rule[LogicalPlan] {
       case InSubquery(Seq(Literal(null, _)), _)
         if SQLConf.get.legacyNullInEmptyBehavior =>
         Literal.create(null, BooleanType)
-      case InSubquery(Seq(Literal(null, _)), ListQuery(sub, _, _, _, conditions, _))
+      case InSubquery(Seq(Literal(null, _)), ListQuery(sub, _, _, _, _, conditions, _))
         if !SQLConf.get.legacyNullInEmptyBehavior
         && conditions.isEmpty =>
         If(Exists(sub), Literal(null, BooleanType), FalseLiteral)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -152,17 +152,17 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
 
       // Filter the plan by applying left semi and left anti joins.
       withSubquery.foldLeft(newFilter) {
-        case (p, Exists(sub, _, _, conditions, subHint)) =>
+        case (p, Exists(sub, _, _, _, conditions, subHint)) =>
           val (joinCond, outerPlan) = rewriteExistentialExpr(conditions, p)
           val join = buildJoin(outerPlan, rewriteDomainJoinsIfPresent(outerPlan, sub, joinCond),
             LeftSemi, joinCond, subHint)
           Project(p.output, join)
-        case (p, Not(Exists(sub, _, _, conditions, subHint))) =>
+        case (p, Not(Exists(sub, _, _, _, conditions, subHint))) =>
           val (joinCond, outerPlan) = rewriteExistentialExpr(conditions, p)
           val join = buildJoin(outerPlan, rewriteDomainJoinsIfPresent(outerPlan, sub, joinCond),
             LeftAnti, joinCond, subHint)
           Project(p.output, join)
-        case (p, InSubquery(values, ListQuery(sub, _, _, _, conditions, subHint))) =>
+        case (p, InSubquery(values, ListQuery(sub, _, _, _, _, conditions, subHint))) =>
           // Deduplicate conflicting attributes if any.
           val newSub = dedupSubqueryOnSelfJoin(p, sub, Some(values))
           val inConditions = values.zip(newSub.output).map(EqualTo.tupled)
@@ -170,7 +170,7 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
           val join = Join(outerPlan, rewriteDomainJoinsIfPresent(outerPlan, newSub, joinCond),
             LeftSemi, joinCond, JoinHint(None, subHint))
           Project(p.output, join)
-        case (p, Not(InSubquery(values, ListQuery(sub, _, _, _, conditions, subHint)))) =>
+        case (p, Not(InSubquery(values, ListQuery(sub, _, _, _, _, conditions, subHint)))) =>
           // This is a NULL-aware (left) anti join (NAAJ) e.g. col NOT IN expr
           // Construct the condition. A NULL in one of the conditions is regarded as a positive
           // result; such a row will be filtered out by the Anti-Join operator.
@@ -400,7 +400,7 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
     val introducedAttrs = ArrayBuffer.empty[Attribute]
     val newExprs = exprs.map { e =>
       e.transformDownWithPruning(_.containsAnyPattern(EXISTS_SUBQUERY, IN_SUBQUERY)) {
-        case Exists(sub, _, _, conditions, subHint) =>
+        case Exists(sub, _, _, _, conditions, subHint) =>
           val exists = AttributeReference("exists", BooleanType, nullable = false)()
           val existenceJoin = ExistenceJoin(exists)
           val newCondition = conditions.reduceLeftOption(And)
@@ -409,7 +409,7 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
               existenceJoin, newCondition, subHint)
           introducedAttrs += exists
           exists
-        case Not(InSubquery(values, ListQuery(sub, _, _, _, conditions, subHint))) =>
+        case Not(InSubquery(values, ListQuery(sub, _, _, _, _, conditions, subHint))) =>
           val exists = AttributeReference("exists", BooleanType, nullable = false)()
           // Deduplicate conflicting attributes if any.
           val newSub = dedupSubqueryOnSelfJoin(newPlan, sub, Some(values))
@@ -434,7 +434,7 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
             ExistenceJoin(exists), Some(finalJoinCond), joinHint)
           introducedAttrs += exists
           Not(exists)
-        case InSubquery(values, ListQuery(sub, _, _, _, conditions, subHint)) =>
+        case InSubquery(values, ListQuery(sub, _, _, _, _, conditions, subHint)) =>
           val exists = AttributeReference("exists", BooleanType, nullable = false)()
           // Deduplicate conflicting attributes if any.
           val newSub = dedupSubqueryOnSelfJoin(newPlan, sub, Some(values))
@@ -587,7 +587,7 @@ object PullupCorrelatedPredicates extends Rule[LogicalPlan] with PredicateHelper
     }
 
     plan.transformExpressionsWithPruning(_.containsPattern(PLAN_EXPRESSION)) {
-      case ScalarSubquery(sub, children, exprId, conditions, hint,
+      case ScalarSubquery(sub, children, outerScopeAttrs, exprId, conditions, hint,
       mayHaveCountBugOld, needSingleJoinOld)
         if children.nonEmpty =>
 
@@ -639,26 +639,26 @@ object PullupCorrelatedPredicates extends Rule[LogicalPlan] with PredicateHelper
         } else {
           conf.getConf(SQLConf.SCALAR_SUBQUERY_USE_SINGLE_JOIN) && !guaranteedToReturnOneRow(sub)
         }
-        ScalarSubquery(newPlan, children, exprId, getJoinCondition(newCond, conditions),
+        ScalarSubquery(newPlan, children, outerScopeAttrs, exprId, getJoinCondition(newCond, conditions),
           hint, Some(mayHaveCountBug), Some(needSingleJoin))
-      case Exists(sub, children, exprId, conditions, hint) if children.nonEmpty =>
+      case Exists(sub, children, outerScopeAttrs, exprId, conditions, hint) if children.nonEmpty =>
         val (newPlan, newCond) = if (SQLConf.get.decorrelateInnerQueryEnabledForExistsIn) {
           decorrelate(sub, plan, handleCountBug = true)
         } else {
           pullOutCorrelatedPredicates(sub, plan)
         }
-        Exists(newPlan, children, exprId, getJoinCondition(newCond, conditions), hint)
-      case ListQuery(sub, children, exprId, numCols, conditions, hint) if children.nonEmpty =>
+        Exists(newPlan, children, outerScopeAttrs, exprId, getJoinCondition(newCond, conditions), hint)
+      case ListQuery(sub, children, outerScopeAttrs, exprId, numCols, conditions, hint) if children.nonEmpty =>
         val (newPlan, newCond) = if (SQLConf.get.decorrelateInnerQueryEnabledForExistsIn) {
           decorrelate(sub, plan, handleCountBug = true)
         } else {
           pullOutCorrelatedPredicates(sub, plan)
         }
         val joinCond = getJoinCondition(newCond, conditions)
-        ListQuery(newPlan, children, exprId, numCols, joinCond, hint)
-      case LateralSubquery(sub, children, exprId, conditions, hint) if children.nonEmpty =>
+        ListQuery(newPlan, children, outerScopeAttrs, exprId, numCols, joinCond, hint)
+      case LateralSubquery(sub, children, outerScopeAttrs, exprId, conditions, hint) if children.nonEmpty =>
         val (newPlan, newCond) = decorrelate(sub, plan, handleCountBug = true)
-        LateralSubquery(newPlan, children, exprId, getJoinCondition(newCond, conditions), hint)
+        LateralSubquery(newPlan, children, outerScopeAttrs, exprId, getJoinCondition(newCond, conditions), hint)
     }
   }
 
@@ -898,7 +898,7 @@ object RewriteCorrelatedScalarSubquery extends Rule[LogicalPlan] with AliasHelpe
       subqueries: ArrayBuffer[ScalarSubquery]): (LogicalPlan, AttributeMap[Attribute]) = {
     val subqueryAttrMapping = ArrayBuffer[(Attribute, Attribute)]()
     val newChild = subqueries.foldLeft(child) {
-      case (currentChild, ScalarSubquery(sub, _, _, conditions, subHint, mayHaveCountBug,
+      case (currentChild, ScalarSubquery(sub, _, _, _, conditions, subHint, mayHaveCountBug,
       needSingleJoin)) =>
         val query = DecorrelateInnerQuery.rewriteDomainJoins(currentChild, sub, conditions)
         val origOutput = query.output.head
@@ -1085,7 +1085,7 @@ object RewriteCorrelatedScalarSubquery extends Rule[LogicalPlan] with AliasHelpe
 object RewriteLateralSubquery extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformUpWithPruning(
     _.containsPattern(LATERAL_JOIN)) {
-    case LateralJoin(left, LateralSubquery(sub, _, _, joinCond, subHint), joinType, condition) =>
+    case LateralJoin(left, LateralSubquery(sub, _, _, _, joinCond, subHint), joinType, condition) =>
       val newRight = DecorrelateInnerQuery.rewriteDomainJoins(left, sub, joinCond)
       val newCond = (condition ++ joinCond).reduceOption(And)
       // The subquery appears on the right side of the join, hence add the hint to the right side
@@ -1122,7 +1122,7 @@ object OptimizeOneRowRelationSubquery extends Rule[LogicalPlan] {
    */
   private def rewrite(plan: LogicalPlan): LogicalPlan = plan.transformUpWithSubqueries {
     case LateralJoin(
-      left, right @ LateralSubquery(OneRowSubquery(plan), _, _, _, _), _, None)
+      left, right @ LateralSubquery(OneRowSubquery(plan), _, _, _, _, _), _, None)
         if !hasCorrelatedSubquery(right.plan) && right.joinCond.isEmpty =>
       plan match {
         case Project(projectList, _: OneRowRelation) =>
@@ -1145,7 +1145,7 @@ object OptimizeOneRowRelationSubquery extends Rule[LogicalPlan] {
 
     case p: LogicalPlan => p.transformExpressionsUpWithPruning(
       _.containsPattern(SCALAR_SUBQUERY)) {
-      case s @ ScalarSubquery(OneRowSubquery(p @ Project(_, _: OneRowRelation)), _, _, _, _, _, _)
+      case s @ ScalarSubquery(OneRowSubquery(p @ Project(_, _: OneRowRelation)), _, _, _, _, _, _, _)
           if !hasCorrelatedSubquery(s.plan) && s.joinCond.isEmpty =>
         assert(p.projectList.size == 1)
         stripOuterReferences(p.projectList).head

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -78,6 +78,7 @@ object TreePattern extends Enumeration  {
   val SERIALIZE_FROM_OBJECT: Value = Value
   val OR: Value = Value
   val OUTER_REFERENCE: Value = Value
+  val OUTER_REFERENCE_FOR_DOMAIN_JOIN: Value = Value
   val PARAMETER: Value = Value
   val PARAMETERIZED_QUERY: Value = Value
   val PIPE_EXPRESSION: Value = Value

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -69,6 +69,7 @@ object TreePattern extends Enumeration  {
   val LITERAL: Value = Value
   val MAP_OBJECTS: Value = Value
   val MULTI_ALIAS: Value = Value
+  val NESTED_CORRELATED_SUBQUERY: Value = Value
   val NEW_INSTANCE: Value = Value
   val NOT: Value = Value
   val NULL_CHECK: Value = Value

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveSubqueries.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveSubqueries.scala
@@ -30,11 +30,11 @@ case class PlanAdaptiveSubqueries(
   def apply(plan: SparkPlan): SparkPlan = {
     plan.transformAllExpressionsWithPruning(
       _.containsAnyPattern(SCALAR_SUBQUERY, IN_SUBQUERY, DYNAMIC_PRUNING_SUBQUERY)) {
-      case expressions.ScalarSubquery(_, _, exprId, _, _, _, _) =>
+      case expressions.ScalarSubquery(_, _, _, exprId, _, _, _, _) =>
         val subquery = SubqueryExec.createForScalarSubquery(
           s"subquery#${exprId.id}", subqueryMap(exprId.id))
         execution.ScalarSubquery(subquery, exprId)
-      case expressions.InSubquery(values, ListQuery(_, _, exprId, _, _, _)) =>
+      case expressions.InSubquery(values, ListQuery(_, _, _, exprId, _, _, _)) =>
         val expr = if (values.length == 1) {
           values.head
         } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
@@ -187,7 +187,7 @@ case class PlanSubqueries(sparkSession: SparkSession) extends Rule[SparkPlan] {
           SubqueryExec.createForScalarSubquery(
             s"scalar-subquery#${subquery.exprId.id}", executedPlan),
           subquery.exprId)
-      case expressions.InSubquery(values, ListQuery(query, _, exprId, _, _, _)) =>
+      case expressions.InSubquery(values, ListQuery(query, _, _, exprId, _, _, _)) =>
         val expr = if (values.length == 1) {
           values.head
         } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -2846,4 +2846,110 @@ class SubquerySuite extends QueryTest
         :: Row(true) :: Row(true) :: Row(true) :: Nil
     )
   }
+
+  test("query without count bug without domain joins") {
+    sql("CREATE TEMP VIEW t0 AS SELECT 1 AS a, 2 AS b, 3 AS c")
+    sql("CREATE TEMP VIEW t1 AS SELECT 1 AS a, 2 AS b, 3 AS c")
+    sql("CREATE TEMP VIEW t2 AS SELECT 1 AS a, 2 AS b, 3 AS c")
+    sql("CREATE TEMP VIEW t3 AS SELECT 1 AS a, 2 AS b, 3 AS c")
+    val query =
+      """
+        |SELECT *
+        |FROM t1
+        |WHERE t1.a = (
+        |  SELECT MAX(t2.a)
+        |  FROM t2
+        |  WHERE t2.a = (
+        |   SELECT MAX(t3.a)
+        |   FROM t3
+        |   WHERE t3.b = t2.b AND t3.c = t1.c
+        |  ) AND t2.b = t1.b
+        |)
+        |""".stripMargin
+    withSQLConf(
+      "spark.sql.optimizer.supportNestedCorrelatedSubqueries.enabled" -> "true",
+      "spark.sql.optimizer.supportNestedCorrelatedSubqueriesForScalarSubqueries.enabled" -> "true",
+      "spark.sql.planChangeLog.level" -> "info"
+    ) {
+      val df = sql(query).collect()
+    }
+    val querySuperNested =
+      """
+        |SELECT *
+        |FROM t0
+        |WHERE t0.a = (
+        |SELECT t1.a
+        |FROM t1
+        |WHERE t1.a = (
+        |  SELECT MAX(t2.a)
+        |  FROM t2
+        |  WHERE t2.a = (
+        |   SELECT MAX(t3.a)
+        |   FROM t3
+        |   WHERE t3.b = t2.b AND t3.c = t0.c
+        |  ) AND t2.b = t1.b
+        | )
+        |)
+        |""".stripMargin
+    withSQLConf(
+      "spark.sql.optimizer.supportNestedCorrelatedSubqueries.enabled" -> "true",
+      "spark.sql.optimizer.supportNestedCorrelatedSubqueriesForScalarSubqueries.enabled" -> "true",
+      "spark.sql.planChangeLog.level" -> "info"
+    ) {
+      val df = sql(querySuperNested).collect()
+    }
+  }
+
+  test("query without count bug with domain joins") {
+    sql("CREATE TEMP VIEW t0 AS SELECT 1 AS a, 2 AS b, 3 AS c")
+    sql("CREATE TEMP VIEW t1 AS SELECT 1 AS a, 2 AS b, 3 AS c")
+    sql("CREATE TEMP VIEW t2 AS SELECT 1 AS a, 2 AS b, 3 AS c")
+    sql("CREATE TEMP VIEW t3 AS SELECT 1 AS a, 2 AS b, 3 AS c")
+    val query =
+      """
+        |SELECT *
+        |FROM t1
+        |WHERE t1.a > (
+        |  SELECT MAX(t2.a)
+        |  FROM t2
+        |  WHERE t2.a > (
+        |   SELECT MAX(t3.a)
+        |   FROM t3
+        |   WHERE t3.b > t2.b AND t3.c > t1.c
+        |  ) AND t2.b > t1.b
+        |)
+        |""".stripMargin
+    withSQLConf(
+      "spark.sql.optimizer.supportNestedCorrelatedSubqueries.enabled" -> "true",
+      "spark.sql.optimizer.supportNestedCorrelatedSubqueriesForScalarSubqueries.enabled" -> "true",
+      "spark.sql.planChangeLog.level" -> "info"
+    ) {
+      val df = sql(query).collect()
+    }
+    val querySuperNested =
+      """
+        |SELECT *
+        |FROM t0
+        |WHERE t0.a > (
+        |SELECT t1.a
+        |FROM t1
+        |WHERE t1.a > (
+        |  SELECT MAX(t2.a)
+        |  FROM t2
+        |  WHERE t2.a > (
+        |   SELECT MAX(t3.a)
+        |   FROM t3
+        |   WHERE t3.b > t2.b AND t3.c > t0.c
+        |  ) AND t2.b > t1.b
+        | )
+        |)
+        |""".stripMargin
+    withSQLConf(
+      "spark.sql.optimizer.supportNestedCorrelatedSubqueries.enabled" -> "true",
+      "spark.sql.optimizer.supportNestedCorrelatedSubqueriesForScalarSubqueries.enabled" -> "true",
+      "spark.sql.planChangeLog.level" -> "info"
+    ) {
+      val df = sql(querySuperNested).collect()
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -1012,7 +1012,7 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
           query match {
             case ListQuery(Project(projects, SubqueryAlias(AliasIdentifier("s", Seq()),
                 UnresolvedSubqueryColumnAliases(outputColumnNames, Project(_, _: OneRowRelation)))),
-                _, _, _, _, _) =>
+                _, _, _, _, _, _) =>
               assert(projects.size == 1 && projects.head.name == "s.name")
               assert(outputColumnNames.size == 1 && outputColumnNames.head == "name")
             case o => fail("Unexpected subquery: \n" + o.treeString)
@@ -1093,7 +1093,7 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
           query match {
             case ListQuery(Project(projects, SubqueryAlias(AliasIdentifier("s", Seq()),
                 UnresolvedSubqueryColumnAliases(outputColumnNames, Project(_, _: OneRowRelation)))),
-                _, _, _, _, _) =>
+                _, _, _, _, _, _) =>
               assert(projects.size == 1 && projects.head.name == "s.name")
               assert(outputColumnNames.size == 1 && outputColumnNames.head == "name")
             case o => fail("Unexpected subquery: \n" + o.treeString)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
status: 
- [x] basic framework
- [ ] golden files testing for optimizer 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Spark only supports one layer of correlation now and does not support nested correlation.
For example, 
```sql
SELECT col1 FROM VALUES (1, 2) t1 (col1, col2) WHERE EXISTS (
 SELECT col1 FROM VALUES (1, 2) t2 (col1, col2) WHERE t2.col2 == MAX(t1.col2)
)GROUP BY col1;
```
is supported and 
```sql
SELECT col1 FROM VALUES (1, 2) t1 (col1, col2) WHERE EXISTS (
 SELECT col1 FROM VALUES (1, 2) t2 (col1, col2) WHERE t2.col2 == (
   SELECT MAX(t1.col2)
 )
)GROUP BY col1;
```
is not supported.

The reason spark does not support it is because the Analyzer and Optimizer resolves and plans Subquery in a recursive way. 

This pr is to modify current decorrelation framework to make it support nested correlated subqueries.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
WIP, it relies on Part1.a and Part1.b to be merged first to test it in golden file testings.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
