### PR TITLE
[SPARK-51710][PYTHON] Passing an empty array to PySpark Dataframe.dropDuplicates should behave the same as passing no arguments

### DIFF
--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1171,7 +1171,7 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                 messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
             )
 
-        if not subset:
+        if subset is None or len(subset) == 0:
             jdf = self._jdf.dropDuplicates()
         else:
             for c in subset:
@@ -1190,7 +1190,7 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                 messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
             )
 
-        if not subset:
+        if subset is None or len(subset) == 0:
             jdf = self._jdf.dropDuplicatesWithinWatermark()
         else:
             for c in subset:

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1171,7 +1171,7 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                 messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
             )
 
-        if subset is None:
+        if not subset:
             jdf = self._jdf.dropDuplicates()
         else:
             for c in subset:
@@ -1190,7 +1190,7 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                 messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
             )
 
-        if subset is None:
+        if not subset:
             jdf = self._jdf.dropDuplicatesWithinWatermark()
         else:
             for c in subset:

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -276,6 +276,8 @@ class DataFrameTestsMixin:
         # shouldn't drop a non-null row
         self.assertEqual(df.dropDuplicates().count(), 2)
 
+        self.assertEqual(df.dropDuplicates([]).count(), 2)
+
         self.assertEqual(df.dropDuplicates(["name"]).count(), 1)
 
         self.assertEqual(df.dropDuplicates(["name", "age"]).count(), 2)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR aligns the behavior of `DataFrame.dropDuplicates([])` to be the same as `DataFrame.dropDuplicates()`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When using PySpark `DataFrame.dropDuplicates` with an empty array as the `subset` argument, the resulting `DataFrame` contains a single row (the first row). This behavior is different than using `DataFrame.dropDuplicates` without any parameters or with None as the `subset` argument. I would expect that passing an empty array to `dropDuplicates` would use all the columns to detect duplicates and remove them.

```
from pyspark.sql import SparkSession
 
spark = SparkSession.builder.getOrCreate()
data = [
    (1, "Alice"),
    (2, "Bob"),
    (3, "Alice"),
    (3, "Alice"),
    (2, "Bob")
]
df = spark.createDataFrame(data, ["id", "name"])

df_dedup = df.dropDuplicates([])

df_dedup.show()
```
The above snippet will show the following DataFrame:
```
+---+-----+
| id| name|
+---+-----+
|  1|Alice|
+---+-----+ 
```
I would expect the behavior to be the same as df.dropDuplicates() which returns:
```
+---+-----+
| id| name|
+---+-----+
|  1|Alice|
|  2|  Bob|
|  3|Alice|
+---+-----+ 
```
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
An assertion was added to `python/pyspark/sql/tests/test_dataframe.py`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
