### PR TITLE
[SPARK-50585][PYTHON][DOCS] Render interactive PySpark plot examples

### DIFF
--- a/python/pyspark/sql/plot/core.py
+++ b/python/pyspark/sql/plot/core.py
@@ -157,6 +157,9 @@ class PySparkPlotAccessor:
             >>> columns = ["category", "int_val", "float_val"]
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.line(x="category", y="int_val")  # doctest: +SKIP
+
+        .. plotly::
+
             >>> df.plot.line(x="category", y=["int_val", "float_val"])  # doctest: +SKIP
         """
         return self(kind="line", x=x, y=y, **kwargs)
@@ -194,6 +197,9 @@ class PySparkPlotAccessor:
             >>> columns = ["category", "int_val", "float_val"]
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.bar(x="category", y="int_val")  # doctest: +SKIP
+
+        .. plotly::
+
             >>> df.plot.bar(x="category", y=["int_val", "float_val"])  # doctest: +SKIP
         """
         return self(kind="bar", x=x, y=y, **kwargs)
@@ -240,6 +246,9 @@ class PySparkPlotAccessor:
             >>> columns = ["category", "int_val", "float_val"]
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.barh(x="int_val", y="category")  # doctest: +SKIP
+
+        .. plotly::
+
             >>> df.plot.barh(
             ...     x=["int_val", "float_val"], y="category"
             ... )  # doctest: +SKIP
@@ -357,6 +366,9 @@ class PySparkPlotAccessor:
             >>> columns = ["sales", "signups", "visits", "date"]
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.pie(x='date', y='sales')  # doctest: +SKIP
+
+        .. plotly::
+
             >>> df.plot.pie(x='date', subplots=True)  # doctest: +SKIP
         """
         return self(kind="pie", x=x, y=y, **kwargs)
@@ -406,7 +418,13 @@ class PySparkPlotAccessor:
             >>> columns = ["student", "math_score", "english_score"]
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.box()  # doctest: +SKIP
+
+        .. plotly::
+
             >>> df.plot.box(column="math_score")  # doctest: +SKIP
+
+        .. plotly::
+
             >>> df.plot.box(column=["math_score", "english_score"])  # doctest: +SKIP
         """
         return self(kind="box", column=column, **kwargs)
@@ -455,7 +473,13 @@ class PySparkPlotAccessor:
             >>> columns = ["length", "width", "species"]
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.kde(bw_method=0.3, ind=100)  # doctest: +SKIP
+
+        .. plotly::
+
             >>> df.plot.kde(column=["length", "width"], bw_method=0.3, ind=100)  # doctest: +SKIP
+
+        .. plotly::
+
             >>> df.plot.kde(column="length", bw_method=0.3, ind=100)  # doctest: +SKIP
         """
         return self(kind="kde", column=column, bw_method=bw_method, ind=ind, **kwargs)
@@ -494,7 +518,13 @@ class PySparkPlotAccessor:
             >>> columns = ["length", "width", "species"]
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.hist(bins=4)  # doctest: +SKIP
+
+        .. plotly::
+
             >>> df.plot.hist(column=["length", "width"])  # doctest: +SKIP
+
+        .. plotly::
+
             >>> df.plot.hist(column="length", bins=4)  # doctest: +SKIP
         """
         return self(kind="hist", column=column, bins=bins, **kwargs)

--- a/python/pyspark/sql/plot/core.py
+++ b/python/pyspark/sql/plot/core.py
@@ -157,10 +157,6 @@ class PySparkPlotAccessor:
             >>> columns = ["category", "int_val", "float_val"]
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.line(x="category", y="int_val")  # doctest: +SKIP
-
-        .. plotly::
-
-            >>> df.plot.line(x="category", y=["int_val", "float_val"])  # doctest: +SKIP
         """
         return self(kind="line", x=x, y=y, **kwargs)
 
@@ -197,10 +193,6 @@ class PySparkPlotAccessor:
             >>> columns = ["category", "int_val", "float_val"]
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.bar(x="category", y="int_val")  # doctest: +SKIP
-
-        .. plotly::
-
-            >>> df.plot.bar(x="category", y=["int_val", "float_val"])  # doctest: +SKIP
         """
         return self(kind="bar", x=x, y=y, **kwargs)
 
