### PR TITLE
[SPARK-52040][PYTHON][SQL][CONNECT] ResolveLateralColumnAliasReference should retain the plan id

### DIFF
--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -148,6 +148,15 @@ class DataFrameTestsMixin:
         self.assertTrue(df3.columns, ["id", "value", "id", "value"])
         self.assertTrue(df3.count() == 20)
 
+    def test_self_join_V(self):
+        df1 = self.spark.range(10).select(
+            (col("id") + lit(1)).alias("x"), (col("x") + lit(1)).alias("y")
+        )
+        df2 = self.spark.range(10).select(col("id").alias("x"))
+        df3 = df1.join(df2, df1.x == df2.x).select(df1.y)
+        self.assertTrue(df3.columns, ["y"])
+        self.assertTrue(df3.count() == 9)
+
     def test_duplicated_column_names(self):
         df = self.spark.createDataFrame([(1, 2)], ["c", "c"])
         row = df.select("*").first()

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -148,7 +148,7 @@ class DataFrameTestsMixin:
         self.assertTrue(df3.columns, ["id", "value", "id", "value"])
         self.assertTrue(df3.count() == 20)
 
-    def test_self_join_V(self):
+    def test_lateral_column_alias(self):
         df1 = self.spark.range(10).select(
             (col("id") + lit(1)).alias("x"), (col("x") + lit(1)).alias("y")
         )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveLateralColumnAliasReference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveLateralColumnAliasReference.scala
@@ -194,11 +194,12 @@ object ResolveLateralColumnAliasReference extends Rule[LogicalPlan] {
               outerProjectList.update(idx, alias.toAttribute)
               innerProjectList += alias
           }
-
-          p.copy(
+          val newProject = p.copy(
             projectList = outerProjectList.toSeq,
             child = Project(innerProjectList.toSeq, child)
           )
+          newProject.copyTagsFrom(p)
+          newProject
         }
 
       case aggOriginal: Aggregate
@@ -269,10 +270,12 @@ object ResolveLateralColumnAliasReference extends Rule[LogicalPlan] {
           }
           val projectExprs = aggregateExpressions.map(
             extractExpressions(_).asInstanceOf[NamedExpression])
-          Project(
+          val newProject = Project(
             projectList = projectExprs,
             child = agg.copy(aggregateExpressions = newAggExprs.asScala.toSeq)
           )
+          newProject.copyTagsFrom(agg)
+          newProject
         }
 
       case p: LogicalPlan =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
ResolveLateralColumnAliasReference should retain the plan id


### Why are the changes needed?
bug fix

before:
```
In [1]: from pyspark.sql import functions as sf

In [2]: df1 = spark.range(10).select((sf.col("id") + sf.lit(1)).alias("x"), (sf.col("x") + sf.lit(1)).alias("y"))

In [3]: df2 = spark.range(10).select(sf.col("id").alias("x"))

In [4]: df1.join(df2, df1.x == df2.x).select(df1.y)
Out[4]: 25/05/08 16:38:28 ERROR ErrorUtils: Spark Connect RPC error during: analyze. UserId: ruifeng.zheng. SessionId: af3deba7-1e48-49fd-adad-2046a72ed341.
org.apache.spark.sql.AnalysisException: [CANNOT_RESOLVE_DATAFRAME_COLUMN] Cannot resolve dataframe column "y". It's probably because of illegal references like `df1.select(df2.col("a"))`. SQLSTATE: 42704
	at org.apache.spark.sql.errors.QueryCompilationErrors$.cannotResolveDataFrameColumn(QueryCompilationErrors.scala:4147)
	at org.apache.spark.sql.catalyst.analysis.ColumnResolutionHelper.resolveDataFrameColumn(ColumnResolutionHelper.scala:562)
	at org.apache.spark.sql.catalyst.analysis.ColumnResolutionHelper.tryResolveDataFrameColumns(ColumnResolutionHelper.scala:537)
```

after:
```
In [1]: from pyspark.sql import functions as sf

In [2]: df1 = spark.range(10).select((sf.col("id") + sf.lit(1)).alias("x"), (sf.col("x") + sf.lit(1)).alias("y"))

In [3]: df2 = spark.range(10).select(sf.col("id").alias("x"))

In [4]: df1.join(df2, df1.x == df2.x).select(df1.y).show() 
                                                                                                                           +---+
|  y|
+---+
|  2|
|  3|
|  4|
|  5|
|  6|
|  7|
|  8|
|  9|
| 10|
+---+
```


### Does this PR introduce _any_ user-facing change?
yes, above query works after this change


### How was this patch tested?
added test

### Was this patch authored or co-authored using generative AI tooling?
no
