### PR TITLE
[SPARK-51820][SQL][CONNECT] Address remaining issues for new `group`/`order` by ordinal approach

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -4108,7 +4108,8 @@ class SparkConnectPlanner(
    */
   private def replaceIntegerLiteralWithOrdinal(groupingExpression: Expression) =
     groupingExpression match {
-      case Literal(value: Int, IntegerType) => UnresolvedOrdinal(value)
+      case literal @ Literal(value: Int, IntegerType) =>
+        CurrentOrigin.withOrigin(literal.origin) { UnresolvedOrdinal(value) }
       case other => other
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ReplaceIntegerLiteralsWithOrdinalsDataframeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ReplaceIntegerLiteralsWithOrdinalsDataframeSuite.scala
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.analysis.UnresolvedOrdinal
+import org.apache.spark.sql.catalyst.expressions.SortOrder
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class ReplaceIntegerLiteralsWithOrdinalsDataframeSuite extends QueryTest with SharedSparkSession {
+
+  test("Group by ordinal - Dataframe") {
+    val query = "SELECT * FROM VALUES(1,2),(1,3),(2,4)"
+
+    withSQLConf(SQLConf.GROUP_BY_ORDINAL.key -> "true") {
+      val groupedDataset = sql(query).groupBy(lit(1))
+
+      assert(groupedDataset.groupingExprs.collect {
+        case ordinal @ UnresolvedOrdinal(1) => ordinal
+      }.nonEmpty)
+
+      checkError(
+        exception = intercept[AnalysisException](sql(query).groupBy(lit(-1)).count()),
+        condition = "GROUP_BY_POS_OUT_OF_RANGE",
+        parameters = Map("index" -> "-1", "size" -> "2"),
+        context = ExpectedContext(fragment = "lit", getCurrentClassCallSitePattern)
+      )
+    }
+
+    withSQLConf(SQLConf.GROUP_BY_ORDINAL.key -> "false") {
+      val groupedDataset = sql(query).groupBy(lit(1))
+
+      assert(groupedDataset.groupingExprs.collect {
+        case ordinal @ UnresolvedOrdinal(1) => ordinal
+      }.isEmpty)
+    }
+  }
+
+  test("Order/Sort by ordinal - Dataframe") {
+    val sqlText = "SELECT * FROM VALUES(2,1),(1,2)"
+
+    withSQLConf(SQLConf.ORDER_BY_ORDINAL.key -> "true") {
+      val queries = Seq(
+        sql(sqlText).orderBy(lit(1)),
+        sql(sqlText).sort(lit(1))
+      )
+
+      for (query <- queries) {
+        val unresolvedPlan = query.queryExecution.logical
+        val resolvedPlan = query.queryExecution.analyzed
+
+        assert(unresolvedPlan.expressions.collect {
+          case ordinal @ SortOrder(UnresolvedOrdinal(1), _, _, _) => ordinal
+        }.nonEmpty)
+
+        assert(resolvedPlan.expressions.collect {
+          case ordinal @ SortOrder(UnresolvedOrdinal(1), _, _, _) => ordinal
+        }.isEmpty)
+
+        checkAnswer(query, Row(1, 2) :: Row(2, 1) :: Nil)
+      }
+
+      checkError(
+        exception = intercept[AnalysisException](sql(sqlText).orderBy(lit(-1))),
+        condition = "ORDER_BY_POS_OUT_OF_RANGE",
+        parameters = Map("index" -> "-1", "size" -> "2")
+      )
+
+      checkError(
+        exception = intercept[AnalysisException](sql(sqlText).sort(lit(-1))),
+        condition = "ORDER_BY_POS_OUT_OF_RANGE",
+        parameters = Map("index" -> "-1", "size" -> "2")
+      )
+    }
+
+    withSQLConf(SQLConf.ORDER_BY_ORDINAL.key -> "false") {
+      val queries = Seq(
+        sql(sqlText).orderBy(lit(1)),
+        sql(sqlText).sort(lit(1))
+      )
+
+      for (query <- queries) {
+        val unresolvedPlan = query.queryExecution.logical
+        val resolvedPlan = query.queryExecution.analyzed
+
+        assert(unresolvedPlan.expressions.collect {
+          case ordinal @ SortOrder(UnresolvedOrdinal(1), _, _, _) => ordinal
+        }.isEmpty)
+
+        assert(resolvedPlan.expressions.collect {
+          case ordinal @ SortOrder(UnresolvedOrdinal(1), _, _, _) => ordinal
+        }.isEmpty)
+
+        checkAnswer(query, Row(2, 1) :: Row(1, 2) :: Nil)
+      }
+
+      checkAnswer(sql(sqlText).orderBy(lit(-1)), Row(2, 1) :: Row(1, 2) :: Nil)
+
+      checkAnswer(sql(sqlText).sort(lit(-1)), Row(2, 1) :: Row(1, 2) :: Nil)
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/ReplaceIntegerLiteralsWithOrdinalsSqlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ReplaceIntegerLiteralsWithOrdinalsSqlSuite.scala
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.analysis.UnresolvedOrdinal
+import org.apache.spark.sql.catalyst.expressions.SortOrder
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class ReplaceIntegerLiteralsWithOrdinalsSqlSuite extends QueryTest with SharedSparkSession {
+
+  test("Group by ordinal - SQL") {
+    val correctSqlText = "SELECT col1, max(col2) FROM VALUES(1,2),(1,3),(2,4) GROUP BY 1"
+    val groupByPosOutOfRangeSqlText =
+      "SELECT col1, max(col2) FROM VALUES(1,2),(1,3),(2,4) GROUP BY -1"
+
+    withSQLConf(SQLConf.GROUP_BY_ORDINAL.key -> "true") {
+      val query = sql(correctSqlText)
+      val parsedPlan = query.queryExecution.logical
+      val analyzedPlan = query.queryExecution.analyzed
+
+      assert(parsedPlan.expressions.collect {
+        case ordinal @ UnresolvedOrdinal(1) => ordinal
+      }.nonEmpty)
+
+      assert(analyzedPlan.expressions.collect {
+        case ordinal @ UnresolvedOrdinal(1) => ordinal
+      }.isEmpty)
+
+      checkAnswer(query, Row(1, 3) :: Row(2, 4) :: Nil)
+
+      checkError(
+        exception = intercept[AnalysisException](sql(groupByPosOutOfRangeSqlText)),
+        condition = "GROUP_BY_POS_OUT_OF_RANGE",
+        parameters = Map("index" -> "-1", "size" -> "2"),
+        queryContext = Array(ExpectedContext(fragment = "-1", start = 61, stop = 62))
+      )
+    }
+
+    withSQLConf(SQLConf.GROUP_BY_ORDINAL.key -> "false") {
+      val parsedPlan = spark.sessionState.sqlParser.parsePlan(correctSqlText)
+
+      assert(parsedPlan.expressions.collect {
+        case ordinal @ UnresolvedOrdinal(1) => ordinal
+      }.isEmpty)
+
+      checkError(
+        exception = intercept[AnalysisException](sql(groupByPosOutOfRangeSqlText)),
+        condition = "MISSING_AGGREGATION",
+        parameters = Map("expression" -> "\"col1\"", "expressionAnyValue" -> "\"any_value(col1)\"")
+      )
+    }
+  }
+
+  test("Order by ordinal - SQL") {
+    val correctSqlText = "SELECT col1 FROM VALUES(2,1),(1,2) ORDER BY 1"
+    val orderByPosOutOfRangeSqlText = "SELECT col1 FROM VALUES(2,1),(1,2) ORDER BY -1"
+
+    withSQLConf(SQLConf.ORDER_BY_ORDINAL.key -> "true") {
+      val query = sql(correctSqlText)
+      val parsedPlan = query.queryExecution.logical
+      val analyzedPlan = query.queryExecution.analyzed
+
+      assert(parsedPlan.expressions.collect {
+        case ordinal @ SortOrder(UnresolvedOrdinal(1), _, _, _) => ordinal
+      }.nonEmpty)
+
+      assert(analyzedPlan.expressions.collect {
+        case ordinal @ SortOrder(UnresolvedOrdinal(1), _, _, _) => ordinal
+      }.isEmpty)
+
+      checkAnswer(query, Row(1) :: Row(2) :: Nil)
+
+      checkError(
+        exception = intercept[AnalysisException](sql(orderByPosOutOfRangeSqlText)),
+        condition = "ORDER_BY_POS_OUT_OF_RANGE",
+        parameters = Map("index" -> "-1", "size" -> "1"),
+        queryContext = Array(ExpectedContext(fragment = "-1", start = 44, stop = 45))
+      )
+    }
+
+    withSQLConf(SQLConf.ORDER_BY_ORDINAL.key -> "false") {
+      val query = sql(correctSqlText)
+      val parsedPlan = query.queryExecution.logical
+      val analyzedPlan = query.queryExecution.analyzed
+
+      assert(parsedPlan.expressions.collect {
+        case ordinal @ SortOrder(UnresolvedOrdinal(1), _, _, _) => ordinal
+      }.isEmpty)
+
+      assert(analyzedPlan.expressions.collect {
+        case ordinal @ SortOrder(UnresolvedOrdinal(1), _, _, _) => ordinal
+      }.isEmpty)
+
+      checkAnswer(query, Row(2) :: Row(1) :: Nil)
+
+      checkAnswer(sql(orderByPosOutOfRangeSqlText), Row(2) :: Row(1) :: Nil)
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This is a followup to https://github.com/apache/spark/pull/50606, to address remaining issues in fixed-point analyzer and parser. This PR does the following:

1. Set correct origin in `SparkConnect` and `Dataframe` API
2. Handle remaining cases for order by ordinal in `Dataframe` API
3. Add a test suite for Dataframe use cases since we are missing those

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  4. If you fix some SQL features, you can provide some references of other DBMSes.
  5. If there is design documentation, please add the link.
  6. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
To address current issue with `UnresolvedOrdinal`
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Added a new test suite and existing tests.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