@@ -246,12 +238,6 @@ class PySparkPlotAccessor:
             >>> columns = ["category", "int_val", "float_val"]
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.barh(x="int_val", y="category")  # doctest: +SKIP
-
-        .. plotly::
-
-            >>> df.plot.barh(
-            ...     x=["int_val", "float_val"], y="category"
-            ... )  # doctest: +SKIP
         """
         return self(kind="barh", x=x, y=y, **kwargs)
 
@@ -366,10 +352,6 @@ class PySparkPlotAccessor:
             >>> columns = ["sales", "signups", "visits", "date"]
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.pie(x='date', y='sales')  # doctest: +SKIP
-
-        .. plotly::
-
-            >>> df.plot.pie(x='date', subplots=True)  # doctest: +SKIP
         """
         return self(kind="pie", x=x, y=y, **kwargs)
 
@@ -418,14 +400,6 @@ class PySparkPlotAccessor:
             >>> columns = ["student", "math_score", "english_score"]
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.box()  # doctest: +SKIP
-
-        .. plotly::
-
-            >>> df.plot.box(column="math_score")  # doctest: +SKIP
-
-        .. plotly::
-
-            >>> df.plot.box(column=["math_score", "english_score"])  # doctest: +SKIP
         """
         return self(kind="box", column=column, **kwargs)
 
@@ -473,14 +447,6 @@ class PySparkPlotAccessor:
             >>> columns = ["length", "width", "species"]
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.kde(bw_method=0.3, ind=100)  # doctest: +SKIP
-
-        .. plotly::
-
-            >>> df.plot.kde(column=["length", "width"], bw_method=0.3, ind=100)  # doctest: +SKIP
-
-        .. plotly::
-
-            >>> df.plot.kde(column="length", bw_method=0.3, ind=100)  # doctest: +SKIP
         """
         return self(kind="kde", column=column, bw_method=bw_method, ind=ind, **kwargs)
 
@@ -518,14 +484,6 @@ class PySparkPlotAccessor:
             >>> columns = ["length", "width", "species"]
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.hist(bins=4)  # doctest: +SKIP
-
-        .. plotly::
-
-            >>> df.plot.hist(column=["length", "width"])  # doctest: +SKIP
-
-        .. plotly::
-
-            >>> df.plot.hist(column="length", bins=4)  # doctest: +SKIP
         """
         return self(kind="hist", column=column, bins=bins, **kwargs)
 

--- a/python/pyspark/sql/plot/core.py
+++ b/python/pyspark/sql/plot/core.py
@@ -149,11 +149,13 @@ class PySparkPlotAccessor:
 
         Examples
         --------
-        >>> data = [("A", 10, 1.5), ("B", 30, 2.5), ("C", 20, 3.5)]
-        >>> columns = ["category", "int_val", "float_val"]
-        >>> df = spark.createDataFrame(data, columns)
-        >>> df.plot.line(x="category", y="int_val")  # doctest: +SKIP
-        >>> df.plot.line(x="category", y=["int_val", "float_val"])  # doctest: +SKIP
+        .. plotly::
+
+            >>> data = [("A", 10, 1.5), ("B", 30, 2.5), ("C", 20, 3.5)]
+            >>> columns = ["category", "int_val", "float_val"]
+            >>> df = spark.createDataFrame(data, columns)
+            >>> df.plot.line(x="category", y="int_val")  # doctest: +SKIP
+            >>> df.plot.line(x="category", y=["int_val", "float_val"])  # doctest: +SKIP
         """
         return self(kind="line", x=x, y=y, **kwargs)
 
@@ -182,11 +184,13 @@ class PySparkPlotAccessor:
 
         Examples
         --------
