### PR TITLE
[SPARK-52014][SQL] Support FoldableUnevaluable in HiveGenericUDFEvaluator

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -919,6 +919,10 @@ private[hive] trait HiveInspectors {
     // We will enumerate all of the possible constant expressions, throw exception if we missed
     case Literal(_, dt) =>
       throw SparkException.internalError(s"Hive doesn't support the constant type [$dt].")
+    // FoldableUnevaluable will be replaced with a foldable value in FinishAnalysis rule,
+    // skip eval() for them.
+    case _ if expr.collectFirst { case e: FoldableUnevaluable => e }.isDefined =>
+      toInspector(expr.dataType)
     // ideally, we don't test the foldable here(but in optimizer), however, some of the
     // Hive UDF / UDAF requires its argument to be constant objectinspector, we do it eagerly.
     case _ if expr.foldable => toInspector(Literal.create(expr.eval(), expr.dataType))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -824,6 +824,17 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
       }
     }
   }
+
+  test("SPARK-52014: Support FoldableUnevaluable in HiveGenericUDFEvaluator") {
+    withUserDefinedFunction("hive_concat" -> true) {
+      sql(s"CREATE TEMPORARY FUNCTION hive_concat AS '${classOf[GenericUDFConcat].getName}'")
+      assert(sql(
+        s"""SELECT hive_concat(
+           |         date_format(CAST(CURRENT_DATE() AS DATE), 'yyyyMMdd'),
+           |         now())""".stripMargin).collect().length == 1)
+    }
+    hiveContext.reset()
+  }
 }
 
 class TestPair(x: Int, y: Int) extends Writable with Serializable {


### PR DESCRIPTION
### What changes were proposed in this pull request?

FoldableUnevaluable expression will throw exception in HiveGenericUDFEvaluator, we should skip eval() for them.

https://github.com/apache/spark/blob/aff3a33eef551e6f5f4b8bd601dbbb3f0ccf4ba1/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala#L928


### Why are the changes needed?

Bug fix for HiveGenericUDFEvaluator


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Add UT


### Was this patch authored or co-authored using generative AI tooling?

No