### PR TITLE
[SPARK-51827][PYTHON][CONNECT][FOLLOWUP] Fix incorrect `PythonEvalType` reference in `python/pyspark/sql/connect/group.py`

### DIFF
--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -434,7 +434,7 @@ class GroupedData:
             udf_obj = UserDefinedFunction(
                 udf_util.transformWithStateUDF,
                 returnType=outputStructType,
-                evalType=PythonEvalType.SQL_TRANSFORM_WITH_STATE_UDF,
+                evalType=PythonEvalType.SQL_TRANSFORM_WITH_STATE_PYTHON_ROW_UDF,
             )
             initial_state_plan = None
             initial_state_grouping_cols = None
@@ -443,7 +443,7 @@ class GroupedData:
             udf_obj = UserDefinedFunction(
                 udf_util.transformWithStateWithInitStateUDF,
                 returnType=outputStructType,
-                evalType=PythonEvalType.SQL_TRANSFORM_WITH_STATE_INIT_STATE_UDF,
+                evalType=PythonEvalType.SQL_TRANSFORM_WITH_STATE_PYTHON_ROW_INIT_STATE_UDF,
             )
             initial_state_plan = initialState._df._plan
             initial_state_grouping_cols = initialState._grouping_cols


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pull request revises the usage of `PythonEvalType` in https://github.com/apache/spark/pull/50704 by referencing the modifications made in https://github.com/apache/spark/pull/50728, as follows:

1. Renames `PythonEvalType.SQL_TRANSFORM_WITH_STATE_UDF` to `PythonEvalType.SQL_TRANSFORM_WITH_STATE_PYTHON_ROW_UDF`.
2. Renames `PythonEvalType.SQL_TRANSFORM_WITH_STATE_INIT_STATE_UDF` to `PythonEvalType.SQL_TRANSFORM_WITH_STATE_PYTHON_ROW_INIT_STATE_UDF`.

This issue appears to stem from a code synchronization problem caused by the merging order of https://github.com/apache/spark/pull/50728 and https://github.com/apache/spark/pull/50704. 

### Why are the changes needed?
Fix incorrect PythonEvalType reference in `python/pyspark/sql/connect/group.py` and restore  master GA

- https://github.com/apache/spark/actions/runs/14689575181/job/41222899818

![image](https://github.com/user-attachments/assets/c15fc85d-4f25-4aab-835d-503fe222bedf)

- https://github.com/apache/spark/actions/runs/14689575181/job/41222900672

![image](https://github.com/user-attachments/assets/125b3aca-94e7-4d81-a6dc-945496b93bce)



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No