### PR TITLE
[SPARK-52024][SQL] Support cancel ShuffleQueryStage when propagate empty relations

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/SparkException.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkException.scala
@@ -134,6 +134,11 @@ object SparkException {
 }
 
 /**
+ * Exception which indicates that the queryStage should be cancelled.
+ */
+private[spark] class SparkAQEStageCancelException extends RuntimeException
+
+/**
  * Exception thrown when execution of some user code in the driver process fails, e.g.
  * accumulator update fails or failure in takeOrdered (user supplies an Ordering implementation
  * that can be misbehaving.

--- a/core/src/main/scala/org/apache/spark/FutureAction.scala
+++ b/core/src/main/scala/org/apache/spark/FutureAction.scala
@@ -119,7 +119,7 @@ class SimpleFutureAction[T] private[spark](jobWaiter: JobWaiter[_], resultFunc: 
 
   @volatile private var _cancelled: Boolean = false
 
-  override def cancel(reason: Option[String] = None, quiet: Boolean = false): Unit = {
+  override def cancel(reason: Option[String], quiet: Boolean = false): Unit = {
     _cancelled = true
     jobWaiter.cancel(reason, quiet)
   }
@@ -193,11 +193,11 @@ class ComplexFutureAction[T](run : JobSubmitter => Future[T])
   // A promise used to signal the future.
   private val p = Promise[T]().completeWith(run(jobSubmitter))
 
-  override def cancel(reason: Option[String] = None, quiet: Boolean = false): Unit =
+  override def cancel(reason: Option[String], quiet: Boolean = false): Unit =
     synchronized {
       _cancelled = true
       p.tryFailure(new SparkException("Action has been cancelled"))
-      subActions.foreach(_.cancel(reason, quiet))
+      subActions.foreach(_.cancel(reason, quiet = quiet))
   }
 
   private def jobSubmitter = new JobSubmitter {

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
@@ -62,7 +62,8 @@ private[scheduler] case class StageCancelled(
 
 private[scheduler] case class JobCancelled(
     jobId: Int,
-    reason: Option[String])
+    reason: Option[String],
+    quiet: Boolean = false)
   extends DAGSchedulerEvent
 
 private[scheduler] case class JobGroupCancelled(

--- a/core/src/main/scala/org/apache/spark/scheduler/JobListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/JobListener.scala
@@ -25,4 +25,6 @@ package org.apache.spark.scheduler
 private[spark] trait JobListener {
   def taskSucceeded(index: Int, result: Any): Unit
   def jobFailed(exception: Exception): Unit
+
+  def jobCancel(exception: Exception): Unit = {}
 }

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -39,12 +39,12 @@ object MimaExcludes {
     ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.ml.linalg.Vector.getSizeInBytes"),
 
     // [SPARK-52221][SQL] Refactor SqlScriptingLocalVariableManager into more generic context manager
-    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.scripting.SqlScriptingExecution.withLocalVariableManager")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.scripting.SqlScriptingExecution.withLocalVariableManager"),
 
     // [SPARK-52024][SQL] Support cancel ShuffleQueryStage when propagate empty relations
-    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.FutureAction.cancel")
-    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.ComplexFutureAction.cancel")
-    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.SimpleFutureAction.cancel")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.FutureAction.cancel"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.ComplexFutureAction.cancel"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.SimpleFutureAction.cancel"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.FutureAction.cancel")
   )
 

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -40,6 +40,12 @@ object MimaExcludes {
 
     // [SPARK-52221][SQL] Refactor SqlScriptingLocalVariableManager into more generic context manager
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.scripting.SqlScriptingExecution.withLocalVariableManager")
+
+    // [SPARK-52024][SQL] Support cancel ShuffleQueryStage when propagate empty relations
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.FutureAction.cancel")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.ComplexFutureAction.cancel")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.SimpleFutureAction.cancel")
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.FutureAction.cancel")
   )
 
   // Default exclude rules

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -930,6 +930,14 @@ object SQLConf {
       .checkValue(_ > 0, "The initial number of partitions must be positive.")
       .createOptional
 
+  val ADAPTIVE_EMPTY_TRIGGER_CANCEL_ENABLED =
+    buildConf("spark.sql.adaptive.empty.trigger.cancel.enabled")
+      .doc(s"When true and '${ADAPTIVE_EXECUTION_ENABLED.key}' is true, when propagate " +
+        " empty relation, Spark will try to cancel QueryStage that is unnecessary.")
+      .version("3.5.5")
+      .booleanConf
+      .createWithDefault(true)
+
   lazy val ALLOW_COLLATIONS_IN_MAP_KEYS =
     buildConf("spark.sql.collation.allowInMapKeys")
       .doc("Allow for non-UTF8_BINARY collated strings inside of map's keys")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEOptimizer.scala
@@ -29,7 +29,10 @@ import org.apache.spark.util.Utils
 /**
  * The optimizer for re-optimizing the logical plan used by AdaptiveSparkPlanExec.
  */