-        >>> data = [("A", 10, 1.5), ("B", 30, 2.5), ("C", 20, 3.5)]
-        >>> columns = ["category", "int_val", "float_val"]
-        >>> df = spark.createDataFrame(data, columns)
-        >>> df.plot.bar(x="category", y="int_val")  # doctest: +SKIP
-        >>> df.plot.bar(x="category", y=["int_val", "float_val"])  # doctest: +SKIP
+        .. plotly::
+
+            >>> data = [("A", 10, 1.5), ("B", 30, 2.5), ("C", 20, 3.5)]
+            >>> columns = ["category", "int_val", "float_val"]
+            >>> df = spark.createDataFrame(data, columns)
+            >>> df.plot.bar(x="category", y="int_val")  # doctest: +SKIP
+            >>> df.plot.bar(x="category", y=["int_val", "float_val"])  # doctest: +SKIP
         """
         return self(kind="bar", x=x, y=y, **kwargs)
 
@@ -224,13 +228,15 @@ class PySparkPlotAccessor:
 
         Examples
         --------
-        >>> data = [("A", 10, 1.5), ("B", 30, 2.5), ("C", 20, 3.5)]
-        >>> columns = ["category", "int_val", "float_val"]
-        >>> df = spark.createDataFrame(data, columns)
-        >>> df.plot.barh(x="int_val", y="category")  # doctest: +SKIP
-        >>> df.plot.barh(
-        ...     x=["int_val", "float_val"], y="category"
-        ... )  # doctest: +SKIP
+        .. plotly::
+
+            >>> data = [("A", 10, 1.5), ("B", 30, 2.5), ("C", 20, 3.5)]
+            >>> columns = ["category", "int_val", "float_val"]
+            >>> df = spark.createDataFrame(data, columns)
+            >>> df.plot.barh(x="int_val", y="category")  # doctest: +SKIP
+            >>> df.plot.barh(
+            ...     x=["int_val", "float_val"], y="category"
+            ... )  # doctest: +SKIP
         """
         return self(kind="barh", x=x, y=y, **kwargs)
 
@@ -260,10 +266,12 @@ class PySparkPlotAccessor:
 
         Examples
         --------
-        >>> data = [(5.1, 3.5, 0), (4.9, 3.0, 0), (7.0, 3.2, 1), (6.4, 3.2, 1), (5.9, 3.0, 2)]
-        >>> columns = ['length', 'width', 'species']
-        >>> df = spark.createDataFrame(data, columns)
-        >>> df.plot.scatter(x='length', y='width')  # doctest: +SKIP
+        .. plotly::
+
+            >>> data = [(5.1, 3.5, 0), (4.9, 3.0, 0), (7.0, 3.2, 1), (6.4, 3.2, 1), (5.9, 3.0, 2)]
+            >>> columns = ['length', 'width', 'species']
+            >>> df = spark.createDataFrame(data, columns)
+            >>> df.plot.scatter(x='length', y='width')  # doctest: +SKIP
         """
         return self(kind="scatter", x=x, y=y, **kwargs)
 
@@ -288,16 +296,18 @@ class PySparkPlotAccessor:
 
         Examples
         --------
-        >>> from datetime import datetime
-        >>> data = [
-        ...     (3, 5, 20, datetime(2018, 1, 31)),
-        ...     (2, 5, 42, datetime(2018, 2, 28)),
-        ...     (3, 6, 28, datetime(2018, 3, 31)),
-        ...     (9, 12, 62, datetime(2018, 4, 30))
-        ... ]
-        >>> columns = ["sales", "signups", "visits", "date"]
-        >>> df = spark.createDataFrame(data, columns)
-        >>> df.plot.area(x='date', y=['sales', 'signups', 'visits'])  # doctest: +SKIP
+        .. plotly::
+
+            >>> from datetime import datetime
+            >>> data = [
+            ...     (3, 5, 20, datetime(2018, 1, 31)),
+            ...     (2, 5, 42, datetime(2018, 2, 28)),
+            ...     (3, 6, 28, datetime(2018, 3, 31)),
+            ...     (9, 12, 62, datetime(2018, 4, 30))
+            ... ]
+            >>> columns = ["sales", "signups", "visits", "date"]
+            >>> df = spark.createDataFrame(data, columns)
+            >>> df.plot.area(x='date', y=['sales', 'signups', 'visits'])  # doctest: +SKIP
         """
         return self(kind="area", x=x, y=y, **kwargs)
 
@@ -323,17 +333,19 @@ class PySparkPlotAccessor:
 
         Examples
         --------
