### PR TITLE
[SPARK-51915][PYTHON][CONNECT][TESTS] Enable SparkConnectDataFrameDebug in connect-only mode

### DIFF
--- a/python/pyspark/sql/tests/connect/test_df_debug.py
+++ b/python/pyspark/sql/tests/connect/test_df_debug.py
@@ -17,17 +17,13 @@
 
 import unittest
 
-from pyspark.sql.tests.connect.test_connect_basic import SparkConnectSQLTestCase
-from pyspark.testing.connectutils import should_test_connect
+from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.utils import have_graphviz, graphviz_requirement_message
 
-if should_test_connect:
-    from pyspark.sql.connect.dataframe import DataFrame
 
-
-class SparkConnectDataFrameDebug(SparkConnectSQLTestCase):
+class SparkConnectDataFrameDebug(ReusedConnectTestCase):
     def test_df_debug_basics(self):
-        df: DataFrame = self.connect.range(100).repartition(10).groupBy("id").count()
+        df = self.spark.range(100).repartition(10).groupBy("id").count()
         x = df.collect()  # noqa: F841
         ei = df.executionInfo
 
@@ -35,12 +31,12 @@ class SparkConnectDataFrameDebug(SparkConnectSQLTestCase):
         self.assertIn(root, graph, "The root must be rooted in the graph")
 
     def test_df_quey_execution_empty_before_execution(self):
-        df: DataFrame = self.connect.range(100).repartition(10).groupBy("id").count()
+        df = self.spark.range(100).repartition(10).groupBy("id").count()
         ei = df.executionInfo
         self.assertIsNone(ei, "The query execution must be None before the action is executed")
 
     def test_df_query_execution_with_writes(self):
-        df: DataFrame = self.connect.range(100).repartition(10).groupBy("id").count()
+        df = self.spark.range(100).repartition(10).groupBy("id").count()
         df.write.save("/tmp/test_df_query_execution_with_writes", format="json", mode="overwrite")
         ei = df.executionInfo
         self.assertIsNotNone(
@@ -48,18 +44,18 @@ class SparkConnectDataFrameDebug(SparkConnectSQLTestCase):
         )
 
     def test_query_execution_text_format(self):
-        df: DataFrame = self.connect.range(100).repartition(10).groupBy("id").count()
+        df = self.spark.range(100).repartition(10).groupBy("id").count()
         df.collect()
         self.assertIn("HashAggregate", df.executionInfo.metrics.toText())
 
         # Different execution mode.
-        df: DataFrame = self.connect.range(100).repartition(10).groupBy("id").count()
+        df = self.spark.range(100).repartition(10).groupBy("id").count()
         df.toPandas()
         self.assertIn("HashAggregate", df.executionInfo.metrics.toText())
 
     @unittest.skipIf(not have_graphviz, graphviz_requirement_message)
     def test_df_query_execution_metrics_to_dot(self):
-        df: DataFrame = self.connect.range(100).repartition(10).groupBy("id").count()
+        df = self.spark.range(100).repartition(10).groupBy("id").count()
         x = df.collect()  # noqa: F841
         ei = df.executionInfo
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Enable SparkConnectDataFrameDebug in connect-only mode


### Why are the changes needed?
to improve test coverage


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
no
