### PR TITLE
[SPARK-51882][SS][PYTHON][TESTS][4.0] Skip the test `test_transform_with_state_with_wmark_and_non_event_time`

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
@@ -595,6 +595,7 @@ class TransformWithStateInPandasTestsMixin:
         q.awaitTermination(10)
         self.assertTrue(q.exception() is None)
 
+    @unittest.skip("skipping until we can resolve")
     def test_transform_with_state_in_pandas_event_time(self):
         def check_results(batch_df, batch_id):
             if batch_id == 0:

--- a/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
@@ -595,7 +595,6 @@ class TransformWithStateInPandasTestsMixin:
         q.awaitTermination(10)
         self.assertTrue(q.exception() is None)
 
-    @unittest.skip("test will hang during the GA testing, skipping until we can resolve")
     def test_transform_with_state_in_pandas_event_time(self):
         def check_results(batch_df, batch_id):
             if batch_id == 0:
@@ -630,6 +629,7 @@ class TransformWithStateInPandasTestsMixin:
             EventTimeStatefulProcessor(), check_results
         )
 
+    @unittest.skip("test will hang during the GA testing, skipping until we can resolve")
     def test_transform_with_state_with_wmark_and_non_event_time(self):
         def check_results(batch_df, batch_id):
             if batch_id == 0:

--- a/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
@@ -595,7 +595,7 @@ class TransformWithStateInPandasTestsMixin:
         q.awaitTermination(10)
         self.assertTrue(q.exception() is None)
 
-    @unittest.skip("skipping until we can resolve")
+    @unittest.skip("test will hang during the GA testing, skipping until we can resolve")
     def test_transform_with_state_in_pandas_event_time(self):
         def check_results(batch_df, batch_id):
             if batch_id == 0:


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr skips the test case `test_transform_with_state_with_wmark_and_non_event_time` to prevent the `pyspark-sql` module tests from timing out.

### Why are the changes needed?
To prevent test timeouts in the `pyspark-sql` module on branch-4.0, note that this issue does not exist on the master branch.

- https://github.com/apache/spark/actions/runs/14616850457/job/41007046673
- https://github.com/apache/spark/actions/runs/14616825904/job/41006965297
- https://github.com/apache/spark/actions/runs/14617806845/job/41010114906

![image](https://github.com/user-attachments/assets/4039aa6d-6133-4506-ab9c-0388c438c1d4)


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