-        >>> from datetime import datetime
-        >>> data = [
-        ...     (3, 5, 20, datetime(2018, 1, 31)),
-        ...     (2, 5, 42, datetime(2018, 2, 28)),
-        ...     (3, 6, 28, datetime(2018, 3, 31)),
-        ...     (9, 12, 62, datetime(2018, 4, 30))
-        ... ]
-        >>> columns = ["sales", "signups", "visits", "date"]
-        >>> df = spark.createDataFrame(data, columns)
-        >>> df.plot.pie(x='date', y='sales')  # doctest: +SKIP
-        >>> df.plot.pie(x='date', subplots=True)  # doctest: +SKIP
+        .. plotly::
+
+            >>> from datetime import datetime
+            >>> data = [
+            ...     (3, 5, 20, datetime(2018, 1, 31)),
+            ...     (2, 5, 42, datetime(2018, 2, 28)),
+            ...     (3, 6, 28, datetime(2018, 3, 31)),
+            ...     (9, 12, 62, datetime(2018, 4, 30))
+            ... ]
+            >>> columns = ["sales", "signups", "visits", "date"]
+            >>> df = spark.createDataFrame(data, columns)
+            >>> df.plot.pie(x='date', y='sales')  # doctest: +SKIP
+            >>> df.plot.pie(x='date', subplots=True)  # doctest: +SKIP
         """
         return self(kind="pie", x=x, y=y, **kwargs)
 
@@ -365,21 +377,23 @@ class PySparkPlotAccessor:
 
         Examples
         --------
-        >>> data = [
-        ...     ("A", 50, 55),
-        ...     ("B", 55, 60),
-        ...     ("C", 60, 65),
-        ...     ("D", 65, 70),
-        ...     ("E", 70, 75),
-        ...     ("F", 10, 15),
-        ...     ("G", 85, 90),
-        ...     ("H", 5, 150),
-        ... ]
-        >>> columns = ["student", "math_score", "english_score"]
-        >>> df = spark.createDataFrame(data, columns)
-        >>> df.plot.box()  # doctest: +SKIP
-        >>> df.plot.box(column="math_score")  # doctest: +SKIP
-        >>> df.plot.box(column=["math_score", "english_score"])  # doctest: +SKIP
+        .. plotly::
+
+            >>> data = [
+            ...     ("A", 50, 55),
+            ...     ("B", 55, 60),
+            ...     ("C", 60, 65),
+            ...     ("D", 65, 70),
+            ...     ("E", 70, 75),
+            ...     ("F", 10, 15),
+            ...     ("G", 85, 90),
+            ...     ("H", 5, 150),
+            ... ]
+            >>> columns = ["student", "math_score", "english_score"]
+            >>> df = spark.createDataFrame(data, columns)
+            >>> df.plot.box()  # doctest: +SKIP
+            >>> df.plot.box(column="math_score")  # doctest: +SKIP
+            >>> df.plot.box(column=["math_score", "english_score"])  # doctest: +SKIP
         """
         return self(kind="box", column=column, **kwargs)
 
@@ -419,12 +433,14 @@ class PySparkPlotAccessor:
 
         Examples
         --------
