### PR TITLE
[SPARK-52013] [CONNECT] [ML] Remove `SparkConnectClient.ml_caches`

### DIFF
--- a/python/pyspark/ml/connect/readwrite.py
+++ b/python/pyspark/ml/connect/readwrite.py
@@ -275,7 +275,6 @@ class RemoteMLReader(MLReader[RL]):
                 from pyspark.ml.util import RemoteModelRef
 
                 if ml_type == pb2.MlOperator.OPERATOR_TYPE_MODEL:
-                    session.client.add_ml_cache(result.obj_ref.id)
                     remote_model_ref = RemoteModelRef(result.obj_ref.id)
                     instance = py_type(remote_model_ref)
                 else:

--- a/python/pyspark/ml/tests/connect/test_connect_cache.py
+++ b/python/pyspark/ml/tests/connect/test_connect_cache.py
@@ -42,8 +42,6 @@ class MLConnectCacheTests(ReusedConnectTestCase):
 
         model = svc.fit(df)
 
-        # model is cached in python side
-        self.assertEqual(len(spark.client.thread_local.ml_caches), 1)
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 1)
         self.assertTrue(
@@ -54,8 +52,6 @@ class MLConnectCacheTests(ReusedConnectTestCase):
         # explicitly delete the model
         del model
 
-        # model is removed in python side
-        self.assertEqual(len(spark.client.thread_local.ml_caches), 0)
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 0)
 
@@ -79,10 +75,7 @@ class MLConnectCacheTests(ReusedConnectTestCase):
         model1 = svc.fit(df)
         model2 = svc.fit(df)
         model3 = svc.fit(df)
-        self.assertEqual(len([model1, model2, model3]), 3)
 
-        # all 3 models are cached in python side
-        self.assertEqual(len(spark.client.thread_local.ml_caches), 3)
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 3)
         self.assertTrue(
@@ -96,15 +89,11 @@ class MLConnectCacheTests(ReusedConnectTestCase):
         # explicitly delete the model1
         del model1
 
-        # model1 is removed in python side
-        self.assertEqual(len(spark.client.thread_local.ml_caches), 2)
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 2)
 
         spark.client._cleanup_ml_cache()
 
-        # All models are removed in python side
-        self.assertEqual(len(spark.client.thread_local.ml_caches), 0)
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 0)
 

--- a/python/pyspark/ml/tests/connect/test_connect_cache.py
+++ b/python/pyspark/ml/tests/connect/test_connect_cache.py
@@ -48,10 +48,22 @@ class MLConnectCacheTests(ReusedConnectTestCase):
             "obj: class org.apache.spark.ml.classification.LinearSVCModel" in cache_info[0],
             cache_info,
         )
+        assert model._java_obj._ref_count == 1
+
+        model2 = model.copy()
+        cache_info = spark.client._get_ml_cache_info()
+        self.assertEqual(len(cache_info), 1)
+        assert model._java_obj._ref_count == 2
+        assert model2._java_obj._ref_count == 2
 
         # explicitly delete the model
         del model
 
+        cache_info = spark.client._get_ml_cache_info()
+        self.assertEqual(len(cache_info), 1)
+        assert model2._java_obj._ref_count == 1
+
+        del model2
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 0)
 

--- a/python/pyspark/ml/tests/connect/test_connect_cache.py
+++ b/python/pyspark/ml/tests/connect/test_connect_cache.py
@@ -85,8 +85,9 @@ class MLConnectCacheTests(ReusedConnectTestCase):
 
         svc = LinearSVC(maxIter=1, regParam=1.0)
         model1 = svc.fit(df)
-        svc.fit(df)
-        svc.fit(df)
+        model2 = svc.fit(df)
+        model3 = svc.fit(df)
+        self.assertEqual(len([model1, model2, model3]), 3)
 
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 3)

--- a/python/pyspark/ml/tests/connect/test_connect_cache.py
+++ b/python/pyspark/ml/tests/connect/test_connect_cache.py
@@ -85,8 +85,8 @@ class MLConnectCacheTests(ReusedConnectTestCase):
 
         svc = LinearSVC(maxIter=1, regParam=1.0)
         model1 = svc.fit(df)
-        model2 = svc.fit(df)
-        model3 = svc.fit(df)
+        svc.fit(df)
+        svc.fit(df)
 
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 3)

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -197,7 +197,6 @@ def try_remote_fit(f: FuncT) -> FuncT:
             )
             (_, properties, _) = client.execute_command(command)
             model_info = deserialize(properties)
-            client.add_ml_cache(model_info.obj_ref.id)
             remote_model_ref = RemoteModelRef(model_info.obj_ref.id)
             model = self._create_model(remote_model_ref)
             if model.__class__.__name__ not in ["Bucketizer"]:
@@ -303,11 +302,9 @@ def try_remote_call(f: FuncT) -> FuncT:
             ml_command_result = properties["ml_command_result"]
             if ml_command_result.HasField("summary"):
                 summary = ml_command_result.summary
