### PR TITLE
[SPARK-52025][BUILD][3.5] Upgrade ORC to 1.9.6

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -212,9 +212,9 @@ opencsv/2.3//opencsv-2.3.jar
 opentracing-api/0.33.0//opentracing-api-0.33.0.jar
 opentracing-noop/0.33.0//opentracing-noop-0.33.0.jar
 opentracing-util/0.33.0//opentracing-util-0.33.0.jar
-orc-core/1.9.5/shaded-protobuf/orc-core-1.9.5-shaded-protobuf.jar
-orc-mapreduce/1.9.5/shaded-protobuf/orc-mapreduce-1.9.5-shaded-protobuf.jar
-orc-shims/1.9.5//orc-shims-1.9.5.jar
+orc-core/1.9.6/shaded-protobuf/orc-core-1.9.6-shaded-protobuf.jar
+orc-mapreduce/1.9.6/shaded-protobuf/orc-mapreduce-1.9.6-shaded-protobuf.jar
+orc-shims/1.9.6//orc-shims-1.9.6.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <!-- After 10.15.1.3, the minimum required version is JDK9 -->
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.13.1</parquet.version>
-    <orc.version>1.9.5</orc.version>
+    <orc.version>1.9.6</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
     <jetty.version>9.4.56.v20240826</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade ORC to 1.9.6.

### Why are the changes needed?

To bring the latest bug fixes.
- https://orc.apache.org/news/2025/05/06/ORC-1.9.6/
- https://github.com/apache/orc/releases/tag/v1.9.6

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.