### PR TITLE
[SPARK-51924][BUILD] Upgrade jupiter-interface to 0.14.0 and Junit5 to 5.12.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,13 +218,13 @@
     <netty.version>4.1.119.Final</netty.version>
     <netty-tcnative.version>2.0.70.Final</netty-tcnative.version>
     <icu4j.version>76.1</icu4j.version>
-    <junit-jupiter.version>5.11.4</junit-jupiter.version>
-    <junit-platform.version>1.11.4</junit-platform.version>
+    <junit-jupiter.version>5.12.2</junit-jupiter.version>
+    <junit-platform.version>1.12.2</junit-platform.version>
     <!--
       SPARK-50299: When updating `sbt-jupiter-interface.version`,
       also need to update the version in `SparkBuild.scala` and `plugins.sbt`.
     -->
-    <sbt-jupiter-interface.version>0.13.3</sbt-jupiter-interface.version>
+    <sbt-jupiter-interface.version>0.14.0</sbt-jupiter-interface.version>
     <!--
     If you are changing Arrow version specification, please check
     ./python/pyspark/sql/pandas/utils.py, ./python/packaging/classic/setup.py,

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1715,7 +1715,7 @@ object TestSettings {
     (Test / testOptions) += Tests.Argument(TestFrameworks.ScalaTest, "-W", "120", "300"),
     (Test / testOptions) += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
     // Enable Junit testing.
-    libraryDependencies += "com.github.sbt.junit" % "jupiter-interface" % "0.13.3" % "test",
+    libraryDependencies += "com.github.sbt.junit" % "jupiter-interface" % "0.14.0" % "test",
     // `parallelExecutionInTest` controls whether test suites belonging to the same SBT project
     // can run in parallel with one another. It does NOT control whether tests execute in parallel
     // within the same JVM (which is controlled by `testForkedParallel`) or whether test cases

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -41,6 +41,6 @@ addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
 
 addSbtPlugin("com.github.sbt" % "sbt-pom-reader" % "2.4.0")
 
-addSbtPlugin("com.github.sbt.junit" % "sbt-jupiter-interface" % "0.13.3")
+addSbtPlugin("com.github.sbt.junit" % "sbt-jupiter-interface" % "0.14.0")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.7")


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade `jupiter-interface` from 0.13.3 to 0.14.0 and Junit5 to the latest version（Platform 1.12.2 + Jupiter 5.12.2）.

### Why are the changes needed?
The full release notes of `jupiter-interface` as follows:

- https://github.com/sbt/sbt-jupiter-interface/releases/tag/v0.14.0

and the full release notes between Junit 5.11.4 to 5.12.2 as follows:

- https://junit.org/junit5/docs/5.12.2/release-notes/#release-notes-5.12.2


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
