### PR TITLE
[SPARK-51820][SQL][FOLLOWUP] Fix `origin` for `UnresolvedOrdinal`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -6615,7 +6615,8 @@ class AstBuilder extends DataTypeAstBuilder
   private def replaceIntegerLiteralWithOrdinal(
       expression: Expression,
       canReplaceWithOrdinal: Boolean = true) = expression match {
-    case Literal(value: Int, IntegerType) if canReplaceWithOrdinal => UnresolvedOrdinal(value)
+    case literal @ Literal(value: Int, IntegerType) if canReplaceWithOrdinal =>
+      CurrentOrigin.withOrigin(literal.origin) { UnresolvedOrdinal(value) }
     case other => other
   }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/group-by-ordinal.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/group-by-ordinal.sql.out
@@ -120,9 +120,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 23,
+    "startIndex" : 32,
     "stopIndex" : 33,
-    "fragment" : "group by -1"
+    "fragment" : "-1"
   } ]
 }
 
@@ -141,9 +141,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 23,
+    "startIndex" : 32,
     "stopIndex" : 32,
-    "fragment" : "group by 0"
+    "fragment" : "0"
   } ]
 }
 
@@ -162,9 +162,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 23,
+    "startIndex" : 32,
     "stopIndex" : 32,
-    "fragment" : "group by 3"
+    "fragment" : "3"
   } ]
 }
 
@@ -183,9 +183,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 31,
+    "startIndex" : 40,
     "stopIndex" : 40,
-    "fragment" : "group by 3"
+    "fragment" : "3"
   } ]
 }
 
@@ -204,9 +204,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 35,
+    "startIndex" : 44,
     "stopIndex" : 44,
-    "fragment" : "group by 3"
+    "fragment" : "3"
   } ]
 }
 
@@ -401,9 +401,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 33,
+    "startIndex" : 45,
     "stopIndex" : 46,
-    "fragment" : "group by a, -1"
+    "fragment" : "-1"
   } ]
 }
 
@@ -422,9 +422,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 33,
+    "startIndex" : 45,
     "stopIndex" : 45,
-    "fragment" : "group by a, 3"
+    "fragment" : "3"
   } ]
 }
 
@@ -443,9 +443,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 33,
-    "stopIndex" : 52,
-    "fragment" : "group by cube(-1, 2)"
+    "startIndex" : 47,
+    "stopIndex" : 48,
+    "fragment" : "-1"
   } ]
 }
 
@@ -464,9 +464,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 33,
-    "stopIndex" : 51,
-    "fragment" : "group by cube(1, 3)"
+    "startIndex" : 50,
+    "stopIndex" : 50,
+    "fragment" : "3"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/select_implicit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/select_implicit.sql.out
@@ -197,9 +197,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 45,
+    "startIndex" : 54,
     "stopIndex" : 54,
-    "fragment" : "GROUP BY 3"
+    "fragment" : "3"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/udf/postgreSQL/udf-select_implicit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/udf/postgreSQL/udf-select_implicit.sql.out
@@ -200,9 +200,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 55,
+    "startIndex" : 64,
     "stopIndex" : 64,
-    "fragment" : "GROUP BY 3"
+    "fragment" : "3"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/group-by-ordinal.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-ordinal.sql.out
@@ -102,9 +102,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 23,
+    "startIndex" : 32,
     "stopIndex" : 33,
-    "fragment" : "group by -1"
+    "fragment" : "-1"
   } ]
 }
 
@@ -125,9 +125,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 23,
+    "startIndex" : 32,
     "stopIndex" : 32,
-    "fragment" : "group by 0"
+    "fragment" : "0"
   } ]
 }
 
@@ -148,9 +148,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 23,
+    "startIndex" : 32,
     "stopIndex" : 32,
-    "fragment" : "group by 3"
+    "fragment" : "3"
   } ]
 }
 
@@ -171,9 +171,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 31,
+    "startIndex" : 40,
     "stopIndex" : 40,
-    "fragment" : "group by 3"
+    "fragment" : "3"
   } ]
 }
 
@@ -194,9 +194,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 35,
+    "startIndex" : 44,
     "stopIndex" : 44,
-    "fragment" : "group by 3"
+    "fragment" : "3"
   } ]
 }
 
@@ -432,9 +432,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 33,
+    "startIndex" : 45,
     "stopIndex" : 46,
-    "fragment" : "group by a, -1"
+    "fragment" : "-1"
   } ]
 }
 
@@ -455,9 +455,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 33,
+    "startIndex" : 45,
     "stopIndex" : 45,
-    "fragment" : "group by a, 3"
+    "fragment" : "3"
   } ]
 }
 
@@ -478,9 +478,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 33,
-    "stopIndex" : 52,
-    "fragment" : "group by cube(-1, 2)"
+    "startIndex" : 47,
+    "stopIndex" : 48,
+    "fragment" : "-1"
   } ]
 }
 
@@ -501,9 +501,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 33,
-    "stopIndex" : 51,
-    "fragment" : "group by cube(1, 3)"
+    "startIndex" : 50,
+    "stopIndex" : 50,
+    "fragment" : "3"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_implicit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_implicit.sql.out
@@ -224,9 +224,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 45,
+    "startIndex" : 54,
     "stopIndex" : 54,
-    "fragment" : "GROUP BY 3"
+    "fragment" : "3"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by-ordinal.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by-ordinal.sql.out
@@ -102,9 +102,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 32,
+    "startIndex" : 41,
     "stopIndex" : 41,
-    "fragment" : "group by 3"
+    "fragment" : "3"
   } ]
 }
 
@@ -125,9 +125,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 36,
+    "startIndex" : 45,
     "stopIndex" : 45,
-    "fragment" : "group by 3"
+    "fragment" : "3"
   } ]
 }
 
@@ -351,9 +351,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 32,
+    "startIndex" : 44,
     "stopIndex" : 45,
-    "fragment" : "group by a, -1"
+    "fragment" : "-1"
   } ]
 }
 
@@ -374,9 +374,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 32,
+    "startIndex" : 44,
     "stopIndex" : 44,
-    "fragment" : "group by a, 3"
+    "fragment" : "3"
   } ]
 }
 
@@ -397,9 +397,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 32,
-    "stopIndex" : 51,
-    "fragment" : "group by cube(-1, 2)"
+    "startIndex" : 46,
+    "stopIndex" : 47,
+    "fragment" : "-1"
   } ]
 }
 
@@ -420,9 +420,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 32,
-    "stopIndex" : 50,
-    "fragment" : "group by cube(1, 3)"
+    "startIndex" : 49,
+    "stopIndex" : 49,
+    "fragment" : "3"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_implicit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_implicit.sql.out
@@ -227,9 +227,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 55,
+    "startIndex" : 64,
     "stopIndex" : 64,
-    "fragment" : "GROUP BY 3"
+    "fragment" : "3"
   } ]
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This is a followup to https://github.com/apache/spark/pull/50606 to fix the origin and context of newly created `UnresolvedOrdinal`.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Origin and context of `UnresolvedOrdinal` should be the same as for the original `Literal`.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Existing tests.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
