### PR TITLE
[SPARK-51898][PYTHON][CONNECT][TESTS][FOLLOW-UP] Fix inconsistent exception

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -2190,18 +2190,20 @@ class DataFrame(ParentDataFrame):
         assert isinstance(checkpointed._plan, plan.CachedRemoteRelation)
         return checkpointed
 
-    def toJSON(self, use_unicode: bool = True) -> "RDD[str]":
-        raise PySparkNotImplementedError(
-            errorClass="NOT_IMPLEMENTED",
-            messageParameters={"feature": "toJSON()"},
-        )
+    if not is_remote_only():
 
-    @property
-    def rdd(self) -> "RDD[Row]":
-        raise PySparkNotImplementedError(
-            errorClass="NOT_IMPLEMENTED",
-            messageParameters={"feature": "rdd"},
-        )
+        def toJSON(self, use_unicode: bool = True) -> "RDD[str]":
+            raise PySparkNotImplementedError(
+                errorClass="NOT_IMPLEMENTED",
+                messageParameters={"feature": "toJSON()"},
+            )
+
+        @property
+        def rdd(self) -> "RDD[Row]":
+            raise PySparkNotImplementedError(
+                errorClass="NOT_IMPLEMENTED",
+                messageParameters={"feature": "rdd"},
+            )
 
     @property
     def executionInfo(self) -> Optional["ExecutionInfo"]:

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -2190,20 +2190,18 @@ class DataFrame(ParentDataFrame):
         assert isinstance(checkpointed._plan, plan.CachedRemoteRelation)
         return checkpointed
 
-    if not is_remote_only():
+    def toJSON(self, use_unicode: bool = True) -> "RDD[str]":
+        raise PySparkNotImplementedError(
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "toJSON()"},
+        )
 
-        def toJSON(self, use_unicode: bool = True) -> "RDD[str]":
-            raise PySparkNotImplementedError(
-                errorClass="NOT_IMPLEMENTED",
-                messageParameters={"feature": "toJSON()"},
-            )
-
-        @property
-        def rdd(self) -> "RDD[Row]":
-            raise PySparkNotImplementedError(
-                errorClass="NOT_IMPLEMENTED",
-                messageParameters={"feature": "rdd"},
-            )
+    @property
+    def rdd(self) -> "RDD[Row]":
+        raise PySparkNotImplementedError(
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "rdd"},
+        )
 
     @property
     def executionInfo(self) -> Optional["ExecutionInfo"]:

--- a/python/pyspark/sql/tests/connect/test_connect_error.py
+++ b/python/pyspark/sql/tests/connect/test_connect_error.py
@@ -23,6 +23,7 @@ from pyspark.sql.types import Row
 from pyspark.sql import functions as F
 from pyspark.errors import PySparkTypeError
 from pyspark.testing.connectutils import ReusedConnectTestCase
+from pyspark.util import is_remote_only
 
 
 class SparkConnectErrorTests(ReusedConnectTestCase):
@@ -165,6 +166,7 @@ class SparkConnectErrorTests(ReusedConnectTestCase):
             messageParameters={},
         )
 
+    @unittest.skipIf(is_remote_only(), "Disabled for remote only")
     def test_unsupported_functions(self):
         # SPARK-41225: Disable unsupported functions.
         df = self.spark.range(10)


### PR DESCRIPTION
### What changes were proposed in this pull request?

https://github.com/apache/spark/pull/50693 enabled `SparkConnectErrorTests` in connect-only mode

`toJSON` and `rdd` throw `PySparkNotImplementedError` in connect model, but `PySparkAttributeError` in connect-only model


### Why are the changes needed?
to fix https://github.com/apache/spark/actions/runs/14649632571/job/41112060443


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
will be tested in daily builder


### Was this patch authored or co-authored using generative AI tooling?
no