### PR TITLE
[SQL][MINOR][FOLLOW-UP] Fix warnings in DataSource/WriterV2Suites

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{CannotReplaceMissingTableException, TableAlreadyExistsException}
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, LogicalPlan, OverwriteByExpression, OverwritePartitionsDynamic}
 import org.apache.spark.sql.connector.InMemoryV1Provider
-import org.apache.spark.sql.connector.catalog.{Column, Identifier, InMemoryTable, InMemoryTableCatalog, TableCatalog}
+import org.apache.spark.sql.connector.catalog.{Column => ColumnV2, Identifier, InMemoryTable, InMemoryTableCatalog, TableCatalog}
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.connector.expressions.{BucketTransform, ClusterByTransform, DaysTransform, FieldReference, HoursTransform, IdentityTransform, LiteralValue, MonthsTransform, YearsTransform}
 import org.apache.spark.sql.execution.QueryExecution
@@ -410,7 +410,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
 
     assert(table.name === "testcat.table_name")
     assert(table.columns sameElements
-      Array(Column.create("id", LongType), Column.create("data", StringType)))
+      Array(ColumnV2.create("id", LongType), ColumnV2.create("data", StringType)))
     assert(table.partitioning.isEmpty)
     assert(table.properties == defaultOwnership.asJava)
   }
@@ -426,7 +426,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
 
     assert(table.name === "testcat.table_name")
     assert(table.columns sameElements
-      Array(Column.create("id", LongType), Column.create("data", StringType)))
+      Array(ColumnV2.create("id", LongType), ColumnV2.create("data", StringType)))
     assert(table.partitioning.isEmpty)
     assert(table.properties === (Map("provider" -> "foo") ++ defaultOwnership).asJava)
   }
@@ -442,7 +442,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
 
     assert(table.name === "testcat.table_name")
     assert(table.columns sameElements
-      Array(Column.create("id", LongType), Column.create("data", StringType)))
+      Array(ColumnV2.create("id", LongType), ColumnV2.create("data", StringType)))
     assert(table.partitioning.isEmpty)
     assert(table.properties === (Map("prop" -> "value") ++ defaultOwnership).asJava)
   }
@@ -458,7 +458,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
 
     assert(table.name === "testcat.table_name")
     assert(table.columns sameElements
-      Array(Column.create("id", LongType), Column.create("data", StringType)))
+      Array(ColumnV2.create("id", LongType), ColumnV2.create("data", StringType)))
     assert(table.partitioning === Seq(IdentityTransform(FieldReference("id"))))
     assert(table.properties == defaultOwnership.asJava)
   }
@@ -555,7 +555,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
     // table should not have been changed
     assert(table.name === "testcat.table_name")
     assert(table.columns sameElements
-      Array(Column.create("id", LongType), Column.create("data", StringType)))
+      Array(ColumnV2.create("id", LongType), ColumnV2.create("data", StringType)))
     assert(table.partitioning === Seq(IdentityTransform(FieldReference("id"))))
     assert(table.properties === (Map("provider" -> "foo") ++ defaultOwnership).asJava)
   }
@@ -592,7 +592,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
     // validate the initial table
     assert(table.name === "testcat.table_name")
     assert(table.columns sameElements
-      Array(Column.create("id", LongType), Column.create("data", StringType)))
+      Array(ColumnV2.create("id", LongType), ColumnV2.create("data", StringType)))
     assert(table.partitioning === Seq(IdentityTransform(FieldReference("id"))))
     assert(table.properties === (Map("provider" -> "foo") ++ defaultOwnership).asJava)
 
@@ -609,9 +609,9 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
     // validate the replacement table
     assert(replaced.name === "testcat.table_name")
     assert(replaced.columns sameElements Array(
-      Column.create("id", LongType),
-      Column.create("data", StringType),
-      Column.create("even_or_odd", StringType)))
+      ColumnV2.create("id", LongType),
+      ColumnV2.create("data", StringType),
+      ColumnV2.create("even_or_odd", StringType)))
     assert(replaced.partitioning.isEmpty)
     assert(replaced.properties === defaultOwnership.asJava)
   }
