### PR TITLE
[SPARK-51981][SS] Add JobTags to queryStartedEvent

### DIFF
--- a/python/pyspark/sql/streaming/listener.py
+++ b/python/pyspark/sql/streaming/listener.py
@@ -193,29 +193,29 @@ class QueryStartedEvent:
 
     @classmethod
     def fromJObject(cls, jevent: "JavaObject") -> "QueryStartedEvent":
-        jobTags = set()
-        javaIterator = jevent.jobTags().iterator()
-        while javaIterator.hasNext():
-            jobTags.add(javaIterator.next().toString())
+        job_tags = set()
+        java_iterator = jevent.jobTags().iterator()
+        while java_iterator.hasNext():
+            job_tags.add(java_iterator.next().toString())
 
         return cls(
             id=uuid.UUID(jevent.id().toString()),
             runId=uuid.UUID(jevent.runId().toString()),
             name=jevent.name(),
             timestamp=jevent.timestamp(),
-            jobTags=jobTags,
+            jobTags=job_tags,
         )
 
     @classmethod
     def fromJson(cls, j: Dict[str, Any]) -> "QueryStartedEvent":
         # Json4s will convert jobTags to a list, so we need to convert it back to a set.
-        jobTags = j["jobTags"] if "jobTags" in j else []
+        job_tags = j["jobTags"] if "jobTags" in j else []
         return cls(
             id=uuid.UUID(j["id"]),
             runId=uuid.UUID(j["runId"]),
             name=j["name"],
             timestamp=j["timestamp"],
-            jobTags=set(jobTags),
+            jobTags=set(job_tags),
         )
 
     @property

--- a/python/pyspark/sql/streaming/listener.py
+++ b/python/pyspark/sql/streaming/listener.py
@@ -183,7 +183,7 @@ class QueryStartedEvent:
         runId: uuid.UUID,
         name: Optional[str],
         timestamp: str,
-        jobTags: Set[str] = set(),
+        jobTags: Set[str],
     ) -> None:
         self._id: uuid.UUID = id
         self._runId: uuid.UUID = runId

