### PR TITLE
[SPARK-51884][SQL]Part 1.a Add outer scope attributes for SubqueryExpression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2326,7 +2326,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
     private def resolveSubQuery(
         e: SubqueryExpression,
         outer: LogicalPlan)(
-        f: (LogicalPlan, Seq[Expression]) => SubqueryExpression): SubqueryExpression = {
+        f: (LogicalPlan, Seq[(Expression, Boolean)]) => SubqueryExpression): SubqueryExpression = {
       val newSubqueryPlan = AnalysisContext.withOuterPlan(outer) {
         executeSameContext(e.plan)
       }
@@ -2335,7 +2335,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
       // them as children of SubqueryExpression.
       if (newSubqueryPlan.resolved) {
         // Record the outer references as children of subquery expression.
-        f(newSubqueryPlan, SubExprUtils.getOuterReferences(newSubqueryPlan))
+        f(newSubqueryPlan, SubExprUtils.getOuterReferences(newSubqueryPlan).map((_, true)))
       } else {
         e.withNewPlan(newSubqueryPlan)
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ValidateSubqueryExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ValidateSubqueryExpression.scala
@@ -129,7 +129,8 @@ object ValidateSubqueryExpression
     checkOuterReference(plan, expr)
 
     expr match {
-      case ScalarSubquery(query, outerAttrs, _, _, _, _, _) =>
+      case ScalarSubquery(query, rawOuterAttrs, _, _, _, _, _) =>
+        val outerAttrs = rawOuterAttrs.map(_._1)
         // Scalar subquery must return one column as output.
         if (query.output.size != 1) {
           throw QueryCompilationErrors.subqueryReturnMoreThanOneColumn(query.output.size,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ExpressionResolutionValidator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ExpressionResolutionValidator.scala
@@ -140,7 +140,7 @@ class ExpressionResolutionValidator(resolutionValidator: ResolutionValidator) {
       resolutionValidator.validate(scalarSubquery.plan)
     }
 
-    for (outerAttribute <- scalarSubquery.outerAttrs) {
+    for (outerAttribute <- scalarSubquery.getOuterAttrs) {
       validate(outerAttribute)
     }
 
@@ -163,7 +163,7 @@ class ExpressionResolutionValidator(resolutionValidator: ResolutionValidator) {
       resolutionValidator.validate(listQuery.plan)
     }
 
-    for (outerAttribute <- listQuery.outerAttrs) {
+    for (outerAttribute <- listQuery.getOuterAttrs) {
       validate(outerAttribute)
     }
   }
@@ -173,7 +173,7 @@ class ExpressionResolutionValidator(resolutionValidator: ResolutionValidator) {
       resolutionValidator.validate(exists.plan)
     }
 
-    for (outerAttribute <- exists.outerAttrs) {
+    for (outerAttribute <- exists.getOuterAttrs) {
       validate(outerAttribute)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/SubqueryExpressionResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/SubqueryExpressionResolver.scala
@@ -63,7 +63,7 @@ class SubqueryExpressionResolver(expressionResolver: ExpressionResolver, resolve
 
     val resolvedScalarSubquery = unresolvedScalarSubquery.copy(
       plan = resolvedSubqueryExpressionPlan.plan,
-      outerAttrs = resolvedSubqueryExpressionPlan.outerExpressions
+      outerAttrs = resolvedSubqueryExpressionPlan.outerExpressions.map((_, true))
     )
 
     val coercedScalarSubquery =
@@ -108,7 +108,7 @@ class SubqueryExpressionResolver(expressionResolver: ExpressionResolver, resolve
 
     unresolvedListQuery.copy(
       plan = resolvedSubqueryExpressionPlan.plan,
-      outerAttrs = resolvedSubqueryExpressionPlan.outerExpressions,
+      outerAttrs = resolvedSubqueryExpressionPlan.outerExpressions.map((_, true)),
       numCols = resolvedSubqueryExpressionPlan.output.size
     )
   }
@@ -125,7 +125,7 @@ class SubqueryExpressionResolver(expressionResolver: ExpressionResolver, resolve
 
     val resolvedExists = unresolvedExists.copy(
       plan = resolvedSubqueryExpressionPlan.plan,
-      outerAttrs = resolvedSubqueryExpressionPlan.outerExpressions
+      outerAttrs = resolvedSubqueryExpressionPlan.outerExpressions.map((_, true))
     )
 
     val coercedExists = typeCoercionResolver.resolve(resolvedExists).asInstanceOf[Exists]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PullOutNestedDataOuterRefExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PullOutNestedDataOuterRefExpressions.scala
@@ -113,7 +113,7 @@ object PullOutNestedDataOuterRefExpressions extends Rule[LogicalPlan] {
           // them from the project.
           subqueryExpression
             .withNewPlan(newInnerPlan)
-            .withNewOuterAttrs(SubExprUtils.getOuterReferences(newInnerPlan))
+            .withNewOuterAttrs(SubExprUtils.getOuterReferences(newInnerPlan).map((_, true)))
       }
       if (newExprMap.isEmpty) {
         // Nothing to change

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAliasAndProjectSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAliasAndProjectSuite.scala
@@ -146,7 +146,7 @@ class RemoveRedundantAliasAndProjectSuite extends PlanTest {
     val query = Filter(
       Exists(
         LocalRelation(b),
-        outerAttrs = Seq(a_alias_attr),
+        outerAttrs = Seq(a_alias_attr).map((_, true)),
         joinCond = Seq(EqualTo(a_alias_attr, b))
       ),
       Project(Seq(a_alias), LocalRelation(a))
@@ -162,7 +162,7 @@ class RemoveRedundantAliasAndProjectSuite extends PlanTest {
     val expectedWhenNotExcluded = Filter(
       Exists(
         LocalRelation(b),
-        outerAttrs = Seq(a),
+        outerAttrs = Seq(a).map((_, true)),
         joinCond = Seq(EqualTo(a, b))
       ),
       LocalRelation(a)
@@ -201,7 +201,7 @@ class RemoveRedundantAliasAndProjectSuite extends PlanTest {
         CaseWhen(Seq((
           Exists(
             LocalRelation(a),
-            outerAttrs = Seq(a_alias_attr),
+            outerAttrs = Seq(a_alias_attr).map((_, true)),
             joinCond = Seq(EqualTo(a_alias_attr, a))
           ), Literal(1))),
           Some(Literal(2))),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
- Add OuterScopeAttrs and related getter and setter methods for SubqueryExpression
- Change outerAttrs from Seq[Expression] to Seq[(Expression, Boolean)] and change related methods
- Update the usage of SubqueryExpression and classes extending SubqueryExpression


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Spark only supports one layer of correlation now and does not support nested correlation.
For example, 
```sql
SELECT col1 FROM VALUES (1, 2) t1 (col1, col2) WHERE EXISTS (
 SELECT col1 FROM VALUES (1, 2) t2 (col1, col2) WHERE t2.col2 == MAX(t1.col2)
)GROUP BY col1;
```
is supported and 
```sql
SELECT col1 FROM VALUES (1, 2) t1 (col1, col2) WHERE EXISTS (
 SELECT col1 FROM VALUES (1, 2) t2 (col1, col2) WHERE t2.col2 == (
   SELECT MAX(t1.col2)
 )
)GROUP BY col1;
```
is not supported.

The reason spark does not support it is because the Analyzer and Optimizer resolves and plans Subquery in a recursive way. 

The definition change for the SubqueryExpression adds the metadata OuterScopeAttrs which helps later rewrites for the Analyzer and Optimizer.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Current UT and Suite


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