-class AQEOptimizer(conf: SQLConf, extendedRuntimeOptimizerRules: Seq[Rule[LogicalPlan]])
+class AQEOptimizer(
+  conf: SQLConf,
+  stagesToCancel: collection.mutable.Map[Int, (String, ExchangeQueryStageExec)],
+  extendedRuntimeOptimizerRules: Seq[Rule[LogicalPlan]])
   extends RuleExecutor[LogicalPlan] {
 
   private def fixedPoint =
@@ -39,7 +42,7 @@ class AQEOptimizer(conf: SQLConf, extendedRuntimeOptimizerRules: Seq[Rule[Logica
 
   private val defaultBatches = Seq(
     Batch("Propagate Empty Relations", fixedPoint,
-      AQEPropagateEmptyRelation,
+      AQEPropagateEmptyRelation(stagesToCancel),
       ConvertToLocalRelation,
       UpdateAttributeNullability),
     Batch("Dynamic Join Selection", Once, DynamicJoinSelection),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -137,7 +137,7 @@ trait ShuffleExchangeLike extends Exchange {
           quietly = quiet
           promise.tryFailure(new SparkAQEStageCancelException)
         }
-        futureAction.get().foreach(_.cancel(reason, quiet))
+        futureAction.get().foreach(_.cancel(reason, quiet = quiet))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CTEInlineSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CTEInlineSuite.scala
@@ -179,7 +179,8 @@ abstract class CTEInlineSuiteBase
 
   test("SPARK-36447: With in subquery of main query") {
     withSQLConf(
-      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key -> AQEPropagateEmptyRelation.ruleName) {
+      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
+        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
       withTempView("t") {
         Seq((2, 1), (2, 2)).toDF("c1", "c2").createOrReplaceTempView("t")
         val df = sql(

--- a/sql/core/src/test/scala/org/apache/spark/sql/CTEInlineSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CTEInlineSuite.scala
@@ -180,7 +180,9 @@ abstract class CTEInlineSuiteBase
   test("SPARK-36447: With in subquery of main query") {
     withSQLConf(
       SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
-        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
+        AQEPropagateEmptyRelation(
+          scala.collection.concurrent.TrieMap.empty,
+          collection.mutable.Map.empty).ruleName) {
       withTempView("t") {
         Seq((2, 1), (2, 2)).toDF("c1", "c2").createOrReplaceTempView("t")
         val df = sql(

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -840,7 +840,9 @@ class CachedTableSuite extends QueryTest with SQLTestUtils
         withSQLConf(
           SQLConf.CAN_CHANGE_CACHED_PLAN_OUTPUT_PARTITIONING.key -> enabled.toString,
           SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
-            AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
+            AQEPropagateEmptyRelation(
+              scala.collection.concurrent.TrieMap.empty,
+              collection.mutable.Map.empty).ruleName) {
 
           Seq(1).toDF("c1").createOrReplaceTempView("t1")
           spark.catalog.cacheTable("t1")

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -840,7 +840,7 @@ class CachedTableSuite extends QueryTest with SQLTestUtils
         withSQLConf(
           SQLConf.CAN_CHANGE_CACHED_PLAN_OUTPUT_PARTITIONING.key -> enabled.toString,
           SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
-            AQEPropagateEmptyRelation.ruleName) {
+            AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
 
           Seq(1).toDF("c1").createOrReplaceTempView("t1")
           spark.catalog.cacheTable("t1")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -456,7 +456,8 @@ abstract class DynamicPartitionPruningSuiteBase
     withSQLConf(
       SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "false",
       SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false",
-      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key -> AQEPropagateEmptyRelation.ruleName) {
+      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
+        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
       Given("no stats and selective predicate")
       withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
         SQLConf.DYNAMIC_PARTITION_PRUNING_USE_STATS.key -> "true") {
@@ -1153,7 +1154,8 @@ abstract class DynamicPartitionPruningSuiteBase
 
   test("join key with multiple references on the filtering plan") {
     withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "true",
-      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key -> AQEPropagateEmptyRelation.ruleName,
+      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
+        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName,
       SQLConf.ANSI_ENABLED.key -> "false" // ANSI mode doesn't support "String + String"
     ) {
       // when enable AQE, the reusedExchange is inserted when executed.
@@ -1316,7 +1318,8 @@ abstract class DynamicPartitionPruningSuiteBase
     withSQLConf(
       SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
       SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "true",
-      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key -> AQEPropagateEmptyRelation.ruleName) {
+      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
+        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
       val df = sql(
         """
           |SELECT * FROM fact_sk f

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -457,7 +457,9 @@ abstract class DynamicPartitionPruningSuiteBase
       SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "false",
       SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false",
       SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
-        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
+        AQEPropagateEmptyRelation(
+          scala.collection.concurrent.TrieMap.empty,
+          collection.mutable.Map.empty).ruleName) {
       Given("no stats and selective predicate")
       withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
         SQLConf.DYNAMIC_PARTITION_PRUNING_USE_STATS.key -> "true") {
@@ -1155,7 +1157,9 @@ abstract class DynamicPartitionPruningSuiteBase
   test("join key with multiple references on the filtering plan") {
     withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "true",
       SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
-        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName,
+        AQEPropagateEmptyRelation(
+          scala.collection.concurrent.TrieMap.empty,
+          collection.mutable.Map.empty).ruleName,
       SQLConf.ANSI_ENABLED.key -> "false" // ANSI mode doesn't support "String + String"
     ) {
       // when enable AQE, the reusedExchange is inserted when executed.
@@ -1319,7 +1323,9 @@ abstract class DynamicPartitionPruningSuiteBase
       SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
       SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "true",
       SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
-        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
+        AQEPropagateEmptyRelation(
+          scala.collection.concurrent.TrieMap.empty,
+          collection.mutable.Map.empty).ruleName) {
       val df = sql(
         """
           |SELECT * FROM fact_sk f

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -562,7 +562,8 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
       SQLConf.RUNTIME_BLOOM_FILTER_ENABLED.key -> "true",
       // Re-enable `MergeScalarSubqueries`
       SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> "",
-      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key -> AQEPropagateEmptyRelation.ruleName) {
+      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
+        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
 
       val query = "select * from bf1 join bf2 on bf1.c1 = bf2.c2 and " +
         "bf1.b1 = bf2.b2 where bf2.a2 = 62"

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -563,7 +563,9 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
       // Re-enable `MergeScalarSubqueries`
       SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> "",
       SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
-        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
+        AQEPropagateEmptyRelation(
+          scala.collection.concurrent.TrieMap.empty,
+          collection.mutable.Map.empty).ruleName) {
 
       val query = "select * from bf1 join bf2 on bf1.c1 = bf2.c2 and " +
         "bf1.b1 = bf2.b2 where bf2.a2 = 62"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -318,7 +318,9 @@ class AdaptiveQueryExecSuite
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.COALESCE_PARTITIONS_ENABLED.key -> "true",
       SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
-        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
+        AQEPropagateEmptyRelation(
+          scala.collection.concurrent.TrieMap.empty,
+          collection.mutable.Map.empty).ruleName) {
       val df1 = spark.range(10).withColumn("a", $"id")
       val df2 = spark.range(10).withColumn("b", $"id")
       withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
@@ -1473,7 +1475,9 @@ class AdaptiveQueryExecSuite
       // This test is a copy of test(SPARK-32573), in order to test the configuration
       // `spark.sql.adaptive.optimizer.excludedRules` works as expect.
       SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
-        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
+        AQEPropagateEmptyRelation(
+          scala.collection.concurrent.TrieMap.empty,
+          collection.mutable.Map.empty).ruleName) {
       val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(
         "SELECT * FROM testData2 t1 WHERE t1.b NOT IN (SELECT b FROM testData3)")
       val bhj = findTopLevelBroadcastHashJoin(plan)
@@ -2104,7 +2108,9 @@ class AdaptiveQueryExecSuite
       withSQLConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM.key -> "1",
         SQLConf.SHUFFLE_PARTITIONS.key -> "2",
         SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
-          AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
+          AQEPropagateEmptyRelation(
+            scala.collection.concurrent.TrieMap.empty,
+            collection.mutable.Map.empty).ruleName) {
         spark.sql("CREATE TABLE t (c1 int) USING PARQUET")
         val (_, adaptive) = runAdaptiveAndVerifyResult("SELECT c1, count(*) FROM t GROUP BY c1")
         assert(
@@ -2285,7 +2291,9 @@ class AdaptiveQueryExecSuite
       SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM.key -> "1",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
       SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
-        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
+        AQEPropagateEmptyRelation(
+          scala.collection.concurrent.TrieMap.empty,
+          collection.mutable.Map.empty).ruleName) {
       withTempView("t2") {
         // create a temp view with 0 partition
         spark.createDataFrame(sparkContext.emptyRDD[Row], new StructType().add("b", IntegerType))
@@ -2605,7 +2613,9 @@ class AdaptiveQueryExecSuite
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "1048584",
       SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
-        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
+        AQEPropagateEmptyRelation(
+          scala.collection.concurrent.TrieMap.empty,
+          collection.mutable.Map.empty).ruleName) {
       // Spark estimates a string column as 20 bytes so with 60k rows, these relations should be
       // estimated at ~120m bytes which is greater than the broadcast join threshold.
       val joinKeyOne = "00112233445566778899"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -317,7 +317,8 @@ class AdaptiveQueryExecSuite
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.COALESCE_PARTITIONS_ENABLED.key -> "true",
-      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key -> AQEPropagateEmptyRelation.ruleName) {
+      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
+        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
       val df1 = spark.range(10).withColumn("a", $"id")
       val df2 = spark.range(10).withColumn("b", $"id")
       withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
@@ -1471,7 +1472,8 @@ class AdaptiveQueryExecSuite
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString,
       // This test is a copy of test(SPARK-32573), in order to test the configuration
       // `spark.sql.adaptive.optimizer.excludedRules` works as expect.
-      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key -> AQEPropagateEmptyRelation.ruleName) {
+      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
+        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
       val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(
         "SELECT * FROM testData2 t1 WHERE t1.b NOT IN (SELECT b FROM testData3)")
       val bhj = findTopLevelBroadcastHashJoin(plan)
@@ -2101,7 +2103,8 @@ class AdaptiveQueryExecSuite
     withTable("t") {
       withSQLConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM.key -> "1",
         SQLConf.SHUFFLE_PARTITIONS.key -> "2",
-        SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key -> AQEPropagateEmptyRelation.ruleName) {
+        SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
+          AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
         spark.sql("CREATE TABLE t (c1 int) USING PARQUET")
         val (_, adaptive) = runAdaptiveAndVerifyResult("SELECT c1, count(*) FROM t GROUP BY c1")
         assert(
@@ -2281,7 +2284,8 @@ class AdaptiveQueryExecSuite
     withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM.key -> "1",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
-      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key -> AQEPropagateEmptyRelation.ruleName) {
+      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
+        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
       withTempView("t2") {
         // create a temp view with 0 partition
         spark.createDataFrame(sparkContext.emptyRDD[Row], new StructType().add("b", IntegerType))
@@ -2600,7 +2604,8 @@ class AdaptiveQueryExecSuite
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "1048584",
-      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key -> AQEPropagateEmptyRelation.ruleName) {
+      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
+        AQEPropagateEmptyRelation(collection.mutable.Map.empty).ruleName) {
       // Spark estimates a string column as 20 bytes so with 60k rows, these relations should be
       // estimated at ~120m bytes which is greater than the broadcast join threshold.
       val joinKeyOne = "00112233445566778899"


### PR DESCRIPTION
### What changes were proposed in this pull request?
a.This pr introduce  cancel queryStage mechanism. 
 1. Cancel shuffle queryStage only When it's not reused nor reusing others
 2. Mark the cancellable queryStage when it's not completed yet in reOptimize stage
 3. When cancellable queryStage is determined to be cancelled by costEvaluator(cancellable queryStage in `EmptyPropagate` should always be cancelled), the queryStage has no relation with current logical plan nor physical plan any more
 4. Cancel the queryStage after the corresponding job is completed, will effect nothing
 5. Cancel the queryStage when the corresponding job is running, the job will be cancelled
 6. Cancel the queryStage before he corresponding job is started, the job corresponding this queryStage will still be submitted, this case should be optimized in future commit, however it's not worse than before this pr

b.Apply this mechanism to `AQEPropagateEmptyRelation`, cancel the running queryStages which are unnecessary since propagate empty relations.

### Why are the changes needed?
1. Cancel queryStage mechanism can make AQE more flexible, we can add more CBO feature by using this mechanism after this pr merged.
2. Tasks corresponding to unnecessary running queryStages  occupy the executor cores, thus wasting compute resource


### Does this PR introduce _any_ user-facing change?
Yes, user will see stage failure because of optimized stage cancellation , but this failure takes no effect to the query result


### How was this patch tested?
Manual test, since we can not guarantee the completion order of query stages, it's not reliable to put it in unit test
```
./bin/spark-shell --master local[4]

scala> case class TestData(key: Int, value: String)
defined class TestData

scala> case class TestData2(a: Int, b: Int)
defined class TestData2

scala> spark.sparkContext.parallelize(Seq.empty[Int].map(i => TestData(i, i.toString))).toDF().createOrReplaceTempView("emptyTestData")

scala> spark.sparkContext.parallelize((1 to 100).map(i => TestData(i, i.toString))).toDF().createOrReplaceTempView("testData")

scala> spark.sparkContext.parallelize(TestData2(1, 1) ::TestData2(1, 2) ::TestData2(2, 1) ::TestData2(2, 2) ::TestData2(3, 1) ::TestData2(3, 2) :: Nil,2).toDF().createOrReplaceTempView("testData2")

scala>     spark.udf.register("fake_udf", (input: Int) => {
     |       Thread.sleep(100)
     |       input
     |     })

scala> spark.sql("SELECT t.key1 FROM emptyTestData join (SELECT testData.key as key1 FROM testData join testData2 ON fake_udf(testData.key)=fake_udf(testData2.a) ) t on t.key1 = emptyTestData.key union SELECT testData.key FROM testData join testData2 ON testData.key=testData2.a ").collect

```
before this pr
<img width="943" alt="image" src="https://github.com/user-attachments/assets/de83de00-16b7-4bcb-9b06-2edbfebdd313" />
after this pr
<img width="918" alt="image" src="https://github.com/user-attachments/assets/64d60a50-862a-4912-95a2-971a9ccc4f82" />


### Was this patch authored or co-authored using generative AI tooling?
No.
