### PR TITLE
[SPARK-][CORE] Expand tilde `(~)` in spark.jars.ivy path configuration

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/MavenUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/MavenUtils.scala
@@ -355,7 +355,7 @@ private[spark] object MavenUtils extends Logging {
             new File(expandedPath).getCanonicalPath()
           } catch {
             case e: IOException =>
-              logWarning(s"Could not get canonical path for expanded tilde path: $path", e)
+              logWarning(log"Could not get canonical path for expanded tilde path: ${MDC(LogKeys.PATH, path)}", e)
               System.getProperty("user.home") + subPath // Use unnormalized path as fallback
           }
         } else {
@@ -379,7 +379,7 @@ private[spark] object MavenUtils extends Logging {
       } catch {
         case e: IOException =>
           // Log warning and fall back to unnormalized path if canonical path fails
-          logWarning(s"Could not get canonical path for default Ivy path.", e)
+          logWarning(log"Could not get canonical path for default Ivy path.", e)
           System.getProperty("ivy.home",
             System.getProperty("user.home") + File.separator + ".ivy2.5.2")
       }

--- a/common/utils/src/main/scala/org/apache/spark/util/MavenUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/MavenUtils.scala
@@ -381,7 +381,7 @@ private[spark] object MavenUtils extends Logging {
           // Log warning and fall back to unnormalized path if canonical path fails
           logWarning(s"Could not get canonical path for default Ivy path.", e)
           System.getProperty("ivy.home",
-            System.getProperty("user.home") + File.separator + ".ivy2.5.2") // Use unnormalized path as fallback
+            System.getProperty("user.home") + File.separator + ".ivy2.5.2")
       }
     }
 

--- a/common/utils/src/main/scala/org/apache/spark/util/MavenUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/MavenUtils.scala
@@ -356,7 +356,8 @@ private[spark] object MavenUtils extends Logging {
           } catch {
             case e: IOException =>
               logWarning(
-                log"Could not get canonical path for expanded tilde path: ${MDC(LogKeys.PATH, path)}", 
+                log"Could not get canonical path for expanded tilde path: " +
+                log"${MDC(LogKeys.PATH, path)}",
                 e)
               System.getProperty("user.home") + subPath // Use unnormalized path as fallback
           }

--- a/common/utils/src/main/scala/org/apache/spark/util/MavenUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/MavenUtils.scala
@@ -355,7 +355,9 @@ private[spark] object MavenUtils extends Logging {
             new File(expandedPath).getCanonicalPath()
           } catch {
             case e: IOException =>
-              logWarning(log"Could not get canonical path for expanded tilde path: ${MDC(LogKeys.PATH, path)}", e)
+              logWarning(
+                log"Could not get canonical path for expanded tilde path: ${MDC(LogKeys.PATH, path)}", 
+                e)
               System.getProperty("user.home") + subPath // Use unnormalized path as fallback
           }
         } else {

--- a/common/utils/src/test/scala/org/apache/spark/util/MavenUtilsSuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/MavenUtilsSuite.scala
@@ -330,13 +330,13 @@ class MavenUtilsSuite
     val expectedTildePath = getNormalizedPath(s"$homeDir${fs}.myIvy")
     MavenUtils.processIvyPathArg(settingsTilde, Some(inputTilde))
     assert(settingsTilde.getDefaultIvyUserDir.getPath === expectedTildePath)
-    assert(settingsTilde.getDefaultCache.getPath === s"$expectedTildePath${fs}cache") // Check cache
+    assert(settingsTilde.getDefaultCache.getPath === s"$expectedTildePath${fs}cache")
 
     // --- Test with tilde alone ---
     val settingsTildeAlone = new IvySettings()
     MavenUtils.processIvyPathArg(settingsTildeAlone, Some("~"))
     assert(settingsTildeAlone.getDefaultIvyUserDir.getPath === normalizedHomeDir)
-    assert(settingsTildeAlone.getDefaultCache.getPath === s"$normalizedHomeDir${fs}cache") // Check cache
+    assert(settingsTildeAlone.getDefaultCache.getPath === s"$normalizedHomeDir${fs}cache")
 
     // --- Test with absolute path ---
     val settingsAbsolute = new IvySettings()
@@ -344,7 +344,7 @@ class MavenUtilsSuite
     MavenUtils.processIvyPathArg(settingsAbsolute, Some(inputAbsolute))
     // Absolute paths provided by user are NOT normalized by our code
     assert(settingsAbsolute.getDefaultIvyUserDir.getPath === inputAbsolute)
-    assert(settingsAbsolute.getDefaultCache.getPath === s"$inputAbsolute${fs}cache") // Check cache
+    assert(settingsAbsolute.getDefaultCache.getPath === s"$inputAbsolute${fs}cache")
 
     // --- Test with relative path ---
     val settingsRelative = new IvySettings()
@@ -353,20 +353,20 @@ class MavenUtilsSuite
     // Relative paths provided by user are NOT normalized by our code
     assert(settingsRelative.getDefaultIvyUserDir.getPath === inputRelative)
     // Note: Cache path will be relative too!
-    assert(settingsRelative.getDefaultCache.getPath === s"$inputRelative${fs}cache") // Check cache
+    assert(settingsRelative.getDefaultCache.getPath === s"$inputRelative${fs}cache")
 
     // --- Test with default (None) ---
     val settingsDefaultNone = new IvySettings()
     val expectedDefaultPath = getNormalizedPath(s"$homeDir${fs}.ivy2.5.2")
     MavenUtils.processIvyPathArg(settingsDefaultNone, None) // Use None
     assert(settingsDefaultNone.getDefaultIvyUserDir.getPath === expectedDefaultPath)
-    assert(settingsDefaultNone.getDefaultCache.getPath === s"$expectedDefaultPath${fs}cache") // Check cache
+    assert(settingsDefaultNone.getDefaultCache.getPath === s"$expectedDefaultPath${fs}cache")
 
     // --- Test with default (Empty String) ---
     val settingsDefaultEmpty = new IvySettings()
     MavenUtils.processIvyPathArg(settingsDefaultEmpty, Some("")) // Use ""
     assert(settingsDefaultEmpty.getDefaultIvyUserDir.getPath === expectedDefaultPath)
-    assert(settingsDefaultEmpty.getDefaultCache.getPath === s"$expectedDefaultPath${fs}cache") // Check cache
+    assert(settingsDefaultEmpty.getDefaultCache.getPath === s"$expectedDefaultPath${fs}cache")
   }
 
   test("SPARK-XXXX: processIvyPathArg rejects user-specific home directory expansion") {

--- a/common/utils/src/test/scala/org/apache/spark/util/MavenUtilsSuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/MavenUtilsSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.util
 
-import java.io.{File, OutputStream, PrintStream}
+import java.io.{File, IOException, OutputStream, PrintStream}
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}

