### PR TITLE
[SPARK-52006][SQL][CORE] Exclude CollectMetricsExec accumulator from Spark UI + event logs + metric heartbeats

### DIFF
--- a/core/src/main/scala/org/apache/spark/InternalAccumulator.scala
+++ b/core/src/main/scala/org/apache/spark/InternalAccumulator.scala
@@ -88,5 +88,7 @@ private[spark] object InternalAccumulator {
     val RECORDS_READ = INPUT_METRICS_PREFIX + "recordsRead"
   }
 
+  val COLLECT_METRICS_ACCUMULATOR = METRICS_PREFIX + "collectMetricsAccumulator"
+
   // scalastyle:on
 }

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -1271,12 +1271,13 @@ private[spark] class Executor(
       if (taskRunner.task != null) {
         taskRunner.task.metrics.mergeShuffleReadMetrics()
         taskRunner.task.metrics.setJvmGCTime(curGCTime - taskRunner.startGCTime)
-        val accumulatorsToReport =
+        val accumulatorsToReport = {
           if (HEARTBEAT_DROP_ZEROES) {
             taskRunner.task.metrics.accumulators().filterNot(_.isZero)
           } else {
             taskRunner.task.metrics.accumulators()
           }
+        }.filterNot(_.excludeFromHeartbeat)
         accumUpdates += ((taskRunner.taskId, accumulatorsToReport))
       }
     }

