### PR TITLE
[SPARK-51895][K8S][INFRA] Update K8s IT CI to use K8s 1.33

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1242,7 +1242,7 @@ jobs:
       - name: Start Minikube
         uses: medyagh/setup-minikube@v0.0.18
         with:
-          kubernetes-version: "1.32.0"
+          kubernetes-version: "1.33.0"
           # Github Action limit cpu:2, memory: 6947MB, limit to 2U6G for better resource statistic
           cpus: 2
           memory: 6144m


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to increase the maximum K8s test version to 1.33 from 1.32.

### Why are the changes needed?

To improve the test coverage because K8s 1.33.0 was released on 2025-04-23.
- https://kubernetes.io/releases/#release-v1-33

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check the CI log.

```
...
* Downloading Kubernetes v1.33.0 preload ...
...
System Info:
...
  Kubelet Version:            v1.33.0
```

### Was this patch authored or co-authored using generative AI tooling?

No.