### PR TITLE
[SPARK-51827][SS][CONNECT] Support Spark Connect on transformWithState in PySpark

### DIFF
--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -434,7 +434,7 @@ class GroupedData:
             udf_obj = UserDefinedFunction(
                 udf_util.transformWithStateUDF,
                 returnType=outputStructType,
-                evalType=PythonEvalType.SQL_TRANSFORM_WITH_STATE_UDF,
+                evalType=PythonEvalType.SQL_TRANSFORM_WITH_STATE_PYTHON_ROW_UDF,
             )
             initial_state_plan = None
             initial_state_grouping_cols = None
@@ -443,7 +443,7 @@ class GroupedData:
             udf_obj = UserDefinedFunction(
                 udf_util.transformWithStateWithInitStateUDF,
                 returnType=outputStructType,
-                evalType=PythonEvalType.SQL_TRANSFORM_WITH_STATE_INIT_STATE_UDF,
+                evalType=PythonEvalType.SQL_TRANSFORM_WITH_STATE_PYTHON_ROW_INIT_STATE_UDF,
             )
             initial_state_plan = initialState._df._plan
             initial_state_grouping_cols = initialState._grouping_cols

--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -414,7 +414,7 @@ class GroupedData:
 
     transformWithStateInPandas.__doc__ = PySparkGroupedData.transformWithStateInPandas.__doc__
 
