### PR TITLE
[SPARK-51877][PYTHON][CONNECT] Add functions 'chr', 'random' and 'uuid'

### DIFF
--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -3002,7 +3002,7 @@ def character_length(str: "ColumnOrName") -> Column:
 character_length.__doc__ = pysparkfuncs.character_length.__doc__
 
 
-def chr(n: Column) -> Column:
+def chr(n: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("chr", n)
 
 

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -37,7 +37,7 @@ from typing import (
     ValuesView,
     cast,
 )
-import random
+import random as py_random
 import sys
 
 import numpy as np
@@ -411,17 +411,20 @@ def rand(seed: Optional[int] = None) -> Column:
     if seed is not None:
         return _invoke_function("rand", lit(seed))
     else:
-        return _invoke_function("rand", lit(random.randint(0, sys.maxsize)))
+        return _invoke_function("rand", lit(py_random.randint(0, sys.maxsize)))
 
 
 rand.__doc__ = pysparkfuncs.rand.__doc__
+
+
+random = rand
 
 
 def randn(seed: Optional[int] = None) -> Column:
     if seed is not None:
         return _invoke_function("randn", lit(seed))
     else:
-        return _invoke_function("randn", lit(random.randint(0, sys.maxsize)))
+        return _invoke_function("randn", lit(py_random.randint(0, sys.maxsize)))
 
 
 randn.__doc__ = pysparkfuncs.randn.__doc__
@@ -1009,7 +1012,7 @@ def uniform(
 ) -> Column:
     if seed is None:
         return _invoke_function_over_columns(
-            "uniform", lit(min), lit(max), lit(random.randint(0, sys.maxsize))
+            "uniform", lit(min), lit(max), lit(py_random.randint(0, sys.maxsize))
         )
     else:
         return _invoke_function_over_columns("uniform", lit(min), lit(max), lit(seed))
@@ -1198,7 +1201,7 @@ def count_min_sketch(
     confidence: Union[Column, float],
     seed: Optional[Union[Column, int]] = None,
 ) -> Column:
-    _seed = lit(random.randint(0, sys.maxsize)) if seed is None else lit(seed)
+    _seed = lit(py_random.randint(0, sys.maxsize)) if seed is None else lit(seed)
     return _invoke_function_over_columns("count_min_sketch", col, lit(eps), lit(confidence), _seed)
 
 
@@ -2282,7 +2285,7 @@ schema_of_xml.__doc__ = pysparkfuncs.schema_of_xml.__doc__
 
 
 def shuffle(col: "ColumnOrName", seed: Optional[Union[Column, int]] = None) -> Column:
-    _seed = lit(random.randint(0, sys.maxsize)) if seed is None else lit(seed)
+    _seed = lit(py_random.randint(0, sys.maxsize)) if seed is None else lit(seed)
     return _invoke_function("shuffle", _to_col(col), _seed)
 
 
@@ -2706,7 +2709,7 @@ regexp_like.__doc__ = pysparkfuncs.regexp_like.__doc__
 def randstr(length: Union[Column, int], seed: Optional[Union[Column, int]] = None) -> Column:
     if seed is None:
         return _invoke_function_over_columns(
-            "randstr", lit(length), lit(random.randint(0, sys.maxsize))
+            "randstr", lit(length), lit(py_random.randint(0, sys.maxsize))
         )
     else:
         return _invoke_function_over_columns("randstr", lit(length), lit(seed))
@@ -2997,6 +3000,13 @@ def character_length(str: "ColumnOrName") -> Column:
 
 
 character_length.__doc__ = pysparkfuncs.character_length.__doc__
+
+
+def chr(n: Column) -> Column:
+    return _invoke_function_over_columns("chr", n)
+
+
+chr.__doc__ = pysparkfuncs.chr.__doc__
 
 
 def contains(left: "ColumnOrName", right: "ColumnOrName") -> Column:
@@ -4011,6 +4021,10 @@ def session_user() -> Column:
 
 
 session_user.__doc__ = pysparkfuncs.session_user.__doc__
+
+
+def uuid() -> Column:
+    return _invoke_function("uuid", lit(py_random.randint(0, sys.maxsize)))
 
 
 def assert_true(col: "ColumnOrName", errMsg: Optional[Union[Column, str]] = None) -> Column:

--- a/python/pyspark/sql/functions/__init__.py
+++ b/python/pyspark/sql/functions/__init__.py
@@ -98,6 +98,7 @@ __all__ = [  # noqa: F405
     "power",
     "radians",
     "rand",
+    # "random": Excluded because of the name conflict with builtin random module
     "randn",
     "rint",
     "round",
@@ -125,6 +126,7 @@ __all__ = [  # noqa: F405
     "char",
     "char_length",
     "character_length",
+    # "chr": Excluded because of the name conflict with builtin chr function
     "collate",
     "collation",
     "concat_ws",
@@ -491,6 +493,7 @@ __all__ = [  # noqa: F405
     "try_reflect",
     "typeof",
     "user",
+    # "uuid": Excluded because of the name conflict with builtin uuid module
     "version",
     # UDF, UDTF and UDT
     "AnalyzeArgument",

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -13203,11 +13203,15 @@ def uuid() -> Column:
     Examples
     --------
     >>> import pyspark.sql.functions as sf
-    >>> spark.range(1).select(sf.uuid()).show(truncate=False) # doctest: +SKIP
+    >>> spark.range(5).select(sf.uuid()).show(truncate=False) # doctest: +SKIP
     +------------------------------------+
     |uuid()                              |
     +------------------------------------+
-    |762ad649-a230-4ecc-abe9-92870251155d|
+    |627ae05e-b319-42b5-b4e4-71c8c9754dd1|
+    |f781cce5-a2e2-464d-bc8b-426ff448e404|
+    |15e2e66e-8416-4ea2-af3c-409363408189|
+    |fb1d6178-7676-4791-baa9-f2ddcc494515|
+    |d48665e8-2657-4c6b-b7c8-8ae0cd646e41|
     +------------------------------------+
     """
     return _invoke_function("uuid")

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -7687,6 +7687,9 @@ def rand(seed: Optional[int] = None) -> Column:
         return _invoke_function("rand")
 
 
+random = rand
+
+
 @_try_remote_functions
 def randn(seed: Optional[int] = None) -> Column:
     """Generates a random column with independent and identically distributed (i.i.d.) samples
@@ -13191,6 +13194,26 @@ def session_user() -> Column:
 
 
 @_try_remote_functions
+def uuid() -> Column:
+    """Returns an universally unique identifier (UUID) string.
+    The value is returned as a canonical UUID 36-character string.
+
+    .. versionadded:: 4.1.0
+
+    Examples
+    --------
+    >>> import pyspark.sql.functions as sf
+    >>> spark.range(1).select(sf.uuid()).show(truncate=False) # doctest: +SKIP
+    +------------------------------------+
+    |uuid()                              |
+    +------------------------------------+
+    |762ad649-a230-4ecc-abe9-92870251155d|
+    +------------------------------------+
+    """
+    return _invoke_function("uuid")
+
+
+@_try_remote_functions
 def crc32(col: "ColumnOrName") -> Column:
     """
     Calculates the cyclic redundancy check value (CRC32) of a binary column and
@@ -17156,6 +17179,41 @@ def character_length(str: "ColumnOrName") -> Column:
     +--------------------------+
     """
     return _invoke_function_over_columns("character_length", str)
+
+
+@_try_remote_functions
+def chr(n: Column) -> Column:
+    """
+    Returns the ASCII character having the binary equivalent to `n`.
+    If n is larger than 256 the result is equivalent to chr(n % 256).
+
+    .. versionadded:: 4.1.0
+
+    Parameters
+    ----------
+    n : :class:`~pyspark.sql.Column`
+        Input column.
+
+    Examples
+    --------
+    >>> import pyspark.sql.functions as sf
+    >>> spark.range(60, 70).select("*", sf.chr(sf.col("id"))).show()
+    +---+-------+
+    | id|chr(id)|
+    +---+-------+
+    | 60|      <|
+    | 61|      =|
+    | 62|      >|
+    | 63|      ?|
+    | 64|      @|
+    | 65|      A|
+    | 66|      B|
+    | 67|      C|
+    | 68|      D|
+    | 69|      E|
+    +---+-------+
+    """
+    return _invoke_function_over_columns("chr", n)
 
 
 @_try_remote_functions

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -17182,7 +17182,7 @@ def character_length(str: "ColumnOrName") -> Column:
 
 
 @_try_remote_functions
-def chr(n: Column) -> Column:
+def chr(n: "ColumnOrName") -> Column:
     """
     Returns the ASCII character having the binary equivalent to `n`.
     If n is larger than 256 the result is equivalent to chr(n % 256).
@@ -17191,13 +17191,13 @@ def chr(n: Column) -> Column:
 
     Parameters
     ----------
-    n : :class:`~pyspark.sql.Column`
-        Input column.
+    n : :class:`~pyspark.sql.Column` or column name
+        target column to compute on.
 
     Examples
     --------
     >>> import pyspark.sql.functions as sf
-    >>> spark.range(60, 70).select("*", sf.chr(sf.col("id"))).show()
+    >>> spark.range(60, 70).select("*", sf.chr("id")).show()
     +---+-------+
     | id|chr(id)|
     +---+-------+

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -105,7 +105,7 @@ class FunctionsTestsMixin:
             if name[0] != "_" and value.__module__ != "typing"
         }
 
-        expected_fn_all_diff = {
+        deprecated_fn_list = [
             "approxCountDistinct",  # deprecated
             "bitwiseNOT",  # deprecated
             "countDistinct",  # deprecated
@@ -118,13 +118,14 @@ class FunctionsTestsMixin:
             "toDegrees",  # deprecated
             "toRadians",  # deprecated
             "uuid",  # name conflict with builtin module
-        }
-
-        self.assertEqual(
-            expected_fn_all_diff,
-            fn_set - all_set,
-            "some functions are not registered in __all__",
-        )
+        ]
+        unregistered_fn_list = [
+            "chr",  # name conflict with builtin function
+            "random",  # name conflict with builtin function
+            "uuid",  # name conflict with builtin module
+        ]
+        expected_fn_all_diff = set(deprecated_fn_list + unregistered_fn_list)
+        self.assertEqual(expected_fn_all_diff, fn_set - all_set)
 
         # {
         #     "AnalyzeArgument",
@@ -151,19 +152,10 @@ class FunctionsTestsMixin:
             "StringType",  # should be imported from pyspark.sql.types
             "StructType",  # should be imported from pyspark.sql.types
         }
-
-        self.assertEqual(
-            expected_clz_all_diff,
-            clz_set - all_set,
-            "some classes are not registered in __all__",
-        )
+        self.assertEqual(expected_clz_all_diff, clz_set - all_set)
 
         unknonw_set = all_set - (fn_set | clz_set)
-        self.assertEqual(
-            unknonw_set,
-            set(),
-            "some unknown items are registered in __all__",
-        )
+        self.assertEqual(unknonw_set, set())
 
     def test_explode(self):
         d = [

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -65,9 +65,6 @@ class FunctionsTestsMixin:
             "any",  # equivalent to python ~some
             "len",  # equivalent to python ~length
             "udaf",  # used for creating UDAF's which are not supported in PySpark
-            "random",  # namespace conflict with python built-in module
-            "uuid",  # namespace conflict with python built-in module
-            "chr",  # namespace conflict with python built-in function
             "partitioning$",  # partitioning expressions for DSv2
         ]
 
@@ -112,12 +109,15 @@ class FunctionsTestsMixin:
             "approxCountDistinct",  # deprecated
             "bitwiseNOT",  # deprecated
             "countDistinct",  # deprecated
+            "chr",  # name conflict with builtin function
+            "random",  # name conflict with builtin function
             "shiftLeft",  # deprecated
             "shiftRight",  # deprecated
             "shiftRightUnsigned",  # deprecated
             "sumDistinct",  # deprecated
             "toDegrees",  # deprecated
             "toRadians",  # deprecated
+            "uuid",  # name conflict with builtin module
         }
 
         self.assertEqual(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add functions 'chr', 'random' and 'uuid'

### Why are the changes needed?
for feature parity between python and scala


### Does this PR introduce _any_ user-facing change?
yes, but the 3 functions must be explicitly imported. They will **NOT** be included in wildcard import `from pyspark.sql.functions import *` due to namespace conflicts.


### How was this patch tested?
new doctests and updated unittests

### Was this patch authored or co-authored using generative AI tooling?
no