### PR TITLE
[SPARK-51914][SQL] Add com.mysql.cj to spark.sql.hive.metastore.sharedPrefixes

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -195,7 +195,7 @@ private[spark] object HiveUtils extends Logging {
     .createWithDefault(jdbcPrefixes)
 
   private def jdbcPrefixes = Seq(
-    "com.mysql.jdbc", "org.postgresql", "com.microsoft.sqlserver", "oracle.jdbc")
+    "com.mysql.jdbc", "com.mysql.cj", "org.postgresql", "com.microsoft.sqlserver", "oracle.jdbc")
 
   val HIVE_METASTORE_BARRIER_PREFIXES = buildStaticConf("spark.sql.hive.metastore.barrierPrefixes")
     .doc("A comma separated list of class prefixes that should explicitly be reloaded for each " +


### PR DESCRIPTION


### What changes were proposed in this pull request?
This PR adds `com.mysql.cj` to `spark.sql.hive.metastore.sharedPrefixes`


### Why are the changes needed?

Following upstream changes https://github.com/mysql/mysql-connector-j


### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?

existing tests

### Was this patch authored or co-authored using generative AI tooling?
no
