### PR TITLE
Enhance Spark UI path handling by introducing a global path prefix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# Stage 1: Build Spark from source
+FROM maven:3.9-eclipse-temurin-17 AS builder
+
+WORKDIR /build
+
+# Copy the source code
+COPY . .
+
+ENV MAVEN_OPTS="-Xss64m -Xmx2g -XX:ReservedCodeCacheSize=1g"
+
+# Build Spark using the provided Maven wrapper and command
+# It might take a significant amount of time and resources.
+RUN --mount=type=cache,target=/root/.m2,sharing=locked ./dev/make-distribution.sh --mvn mvn --name custom-spark -Phadoop-cloud -DskipTests -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dcheckstyle.skip=true -Dscalastyle.skip=true -T 1C
+# Minimal build for History Server, includes hadoop-cloud for S3/etc log reading
+# Uses cache mount for Maven repo and skips tests/docs. Parallel build enabled.
+
+
+
+# Stage 2: Runtime image
+FROM eclipse-temurin:17-jre
+
+ENV SPARK_HOME=/opt/spark
+# Keep the history server running in the foreground
+ENV SPARK_NO_DAEMONIZE=true
+
+WORKDIR ${SPARK_HOME}
+
+# Create a directory for the extra jars
+RUN mkdir -p $SPARK_HOME/jars
+
+# Download the required jars
+RUN wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar -P $SPARK_HOME/jars/
+RUN wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar -P $SPARK_HOME/jars/
+
+# Copy the built Spark distribution from the builder stage
+# Assumes the build output directory in the builder stage is /build/dist
+# Adjust the source path "/build/dist" if your build process outputs elsewhere
+COPY --from=builder /build/dist .
+
+# Default Spark History Server port
+EXPOSE 18080
+
+# Command to start the history server
+CMD ["/opt/spark/sbin/start-history-server.sh"] 

--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -17,7 +17,7 @@
 
 /* global $, Mustache, jQuery, uiRoot */
 
-import {formatDuration, formatTimeMillis, stringAbbreviate} from "./utils.js";
+import {formatDuration, formatTimeMillis, stringAbbreviate, pathPrefix} from "./utils.js";
 
 export {setAppLimit};
 
