### PR TITLE
[SPARK-51929][BUILD] Upgrade AWS SDK v2 to 2.29.52

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -31,7 +31,7 @@ bcprov-jdk18on/1.80//bcprov-jdk18on-1.80.jar
 blas/3.0.3//blas-3.0.3.jar
 breeze-macros_2.13/2.1.0//breeze-macros_2.13-2.1.0.jar
 breeze_2.13/2.1.0//breeze_2.13-2.1.0.jar
-bundle/2.25.53//bundle-2.25.53.jar
+bundle/2.29.52//bundle-2.29.52.jar
 cats-kernel_2.13/2.8.0//cats-kernel_2.13-2.8.0.jar
 checker-qual/3.43.0//checker-qual-3.43.0.jar
 chill-java/0.10.0//chill-java-0.10.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
     <aws.kinesis.client.version>1.12.0</aws.kinesis.client.version>
     <!-- Should be consistent with Kinesis client dependency -->
     <aws.java.sdk.version>1.11.655</aws.java.sdk.version>
-    <aws.java.sdk.v2.version>2.25.53</aws.java.sdk.v2.version>
+    <aws.java.sdk.v2.version>2.29.52</aws.java.sdk.v2.version>
     <!-- the producer is used in tests -->
     <aws.kinesis.producer.version>0.12.8</aws.kinesis.producer.version>
     <!-- Do not use 3.0.0: https://github.com/GoogleCloudDataproc/hadoop-connectors/issues/1114 -->


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade AWS SDK v2 to 2.29.52.

### Why are the changes needed?

Like [Apache Iceberg v1.8.1](https://iceberg.apache.org/releases/#181-release) and Apache Hadoop 3.4.2 (HADOOP-19485), Apache Spark 4.1.0 had better use the latest one.
- https://github.com/apache/hadoop/pull/7479
- https://github.com/apache/iceberg/pull/12339

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.