### PR TITLE
[Python] (PySpark) Support for subclasses in type_verifier

### DIFF
--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -2701,46 +2701,61 @@ class DataTypeVerificationTests(unittest.TestCase, PySparkErrorTestUtils):
 
 
 class ExtendedDataTypeVerificationTests(unittest.TestCase, PySparkErrorTestUtils):
-    class _ExtendedBooleanType(BooleanType): ...
+    class _ExtendedBooleanType(BooleanType):
+        ...
 
-    class _ExtendedByteType(ByteType): ...
+    class _ExtendedByteType(ByteType):
+        ...
 
-    class _ExtendedShortType(ShortType): ...
+    class _ExtendedShortType(ShortType):
+        ...
 
-    class _ExtendedIntegerType(IntegerType): ...
+    class _ExtendedIntegerType(IntegerType):
+        ...
 
-    class _ExtendedLongType(LongType): ...
+    class _ExtendedLongType(LongType):
+        ...
 
-    class _ExtendedFloatType(FloatType): ...
+    class _ExtendedFloatType(FloatType):
+        ...
 
-    class _ExtendedDoubleType(DoubleType): ...
+    class _ExtendedDoubleType(DoubleType):
+        ...
 
-    class _ExtendedDecimalType(DecimalType): ...
+    class _ExtendedDecimalType(DecimalType):
+        ...
 
-    class _ExtendedStringType(StringType): ...
+    class _ExtendedStringType(StringType):
+        ...
 
-    class _ExtendedCharType(CharType): ...
+    class _ExtendedCharType(CharType):
+        ...
 
-    class _ExtendedVarcharType(VarcharType): ...
+    class _ExtendedVarcharType(VarcharType):
+        ...
 
-    class _ExtendedBinaryType(BinaryType): ...
+    class _ExtendedBinaryType(BinaryType):
+        ...
 
-    class _ExtendedDateType(DateType): ...
+    class _ExtendedDateType(DateType):
+        ...
 
-    class _ExtendedTimestampType(TimestampType): ...
+    class _ExtendedTimestampType(TimestampType):
+        ...
 
-    class _ExtendedArrayType(ArrayType): ...
+    class _ExtendedArrayType(ArrayType):
+        ...
 
-    class _ExtendedMapType(MapType): ...
+    class _ExtendedMapType(MapType):
+        ...
 
-    class _ExtendedStructType(StructType): ...
+    class _ExtendedStructType(StructType):
+        ...
 
     def test_verify_type_exception_msg(self):
         # tests similar to DataTypeVerificationTests.test_verify_type_exception_msg
         with self.assertRaises(PySparkValueError) as pe:
-            _make_type_verifier(
-                self._ExtendedStringType(), nullable=False, name="test_name"
-            )(None)
+            _make_type_verifier(self._ExtendedStringType(), nullable=False, name="test_name")(None)
 
         self.check_error(
             exception=pe.exception,
@@ -2865,15 +2880,11 @@ class ExtendedDataTypeVerificationTests(unittest.TestCase, PySparkErrorTestUtils
             # Map
             (
                 {},
-                self._ExtendedMapType(
-                    self._ExtendedStringType(), self._ExtendedIntegerType()
-                ),
+                self._ExtendedMapType(self._ExtendedStringType(), self._ExtendedIntegerType()),
             ),
             (
                 {"a": 1},
-                self._ExtendedMapType(
-                    self._ExtendedStringType(), self._ExtendedIntegerType()
-                ),
+                self._ExtendedMapType(self._ExtendedStringType(), self._ExtendedIntegerType()),
             ),
             (
                 {"a": None},
@@ -2946,16 +2957,12 @@ class ExtendedDataTypeVerificationTests(unittest.TestCase, PySparkErrorTestUtils
             # Map
             (
                 {"a": 1},
-                self._ExtendedMapType(
-                    self._ExtendedIntegerType(), self._ExtendedIntegerType()
-                ),
+                self._ExtendedMapType(self._ExtendedIntegerType(), self._ExtendedIntegerType()),
                 TypeError,
             ),
             (
                 {"a": "1"},
-                self._ExtendedMapType(
-                    self._ExtendedStringType(), self._ExtendedIntegerType()
-                ),
+                self._ExtendedMapType(self._ExtendedStringType(), self._ExtendedIntegerType()),
                 TypeError,
             ),
             (

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -2736,6 +2736,7 @@ class ExtendedDataTypeVerificationTests(unittest.TestCase, PySparkErrorTestUtils
     class _ExtendedStructType(StructType): ...
 
     def test_verify_type_exception_msg(self):
+        # tests similar to DataTypeVerificationTests.test_verify_type_exception_msg
         with self.assertRaises(PySparkValueError) as pe:
             _make_type_verifier(
                 self._ExtendedStringType(), nullable=False, name="test_name"
@@ -2752,9 +2753,7 @@ class ExtendedDataTypeVerificationTests(unittest.TestCase, PySparkErrorTestUtils
         schema = self._ExtendedStructType(
             [
                 StructField(
-                    "a", self._ExtendedStructType(
-                        [StructField("b", self._ExtendedIntegerType())]
-                    )
+                    "a", self._ExtendedStructType([StructField("b", self._ExtendedIntegerType())])
                 )
             ]
         )
@@ -2773,6 +2772,7 @@ class ExtendedDataTypeVerificationTests(unittest.TestCase, PySparkErrorTestUtils
         )
 
     def test_verify_type_ok_nullable(self):
+        # tests similar to DataTypeVerificationTests.test_verify_type_ok_nullable
         obj = None
         types = [
             self._ExtendedIntegerType(),
@@ -2787,7 +2787,7 @@ class ExtendedDataTypeVerificationTests(unittest.TestCase, PySparkErrorTestUtils
                 self.fail("verify_type(%s, %s, nullable=True)" % (obj, data_type))
 
     def test_verify_type_not_nullable(self):
-        # tests from test_verify_type_not_nullable
+        # tests similar to DataTypeVerificationTests.test_verify_type_not_nullable
         import array
         import datetime
         import decimal

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2706,7 +2706,7 @@ def _make_type_verifier(
             "unknown datatype: %s for object %r" % (dataType, obj)
         )
 
-    def _get_supported_types():
+    def _get_supported_types() -> Tuple[Any, ...]:
         for _type, data_types in _acceptable_types.items():
             if isinstance(dataType, _type):
                 return data_types

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2706,15 +2706,15 @@ def _make_type_verifier(
             "unknown datatype: %s for object %r" % (dataType, obj)
         )
 
-    def _get_acceptable_type():
-        for _type, obj in _acceptable_types.items():
+    def _get_supported_data_types():
+        for _type, data_types in _acceptable_types.items():
             if isinstance(dataType, _type):
-                return obj
+                return data_types
         raise PySparkTypeError("unknown datatype: %s" % dataType)
 
     def verify_acceptable_types(obj: Any) -> None:
         # subclass of them can not be fromInternal in JVM
-        if type(obj) not in _get_acceptable_type():
+        if type(obj) not in _get_supported_data_types():
             if name is not None:
                 raise PySparkTypeError(
                     errorClass="FIELD_DATA_TYPE_UNACCEPTABLE_WITH_NAME",

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2701,16 +2701,20 @@ def _make_type_verifier(
         else:
             return False
 
-    _type = type(dataType)
-
     def assert_acceptable_types(obj: Any) -> None:
-        assert _type in _acceptable_types, new_msg(
+        assert any(isinstance(dataType, _type) for _type in _acceptable_types), new_msg(
             "unknown datatype: %s for object %r" % (dataType, obj)
         )
 
+    def _get_acceptable_type():
+        for _type, obj in _acceptable_types.items():
+            if isinstance(dataType, _type):
+                return obj
+        raise PySparkTypeError("unknown datatype: %s" % dataType)
+
     def verify_acceptable_types(obj: Any) -> None:
         # subclass of them can not be fromInternal in JVM
-        if type(obj) not in _acceptable_types[_type]:
+        if type(obj) not in _get_acceptable_type():
             if name is not None:
                 raise PySparkTypeError(
                     errorClass="FIELD_DATA_TYPE_UNACCEPTABLE_WITH_NAME",

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2706,7 +2706,7 @@ def _make_type_verifier(
             "unknown datatype: %s for object %r" % (dataType, obj)
         )
 
-    def _get_supported_data_types():
+    def _get_supported_types():
         for _type, data_types in _acceptable_types.items():
             if isinstance(dataType, _type):
                 return data_types
@@ -2714,7 +2714,7 @@ def _make_type_verifier(
 
     def verify_acceptable_types(obj: Any) -> None:
         # subclass of them can not be fromInternal in JVM
-        if type(obj) not in _get_supported_data_types():
+        if type(obj) not in _get_supported_types():
             if name is not None:
                 raise PySparkTypeError(
                     errorClass="FIELD_DATA_TYPE_UNACCEPTABLE_WITH_NAME",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Current implementation of [_type_verifier](https://github.com/apache/spark/blob/b634978936499f58f8cb2e8ea16339feb02ffb52/python/pyspark/sql/types.py#L2607) does not support classes extending the [acceptable types](https://github.com/apache/spark/blob/b634978936499f58f8cb2e8ea16339feb02ffb52/python/pyspark/sql/types.py#L2568).  Here is a small test case for same that fails in current implementation:
<details>
<summary>Sample test case that fails currently</summary>

```python
import unittest
from pyspark.sql.types import StructType, _make_type_verifier

class ExtendedStructType(StructType): ...

class SampleTest(unittest.TestCase):
    def test_extended_struct_type(self):
        schema = ExtendedStructType([])
        _make_type_verifier(schema)([])
```

<details>
<summary>Failure logs</summary>

```sh
Failure
Traceback (most recent call last):
  File ".../spark/python/pyspark/sql/tests/test_types.py", line 3016, in test_extended_struct_type
    _make_type_verifier(schema)([])
  File ".../spark/python/pyspark/sql/types.py", line 2947, in verify
    verify_value(obj)
  File ".../spark/python/pyspark/sql/types.py", line 2878, in verify_struct
    assert_acceptable_types(obj)
  File ".../spark/python/pyspark/sql/types.py", line 2707, in assert_acceptable_types
    assert _type in _acceptable_types, new_msg(
AssertionError: unknown datatype: StructType([]) for object []
```
</details>
</details>

**This is happening due to** current implementation using `type(data_type)` which does not return *StructType* for classes extending *StructType*. [(ref)](https://github.com/apache/spark/blob/b634978936499f58f8cb2e8ea16339feb02ffb52/python/pyspark/sql/types.py#L2704)

### Why are the changes needed?

**proposal:** Changing implementation to use `isinstance()` instead of `type()` 

I believe inheritance should be allowed for DataTypes as it enables users to add behavior, validations or schematic meanings to them. 

<details>
<summary>Example: my use case that is failing currently</summary>

I was trying to achieve this behavior:
```python
class Schema(StructType):
   """Some implementation allowing class attributes as fields of StructType"""

class Person(Schema):
   name = StructField("name", StringType())

person = Person()  # Equivalent to StructType([StructField("name", StringType())])

# this was failing
df = spark.createDataFrame({...}, schema=Person())
```
</details>


> If you fix a bug, you can clarify why it is a bug.

The current implementation only checks for behavior of a data type. By using `type` it restricts inheritance. It can achieve same by using `isinstance` too. IF inheritance is not desirable, then maybe types should be annotated with `@final`. But in either cases, I would consider it to be a bug.

### Does this PR introduce _any_ user-facing change?

No. This PR does not change any existing user facing behavior, but allows them to extend DataTypes if they need to.

### How was this patch tested?

There are already few unit tests for `_make_type_verifier` [(here)](https://github.com/apache/spark/blob/b634978936499f58f8cb2e8ea16339feb02ffb52/python/pyspark/sql/tests/test_types.py#L2488) that test against the direct supported data types. Created a copy of those tests and instead of using the direct types, checked against extended datatypes. 

### Was this patch authored or co-authored using generative AI tooling?
No.