-        >>> data = [(5.1, 3.5, 0), (4.9, 3.0, 0), (7.0, 3.2, 1), (6.4, 3.2, 1), (5.9, 3.0, 2)]
-        >>> columns = ["length", "width", "species"]
-        >>> df = spark.createDataFrame(data, columns)
-        >>> df.plot.kde(bw_method=0.3, ind=100)  # doctest: +SKIP
-        >>> df.plot.kde(column=["length", "width"], bw_method=0.3, ind=100)  # doctest: +SKIP
-        >>> df.plot.kde(column="length", bw_method=0.3, ind=100)  # doctest: +SKIP
+        .. plotly::
+
+            >>> data = [(5.1, 3.5, 0), (4.9, 3.0, 0), (7.0, 3.2, 1), (6.4, 3.2, 1), (5.9, 3.0, 2)]
+            >>> columns = ["length", "width", "species"]
+            >>> df = spark.createDataFrame(data, columns)
+            >>> df.plot.kde(bw_method=0.3, ind=100)  # doctest: +SKIP
+            >>> df.plot.kde(column=["length", "width"], bw_method=0.3, ind=100)  # doctest: +SKIP
+            >>> df.plot.kde(column="length", bw_method=0.3, ind=100)  # doctest: +SKIP
         """
         return self(kind="kde", column=column, bw_method=bw_method, ind=ind, **kwargs)
 
@@ -454,12 +470,14 @@ class PySparkPlotAccessor:
 
         Examples
         --------
-        >>> data = [(5.1, 3.5, 0), (4.9, 3.0, 0), (7.0, 3.2, 1), (6.4, 3.2, 1), (5.9, 3.0, 2)]
-        >>> columns = ["length", "width", "species"]
-        >>> df = spark.createDataFrame(data, columns)
-        >>> df.plot.hist(bins=4)  # doctest: +SKIP
-        >>> df.plot.hist(column=["length", "width"])  # doctest: +SKIP
-        >>> df.plot.hist(column="length", bins=4)  # doctest: +SKIP
+        .. plotly::
+
+            >>> data = [(5.1, 3.5, 0), (4.9, 3.0, 0), (7.0, 3.2, 1), (6.4, 3.2, 1), (5.9, 3.0, 2)]
+            >>> columns = ["length", "width", "species"]
+            >>> df = spark.createDataFrame(data, columns)
+            >>> df.plot.hist(bins=4)  # doctest: +SKIP
+            >>> df.plot.hist(column=["length", "width"])  # doctest: +SKIP
+            >>> df.plot.hist(column="length", bins=4)  # doctest: +SKIP
         """
         return self(kind="hist", column=column, bins=bins, **kwargs)
 

--- a/python/pyspark/sql/plot/core.py
+++ b/python/pyspark/sql/plot/core.py
@@ -20,7 +20,7 @@ import math
 from typing import Any, TYPE_CHECKING, List, Optional, Union, Sequence
 from types import ModuleType
 from pyspark.errors import PySparkValueError
-from pyspark.sql import Column, functions as F, SparkSession
+from pyspark.sql import Column, functions as F, SparkSession  # noqa: F401
 from pyspark.sql.internal import InternalFunction as SF
 from pyspark.sql.pandas.utils import require_minimum_pandas_version
 from pyspark.sql.utils import NumpyHelper, require_minimum_plotly_version

--- a/python/pyspark/sql/plot/core.py
+++ b/python/pyspark/sql/plot/core.py
@@ -20,7 +20,7 @@ import math
 from typing import Any, TYPE_CHECKING, List, Optional, Union, Sequence
 from types import ModuleType
 from pyspark.errors import PySparkValueError
-from pyspark.sql import Column, functions as F, SparkSession  # noqa: F401
+from pyspark.sql import Column, functions as F
 from pyspark.sql.internal import InternalFunction as SF
 from pyspark.sql.pandas.utils import require_minimum_pandas_version
 from pyspark.sql.utils import NumpyHelper, require_minimum_plotly_version
@@ -151,9 +151,10 @@ class PySparkPlotAccessor:
         --------
         .. plotly::
 
+            >>> from pyspark.sql import SparkSession
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> data = [("A", 10, 1.5), ("B", 30, 2.5), ("C", 20, 3.5)]
             >>> columns = ["category", "int_val", "float_val"]
-            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.line(x="category", y="int_val")  # doctest: +SKIP
             >>> df.plot.line(x="category", y=["int_val", "float_val"])  # doctest: +SKIP
@@ -187,9 +188,10 @@ class PySparkPlotAccessor:
         --------
         .. plotly::
 
+            >>> from pyspark.sql import SparkSession
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> data = [("A", 10, 1.5), ("B", 30, 2.5), ("C", 20, 3.5)]
             >>> columns = ["category", "int_val", "float_val"]
-            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.bar(x="category", y="int_val")  # doctest: +SKIP
             >>> df.plot.bar(x="category", y=["int_val", "float_val"])  # doctest: +SKIP
@@ -232,9 +234,10 @@ class PySparkPlotAccessor:
         --------
         .. plotly::
 
