### PR TITLE
[SPARK-51931][SQL] Add maxBytesPerOutputBatch to limit the number of bytes of Arrow output batch

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_map.py
@@ -246,12 +246,20 @@ class MapInArrowWithArrowBatchSlicingTestsAndReducedBatchSizeTests(MapInArrowTes
         cls.spark.conf.set("spark.sql.execution.arrow.maxBytesPerBatch", "10")
 
 
-class MapInArrowWithOutputArrowBatchSlicingTests(MapInArrowTests):
+class MapInArrowWithOutputArrowBatchSlicingRecordsTests(MapInArrowTests):
     @classmethod
     def setUpClass(cls):
         MapInArrowTests.setUpClass()
         cls.spark.conf.set("spark.sql.execution.arrow.maxRecordsPerBatch", "10")
         cls.spark.conf.set("spark.sql.execution.arrow.maxRecordsPerOutputBatch", "3")
+
+
+class MapInArrowWithOutputArrowBatchSlicingBytesTests(MapInArrowTests):
+    @classmethod
+    def setUpClass(cls):
+        MapInArrowTests.setUpClass()
+        cls.spark.conf.set("spark.sql.execution.arrow.maxRecordsPerBatch", "10")
+        cls.spark.conf.set("spark.sql.execution.arrow.maxBytesPerOutputBatch", "3")
 
 
 if __name__ == "__main__":

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3533,6 +3533,25 @@ object SQLConf {
       .intConf
       .createWithDefault(-1)
 
+  val ARROW_EXECUTION_MAX_BYTES_PER_OUTPUT_BATCH =
+    buildConf("spark.sql.execution.arrow.maxBytesPerOutputBatch")
+      .doc("When using Apache Arrow, limit the maximum bytes that can be output " +
+        "in a single ArrowRecordBatch to the downstream operator. If set to zero or negative " +
+        "there is no limit. Note that the complete ArrowRecordBatch is actually created but " +
+        "the number of bytes is limited when sending it to the downstream operator. This is " +
+        "used to avoid large batches being sent to the downstream operator including " +
+        "the columnar-based operator implemented by third-party libraries. Spark will try to " +
+        "create batches with the size equal or less than this value. Normally it should not " +
+        "happen, but if in extreme case that even one record is still larger than this value, " +
+        "Spark will create a batch with one record.")
+      .version("4.1.0")
+      .internal()
+      .bytesConf(ByteUnit.BYTE)
+      .checkValue(x => x <= Int.MaxValue,
+        errorMsg = "The value of " +
+          "spark.sql.execution.arrow.maxBytesPerOutputBatch should be less than INT_MAX.")
+      .createWithDefault(-1)
+
   val ARROW_EXECUTION_MAX_BYTES_PER_BATCH =
     buildConf("spark.sql.execution.arrow.maxBytesPerBatch")
       .internal()
@@ -6532,6 +6551,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def arrowMaxRecordsPerBatch: Int = getConf(ARROW_EXECUTION_MAX_RECORDS_PER_BATCH)
 
   def arrowMaxRecordsPerOutputBatch: Int = getConf(ARROW_EXECUTION_MAX_RECORDS_PER_OUTPUT_BATCH)
+
+  def arrowMaxBytesPerOutputBatch: Long = getConf(ARROW_EXECUTION_MAX_BYTES_PER_OUTPUT_BATCH)
 
   def arrowMaxBytesPerBatch: Long = getConf(ARROW_EXECUTION_MAX_BYTES_PER_BATCH)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonArrowOutput.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonArrowOutput.scala
@@ -255,9 +255,11 @@ class SliceBytesArrowOutputProcessorImpl(
       currentRowIdx = currentRowIdx + root.getRowCount
       root
     } else {
+      // We iteratively slice the batch by 90% until we reach a batch with required byte size.
+      // If we cannot have it even with one single row, we will output a batch with one row.
       var rootSlice = root
       val stepRatio = 0.9
-      var sliceBatchCount = ((rowCount - currentRowIdx) * stepRatio).toInt
+      var sliceBatchCount = rowCount - currentRowIdx
 
       while (sliceBatchCount > 0) {
         rootSlice = root.slice(currentRowIdx, sliceBatchCount)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonArrowOutput.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonArrowOutput.scala
@@ -46,6 +46,13 @@ private[python] trait PythonArrowOutput[OUT <: AnyRef] { self: BasePythonRunner[
 
   protected def arrowMaxRecordsPerOutputBatch: Int = SQLConf.get.arrowMaxRecordsPerOutputBatch
 
+  protected def arrowMaxBytesPerOutputBatch: Int = SQLConf.get.arrowMaxBytesPerOutputBatch.toInt
+
+  if (arrowMaxRecordsPerOutputBatch > 0 && arrowMaxBytesPerOutputBatch > 0) {
+    throw new IllegalArgumentException(
+      "Both max records and max bytes of an Arrow output batch cannot be set at the same time.")
+  }
+
   protected def newReaderIterator(
       stream: DataInputStream,
       writer: Writer,
@@ -106,8 +113,11 @@ private[python] trait PythonArrowOutput[OUT <: AnyRef] { self: BasePythonRunner[
                 schema = ArrowUtils.fromArrowSchema(root.getSchema())
 
                 if (arrowMaxRecordsPerOutputBatch > 0) {
-                  processor = new SliceArrowOutputProcessorImpl(
+                  processor = new SliceRecordsArrowOutputProcessorImpl(
                     reader, pythonMetrics, arrowMaxRecordsPerOutputBatch)
+                } else if (arrowMaxBytesPerOutputBatch > 0) {
+                  processor = new SliceBytesArrowOutputProcessorImpl(
+                    reader, pythonMetrics, arrowMaxBytesPerOutputBatch)
                 } else {
                   processor = new ArrowOutputProcessorImpl(reader, pythonMetrics)
                 }
@@ -182,15 +192,24 @@ class ArrowOutputProcessorImpl(reader: ArrowStreamReader, pythonMetrics: Map[Str
   }
 }
 
-class SliceArrowOutputProcessorImpl(
+abstract class BaseSliceArrowOutputProcessor(
     reader: ArrowStreamReader,
-    pythonMetrics: Map[String, SQLMetric],
-    arrowMaxRecordsPerOutputBatch: Int)
+    pythonMetrics: Map[String, SQLMetric])
   extends ArrowOutputProcessorImpl(reader, pythonMetrics) {
 
-  private var currentRowIdx = -1
-  private var prevRoot: VectorSchemaRoot = null
-  private var prevVectors: Array[ColumnVector] = _
+  protected var currentRowIdx = -1
+  protected var prevRoot: VectorSchemaRoot = null
+  protected var prevVectors: Array[ColumnVector] = _
+
+  override def loadBatch(): Boolean = {
+    if (rowCount > 0 && currentRowIdx < rowCount) {
+      true
+    } else {
+      val loaded = super.loadBatch()
+      currentRowIdx = 0
+      loaded
+    }
+  }
 
   override def produceBatch(): ColumnarBatch = {
     val batchRoot = getRoot
@@ -211,15 +230,72 @@ class SliceArrowOutputProcessorImpl(
     batch
   }
 
-  override def loadBatch(): Boolean = {
-    if (rowCount > 0 && currentRowIdx < rowCount) {
-      true
-    } else {
-      val loaded = super.loadBatch()
-      currentRowIdx = 0
-      loaded
+  protected override def getVectors(root: VectorSchemaRoot): Array[ColumnVector] = {
+    root.getFieldVectors.asScala.map { vector =>
+      new ArrowColumnVector(vector)
+    }.toArray[ColumnVector]
+  }
+
+  override def close(): Unit = {
+    if (prevRoot != null) {
+      prevVectors.foreach(_.close())
+      prevRoot.close()
     }
   }
+}
+
+class SliceBytesArrowOutputProcessorImpl(
+    reader: ArrowStreamReader,
+    pythonMetrics: Map[String, SQLMetric],
+    arrowMaxBytesPerOutputBatch: Int)
+  extends BaseSliceArrowOutputProcessor(reader, pythonMetrics) {
+
+  protected override def getRoot: VectorSchemaRoot = {
+    if (getBatchBytes(root) < arrowMaxBytesPerOutputBatch) {
+      currentRowIdx = currentRowIdx + root.getRowCount
+      root
+    } else {
+      var rootSlice = root
+      val stepRatio = 0.9
+      var sliceBatchCount = ((rowCount - currentRowIdx) * stepRatio).toInt
+
+      while (sliceBatchCount > 0) {
+        rootSlice = root.slice(currentRowIdx, sliceBatchCount)
+        val batchBytes = getBatchBytes(rootSlice)
+        if (batchBytes < arrowMaxBytesPerOutputBatch) {
+          currentRowIdx = currentRowIdx + rootSlice.getRowCount
+
+          return rootSlice
+        } else {
+          rootSlice.close()
+          sliceBatchCount = (sliceBatchCount * stepRatio).toInt
+        }
+      }
+      // If the batch size is still too large, we need to slice it down to a single row.
+      // Normally, this should not happen, but it is possible if the data is very large.
+      if (sliceBatchCount == 0) {
+        sliceBatchCount = 1
+      }
+      rootSlice = root.slice(currentRowIdx, sliceBatchCount)
+      currentRowIdx = currentRowIdx + rootSlice.getRowCount
+      rootSlice
+    }
+  }
+
+  private def getBatchBytes(root: VectorSchemaRoot): Int = {
+    var batchBytes = 0
+    root.getFieldVectors.asScala.foreach { vector =>
+      batchBytes += vector.getBufferSize
+    }
+    batchBytes
+  }
+}
+
+class SliceRecordsArrowOutputProcessorImpl(
+    reader: ArrowStreamReader,
+    pythonMetrics: Map[String, SQLMetric],
+    arrowMaxRecordsPerOutputBatch: Int)
+  extends BaseSliceArrowOutputProcessor(reader, pythonMetrics) {
 
   protected override def getRoot: VectorSchemaRoot = {
     val remainingRows = rowCount - currentRowIdx
@@ -232,18 +308,5 @@ class SliceArrowOutputProcessorImpl(
     currentRowIdx = currentRowIdx + rootSlice.getRowCount
 
     rootSlice
-  }
-
-  protected override def getVectors(root: VectorSchemaRoot): Array[ColumnVector] = {
-    root.getFieldVectors.asScala.map { vector =>
-      new ArrowColumnVector(vector)
-    }.toArray[ColumnVector]
-  }
-
-  override def close(): Unit = {
-    if (prevRoot != null) {
-      prevVectors.foreach(_.close())
-      prevRoot.close()
-    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch adds a new config `maxBytesPerOutputBatch` to limit the number of bytes of Arrow output batch.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

While implementing columnar-based operator for Spark, if the operator takes input from Arrow-based evaluation operator in Spark, the number of bytes of output batch is unlimited for now. For such columnar-based operator, sometimes we want to limit the maximum bytes of input batch. If we need to limit the batch size in bytes, it seems there is no existing way we can do.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No