### PR TITLE
[SPARK-52008] [SS] Add StateStore TaskCompletionListener to abort store and throw error

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4986,6 +4986,13 @@
     ],
     "sqlState" : "42802"
   },
+  "STATE_STORE_UPDATING_AFTER_TASK_COMPLETION" : {
+    "message" : [
+      "State store id=<stateStoreId> still in updating state after task completed. If using foreachBatch, ",
+      "verify that it consumes the entire dataframe and does not catch and suppress errors during dataframe iteration."
+    ],
+    "sqlState" : "XXKST"
+  },
   "STATE_STORE_VALUE_ROW_FORMAT_VALIDATION_FAILURE" : {
     "message" : [
       "The streaming query failed to validate written state for value row.",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -26,7 +26,7 @@ import scala.util.control.NonFatal
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.{SparkConf, SparkEnv, SparkException}
+import org.apache.spark.{SparkConf, SparkEnv, SparkException, TaskContext}
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.io.CompressionCodec
@@ -51,6 +51,19 @@ private[sql] class RocksDBStateStoreProvider
     case object ABORTED extends STATE
 
     @volatile private var state: STATE = UPDATING
+
+    Option(TaskContext.get()).foreach { ctxt =>
+      ctxt.addTaskCompletionListener[Unit]( ctx => {
+        if (state == UPDATING) {
+          abort()
+          // Only throw error if the task is not already failed or interrupted
+          if (!ctx.isFailed() && !ctx.isInterrupted()) {
+            throw StateStoreErrors.stateStoreUpdatingAfterTaskCompletion(id)
+          }
+        }
+      })
+    }
+
     @volatile private var isValidated = false
 
     override def id: StateStoreId = RocksDBStateStoreProvider.this.stateStoreId

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
@@ -221,6 +221,11 @@ object StateStoreErrors {
   def stateStoreOperationOutOfOrder(errorMsg: String): StateStoreOperationOutOfOrder = {
     new StateStoreOperationOutOfOrder(errorMsg)
   }
+
+  def stateStoreUpdatingAfterTaskCompletion(stateStoreId: StateStoreId):
+    StateStoreUpdatingAfterTaskCompletion = {
+    new StateStoreUpdatingAfterTaskCompletion(stateStoreId.toString)
+  }
 }
 
 class StateStoreDuplicateStateVariableDefined(stateVarName: String)
@@ -454,4 +459,10 @@ class StateStoreOperationOutOfOrder(errorMsg: String)
   extends SparkRuntimeException(
     errorClass = "STATE_STORE_OPERATION_OUT_OF_ORDER",
     messageParameters = Map("errorMsg" -> errorMsg)
+  )
+
+class StateStoreUpdatingAfterTaskCompletion(stateStoreID: String)
+  extends SparkRuntimeException(
+    errorClass = "STATE_STORE_UPDATING_AFTER_TASK_COMPLETION",
+    messageParameters = Map("stateStoreId" -> stateStoreID)
   )

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -1734,9 +1734,8 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
 
         store = provider.getStore(0)
 
-        // Task completion listener should unlock
-        taskContext.markTaskCompleted(
-          Some(new SparkException("Task failure injection")))
+        // Task completion listener should abort and throw exception
+        taskContext.markTaskCompleted(None)
       }
 
       val ex = intercept[SparkException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -1719,7 +1719,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
     assert(encoderSpec == deserializedEncoderSpec)
   }
 
-  test("SPARK-52008: TaskCompletionListener aborts store") {
+  test("SPARK-52008: TaskCompletionListener fails if store isn't committed/aborted") {
     // Create a custom ExecutionContext with 1 thread
     implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(
       ThreadUtils.newDaemonSingleThreadExecutor("single-thread-executor"))
@@ -1742,7 +1742,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
       val ex = intercept[SparkException] {
         ThreadUtils.awaitResult(fut, timeout)
       }
-      assert(ex.getMessage.contains("STATE_STORE_UPDATING_AFTER_TASK_COMPLETION"))
+      assert(ex.getCause.getMessage.contains("STATE_STORE_UPDATING_AFTER_TASK_COMPLETION"))
       assert(taskContext.isFailed())
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Added TaskCompletionListener for both HDFS and RocksDB StateStore that will check whether the state is still in the UPDATING state (not committed or aborted) and abort it. If the task isn't failed or interrupted, it will fail the task with `STATE_STORE_UPDATING_AFTER_TASK_COMPLETION`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

As explained in SPARK-52008, when a user defines a function with foreachBatch that does not completely consume the passed in iterator, state stores will be opened but not committed when the batch finishes and no error will be thrown. This will lead to "changelog/delta file not found" error for the next batch which confuses users.

Instead, we should explicitly throw an error in the TaskCompletionListener that will abort any state stores still in the updating state and throw an exception to fail the task (if the task is not already failed or interrupted).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, throws `STATE_STORE_UPDATING_AFTER_TASK_COMPLETION` instead of `FileNotFound` error.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

New FEB integration test and unit test.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No