### PR TITLE
[SPARK-51948][BUILD] Make changes of `mllib` module to trigger the test for the `connect` module

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -329,18 +329,6 @@ protobuf = Module(
     ],
 )
 
-connect = Module(
-    name="connect",
-    dependencies=[hive, avro, protobuf],
-    source_file_regexes=[
-        "sql/connect",
-    ],
-    sbt_test_goals=[
-        "connect/test",
-        "connect-client-jvm/test",
-    ],
-)
-
 graphx = Module(
     name="graphx",
     dependencies=[tags, core],
@@ -420,6 +408,17 @@ mllib = Module(
     ],
 )
 
+connect = Module(
+    name="connect",
+    dependencies=[hive, avro, protobuf, mllib],
+    source_file_regexes=[
+        "sql/connect",
+    ],
+    sbt_test_goals=[
+        "connect/test",
+        "connect-client-jvm/test",
+    ],
+)
 
 examples = Module(
     name="examples",


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr appends `mllib` to the `dependencies` list of the `connect` module in the file `dev/sparktestsupport/modules.py`, ensuring that changes to the `mllib` module will trigger the tests for the `connect` module.


### Why are the changes needed?
Changes to the `mllib` module should trigger the tests for the connect module.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No
