### PR TITLE
[SPARK-51880][ML][PYTHON][CONNECT] Fix ML cache object python client references

### DIFF
--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -2809,7 +2809,11 @@ class GBTClassificationModel(
     def trees(self) -> List[DecisionTreeRegressionModel]:
         """Trees in this ensemble. Warning: These have null parent Estimators."""
         if is_remote():
-            return [DecisionTreeRegressionModel(m) for m in self._call_java("trees").split(",")]
+            from pyspark.ml.util import RemoteModelRef
+            return [
+                DecisionTreeRegressionModel(RemoteModelRef(m))
+                for m in self._call_java("trees").split(",")
+            ]
         return [DecisionTreeRegressionModel(m) for m in list(self._call_java("trees"))]
 
     def evaluateEachIteration(self, dataset: DataFrame) -> List[float]:

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -2307,6 +2307,7 @@ class RandomForestClassificationModel(
         """Trees in this ensemble. Warning: These have null parent Estimators."""
         if is_remote():
             from pyspark.ml.util import RemoteModelRef
+
             return [
                 DecisionTreeClassificationModel(RemoteModelRef(m))
                 for m in self._call_java("trees").split(",")
@@ -2810,6 +2811,7 @@ class GBTClassificationModel(
         """Trees in this ensemble. Warning: These have null parent Estimators."""
         if is_remote():
             from pyspark.ml.util import RemoteModelRef
+
             return [
                 DecisionTreeRegressionModel(RemoteModelRef(m))
                 for m in self._call_java("trees").split(",")

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -2306,7 +2306,11 @@ class RandomForestClassificationModel(
     def trees(self) -> List[DecisionTreeClassificationModel]:
         """Trees in this ensemble. Warning: These have null parent Estimators."""
         if is_remote():
-            return [DecisionTreeClassificationModel(m) for m in self._call_java("trees").split(",")]
+            from pyspark.ml.util import RemoteModelRef
+            return [
+                DecisionTreeClassificationModel(RemoteModelRef(m))
+                for m in self._call_java("trees").split(",")
+            ]
         return [DecisionTreeClassificationModel(m) for m in list(self._call_java("trees"))]
 
     @property

--- a/python/pyspark/ml/connect/readwrite.py
+++ b/python/pyspark/ml/connect/readwrite.py
@@ -78,6 +78,7 @@ class RemoteMLWriter(MLWriter):
         # supporting JavaModel or JavaEstimator or JavaEvaluator
         if isinstance(instance, JavaModel):
             from pyspark.ml.util import RemoteModelRef
+
             model = cast("JavaModel", instance)
             params = serialize_ml_params(model, session.client)
             assert isinstance(model._java_obj, RemoteModelRef)
@@ -272,6 +273,7 @@ class RemoteMLReader(MLReader[RL]):
             # It must be JavaWrapper, since we're passing the string to the _java_obj
             if issubclass(py_type, JavaWrapper):
                 from pyspark.ml.util import RemoteModelRef
+
                 if ml_type == pb2.MlOperator.OPERATOR_TYPE_MODEL:
                     session.client.add_ml_cache(result.obj_ref.id)
                     remote_model_ref = RemoteModelRef(result.obj_ref.id)

--- a/python/pyspark/ml/connect/readwrite.py
+++ b/python/pyspark/ml/connect/readwrite.py
@@ -77,11 +77,12 @@ class RemoteMLWriter(MLWriter):
         # Spark Connect ML is built on scala Spark.ML, that means we're only
         # supporting JavaModel or JavaEstimator or JavaEvaluator
         if isinstance(instance, JavaModel):
+            from pyspark.ml.util import RemoteModelRef
             model = cast("JavaModel", instance)
             params = serialize_ml_params(model, session.client)
-            assert isinstance(model._java_obj, str)
+            assert isinstance(model._java_obj, RemoteModelRef)
             writer = pb2.MlCommand.Write(
-                obj_ref=pb2.ObjectRef(id=model._java_obj),
+                obj_ref=pb2.ObjectRef(id=model._java_obj.ref_id),
                 params=params,
                 path=path,
                 should_overwrite=shouldOverwrite,
@@ -270,9 +271,11 @@ class RemoteMLReader(MLReader[RL]):
             py_type = _get_class()
             # It must be JavaWrapper, since we're passing the string to the _java_obj
             if issubclass(py_type, JavaWrapper):
+                from pyspark.ml.util import RemoteModelRef
                 if ml_type == pb2.MlOperator.OPERATOR_TYPE_MODEL:
                     session.client.add_ml_cache(result.obj_ref.id)
-                    instance = py_type(result.obj_ref.id)
+                    remote_model_ref = RemoteModelRef(result.obj_ref.id)
+                    instance = py_type(remote_model_ref)
                 else:
                     instance = py_type()
                 instance._resetUid(result.uid)

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -64,6 +64,7 @@ from pyspark.ml.wrapper import (
     _jvm,
 )
 from pyspark.ml.common import inherit_doc
+from pyspark.ml.util import RemoteModelRef
 from pyspark.sql.types import ArrayType, StringType
 from pyspark.sql.utils import is_remote
 
@@ -1224,11 +1225,11 @@ class CountVectorizerModel(
 
         if is_remote():
             model = CountVectorizerModel()
-            model._java_obj = invoke_helper_attr(
+            model._java_obj = RemoteModelRef(invoke_helper_attr(
                 "countVectorizerModelFromVocabulary",
                 model.uid,
                 list(vocabulary),
-            )
+            ))
 
         else:
             from pyspark.core.context import SparkContext
@@ -4843,11 +4844,11 @@ class StringIndexerModel(
         """
         if is_remote():
             model = StringIndexerModel()
-            model._java_obj = invoke_helper_attr(
+            model._java_obj = RemoteModelRef(invoke_helper_attr(
                 "stringIndexerModelFromLabels",
                 model.uid,
                 (list(labels), ArrayType(StringType())),
-            )
+            ))
 
         else:
             from pyspark.core.context import SparkContext
@@ -4882,14 +4883,14 @@ class StringIndexerModel(
         """
         if is_remote():
             model = StringIndexerModel()
-            model._java_obj = invoke_helper_attr(
+            model._java_obj = RemoteModelRef(invoke_helper_attr(
                 "stringIndexerModelFromLabelsArray",
                 model.uid,
                 (
                     [list(labels) for labels in arrayOfLabels],
                     ArrayType(ArrayType(StringType())),
                 ),
-            )
+            ))
 
         else:
             from pyspark.core.context import SparkContext

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -1225,11 +1225,13 @@ class CountVectorizerModel(
 
         if is_remote():
             model = CountVectorizerModel()
-            model._java_obj = RemoteModelRef(invoke_helper_attr(
-                "countVectorizerModelFromVocabulary",
-                model.uid,
-                list(vocabulary),
-            ))
+            model._java_obj = RemoteModelRef(
+                invoke_helper_attr(
+                    "countVectorizerModelFromVocabulary",
+                    model.uid,
+                    list(vocabulary),
+                )
+            )
 
         else:
             from pyspark.core.context import SparkContext
@@ -4844,11 +4846,13 @@ class StringIndexerModel(
         """
         if is_remote():
             model = StringIndexerModel()
-            model._java_obj = RemoteModelRef(invoke_helper_attr(
-                "stringIndexerModelFromLabels",
-                model.uid,
-                (list(labels), ArrayType(StringType())),
-            ))
+            model._java_obj = RemoteModelRef(
+                invoke_helper_attr(
+                    "stringIndexerModelFromLabels",
+                    model.uid,
+                    (list(labels), ArrayType(StringType())),
+                )
+            )
 
         else:
             from pyspark.core.context import SparkContext
@@ -4883,14 +4887,16 @@ class StringIndexerModel(
         """
         if is_remote():
             model = StringIndexerModel()
-            model._java_obj = RemoteModelRef(invoke_helper_attr(
-                "stringIndexerModelFromLabelsArray",
-                model.uid,
-                (
-                    [list(labels) for labels in arrayOfLabels],
-                    ArrayType(ArrayType(StringType())),
-                ),
-            ))
+            model._java_obj = RemoteModelRef(
+                invoke_helper_attr(
+                    "stringIndexerModelFromLabelsArray",
+                    model.uid,
+                    (
+                        [list(labels) for labels in arrayOfLabels],
+                        ArrayType(ArrayType(StringType())),
+                    ),
+                )
+            )
 
         else:
             from pyspark.core.context import SparkContext

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -1614,7 +1614,11 @@ class RandomForestRegressionModel(
     def trees(self) -> List[DecisionTreeRegressionModel]:
         """Trees in this ensemble. Warning: These have null parent Estimators."""
         if is_remote():
-            return [DecisionTreeRegressionModel(m) for m in self._call_java("trees").split(",")]
+            from pyspark.ml.util import RemoteModelRef
+            return [
+                DecisionTreeRegressionModel(RemoteModelRef(m))
+                for m in self._call_java("trees").split(",")
+            ]
         return [DecisionTreeRegressionModel(m) for m in list(self._call_java("trees"))]
 
     @property
@@ -2005,7 +2009,11 @@ class GBTRegressionModel(
     def trees(self) -> List[DecisionTreeRegressionModel]:
         """Trees in this ensemble. Warning: These have null parent Estimators."""
         if is_remote():
-            return [DecisionTreeRegressionModel(m) for m in self._call_java("trees").split(",")]
+            from pyspark.ml.util import RemoteModelRef
+            return [
+                DecisionTreeRegressionModel(RemoteModelRef(m))
+                for m in self._call_java("trees").split(",")
+            ]
         return [DecisionTreeRegressionModel(m) for m in list(self._call_java("trees"))]
 
     def evaluateEachIteration(self, dataset: DataFrame, loss: str) -> List[float]:

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -1615,6 +1615,7 @@ class RandomForestRegressionModel(
         """Trees in this ensemble. Warning: These have null parent Estimators."""
         if is_remote():
             from pyspark.ml.util import RemoteModelRef
+
             return [
                 DecisionTreeRegressionModel(RemoteModelRef(m))
                 for m in self._call_java("trees").split(",")
@@ -2010,6 +2011,7 @@ class GBTRegressionModel(
         """Trees in this ensemble. Warning: These have null parent Estimators."""
         if is_remote():
             from pyspark.ml.util import RemoteModelRef
+
             return [
                 DecisionTreeRegressionModel(RemoteModelRef(m))
                 for m in self._call_java("trees").split(",")

--- a/python/pyspark/ml/tests/connect/test_connect_cache.py
+++ b/python/pyspark/ml/tests/connect/test_connect_cache.py
@@ -43,7 +43,7 @@ class MLConnectCacheTests(ReusedConnectTestCase):
         model = svc.fit(df)
 
         # model is cached in python side
-        self.assertEqual(len(spark.client.thread_local.ml_caches), 1)
+        self.assertEqual(len(spark.client.ml_caches), 1)
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 1)
         self.assertTrue(
@@ -55,7 +55,7 @@ class MLConnectCacheTests(ReusedConnectTestCase):
         del model
 
         # model is removed in python side
-        self.assertEqual(len(spark.client.thread_local.ml_caches), 0)
+        self.assertEqual(len(spark.client.ml_caches), 0)
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 0)
 
@@ -82,7 +82,7 @@ class MLConnectCacheTests(ReusedConnectTestCase):
         self.assertEqual(len([model1, model2, model3]), 3)
 
         # all 3 models are cached in python side
-        self.assertEqual(len(spark.client.thread_local.ml_caches), 3)
+        self.assertEqual(len(spark.client.ml_caches), 3)
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 3)
         self.assertTrue(
@@ -97,14 +97,14 @@ class MLConnectCacheTests(ReusedConnectTestCase):
         del model1
 
         # model1 is removed in python side
-        self.assertEqual(len(spark.client.thread_local.ml_caches), 2)
+        self.assertEqual(len(spark.client.ml_caches), 2)
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 2)
 
         spark.client._cleanup_ml_cache()
 
         # All models are removed in python side
-        self.assertEqual(len(spark.client.thread_local.ml_caches), 0)
+        self.assertEqual(len(spark.client.ml_caches), 0)
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 0)
 

--- a/python/pyspark/ml/tests/connect/test_connect_cache.py
+++ b/python/pyspark/ml/tests/connect/test_connect_cache.py
@@ -43,7 +43,7 @@ class MLConnectCacheTests(ReusedConnectTestCase):
         model = svc.fit(df)
 
         # model is cached in python side
-        self.assertEqual(len(spark.client.ml_caches), 1)
+        self.assertEqual(len(spark.client.thread_local.ml_caches), 1)
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 1)
         self.assertTrue(
@@ -55,7 +55,7 @@ class MLConnectCacheTests(ReusedConnectTestCase):
         del model
 
         # model is removed in python side
-        self.assertEqual(len(spark.client.ml_caches), 0)
+        self.assertEqual(len(spark.client.thread_local.ml_caches), 0)
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 0)
 
@@ -82,7 +82,7 @@ class MLConnectCacheTests(ReusedConnectTestCase):
         self.assertEqual(len([model1, model2, model3]), 3)
 
         # all 3 models are cached in python side
-        self.assertEqual(len(spark.client.ml_caches), 3)
+        self.assertEqual(len(spark.client.thread_local.ml_caches), 3)
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 3)
         self.assertTrue(
@@ -97,14 +97,14 @@ class MLConnectCacheTests(ReusedConnectTestCase):
         del model1
 
         # model1 is removed in python side
-        self.assertEqual(len(spark.client.ml_caches), 2)
+        self.assertEqual(len(spark.client.thread_local.ml_caches), 2)
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 2)
 
         spark.client._cleanup_ml_cache()
 
         # All models are removed in python side
-        self.assertEqual(len(spark.client.ml_caches), 0)
+        self.assertEqual(len(spark.client.thread_local.ml_caches), 0)
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 0)
 

--- a/python/pyspark/ml/tests/test_tuning.py
+++ b/python/pyspark/ml/tests/test_tuning.py
@@ -97,7 +97,6 @@ class TuningTestsMixin:
             self.assertEqual(str(tvs_model.getEstimator()), str(model2.getEstimator()))
             self.assertEqual(str(tvs_model.getEvaluator()), str(model2.getEvaluator()))
 
-    @unittest.skip("Disabled due to a Python side reference count issue in _parallelFitTasks.")
     def test_cross_validator(self):
         dataset = self.spark.createDataFrame(
             [

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -327,10 +327,6 @@ def del_remote_cache(ref_id: str) -> None:
 
             session = SparkSession.getActiveSession()
             if session is not None:
-                # TODO: `remove_ml_cache` is buggy, to ensure server side object is deleted,
-                #  we need to call `_delete_ml_cache` here.
-                #  remove `_delete_ml_cache` invocation once `remove_ml_cache` is fixed.
-                session.client._delete_ml_cache([ref_id])
                 session.client.remove_ml_cache(ref_id)
                 return
         except Exception:

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -327,6 +327,10 @@ def del_remote_cache(ref_id: str) -> None:
 
             session = SparkSession.getActiveSession()
             if session is not None:
+                # TODO: `remove_ml_cache` is buggy, to ensure server side object is deleted,
+                #  we need to call `_delete_ml_cache` here.
+                #  remove `_delete_ml_cache` invocation once `remove_ml_cache` is fixed.
+                session.client._delete_ml_cache([ref_id])
                 session.client.remove_ml_cache(ref_id)
                 return
         except Exception:

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -119,7 +119,7 @@ def invoke_remote_attribute_relation(
         object_id = instance._java_obj.ref_id
     else:
         # model summary
-        object_id = instance._java_obj
+        object_id = instance._java_obj  # type: ignore
     methods, obj_ref = _extract_id_methods(object_id)
     methods.append(pb2.Fetch.Method(method=method, args=serialize(session.client, *args)))
     plan = AttributeRelation(obj_ref, methods)

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -278,8 +278,12 @@ def try_remote_call(f: FuncT) -> FuncT:
 
             session = SparkSession.getActiveSession()
             assert session is not None
-            assert isinstance(self._java_obj, RemoteModelRef)
-            methods, obj_ref = _extract_id_methods(self._java_obj.ref_id)
+            if self._java_obj == ML_CONNECT_HELPER_ID:
+                obj_id = ML_CONNECT_HELPER_ID
+            else:
+                assert isinstance(self._java_obj, RemoteModelRef)
+                obj_id = self._java_obj.ref_id
+            methods, obj_ref = _extract_id_methods(obj_id)
             methods.append(pb2.Fetch.Method(method=name, args=serialize(session.client, *args)))
             command = pb2.Command()
             command.ml_command.fetch.CopyFrom(

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -158,7 +158,8 @@ class RemoteModelRef:
         with self._lock:
             self._ref_count -= 1
             if self._ref_count == 0:
-                del_remote_cache(self._ref_id)
+                # Delete the model if possible
+                del_remote_cache(self.ref_id)
 
     def __str__(self):
         return self.ref_id
@@ -328,9 +329,7 @@ def try_remote_del(f: FuncT) -> FuncT:
             return
 
         if in_remote and isinstance(self._java_obj, RemoteModelRef):
-            # Delete the model if possible
-            model_id = self._java_obj.ref_id
-            del_remote_cache(cast(str, model_id))
+            self._java_obj.release_ref()
             return
         else:
             return f(self)

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -152,10 +152,12 @@ class RemoteModelRef:
 
     def add_ref(self):
         with self._lock:
+            assert self._ref_count > 0
             self._ref_count += 1
 
     def release_ref(self):
         with self._lock:
+            assert self._ref_count > 0
             self._ref_count -= 1
             if self._ref_count == 0:
                 # Delete the model if possible

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -146,21 +146,21 @@ def try_remote_attribute_relation(f: FuncT) -> FuncT:
 
 
 class RemoteModelRef:
-    def __init__(self, ref_id):
+    def __init__(self, ref_id: str) -> None:
         self._ref_id = ref_id
         self._ref_count = 1
         self._lock = threading.Lock()
 
     @property
-    def ref_id(self):
+    def ref_id(self) -> str:
         return self._ref_id
 
-    def add_ref(self):
+    def add_ref(self) -> None:
         with self._lock:
             assert self._ref_count > 0
             self._ref_count += 1
 
-    def release_ref(self):
+    def release_ref(self) -> None:
         with self._lock:
             assert self._ref_count > 0
             self._ref_count -= 1
@@ -168,7 +168,7 @@ class RemoteModelRef:
                 # Delete the model if possible
                 del_remote_cache(self.ref_id)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.ref_id
 
 
@@ -292,7 +292,7 @@ def try_remote_call(f: FuncT) -> FuncT:
                     obj_id = self._java_obj.ref_id
                 else:
                     # model summary
-                    obj_id = self._java_obj
+                    obj_id = self._java_obj  # type: ignore
             methods, obj_ref = _extract_id_methods(obj_id)
             methods.append(pb2.Fetch.Method(method=name, args=serialize(session.client, *args)))
             command = pb2.Command()

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -358,6 +358,7 @@ class JavaParams(JavaWrapper, Params, metaclass=ABCMeta):
         that = super(JavaParams, self).copy(extra)
         if self._java_obj is not None:
             from pyspark.ml.util import RemoteModelRef
+
             if isinstance(self._java_obj, RemoteModelRef):
                 that._java_obj = self._java_obj
                 self._java_obj.add_ref()
@@ -459,6 +460,7 @@ class JavaModel(JavaTransformer, Model, metaclass=ABCMeta):
         super(JavaModel, self).__init__(java_model)
         if is_remote() and java_model is not None:
             from pyspark.ml.util import RemoteModelRef
+
             assert isinstance(java_model, RemoteModelRef)
         if java_model is not None and not is_remote():
             # SPARK-10931: This is a temporary fix to allow models to own params

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -457,7 +457,7 @@ class JavaModel(JavaTransformer, Model, metaclass=ABCMeta):
         other ML classes).
         """
         super(JavaModel, self).__init__(java_model)
-        if is_remote():
+        if is_remote() and java_model is not None:
             from pyspark.ml.util import RemoteModelRef
             assert isinstance(java_model, RemoteModelRef)
         if java_model is not None and not is_remote():

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -356,9 +356,14 @@ class JavaParams(JavaWrapper, Params, metaclass=ABCMeta):
         if extra is None:
             extra = dict()
         that = super(JavaParams, self).copy(extra)
-        if self._java_obj is not None and not isinstance(self._java_obj, str):
-            that._java_obj = self._java_obj.copy(self._empty_java_param_map())
-            that._transfer_params_to_java()
+        if self._java_obj is not None:
+            from pyspark.ml.util import RemoteModelRef
+            if isinstance(self._java_obj, RemoteModelRef):
+                that._java_obj = self._java_obj
+                self._java_obj.add_ref()
+            elif not isinstance(self._java_obj, str):
+                that._java_obj = self._java_obj.copy(self._empty_java_param_map())
+                that._transfer_params_to_java()
         return that
 
     @try_remote_intercept

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -457,6 +457,9 @@ class JavaModel(JavaTransformer, Model, metaclass=ABCMeta):
         other ML classes).
         """
         super(JavaModel, self).__init__(java_model)
+        if is_remote():
+            from pyspark.ml.util import RemoteModelRef
+            assert isinstance(java_model, RemoteModelRef)
         if java_model is not None and not is_remote():
             # SPARK-10931: This is a temporary fix to allow models to own params
             # from estimators. Eventually, these params should be in models through

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1981,9 +1981,10 @@ class SparkConnectClient(object):
         self.thread_local.ml_caches.add(cache_id)
 
     def remove_ml_cache(self, cache_id: str) -> None:
+        deleted = self._delete_ml_cache([cache_id])
+        # TODO: Fix the code: change thread-local `ml_caches` to global `ml_caches`.
         if hasattr(self.thread_local, "ml_caches"):
             if cache_id in self.thread_local.ml_caches:
-                deleted = self._delete_ml_cache([cache_id])
                 for obj_id in deleted:
                     self.thread_local.ml_caches.remove(obj_id)
 

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -638,7 +638,7 @@ class SparkConnectClient(object):
             Enable reattachable execution.
         """
         self.thread_local = threading.local()
-        self.ml_caches = set()
+        self.ml_caches = set()  # type: ignore
 
         # Parse the connection string.
         self._builder = (
@@ -2024,3 +2024,5 @@ class SparkConnectClient(object):
         if properties is not None and "ml_command_result" in properties:
             ml_command_result = properties["ml_command_result"]
             return [item.string for item in ml_command_result.param.array.elements]
+
+        return []

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -638,6 +638,7 @@ class SparkConnectClient(object):
             Enable reattachable execution.
         """
         self.thread_local = threading.local()
+        self.ml_caches = set()
 
         # Parse the connection string.
         self._builder = (
@@ -1976,16 +1977,13 @@ class SparkConnectClient(object):
         return profile_id
 
     def add_ml_cache(self, cache_id: str) -> None:
-        if not hasattr(self.thread_local, "ml_caches"):
-            self.thread_local.ml_caches = set()
-        self.thread_local.ml_caches.add(cache_id)
+        self.ml_caches.add(cache_id)
 
     def remove_ml_cache(self, cache_id: str) -> None:
-        if hasattr(self.thread_local, "ml_caches"):
-            if cache_id in self.thread_local.ml_caches:
-                deleted = self._delete_ml_cache([cache_id])
-                for obj_id in deleted:
-                    self.thread_local.ml_caches.remove(obj_id)
+        if cache_id in self.ml_caches:
+            deleted = self._delete_ml_cache([cache_id])
+            for obj_id in deleted:
+                self.ml_caches.remove(obj_id)
 
     def _delete_ml_cache(self, cache_ids: List[str]) -> List[str]:
         # try best to delete the cache
@@ -2008,24 +2006,21 @@ class SparkConnectClient(object):
             return []
 
     def _cleanup_ml_cache(self) -> None:
-        if hasattr(self.thread_local, "ml_caches"):
-            try:
-                command = pb2.Command()
-                command.ml_command.clean_cache.SetInParent()
-                self.execute_command(command)
-                self.thread_local.ml_caches.clear()
-            except Exception:
-                pass
+        try:
+            command = pb2.Command()
+            command.ml_command.clean_cache.SetInParent()
+            self.execute_command(command)
+            self.ml_caches.clear()
+        except Exception:
+            pass
 
     def _get_ml_cache_info(self) -> List[str]:
-        if hasattr(self.thread_local, "ml_caches"):
-            command = pb2.Command()
-            command.ml_command.get_cache_info.SetInParent()
-            (_, properties, _) = self.execute_command(command)
+        command = pb2.Command()
+        command.ml_command.get_cache_info.SetInParent()
+        (_, properties, _) = self.execute_command(command)
 
-            assert properties is not None
+        assert properties is not None
 
-            if properties is not None and "ml_command_result" in properties:
-                ml_command_result = properties["ml_command_result"]
-                return [item.string for item in ml_command_result.param.array.elements]
-        return []
+        if properties is not None and "ml_command_result" in properties:
+            ml_command_result = properties["ml_command_result"]
+            return [item.string for item in ml_command_result.param.array.elements]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix ML cache object python client references.

When a model is copied from client, it results in multiple client model objects refer to the same server cached model.
In this case, we need a reference count, only when reference count decreases to zero, we can release the server cached model.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bugfix.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.