### PR TITLE
[SPARK-52019] [SQL] Strip outer reference before creating a name in toPrettySQL

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/LiteralFunctionResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/LiteralFunctionResolution.scala
@@ -41,12 +41,12 @@ object LiteralFunctionResolution {
   // support CURRENT_DATE, CURRENT_TIMESTAMP, CURRENT_TIME,
   //  CURRENT_USER, USER, SESSION_USER and grouping__id
   private val literalFunctions: Seq[(String, () => Expression, Expression => String)] = Seq(
-    (CurrentDate().prettyName, () => CurrentDate(), toPrettySQL(_)),
-    (CurrentTimestamp().prettyName, () => CurrentTimestamp(), toPrettySQL(_)),
-    (CurrentTime().prettyName, () => CurrentTime(), toPrettySQL(_)),
-    (CurrentUser().prettyName, () => CurrentUser(), toPrettySQL),
-    ("user", () => CurrentUser(), toPrettySQL),
-    ("session_user", () => CurrentUser(), toPrettySQL),
+    (CurrentDate().prettyName, () => CurrentDate(), e => toPrettySQL(e)),
+    (CurrentTimestamp().prettyName, () => CurrentTimestamp(), e => toPrettySQL(e)),
+    (CurrentTime().prettyName, () => CurrentTime(), e => toPrettySQL(e)),
+    (CurrentUser().prettyName, () => CurrentUser(), e => toPrettySQL(e)),
+    ("user", () => CurrentUser(), e => toPrettySQL(e)),
+    ("session_user", () => CurrentUser(), e => toPrettySQL(e)),
     (VirtualColumn.hiveGroupingIdName, () => GroupingID(Nil), _ => VirtualColumn.hiveGroupingIdName)
   )
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -25,6 +25,7 @@ import com.google.common.io.ByteStreams
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.connector.catalog.MetadataColumn
 import org.apache.spark.sql.types.{MetadataBuilder, NumericType, StringType, StructType}
 import org.apache.spark.unsafe.types.UTF8String
@@ -91,24 +92,45 @@ package object util extends Logging {
 
   def stackTraceToString(t: Throwable): String = SparkErrorUtils.stackTraceToString(t)
 
-  // Replaces attributes, string literals, complex type extractors with their pretty form so that
-  // generated column names don't contain back-ticks or double-quotes.
-  def usePrettyExpression(e: Expression): Expression = e transform {
-    case a: Attribute => new PrettyAttribute(a)
-    case Literal(s: UTF8String, StringType) => PrettyAttribute(s.toString, StringType)
-    case Literal(v, t: NumericType) if v != null => PrettyAttribute(v.toString, t)
-    case Literal(null, dataType) => PrettyAttribute("NULL", dataType)
-    case e: GetStructField =>
-      val name = e.name.getOrElse(e.childSchema(e.ordinal).name)
-      PrettyAttribute(usePrettyExpression(e.child).sql + "." + name, e.dataType)
-    case e: GetArrayStructFields =>
-      PrettyAttribute(s"${usePrettyExpression(e.child)}.${e.field.name}", e.dataType)
-    case r: InheritAnalysisRules =>
-      PrettyAttribute(r.makeSQLString(r.parameters.map(toPrettySQL)), r.dataType)
-    case c: Cast if c.getTagValue(Cast.USER_SPECIFIED_CAST).isEmpty =>
-      PrettyAttribute(usePrettyExpression(c.child).sql, c.dataType)
-    case p: PythonFuncExpression => PrettyPythonUDF(p.name, p.dataType, p.children)
-  }
+  /**
+   * Replaces attributes, string literals, complex type extractors, casts and python functions with
+   * their pretty form so that generated column names don't contain back-ticks or double-quotes.
+   *
+   * In case provided expression is [[AggregateExpression]] that contains a [[OuterReference]],
+   * pull out the outer reference and compute the name to maintain compatibility with single-pass
+   * analyzer.
+   */
+  private def usePrettyExpression(e: Expression, stripOuterReference: Boolean = true): Expression =
+    e transform {
+      case aggregateExpression: AggregateExpression
+        if stripOuterReference && SubExprUtils.containsOuter(aggregateExpression) =>
+        val strippedAggregateExpression = SubExprUtils.stripOuterReference(aggregateExpression)
+        OuterReference(
+          new PrettyAttribute(
+            Alias(
+              strippedAggregateExpression,
+              toPrettySQL(strippedAggregateExpression)
+            )().toAttribute
+          )
+        )
+      case a: Attribute => new PrettyAttribute(a)
+      case Literal(s: UTF8String, StringType) => PrettyAttribute(s.toString, StringType)
+      case Literal(v, t: NumericType) if v != null => PrettyAttribute(v.toString, t)
+      case Literal(null, dataType) => PrettyAttribute("NULL", dataType)
+      case e: GetStructField =>
+        val name = e.name.getOrElse(e.childSchema(e.ordinal).name)
+        PrettyAttribute(usePrettyExpression(e.child).sql + "." + name, e.dataType)
+      case e: GetArrayStructFields =>
+        PrettyAttribute(s"${usePrettyExpression(e.child)}.${e.field.name}", e.dataType)
+      case r: InheritAnalysisRules =>
+        PrettyAttribute(
+          r.makeSQLString(r.parameters.map(parameter => toPrettySQL(parameter))),
+          r.dataType
+        )
+      case c: Cast if c.getTagValue(Cast.USER_SPECIFIED_CAST).isEmpty =>
+        PrettyAttribute(usePrettyExpression(c.child).sql, c.dataType)
+      case p: PythonFuncExpression => PrettyPythonUDF(p.name, p.dataType, p.children)
+    }
 
   def quoteIdentifier(name: String): String = {
     QuotingUtils.quoteIdentifier(name)
@@ -122,7 +144,8 @@ package object util extends Logging {
     QuotingUtils.quoteIfNeeded(part)
   }
 
-  def toPrettySQL(e: Expression): String = usePrettyExpression(e).sql
+  def toPrettySQL(e: Expression, stripOuterReference: Boolean = true): String =
+    usePrettyExpression(e, stripOuterReference).sql
 
   def escapeSingleQuotedString(str: String): String = {
     QuotingUtils.escapeSingleQuotedString(str)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/negative-cases/invalid-correlation.sql.out
@@ -159,7 +159,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.CORRELATED_REFERENCE",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "sqlExprs" : "\"min(t2a) AS `min(outer(t2.t2a))`\""
+    "sqlExprs" : "\"min(t2a) AS `outer(min(t2a))`\""
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
@@ -160,7 +160,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.CORRELATED_REFERENCE",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "sqlExprs" : "\"min(t2a) AS `min(outer(t2.t2a))`\""
+    "sqlExprs" : "\"min(t2a) AS `outer(min(t2a))`\""
   },
   "queryContext" : [ {
     "objectType" : "",


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the following query we would have `min(outer(t2.t2a))` as a name for `min(t2a)` expression.
```
SELECT t1a 
FROM   t1
WHERE  t1a IN (SELECT t2a 
               FROM   t2
               WHERE  EXISTS (SELECT min(t2a) 
                              FROM   t3))
```
This is a problem in compatibility between single-pass resolver and fixed-point analyzer because names in single-pass are generated after we finish resolution of aggregate expression `min(t2a)` (bottom-up manner) and at that point we have `OuterReference` wrapped around aggregate expression (name looks like `outer(min(t2a))`).
I propose that we fix it in fixed point so we can compute the name in single-pass more easily.

### Why are the changes needed?
To ease development of single-pass analyzer.

### Does this PR introduce _any_ user-facing change?
`Explain extended` of affected plans would be different.

### How was this patch tested?
Existing tests (regenerated golden files).

### Was this patch authored or co-authored using generative AI tooling?
No.