### PR TITLE
[SPARK-52027][K8S][DOCS] Update `YuniKorn` docs with `1.6.3`

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1988,10 +1988,10 @@ Install Apache YuniKorn:
 ```bash
 helm repo add yunikorn https://apache.github.io/yunikorn-release
 helm repo update
-helm install yunikorn yunikorn/yunikorn --namespace yunikorn --version 1.6.2 --create-namespace --set embedAdmissionController=false
+helm install yunikorn yunikorn/yunikorn --namespace yunikorn --version 1.6.3 --create-namespace --set embedAdmissionController=false
 ```
 
-The above steps will install YuniKorn v1.6.2 on an existing Kubernetes cluster.
+The above steps will install YuniKorn v1.6.3 on an existing Kubernetes cluster.
 
 ##### Get started
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `YuniKorn` docs with v1.6.3 for Apache Spark 4.0.0.

### Why are the changes needed?

Apache YuniKorn v1.6.3 was released on 2025-05-06 with 1 [JIRAs](https://yunikorn.apache.org/release-announce/1.6.3) issue.

  - https://yunikorn.apache.org/release-announce/1.6.3/
      - https://github.com/apache/yunikorn-core/pull/1007

I installed YuniKorn v1.6.3 on K8s 1.32 and tested manually.

**K8s v1.32**
```
$ kubectl version
Client Version: v1.33.0
Kustomize Version: v5.6.0
Server Version: v1.32.2
```

**YuniKorn v1.6.3**
```
$ helm list -n yunikorn
NAME    	NAMESPACE	REVISION	UPDATED                             	STATUS  	CHART         	APP VERSION
yunikorn	yunikorn 	1       	2025-05-07 14:07:05.198259 -0700 PDT	deployed	yunikorn-1.6.3
```

```
$ build/sbt -Pkubernetes -Pkubernetes-integration-tests -Dspark.kubernetes.test.deployMode=docker-desktop "kubernetes-integration-tests/testOnly *.YuniKornSuite" -Dtest.exclude.tags=minikube,local,decom,r -Dtest.default.exclude.tags=
...
[info] YuniKornSuite:
[info] - SPARK-42190: Run SparkPi with local[*] (8 seconds, 446 milliseconds)
[info] - Run SparkPi with no resources (12 seconds, 700 milliseconds)
[info] - Run SparkPi with no resources & statefulset allocation (12 seconds, 669 milliseconds)
[info] - Run SparkPi with a very long application name. (11 seconds, 759 milliseconds)
...
[info] All tests passed.
[success] Total time: 482 s (08:02), completed May 7, 2025, 2:21:08 PM
```

```
Normal  Scheduling         2s    yunikorn  spark-e21673d6768f420989481181243e555f/spark-test-app-77 ..
```