### PR TITLE
[SPARK-52042][SQL] Fix an error of supported typed literals

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3439,7 +3439,7 @@ class AstBuilder extends DataTypeAstBuilder
         throw QueryParsingErrors.literalValueTypeUnsupportedError(
           unsupportedType = ctx.literalType.getText,
           supportedTypes =
-            Seq("DATE", "TIMESTAMP_NTZ", "TIMESTAMP_LTZ", "TIMESTAMP", "INTERVAL", "X"),
+            Seq("DATE", "TIMESTAMP_NTZ", "TIMESTAMP_LTZ", "TIMESTAMP", "INTERVAL", "X", "TIME"),
           ctx)
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -705,7 +705,7 @@ class ExpressionParserSuite extends AnalysisTest {
       parameters = Map(
         "unsupportedType" -> "\"GEO\"",
         "supportedTypes" ->
-        """"DATE", "TIMESTAMP_NTZ", "TIMESTAMP_LTZ", "TIMESTAMP", "INTERVAL", "X""""),
+        """"DATE", "TIMESTAMP_NTZ", "TIMESTAMP_LTZ", "TIMESTAMP", "INTERVAL", "X", "TIME""""),
       context = ExpectedContext(
         fragment = "GEO '(10,-6)'",
         start = 0,

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/literals.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/literals.sql.out
@@ -402,7 +402,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "errorClass" : "UNSUPPORTED_TYPED_LITERAL",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "supportedTypes" : "\"DATE\", \"TIMESTAMP_NTZ\", \"TIMESTAMP_LTZ\", \"TIMESTAMP\", \"INTERVAL\", \"X\"",
+    "supportedTypes" : "\"DATE\", \"TIMESTAMP_NTZ\", \"TIMESTAMP_LTZ\", \"TIMESTAMP\", \"INTERVAL\", \"X\", \"TIME\"",
     "unsupportedType" : "\"GEO\""
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/nonansi/literals.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/nonansi/literals.sql.out
@@ -402,7 +402,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "errorClass" : "UNSUPPORTED_TYPED_LITERAL",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "supportedTypes" : "\"DATE\", \"TIMESTAMP_NTZ\", \"TIMESTAMP_LTZ\", \"TIMESTAMP\", \"INTERVAL\", \"X\"",
+    "supportedTypes" : "\"DATE\", \"TIMESTAMP_NTZ\", \"TIMESTAMP_LTZ\", \"TIMESTAMP\", \"INTERVAL\", \"X\", \"TIME\"",
     "unsupportedType" : "\"GEO\""
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/results/literals.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/literals.sql.out
@@ -454,7 +454,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "errorClass" : "UNSUPPORTED_TYPED_LITERAL",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "supportedTypes" : "\"DATE\", \"TIMESTAMP_NTZ\", \"TIMESTAMP_LTZ\", \"TIMESTAMP\", \"INTERVAL\", \"X\"",
+    "supportedTypes" : "\"DATE\", \"TIMESTAMP_NTZ\", \"TIMESTAMP_LTZ\", \"TIMESTAMP\", \"INTERVAL\", \"X\", \"TIME\"",
     "unsupportedType" : "\"GEO\""
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/results/nonansi/literals.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/nonansi/literals.sql.out
@@ -454,7 +454,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "errorClass" : "UNSUPPORTED_TYPED_LITERAL",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "supportedTypes" : "\"DATE\", \"TIMESTAMP_NTZ\", \"TIMESTAMP_LTZ\", \"TIMESTAMP\", \"INTERVAL\", \"X\"",
+    "supportedTypes" : "\"DATE\", \"TIMESTAMP_NTZ\", \"TIMESTAMP_LTZ\", \"TIMESTAMP\", \"INTERVAL\", \"X\", \"TIME\"",
     "unsupportedType" : "\"GEO\""
   },
   "queryContext" : [ {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to fix the list of supported typed literals in the error message, for example:
```sql
[UNSUPPORTED_TYPED_LITERAL] Literals of the type "LOCALTIME" are not supported. Supported types are "DATE", "TIMESTAMP_NTZ", "TIMESTAMP_LTZ", "TIMESTAMP", "INTERVAL", "X". SQLSTATE: 0A000
== SQL (line 1, position 8) ==
SELECT localtime'12:30:41'
```
The error message does not include `TIME` which was added by https://github.com/apache/spark/pull/50228.

### Why are the changes needed?
To don't confuse users regarding the supported typed literals.


### Does this PR introduce _any_ user-facing change?
No, it shouldn't.


### How was this patch tested?
By running the modified test suites:
```
$ build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z literals.sql"
$ build/sbt "test:testOnly *ExpressionParserSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.