-    def transformWithStateInPySpark(
+    def transformWithState(
         self,
         statefulProcessor: StatefulProcessor,
         outputStructType: Union[StructType, str],
@@ -464,7 +464,7 @@ class GroupedData:
             session=self._df._session,
         )
 
-    transformWithStateInPySpark.__doc__ = PySparkGroupedData.transformWithStateInPySpark.__doc__
+    transformWithState.__doc__ = PySparkGroupedData.transformWithState.__doc__
 
     def applyInArrow(
         self, func: "ArrowGroupedMapFunction", schema: Union[StructType, str]

--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -414,6 +414,58 @@ class GroupedData:
 
     transformWithStateInPandas.__doc__ = PySparkGroupedData.transformWithStateInPandas.__doc__
 
+    def transformWithStateInPySpark(
+        self,
+        statefulProcessor: StatefulProcessor,
+        outputStructType: Union[StructType, str],
+        outputMode: str,
+        timeMode: str,
+        initialState: Optional["GroupedData"] = None,
+        eventTimeColumnName: str = "",
+    ) -> "DataFrame":
+        from pyspark.sql.connect.udf import UserDefinedFunction
+        from pyspark.sql.connect.dataframe import DataFrame
+        from pyspark.sql.streaming.stateful_processor_util import (
+            TransformWithStateInPySparkUdfUtils,
+        )
+
+        udf_util = TransformWithStateInPySparkUdfUtils(statefulProcessor, timeMode)
+        if initialState is None:
+            udf_obj = UserDefinedFunction(
+                udf_util.transformWithStateUDF,
+                returnType=outputStructType,
+                evalType=PythonEvalType.SQL_TRANSFORM_WITH_STATE_UDF,
+            )
+            initial_state_plan = None
+            initial_state_grouping_cols = None
+        else:
+            self._df._check_same_session(initialState._df)
+            udf_obj = UserDefinedFunction(
+                udf_util.transformWithStateWithInitStateUDF,
+                returnType=outputStructType,
+                evalType=PythonEvalType.SQL_TRANSFORM_WITH_STATE_INIT_STATE_UDF,
+            )
+            initial_state_plan = initialState._df._plan
+            initial_state_grouping_cols = initialState._grouping_cols
+
+        return DataFrame(
+            plan.TransformWithStateInPySpark(
+                child=self._df._plan,
+                grouping_cols=self._grouping_cols,
+                function=udf_obj,
+                output_schema=outputStructType,
+                output_mode=outputMode,
+                time_mode=timeMode,
+                event_time_col_name=eventTimeColumnName,
+                cols=self._df.columns,
+                initial_state_plan=initial_state_plan,
+                initial_state_grouping_cols=initial_state_grouping_cols,
+            ),
+            session=self._df._session,
+        )
+
+    transformWithStateInPySpark.__doc__ = PySparkGroupedData.transformWithStateInPySpark.__doc__
+
     def applyInArrow(
         self, func: "ArrowGroupedMapFunction", schema: Union[StructType, str]
     ) -> "DataFrame":

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -2549,17 +2549,17 @@ class ApplyInPandasWithState(LogicalPlan):
 class BaseTransformWithStateInPySpark(LogicalPlan):
     """Base implementation of logical plan object for a TransformWithStateIn(PySpark/Pandas)."""
     def __init__(
-            self,
-            child: Optional["LogicalPlan"],
-            grouping_cols: Sequence[Column],
-            function: "UserDefinedFunction",
-            output_schema: Union[DataType, str],
-            output_mode: str,
-            time_mode: str,
-            event_time_col_name: str,
-            cols: List[str],
-            initial_state_plan: Optional["LogicalPlan"],
-            initial_state_grouping_cols: Optional[Sequence[Column]],
+        self,
+        child: Optional["LogicalPlan"],
+        grouping_cols: Sequence[Column],
+        function: "UserDefinedFunction",
+        output_schema: Union[DataType, str],
+        output_mode: str,
+        time_mode: str,
+        event_time_col_name: str,
+        cols: List[str],
+        initial_state_plan: Optional["LogicalPlan"],
+        initial_state_grouping_cols: Optional[Sequence[Column]],
     ):
         assert isinstance(grouping_cols, list) and all(isinstance(c, Column) for c in grouping_cols)
         if initial_state_plan is not None:

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -2548,6 +2548,7 @@ class ApplyInPandasWithState(LogicalPlan):
 
 class BaseTransformWithStateInPySpark(LogicalPlan):
     """Base implementation of logical plan object for a TransformWithStateIn(PySpark/Pandas)."""
+
     def __init__(
         self,
         child: Optional["LogicalPlan"],
@@ -2615,12 +2616,14 @@ class BaseTransformWithStateInPySpark(LogicalPlan):
 
 class TransformWithStateInPySpark(BaseTransformWithStateInPySpark):
     """Logical plan object for a TransformWithStateInPySpark."""
+
     pass
 
 
 # Retaining this to avoid breaking backward compatibility.
 class TransformWithStateInPandas(BaseTransformWithStateInPySpark):
     """Logical plan object for a TransformWithStateInPandas."""
+
     pass
 
 

--- a/python/pyspark/sql/tests/connect/pandas/test_parity_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/connect/pandas/test_parity_pandas_transform_with_state.py
@@ -57,14 +57,14 @@ class TransformWithStateInPySparkParityTests(
     TransformWithStateInPySparkTestsMixin, ReusedConnectTestCase
 ):
     """
-    Spark connect parity tests for TransformWithStateInPandas. Run every test case in
-     `TransformWithStateInPandasTestsMixin` in spark connect mode.
+    Spark connect parity tests for TransformWithStateInPySpark. Run every test case in
+     `TransformWithStateInPySparkTestsMixin` in spark connect mode.
     """
 
     @classmethod
     def conf(cls):
         # Due to multiple inheritance from the same level, we need to explicitly setting configs in
-        # both TransformWithStateInPandasTestsMixin and ReusedConnectTestCase here
+        # both TransformWithStateInPySparkTestsMixin and ReusedConnectTestCase here
         cfg = SparkConf(loadDefaults=False)
         for base in cls.__bases__:
             if hasattr(base, "conf"):
@@ -82,9 +82,6 @@ class TransformWithStateInPySparkParityTests(
     def test_schema_evolution_scenarios(self):
         pass
 
-
-# TODO(SPARK-51827): Need to copy the parity test when we implement transformWithState in
-#  Python Spark Connect
 
 if __name__ == "__main__":
     from pyspark.sql.tests.connect.pandas.test_parity_pandas_transform_with_state import *  # noqa: F401,E501

--- a/python/pyspark/sql/tests/connect/pandas/test_parity_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/connect/pandas/test_parity_pandas_transform_with_state.py
@@ -53,6 +53,7 @@ class TransformWithStateInPandasParityTests(
     def test_schema_evolution_scenarios(self):
         pass
 
+
 class TransformWithStateInPySparkParityTests(
     TransformWithStateInPySparkTestsMixin, ReusedConnectTestCase
 ):

--- a/python/pyspark/sql/tests/connect/pandas/test_parity_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/connect/pandas/test_parity_pandas_transform_with_state.py
@@ -18,6 +18,7 @@ import unittest
 
 from pyspark.sql.tests.pandas.test_pandas_transform_with_state import (
     TransformWithStateInPandasTestsMixin,
+    TransformWithStateInPySparkTestsMixin,
 )
 from pyspark import SparkConf
 from pyspark.testing.connectutils import ReusedConnectTestCase
@@ -25,6 +26,35 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 class TransformWithStateInPandasParityTests(
     TransformWithStateInPandasTestsMixin, ReusedConnectTestCase
+):
+    """
+    Spark connect parity tests for TransformWithStateInPandas. Run every test case in
+     `TransformWithStateInPandasTestsMixin` in spark connect mode.
+    """
+
+    @classmethod
+    def conf(cls):
+        # Due to multiple inheritance from the same level, we need to explicitly setting configs in
+        # both TransformWithStateInPandasTestsMixin and ReusedConnectTestCase here
+        cfg = SparkConf(loadDefaults=False)
+        for base in cls.__bases__:
+            if hasattr(base, "conf"):
+                parent_cfg = base.conf()
+                for k, v in parent_cfg.getAll():
+                    cfg.set(k, v)
+
+        # Extra removing config for connect suites
+        if cfg._jconf is not None:
+            cfg._jconf.remove("spark.master")
+
+        return cfg
+
+    @unittest.skip("Flaky in spark connect on CI. Skip for now. See SPARK-51368 for details.")
+    def test_schema_evolution_scenarios(self):
+        pass
+
+class TransformWithStateInPySparkParityTests(
+    TransformWithStateInPySparkTestsMixin, ReusedConnectTestCase
 ):
     """
     Spark connect parity tests for TransformWithStateInPandas. Run every test case in

--- a/python/pyspark/sql/tests/test_connect_compatibility.py
+++ b/python/pyspark/sql/tests/test_connect_compatibility.py
@@ -395,8 +395,7 @@ class ConnectCompatibilityTestsMixin:
         """Test Grouping compatibility between classic and connect."""
         expected_missing_connect_properties = set()
         expected_missing_classic_properties = set()
-        # TODO(SPARK-51827): Add missing method `transformWithState` to the connect version
-        expected_missing_connect_methods = {"transformWithState"}
+        expected_missing_connect_methods = set()
         expected_missing_classic_methods = set()
         self.check_compatibility(
             ClassicGroupedData,

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -661,7 +661,11 @@ class SparkConnectPlanner(
 
           case PythonEvalType.SQL_TRANSFORM_WITH_STATE_PANDAS_UDF |
               PythonEvalType.SQL_TRANSFORM_WITH_STATE_PANDAS_INIT_STATE_UDF =>
-            transformTransformWithStateInPandas(pythonUdf, group, rel)
+            transformTransformWithStateInPySpark(pythonUdf, group, rel, usePandas=true)
+
+          case PythonEvalType.SQL_TRANSFORM_WITH_STATE_PYTHON_ROW_UDF |
+              PythonEvalType.SQL_TRANSFORM_WITH_STATE_PYTHON_ROW_INIT_STATE_UDF =>
+            transformTransformWithStateInPySpark(pythonUdf, group, rel, usePandas=false)
 
           case _ =>
             throw InvalidPlanInput(
@@ -1102,10 +1106,11 @@ class SparkConnectPlanner(
       .logicalPlan
   }
 
-  private def transformTransformWithStateInPandas(
+  private def transformTransformWithStateInPySpark(
       pythonUdf: PythonUDF,
       groupedDs: RelationalGroupedDataset,
-      rel: proto.GroupMap): LogicalPlan = {
+      rel: proto.GroupMap,
+      usePandas: Boolean): LogicalPlan = {
     val twsInfo = rel.getTransformWithStateInfo
     val outputSchema: StructType = {
       transformDataType(twsInfo.getOutputSchema) match {
@@ -1131,25 +1136,52 @@ class SparkConnectPlanner(
         .builder(groupedDs.df.logicalPlan.output)
         .asInstanceOf[PythonUDF]
 
-      groupedDs
-        .transformWithStateInPandas(
-          Column(resolvedPythonUDF),
-          outputSchema,
-          rel.getOutputMode,
-          twsInfo.getTimeMode,
-          initialStateDs,
-          twsInfo.getEventTimeColumnName)
-        .logicalPlan
+      if (usePandas) {
+        groupedDs
+          .transformWithStateInPandas(
+            Column(resolvedPythonUDF),
+            outputSchema,
+            rel.getOutputMode,
+            twsInfo.getTimeMode,
+            initialStateDs,
+            twsInfo.getEventTimeColumnName)
+          .logicalPlan
+      } else {
+        // use Row
+        groupedDs
+          .transformWithStateInPySpark(
+            Column(resolvedPythonUDF),
+            outputSchema,
+            rel.getOutputMode,
+            twsInfo.getTimeMode,
+            initialStateDs,
+            twsInfo.getEventTimeColumnName)
+          .logicalPlan
+      }
+
     } else {
-      groupedDs
-        .transformWithStateInPandas(
-          Column(pythonUdf),
-          outputSchema,
-          rel.getOutputMode,
-          twsInfo.getTimeMode,
-          null,
-          twsInfo.getEventTimeColumnName)
-        .logicalPlan
+      if (usePandas) {
+        groupedDs
+          .transformWithStateInPandas(
+            Column(pythonUdf),
+            outputSchema,
+            rel.getOutputMode,
+            twsInfo.getTimeMode,
+            null,
+            twsInfo.getEventTimeColumnName)
+          .logicalPlan
+      } else {
+        // use Row
+        groupedDs
+          .transformWithStateInPySpark(
+            Column(pythonUdf),
+            outputSchema,
+            rel.getOutputMode,
+            twsInfo.getTimeMode,
+            null,
+            twsInfo.getEventTimeColumnName)
+          .logicalPlan
+      }
     }
   }
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -661,11 +661,11 @@ class SparkConnectPlanner(
 
           case PythonEvalType.SQL_TRANSFORM_WITH_STATE_PANDAS_UDF |
               PythonEvalType.SQL_TRANSFORM_WITH_STATE_PANDAS_INIT_STATE_UDF =>
-            transformTransformWithStateInPySpark(pythonUdf, group, rel, usePandas=true)
+            transformTransformWithStateInPySpark(pythonUdf, group, rel, usePandas = true)
 
           case PythonEvalType.SQL_TRANSFORM_WITH_STATE_PYTHON_ROW_UDF |
               PythonEvalType.SQL_TRANSFORM_WITH_STATE_PYTHON_ROW_INIT_STATE_UDF =>
-            transformTransformWithStateInPySpark(pythonUdf, group, rel, usePandas=false)
+            transformTransformWithStateInPySpark(pythonUdf, group, rel, usePandas = false)
 
           case _ =>
             throw InvalidPlanInput(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to support Spark Connect on transformWithState in PySpark. The code is mostly reused between Pandas version and Row version.

We rely on PythonEvanType to determine the user facing type of API, hence no proto change.

### Why are the changes needed?

The new API needs to be supported with Spark Connect.

### Does this PR introduce _any_ user-facing change?

Yes, we will expose a new API to be available in Spark Connect.

### How was this patch tested?

New test suites.

### Was this patch authored or co-authored using generative AI tooling?

No.