### PR TITLE
[SPARK-51958][CORE][SQL][TESTS] Replace hardcoded icu version with `c.ibm.icu.util.VersionInfo.ICU_VERSION` it tests

### DIFF
--- a/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
+++ b/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
@@ -27,13 +27,14 @@ import org.apache.spark.sql.catalyst.util.CollationFactory.fetchCollation
 // scalastyle:off
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.must.Matchers
+import com.ibm.icu.util.VersionInfo.ICU_VERSION
 
 import org.apache.spark.sql.catalyst.util.CollationFactory._
 import org.apache.spark.unsafe.types.UTF8String.{fromString => toUTF8}
 
 class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ignore funsuite
 
-  val currentIcuVersion: String = "76.1"
+  val currentIcuVersion: String = s"${ICU_VERSION.getMajor}.${ICU_VERSION.getMinor}"
 
   test("collationId stability") {
     assert(INDETERMINATE_COLLATION_ID == -1)

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.collation
 
 import scala.jdk.CollectionConverters.MapHasAsJava
 
+import com.ibm.icu.util.VersionInfo.ICU_VERSION
+
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.ExtendedAnalysisException
@@ -1919,7 +1921,7 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
 
     // verify that the output ordering is as expected (UTF8_BINARY, UTF8_LCASE, etc.)
     val df = sql("SELECT * FROM collations() limit 10")
-    val icvVersion = "76.1.0.0"
+    val icvVersion = ICU_VERSION.toString
     checkAnswer(df,
       Seq(Row("SYSTEM", "BUILTIN", "UTF8_BINARY", null, null,
         "ACCENT_SENSITIVE", "CASE_SENSITIVE", "NO_PAD", null),


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr replace hardcoded icu version with `com.ibm.icu.util.VersionInfo.ICU_VERSION` in `CollationFactorySuite` and `CollationSuite`.


### Why are the changes needed?
Avoid manually modifying hardcoded version in tests when upgrading the ICU.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Acitons


### Was this patch authored or co-authored using generative AI tooling?
No