@@ -629,7 +629,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
     // validate the initial table
     assert(table.name === "testcat.table_name")
     assert(table.columns sameElements
-      Array(Column.create("id", LongType), Column.create("data", StringType)))
+      Array(ColumnV2.create("id", LongType), ColumnV2.create("data", StringType)))
     assert(table.partitioning.isEmpty)
     assert(table.properties === (Map("provider" -> "foo") ++ defaultOwnership).asJava)
 
@@ -646,9 +646,9 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
     // validate the replacement table
     assert(replaced.name === "testcat.table_name")
     assert(replaced.columns sameElements Array(
-      Column.create("id", LongType),
-      Column.create("data", StringType),
-      Column.create("even_or_odd", StringType)))
+      ColumnV2.create("id", LongType),
+      ColumnV2.create("data", StringType),
+      ColumnV2.create("even_or_odd", StringType)))
     assert(replaced.partitioning === Seq(IdentityTransform(FieldReference("id"))))
     assert(replaced.properties === defaultOwnership.asJava)
   }
@@ -666,7 +666,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
     // validate the initial table
     assert(table.name === "testcat.table_name")
     assert(table.columns sameElements
-      Array(Column.create("id", LongType), Column.create("data", StringType)))
+      Array(ColumnV2.create("id", LongType), ColumnV2.create("data", StringType)))
     assert(table.partitioning.isEmpty)
     assert(table.properties === (Map("provider" -> "foo") ++ defaultOwnership).asJava)
 
@@ -683,9 +683,9 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
     // validate the replacement table
     assert(replaced.name === "testcat.table_name")
     assert(replaced.columns sameElements
-      Array(Column.create("id", LongType),
-        Column.create("data", StringType),
-        Column.create("even_or_odd", StringType)))
+      Array(ColumnV2.create("id", LongType),
+        ColumnV2.create("data", StringType),
+        ColumnV2.create("even_or_odd", StringType)))
     assert(replaced.partitioning === Seq(ClusterByTransform(Seq(FieldReference("id")))))
     assert(replaced.properties === defaultOwnership.asJava)
   }
@@ -710,7 +710,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
     // validate the replacement table
     assert(replaced.name === "testcat.table_name")
     assert(replaced.columns sameElements
-      Array(Column.create("id", LongType), Column.create("data", StringType)))
+      Array(ColumnV2.create("id", LongType), ColumnV2.create("data", StringType)))
     assert(replaced.partitioning.isEmpty)
     assert(replaced.properties === defaultOwnership.asJava)
   }
@@ -729,7 +729,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
     // validate the initial table
     assert(table.name === "testcat.table_name")
     assert(table.columns sameElements
-      Array(Column.create("id", LongType), Column.create("data", StringType)))
+      Array(ColumnV2.create("id", LongType), ColumnV2.create("data", StringType)))
     assert(table.partitioning === Seq(IdentityTransform(FieldReference("id"))))
     assert(table.properties === (Map("provider" -> "foo") ++ defaultOwnership).asJava)
 
@@ -746,9 +746,9 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
     // validate the replacement table
     assert(replaced.name === "testcat.table_name")
     assert(replaced.columns sameElements Array(
-      Column.create("id", LongType),
-      Column.create("data", StringType),
-      Column.create("even_or_odd", StringType)))
+      ColumnV2.create("id", LongType),
+      ColumnV2.create("data", StringType),
+      ColumnV2.create("even_or_odd", StringType)))
     assert(replaced.partitioning.isEmpty)
     assert(replaced.properties === defaultOwnership.asJava)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
A very small follow up for https://github.com/apache/spark/pull/50523
In that PR, I had changed some method to use Column...   

It should go to explicitly imported org.apache.spark.sql.connector.catalog.Column (ie, DSV2 Column), but in some environment it may go to this test package's Column (org.apache.spark.sql.Column).

As there is some ambiguity in the import, I think its better to have an alias to avoid this import shadow problem, following example of DataSourceV2SQLSuite

### Why are the changes needed?

Scala import precedence seems a bit not-easily predictable , defined by the compilation unit, which may change based on tool. 
 See:  https://www.scala-lang.org/files/archive/spec/2.12/02-identifiers-names-and-scopes.html.  I saw this error in another build environment where it went to the package Column: org.apache.spark.sql.Column

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Test change, existing test ran.


### Was this patch authored or co-authored using generative AI tooling?
No
