### PR TITLE
[SPARK-51878][SQL] Improve fillDefaultValue by exec the foldable default expression.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowFunctionFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowFunctionFrame.scala
@@ -123,9 +123,12 @@ abstract class OffsetWindowFunctionFrameBase(
   protected val fillDefaultValue = {
     // Collect the expressions and bind them.
     val boundExpressions = Seq.fill(ordinal)(NoOp) ++ expressions.toImmutableArraySeq.map { e =>
-      if (e.default == null || e.default.foldable && e.default.eval() == null) {
+      if (e.default == null) {
         // The default value is null.
         Literal.create(null, e.dataType)
+      } else if (e.default.foldable) {
+        // The default value is foldable.
+        Literal.create(e.default.eval(), e.dataType)
       } else {
         // The default value is an expression.
         BindReferences.bindReference(e.default, inputAttrs)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to improve `fillDefaultValue` by exec the foldable default expression.


### Why are the changes needed?
We can avoid duplicate computation if the default expression of Lead/Lag is foldable.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
