### PR TITLE
[SPARK-51946][SQL] Eagerly fail for creating hive-incompatible datasource table with 'col' a partition name

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -755,6 +755,14 @@
     ],
     "sqlState" : "KD009"
   },
+  "CONFLICTING_PARTITION_COLUMN_NAME_WITH_RESERVED" : {
+    "message" : [
+      "Partition column name '<partitionColumnName>' conflicts with reserved column name.",
+      "The schema of <tableName> is Hive-incompatible, Spark automatically generates a reserved column '<partitionColumnName>' to store the table in a specific way.",
+      "Please use a different name for the partition column."
+    ],
+    "sqlState" : "KD009"
+  },
   "CONNECT" : {
     "message" : [
       "Generic Spark Connect error."

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -321,6 +321,16 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     // bucket specification to empty. Note that partition columns are retained, so that we can
     // call partition-related Hive API later.
     def newSparkSQLSpecificMetastoreTable(): CatalogTable = {
+      if (table.partitionColumnNames.contains(EMPTY_DATA_SCHEMA.head.name)) {
+        // This is a valid use case but for historical reasons we don't allow it as the 'col' name
+        // is taken by the empty schema. We should allow this in the future if we find a proper
+        // way.
+        throw new AnalysisException(
+          errorClass = "CONFLICTING_PARTITION_COLUMN_NAME_WITH_RESERVED",
+          messageParameters = Map(
+            "tableName" -> table.qualifiedName,
+            "partitionColumnName" -> EMPTY_DATA_SCHEMA.head.name))
+      }
       table.copy(
         // Hive only allows directory paths as location URIs while Spark SQL data source tables
         // also allow file paths. For non-hive-compatible format, we should not set location URI

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -322,7 +322,8 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     // call partition-related Hive API later.
     def newSparkSQLSpecificMetastoreTable(): CatalogTable = {
       if (table.partitionColumnNames.contains(EMPTY_DATA_SCHEMA.head.name)) {
-        // This is a valid use case but for historical reasons we don't allow it as the 'col' name
+        // TODO: SPARK-51957: Fix partition column and EMTPY_DATA_SCHEMA naming conflict
+        // This is a valid use case, but for historical reason,s we don't allow it as the 'col' name
         // is taken by the empty schema. We should allow this in the future if we find a proper
         // way.
         throw new AnalysisException(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -3377,4 +3377,21 @@ class HiveDDLSuite
       checkAnswer(sql("SELECT * FROM t1"), Row(0))
     }
   }
+
+  test("create table - partition column duplicates EMPTY_DATA_SCHEMA") {
+    withTable("t") {
+      val e = intercept[AnalysisException] {
+        sql("CREATE TABLE t (col int, b TIMESTAMP_NTZ) USING PARQUET PARTITIONED BY (col)")
+      }
+      // scalastyle:off
+      println(e)
+      checkError(
+        exception = e,
+        condition = "CONFLICTING_PARTITION_COLUMN_NAME_WITH_RESERVED",
+        parameters = Map(
+          "tableName" -> "spark_catalog.default.t",
+          "partitionColumnName" -> "col")
+      )
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -3383,8 +3383,6 @@ class HiveDDLSuite
       val e = intercept[AnalysisException] {
         sql("CREATE TABLE t (col int, b TIMESTAMP_NTZ) USING PARQUET PARTITIONED BY (col)")
       }
-      // scalastyle:off
-      println(e)
       checkError(
         exception = e,
         condition = "CONFLICTING_PARTITION_COLUMN_NAME_WITH_RESERVED",


### PR DESCRIPTION
### What changes were proposed in this pull request?

Eagerly fail for creating hive-incompatible datasource table with 'col' a partition name

### Why are the changes needed?

The EMPTY_DATA_SCHEMA will be treated as a partition column in HiveClientImpl, and the data schema being put in the HMS table is empty. 


```
spark-sql (default)> CREATE TABLE t (col int, b TIMESTAMP_NTZ) USING json PARTITIONED BY (col)
                   > ;
25/04/29 16:17:37 WARN HiveExternalCatalog: Hive incompatible types found: timestamp_ntz. Persisting data source table `spark_catalog`.`default`.`t` into Hive metastore in Spark SQL specific format, which is NOT compatible with Hive.
25/04/29 16:17:37 WARN SessionState: METASTORE_FILTER_HOOK will be ignored, since hive.security.authorization.manager is set to instance of HiveAuthorizerFactory.
org.apache.hadoop.hive.ql.metadata.HiveException: org.apache.hadoop.hive.ql.metadata.HiveException: at least one column must be specified for the table
org.apache.spark.sql.AnalysisException: org.apache.hadoop.hive.ql.metadata.HiveException: org.apache.hadoop.hive.ql.metadata.HiveException: at least one column must be specified for the table
```

This kind of error is meaningless and misleading for users


### Does this PR introduce _any_ user-facing change?

No, the invalid case is AS-IS w/ an error message change

### How was this patch tested?
new tests


### Was this patch authored or co-authored using generative AI tooling?
no