### PR TITLE
[SPARK-51920][SS][PYTHON] Fix composite/nested StructType in value state for python

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
@@ -68,6 +68,7 @@ from pyspark.sql.tests.pandas.helper.helper_pandas_transform_with_state import (
     ReorderedFieldsProcessorFactory,
     UpcastProcessorFactory,
     MinEventTimeStatefulProcessorFactory,
+    StatefulProcessorCompositeTypeFactory
 )
 
 
@@ -138,6 +139,12 @@ class TransformWithStateTestsMixin:
         timeMode="None",
         checkpoint_path=None,
         initial_state=None,
+        output_schema=StructType(
+            [
+                StructField("id", StringType(), True),
+                StructField("countAsString", StringType(), True),
+            ]
+        ),
     ):
         input_path = tempfile.mkdtemp()
         if checkpoint_path is None:
@@ -152,13 +159,6 @@ class TransformWithStateTestsMixin:
         for q in self.spark.streams.active:
             q.stop()
         self.assertTrue(df.isStreaming)
-
-        output_schema = StructType(
-            [
-                StructField("id", StringType(), True),
-                StructField("countAsString", StringType(), True),
-            ]
-        )
 
         stateful_processor = self.get_processor(stateful_processor_factory)
         if self.use_pandas():
@@ -1478,6 +1478,31 @@ class TransformWithStateTestsMixin:
             checkpoint_path=new_checkpoint_path,
             initial_state=init_df,
         )
+
+    def test_transform_with_state_in_pandas_composite_type(self):
+        def check_results(batch_df, batch_id):
+            if batch_id == 0:
+                map_val = {'key1': [1], 'key2': [10]}
+                assert set(batch_df.sort("id").collect()) == {
+                    Row(id="0", value_arr="0", list_state_arr="0", map_state_arr=str(map_val)),
+                    Row(id="1", value_arr="0", list_state_arr="0", map_state_arr=str(map_val)),
+                }, f"batch id: {batch_id}, real df is: {batch_df.collect()}"
+            else:
+                map_val_0 = {'key1': [1], 'key2': [10], ('0',): [669]}
+                map_val_1 = {'key1': [1], 'key2': [10], ('1',): [252]}
+                assert set(batch_df.sort("id").collect()) == {
+                    Row(id="0", countAsString="669", list_state_arr="0,669", map_state_arr=str(map_val_0)),
+                    Row(id="1", countAsString="252", list_state_arr="0,252", map_state_arr=str(map_val_1)),
+                }, f"batch id: {batch_id}, real df is: {batch_df.collect()}"
+        output_schema = StructType([
+            StructField("id", StringType(), True),
+            StructField("value_arr", StringType(), True),
+            StructField("list_state_arr", StringType(), True),
+            StructField("map_state_arr", StringType(), True),
+        ])
+
+        self._test_transform_with_state_basic(StatefulProcessorCompositeTypeFactory(), check_results,
+                                              output_schema=output_schema)
 
     # run the same test suites again but with single shuffle partition
     def test_transform_with_state_with_timers_single_partition(self):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix a bug in TransformWithStateInPandas in Python. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, all user provided state values are calling `_serialize_to_bytes` underneath to transmit user input object from state client to JVM. On Python worker, the user input state object is first serialized into Row type, and the pickler serialized the Row into Arrow Batch compatible format.
Issues happen if the user input schema for state schema contains composite type like ArrayType and MapType. `_serialize_to_bytes` is not able to parse StructType and serialize it into Row properly. This fix aims to fix `_serialize_to_bytes` so that it can handle recursive & composite user input types.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No