+            >>> from pyspark.sql import SparkSession
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> data = [("A", 10, 1.5), ("B", 30, 2.5), ("C", 20, 3.5)]
             >>> columns = ["category", "int_val", "float_val"]
-            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.barh(x="int_val", y="category")  # doctest: +SKIP
             >>> df.plot.barh(
@@ -271,9 +274,10 @@ class PySparkPlotAccessor:
         --------
         .. plotly::
 
+            >>> from pyspark.sql import SparkSession
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> data = [(5.1, 3.5, 0), (4.9, 3.0, 0), (7.0, 3.2, 1), (6.4, 3.2, 1), (5.9, 3.0, 2)]
             >>> columns = ['length', 'width', 'species']
-            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.scatter(x='length', y='width')  # doctest: +SKIP
         """
@@ -302,6 +306,8 @@ class PySparkPlotAccessor:
         --------
         .. plotly::
 
+            >>> from pyspark.sql import SparkSession
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> from datetime import datetime
             >>> data = [
             ...     (3, 5, 20, datetime(2018, 1, 31)),
@@ -310,7 +316,6 @@ class PySparkPlotAccessor:
             ...     (9, 12, 62, datetime(2018, 4, 30))
             ... ]
             >>> columns = ["sales", "signups", "visits", "date"]
-            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.area(x='date', y=['sales', 'signups', 'visits'])  # doctest: +SKIP
         """
@@ -340,6 +345,8 @@ class PySparkPlotAccessor:
         --------
         .. plotly::
 
+            >>> from pyspark.sql import SparkSession
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> from datetime import datetime
             >>> data = [
             ...     (3, 5, 20, datetime(2018, 1, 31)),
@@ -348,7 +355,6 @@ class PySparkPlotAccessor:
             ...     (9, 12, 62, datetime(2018, 4, 30))
             ... ]
             >>> columns = ["sales", "signups", "visits", "date"]
-            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.pie(x='date', y='sales')  # doctest: +SKIP
             >>> df.plot.pie(x='date', subplots=True)  # doctest: +SKIP
@@ -385,6 +391,8 @@ class PySparkPlotAccessor:
         --------
         .. plotly::
 
+            >>> from pyspark.sql import SparkSession
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> data = [
             ...     ("A", 50, 55),
             ...     ("B", 55, 60),
@@ -396,7 +404,6 @@ class PySparkPlotAccessor:
             ...     ("H", 5, 150),
             ... ]
             >>> columns = ["student", "math_score", "english_score"]
-            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.box()  # doctest: +SKIP
             >>> df.plot.box(column="math_score")  # doctest: +SKIP
@@ -442,9 +449,10 @@ class PySparkPlotAccessor:
         --------
         .. plotly::
 
+            >>> from pyspark.sql import SparkSession
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> data = [(5.1, 3.5, 0), (4.9, 3.0, 0), (7.0, 3.2, 1), (6.4, 3.2, 1), (5.9, 3.0, 2)]
             >>> columns = ["length", "width", "species"]
-            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.kde(bw_method=0.3, ind=100)  # doctest: +SKIP
             >>> df.plot.kde(column=["length", "width"], bw_method=0.3, ind=100)  # doctest: +SKIP
@@ -480,9 +488,10 @@ class PySparkPlotAccessor:
         --------
         .. plotly::
 
+            >>> from pyspark.sql import SparkSession
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> data = [(5.1, 3.5, 0), (4.9, 3.0, 0), (7.0, 3.2, 1), (6.4, 3.2, 1), (5.9, 3.0, 2)]
             >>> columns = ["length", "width", "species"]
-            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.hist(bins=4)  # doctest: +SKIP
             >>> df.plot.hist(column=["length", "width"])  # doctest: +SKIP

--- a/python/pyspark/sql/plot/core.py
+++ b/python/pyspark/sql/plot/core.py
@@ -20,7 +20,7 @@ import math
 from typing import Any, TYPE_CHECKING, List, Optional, Union, Sequence
 from types import ModuleType
 from pyspark.errors import PySparkValueError
-from pyspark.sql import Column, functions as F
+from pyspark.sql import Column, functions as F, SparkSession
 from pyspark.sql.internal import InternalFunction as SF
 from pyspark.sql.pandas.utils import require_minimum_pandas_version
 from pyspark.sql.utils import NumpyHelper, require_minimum_plotly_version
@@ -153,6 +153,7 @@ class PySparkPlotAccessor:
 
             >>> data = [("A", 10, 1.5), ("B", 30, 2.5), ("C", 20, 3.5)]
             >>> columns = ["category", "int_val", "float_val"]
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.line(x="category", y="int_val")  # doctest: +SKIP
             >>> df.plot.line(x="category", y=["int_val", "float_val"])  # doctest: +SKIP
@@ -188,6 +189,7 @@ class PySparkPlotAccessor:
 
             >>> data = [("A", 10, 1.5), ("B", 30, 2.5), ("C", 20, 3.5)]
             >>> columns = ["category", "int_val", "float_val"]
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.bar(x="category", y="int_val")  # doctest: +SKIP
             >>> df.plot.bar(x="category", y=["int_val", "float_val"])  # doctest: +SKIP
@@ -232,6 +234,7 @@ class PySparkPlotAccessor:
 
             >>> data = [("A", 10, 1.5), ("B", 30, 2.5), ("C", 20, 3.5)]
             >>> columns = ["category", "int_val", "float_val"]
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.barh(x="int_val", y="category")  # doctest: +SKIP
             >>> df.plot.barh(
@@ -270,6 +273,7 @@ class PySparkPlotAccessor:
 
             >>> data = [(5.1, 3.5, 0), (4.9, 3.0, 0), (7.0, 3.2, 1), (6.4, 3.2, 1), (5.9, 3.0, 2)]
             >>> columns = ['length', 'width', 'species']
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.scatter(x='length', y='width')  # doctest: +SKIP
         """
@@ -306,6 +310,7 @@ class PySparkPlotAccessor:
             ...     (9, 12, 62, datetime(2018, 4, 30))
             ... ]
             >>> columns = ["sales", "signups", "visits", "date"]
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.area(x='date', y=['sales', 'signups', 'visits'])  # doctest: +SKIP
         """
@@ -343,6 +348,7 @@ class PySparkPlotAccessor:
             ...     (9, 12, 62, datetime(2018, 4, 30))
             ... ]
             >>> columns = ["sales", "signups", "visits", "date"]
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.pie(x='date', y='sales')  # doctest: +SKIP
             >>> df.plot.pie(x='date', subplots=True)  # doctest: +SKIP
@@ -390,6 +396,7 @@ class PySparkPlotAccessor:
             ...     ("H", 5, 150),
             ... ]
             >>> columns = ["student", "math_score", "english_score"]
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.box()  # doctest: +SKIP
             >>> df.plot.box(column="math_score")  # doctest: +SKIP
