### PR TITLE
[SPARK-52021][SQL] Separate operator and expression patterns

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
@@ -248,6 +248,24 @@ class BitSet(numBits: Int) extends Serializable {
     }
   }
 
+  /**
+   * Returns true if the bitset intersects with the given other bitset.
+   *
+   * @param other -- the bitset, should have the same size in words as the current one.
+   * @return true if the intersection of two bitsets is non-empty.
+   */
+  def intersects(other: BitSet): Boolean = {
+    assert(numWords == other.numWords)
+    var ind = 0
+    while (ind < numWords) {
+      if ((words(ind) & other.words(ind)) != 0) {
+        return true
+      }
+      ind += 1
+    }
+    false
+  }
+
   /** Return the number of longs it would take to hold numBits. */
   private def bit2words(numBits: Int) = ((numBits - 1) >> 6) + 1
 

--- a/core/src/test/scala/org/apache/spark/util/collection/BitSetSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/BitSetSuite.scala
@@ -184,4 +184,34 @@ class BitSetSuite extends SparkFunSuite {
       assert(!bitSet.get(i))
     }
   }
+
+  test("empty intersect non-empty") {
+    val emptyBitSet = new BitSet(numBits = 10)
+    val bitSet = new BitSet(numBits = 10)
+
+    val setBits = Seq(0, 10, 20, 30)
+    setBits.foreach(bitSet.set)
+
+    assert(!bitSet.intersects(emptyBitSet))
+  }
+
+  test("intersect bitsets of different size") {
+    val oneBitSet = new BitSet(numBits = 1000)
+    val otherBitSet = new BitSet(numBits = 20)
+
+    Seq(0, 10, 20, 30).foreach(otherBitSet.set)
+    Seq(0, 10).foreach(oneBitSet.set)
+    val e = intercept[java.lang.AssertionError] {
+      oneBitSet.intersects(otherBitSet)
+    }
+    assert(e.getMessage.contains("assertion failed"))
+  }
+
+  test("intersect bitsets ") {
+    val oneBitSet = new BitSet(numBits = 1000)
+    val otherBitSet = new BitSet(numBits = 1000)
+    Seq(0, 10, 20, 900).foreach(otherBitSet.set)
+    Seq(1, 12, 22, 900).foreach(oneBitSet.set)
+    assert(oneBitSet.intersects(otherBitSet))
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CTESubstitution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CTESubstitution.scala
@@ -408,7 +408,7 @@ object CTESubstitution extends Rule[LogicalPlan] {
       recursiveCTERelation: Option[(String, CTERelationDef)]): LogicalPlan = {
     plan.resolveOperatorsUpWithPruning(
         _.containsAnyPattern(RELATION_TIME_TRAVEL, UNRESOLVED_RELATION, PLAN_EXPRESSION,
-          UNRESOLVED_IDENTIFIER)) {
+          UNRESOLVED_IDENTIFIER, PLAN_WITH_UNRESOLVED_IDENTIFIER)) {
       case RelationTimeTravel(UnresolvedRelation(Seq(table), _, _), _, _)
         if cteRelations.exists(r => plan.conf.resolver(r._1, table)) =>
         throw QueryCompilationErrors.timeTravelUnsupportedError(toSQLId(table))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveIdentifierClause.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveIdentifierClause.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.{AliasHelper, EvalHelper, Expre
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.plans.logical.{CreateView, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.{Rule, RuleExecutor}
-import org.apache.spark.sql.catalyst.trees.TreePattern.UNRESOLVED_IDENTIFIER
+import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StringType
@@ -62,7 +62,8 @@ class ResolveIdentifierClause(earlyBatches: Seq[RuleExecutor[LogicalPlan]#Batch]
   private def apply0(
       plan: LogicalPlan,
       referredTempVars: Option[mutable.ArrayBuffer[Seq[String]]] = None): LogicalPlan =
-    plan.resolveOperatorsUpWithPruning(_.containsPattern(UNRESOLVED_IDENTIFIER)) {
+    plan.resolveOperatorsUpWithPruning(_.containsAnyPattern(
+      UNRESOLVED_IDENTIFIER, PLAN_WITH_UNRESOLVED_IDENTIFIER)) {
       case p: PlanWithUnresolvedIdentifier if p.identifierExpr.resolved && p.childrenResolved =>
 
         if (referredTempVars.isDefined) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -69,7 +69,7 @@ case class PlanWithUnresolvedIdentifier(
     this(identifierExpr, Nil, (ident, _) => planBuilder(ident))
   }
 
-  final override val nodePatterns: Seq[TreePattern] = Seq(UNRESOLVED_IDENTIFIER)
+  final override val nodePatterns: Seq[TreePattern] = Seq(PLAN_WITH_UNRESOLVED_IDENTIFIER)
 
   override protected def withNewChildrenInternal(
       newChildren: IndexedSeq[LogicalPlan]): LogicalPlan =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -28,13 +28,17 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateFunction
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.trees.{BinaryLike, CurrentOrigin, LeafLike, QuaternaryLike, TernaryLike, TreeNode, UnaryLike}
-import org.apache.spark.sql.catalyst.trees.TreePattern.{RUNTIME_REPLACEABLE, TreePattern}
+import org.apache.spark.sql.catalyst.trees.TreePattern
+import org.apache.spark.sql.catalyst.trees.TreePattern._
+import org.apache.spark.sql.catalyst.trees.TreePatternBits.toPatternBits
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.errors.{QueryErrorsBase, QueryExecutionErrors}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.MULTI_COMMUTATIVE_OP_OPT_THRESHOLD
 import org.apache.spark.sql.types._
+import org.apache.spark.util.Utils
+import org.apache.spark.util.collection.BitSet
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // This file defines the basic expression abstract classes in Catalyst.
@@ -371,6 +375,17 @@ abstract class Expression extends TreeNode[Expression] {
     throw SparkException.internalError(s"$nodeName does not implement simpleStringWithNodeId")
   }
 
+  final override def validateNodePatterns(): Unit = {
+    if (Utils.isTesting) {
+      if (toPatternBits(nodePatterns: _*).intersects(ExpressionPatternBitMask.mask)) {
+        println(s"${this.getClass.getName} returns Operator patterns")
+      }
+      assert(
+        !toPatternBits(nodePatterns: _*).intersects(ExpressionPatternBitMask.mask),
+        s"${this.getClass.getName} returns Operator patterns")
+    }
+  }
+
   protected def typeSuffix =
     if (resolved) {
       dataType match {
@@ -380,6 +395,15 @@ abstract class Expression extends TreeNode[Expression] {
     } else {
       ""
     }
+}
+
+object ExpressionPatternBitMask {
+  val mask: BitSet = {
+    val bits = new BitSet(TreePattern.maxId)
+    bits.setUntil(TreePattern.maxId)
+    bits.clearUntil(OPERATOR_START.id)
+    bits
+  }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -377,9 +377,6 @@ abstract class Expression extends TreeNode[Expression] {
 
   final override def validateNodePatterns(): Unit = {
     if (Utils.isTesting) {
-      if (toPatternBits(nodePatterns: _*).intersects(ExpressionPatternBitMask.mask)) {
-        println(s"${this.getClass.getName} returns Operator patterns")
-      }
       assert(
         !toPatternBits(nodePatterns: _*).intersects(ExpressionPatternBitMask.mask),
         s"${this.getClass.getName} returns Operator patterns")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -35,7 +35,8 @@ import org.apache.spark.sql.catalyst.trees.TreePatternBits.toPatternBits
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, StructType}
-import org.apache.spark.util.{BestEffortLazyVal, TransientBestEffortLazyVal, Utils}
+import org.apache.spark.util.{BestEffortLazyVal, TransientBestEffortLazyVal}
+import org.apache.spark.util.Utils
 import org.apache.spark.util.collection.BitSet
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -28,12 +28,14 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.rules.RuleId
 import org.apache.spark.sql.catalyst.rules.UnknownRuleId
 import org.apache.spark.sql.catalyst.trees.{AlwaysProcess, CurrentOrigin, TreeNode, TreeNodeTag}
-import org.apache.spark.sql.catalyst.trees.TreePattern.{OUTER_REFERENCE, PLAN_EXPRESSION}
+import org.apache.spark.sql.catalyst.trees.TreePattern
+import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.trees.TreePatternBits
+import org.apache.spark.sql.catalyst.trees.TreePatternBits.toPatternBits
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, StructType}
-import org.apache.spark.util.{BestEffortLazyVal, TransientBestEffortLazyVal}
+import org.apache.spark.util.{BestEffortLazyVal, TransientBestEffortLazyVal, Utils}
 import org.apache.spark.util.collection.BitSet
 
 /**
@@ -699,6 +701,23 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * significant memory overhead on the driver.
    */
   def allAttributes: AttributeSeq = children.flatMap(_.output)
+
+  final override def validateNodePatterns(): Unit = {
+    if (Utils.isTesting) {
+      assert(
+        !toPatternBits(nodePatterns: _*).intersects(QueryPlanPatternBitMask.mask),
+        s"${this.getClass.getName} returns Expression patterns")
+    }
+  }
+}
+
+object QueryPlanPatternBitMask {
+  val mask: BitSet = {
+    val bits = new BitSet(TreePattern.maxId)
+    bits.clear()
+    bits.setUntil(OPERATOR_START.id)
+    bits
+  }
 }
 
 object QueryPlan extends PredicateHelper {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -109,6 +109,11 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
   }
 
   /**
+   * For child classes to validate `nodePatterns`.
+   */
+  protected def validateNodePatterns(): Unit = {}
+
+  /**
    * A BitSet of tree patterns for this TreeNode and its subtree. If this TreeNode and its
    * subtree contains a pattern `P`, the corresponding bit for `P.id` is set in this BitSet.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -95,6 +95,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
    */
   protected def getDefaultTreePatternBits: BitSet = {
     val bits: BitSet = new BitSet(TreePattern.maxId)
+    validateNodePatterns()
     // Propagate node pattern bits
     val nodePatternIterator = nodePatterns.iterator
     while (nodePatternIterator.hasNext) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatternBits.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatternBits.scala
@@ -60,3 +60,18 @@ trait TreePatternBits {
     false
   }
 }
+
+object TreePatternBits {
+
+  // Constructs a tree pattern BitSet that contains all tree patterns in `patterns`.
+  def toPatternBits(patterns: TreePattern*): BitSet = {
+    val bits: BitSet = new BitSet(TreePattern.maxId)
+    bits.clear()
+    val iterator = patterns.iterator
+    while (iterator.hasNext) {
+      bits.set(iterator.next().id)
+    }
+    bits
+  }
+}
+

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -21,6 +21,8 @@ package org.apache.spark.sql.catalyst.trees
 object TreePattern extends Enumeration  {
   type TreePattern = Value
 
+  // !!! DO NOT add any operator pattern before `OPERATOR_START`.
+  // !!! DO NOT add any expression pattern after `OPERATOR_START`.
   // Enum Ids start from 0.
   // Expression patterns (alphabetically ordered)
   val AGGREGATE_EXPRESSION = Value(0)
@@ -28,7 +30,6 @@ object TreePattern extends Enumeration  {
   val AND: Value = Value
   val ARRAYS_ZIP: Value = Value
   val ATTRIBUTE_REFERENCE: Value = Value
-  val APPEND_COLUMNS: Value = Value
   val AVERAGE: Value = Value
   val GROUPING_ANALYTICS: Value = Value
   val BINARY_ARITHMETIC: Value = Value
@@ -48,7 +49,6 @@ object TreePattern extends Enumeration  {
   val EXPRESSION_WITH_RANDOM_SEED: Value = Value
   val EXTRACT_VALUE: Value = Value
   val FUNCTION_TABLE_RELATION_ARGUMENT_EXPRESSION: Value = Value
-  val GENERATE: Value = Value
   val GENERATOR: Value = Value
   val HIGH_ORDER_FUNCTION: Value = Value
   val IF: Value = Value
@@ -56,7 +56,6 @@ object TreePattern extends Enumeration  {
   val IN_SUBQUERY: Value = Value
   val INLINE_TABLE_EVAL: Value = Value
   val INSET: Value = Value
-  val INTERSECT: Value = Value
   val INVOKE: Value = Value
   val JSON_TO_STRUCT: Value = Value
   val LAMBDA_FUNCTION: Value = Value
@@ -73,15 +72,11 @@ object TreePattern extends Enumeration  {
   val NOT: Value = Value
   val NULL_CHECK: Value = Value
   val NULL_LITERAL: Value = Value
-  val PIPE_OPERATOR_SELECT: Value = Value
-  val SERIALIZE_FROM_OBJECT: Value = Value
   val OR: Value = Value
   val OUTER_REFERENCE: Value = Value
   val PARAMETER: Value = Value
   val PARAMETERIZED_QUERY: Value = Value
   val PIPE_EXPRESSION: Value = Value
-  val PIPE_OPERATOR: Value = Value
-  val PIVOT: Value = Value
   val PLAN_EXPRESSION: Value = Value
   val PYTHON_UDF: Value = Value
   val REGEXP_EXTRACT_FAMILY: Value = Value
@@ -110,45 +105,6 @@ object TreePattern extends Enumeration  {
   val UP_CAST: Value = Value
   val DISTRIBUTED_SEQUENCE_ID: Value = Value
 
-  // Logical plan patterns (alphabetically ordered)
-  val AGGREGATE: Value = Value
-  val AS_OF_JOIN: Value = Value
-  val COMMAND: Value = Value
-  val CTE: Value = Value
-  val DF_DROP_COLUMNS: Value = Value
-  val DISTINCT_LIKE: Value = Value
-  val EVAL_PYTHON_UDF: Value = Value
-  val EVAL_PYTHON_UDTF: Value = Value
-  val EVENT_TIME_WATERMARK: Value = Value
-  val EXCEPT: Value = Value
-  val EXECUTE_IMMEDIATE: Value = Value
-  val FILTER: Value = Value
-  val INNER_LIKE_JOIN: Value = Value
-  val JOIN: Value = Value
-  val LATERAL_JOIN: Value = Value
-  val LEFT_SEMI_OR_ANTI_JOIN: Value = Value
-  val LIMIT: Value = Value
-  val LOCAL_RELATION: Value = Value
-  val LOGICAL_QUERY_STAGE: Value = Value
-  val NATURAL_LIKE_JOIN: Value = Value
-  val OFFSET: Value = Value
-  val OUTER_JOIN: Value = Value
-  val PROJECT: Value = Value
-  val PYTHON_DATA_SOURCE: Value = Value
-  val RELATION_TIME_TRAVEL: Value = Value
-  val REPARTITION_OPERATION: Value = Value
-  val REBALANCE_PARTITIONS: Value = Value
-  val UNION: Value = Value
-  val UNRESOLVED_RELATION: Value = Value
-  val UNRESOLVED_WITH: Value = Value
-  val UPDATE_EVENT_TIME_WATERMARK_COLUMN: Value = Value
-  val TEMP_RESOLVED_COLUMN: Value = Value
-  val TYPED_FILTER: Value = Value
-  val WINDOW: Value = Value
-  val WINDOW_GROUP_LIMIT: Value = Value
-  val WITH_EXPRESSION: Value = Value
-  val WITH_WINDOW_DEFINITION: Value = Value
-
   // Unresolved expression patterns (Alphabetically ordered)
   val UNRESOLVED_ALIAS: Value = Value
   val UNRESOLVED_ATTRIBUTE: Value = Value
@@ -163,6 +119,58 @@ object TreePattern extends Enumeration  {
   val UNRESOLVED_WINDOW_EXPRESSION: Value = Value
   val UNRESOLVED_PLAN_ID: Value = Value
 
+  // Execution expression patterns (alphabetically ordered)
+  val IN_SUBQUERY_EXEC: Value = Value
+
+  // Boundary between Expression patterns and Operator patterns.
+  val OPERATOR_START: Value = Value
+  // Logical plan patterns (alphabetically ordered)
+  val AGGREGATE: Value = Value
+  val APPEND_COLUMNS: Value = Value
+  val AS_OF_JOIN: Value = Value
+  val COMMAND: Value = Value
+  val CTE: Value = Value
+  val DF_DROP_COLUMNS: Value = Value
+  val DISTINCT_LIKE: Value = Value
+  val EVAL_PYTHON_UDF: Value = Value
+  val EVAL_PYTHON_UDTF: Value = Value
+  val EVENT_TIME_WATERMARK: Value = Value
+  val EXCEPT: Value = Value
+  val EXECUTE_IMMEDIATE: Value = Value
+  val INTERSECT: Value = Value
+  val FILTER: Value = Value
+  val GENERATE: Value = Value
+  val INNER_LIKE_JOIN: Value = Value
+  val JOIN: Value = Value
+  val LATERAL_JOIN: Value = Value
+  val LEFT_SEMI_OR_ANTI_JOIN: Value = Value
+  val LIMIT: Value = Value
+  val LOCAL_RELATION: Value = Value
+  val LOGICAL_QUERY_STAGE: Value = Value
+  val NATURAL_LIKE_JOIN: Value = Value
+  val OFFSET: Value = Value
+  val OUTER_JOIN: Value = Value
+  val PIPE_OPERATOR: Value = Value
+  val PIPE_OPERATOR_SELECT: Value = Value
+  val PIVOT: Value = Value
+  val PLAN_WITH_UNRESOLVED_IDENTIFIER: Value = Value
+  val PROJECT: Value = Value
+  val PYTHON_DATA_SOURCE: Value = Value
+  val RELATION_TIME_TRAVEL: Value = Value
+  val REPARTITION_OPERATION: Value = Value
+  val REBALANCE_PARTITIONS: Value = Value
+  val SERIALIZE_FROM_OBJECT: Value = Value
+  val UNION: Value = Value
+  val UNRESOLVED_RELATION: Value = Value
+  val UNRESOLVED_WITH: Value = Value
+  val UPDATE_EVENT_TIME_WATERMARK_COLUMN: Value = Value
+  val TEMP_RESOLVED_COLUMN: Value = Value
+  val TYPED_FILTER: Value = Value
+  val WINDOW: Value = Value
+  val WINDOW_GROUP_LIMIT: Value = Value
+  val WITH_EXPRESSION: Value = Value
+  val WITH_WINDOW_DEFINITION: Value = Value
+
   // Unresolved Plan patterns (Alphabetically ordered)
   val UNRESOLVED_FUNC: Value = Value
   val UNRESOLVED_PROCEDURE: Value = Value
@@ -170,9 +178,6 @@ object TreePattern extends Enumeration  {
   val UNRESOLVED_TABLE_VALUED_FUNCTION: Value = Value
   val UNRESOLVED_TRANSPOSE: Value = Value
   val UNRESOLVED_TVF_ALIASES: Value = Value
-
-  // Execution expression patterns (alphabetically ordered)
-  val IN_SUBQUERY_EXEC: Value = Value
 
   // Execution Plan patterns (alphabetically ordered)
   val EXCHANGE: Value = Value

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -86,12 +86,14 @@ object TreePattern extends Enumeration  {
   val SQL_FUNCTION_EXPRESSION: Value = Value
   val SQL_SCALAR_FUNCTION: Value = Value
   val SUM: Value = Value
+  val TEMP_RESOLVED_COLUMN: Value = Value
   val TIME_WINDOW: Value = Value
   val TIME_ZONE_AWARE_EXPRESSION: Value = Value
   val TRUE_OR_FALSE_LITERAL: Value = Value
   val VARIANT_GET: Value = Value
   val WINDOW_EXPRESSION: Value = Value
   val WINDOW_TIME: Value = Value
+  val WITH_EXPRESSION: Value = Value
   val UPDATE_FIELDS: Value = Value
   val UPPER_OR_LOWER: Value = Value
   val UP_CAST: Value = Value
@@ -159,11 +161,9 @@ object TreePattern extends Enumeration  {
   val UNION: Value = Value
   val UNPIVOT: Value = Value
   val UPDATE_EVENT_TIME_WATERMARK_COLUMN: Value = Value
-  val TEMP_RESOLVED_COLUMN: Value = Value
   val TYPED_FILTER: Value = Value
   val WINDOW: Value = Value
   val WINDOW_GROUP_LIMIT: Value = Value
-  val WITH_EXPRESSION: Value = Value
   val WITH_WINDOW_DEFINITION: Value = Value
 
   // Unresolved Plan patterns (Alphabetically ordered)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -31,7 +31,6 @@ object TreePattern extends Enumeration  {
   val ARRAYS_ZIP: Value = Value
   val ATTRIBUTE_REFERENCE: Value = Value
   val AVERAGE: Value = Value
-  val GROUPING_ANALYTICS: Value = Value
   val BINARY_ARITHMETIC: Value = Value
   val BINARY_COMPARISON: Value = Value
   val CASE_WHEN: Value = Value
@@ -42,7 +41,6 @@ object TreePattern extends Enumeration  {
   val COUNT: Value = Value
   val CREATE_NAMED_STRUCT: Value = Value
   val CURRENT_LIKE: Value = Value
-  val DESERIALIZE_TO_OBJECT: Value = Value
   val DYNAMIC_PRUNING_EXPRESSION: Value = Value
   val DYNAMIC_PRUNING_SUBQUERY: Value = Value
   val EXISTS_SUBQUERY = Value
@@ -50,11 +48,11 @@ object TreePattern extends Enumeration  {
   val EXTRACT_VALUE: Value = Value
   val FUNCTION_TABLE_RELATION_ARGUMENT_EXPRESSION: Value = Value
   val GENERATOR: Value = Value
+  val GROUPING_ANALYTICS: Value = Value
   val HIGH_ORDER_FUNCTION: Value = Value
   val IF: Value = Value
   val IN: Value = Value
   val IN_SUBQUERY: Value = Value
-  val INLINE_TABLE_EVAL: Value = Value
   val INSET: Value = Value
   val INVOKE: Value = Value
   val JSON_TO_STRUCT: Value = Value
@@ -75,7 +73,6 @@ object TreePattern extends Enumeration  {
   val OR: Value = Value
   val OUTER_REFERENCE: Value = Value
   val PARAMETER: Value = Value
-  val PARAMETERIZED_QUERY: Value = Value
   val PIPE_EXPRESSION: Value = Value
   val PLAN_EXPRESSION: Value = Value
   val PYTHON_UDF: Value = Value
@@ -86,20 +83,15 @@ object TreePattern extends Enumeration  {
   val SCALAR_SUBQUERY_REFERENCE: Value = Value
   val SCALA_UDF: Value = Value
   val SESSION_WINDOW: Value = Value
-  val SORT: Value = Value
   val SQL_FUNCTION_EXPRESSION: Value = Value
   val SQL_SCALAR_FUNCTION: Value = Value
-  val SQL_TABLE_FUNCTION: Value = Value
-  val SUBQUERY_ALIAS: Value = Value
   val SUM: Value = Value
   val TIME_WINDOW: Value = Value
   val TIME_ZONE_AWARE_EXPRESSION: Value = Value
-  val TRANSPOSE: Value = Value
   val TRUE_OR_FALSE_LITERAL: Value = Value
   val VARIANT_GET: Value = Value
   val WINDOW_EXPRESSION: Value = Value
   val WINDOW_TIME: Value = Value
-  val UNPIVOT: Value = Value
   val UPDATE_FIELDS: Value = Value
   val UPPER_OR_LOWER: Value = Value
   val UP_CAST: Value = Value
@@ -111,13 +103,11 @@ object TreePattern extends Enumeration  {
   val UNRESOLVED_COLLATION: Value = Value
   val UNRESOLVED_DESERIALIZER: Value = Value
   val UNRESOLVED_DF_STAR: Value = Value
-  val UNRESOLVED_HAVING: Value = Value
+  val UNRESOLVED_FUNCTION: Value = Value
   val UNRESOLVED_IDENTIFIER: Value = Value
   val UNRESOLVED_ORDINAL: Value = Value
-  val UNRESOLVED_FUNCTION: Value = Value
-  val UNRESOLVED_HINT: Value = Value
-  val UNRESOLVED_WINDOW_EXPRESSION: Value = Value
   val UNRESOLVED_PLAN_ID: Value = Value
+  val UNRESOLVED_WINDOW_EXPRESSION: Value = Value
 
   // Execution expression patterns (alphabetically ordered)
   val IN_SUBQUERY_EXEC: Value = Value
@@ -130,6 +120,7 @@ object TreePattern extends Enumeration  {
   val AS_OF_JOIN: Value = Value
   val COMMAND: Value = Value
   val CTE: Value = Value
+  val DESERIALIZE_TO_OBJECT: Value = Value
   val DF_DROP_COLUMNS: Value = Value
   val DISTINCT_LIKE: Value = Value
   val EVAL_PYTHON_UDF: Value = Value
@@ -140,6 +131,7 @@ object TreePattern extends Enumeration  {
   val INTERSECT: Value = Value
   val FILTER: Value = Value
   val GENERATE: Value = Value
+  val INLINE_TABLE_EVAL: Value = Value
   val INNER_LIKE_JOIN: Value = Value
   val JOIN: Value = Value
   val LATERAL_JOIN: Value = Value
@@ -150,19 +142,22 @@ object TreePattern extends Enumeration  {
   val NATURAL_LIKE_JOIN: Value = Value
   val OFFSET: Value = Value
   val OUTER_JOIN: Value = Value
+  val PARAMETERIZED_QUERY: Value = Value
   val PIPE_OPERATOR: Value = Value
   val PIPE_OPERATOR_SELECT: Value = Value
   val PIVOT: Value = Value
-  val PLAN_WITH_UNRESOLVED_IDENTIFIER: Value = Value
   val PROJECT: Value = Value
   val PYTHON_DATA_SOURCE: Value = Value
   val RELATION_TIME_TRAVEL: Value = Value
   val REPARTITION_OPERATION: Value = Value
   val REBALANCE_PARTITIONS: Value = Value
   val SERIALIZE_FROM_OBJECT: Value = Value
+  val SORT: Value = Value
+  val SQL_TABLE_FUNCTION: Value = Value
+  val SUBQUERY_ALIAS: Value = Value
+  val TRANSPOSE: Value = Value
   val UNION: Value = Value
-  val UNRESOLVED_RELATION: Value = Value
-  val UNRESOLVED_WITH: Value = Value
+  val UNPIVOT: Value = Value
   val UPDATE_EVENT_TIME_WATERMARK_COLUMN: Value = Value
   val TEMP_RESOLVED_COLUMN: Value = Value
   val TYPED_FILTER: Value = Value
@@ -172,12 +167,17 @@ object TreePattern extends Enumeration  {
   val WITH_WINDOW_DEFINITION: Value = Value
 
   // Unresolved Plan patterns (Alphabetically ordered)
+  val PLAN_WITH_UNRESOLVED_IDENTIFIER: Value = Value
+  val UNRESOLVED_HAVING: Value = Value
+  val UNRESOLVED_HINT: Value = Value
   val UNRESOLVED_FUNC: Value = Value
   val UNRESOLVED_PROCEDURE: Value = Value
+  val UNRESOLVED_RELATION: Value = Value
   val UNRESOLVED_SUBQUERY_COLUMN_ALIAS: Value = Value
   val UNRESOLVED_TABLE_VALUED_FUNCTION: Value = Value
   val UNRESOLVED_TRANSPOSE: Value = Value
   val UNRESOLVED_TVF_ALIASES: Value = Value
+  val UNRESOLVED_WITH: Value = Value
 
   // Execution Plan patterns (alphabetically ordered)
   val EXCHANGE: Value = Value


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Separate Expression and Operator TreePattern enums into two separate ranges in the TreePattern enum.
- In QueryPlan, validate that operator's `nodePatterns` implementations should only contains operator patterns.
- Added `BitSet::intersects`.
- Added a helper function `toPatternBits`.


### Why are the changes needed?

This would allow quick checks of operator-only patterns or expression-only patterns in a tree.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Added test cases in `BitSetSuite`.
- Added a test-time assert in `QueryPlan::validateNodePatterns`.


### Was this patch authored or co-authored using generative AI tooling?

No.