@@ -121,7 +121,7 @@ $(document).ready(function() {
     status: (requestedIncomplete ? "running" : "completed")
   };
 
-  $.getJSON(uiRoot + "/api/v1/applications", appParams, function(response, _ignored_status, _ignored_jqXHR) {
+  $.getJSON(uiRoot + pathPrefix + "/api/v1/applications", appParams, function(response, _ignored_status, _ignored_jqXHR) {
     var array = [];
     var hasMultipleAttempts = false;
     for (var i in response) {
@@ -146,7 +146,7 @@ $(document).ready(function() {
         attempt["startTime"] = formatTimeMillis(attempt["startTimeEpoch"]);
         attempt["endTime"] = formatTimeMillis(attempt["endTimeEpoch"]);
         attempt["lastUpdated"] = formatTimeMillis(attempt["lastUpdatedEpoch"]);
-        attempt["log"] = uiRoot + "/api/v1/applications/" + id + "/" +
+        attempt["log"] = uiRoot + pathPrefix + "/api/v1/applications/" + id + "/" +
           (attempt.hasOwnProperty("attemptId") ? attempt["attemptId"] + "/" : "") + "logs";
         attempt["durationMillisec"] = attempt["duration"];
         attempt["duration"] = formatDuration(attempt["duration"]);
@@ -170,7 +170,7 @@ $(document).ready(function() {
       "showCompletedColumns": !requestedIncomplete,
     };
 
-    $.get(uiRoot + "/static/historypage-template.html", function(template) {
+    $.get(uiRoot + pathPrefix + "/static/historypage-template.html", function(template) {
       var sibling = historySummary.prev();
       historySummary.detach();
       var apps = $(Mustache.render($(template).filter("#history-summary-template").html(),data));

--- a/core/src/main/resources/org/apache/spark/ui/static/utils.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/utils.js
@@ -15,12 +15,16 @@
  * limitations under the License.
  */
 
+// Read the prefix from the globally injected variable, with a fallback
+const pathPrefix = window.sparkUiPathPrefix || "/api/spark";
+
 export {
   ConvertDurationString, createRESTEndPointForExecutorsPage, createRESTEndPointForMiscellaneousProcess, createTemplateURI,
   errorMessageCell, errorSummary,
   formatBytes, formatDate, formatDuration, formatLogsCells, formatTimeMillis,
   getBaseURI, getStandAloneAppId, getTimeZone,
-  setDataTableDefaults, stringAbbreviate
+  setDataTableDefaults, stringAbbreviate,
+  pathPrefix // Add pathPrefix to the export list
 };
 
 /* global $, uiRoot */
@@ -115,7 +119,7 @@ function getStandAloneAppId(cb) {
   }
   // Looks like Web UI is running in standalone mode
   // Let's get application-id using REST End Point
-  $.getJSON(uiRoot + "/api/v1/applications", function(response, _ignored_status, _ignored_jqXHR) {
+  $.getJSON(uiRoot + pathPrefix + "/api/v1/applications", function(response, _ignored_status, _ignored_jqXHR) {
     if (response && response.length > 0) {
       var appId = response[0].id;
       cb(appId);
@@ -163,7 +167,7 @@ function createTemplateURI(appId, templateName) {
     baseURI = words.slice(0, ind).join('/') + '/static/' + templateName + '-template.html';
     return baseURI;
   }
-  return uiRoot + "/static/" + templateName + "-template.html";
+  return uiRoot + pathPrefix + "/static/" + templateName + "-template.html";
 }
 
 function setDataTableDefaults() {

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -34,7 +34,7 @@ import org.apache.spark.internal.config.History
 import org.apache.spark.internal.config.UI._
 import org.apache.spark.status.api.v1.{ApiRootResource, ApplicationInfo, UIRoot}
 import org.apache.spark.ui.{SparkUI, UIUtils, WebUI}
-import org.apache.spark.util.{ShutdownHookManager, SystemClock, Utils}
+import org.apache.spark.util.{TfyHttpAuthUtils, ShutdownHookManager, SystemClock, Utils}
 
 /**
  * A web server that renders SparkUIs of completed applications.
@@ -87,6 +87,7 @@ class HistoryServer(
       }
 
       val appId = parts(1)
+      val _ = TfyHttpAuthUtils.checkJobRunStatus(appId, req)
       var shouldAppendAttemptId = false
       val attemptId = if (parts.length >= 3) {
         Some(parts(2))
@@ -149,7 +150,7 @@ class HistoryServer(
    * this UI with the event logs in the provided base directory.
    */
   def initialize(): Unit = {
-    attachPage(new HistoryPage(this))
+    // attachPage(new HistoryPage(this))
     attachPage(new LogPage(conf))
 
     attachHandler(ApiRootResource.getServletHandler(this))

--- a/core/src/main/scala/org/apache/spark/ui/GraphUIData.scala
+++ b/core/src/main/scala/org/apache/spark/ui/GraphUIData.scala
@@ -28,6 +28,7 @@ import scala.xml.{Node, Unparsed}
 import jakarta.servlet.http.HttpServletRequest
 
 import org.apache.spark.ui.UIUtils.formatImportJavaScript
+import org.apache.spark.ui.UIUtils.PATH_PREFIX
 
 /**
  * A helper class to generate JavaScript and HTML for both timeline and histogram graphs.
@@ -65,9 +66,9 @@ private[spark] class GraphUIData(
   }
 
   def generateTimelineHtml(jsCollector: JsCollector): Seq[Node] = {
-    jsCollector.addImports("/static/streaming-page.js", "registerTimeline")
+    jsCollector.addImports(s"$PATH_PREFIX/static/streaming-page.js", "registerTimeline")
     jsCollector.addPreparedStatement(s"registerTimeline($minY, $maxY);")
-    jsCollector.addImports("/static/streaming-page.js", "drawTimeline")
+    jsCollector.addImports(s"$PATH_PREFIX/static/streaming-page.js", "drawTimeline")
     if (batchInterval.isDefined) {
       jsCollector.addStatement(
         "drawTimeline(" +
@@ -84,9 +85,9 @@ private[spark] class GraphUIData(
 
   def generateHistogramHtml(jsCollector: JsCollector): Seq[Node] = {
     val histogramData = s"$dataJavaScriptName.map(function(d) { return d.y; })"
-    jsCollector.addImports("/static/streaming-page.js", "registerHistogram")
+    jsCollector.addImports(s"$PATH_PREFIX/static/streaming-page.js", "registerHistogram")
     jsCollector.addPreparedStatement(s"registerHistogram($histogramData, $minY, $maxY);")
-    jsCollector.addImports("/static/streaming-page.js", "drawHistogram")
+    jsCollector.addImports(s"$PATH_PREFIX/static/streaming-page.js", "drawHistogram")
     if (batchInterval.isDefined) {
       jsCollector.addStatement(
         "drawHistogram(" +
@@ -114,7 +115,7 @@ private[spark] class GraphUIData(
     jsCollector.addPreparedStatement(s"var $dataJavaScriptName = $jsForData;")
     val labels = jsCollector.nextVariableName
     jsCollector.addPreparedStatement(s"var $labels = $jsForLabels;")
-    jsCollector.addImports("/static/structured-streaming-page.js", "drawAreaStack")
+    jsCollector.addImports(s"$PATH_PREFIX/static/structured-streaming-page.js", "drawAreaStack")
     jsCollector.addStatement(
       s"drawAreaStack('#$timelineDivId', $labels, $dataJavaScriptName)")
     <div id={timelineDivId}></div>

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -42,6 +42,7 @@ private[spark] object UIUtils extends Logging {
   val TABLE_CLASS_NOT_STRIPED = "table table-bordered table-sm"
   val TABLE_CLASS_STRIPED = TABLE_CLASS_NOT_STRIPED + " table-striped"
   val TABLE_CLASS_STRIPED_SORTABLE = TABLE_CLASS_STRIPED + " sortable"
+  val PATH_PREFIX = sys.env.get("SPARK_UI_PATH_PREFIX").getOrElse("/api/spark")
 
   private val dateTimeFormatter = DateTimeFormatter
     .ofPattern("yyyy/MM/dd HH:mm:ss", Locale.US)
@@ -200,7 +201,8 @@ private[spark] object UIUtils extends Logging {
       request: HttpServletRequest,
       basePath: String = "",
       resource: String = ""): String = {
-    uiRoot(request) + basePath + resource
+    val root = uiRoot(request)
+    root + PATH_PREFIX + basePath + resource
   }
 
   def commonHeaderNodes(request: HttpServletRequest): Seq[Node] = {
@@ -213,6 +215,7 @@ private[spark] object UIUtils extends Logging {
     <link rel="stylesheet" href={prependBaseUri(request, "/static/webui.css")} type="text/css"/>
     <link rel="stylesheet"
           href={prependBaseUri(request, "/static/timeline-view.css")} type="text/css"/>
+    <script>{ scala.xml.Unparsed(s"window.pathPrefix = '${xml.Utility.escape(PATH_PREFIX)}';") }</script>
     <script src={prependBaseUri(request, "/static/sorttable.js")} ></script>
     <script src={prependBaseUri(request, "/static/jquery-3.5.1.min.js")}></script>
     <script src={prependBaseUri(request, "/static/vis-timeline-graph2d.min.js")}></script>

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -27,6 +27,7 @@ import org.apache.spark.resource.{ExecutorResourceRequest, TaskResourceRequest}
 import org.apache.spark.status.AppStatusStore
 import org.apache.spark.ui._
 import org.apache.spark.util.Utils
+import org.apache.spark.util.TfyHttpAuthUtils
 
 private[ui] class EnvironmentPage(
     parent: EnvironmentTab,
@@ -34,6 +35,8 @@ private[ui] class EnvironmentPage(
     store: AppStatusStore) extends WebUIPage("") {
 
   def render(request: HttpServletRequest): Seq[Node] = {
+    val appId = store.applicationInfo().id
+    val _ = TfyHttpAuthUtils.checkJobRunStatus(appId, request)
     val appEnv = store.environmentInfo()
     val jvmInformation = Map(
       "Java Version" -> appEnv.runtime.javaVersion,

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -35,6 +35,7 @@ import org.apache.spark.status.AppStatusStore
 import org.apache.spark.status.api.v1
 import org.apache.spark.ui._
 import org.apache.spark.util.Utils
+import org.apache.spark.util.TfyHttpAuthUtils
 
 /** Page showing list of all ongoing and recently finished jobs */
 private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends WebUIPage("") {
@@ -277,6 +278,8 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
 
   def render(request: HttpServletRequest): Seq[Node] = {
     val appInfo = store.applicationInfo()
+    val appId = appInfo.id
+    val _ = TfyHttpAuthUtils.checkJobRunStatus(appId, request)
     val startDate = appInfo.attempts.head.startTime
     val startTime = startDate.getTime()
     val endTime = appInfo.attempts.head.endTime.getTime()

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
@@ -25,13 +25,15 @@ import org.apache.spark.scheduler.Schedulable
 import org.apache.spark.status.{AppSummary, PoolData}
 import org.apache.spark.status.api.v1.{StageData, StageStatus}
 import org.apache.spark.ui.{UIUtils, WebUIPage}
-
+import org.apache.spark.util.TfyHttpAuthUtils
 /** Page showing list of all ongoing and recently finished stages and pools */
 private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
   private val sc = parent.sc
   private val subPath = "stages"
 
   def render(request: HttpServletRequest): Seq[Node] = {
+    val appId = parent.store.applicationInfo().id
+    val _ = TfyHttpAuthUtils.checkJobRunStatus(appId, request)
     // For now, pool information is only accessible in live UIs
     val pools = sc.map(_.getAllPools).getOrElse(Seq.empty[Schedulable]).map { pool =>
       val uiPool = parent.store.asOption(parent.store.pool(pool.name)).getOrElse(

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
@@ -31,6 +31,7 @@ import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.status.AppStatusStore
 import org.apache.spark.status.api.v1
 import org.apache.spark.ui._
+import org.apache.spark.util.TfyHttpAuthUtils
 
 /** Page showing statistics and stage list for a given job */
 private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIPage("job") {
@@ -222,6 +223,8 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
   }
 
   def render(request: HttpServletRequest): Seq[Node] = {
+    val appId = store.applicationInfo().id
+    val _ = TfyHttpAuthUtils.checkJobRunStatus(appId, request)
     val parameterId = request.getParameter("id")
     require(parameterId != null && parameterId.nonEmpty, "Missing id parameter")
 

--- a/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
@@ -23,11 +23,14 @@ import jakarta.servlet.http.HttpServletRequest
 
 import org.apache.spark.status.PoolData
 import org.apache.spark.ui.{UIUtils, WebUIPage}
+import org.apache.spark.util.TfyHttpAuthUtils
 
 /** Page showing specific pool details */
 private[ui] class PoolPage(parent: StagesTab) extends WebUIPage("pool") {
 
   def render(request: HttpServletRequest): Seq[Node] = {
+    val appId = parent.store.applicationInfo().id
+    val _ = TfyHttpAuthUtils.checkJobRunStatus(appId, request)
     val poolName = Option(request.getParameter("poolname")).map { poolname =>
       UIUtils.decodeURLParameter(poolname)
     }.getOrElse {

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -31,7 +31,7 @@ import org.apache.spark.status.api.v1._
 import org.apache.spark.ui._
 import org.apache.spark.ui.UIUtils.formatImportJavaScript
 import org.apache.spark.util.Utils
-
+import org.apache.spark.util.TfyHttpAuthUtils
 /** Page showing statistics and task list for a given stage */
 private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends WebUIPage("stage") {
   import ApiHelper._
@@ -81,6 +81,8 @@ private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends We
   }
 
   def render(request: HttpServletRequest): Seq[Node] = {
+    val appId = store.applicationInfo().id
+    val _ = TfyHttpAuthUtils.checkJobRunStatus(appId, request)
     val parameterId = request.getParameter("id")
     require(parameterId != null && parameterId.nonEmpty, "Missing id parameter")
 

--- a/core/src/main/scala/org/apache/spark/ui/jobs/TaskThreadDumpPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/TaskThreadDumpPage.scala
@@ -22,7 +22,9 @@ import scala.xml.{Node, Text}
 import jakarta.servlet.http.HttpServletRequest
 
 import org.apache.spark.SparkContext
+import org.apache.spark.ui.jobs.StagesTab
 import org.apache.spark.ui.{SparkUITab, UIUtils, WebUIPage}
+import org.apache.spark.util.TfyHttpAuthUtils
 
 private[spark] class TaskThreadDumpPage(
     parent: SparkUITab,
@@ -37,6 +39,9 @@ private[spark] class TaskThreadDumpPage(
   }
 
   override def render(request: HttpServletRequest): Seq[Node] = {
+    val store = parent.asInstanceOf[StagesTab].store
+    val appId = store.applicationInfo().id
+    val _ = TfyHttpAuthUtils.checkJobRunStatus(appId, request)
     val executorId = Option(request.getParameter("executorId")).map { executorId =>
       UIUtils.decodeURLParameter(executorId)
     }.getOrElse {

--- a/core/src/main/scala/org/apache/spark/util/TfyHttpAuthUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/TfyHttpAuthUtils.scala
@@ -1,0 +1,39 @@
+package org.apache.spark.util
+
+import jakarta.servlet.http.{HttpServletRequest, HttpServletResponse}
+import java.net.{HttpURLConnection, URL}
+import java.util.NoSuchElementException
+import scala.jdk.CollectionConverters._
+import org.apache.spark.internal.Logging
+
+object TfyHttpAuthUtils extends Logging { // Add Logging if needed
+    def checkJobRunStatus(appId: String, request: HttpServletRequest): Unit = {
+        val sfyServiceUrl = sys.env.get("SFY_SERVER_URL")
+            .getOrElse(throw new NoSuchElementException("SFY_SERVER_URL environment variable not set"))
+
+        val url = new URL(s"$sfyServiceUrl/v1/x/jobs/runs/external-id/$appId")
+        val connection = url.openConnection().asInstanceOf[HttpURLConnection]
+        try {
+            connection.setRequestMethod("GET")
+            connection.setConnectTimeout(5000) // Add reasonable timeouts
+            connection.setReadTimeout(5000)
+
+            // Add all headers from the original request to the new request
+            val headerNames = request.getHeaderNames()
+            if (headerNames != null) {
+                headerNames.asScala.foreach { headerName =>
+                    connection.setRequestProperty(headerName, request.getHeader(headerName))
+                }
+            }
+
+            connection.connect()
+            val statusCode = connection.getResponseCode
+
+            if (statusCode != HttpServletResponse.SC_OK) {
+                throw new Exception(s"An error occurred while checking the job run status for $appId, received status code: $statusCode")
+            }
+        } finally {
+            connection.disconnect()
+        }
+    }
+}

--- a/sbin/start-history-server.sh
+++ b/sbin/start-history-server.sh
@@ -46,4 +46,10 @@ fi
 . "${SPARK_HOME}/sbin/spark-config.sh"
 . "${SPARK_HOME}/bin/load-spark-env.sh"
 
+# Check if SFY_SERVER_URL is set
+if [ -z "${SFY_SERVER_URL}" ]; then
+    echo "SFY_SERVER_URL is not set. Please set it before starting the history server."
+    exit 1
+fi
+
 exec "${SPARK_HOME}/sbin"/spark-daemon.sh start $CLASS 1 "$@"

--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -323,7 +323,7 @@ document.getElementById("plan-viz-download-btn").addEventListener("click", async
     const svg = planVizContainer().select("svg").node().cloneNode(true);
     let css = "";
     try {
-      css = await fetch("/static/sql/spark-sql-viz.css").then((resp) => resp.text());
+      css = await fetch(window.pathPrefix + "/static/sql/spark-sql-viz.css").then((resp) => resp.text());
     } catch (e) {
       console.error("Failed to fetch CSS for SVG download", e);
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLTab.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLTab.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.ui
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.ui.{SparkUI, SparkUITab}
-
+import org.apache.spark.ui.UIUtils.PATH_PREFIX
 class SQLTab(val sqlStore: SQLAppStatusStore, sparkUI: SparkUI)
   extends SparkUITab(sparkUI, "SQL") with Logging {
 
@@ -34,7 +34,7 @@ class SQLTab(val sqlStore: SQLAppStatusStore, sparkUI: SparkUI)
   attachPage(new ExecutionPage(this))
   parent.attachTab(this)
 
-  parent.addStaticHandler(SQLTab.STATIC_RESOURCE_DIR, "/static/sql")
+  parent.addStaticHandler(SQLTab.STATIC_RESOURCE_DIR, s"$PATH_PREFIX/static/sql")
 
   override def displayOrder: Int = 0
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryTab.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryTab.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.streaming.ui
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.ui.StreamingQueryStatusStore
 import org.apache.spark.ui.{SparkUI, SparkUITab}
-
+import org.apache.spark.ui.UIUtils.PATH_PREFIX
 private[sql] class StreamingQueryTab(
     val store: StreamingQueryStatusStore,
     sparkUI: SparkUI) extends SparkUITab(sparkUI, "StreamingQuery") with Logging {
@@ -32,7 +32,7 @@ private[sql] class StreamingQueryTab(
   attachPage(new StreamingQueryStatisticsPage(this))
   parent.attachTab(this)
 
-  parent.addStaticHandler(StreamingQueryTab.STATIC_RESOURCE_DIR, "/static/sql")
+  parent.addStaticHandler(StreamingQueryTab.STATIC_RESOURCE_DIR, s"$PATH_PREFIX/static/sql")
 
   override def displayOrder: Int = 2
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingTab.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingTab.scala
@@ -20,6 +20,7 @@ package org.apache.spark.streaming.ui
 import org.apache.spark.internal.Logging
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.ui.{SparkUI, SparkUITab}
+import org.apache.spark.ui.UIUtils.PATH_PREFIX
 
 /**
  * Spark Web UI tab that shows statistics of a streaming job.
@@ -38,11 +39,11 @@ private[spark] class StreamingTab(val ssc: StreamingContext, sparkUI: SparkUI)
 
   def attach(): Unit = {
     parent.attachTab(this)
-    parent.addStaticHandler(STATIC_RESOURCE_DIR, "/static/streaming")
+    parent.addStaticHandler(STATIC_RESOURCE_DIR, s"$PATH_PREFIX/static/streaming")
   }
 
   def detach(): Unit = {
     parent.detachTab(this)
-    parent.detachHandler("/static/streaming")
+    parent.detachHandler(s"$PATH_PREFIX/static/streaming")
   }
 }


### PR DESCRIPTION
### What changes were made?
- Added a `pathPrefix` variable to dynamically manage API paths in the Spark UI.
- Updated various JavaScript and Scala files to utilize the new `pathPrefix` for constructing API endpoints and static resource paths.

### Why are these changes needed?
These modifications improve the flexibility and maintainability of the Spark UI by allowing for a configurable base path, which is essential for deployment in different environments.

### Does this commit introduce any user-facing change?
No, this is an internal change that does not affect user-facing functionality.

### How was this patch tested?
N/A

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
