### PR TITLE
[SPARK-51119][SQL][FOLLOW-UP] Fix missing fallback case for parsing corrupt exists_default value

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -376,7 +376,7 @@ object ResolveDefaultColumns extends QueryErrorsBase
     val expr = Literal.fromSQL(defaultSQL) match {
       // EXISTS_DEFAULT will have a cast from analyze() due to coerceDefaultValue
       // hence we need to add timezone to the cast if necessary
-      case c: Cast if c.needsTimeZone =>
+      case c: Cast if c.child.resolved && c.needsTimeZone =>
         c.withTimeZone(SQLConf.get.sessionLocalTimeZone)
       case e: Expression => e
     }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Add another fallback for broken (non-resolved) exists_default values for SPARK-51119 original fix.

### Why are the changes needed?
https://github.com/apache/spark/pull/49962 added a fallback in case there were already broken (ie, non-resolved) persisted default values in catalogs.  A broken one is something like 'current_database, current_user, current_timestamp' , these are non-deterministic and will bring wrong results in EXISTS_DEFAULT, where user expects the value resolved when they set the default.

However, this fallback missed one case when the current_xxx is in a cast.  This fixes it.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add to existing unit test in StructTypeSuite

### Was this patch authored or co-authored using generative AI tooling?
No