-                session.client.add_ml_cache(summary)
                 return summary
             elif ml_command_result.HasField("operator_info"):
                 model_info = deserialize(properties)
-                session._client.add_ml_cache(model_info.obj_ref.id)
                 # get a new model ref id from the existing model,
                 # it is up to the caller to build the model
                 return model_info.obj_ref.id
@@ -327,7 +324,7 @@ def del_remote_cache(ref_id: str) -> None:
 
             session = SparkSession.getActiveSession()
             if session is not None:
-                session.client.remove_ml_cache(ref_id)
+                session.client._delete_ml_cache([ref_id])
                 return
         except Exception:
             # SparkSession's down.

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -2013,4 +2013,3 @@ class SparkConnectClient(object):
         if properties is not None and "ml_command_result" in properties:
             ml_command_result = properties["ml_command_result"]
             return [item.string for item in ml_command_result.param.array.elements]
-

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -2013,3 +2013,5 @@ class SparkConnectClient(object):
         if properties is not None and "ml_command_result" in properties:
             ml_command_result = properties["ml_command_result"]
             return [item.string for item in ml_command_result.param.array.elements]
+
+        return []

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1975,19 +1975,6 @@ class SparkConnectClient(object):
         profile_id = properties["create_resource_profile_command_result"]
         return profile_id
 
-    def add_ml_cache(self, cache_id: str) -> None:
-        if not hasattr(self.thread_local, "ml_caches"):
-            self.thread_local.ml_caches = set()
-        self.thread_local.ml_caches.add(cache_id)
-
-    def remove_ml_cache(self, cache_id: str) -> None:
-        deleted = self._delete_ml_cache([cache_id])
-        # TODO: Fix the code: change thread-local `ml_caches` to global `ml_caches`.
-        if hasattr(self.thread_local, "ml_caches"):
-            if cache_id in self.thread_local.ml_caches:
-                for obj_id in deleted:
-                    self.thread_local.ml_caches.remove(obj_id)
-
     def _delete_ml_cache(self, cache_ids: List[str]) -> List[str]:
         # try best to delete the cache
         try:
@@ -2009,24 +1996,22 @@ class SparkConnectClient(object):
             return []
 
     def _cleanup_ml_cache(self) -> None:
-        if hasattr(self.thread_local, "ml_caches"):
-            try:
-                command = pb2.Command()
-                command.ml_command.clean_cache.SetInParent()
-                self.execute_command(command)
-                self.thread_local.ml_caches.clear()
-            except Exception:
-                pass
+        try:
+            command = pb2.Command()
+            command.ml_command.clean_cache.SetInParent()
+            self.execute_command(command)
+            self.thread_local.ml_caches.clear()
+        except Exception:
+            pass
 
     def _get_ml_cache_info(self) -> List[str]:
-        if hasattr(self.thread_local, "ml_caches"):
-            command = pb2.Command()
-            command.ml_command.get_cache_info.SetInParent()
-            (_, properties, _) = self.execute_command(command)
+        command = pb2.Command()
+        command.ml_command.get_cache_info.SetInParent()
+        (_, properties, _) = self.execute_command(command)
 
-            assert properties is not None
+        assert properties is not None
 
-            if properties is not None and "ml_command_result" in properties:
-                ml_command_result = properties["ml_command_result"]
-                return [item.string for item in ml_command_result.param.array.elements]
-        return []
+        if properties is not None and "ml_command_result" in properties:
+            ml_command_result = properties["ml_command_result"]
+            return [item.string for item in ml_command_result.param.array.elements]
+

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -2000,7 +2000,6 @@ class SparkConnectClient(object):
             command = pb2.Command()
             command.ml_command.clean_cache.SetInParent()
             self.execute_command(command)
-            self.thread_local.ml_caches.clear()
         except Exception:
             pass
 

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -162,7 +162,7 @@ if should_test_connect:
     # The _cleanup_ml_cache invocation will hang in this test (no valid spark cluster)
     # and it blocks the test process exiting because it is registered as the atexit handler
     # in `SparkConnectClient` constructor. To bypass the issue, patch the method in the test.
-    SparkConnectClient._cleanup_ml_cache = lambda: None
+    SparkConnectClient._cleanup_ml_cache = lambda _: None
 
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -159,6 +159,11 @@ if should_test_connect:
             resp.session_id = self._session_id
             return resp
 
+    # The _cleanup_ml_cache invocation will hang in this test (no valid spark cluster)
+    # and it blocks the test process exiting because it is registered as the atexit handler
+    # in `SparkConnectClient` constructor. To bypass the issue, patch the method in the test.
+    SparkConnectClient._cleanup_ml_cache = lambda: None
+
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
 class SparkConnectClientTestCase(unittest.TestCase):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Remove `SparkConnectClient.ml_caches`

The current implementation of `SparkConnectClient.ml_caches` is buggy (should be global but it is thread-local)
and we already have MLcache dict in Spark driver as the source of truth,
we don't need to maintain a copy of the dict in client,

so in this PR I remove it.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bugfix, and remove redundant data structure.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.