--- a/python/pyspark/sql/tests/streaming/test_streaming_listener.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_listener.py
@@ -45,6 +45,7 @@ class StreamingListenerTestsMixin:
             datetime.strptime(event.timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
         except ValueError:
             self.fail("'%s' is not in ISO 8601 format.")
+        self.assertTrue(isinstance(event.jobTags, set))
 
     def check_progress_event(self, event, is_stateful):
         """Check QueryProgressEvent"""
@@ -287,7 +288,7 @@ class StreamingListenerTests(StreamingListenerTestsMixin, ReusedSQLTestCase):
             get_number_of_public_methods(
                 "org.apache.spark.sql.streaming.StreamingQueryListener$QueryStartedEvent"
             ),
-            15,
+            16,
             msg,
         )
         self.assertEqual(
@@ -451,7 +452,7 @@ class StreamingListenerTests(StreamingListenerTestsMixin, ReusedSQLTestCase):
         verify(TestListenerV2())
 
     def test_query_started_event_fromJson(self):
-        start_event = """
+        start_event_old = """
             {
                 "id" : "78923ec2-8f4d-4266-876e-1f50cf3c283b",
                 "runId" : "55a95d45-e932-4e08-9caa-0a8ecd9391e8",
@@ -459,12 +460,30 @@ class StreamingListenerTests(StreamingListenerTestsMixin, ReusedSQLTestCase):
                 "timestamp" : "2023-06-09T18:13:29.741Z"
             }
         """
-        start_event = QueryStartedEvent.fromJson(json.loads(start_event))
-        self.check_start_event(start_event)
-        self.assertEqual(start_event.id, uuid.UUID("78923ec2-8f4d-4266-876e-1f50cf3c283b"))
-        self.assertEqual(start_event.runId, uuid.UUID("55a95d45-e932-4e08-9caa-0a8ecd9391e8"))
-        self.assertIsNone(start_event.name)
-        self.assertEqual(start_event.timestamp, "2023-06-09T18:13:29.741Z")
+        start_event_old = QueryStartedEvent.fromJson(json.loads(start_event_old))
+        self.check_start_event(start_event_old)
+        self.assertEqual(start_event_old.id, uuid.UUID("78923ec2-8f4d-4266-876e-1f50cf3c283b"))
+        self.assertEqual(start_event_old.runId, uuid.UUID("55a95d45-e932-4e08-9caa-0a8ecd9391e8"))
+        self.assertIsNone(start_event_old.name)
+        self.assertEqual(start_event_old.timestamp, "2023-06-09T18:13:29.741Z")
+        self.assertEqual(start_event_old.jobTags, set())
+
+        start_event_new = """
+            {
+                "id" : "78923ec2-8f4d-4266-876e-1f50cf3c283b",
+                "runId" : "55a95d45-e932-4e08-9caa-0a8ecd9391e8",
+                "name" : null,
+                "timestamp" : "2023-06-09T18:13:29.741Z",
+                "jobTags": ["jobTag1", "jobTag2"]
+            }
+        """
+        start_event_new = QueryStartedEvent.fromJson(json.loads(start_event_new))
+        self.check_start_event(start_event_new)
+        self.assertEqual(start_event_new.id, uuid.UUID("78923ec2-8f4d-4266-876e-1f50cf3c283b"))
+        self.assertEqual(start_event_new.runId, uuid.UUID("55a95d45-e932-4e08-9caa-0a8ecd9391e8"))
+        self.assertIsNone(start_event_new.name)
+        self.assertEqual(start_event_new.timestamp, "2023-06-09T18:13:29.741Z")
+        self.assertEqual(start_event_new.jobTags, set(["jobTag1", "jobTag2"]))
 
     def test_query_terminated_event_fromJson(self):
         terminated_json = """

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
@@ -170,6 +170,10 @@ object StreamingQueryListener extends Serializable {
       extends Event
       with Serializable {
 
+    def this(id: UUID, runId: UUID, name: String, timestamp: String) = {
+      this(id, runId, name, timestamp, Set())
+    }
+
     def json: String = compact(render(jsonValue))
 
     private def jsonValue: JValue = {

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
@@ -157,7 +157,7 @@ object StreamingQueryListener extends Serializable {
    * @param timestamp
    *   The timestamp to start a query.
    * @param jobTags
-   *   The job tags that has been assigned to all the jobs started by this thread
+   *   The job tags that have been assigned to all the jobs started by this thread
    * @since 2.1.0
    */
   @Evolving

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
@@ -166,7 +166,7 @@ object StreamingQueryListener extends Serializable {
       val runId: UUID,
       val name: String,
       val timestamp: String,
-      val jobTags: Set[String] = Set())
+      val jobTags: Set[String])
       extends Event
       with Serializable {
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
@@ -19,10 +19,12 @@ package org.apache.spark.sql.streaming
 
 import java.util.UUID
 
+import scala.jdk.CollectionConverters._
+
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
 import com.fasterxml.jackson.databind.node.TreeTraversingParser
 import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
-import org.json4s.{JObject, JString}
+import org.json4s.{JArray, JObject, JString}
 import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL.{jobject2assoc, pair2Assoc}
 import org.json4s.jackson.JsonMethods.{compact, render}
@@ -123,6 +125,14 @@ object StreamingQueryListener extends Serializable {
     private val tree = mapper.readTree(json)
     def getString(name: String): String = tree.get(name).asText()
     def getUUID(name: String): UUID = UUID.fromString(getString(name))
+    def getStringArray(name: String): List[String] = {
+      val node = tree.get(name)
+      if (node.isArray()) {
+        node.elements().asScala.map(_.asText()).toList
+      } else {
+        List()
+      }
+    }
     def getProgress(name: String): StreamingQueryProgress = {
       val parser = new TreeTraversingParser(tree.get(name), mapper)
       parser.readValueAs(classOf[StreamingQueryProgress])
@@ -146,6 +156,8 @@ object StreamingQueryListener extends Serializable {
    *   User-specified name of the query, null if not specified.
    * @param timestamp
    *   The timestamp to start a query.
+   * @param jobTags
+   *   The job tags that has been assigned to all the jobs started by this thread
    * @since 2.1.0
    */
   @Evolving
@@ -153,7 +165,8 @@ object StreamingQueryListener extends Serializable {
       val id: UUID,
       val runId: UUID,
       val name: String,
-      val timestamp: String)
+      val timestamp: String,
+      val jobTags: Set[String] = Set())
       extends Event
       with Serializable {
 
@@ -163,7 +176,8 @@ object StreamingQueryListener extends Serializable {
       ("id" -> JString(id.toString)) ~
         ("runId" -> JString(runId.toString)) ~
         ("name" -> JString(name)) ~
-        ("timestamp" -> JString(timestamp))
+        ("timestamp" -> JString(timestamp)) ~
+        ("jobTags" -> JArray(jobTags.toList.map(JString)))
     }
   }
 
@@ -175,7 +189,8 @@ object StreamingQueryListener extends Serializable {
         parser.getUUID("id"),
         parser.getUUID("runId"),
         parser.getString("name"),
-        parser.getString("name"))
+        parser.getString("timestamp"),
+        parser.getStringArray("jobTags").toSet)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -288,7 +288,14 @@ abstract class StreamExecution(
       // `postEvent` does not throw non fatal exception.
       val startTimestamp = triggerClock.getTimeMillis()
       postEvent(
-        new QueryStartedEvent(id, runId, name, progressReporter.formatTimestamp(startTimestamp)))
+        new QueryStartedEvent(
+          id,
+          runId,
+          name,
+          progressReporter.formatTimestamp(startTimestamp),
+          sparkSession.sparkContext.getJobTags()
+        )
+      )
 
       // Unblock starting thread
       startLatch.countDown()

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
@@ -262,12 +262,28 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
       assert(newEvent.id === event.id)
       assert(newEvent.runId === event.runId)
       assert(newEvent.name === event.name)
+      assert(newEvent.timestamp === event.timestamp)
+      assert(newEvent.jobTags === event.jobTags)
     }
 
     testSerialization(
-      new QueryStartedEvent(UUID.randomUUID, UUID.randomUUID, "name", "2016-12-05T20:54:20.827Z"))
+      new QueryStartedEvent(
+        UUID.randomUUID,
+        UUID.randomUUID,
+        "name",
+        "2016-12-05T20:54:20.827Z",
+        Set()
+      )
+    )
     testSerialization(
-      new QueryStartedEvent(UUID.randomUUID, UUID.randomUUID, null, "2016-12-05T20:54:20.827Z"))
+      new QueryStartedEvent(
+        UUID.randomUUID,
+        UUID.randomUUID,
+        null,
+        "2016-12-05T20:54:20.827Z",
+        Set("tag1", "tag2")
+      )
+    )
   }
 
   test("QueryProgressEvent serialization") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Adding a new jobTags parameter for QueryStartedEvent so that it can be connected to the actual spark connect command that triggered this streaming. Also besides adding the parameter, a fix has been applied to the timestamp because previously json reads the wrong argument


### Why are the changes needed?
Without this, there is no way to tell where does this streaming originate from.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit test is added


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
