### PR TITLE
[SPARK-51964][SQL] Correctly resolve attributes from hidden output in ORDER BY and HAVING on top of an Aggregate in single-pass Analyzer

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ExpressionResolutionContext.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ExpressionResolutionContext.scala
@@ -43,6 +43,8 @@ package org.apache.spark.sql.catalyst.analysis.resolver
  *   Otherwise, extra [[Alias]]es have to be stripped away.
  * @param resolvingGroupingExpressions A flag indicating whether an expression we are resolving is
  *   one of [[Aggregate.groupingExpressions]].
+ * @param resolvingTreeUnderAggregateExpression A flag indicating whether an expression we are
+ *   resolving a tree under [[AggregateExpression]].
  */
 class ExpressionResolutionContext(
     val isRoot: Boolean = false,
@@ -52,7 +54,8 @@ class ExpressionResolutionContext(
     var hasAttributeOutsideOfAggregateExpressions: Boolean = false,
     var hasLateralColumnAlias: Boolean = false,
     var isTopOfProjectList: Boolean = false,
-    var resolvingGroupingExpressions: Boolean = false) {
+    var resolvingGroupingExpressions: Boolean = false,
+    var resolvingTreeUnderAggregateExpression: Boolean = false) {
 
   /**
    * Propagate generic information that is valid across the whole expression tree from the
@@ -81,7 +84,8 @@ object ExpressionResolutionContext {
       )
     } else {
       new ExpressionResolutionContext(
-        resolvingGroupingExpressions = parent.resolvingGroupingExpressions
+        resolvingGroupingExpressions = parent.resolvingGroupingExpressions,
+        resolvingTreeUnderAggregateExpression = parent.resolvingTreeUnderAggregateExpression
       )
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ExpressionResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ExpressionResolver.scala
@@ -651,7 +651,12 @@ class ExpressionResolver(
               .peek()
               .resolvingGroupingExpressions && conf.groupByAliases
         ),
-        canResolveNameByHiddenOutput = canResolveNameByHiddenOutput
+        canResolveNameByHiddenOutput = canResolveNameByHiddenOutput,
+        canReferenceAggregatedAccessOnlyAttributes = (
+            expressionResolutionContextStack
+              .peek()
+              .resolvingTreeUnderAggregateExpression
+        )
       )
 
       val candidate = nameTarget.pickCandidate(unresolvedAttribute)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -156,6 +156,14 @@ package object util extends Logging {
    */
   val QUALIFIED_ACCESS_ONLY = "__qualified_access_only"
 
+  /**
+   * If set, this metadata column can only be accessed under [[AggregateExpression]]. This is
+   * important when resolving columns in ORDER BY and HAVING clauses on top of [[Aggregate]].
+   * In this case we can only reference attributes from grouping expressions, or attributes marked
+   * as "__aggregated_access_only" under [[AggregateExpression]].
+   */
+  val AGGREGATED_ACCESS_ONLY = "__aggregated_access_only"
+
   implicit class MetadataColumnHelper(attr: Attribute) {
 
     def isMetadataCol: Boolean = MetadataAttribute.isValid(attr.metadata)
@@ -163,6 +171,10 @@ package object util extends Logging {
     def qualifiedAccessOnly: Boolean = attr.isMetadataCol &&
       attr.metadata.contains(QUALIFIED_ACCESS_ONLY) &&
       attr.metadata.getBoolean(QUALIFIED_ACCESS_ONLY)
+
+    def aggregatedAccessOnly: Boolean = attr.isMetadataCol &&
+      attr.metadata.contains(AGGREGATED_ACCESS_ONLY) &&
+      attr.metadata.getBoolean(AGGREGATED_ACCESS_ONLY)
 
     def markAsQualifiedAccessOnly(): Attribute = attr.withMetadata(
       new MetadataBuilder()
@@ -172,12 +184,21 @@ package object util extends Logging {
         .build()
     )
 
+    def markAsAggregatedAccessOnly(): Attribute = attr.withMetadata(
+      new MetadataBuilder()
+        .withMetadata(attr.metadata)
+        .putString(METADATA_COL_ATTR_KEY, attr.name)
+        .putBoolean(AGGREGATED_ACCESS_ONLY, true)
+        .build()
+    )
+
     def markAsAllowAnyAccess(): Attribute = {
       if (qualifiedAccessOnly) {
         attr.withMetadata(
           new MetadataBuilder()
             .withMetadata(attr.metadata)
             .remove(QUALIFIED_ACCESS_ONLY)
+            .remove(AGGREGATED_ACCESS_ONLY)
             .build()
         )
       } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Correctly resolve names in HAVING and ORDER BY in single-pass Analyzer. In case we are resolving those expression trees on top of an `Aggregate`, we can naturally only access attributes which are directly outputted from the `Aggregate` (main output), or if they are present in `Aggregate`'s grouping expressions (hidden output). However, we can actually access any attributes from hidden output if we are resolving an `AggregateExpression` in ORDER BY or HAVING. This `AggregateExpression` will later be pushed down to `Aggregate` by `SortResolver`.

This query fails, because "col2" is not present in grouping expressions and is not present in `Aggregate`'s output:

`SELECT COUNT(col1) FROM VALUES (1, 2) GROUP BY col1 ORDER BY col2;`

This query succeeds, because we are resolving "col2" under `MAX`:

`SELECT COUNT(col1) FROM VALUES (1, 2) GROUP BY col1 ORDER BY MAX(col2);`

### Why are the changes needed?

This improves name resolution in the new single-pass Analyzer.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

copilot.nvim.