### PR TITLE
[SPARK-52039][CORE][SQL][TESTS] Remove unnecessary `with PrivateMethodTester` from `ClosureCleanerSuite2` and `InsertSuite`

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite2.scala
+++ b/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite2.scala
@@ -19,7 +19,7 @@ package org.apache.spark.util
 
 import java.io.NotSerializableException
 
-import org.scalatest.{BeforeAndAfterAll, PrivateMethodTester}
+import org.scalatest.BeforeAndAfterAll
 
 import org.apache.spark.{SparkContext, SparkException, SparkFunSuite}
 import org.apache.spark.serializer.SerializerInstance
@@ -28,7 +28,7 @@ import org.apache.spark.serializer.SerializerInstance
  * Another test suite for the closure cleaner that is finer-grained.
  * For tests involving end-to-end Spark jobs, see {{ClosureCleanerSuite}}.
  */
-class ClosureCleanerSuite2 extends SparkFunSuite with BeforeAndAfterAll with PrivateMethodTester {
+class ClosureCleanerSuite2 extends SparkFunSuite with BeforeAndAfterAll {
 
   // Start a SparkContext so that the closure serializer is accessible
   // We do not actually use this explicitly otherwise

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
@@ -22,7 +22,7 @@ import java.util.Locale
 
 import com.google.common.io.Files
 import org.apache.hadoop.fs.Path
-import org.scalatest.{BeforeAndAfter, PrivateMethodTester}
+import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{QueryTest, _}
@@ -39,7 +39,7 @@ case class TestData(key: Int, value: String)
 case class ThreeColumnTable(key: Int, value: String, key1: String)
 
 class InsertSuite extends QueryTest with TestHiveSingleton with BeforeAndAfter
-    with SQLTestUtils with PrivateMethodTester {
+    with SQLTestUtils {
   import spark.implicits._
 
   override lazy val testData = spark.sparkContext.parallelize(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to remove unnecessary `with PrivateMethodTester` from `ClosureCleanerSuite2` and `InsertSuite`, 

### Why are the changes needed?
Code cleanup.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
```
build/sbt clean "core/testOnly org.apache.spark.util.ClosureCleanerSuite2"
build/sbt clean "hive/testOnly org.apache.spark.sql.hive.InsertSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No