### PR TITLE
[SPARK-51899][SQL] Implement error handling rules for spark.catalog.listTables()

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/Catalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/Catalog.scala
@@ -20,8 +20,7 @@ package org.apache.spark.sql.classic
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.control.NonFatal
 
-import org.apache.spark.internal.{Logging, MDC}
-import org.apache.spark.internal.LogKeys.{CATALOG_NAME, DATABASE_NAME, TABLE_NAME}
+import org.apache.spark.SparkThrowable
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalog
 import org.apache.spark.sql.catalog.{CatalogMetadata, Column, Database, Function, Table}
@@ -50,7 +49,7 @@ import org.apache.spark.util.ArrayImplicits._
 /**
  * Internal implementation of the user-facing `Catalog`.
  */
-class Catalog(sparkSession: SparkSession) extends catalog.Catalog with Logging {
+class Catalog(sparkSession: SparkSession) extends catalog.Catalog {
 
   private def sessionCatalog: SessionCatalog = sparkSession.sessionState.catalog
 
@@ -184,25 +183,20 @@ class Catalog(sparkSession: SparkSession) extends catalog.Catalog with Logging {
     try {
       Some(makeTable(nameParts))
     } catch {
-      case e: AnalysisException if e.getCondition == "TABLE_OR_VIEW_NOT_FOUND" => None
-      // Swallow non-fatal throwables when resolving a table or view and
-      // return a table or view with partial results to
-      // prevent listTables from breaking easily due to a broken table or view.
-      case NonFatal(e) if !isTempView =>
-        val table = new Table(
-            name = tableName,
-            catalog = catalogName,
-            namespace = ns.toArray,
-            description = null,
-            tableType = null,
-            isTemporary = false
-        )
-        logWarning(log"Unable to resolve the table or view [" +
-          log"catalog=${MDC(CATALOG_NAME, table.catalog)}, " +
-          log"database=${MDC(DATABASE_NAME, table.database)}, " +
-          log"name=${MDC(TABLE_NAME, table.name)}" +
-          log"]; partial results will be returned.", e)
-        Some(table)
+      case e: SparkThrowable with Throwable =>
+        Catalog.ListTable.ERROR_HANDLING_RULES.get(e.getCondition) match {
+          case Some(Catalog.ListTable.Skip) => None
+          case Some(Catalog.ListTable.ReturnPartialResults) if !isTempView =>
+            Some(new Table(
+              name = tableName,
+              catalog = catalogName,
+              namespace = ns.toArray,
+              description = null,
+              tableType = null,
+              isTemporary = false
+            ))
+          case _ => throw e
+        }
     }
   }
 
@@ -970,4 +964,18 @@ private[sql] object Catalog {
   }
 
   private val FUNCTION_EXISTS_COMMAND_NAME = "Catalog.functionExists"
+
+  private object ListTable {
+
+    sealed trait ErrorHandlingAction
+
+    case object Skip extends ErrorHandlingAction
+
+    case object ReturnPartialResults extends ErrorHandlingAction
+
+    val ERROR_HANDLING_RULES: Map[String, ErrorHandlingAction] = Map(
+      "UNSUPPORTED_FEATURE.HIVE_TABLE_TYPE" -> ReturnPartialResults,
+      "TABLE_OR_VIEW_NOT_FOUND" -> Skip
+    )
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

- Revert https://github.com/apache/spark/pull/50515
- Implement error handling rules based on error conditions for Spark errors in spark.catalog.listTables().

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

There are risks associated with working with partial data, especially when unaware that some tables are broken. Throwing an exception instead provides a clear indication that something is wrong. 

Instead we can use error handling rules to determine the proper behavior on a case-by-case basis. SparkThrowable should be sufficient to capture the cases we want to handle.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing tests (e.g. `build/sbt "sql/testOnly *CatalogSuite"`, `build/sbt "hive/testOnly *HiveDDLSuite"`)

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
