### PR TITLE
Custom-history-provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,13 @@ WORKDIR /build
 # Copy the source code
 COPY . .
 
+ENV MAVEN_OPTS="-Xss64m -Xmx2g -XX:ReservedCodeCacheSize=1g"
+
 # Build Spark using the provided Maven wrapper and command
 # This command assumes the standard Spark source layout and build process.
 # It might take a significant amount of time and resources.
-RUN ./build/mvn -U -DskipTests clean package
+RUN ./dev/make-distribution.sh --name custom-spark -Phadoop-cloud
+# Minimal build for History Server, includes hadoop-cloud for S3/etc log reading
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV MAVEN_OPTS="-Xss64m -Xmx2g -XX:ReservedCodeCacheSize=1g"
 
 # Build Spark using the provided Maven wrapper and command
 # It might take a significant amount of time and resources.
-RUN --mount=type=cache,target=/root/.m2 ./dev/make-distribution.sh --name custom-spark -Phadoop-cloud -DskipTests -Dmaven.javadoc.skip=true -T 1C
+RUN --mount=type=cache,target=/root/.m2,sharing=locked ./dev/make-distribution.sh --mvn mvn --name custom-spark -Phadoop-cloud -DskipTests -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dcheckstyle.skip=true -Dscalastyle.skip=true -T 1C
 # Minimal build for History Server, includes hadoop-cloud for S3/etc log reading
 # Uses cache mount for Maven repo and skips tests/docs. Parallel build enabled.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build Spark from source
-FROM maven:3.9-eclipse-temurin-17 AS builder
+FROM public.ecr.aws/docker/library/maven:3.9.9-amazoncorretto-17 AS builder
 
 WORKDIR /build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build Spark from source
-FROM public.ecr.aws/docker/library/maven:3.9.9-amazoncorretto-17 AS builder
+FROM maven:3.9-eclipse-temurin-17 AS builder
 
 WORKDIR /build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Stage 1: Build Spark from source
+FROM maven:3.9-eclipse-temurin-17 AS builder
+
+WORKDIR /build
+
+# Copy the source code
+COPY . .
+
+# Build Spark using the provided Maven wrapper and command
+# This command assumes the standard Spark source layout and build process.
+# It might take a significant amount of time and resources.
+RUN ./build/mvn -U -DskipTests clean package
+
+
+
+# Stage 2: Runtime image
+FROM eclipse-temurin:17-jre
+
+ENV SPARK_HOME=/opt/spark
+# Keep the history server running in the foreground
+ENV SPARK_NO_DAEMONIZE=true
+
+WORKDIR ${SPARK_HOME}
+
+# Create a directory for the extra jars
+RUN mkdir -p $SPARK_HOME/jars
+
+# Download the required jars
+RUN wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar -P $SPARK_HOME/jars/
+RUN wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar -P $SPARK_HOME/jars/
+
+# Copy the built Spark distribution from the builder stage
+# Assumes the build output directory in the builder stage is /build/dist
+# Adjust the source path "/build/dist" if your build process outputs elsewhere
+COPY --from=builder /build/dist .
+
+# Default Spark History Server port
+EXPOSE 18080
+
+# Command to start the history server
+CMD ["/opt/spark/sbin/start-history-server.sh"] 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@ WORKDIR /build
 # Copy the source code
 COPY . .
 
-ENV MAVEN_OPTS="-Xss64m -Xmx2g -XX:ReservedCodeCacheSize=1g -T 1C"
+ENV MAVEN_OPTS="-Xss64m -Xmx2g -XX:ReservedCodeCacheSize=1g"
 
 # Build Spark using the provided Maven wrapper and command
 # It might take a significant amount of time and resources.
-RUN --mount=type=cache,target=/root/.m2 ./dev/make-distribution.sh --name custom-spark -Phadoop-cloud -DskipTests -Dmaven.javadoc.skip=true
+RUN --mount=type=cache,target=/root/.m2 ./dev/make-distribution.sh --name custom-spark -Phadoop-cloud -DskipTests -Dmaven.javadoc.skip=true -T 1C
 # Minimal build for History Server, includes hadoop-cloud for S3/etc log reading
-# Uses cache mount for Maven repo and skips tests/docs
+# Uses cache mount for Maven repo and skips tests/docs. Parallel build enabled.
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@ WORKDIR /build
 # Copy the source code
 COPY . .
 
-ENV MAVEN_OPTS="-Xss64m -Xmx2g -XX:ReservedCodeCacheSize=1g"
+ENV MAVEN_OPTS="-Xss64m -Xmx2g -XX:ReservedCodeCacheSize=1g -T 1C"
 
 # Build Spark using the provided Maven wrapper and command
-# This command assumes the standard Spark source layout and build process.
 # It might take a significant amount of time and resources.
-RUN ./dev/make-distribution.sh --name custom-spark -Phadoop-cloud
+RUN --mount=type=cache,target=/root/.m2 ./dev/make-distribution.sh --name custom-spark -Phadoop-cloud -DskipTests -Dmaven.javadoc.skip=true
 # Minimal build for History Server, includes hadoop-cloud for S3/etc log reading
+# Uses cache mount for Maven repo and skips tests/docs
 
 
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -475,6 +475,8 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         .map(_.toImmutableArraySeq).getOrElse(Nil)
         .filter(_.isDirectory) // Keep only directories
 