--- a/common/utils/src/test/scala/org/apache/spark/util/MavenUtilsSuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/MavenUtilsSuite.scala
@@ -309,4 +309,74 @@ class MavenUtilsSuite
         s" Resolved jars are: $jarPath")
     }
   }
+
+  // Helper to get normalized path, falling back if needed (for expected values)
+  private def getNormalizedPath(pathStr: String): String = {
+    try {
+      new File(pathStr).getCanonicalPath()
+    } catch {
+      case e: IOException => pathStr // Fallback for test assertion generation
+    }
+  }
+
+  test("SPARK-XXXX: processIvyPathArg handles tilde, absolute, relative, default paths") {
+    val fs = File.separator
+    val homeDir = System.getProperty("user.home")
+    val normalizedHomeDir = getNormalizedPath(homeDir) // Normalize once for comparison
+
+    // --- Test with tilde path ---
+    val settingsTilde = new IvySettings()
+    val inputTilde = s"~${fs}.myIvy" // Use File.separator
+    val expectedTildePath = getNormalizedPath(s"$homeDir${fs}.myIvy")
+    MavenUtils.processIvyPathArg(settingsTilde, Some(inputTilde))
+    assert(settingsTilde.getDefaultIvyUserDir.getPath === expectedTildePath)
+    assert(settingsTilde.getDefaultCache.getPath === s"$expectedTildePath${fs}cache") // Check cache
+
+    // --- Test with tilde alone ---
+    val settingsTildeAlone = new IvySettings()
+    MavenUtils.processIvyPathArg(settingsTildeAlone, Some("~"))
+    assert(settingsTildeAlone.getDefaultIvyUserDir.getPath === normalizedHomeDir)
+    assert(settingsTildeAlone.getDefaultCache.getPath === s"$normalizedHomeDir${fs}cache") // Check cache
+
+    // --- Test with absolute path ---
+    val settingsAbsolute = new IvySettings()
+    val inputAbsolute = s"${fs}some${fs}absolute${fs}path" // Start with separator
+    MavenUtils.processIvyPathArg(settingsAbsolute, Some(inputAbsolute))
+    // Absolute paths provided by user are NOT normalized by our code
+    assert(settingsAbsolute.getDefaultIvyUserDir.getPath === inputAbsolute)
+    assert(settingsAbsolute.getDefaultCache.getPath === s"$inputAbsolute${fs}cache") // Check cache
+
+    // --- Test with relative path ---
+    val settingsRelative = new IvySettings()
+    val inputRelative = s"relative${fs}path"
+    MavenUtils.processIvyPathArg(settingsRelative, Some(inputRelative))
+    // Relative paths provided by user are NOT normalized by our code
+    assert(settingsRelative.getDefaultIvyUserDir.getPath === inputRelative)
+    // Note: Cache path will be relative too!
+    assert(settingsRelative.getDefaultCache.getPath === s"$inputRelative${fs}cache") // Check cache
+
+    // --- Test with default (None) ---
+    val settingsDefaultNone = new IvySettings()
+    val expectedDefaultPath = getNormalizedPath(s"$homeDir${fs}.ivy2.5.2")
+    MavenUtils.processIvyPathArg(settingsDefaultNone, None) // Use None
+    assert(settingsDefaultNone.getDefaultIvyUserDir.getPath === expectedDefaultPath)
+    assert(settingsDefaultNone.getDefaultCache.getPath === s"$expectedDefaultPath${fs}cache") // Check cache
+
+    // --- Test with default (Empty String) ---
+    val settingsDefaultEmpty = new IvySettings()
+    MavenUtils.processIvyPathArg(settingsDefaultEmpty, Some("")) // Use ""
+    assert(settingsDefaultEmpty.getDefaultIvyUserDir.getPath === expectedDefaultPath)
+    assert(settingsDefaultEmpty.getDefaultCache.getPath === s"$expectedDefaultPath${fs}cache") // Check cache
+  }
+
+  test("SPARK-XXXX: processIvyPathArg rejects user-specific home directory expansion") {
+    val settings = new IvySettings()
+    val invalidPath = "~user/path" // Path that should be rejected
+
+    val e = intercept[IllegalArgumentException] {
+      MavenUtils.processIvyPathArg(settings, Some(invalidPath))
+    }
+    assert(e.getMessage.contains("Cannot expand user-specific home directory"))
+    assert(e.getMessage.contains(invalidPath)) // Ensure path is in message
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR modifies the processIvyPathArg function to correctly handle Ivy paths specified via the spark.jars.ivy configuration property when they start with a tilde (~).

When a non-empty path is provided via spark.jars.ivy:
Check if the path string starts with ~.
If it does, check if it's exactly ~ or if the tilde is followed by a file separator (/ or \).
If these conditions are met, replace the leading ~ with the absolute path to the user's home directory obtained from the user.home system property.
Paths starting with ~ but not followed by a separator (e.g., ~otheruser) are explicitly disallowed and will throw an IllegalArgumentException, as their expansion is complex and platform-dependent.
Paths not starting with ~ are used as-is.
The resulting path (potentially expanded) is then used to set the default Ivy user directory and cache location within the IvySettings object.
This ensures that Ivy components (like FileRepository) which require absolute base directories receive a valid, expanded path instead of a literal path starting with ~.

### Why are the changes needed?

Currently, configuring Spark with spark.jars.ivy=~/.ivy2 (or similar paths starting with ~) fails at runtime. This happens because the literal path string ~/.ivy2 is passed down into the Ivy library. Ivy's FileRepository, used for managing local repositories, requires an absolute basedir path and does not perform shell-style tilde expansion, leading to an IllegalArgumentException: basedir must be absolute: ~/.ivy2/local.

Users familiar with Unix-like shell environments commonly expect ~ to represent their home directory. The current behavior is counter-intuitive and forces users to use $HOME/.ivy2 or the full absolute path instead. This is particularly relevant since the Spark 4.0 migration guide explicitly suggests using spark.jars.ivy to potentially revert to ~/.ivy2 for legacy behavior, making the current failure mode more likely to be encountered.

This PR fixes this bug by performing the tilde expansion within Spark's utility code before the path is used to configure Ivy, aligning the behavior with user expectations for tilde paths.


### Does this PR introduce _any_ user-facing change?
Yes.

Previous Behavior: Running Spark with a configuration like --conf spark.jars.ivy=~/.ivy2 would fail during initialization with an error similar to java.lang.IllegalArgumentException: basedir must be absolute: ~/.ivy2/local.

New Behavior: With this PR, running Spark with --conf spark.jars.ivy=~/.ivy2 (or ~ alone, or ~\.ivy2 on Windows) will now succeed. Spark will correctly interpret the path, expand the ~ to the user's home directory (e.g., /home/user/.ivy2), and configure Ivy to use that absolute path. Paths like --conf spark.jars.ivy=~otheruser/.ivy2 will now explicitly fail with an IllegalArgumentException stating that user-specific home directory expansion is not supported.

This change fixes a bug and makes the behavior of spark.jars.ivy more intuitive for paths starting with ~. It is a user-facing change compared to previous Spark versions where this configuration would fail.


### How was this patch tested?
Pass GA


### Was this patch authored or co-authored using generative AI tooling?
Yes. Assistance was provided by Google Gemini and Claude 3.7 in understanding the root cause, formulating the code changes, and drafting this pull request description. 