### PR TITLE
[SPARK-51932][CONNECT][TESTS] Enable SparkConnectProgressHandlerE2E in connect-only mode

### DIFF
--- a/python/pyspark/sql/tests/connect/shell/test_progress.py
+++ b/python/pyspark/sql/tests/connect/shell/test_progress.py
@@ -23,6 +23,7 @@ from pyspark.sql.tests.connect.test_connect_basic import SparkConnectSQLTestCase
 from pyspark.testing.connectutils import (
     should_test_connect,
     connect_requirement_message,
+    ReusedConnectTestCase,
 )
 from pyspark.testing.utils import PySparkErrorTestUtils
 
@@ -105,7 +106,7 @@ class ProgressBarTest(unittest.TestCase, PySparkErrorTestUtils):
         self.assertTrue(done_called, "After finish, done should be True")
 
 
-class SparkConnectProgressHandlerE2E(SparkConnectSQLTestCase):
+class SparkConnectProgressHandlerE2E(ReusedConnectTestCase):
     def test_custom_handler_works(self):
         called = False
 
@@ -119,11 +120,11 @@ class SparkConnectProgressHandlerE2E(SparkConnectSQLTestCase):
             self.assertGreater(len(kwargs.get("operation_id")), 0)
 
         try:
-            self.connect.registerProgressHandler(handler)
-            self.connect.range(100).repartition(20).count()
+            self.spark.registerProgressHandler(handler)
+            self.spark.range(100).repartition(20).count()
             self.assertTrue(called, "Handler must have been called")
         finally:
-            self.connect.clearProgressHandlers()
+            self.spark.clearProgressHandlers()
 
     def test_progress_properly_recorded(self):
         state = {"counter": 0}
@@ -132,11 +133,11 @@ class SparkConnectProgressHandlerE2E(SparkConnectSQLTestCase):
             state["counter"] += 1
 
         try:
-            self.connect.registerProgressHandler(handler)
-            self.connect.range(10000).repartition(20).count()
+            self.spark.registerProgressHandler(handler)
+            self.spark.range(10000).repartition(20).count()
             self.assertGreaterEqual(state["counter"], 1, "Handler should be called at least once.")
         finally:
-            self.connect.clearProgressHandlers()
+            self.spark.clearProgressHandlers()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/shell/test_progress.py
+++ b/python/pyspark/sql/tests/connect/shell/test_progress.py
@@ -19,7 +19,6 @@ from io import StringIO
 import unittest
 from typing import Iterable
 
-from pyspark.sql.tests.connect.test_connect_basic import SparkConnectSQLTestCase
 from pyspark.testing.connectutils import (
     should_test_connect,
     connect_requirement_message,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
The classic session is not used in `SparkConnectProgressHandlerE2E` at all, so we can enable it in connect-only mode


### Why are the changes needed?
for test coverage


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no