### PR TITLE
[SPARK-51881][SQL] Make AvroOptions comparable

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.avro
 
 import java.net.URI
+import java.util.HashMap
 
 import org.apache.avro.Schema
 import org.apache.hadoop.conf.Configuration
@@ -145,6 +146,37 @@ private[sql] class AvroOptions(
     throw QueryCompilationErrors.avroOptionsException(
       RECURSIVE_FIELD_MAX_DEPTH,
       s"Should not be greater than $RECURSIVE_FIELD_MAX_DEPTH_LIMIT.")
+  }
+
+  /**
+   * [[hadoop.conf.Configuration]] is not comparable so we turn it into a map for [[equals]] and
+   * [[hashCode]].
+   */
+  @transient private lazy val comparableConf = {
+    val iter = conf.iterator()
+    val result = new HashMap[String, String]
+    while (iter.hasNext()) {
+      val entry = iter.next()
+      result.put(entry.getKey(), entry.getValue())
+    }
+    result
+  }
+
+  override def equals(other: Any): Boolean = {
+    other match {
+      case that: AvroOptions =>
+        this.parameters == that.parameters &&
+        this.comparableConf == that.comparableConf
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = {
+    val prime = 31
+    var result = 1
+    result = prime * result + parameters.hashCode
+    result = prime * result + comparableConf.hashCode
+    result
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Make AvroOptions comparable. Hadoop `Configuration` doesn't have equals, but it's enough to compare `parameters`.

### Why are the changes needed?

To properly compare single-pass/fixed-point Analyzer logical plans.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.