@@ -437,6 +444,7 @@ class PySparkPlotAccessor:
 
             >>> data = [(5.1, 3.5, 0), (4.9, 3.0, 0), (7.0, 3.2, 1), (6.4, 3.2, 1), (5.9, 3.0, 2)]
             >>> columns = ["length", "width", "species"]
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.kde(bw_method=0.3, ind=100)  # doctest: +SKIP
             >>> df.plot.kde(column=["length", "width"], bw_method=0.3, ind=100)  # doctest: +SKIP
@@ -474,6 +482,7 @@ class PySparkPlotAccessor:
 
             >>> data = [(5.1, 3.5, 0), (4.9, 3.0, 0), (7.0, 3.2, 1), (6.4, 3.2, 1), (5.9, 3.0, 2)]
             >>> columns = ["length", "width", "species"]
+            >>> spark = SparkSession.builder.getOrCreate()
             >>> df = spark.createDataFrame(data, columns)
             >>> df.plot.hist(bins=4)  # doctest: +SKIP
             >>> df.plot.hist(column=["length", "width"])  # doctest: +SKIP


### PR DESCRIPTION
### What changes were proposed in this pull request?
Render interactive PySpark plot examples using .. plotly::

### Why are the changes needed?
The changes enable interactive Plotly visualizations in the rendered doc, making PySpark plotting examples clearer and more engaging for users.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manual rendering.

### Was this patch authored or co-authored using generative AI tooling?
No.
