### PR TITLE
[SPARK-51940][SS] Add interface for managing streaming checkpoint metadata

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecution.scala
@@ -86,7 +86,7 @@ class AsyncProgressTrackingMicroBatchExecution(
   /**
    * Manages the metadata from this checkpoint location.
    */
-  override protected lazy val checkpointMetadata =
+  protected val asyncCheckpointMetadata =
     new AsyncStreamingQueryCheckpointMetadata(
       sparkSessionForStream,
       resolvedCheckpointRoot,
@@ -95,9 +95,9 @@ class AsyncProgressTrackingMicroBatchExecution(
       triggerClock
     )
 
-  override lazy val offsetLog: AsyncOffsetSeqLog = checkpointMetadata.offsetLog
+  override val offsetLog: AsyncOffsetSeqLog = asyncCheckpointMetadata.offsetLog
 
-  override lazy val commitLog: AsyncCommitLog = checkpointMetadata.commitLog
+  override val commitLog: AsyncCommitLog = asyncCheckpointMetadata.commitLog
 
   // perform quick validation to fail faster
   validateAndGetTrigger()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecution.scala
@@ -84,9 +84,9 @@ class AsyncProgressTrackingMicroBatchExecution(
     })
 
   /**
-   * Manages the metadata from this checkpoint location.
+   * Manages the metadata from this checkpoint location with async write operations.
    */
-  protected val asyncCheckpointMetadata =
+  private val asyncCheckpointMetadata =
     new AsyncStreamingQueryCheckpointMetadata(
       sparkSessionForStream,
       resolvedCheckpointRoot,
@@ -95,9 +95,9 @@ class AsyncProgressTrackingMicroBatchExecution(
       triggerClock
     )
 
-  override val offsetLog: AsyncOffsetSeqLog = asyncCheckpointMetadata.offsetLog
+  override lazy val offsetLog: AsyncOffsetSeqLog = asyncCheckpointMetadata.offsetLog
 
-  override val commitLog: AsyncCommitLog = asyncCheckpointMetadata.commitLog
+  override lazy val commitLog: AsyncCommitLog = asyncCheckpointMetadata.commitLog
 
   // perform quick validation to fail faster
   validateAndGetTrigger()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/AsyncStreamingQueryCheckpointMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/AsyncStreamingQueryCheckpointMetadata.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.streaming
+
+import java.util.concurrent.ThreadPoolExecutor
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.util.Clock
+
+/**
+ * A version of [[StreamingQueryCheckpointMetadata]] that supports async state checkpointing.
+ *
+ * @param sparkSession Spark session
+ * @param resolvedCheckpointRoot The resolved checkpoint root path
+ * @param asyncWritesExecutorService The executor service for async writes
+ * @param asyncProgressTrackingCheckpointingIntervalMs The interval for async progress
+ * @param triggerClock The clock to use for trigger time
+ */
+class AsyncStreamingQueryCheckpointMetadata(
+    sparkSession: SparkSession,
+    resolvedCheckpointRoot: String,
+    asyncWritesExecutorService: ThreadPoolExecutor,
+    asyncProgressTrackingCheckpointingIntervalMs: Long,
+    triggerClock: Clock)
+  extends StreamingQueryCheckpointMetadata(sparkSession, resolvedCheckpointRoot) {
+
+  override lazy val offsetLog = new AsyncOffsetSeqLog(
+    sparkSession,
+    checkpointFile(StreamingCheckpointConstants.DIR_NAME_OFFSETS),
+    asyncWritesExecutorService,
+    asyncProgressTrackingCheckpointingIntervalMs,
+    clock = triggerClock
+  )
+
+  override lazy val commitLog =
+    new AsyncCommitLog(
+      sparkSession,
+      checkpointFile(StreamingCheckpointConstants.DIR_NAME_COMMITS),
+      asyncWritesExecutorService
+    )
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/AsyncStreamingQueryCheckpointMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/AsyncStreamingQueryCheckpointMetadata.scala
@@ -46,11 +46,10 @@ class AsyncStreamingQueryCheckpointMetadata(
     clock = triggerClock
   )
 
-  override lazy val commitLog =
-    new AsyncCommitLog(
-      sparkSession,
-      checkpointFile(StreamingCheckpointConstants.DIR_NAME_COMMITS),
-      asyncWritesExecutorService
-    )
+  override lazy val commitLog = new AsyncCommitLog(
+    sparkSession,
+    checkpointFile(StreamingCheckpointConstants.DIR_NAME_COMMITS),
+    asyncWritesExecutorService
+  )
 
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -157,7 +157,7 @@ abstract class StreamExecution(
   /**
    * Manages the metadata from this checkpoint location.
    */
-  protected lazy val checkpointMetadata =
+  protected val checkpointMetadata =
     new StreamingQueryCheckpointMetadata(sparkSessionForStream, resolvedCheckpointRoot)
 
   /**
@@ -228,14 +228,14 @@ abstract class StreamExecution(
    * processing is done.  Thus, the Nth record in this log indicated data that is currently being
    * processed and the N-1th entry indicates which offsets have been durably committed to the sink.
    */
-  lazy val offsetLog: OffsetSeqLog = checkpointMetadata.offsetLog
+  val offsetLog: OffsetSeqLog = checkpointMetadata.offsetLog
 
   /**
    * A log that records the batch ids that have completed. This is used to check if a batch was
    * fully processed, and its output was committed to the sink, hence no need to process it again.
    * This is used (for instance) during restart, to help identify which batch to run next.
    */
-  lazy val commitLog: CommitLog = checkpointMetadata.commitLog
+  val commitLog: CommitLog = checkpointMetadata.commitLog
 
   /** Whether all fields of the query have been initialized */
   private def isInitialized: Boolean = state.get != INITIALIZING

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingCheckpointConstants.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingCheckpointConstants.scala
@@ -21,4 +21,5 @@ object StreamingCheckpointConstants {
   val DIR_NAME_COMMITS = "commits"
   val DIR_NAME_OFFSETS = "offsets"
   val DIR_NAME_STATE = "state"
+  val DIR_NAME_METADATA = "metadata"
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryCheckpointMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryCheckpointMetadata.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.streaming
+
+import java.util.UUID
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.SparkSession
+
+/**
+ * An interface for accessing the checkpoint metadata associated with a streaming query.
+ * @param sparkSession Spark session
+ * @param resolvedCheckpointRoot The resolved checkpoint root path
+ */
+class StreamingQueryCheckpointMetadata(sparkSession: SparkSession, resolvedCheckpointRoot: String) {
+
+  /**
+   * A write-ahead-log that records the offsets that are present in each batch. In order to ensure
+   * that a given batch will always consist of the same data, we write to this log *before* any
+   * processing is done.  Thus, the Nth record in this log indicated data that is currently being
+   * processed and the N-1th entry indicates which offsets have been durably committed to the sink.
+   */
+  lazy val offsetLog =
+    new OffsetSeqLog(sparkSession, checkpointFile(StreamingCheckpointConstants.DIR_NAME_OFFSETS))
+
+  /**
+   * A log that records the batch ids that have completed. This is used to check if a batch was
+   * fully processed, and its output was committed to the sink, hence no need to process it again.
+   * This is used (for instance) during restart, to help identify which batch to run next.
+   */
+  lazy val commitLog =
+    new CommitLog(sparkSession, checkpointFile(StreamingCheckpointConstants.DIR_NAME_COMMITS))
+
+  /** Metadata associated with the whole query */
+  lazy val streamMetadata: StreamMetadata = {
+    val metadataPath = new Path(checkpointFile(StreamingCheckpointConstants.DIR_NAME_METADATA))
+    val hadoopConf = sparkSession.sessionState.newHadoopConf()
+    StreamMetadata.read(metadataPath, hadoopConf).getOrElse {
+      val newMetadata = new StreamMetadata(UUID.randomUUID.toString)
+      StreamMetadata.write(newMetadata, metadataPath, hadoopConf)
+      newMetadata
+    }
+  }
+
+  /** Returns the path of a file with `name` in the checkpoint directory. */
+  protected def checkpointFile(name: String): String =
+    new Path(new Path(resolvedCheckpointRoot), name).toString
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryCheckpointMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryCheckpointMetadata.scala
@@ -47,7 +47,7 @@ class StreamingQueryCheckpointMetadata(sparkSession: SparkSession, resolvedCheck
     new CommitLog(sparkSession, checkpointFile(StreamingCheckpointConstants.DIR_NAME_COMMITS))
 
   /** Metadata associated with the whole query */
-  lazy val streamMetadata: StreamMetadata = {
+  final lazy val streamMetadata: StreamMetadata = {
     val metadataPath = new Path(checkpointFile(StreamingCheckpointConstants.DIR_NAME_METADATA))
     val hadoopConf = sparkSession.sessionState.newHadoopConf()
     StreamMetadata.read(metadataPath, hadoopConf).getOrElse {
@@ -58,7 +58,7 @@ class StreamingQueryCheckpointMetadata(sparkSession: SparkSession, resolvedCheck
   }
 
   /** Returns the path of a file with `name` in the checkpoint directory. */
-  protected def checkpointFile(name: String): String =
+  final protected def checkpointFile(name: String): String =
     new Path(new Path(resolvedCheckpointRoot), name).toString
 
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Minor refactor to introduce an interface for accessing the metadata (e.g. offset / commit logs) in a streaming checkpoint.

### Why are the changes needed?
To standardize the access pattern.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
This is a pure refactoring, existing tests should suffice.

### Was this patch authored or co-authored using generative AI tooling?
No.
