### PR TITLE
[SPARK-51897][SQL] Fix compilation warnings related to "The auto insertion will be deprecated, please write `TimeType.apply` explicitly"

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -254,7 +254,8 @@ object SparkBuild extends PomBuild {
         // SPARK-46938 to prevent enum scan on pmml-model, under spark-mllib module.
         "-Wconf:cat=other&site=org.dmg.pmml.*:w",
         // SPARK-49937 ban call the method `SparkThrowable#getErrorClass`
-        "-Wconf:cat=deprecation&msg=method getErrorClass in trait SparkThrowable is deprecated:e"
+        "-Wconf:cat=deprecation&msg=method getErrorClass in trait SparkThrowable is deprecated:e",
+        "-Wconf:cat=deprecation&msg=The auto insertion will be deprecated:e"
       )
     }
   )

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -254,8 +254,7 @@ object SparkBuild extends PomBuild {
         // SPARK-46938 to prevent enum scan on pmml-model, under spark-mllib module.
         "-Wconf:cat=other&site=org.dmg.pmml.*:w",
         // SPARK-49937 ban call the method `SparkThrowable#getErrorClass`
-        "-Wconf:cat=deprecation&msg=method getErrorClass in trait SparkThrowable is deprecated:e",
-        "-Wconf:cat=deprecation&msg=The auto insertion will be deprecated:e"
+        "-Wconf:cat=deprecation&msg=method getErrorClass in trait SparkThrowable is deprecated:e"
       )
     }
   )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -207,7 +207,7 @@ case class MinutesOfTime(child: Expression)
   )
 
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(TypeCollection(TimeType.MIN_PRECISION to TimeType.MAX_PRECISION map TimeType: _*))
+    Seq(TypeCollection(TimeType.MIN_PRECISION to TimeType.MAX_PRECISION map TimeType.apply: _*))
 
   override def children: Seq[Expression] = Seq(child)
 
@@ -267,7 +267,7 @@ case class HoursOfTime(child: Expression)
   )
 
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(TypeCollection(TimeType.MIN_PRECISION to TimeType.MAX_PRECISION map TimeType: _*))
+    Seq(TypeCollection(TimeType.MIN_PRECISION to TimeType.MAX_PRECISION map TimeType.apply: _*))
 
   override def children: Seq[Expression] = Seq(child)
 
@@ -351,7 +351,7 @@ case class SecondsOfTime(child: Expression)
   )
 
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(TypeCollection(TimeType.MIN_PRECISION to TimeType.MAX_PRECISION map TimeType: _*))
+    Seq(TypeCollection(TimeType.MIN_PRECISION to TimeType.MAX_PRECISION map TimeType.apply: _*))
 
   override def children: Seq[Expression] = Seq(child)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to fix the following compilation warnings related to "The auto insertion will be deprecated, please write `TimeType.apply` explicitly":

```
[WARNING] [Warn] /Users/yangjie01/SourceCode/git/spark-maven/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala:210: The method `apply` is inserted. The auto insertion will be deprecated, please write `TimeType.apply` explicitly.
Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=deprecation, site=org.apache.spark.sql.catalyst.expressions.MinutesOfTime.inputTypes, origin=org.apache.spark.sql.types.TimeType, version=2.13.13
[WARNING] [Warn] /Users/yangjie01/SourceCode/git/spark-maven/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala:270: The method `apply` is inserted. The auto insertion will be deprecated, please write `TimeType.apply` explicitly.
Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=deprecation, site=org.apache.spark.sql.catalyst.expressions.HoursOfTime.inputTypes, origin=org.apache.spark.sql.types.TimeType, version=2.13.13
[WARNING] [Warn] /Users/yangjie01/SourceCode/git/spark-maven/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala:354: The method `apply` is inserted. The auto insertion will be deprecated, please write `TimeType.apply` explicitly.
Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=deprecation, site=org.apache.spark.sql.catalyst.expressions.SecondsOfTime.inputTypes, origin=org.apache.spark.sql.types.TimeType, version=2.13.13
```

### Why are the changes needed?
Avoid using `auto insertion`, as it will be deprecated.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Acitons


### Was this patch authored or co-authored using generative AI tooling?
No
