### PR TITLE
[SPARK-51985][CORE] Remove `Experimental` from `(Long|Double)AccumulatorSource`

### DIFF
--- a/core/src/main/scala/org/apache/spark/metrics/source/AccumulatorSource.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/source/AccumulatorSource.scala
@@ -20,7 +20,6 @@ package org.apache.spark.metrics.source
 import com.codahale.metrics.{Gauge, MetricRegistry}
 
 import org.apache.spark.SparkContext
-import org.apache.spark.annotation.Experimental
 import org.apache.spark.util.{AccumulatorV2, DoubleAccumulator, LongAccumulator}
 
 /**
@@ -48,21 +47,17 @@ private[spark] class AccumulatorSource extends Source {
   override def metricRegistry: MetricRegistry = registry
 }
 
-@Experimental
 class LongAccumulatorSource extends AccumulatorSource
 
-@Experimental
 class DoubleAccumulatorSource extends AccumulatorSource
 
 /**
- * :: Experimental ::
  * Metrics source specifically for LongAccumulators. Accumulators
  * are only valid on the driver side, so these metrics are reported
  * only by the driver.
  * Register LongAccumulators using:
  *    LongAccumulatorSource.register(sc, {"name" -> longAccumulator})
  */
-@Experimental
 object LongAccumulatorSource {
   def register(sc: SparkContext, accumulators: Map[String, LongAccumulator]): Unit = {
     val source = new LongAccumulatorSource
@@ -72,14 +67,12 @@ object LongAccumulatorSource {
 }
 
 /**
- * :: Experimental ::
  * Metrics source specifically for DoubleAccumulators. Accumulators
  * are only valid on the driver side, so these metrics are reported
  * only by the driver.
  * Register DoubleAccumulators using:
  *    DoubleAccumulatorSource.register(sc, {"name" -> doubleAccumulator})
  */
-@Experimental
 object DoubleAccumulatorSource {
   def register(sc: SparkContext, accumulators: Map[String, DoubleAccumulator]): Unit = {
     val source = new DoubleAccumulatorSource


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `Experimental` tag from `LongAccumulatorSource` and `DoubleAccumulatorSource`.

### Why are the changes needed?

These are added at Apache Spark 3.0.0 and have been used without modifications for 7 years (2018-12-22). We can remove `Experimental` at Apache Spark 4.0.0.
- https://github.com/apache/spark/pull/23242

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.