### PR TITLE
[SPARK-51930][BUILD] Upgrade datasketches-java to 6.2.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -57,7 +57,7 @@ curator-recipes/5.7.1//curator-recipes-5.7.1.jar
 datanucleus-api-jdo/4.2.4//datanucleus-api-jdo-4.2.4.jar
 datanucleus-core/4.1.17//datanucleus-core-4.1.17.jar
 datanucleus-rdbms/4.1.19//datanucleus-rdbms-4.1.19.jar
-datasketches-java/6.1.1//datasketches-java-6.1.1.jar
+datasketches-java/6.2.0//datasketches-java-6.2.0.jar
 datasketches-memory/3.0.2//datasketches-memory-3.0.2.jar
 derby/10.16.1.1//derby-10.16.1.1.jar
 derbyshared/10.16.1.1//derbyshared-10.16.1.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
     <commons-cli.version>1.9.0</commons-cli.version>
     <bouncycastle.version>1.80</bouncycastle.version>
     <tink.version>1.16.0</tink.version>
-    <datasketches.version>6.1.1</datasketches.version>
+    <datasketches.version>6.2.0</datasketches.version>
     <netty.version>4.1.119.Final</netty.version>
     <netty-tcnative.version>2.0.70.Final</netty-tcnative.version>
     <icu4j.version>76.1</icu4j.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade `datasketches-java` from 6.1.1 to 6.2.0.

### Why are the changes needed?
Based on the release notes, this version fixes a bug that was discovered in the Theta compression algorithm.
- https://github.com/apache/datasketches-java/releases/tag/6.2.0

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No