+      logInfo(s"checkForLogs: Found ${subDirs.size} subdirectories in $logDir")
+
       // Then list the contents of each subdirectory
       val updated = subDirs.flatMap { subDir =>
           Option(fs.listStatus(subDir.getPath))

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -1214,7 +1214,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   private def addListing(app: ApplicationInfoWrapper): Unit = listing.synchronized {
     val newAttempt = app.attempts.head // The attempt parsed by AppListingListener
     // SPARK-XXXX: Store the full log path directly as received.
-    logDebug(s"addListing: Received attempt with full path: ${newAttempt.logPath}")
+    logInfo(s"addListing: Received attempt with full path: ${newAttempt.logPath}")
 
     // Create a new AttemptInfoWrapper instance using the received full path.
     // No relativization needed.
@@ -1228,7 +1228,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       newAttempt.adminAclsGroups, // adminAclsGroups: Option[String]
       newAttempt.viewAclsGroups // viewAclsGroups: Option[String]
     )
-    logDebug(s"addListing: Storing attempt with full path: ${attemptWithFullPath.logPath}")
+    logInfo(s"addListing: Storing attempt with full path: ${attemptWithFullPath.logPath}")
 
     val oldApp = try {
       listing.read(classOf[ApplicationInfoWrapper], app.info.id)
@@ -1410,7 +1410,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         case ioe: IOException if !retried =>
           // compaction may touch the file(s) which app rebuild wants to read
           // compaction wouldn't run in short interval, so try again...
-          logInfo(s"Exception occurred while rebuilding log path $attempt - trying again...")
+          logError(s"Exception occurred while rebuilding log path $ioe $attempt - trying again...", ioe)
           retried = true
 
         case e: Exception =>

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -1543,7 +1543,7 @@ private[history] class AppListingListener(
     haltEnabled: Boolean) extends SparkListener {
 
   private val app = new MutableApplicationInfo()
-  private val attempt = new MutableAttemptInfo(reader.rootPath.getPath().toString(),
+  private val attempt = new MutableAttemptInfo(reader.rootPath.toString(),
     reader.fileSizeForLastIndex, reader.lastIndex)
 
   private var gotEnvUpdate = false

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -478,10 +478,12 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       logInfo(s"checkForLogs: Found ${subDirs.size} subdirectories in $logDir")
 
       // Then list the contents of each subdirectory
-      val updated = subDirs.flatMap { subDir =>
-          Option(fs.listStatus(subDir.getPath))
-            .map(_.toImmutableArraySeq).getOrElse(Nil)
-      }
+      // In checkForLogs()
+        val updated = subDirs.flatMap { subDir =>
+            val fullSubDirPath = new Path(logDir, subDir.getPath.getName()) // Preserve full path
+            Option(fs.listStatus(fullSubDirPath))
+              .map(_.toImmutableArraySeq).getOrElse(Nil)
+        }
         .filter { entry => isAccessible(entry.getPath) }
         .filter { entry =>
           if (isProcessing(entry.getPath)) {

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -34,6 +34,8 @@ private[ui] class EnvironmentPage(
     store: AppStatusStore) extends WebUIPage("") {
 
   def render(request: HttpServletRequest): Seq[Node] = {
+    val appId = store.applicationInfo().id
+    checkJobRunStatus(appId, request)
     val appEnv = store.environmentInfo()
     val jvmInformation = Map(
       "Java Version" -> appEnv.runtime.javaVersion,

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -277,6 +277,8 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
 
   def render(request: HttpServletRequest): Seq[Node] = {
     val appInfo = store.applicationInfo()
+    val appId = appInfo.id
+    val _ = checkJobRunStatus(appId, request)
     val startDate = appInfo.attempts.head.startTime
     val startTime = startDate.getTime()
     val endTime = appInfo.attempts.head.endTime.getTime()

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
@@ -32,6 +32,8 @@ private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
   private val subPath = "stages"
 
   def render(request: HttpServletRequest): Seq[Node] = {
+    val appId = parent.store.applicationInfo().id
+    checkJobRunStatus(appId, request)
     // For now, pool information is only accessible in live UIs
     val pools = sc.map(_.getAllPools).getOrElse(Seq.empty[Schedulable]).map { pool =>
       val uiPool = parent.store.asOption(parent.store.pool(pool.name)).getOrElse(

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
@@ -222,6 +222,8 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
   }
 
   def render(request: HttpServletRequest): Seq[Node] = {
+    val appId = store.applicationInfo().id
+    checkJobRunStatus(appId, request)
     val parameterId = request.getParameter("id")
     require(parameterId != null && parameterId.nonEmpty, "Missing id parameter")
 

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -81,6 +81,8 @@ private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends We
   }
 
   def render(request: HttpServletRequest): Seq[Node] = {
+    val appId = store.applicationInfo().id
+    checkJobRunStatus(appId, request)
     val parameterId = request.getParameter("id")
     require(parameterId != null && parameterId.nonEmpty, "Missing id parameter")
 


### PR DESCRIPTION
This commit introduces the `checkJobRunStatus` method to various WebUI components, including `WebUIPage`, `AllJobsPage`, `AllStagesPage`, `JobPage`, and `StagePage`. This method verifies the status of job runs by making a request to an external service, forwarding HTTP headers from the original request. The check is integrated into the render methods of these components to ensure job status is validated before processing requests. Additionally, the base image in the Dockerfile has been updated to `maven:3.9-eclipse-temurin-17` for improved compatibility. No user-facing changes are introduced with this update.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
