### PR TITLE
[SPARK-51016][SQL] Non-deterministic SQL expressions should set indeterminate map stage output level

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -882,12 +882,14 @@ abstract class RDD[T: ClassTag](
   private[spark] def mapPartitionsWithIndexInternal[U: ClassTag](
       f: (Int, Iterator[T]) => Iterator[U],
       preservesPartitioning: Boolean = false,
-      isOrderSensitive: Boolean = false): RDD[U] = withScope {
+      isOrderSensitive: Boolean = false,
+      isNonDeterministic: Boolean = false): RDD[U] = withScope {
     new MapPartitionsRDD(
       this,
       (_: TaskContext, index: Int, iter: Iterator[T]) => f(index, iter),
       preservesPartitioning = preservesPartitioning,
-      isOrderSensitive = isOrderSensitive)
+      isOrderSensitive = isOrderSensitive,
+      isNonDeterministic = isNonDeterministic)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -103,13 +103,21 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
     AttributeSet(expressions) -- producedAttributes)
 
   /**
-   * Returns true when the all the expressions in the current node as well as all of its children
+   * Returns true when the current node (all the expressions in it) is deterministic.
+   */
+  def deterministicNode: Boolean = _deterministicNode()
+
+  private val _deterministicNode =
+    new BestEffortLazyVal[JBoolean](() => expressions.forall(_.deterministic))
+
+  /**
+   * Returns true when all the expressions in the current node as well as all of its children
    * are deterministic
    */
   def deterministic: Boolean = _deterministic()
 
-  private val _deterministic = new BestEffortLazyVal[JBoolean](() =>
-    expressions.forall(_.deterministic) && children.forall(_.deterministic))
+  private val _deterministic =
+    new BestEffortLazyVal[JBoolean](() => deterministicNode && children.forall(_.deterministic))
 
   /**
    * Attributes that are referenced by expressions but not provided by this node's children.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
@@ -83,7 +83,7 @@ case class CollectLimitExec(limit: Int = -1, child: SparkPlan, offset: Int = 0) 
         new ShuffledRowRDD(
           ShuffleExchangeExec.prepareShuffleDependency(
             locallyLimited,
-            child.output,
+            child,
             SinglePartition,
             serializer,
             writeMetrics),
@@ -142,7 +142,7 @@ case class CollectTailExec(limit: Int, child: SparkPlan) extends LimitExec {
         new ShuffledRowRDD(
           ShuffleExchangeExec.prepareShuffleDependency(
             locallyLimited,
-            child.output,
+            child,
             SinglePartition,
             serializer,
             writeMetrics),
@@ -365,7 +365,7 @@ case class TakeOrderedAndProjectExec(
         new ShuffledRowRDD(
           ShuffleExchangeExec.prepareShuffleDependency(
             localTopK,
-            child.output,
+            child,
             SinglePartition,
             serializer,
             writeMetrics),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is an alternative to https://github.com/apache/spark/pull/50029 to identify map stages that contain non-deterministic expressions and set their output deterministic level to `DeterministicLevel.INDETERMINATE`.

The problem with stages whose tasks produce different result during reruns (task retries) is very similar to what has been fixed in https://github.com/apache/spark/pull/22112.
In https://github.com/apache/spark/pull/22112 a map stage without local sort followed by a `RoundRobin` partitioning made the stage "order sensitive", so the output deterministic level of the map stage could become `INDETERMINATE` depending on the previous stage's `UNORDERED` level.

The issue that this PR fixes is when a map stage itself is non-deterministic and so rerunning it might result in different output. Such a stage should be marked non-deterministic and its output deterministic level shoule be `INDETERMINATE`.

### Why are the changes needed?

The PR fixes a correctness issue with task reruns due to fetch failures when the query contains an exhange with a partitioning with a non-deterministic expression or a deterministic expression whose lineage contains non-deterministic ancestors.

E.g.:
```
SELECT sum(id)
FROM (
  SELECT sum(id) AS id
  FROM (
    SELECT id, rand() AS r FROM range(1000)
  )
  GROUP BY r
)
```
has the following plan:
```
*(3) HashAggregate(keys=[], functions=[sum(id#281L)], output=[sum(id)#285L])
+- Exchange SinglePartition, ENSURE_REQUIREMENTS, [plan_id=189]
   +- *(2) HashAggregate(keys=[], functions=[partial_sum(id#281L)], output=[sum#287L])
      +- *(2) HashAggregate(keys=[r#280], functions=[sum(id#282L)], output=[id#281L])
         +- Exchange hashpartitioning(r#280, 5), ENSURE_REQUIREMENTS, [plan_id=184]
            +- *(1) HashAggregate(keys=[knownfloatingpointnormalized(normalizenanandzero(r#280)) AS r#280], functions=[partial_sum(id#282L)], output=[r#280, sum#289L])
               +- *(1) Project [id#282L, rand(3397309393382985772) AS r#280]
                  +- *(1) Range (0, 1000, step=1, splits=2)
```
If there is a fetch failure in the second map stage then a task of the first map stage needs to rerun and it can return a different result to its first run. As the `Exchange hashpartitioning(r#280, 5)` between the first and second map stage uses an expression (`r`) that has a non-deterministic expression (`rand()`) in its linage, some output rows of the task rerun might end up in a different partition in the second stage, which could lead to a correctness issue (result is not equal to 1000 * 999 / 2) if only the failed task of the second stage was reexecuted.
By setting the output deterministic level of the first stage to `INDETERMINATE`, all the tasks of the second stage (and all tasks of succeeding stages) will be reexecuted, which fixes the correctness issue.

Please note that:
- `rand()` is not a good example here because it gets seeded during planning, so it is more like an order sensitive expression during execution. But currently it is hard split non-deterministic expressions to order sensitive or non-deterministic in terms of stage output levels. Mapping all non-deterministic expressions to non-deterministic stage output levels keeps us on the safe side.
- It might seem that if none of the non-deterministic expressions contribute to any `Exchange` partitioning then we can't face any correctness issues, but that's not true. The PR adds a UT to cover a usecase that still requires a stage to be marked non-deterministic.

### Does this PR introduce _any_ user-facing change?

Yes, it fixes a correctness issue.

### How was this patch tested?

This correctness issue is very hard to unit test as it can come up only when there is a fetch failure. The unit test I added only tests whether the right stages are marked non-deterministic.

### Was this patch authored or co-authored using generative AI tooling?

No.