### PR TITLE
[SPARK-50605][CONNECT][TESTS][FOLLOW-UP] Remove unused YarnConnectTest

### DIFF
--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -777,34 +777,6 @@ private object YarnClasspathTest extends Logging {
 
 }
 
-private object YarnConnectTest extends Logging {
-  def main(args: Array[String]): Unit = {
-    val output = new java.io.PrintStream(new File(args(0)))
-    val clz = Utils.classForName("org.apache.spark.sql.SparkSession$")
-    val moduleField = clz.getDeclaredField("MODULE$")
-    val obj = moduleField.get(null)
-    var builder = clz.getMethod("builder").invoke(obj)
-    builder = builder.getClass().getMethod(
-      "config", classOf[String], classOf[String]).invoke(builder, SPARK_API_MODE.key, "connect")
-    builder = builder.getClass().getMethod("master", classOf[String]).invoke(builder, "yarn")
-    val session = builder.getClass().getMethod("getOrCreate").invoke(builder)
-
-    try {
-      // Check if the current session is a Spark Connect session.
-      session.getClass().getDeclaredField("client")
-      val df = session.getClass().getMethod("range", classOf[Long]).invoke(session, 10)
-      assert(df.getClass().getMethod("count").invoke(df) == 10)
-    } catch {
-      case e: Throwable =>
-        e.printStackTrace(new java.io.PrintStream(output))
-        throw e
-    } finally {
-      session.getClass().getMethod("stop").invoke(session)
-      output.close()
-    }
-  }
-}
-
 private object YarnAddJarTest extends Logging {
   def main(args: Array[String]): Unit = {
     if (args.length != 3) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/49107 that removes the unused `YarnConnectTest`.

### Why are the changes needed?

It was mistakenly added, and forgotten to be removed.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI in this PR should verify the change.

### Was this patch authored or co-authored using generative AI tooling?

No