### PR TITLE
[SPARK-51925][CONNECT][TESTS] Fix the erroneous `assume` in the `ClassFinderSuite`

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/ClassFinderSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/ClassFinderSuite.scala
@@ -28,16 +28,15 @@ class ClassFinderSuite extends ConnectFunSuite {
   private val classResourcePath = commonResourcePath.resolve("artifact-tests")
 
   test("REPLClassDirMonitor functionality test") {
+    val requiredClasses = Seq("Hello.class", "smallClassFile.class", "smallClassFileDup.class")
+    requiredClasses.foreach(className =>
+      assume(classResourcePath.resolve(className).toFile.exists))
     val copyDir = SparkFileUtils.createTempDir().toPath
     FileUtils.copyDirectory(classResourcePath.toFile, copyDir.toFile)
     val monitor = new REPLClassDirMonitor(copyDir.toAbsolutePath.toString)
 
     def checkClasses(monitor: REPLClassDirMonitor, additionalClasses: Seq[String] = Nil): Unit = {
-      val expectedClassFiles = (Seq(
-        "Hello.class",
-        "smallClassFile.class",
-        "smallClassFileDup.class") ++ additionalClasses).map(name => Paths.get(name))
-      expectedClassFiles.foreach(p => assume(p.toFile.exists))
+      val expectedClassFiles = (requiredClasses ++ additionalClasses).map(name => Paths.get(name))
 
       val foundArtifacts = monitor.findClasses().toSeq
       assert(expectedClassFiles.forall { classPath =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr fixes an incorrect `assume` behavior in the `ClassFinderSuite` test suite, which was introduced in SPARK-51623. 

The issue stems from the fact that the `expectedClassFiles` list contained file paths without their parent directories. Consequently, the assertion added in SPARK-51623 

https://github.com/apache/spark/blob/b634978936499f58f8cb2e8ea16339feb02ffb52/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/ClassFinderSuite.scala#L40

would always evaluate to `false`, causing the test case to be permanently marked as `CANCELED`.  

We can observe relevant test cases in the GA testing phase, for example:

- https://github.com/apache/spark/actions/runs/14675551942/job/41191081107


![image](https://github.com/user-attachments/assets/15d37903-63b7-41a0-a628-2379f8385623)


Therefore, we should modify the check to `assume` whether the pre-defined class files exist within the source directory (`classResourcePath`).


### Why are the changes needed?
Fix the `erroneous` assume in the `ClassFinderSuite`.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Acitons
- Locally test

```
build/sbt clean "connect-client-jvm/testOnly org.apache.spark.sql.connect.client.ClassFinderSuite"
```

**Before**

```
[info] ClassFinderSuite:
[info] - REPLClassDirMonitor functionality test !!! CANCELED !!! (202 milliseconds)
[info]   p.toFile().exists() was false (ClassFinderSuite.scala:40)
[info]   org.scalatest.exceptions.TestCanceledException:
[info]   at org.scalatest.Assertions.newTestCanceledException(Assertions.scala:475)
[info]   at org.scalatest.Assertions.newTestCanceledException$(Assertions.scala:474)
[info]   at org.scalatest.Assertions$.newTestCanceledException(Assertions.scala:1231)
[info]   at org.scalatest.Assertions$AssertionsHelper.macroAssume(Assertions.scala:1310)
[info]   at org.apache.spark.sql.connect.client.ClassFinderSuite.$anonfun$new$3(ClassFinderSuite.scala:40)
[info]   at scala.collection.immutable.List.foreach(List.scala:334)
[info]   at org.apache.spark.sql.connect.client.ClassFinderSuite.checkClasses$1(ClassFinderSuite.scala:40)
[info]   at org.apache.spark.sql.connect.client.ClassFinderSuite.$anonfun$new$1(ClassFinderSuite.scala:48)
[info]   at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:22)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:20)
[info]   at org.scalatest.funsuite.AnyFunSuiteLike$$anon$1.apply(AnyFunSuiteLike.scala:226)
[info]   at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
[info]   at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
[info]   at org.scalatest.funsuite.AnyFunSuite.withFixture(AnyFunSuite.scala:1564)
[info]   at org.scalatest.funsuite.AnyFunSuiteLike.invokeWithFixture$1(AnyFunSuiteLike.scala:224)
[info]   at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$runTest$1(AnyFunSuiteLike.scala:236)
[info]   at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
[info]   at org.scalatest.funsuite.AnyFunSuiteLike.runTest(AnyFunSuiteLike.scala:236)
[info]   at org.scalatest.funsuite.AnyFunSuiteLike.runTest$(AnyFunSuiteLike.scala:218)
[info]   at org.scalatest.funsuite.AnyFunSuite.runTest(AnyFunSuite.scala:1564)
[info]   at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$runTests$1(AnyFunSuiteLike.scala:269)
[info]   at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:413)
[info]   at scala.collection.immutable.List.foreach(List.scala:334)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
[info]   at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:396)
[info]   at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
[info]   at org.scalatest.funsuite.AnyFunSuiteLike.runTests(AnyFunSuiteLike.scala:269)
[info]   at org.scalatest.funsuite.AnyFunSuiteLike.runTests$(AnyFunSuiteLike.scala:268)
[info]   at org.scalatest.funsuite.AnyFunSuite.runTests(AnyFunSuite.scala:1564)
[info]   at org.scalatest.Suite.run(Suite.scala:1114)
[info]   at org.scalatest.Suite.run$(Suite.scala:1096)
[info]   at org.scalatest.funsuite.AnyFunSuite.org$scalatest$funsuite$AnyFunSuiteLike$$super$run(AnyFunSuite.scala:1564)
[info]   at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$run$1(AnyFunSuiteLike.scala:273)
[info]   at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
[info]   at org.scalatest.funsuite.AnyFunSuiteLike.run(AnyFunSuiteLike.scala:273)
[info]   at org.scalatest.funsuite.AnyFunSuiteLike.run$(AnyFunSuiteLike.scala:272)
[info]   at org.scalatest.funsuite.AnyFunSuite.run(AnyFunSuite.scala:1564)
[info]   at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:321)
[info]   at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:517)
[info]   at sbt.ForkMain$Run.lambda$runTest$1(ForkMain.java:414)
[info]   at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[info]   at java.base/java.lang.Thread.run(Thread.java:840)
[info] Run completed in 628 milliseconds.
[info] Total number of tests run: 0
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 0, failed 0, canceled 1, ignored 0, pending 0
[info] No tests were executed.

```

**After**

```
[info] ClassFinderSuite:
[info] - REPLClassDirMonitor functionality test (169 milliseconds)
[info] Run completed in 530 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```

Manually delete `Hello.class`, `smallClassFile.class` and `smallClassFileDup.class`, then proceed with the test, the test will be skipped.





### Was this patch authored or co-authored using generative AI tooling?
No