### PR TITLE
[SPARK-52017][SQL] Enable multiple self-references and self-references from a Subquery inside rCTEs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveWithCTE.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveWithCTE.scala
@@ -288,7 +288,7 @@ object ResolveWithCTE extends Rule[LogicalPlan] {
       anchor: LogicalPlan,
       cteDefId: Long,
       columnNames: Option[Seq[String]]) = {
-    recursion.transformWithSubqueries {
+    recursion.transformUpWithSubqueriesAndPruning(_.containsPattern(CTE)) {
       case r: CTERelationRef if r.recursive && r.cteId == cteDefId =>
         val ref = UnionLoopRef(r.cteId, anchor.output, false)
         columnNames.map(UnresolvedSubqueryColumnAliases(_, ref)).getOrElse(ref)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveWithCTE.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveWithCTE.scala
@@ -61,7 +61,6 @@ object ResolveWithCTE extends Rule[LogicalPlan] {
             cteDef
           case cteDef =>
             // Multiple self-references are not allowed within one cteDef.
-            checkNumberOfSelfReferences(cteDef)
             cteDef.child match {
               // If it is a supported recursive CTE query pattern (4 so far), extract the anchor and
               // recursive plans from the Union and rewrite Union with UnionLoop. The recursive CTE
@@ -289,25 +288,10 @@ object ResolveWithCTE extends Rule[LogicalPlan] {
       anchor: LogicalPlan,
       cteDefId: Long,
       columnNames: Option[Seq[String]]) = {
-    recursion.transformWithPruning(_.containsPattern(CTE)) {
+    recursion.transformWithSubqueries {
       case r: CTERelationRef if r.recursive && r.cteId == cteDefId =>
         val ref = UnionLoopRef(r.cteId, anchor.output, false)
         columnNames.map(UnresolvedSubqueryColumnAliases(_, ref)).getOrElse(ref)
-    }
-  }
-
-  /**
-   * Counts number of self-references in a recursive CTE definition and throws an error
-   * if that number is bigger than 1.
-   */
-  private def checkNumberOfSelfReferences(cteDef: CTERelationDef): Unit = {
-    val numOfSelfRef = cteDef.collectWithSubqueries {
-      case ref: CTERelationRef if ref.cteId == cteDef.id => ref
-    }.length
-    if (numOfSelfRef > 1) {
-      cteDef.failAnalysis(
-        errorClass = "INVALID_RECURSIVE_REFERENCE.NUMBER",
-        messageParameters = Map.empty)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -603,10 +603,20 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
 
   /**
    * A variant of `collect`. This method not only apply the given function to all elements in this
-   * plan, also considering all the plans in its (nested) subqueries
+   * plan, also considering all the plans in its (nested) subqueries.
    */
   def collectWithSubqueries[B](f: PartialFunction[PlanType, B]): Seq[B] =
     (this +: subqueriesAll).flatMap(_.collect(f))
+
+  /**
+   * A variant of collectFirst. This method not only apply the given function to all elements in
+   * this plan, also considering all the plans in its (nested) subqueries.
+   */
+  def collectFirstWithSubqueries[B](f: PartialFunction[PlanType, B]): Option[B] = {
+    this.collectFirst(f).orElse {
+      subqueriesAll.foldLeft(Option.empty[B]) { (l, r) => l.orElse(r.collectFirst(f)) }
+    }
+  }
 
   override def innerChildren: Seq[QueryPlan[_]] = subqueries
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -614,7 +614,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    */
   def collectFirstWithSubqueries[B](f: PartialFunction[PlanType, B]): Option[B] = {
     this.collectFirst(f).orElse {
-      subqueriesAll.foldLeft(Option.empty[B]) { (l, r) => l.orElse(r.collectFirst(f)) }
+      subqueriesAll.foldLeft(None: Option[B]) { (l, r) => l.orElse(r.collectFirst(f)) }
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/cteOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/cteOperators.scala
@@ -106,14 +106,12 @@ case class CTERelationDef(
 
   override def output: Seq[Attribute] = if (resolved) child.output else Nil
 
-  lazy val hasSelfReferenceAsCTERef: Boolean = child.collectWithSubqueries {
+  lazy val hasSelfReferenceAsCTERef: Boolean = child.collectFirstWithSubqueries {
     case CTERelationRef(this.id, _, _, _, _, true, _) => true
-    case _ => false
-  }.foldLeft(false)(_ || _)
-  lazy val hasSelfReferenceAsUnionLoopRef: Boolean = child.collectWithSubqueries {
+  }.getOrElse(false)
+  lazy val hasSelfReferenceAsUnionLoopRef: Boolean = child.collectFirstWithSubqueries {
     case UnionLoopRef(this.id, _, _) => true
-    case _ => false
-  }.foldLeft(false)(_ || _)
+  }.getOrElse(false)
 }
 
 object CTERelationDef {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/cteOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/cteOperators.scala
@@ -106,22 +106,14 @@ case class CTERelationDef(
 
   override def output: Seq[Attribute] = if (resolved) child.output else Nil
 
-  def hasReferenceToThisCTE(plan: LogicalPlan): Boolean = {
-    plan.collect {
-      case CTERelationRef(this.id, _, _, _, _, true, _) => true
-      case p => p.expressions.filter(_.containsPattern(PLAN_EXPRESSION)).collect {
-        expr => expr.collect {
-          case s: SubqueryExpression => hasReferenceToThisCTE(s.plan)
-          case _ => false
-        }.foldLeft(false)(_ || _)
-      }.foldLeft(false)(_ || _)
-    }.foldLeft(false)(_ || _)
-  }
-  lazy val hasSelfReferenceAsCTERef: Boolean = hasReferenceToThisCTE(child)
-  lazy val hasSelfReferenceAsUnionLoopRef: Boolean = child.exists{
+  lazy val hasSelfReferenceAsCTERef: Boolean = child.collectWithSubqueries {
+    case CTERelationRef(this.id, _, _, _, _, true, _) => true
+    case _ => false
+  }.foldLeft(false)(_ || _)
+  lazy val hasSelfReferenceAsUnionLoopRef: Boolean = child.collectWithSubqueries {
     case UnionLoopRef(this.id, _, _) => true
     case _ => false
-  }
+  }.foldLeft(false)(_ || _)
 }
 
 object CTERelationDef {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/UnionLoopExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/UnionLoopExec.scala
@@ -185,7 +185,7 @@ case class UnionLoopExec(
       // the previous plan.
       // This way we support only UNION ALL case. Additional case should be added for UNION case.
       // One way of supporting UNION case can be seen at SPARK-24497 PR from Peter Toth.
-      val newRecursion = recursion.transform {
+      val newRecursion = recursion.transformWithSubqueries {
         case r: UnionLoopRef if r.loopId == loopId =>
           prevDF.queryExecution.optimizedPlan match {
             case l: LocalRelation =>

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
@@ -345,7 +345,7 @@ WITH RECURSIVE t(col) (
   UNION ALL
   SELECT (SELECT max(col) FROM t)
 )
-SELECT * FROM t
+SELECT * FROM t LIMIT 5
 -- !query analysis
 WithCTE
 :- CTERelationDef xxxx, false
@@ -360,9 +360,11 @@ WithCTE
 :              :        +- Project [1#x AS col#x]
 :              :           +- UnionLoopRef xxxx, [1#x], false
 :              +- OneRowRelation
-+- Project [col#x]
-   +- SubqueryAlias t
-      +- CTERelationRef xxxx, true, [col#x], false, false
++- GlobalLimit 5
+   +- LocalLimit 5
+      +- Project [col#x]
+         +- SubqueryAlias t
+            +- CTERelationRef xxxx, true, [col#x], false, false
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
@@ -347,11 +347,22 @@ WITH RECURSIVE t(col) (
 )
 SELECT * FROM t
 -- !query analysis
-org.apache.spark.sql.catalyst.ExtendedAnalysisException
-{
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.PLACE",
-  "sqlState" : "42836"
-}
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t
+:     +- Project [1#x AS col#x]
+:        +- UnionLoop xxxx
+:           :- Project [1 AS 1#x]
+:           :  +- OneRowRelation
+:           +- Project [scalar-subquery#x [] AS scalarsubquery()#x]
+:              :  +- Aggregate [max(col#x) AS max(col)#x]
+:              :     +- SubqueryAlias t
+:              :        +- Project [1#x AS col#x]
+:              :           +- UnionLoopRef xxxx, [1#x], false
+:              +- OneRowRelation
++- Project [col#x]
+   +- SubqueryAlias t
+      +- CTERelationRef xxxx, true, [col#x], false, false
 
 
 -- !query
@@ -475,18 +486,26 @@ WITH RECURSIVE r(level, data) AS (
 )
 SELECT * FROM r
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.NUMBER",
-  "sqlState" : "42836",
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 183,
-    "fragment" : "WITH RECURSIVE r(level, data) AS (\n  VALUES (0, 0)\n  UNION ALL\n  SELECT r1.level + 1, r1.data\n  FROM r AS r1\n  JOIN r AS r2 ON r2.data = r1.data\n  WHERE r1.level < 9\n)\nSELECT * FROM r"
-  } ]
-}
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias r
+:     +- Project [col1#x AS level#x, col2#x AS data#x]
+:        +- UnionLoop xxxx
+:           :- LocalRelation [col1#x, col2#x]
+:           +- Project [(level#x + 1) AS (level + 1)#x, data#x]
+:              +- Filter (level#x < 9)
+:                 +- Join Inner, (data#x = data#x)
+:                    :- SubqueryAlias r1
+:                    :  +- SubqueryAlias r
+:                    :     +- Project [col1#x AS level#x, col2#x AS data#x]
+:                    :        +- UnionLoopRef xxxx, [col1#x, col2#x], false
+:                    +- SubqueryAlias r2
+:                       +- SubqueryAlias r
+:                          +- Project [col1#x AS level#x, col2#x AS data#x]
+:                             +- UnionLoopRef xxxx, [col1#x, col2#x], false
++- Project [level#x, data#x]
+   +- SubqueryAlias r
+      +- CTERelationRef xxxx, true, [level#x, data#x], false, false
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/with.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/with.sql.out
@@ -1260,18 +1260,25 @@ WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM x
                           WHERE n IN (SELECT * FROM x))
   SELECT * FROM x
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.NUMBER",
-  "sqlState" : "42836",
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 134,
-    "fragment" : "WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM x\n                          WHERE n IN (SELECT * FROM x))\n  SELECT * FROM x"
-  } ]
-}
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias x
+:     +- Project [1#x AS n#x]
+:        +- UnionLoop xxxx
+:           :- Project [1 AS 1#x]
+:           :  +- OneRowRelation
+:           +- Project [(n#x + 1) AS (n + 1)#x]
+:              +- Filter n#x IN (list#x [])
+:                 :  +- Project [n#x]
+:                 :     +- SubqueryAlias x
+:                 :        +- Project [1#x AS n#x]
+:                 :           +- UnionLoopRef xxxx, [1#x], false
+:                 +- SubqueryAlias x
+:                    +- Project [1#x AS n#x]
+:                       +- UnionLoopRef xxxx, [1#x], false
++- Project [n#x]
+   +- SubqueryAlias x
+      +- CTERelationRef xxxx, true, [n#x], false, false
 
 
 -- !query
@@ -1324,18 +1331,24 @@ WITH RECURSIVE x(id) AS (values (1)
     SELECT (SELECT * FROM x) FROM x WHERE id < 5
 ) SELECT * FROM x
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.NUMBER",
-  "sqlState" : "42836",
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 116,
-    "fragment" : "WITH RECURSIVE x(id) AS (values (1)\n    UNION ALL\n    SELECT (SELECT * FROM x) FROM x WHERE id < 5\n) SELECT * FROM x"
-  } ]
-}
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias x
+:     +- Project [col1#x AS id#x]
+:        +- UnionLoop xxxx
+:           :- LocalRelation [col1#x]
+:           +- Project [scalar-subquery#x [] AS scalarsubquery()#x]
+:              :  +- Project [id#x]
+:              :     +- SubqueryAlias x
+:              :        +- Project [col1#x AS id#x]
+:              :           +- UnionLoopRef xxxx, [col1#x], false
+:              +- Filter (id#x < 5)
+:                 +- SubqueryAlias x
+:                    +- Project [col1#x AS id#x]
+:                       +- UnionLoopRef xxxx, [col1#x], false
++- Project [id#x]
+   +- SubqueryAlias x
+      +- CTERelationRef xxxx, true, [id#x], false, false
 
 
 -- !query
@@ -1370,18 +1383,26 @@ WITH RECURSIVE foo(i) AS
        SELECT i+1 FROM foo WHERE i < 5)
 ) SELECT * FROM foo
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.NUMBER",
-  "sqlState" : "42836",
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 175,
-    "fragment" : "WITH RECURSIVE foo(i) AS\n    (values (1)\n    UNION ALL\n       (SELECT i+1 FROM foo WHERE i < 10\n          UNION ALL\n       SELECT i+1 FROM foo WHERE i < 5)\n) SELECT * FROM foo"
-  } ]
-}
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias foo
+:     +- Project [col1#x AS i#x]
+:        +- UnionLoop xxxx
+:           :- LocalRelation [col1#x]
+:           +- Union false, false
+:              :- Project [(i#x + 1) AS (i + 1)#x]
+:              :  +- Filter (i#x < 10)
+:              :     +- SubqueryAlias foo
+:              :        +- Project [col1#x AS i#x]
+:              :           +- UnionLoopRef xxxx, [col1#x], false
+:              +- Project [(i#x + 1) AS (i + 1)#x]
+:                 +- Filter (i#x < 5)
+:                    +- SubqueryAlias foo
+:                       +- Project [col1#x AS i#x]
+:                          +- UnionLoopRef xxxx, [col1#x], false
++- Project [i#x]
+   +- SubqueryAlias foo
+      +- CTERelationRef xxxx, true, [i#x], false, false
 
 
 -- !query
@@ -1394,18 +1415,28 @@ WITH RECURSIVE foo(i) AS
        SELECT i+1 FROM foo WHERE i < 5) AS t
 ) SELECT * FROM foo
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.NUMBER",
-  "sqlState" : "42836",
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 198,
-    "fragment" : "WITH RECURSIVE foo(i) AS\n    (values (1)\n    UNION ALL\n\t   SELECT * FROM\n       (SELECT i+1 FROM foo WHERE i < 10\n          UNION ALL\n       SELECT i+1 FROM foo WHERE i < 5) AS t\n) SELECT * FROM foo"
-  } ]
-}
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias foo
+:     +- Project [col1#x AS i#x]
+:        +- UnionLoop xxxx
+:           :- LocalRelation [col1#x]
+:           +- Project [(i + 1)#x]
+:              +- SubqueryAlias t
+:                 +- Union false, false
+:                    :- Project [(i#x + 1) AS (i + 1)#x]
+:                    :  +- Filter (i#x < 10)
+:                    :     +- SubqueryAlias foo
+:                    :        +- Project [col1#x AS i#x]
+:                    :           +- UnionLoopRef xxxx, [col1#x], false
+:                    +- Project [(i#x + 1) AS (i + 1)#x]
+:                       +- Filter (i#x < 5)
+:                          +- SubqueryAlias foo
+:                             +- Project [col1#x AS i#x]
+:                                +- UnionLoopRef xxxx, [col1#x], false
++- Project [i#x]
+   +- SubqueryAlias foo
+      +- CTERelationRef xxxx, true, [i#x], false, false
 
 
 -- !query
@@ -1417,18 +1448,26 @@ WITH RECURSIVE foo(i) AS
        SELECT i+1 FROM foo WHERE i < 5)
 ) SELECT * FROM foo
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.NUMBER",
-  "sqlState" : "42836",
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 172,
-    "fragment" : "WITH RECURSIVE foo(i) AS\n    (values (1)\n    UNION ALL\n       (SELECT i+1 FROM foo WHERE i < 10\n          EXCEPT\n       SELECT i+1 FROM foo WHERE i < 5)\n) SELECT * FROM foo"
-  } ]
-}
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias foo
+:     +- Project [col1#x AS i#x]
+:        +- UnionLoop xxxx
+:           :- LocalRelation [col1#x]
+:           +- Except false
+:              :- Project [(i#x + 1) AS (i + 1)#x]
+:              :  +- Filter (i#x < 10)
+:              :     +- SubqueryAlias foo
+:              :        +- Project [col1#x AS i#x]
+:              :           +- UnionLoopRef xxxx, [col1#x], false
+:              +- Project [(i#x + 1) AS (i + 1)#x]
+:                 +- Filter (i#x < 5)
+:                    +- SubqueryAlias foo
+:                       +- Project [col1#x AS i#x]
+:                          +- UnionLoopRef xxxx, [col1#x], false
++- Project [i#x]
+   +- SubqueryAlias foo
+      +- CTERelationRef xxxx, true, [i#x], false, false
 
 
 -- !query
@@ -1440,18 +1479,26 @@ WITH RECURSIVE foo(i) AS
        SELECT i+1 FROM foo WHERE i < 5)
 ) SELECT * FROM foo
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.NUMBER",
-  "sqlState" : "42836",
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 175,
-    "fragment" : "WITH RECURSIVE foo(i) AS\n    (values (1)\n    UNION ALL\n       (SELECT i+1 FROM foo WHERE i < 10\n          INTERSECT\n       SELECT i+1 FROM foo WHERE i < 5)\n) SELECT * FROM foo"
-  } ]
-}
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias foo
+:     +- Project [col1#x AS i#x]
+:        +- UnionLoop xxxx
+:           :- LocalRelation [col1#x]
+:           +- Intersect false
+:              :- Project [(i#x + 1) AS (i + 1)#x]
+:              :  +- Filter (i#x < 10)
+:              :     +- SubqueryAlias foo
+:              :        +- Project [col1#x AS i#x]
+:              :           +- UnionLoopRef xxxx, [col1#x], false
+:              +- Project [(i#x + 1) AS (i + 1)#x]
+:                 +- Filter (i#x < 5)
+:                    +- SubqueryAlias foo
+:                       +- Project [col1#x AS i#x]
+:                          +- UnionLoopRef xxxx, [col1#x], false
++- Project [i#x]
+   +- SubqueryAlias foo
+      +- CTERelationRef xxxx, true, [i#x], false, false
 
 
 -- !query
@@ -1623,7 +1670,7 @@ SELECT * FROM outermost ORDER BY 1
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.NUMBER",
+  "errorClass" : "UNION_NOT_SUPPORTED_IN_RECURSIVE_CTE",
   "sqlState" : "42836",
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
@@ -127,7 +127,7 @@ WITH RECURSIVE t(col) (
   UNION ALL
   SELECT (SELECT max(col) FROM t)
 )
-SELECT * FROM t;
+SELECT * FROM t LIMIT 5;
 
 -- complicated subquery example: self-reference in subquery in an inner CTE
 WITH

--- a/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
@@ -325,10 +325,13 @@ SELECT * FROM t
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.ExtendedAnalysisException
+org.apache.spark.SparkException
 {
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.PLACE",
-  "sqlState" : "42836"
+  "errorClass" : "RECURSION_LEVEL_LIMIT_EXCEEDED",
+  "sqlState" : "42836",
+  "messageParameters" : {
+    "levelLimit" : "100"
+  }
 }
 
 
@@ -436,20 +439,18 @@ WITH RECURSIVE r(level, data) AS (
 )
 SELECT * FROM r
 -- !query schema
-struct<>
+struct<level:int,data:int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.NUMBER",
-  "sqlState" : "42836",
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 183,
-    "fragment" : "WITH RECURSIVE r(level, data) AS (\n  VALUES (0, 0)\n  UNION ALL\n  SELECT r1.level + 1, r1.data\n  FROM r AS r1\n  JOIN r AS r2 ON r2.data = r1.data\n  WHERE r1.level < 9\n)\nSELECT * FROM r"
-  } ]
-}
+0	0
+1	0
+2	0
+3	0
+4	0
+5	0
+6	0
+7	0
+8	0
+9	0
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
@@ -321,18 +321,15 @@ WITH RECURSIVE t(col) (
   UNION ALL
   SELECT (SELECT max(col) FROM t)
 )
-SELECT * FROM t
+SELECT * FROM t LIMIT 5
 -- !query schema
-struct<>
+struct<col:int>
 -- !query output
-org.apache.spark.SparkException
-{
-  "errorClass" : "RECURSION_LEVEL_LIMIT_EXCEEDED",
-  "sqlState" : "42836",
-  "messageParameters" : {
-    "levelLimit" : "100"
-  }
-}
+1
+1
+1
+1
+1
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/with.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/with.sql.out
@@ -986,17 +986,13 @@ WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM x
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.AnalysisException
+org.apache.spark.SparkException
 {
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.NUMBER",
+  "errorClass" : "RECURSION_LEVEL_LIMIT_EXCEEDED",
   "sqlState" : "42836",
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 134,
-    "fragment" : "WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM x\n                          WHERE n IN (SELECT * FROM x))\n  SELECT * FROM x"
-  } ]
+  "messageParameters" : {
+    "levelLimit" : "100"
+  }
 }
 
 
@@ -1060,17 +1056,13 @@ WITH RECURSIVE x(id) AS (values (1)
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.AnalysisException
+org.apache.spark.SparkException
 {
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.NUMBER",
+  "errorClass" : "RECURSION_LEVEL_LIMIT_EXCEEDED",
   "sqlState" : "42836",
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 116,
-    "fragment" : "WITH RECURSIVE x(id) AS (values (1)\n    UNION ALL\n    SELECT (SELECT * FROM x) FROM x WHERE id < 5\n) SELECT * FROM x"
-  } ]
+  "messageParameters" : {
+    "levelLimit" : "100"
+  }
 }
 
 
@@ -1108,20 +1100,119 @@ WITH RECURSIVE foo(i) AS
        SELECT i+1 FROM foo WHERE i < 5)
 ) SELECT * FROM foo
 -- !query schema
-struct<>
+struct<i:int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.NUMBER",
-  "sqlState" : "42836",
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 175,
-    "fragment" : "WITH RECURSIVE foo(i) AS\n    (values (1)\n    UNION ALL\n       (SELECT i+1 FROM foo WHERE i < 10\n          UNION ALL\n       SELECT i+1 FROM foo WHERE i < 5)\n) SELECT * FROM foo"
-  } ]
-}
+1
+10
+10
+10
+10
+10
+10
+10
+10
+10
+10
+10
+10
+10
+10
+10
+10
+2
+2
+3
+3
+3
+3
+4
+4
+4
+4
+4
+4
+4
+4
+5
+5
+5
+5
+5
+5
+5
+5
+5
+5
+5
+5
+5
+5
+5
+5
+6
+6
+6
+6
+6
+6
+6
+6
+6
+6
+6
+6
+6
+6
+6
+6
+7
+7
+7
+7
+7
+7
+7
+7
+7
+7
+7
+7
+7
+7
+7
+7
+8
+8
+8
+8
+8
+8
+8
+8
+8
+8
+8
+8
+8
+8
+8
+8
+9
+9
+9
+9
+9
+9
+9
+9
+9
+9
+9
+9
+9
+9
+9
+9
 
 
 -- !query
@@ -1134,20 +1225,119 @@ WITH RECURSIVE foo(i) AS
        SELECT i+1 FROM foo WHERE i < 5) AS t
 ) SELECT * FROM foo
 -- !query schema
-struct<>
+struct<i:int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.NUMBER",
-  "sqlState" : "42836",
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 198,
-    "fragment" : "WITH RECURSIVE foo(i) AS\n    (values (1)\n    UNION ALL\n\t   SELECT * FROM\n       (SELECT i+1 FROM foo WHERE i < 10\n          UNION ALL\n       SELECT i+1 FROM foo WHERE i < 5) AS t\n) SELECT * FROM foo"
-  } ]
-}
+1
+10
+10
+10
+10
+10
+10
+10
+10
+10
+10
+10
+10
+10
+10
+10
+10
+2
+2
+3
+3
+3
+3
+4
+4
+4
+4
+4
+4
+4
+4
+5
+5
+5
+5
+5
+5
+5
+5
+5
+5
+5
+5
+5
+5
+5
+5
+6
+6
+6
+6
+6
+6
+6
+6
+6
+6
+6
+6
+6
+6
+6
+6
+7
+7
+7
+7
+7
+7
+7
+7
+7
+7
+7
+7
+7
+7
+7
+7
+8
+8
+8
+8
+8
+8
+8
+8
+8
+8
+8
+8
+8
+8
+8
+8
+9
+9
+9
+9
+9
+9
+9
+9
+9
+9
+9
+9
+9
+9
+9
+9
 
 
 -- !query
@@ -1159,20 +1349,9 @@ WITH RECURSIVE foo(i) AS
        SELECT i+1 FROM foo WHERE i < 5)
 ) SELECT * FROM foo
 -- !query schema
-struct<>
+struct<i:int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.NUMBER",
-  "sqlState" : "42836",
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 172,
-    "fragment" : "WITH RECURSIVE foo(i) AS\n    (values (1)\n    UNION ALL\n       (SELECT i+1 FROM foo WHERE i < 10\n          EXCEPT\n       SELECT i+1 FROM foo WHERE i < 5)\n) SELECT * FROM foo"
-  } ]
-}
+1
 
 
 -- !query
@@ -1184,20 +1363,13 @@ WITH RECURSIVE foo(i) AS
        SELECT i+1 FROM foo WHERE i < 5)
 ) SELECT * FROM foo
 -- !query schema
-struct<>
+struct<i:int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.NUMBER",
-  "sqlState" : "42836",
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 175,
-    "fragment" : "WITH RECURSIVE foo(i) AS\n    (values (1)\n    UNION ALL\n       (SELECT i+1 FROM foo WHERE i < 10\n          INTERSECT\n       SELECT i+1 FROM foo WHERE i < 5)\n) SELECT * FROM foo"
-  } ]
-}
+1
+2
+3
+4
+5
 
 
 -- !query
@@ -1381,7 +1553,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "INVALID_RECURSIVE_REFERENCE.NUMBER",
+  "errorClass" : "UNION_NOT_SUPPORTED_IN_RECURSIVE_CTE",
   "sqlState" : "42836",
   "queryContext" : [ {
     "objectType" : "",


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enable two different types of rCTEs which have been banned thus far:
- rCTEs where there are multiple self-references
- rCTEs where the self reference happens inside a subquery.

### Why are the changes needed?

More cases covered with rCTEs.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Existing golden file tests which failed previously.

### Was this patch authored or co-authored using generative AI tooling?

No.
