### PR TITLE
[SPARK-51900][SQL] Properly throw datatype mismatch in single-pass Analyzer

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -409,7 +409,7 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
             throw QueryCompilationErrors.windowSpecificationNotDefinedError(windowName)
 
           case e: Expression if e.checkInputDataTypes().isFailure =>
-            TypeCoercionValidation.failOnTypeCheckResult(e, operator)
+            TypeCoercionValidation.failOnTypeCheckResult(e, Some(operator))
 
           case c: Cast if !c.resolved =>
             throw SparkException.internalError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionValidation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionValidation.scala
@@ -27,14 +27,14 @@ import org.apache.spark.sql.types.DataType
 object TypeCoercionValidation extends QueryErrorsBase {
   private val DATA_TYPE_MISMATCH_ERROR = TreeNodeTag[Unit]("dataTypeMismatchError")
 
-  def failOnTypeCheckResult(e: Expression, operator: LogicalPlan): Nothing = {
+  def failOnTypeCheckResult(e: Expression, operator: Option[LogicalPlan] = None): Nothing = {
     e.checkInputDataTypes() match {
       case checkRes: TypeCheckResult.DataTypeMismatch =>
         e.setTagValue(DATA_TYPE_MISMATCH_ERROR, ())
         e.dataTypeMismatch(e, checkRes)
       case TypeCheckResult.TypeCheckFailure(message) =>
         e.setTagValue(DATA_TYPE_MISMATCH_ERROR, ())
-        val extraHint = TypeCoercionValidation.getHintForExpressionCoercion(operator)
+        val extraHint = operator.map(getHintForExpressionCoercion(_)).getOrElse("")
         e.failAnalysis(
           errorClass = "DATATYPE_MISMATCH.TYPE_CHECK_FAILURE_WITH_HINT",
           messageParameters = Map("sqlExpr" -> toSQLExpr(e), "msg" -> message, "hint" -> extraHint)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ExpressionResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ExpressionResolver.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.analysis.{
   withPosition,
   FunctionResolution,
   GetViewColumnByNameAndOrdinal,
+  TypeCoercionValidation,
   UnresolvedAlias,
   UnresolvedAttribute,
   UnresolvedFunction,
@@ -984,6 +985,10 @@ class ExpressionResolver(
   }
 
   private def validateResolvedExpressionGenerically(resolvedExpression: Expression): Unit = {
+    if (resolvedExpression.checkInputDataTypes().isFailure) {
+      TypeCoercionValidation.failOnTypeCheckResult(resolvedExpression)
+    }
+
     if (!resolvedExpression.resolved) {
       throwSinglePassFailedToResolveExpression(resolvedExpression)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Properly throw datatype mismatch in single-pass Analyzer. Currently we don't have a way to pass a resolved operator to `failOnTypeCheckResult`, so we pass `None` - this simply omits the `issueFixedIfAnsiOff` functionality.

### Why are the changes needed?

This improves error message reporting in single-pass Analyzer.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.