### PR TITLE
[SPARK-51883][DOCS][PYTHON] Python Data Source user guide for filter pushdown

### DIFF
--- a/python/docs/source/tutorial/sql/python_data_source.rst
+++ b/python/docs/source/tutorial/sql/python_data_source.rst
@@ -287,7 +287,7 @@ This is the same dummy streaming reader that generate 2 rows every batch impleme
         def readBetweenOffsets(self, start: dict, end: dict) -> Iterator[Tuple]:
             """
             Takes start and end offset as input and read an iterator of data deterministically.
-            This is called whe query replay batches during restart or after failure.
+            This is called when replaying batches during restart or after failure.
             """
             start_idx = start["offset"]
             end_idx = end["offset"]
@@ -356,9 +356,19 @@ For library that are used inside a method, it must be imported inside the method
         from pyspark import TaskContext
         context = TaskContext.get()
 
+Mutating State
+~~~~~~~~~~~~~~
+Some methods such as DataSourceReader.read() and DataSourceReader.partitions() must be stateless. Changes to the object state made in these methods are not guaranteed to be visible or invisible to future invocations.
+
+Other methods such as DataSource.schema() and DataSourceStreamReader.latestOffset() can be stateful. Changes to the object state made in these methods are visible to future invocations.
+
+Refer to the documentation of each method for more details.
+
 Using a Python Data Source
 --------------------------
-**Use a Python Data Source in Batch Query**
+
+Use a Python Data Source in Batch Query
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 After defining your data source, it must be registered before usage.
 
@@ -366,7 +376,8 @@ After defining your data source, it must be registered before usage.
 
     spark.dataSource.register(FakeDataSource)
 
-**Read From a Python Data Source**
+Read From a Python Data Source
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Read from the fake datasource with the default schema and options:
 
@@ -412,7 +423,8 @@ Read from the fake datasource with a different number of rows:
     # | Douglas James|2007-01-18|  46226|     Alabama|
     # +--------------+----------+-------+------------+
 
-**Write To a Python Data Source**
+Write To a Python Data Source
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To write data to a custom location, make sure that you specify the `mode()` clause. Supported modes are `append` and `overwrite`.
 
@@ -424,7 +436,8 @@ To write data to a custom location, make sure that you specify the `mode()` clau
     # You can check the Spark log (standard error) to see the output of the write operation.
     # Total number of rows: 10
 
-**Use a Python Data Source in Streaming Query**
+Use a Python Data Source in Streaming Query
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Once we register the python data source, we can also use it in streaming queries as source of readStream() or sink of writeStream() by passing short name or full name to format().
 

--- a/python/docs/source/tutorial/sql/python_data_source.rst
+++ b/python/docs/source/tutorial/sql/python_data_source.rst
@@ -643,6 +643,20 @@ To enable filter pushdown in your Python Data Source, implement the ``pushFilter
     spark.dataSource.register(PrimesDataSource)
     spark.read.format("primes").load().filter("2000 <= p and p < 2050").show()
 
+    # Got filter: IsNotNull(attribute=('p',))
+    # Got filter: GreaterThanOrEqual(attribute=('p',), value=2000)
+    # Got filter: LessThan(attribute=('p',), value=2050)
+    # +----+
+    # |   p|
+    # +----+
+    # |2003|
+    # |2011|
+    # |2017|
+    # |2027|
+    # |2029|
+    # |2039|
+    # +----+
+
 **Notes**
 
 pushFilters() is called only if there are filters available to push down.

--- a/python/docs/source/tutorial/sql/python_data_source.rst
+++ b/python/docs/source/tutorial/sql/python_data_source.rst
@@ -358,7 +358,7 @@ For library that are used inside a method, it must be imported inside the method
 
 Mutating State
 ~~~~~~~~~~~~~~
-The following methods should not mutate internal state. Changes to the object state made in these methods are not guaranteed to be visible or invisible to future operations.
+The following methods should not mutate internal state. Changes to the object state made in these methods are not guaranteed to be visible or invisible to future calls.
 
 - DataSourceReader.partitions()
 - DataSourceReader.read()
@@ -366,7 +366,7 @@ The following methods should not mutate internal state. Changes to the object st
 - SimpleDataSourceStreamReader.readBetweenOffsets()
 - All writer methods
 
-All other methods such as DataSource.schema() and DataSourceStreamReader.latestOffset() can be stateful. Changes to the object state made in these methods are visible to future invocations.
+All other methods such as DataSource.schema() and DataSourceStreamReader.latestOffset() can be stateful. Changes to the object state made in these methods are visible to future calls.
 
 Using a Python Data Source
 --------------------------

--- a/python/docs/source/tutorial/sql/python_data_source.rst
+++ b/python/docs/source/tutorial/sql/python_data_source.rst
@@ -358,11 +358,15 @@ For library that are used inside a method, it must be imported inside the method
 
 Mutating State
 ~~~~~~~~~~~~~~
-Some methods such as DataSourceReader.read() and DataSourceReader.partitions() must be stateless. Changes to the object state made in these methods are not guaranteed to be visible or invisible to future invocations.
+The following methods should not mutate internal state. Changes to the object state made in these methods are not guaranteed to be visible or invisible to future operations.
 
-Other methods such as DataSource.schema() and DataSourceStreamReader.latestOffset() can be stateful. Changes to the object state made in these methods are visible to future invocations.
+- DataSourceReader.partitions()
+- DataSourceReader.read()
+- DataSourceStreamReader.read()
+- SimpleDataSourceStreamReader.readBetweenOffsets()
+- All writer methods
 
-Refer to the documentation of each method for more details.
+All other methods such as DataSource.schema() and DataSourceStreamReader.latestOffset() can be stateful. Changes to the object state made in these methods are visible to future invocations.
 
 Using a Python Data Source
 --------------------------

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -551,6 +551,11 @@ class DataSourceReader(ABC):
         This method is allowed to modify `self`. The object must remain picklable.
         Modifications to `self` are visible to the `partitions()` and `read()` methods.
 
+        Notes
+        -----
+        Configuration `spark.sql.python.filterPushdown.enabled` must be set to `true`
+        to implement this method.
+
         Examples
         --------
         Example filters and the resulting arguments passed to pushFilters:

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -551,11 +551,6 @@ class DataSourceReader(ABC):
         This method is allowed to modify `self`. The object must remain picklable.
         Modifications to `self` are visible to the `partitions()` and `read()` methods.
 
-        Notes
-        -----
-        Configuration `spark.sql.python.filterPushdown.enabled` must be set to `true`
-        to implement this method.
-
         Examples
         --------
         Example filters and the resulting arguments passed to pushFilters:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Update `python_data_source.rst` to add filter pushdown docs.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Feature was added but documentation was still missing.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Verified locally

![image](https://github.com/user-attachments/assets/8041e08c-b94e-4926-a4d8-373c1d0ce245)
![image](https://github.com/user-attachments/assets/3bf0a6a0-a4f2-43dd-a7ca-2f3ef0b7fad0)
![image](https://github.com/user-attachments/assets/c024ec24-a938-4f0e-9578-e170d757d4d7)
![image](https://github.com/user-attachments/assets/d38b6a34-e47a-4380-87ed-9b2318ad296d)


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Yes. Initial draft was generated using AI then manually edited.

Generated-by: GitHub Copilot with Claude 3.7 Sonnet