--- a/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
+++ b/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
@@ -45,6 +45,8 @@ abstract class AccumulatorV2[IN, OUT] extends Serializable {
   private[spark] var metadata: AccumulatorMetadata = _
   private[this] var atDriverSide = true
 
+  def excludeFromHeartbeat: Boolean = false
+
   private[spark] def register(
       sc: SparkContext,
       name: Option[String] = None,

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -488,7 +488,10 @@ private[spark] object JsonProtocol extends JsonUtils {
     g.writeEndObject()
   }
 
-  private[util] val accumulableExcludeList = Set(InternalAccumulator.UPDATED_BLOCK_STATUSES)
+  private[util] val accumulableExcludeList = Set(
+    InternalAccumulator.UPDATED_BLOCK_STATUSES,
+    InternalAccumulator.COLLECT_METRICS_ACCUMULATOR
+  )
 
   private[this] val taskMetricAccumulableNames = TaskMetrics.empty.nameToAccums.keySet.toSet
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/AggregatingAccumulator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/AggregatingAccumulator.scala
@@ -44,6 +44,8 @@ class AggregatingAccumulator private(
   assert(bufferSchema.size == updateExpressions.size)
   assert(mergeExpressions == null || bufferSchema.size == mergeExpressions.size)
 
+  override def excludeFromHeartbeat: Boolean = true
+
   @transient
   private var joinedRow: JoinedRow = _
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CollectMetricsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CollectMetricsExec.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution
 
-import org.apache.spark.TaskContext
+import org.apache.spark.{InternalAccumulator, TaskContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
@@ -38,7 +38,7 @@ case class CollectMetricsExec(
 
   private lazy val accumulator: AggregatingAccumulator = {
     val acc = AggregatingAccumulator(metricExpressions, child.output)
-    acc.register(sparkContext, Option("Collected metrics"))
+    acc.register(sparkContext, Option(CollectMetricsExec.ACCUMULATOR_NAME))
     acc
   }
 
@@ -95,6 +95,9 @@ case class CollectMetricsExec(
 }
 
 object CollectMetricsExec extends AdaptiveSparkPlanHelper {
+
+  val ACCUMULATOR_NAME: String = InternalAccumulator.COLLECT_METRICS_ACCUMULATOR
+
   /**
    * Recursively collect all collected metrics from a query tree.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CollectMetricsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CollectMetricsExec.scala
@@ -42,6 +42,10 @@ case class CollectMetricsExec(
     acc
   }
 
+  private[sql] def accumulatorId: Long = {
+    accumulator.id
+  }
+
   val metricsSchema: StructType = {
     DataTypeUtils.fromAttributes(metricExpressions.map(_.toAttribute))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/util/DataFrameCallbackSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/util/DataFrameCallbackSuite.scala
@@ -18,19 +18,24 @@
 package org.apache.spark.sql.util
 
 import java.lang.{Long => JLong}
+import java.util.concurrent.{CopyOnWriteArrayList, CountDownLatch, TimeUnit}
 
 import scala.collection.mutable.ArrayBuffer
+import scala.jdk.CollectionConverters._
 
 import org.apache.spark._
+import org.apache.spark.internal.config.{EXECUTOR_HEARTBEAT_DROP_ZERO_ACCUMULATOR_UPDATES, EXECUTOR_HEARTBEAT_INTERVAL}
+import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerExecutorMetricsUpdate}
 import org.apache.spark.sql.{functions, Encoder, Encoders, QueryTest, Row}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan, Project}
 import org.apache.spark.sql.classic.Dataset
-import org.apache.spark.sql.execution.{QueryExecution, WholeStageCodegenExec}
+import org.apache.spark.sql.execution.{CollectMetricsExec, QueryExecution, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.command.{CreateDataSourceTableAsSelectCommand, LeafRunnableCommand}
 import org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand
 import org.apache.spark.sql.execution.datasources.json.JsonFileFormat
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
 import org.apache.spark.sql.expressions.Aggregator
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -41,6 +46,10 @@ class DataFrameCallbackSuite extends QueryTest
   with AdaptiveSparkPlanHelper {
   import testImplicits._
   import functions._
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf.set(EXECUTOR_HEARTBEAT_DROP_ZERO_ACCUMULATOR_UPDATES, false)
+  }
 
   test("execute callback functions when a DataFrame action finished successfully") {
     val metrics = ArrayBuffer.empty[(String, QueryExecution, Long)]
@@ -341,6 +350,51 @@ class DataFrameCallbackSuite extends QueryTest
     }
   }
 
+  test("SPARK-52006: executor heartbeat should exclude observable metrics") {
+    val metricMaps = ArrayBuffer.empty[Map[String, Row]]
+    @volatile var accumulatorId = 0L
+    val listener = new SparkListener {
+      override def onExecutorMetricsUpdate(msg: SparkListenerExecutorMetricsUpdate): Unit = {
+        HeartbeatMonitor.heartbeatReceived(msg)
+      }
+
+      override def onOtherEvent(event: SparkListenerEvent): Unit = event match {
+        case e: SparkListenerSQLExecutionEnd =>
+          metricMaps += e.qe.observedMetrics
+          val accumulators = e.qe.executedPlan
+            .collect { case exec: CollectMetricsExec => exec.accumulatorId }
+          assert(accumulators.length === 1)
+          accumulatorId = accumulators.head
+        case _ => // Ignore
+      }
+    }
+    sparkContext.listenerBus.waitUntilEmpty()
+    sparkContext.addSparkListener(listener)
+
+    val heartbeatInterval = sparkContext.getConf.get(EXECUTOR_HEARTBEAT_INTERVAL)
+    val df = spark.range(0, 100, 1, 1)
+      .mapPartitions { iter =>
+        TaskContext.get().addTaskCompletionListener[Unit] { _ =>
+          // Wait for heartbeat sent, 30s timeout by default
+          assert(HeartbeatMonitor.await(heartbeatInterval * 3, TimeUnit.MILLISECONDS))
+        }
+        iter
+      }.toDF("id")
+      .observe(
+        name = "my_event",
+        max($"id").as("max_val"),
+        percentile_approx($"id", lit(0.5), lit(100)),
+        percentile_approx($"id", lit(0.5), lit(100)),
+        min($"id").as("min_val"))
+    df.collect()
+    sparkContext.listenerBus.waitUntilEmpty()
+
+    val msgs = HeartbeatMonitor.msgs.asScala
+    val accumulatorIds = msgs.flatMap(_.accumUpdates.flatMap(_._4)).map(_.id).toSet
+    assert(accumulatorId != 0)
+    assert(msgs.nonEmpty && !accumulatorIds.contains(accumulatorId))
+  }
+
   test("SPARK-50581: support observe with udaf") {
     withUserDefinedFunction(("someUdaf", true)) {
       spark.udf.register("someUdaf", functions.udaf(new Aggregator[JLong, JLong, JLong] {
@@ -451,4 +505,21 @@ case class ErrorTestCommand(foo: String) extends LeafRunnableCommand {
 
   override def run(sparkSession: org.apache.spark.sql.SparkSession): Seq[Row] =
     throw new java.lang.Error(foo)
+}
+
+/** Singleton utils for testing SPARK-52006 */
+object HeartbeatMonitor {
+  private val heartbeatLatch = new CountDownLatch(1)
+  val msgs = new CopyOnWriteArrayList[SparkListenerExecutorMetricsUpdate]()
+
+  def heartbeatReceived(msg: SparkListenerExecutorMetricsUpdate): Unit = {
+    if (msg.accumUpdates.nonEmpty) {
+      msgs.add(msg)
+      heartbeatLatch.countDown()
+    }
+  }
+
+  def await(timeout: Long, timeUnit: TimeUnit): Boolean = {
+    heartbeatLatch.await(timeout, timeUnit)
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/util/DataFrameCallbackSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/util/DataFrameCallbackSuite.scala
@@ -395,7 +395,7 @@ class DataFrameCallbackSuite extends QueryTest
       assert(accumulatorId != 0)
       assert(msgs.nonEmpty && !accumulatorIds.contains(accumulatorId))
     } finally {
-      sparkContext.listenerBus.removeListener(listener)
+      sparkContext.removeSparkListener(listener)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
[CollectMetricsExec](https://github.com/apache/spark/blob/1d0e82fb59afbc8d846470b980c3e926ad91513b/sql/core/src/main/scala/org/apache/spark/sql/execution/CollectMetricsExec.scala#L33) uses an [AggregatingAccumulator](https://github.com/apache/spark/blob/1d0e82fb59afbc8d846470b980c3e926ad91513b/sql/core/src/main/scala/org/apache/spark/sql/execution/AggregatingAccumulator.scala#L33) for emitting metrics in a side-channel that can be collected to the driver. And there are a few issues with this:

- It is a named accumulator but not an internal accumulator, so its result is shown in the Spark UI. But that result isn’t meaningful to users because it’s the `.toString` representation of an UnsafeRow representing an aggregation buffer.
- This same string representation is also logged in event logs on a per-task basis which is not necessary.
- **Last and the most important** is that there could be a race condition issue serializing the accumulator between task result serialization and executor heartbeat (heartbeat serialize it firstly and then task result serialization happens) which would lead to task failures since [TypedImperativeAggregate.serializeAggregateBufferInPlace](https://github.com/apache/spark/blob/1d0e82fb59afbc8d846470b980c3e926ad91513b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala#L620) is not idempotent.
    <img width="1726" alt="Error Stack" src="https://github.com/user-attachments/assets/c86bc38e-8e97-495a-8dbd-9dc9e84bf6c4" />

To fix the issues, below changes are made in this PR:
- Mark the accumulator as internal metrics to exclude it from Spark UI.
- JsonProtocol to explicitly exclude this accumulator from event logs.
- Executor to explicitly exclude it from heartbeats.

### Why are the changes needed?
Fixing the race condition issues and remove unnecessary information from Spark UI and event log.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT added.
Manually tested with below repro in standalone cluster since the issue can't be triggered with local mode:
```
import org.apache.spark.TaskContext

val df = spark.range(100)
  .mapPartitions { iter =>
    TaskContext.get().addTaskCompletionListener[Unit] { _ =>
      Thread.sleep(30000L)
    }
    iter
  }.toDF("id")
  .observe(
    name = "my_event",
    max($"id").as("max_val"),
    percentile_approx($"id", lit(0.5), lit(100)),
    percentile_approx($"id", lit(0.5), lit(100)),
    min($"id").as("min_val"))

df.collect()
```

### Was this patch authored or co-authored using generative AI tooling?
No