### PR TITLE
 [SPARK-52159][SQL] Properly handle table existence check for jdbc dialects

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -179,6 +179,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
   override def indexOptions: String = "KEY_BLOCK_SIZE=10"
 
   test("SPARK-42943: Use LONGTEXT instead of TEXT for StringType for effective length") {
+    assert(false)
     val tableName = catalogName + ".t1"
     withTable(tableName) {
       sql(s"CREATE TABLE $tableName(c1 string)")

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -179,7 +179,6 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
   override def indexOptions: String = "KEY_BLOCK_SIZE=10"
 
   test("SPARK-42943: Use LONGTEXT instead of TEXT for StringType for effective length") {
-    assert(false)
     val tableName = catalogName + ".t1"
     withTable(tableName) {
       sql(s"CREATE TABLE $tableName(c1 string)")

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -1051,11 +1051,11 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
   }
 
   test("SPARK-48618: Test table does not exists error") {
-    withTable(s"$catalogName.tbl1") {
-      val tbl = s"$catalogName.tbl1"
-      val sqlStatement = s"SELECT * FROM $tbl"
-      val startPos = sqlStatement.indexOf(tbl)
+    val tbl = s"$catalogName.tbl1"
+    val sqlStatement = s"SELECT * FROM $tbl"
+    val startPos = sqlStatement.indexOf(tbl)
 
+    withTable(tbl) {
       sql(s"CREATE TABLE $tbl (col1 INT, col2 INT)")
       sql(s"INSERT INTO $tbl VALUES (1, 2)")
       val df = sql(sqlStatement)

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -1052,18 +1052,18 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
 
   test("SPARK-48618: Test table does not exists error") {
     withTable(s"$catalogName.tbl1") {
-      val tbl = "$catalogName.tbl1"
-      val sqlStatement = "SELECT * FROM $catalogName.tbl1"
+      val tbl = s"$catalogName.tbl1"
+      val sqlStatement = s"SELECT * FROM $tbl"
       val startPos = sqlStatement.indexOf(tbl)
 
-      sql(s"CREATE TABLE $catalogName.tbl1 (col1 INT, col2 INT)")
-      sql(s"INSERT INTO $catalogName.tbl1 VALUES (1, 2)")
+      sql(s"CREATE TABLE $tbl (col1 INT, col2 INT)")
+      sql(s"INSERT INTO $tbl VALUES (1, 2)")
       val df = sql(sqlStatement)
       val row = df.collect()
       assert(row.length === 1)
 
       // Drop the table
-      sql(s"DROP TABLE IF EXISTS $catalogName.tbl1")
+      sql(s"DROP TABLE IF EXISTS $tbl")
 
       checkError(
         exception = intercept[AnalysisException] {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -1057,8 +1057,8 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
       val df = sql(s"SELECT * FROM $catalogName.tbl1")
       val row = df.collect()
       assert(row.length === 1)
-      assert(row(0).getInt(0) === 1)
-      assert(row(0).getInt(1) === 2)
+      assert(row(0).getInt(0).intValue() === 1)
+      assert(row(0).getInt(1).intValue() === 2)
 
       // Drop the table
       sql(s"DROP TABLE IF EXISTS $catalogName.tbl1")

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -1052,6 +1052,9 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
 
   test("SPARK-48618: Test table does not exists error") {
     withTable(s"$catalogName.tbl1") {
+      val tbl = "$catalogName.tbl1"
+      val startPos = sqlStatement.indexOf(tbl)
+
       sql(s"CREATE TABLE $catalogName.tbl1 (col1 INT, col2 INT)")
       sql(s"INSERT INTO $catalogName.tbl1 VALUES (1, 2)")
       val df = sql(s"SELECT * FROM $catalogName.tbl1")
@@ -1066,7 +1069,8 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
           sql(s"SELECT * FROM $catalogName.tbl1").collect()
         },
         condition = "TABLE_OR_VIEW_NOT_FOUND",
-        parameters = Map("relationName" -> s"`$catalogName`.`tbl1`")
+        parameters = Map("relationName" -> s"`$catalogName`.`tbl1`"),
+        context = ExpectedContext(tbl, startPos, startPos + tbl.length - 1)
       )
     }
   }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -1057,8 +1057,8 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
       val df = sql(s"SELECT * FROM $catalogName.tbl1")
       val row = df.collect()
       assert(row.length === 1)
-      assert(row(0).getInt(0).intValue() === 1)
-      assert(row(0).getInt(1).intValue() === 2)
+      assert(row(0).getDecimal(0).intValue() === 1)
+      assert(row(0).getDecimal(1).intValue() === 2)
 
       // Drop the table
       sql(s"DROP TABLE IF EXISTS $catalogName.tbl1")
@@ -1068,7 +1068,7 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
           sql(s"SELECT * FROM $catalogName.tbl1")
         },
         condition = "TABLE_OR_VIEW_NOT_FOUND",
-        parameters = Map("relationName" -> "`tbl1`")
+        parameters = Map("relationName" -> s"`$catalogName`.`tbl1`")
       )
     }
   }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -1053,11 +1053,12 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
   test("SPARK-48618: Test table does not exists error") {
     withTable(s"$catalogName.tbl1") {
       val tbl = "$catalogName.tbl1"
+      val sqlStatement = "SELECT * FROM $catalogName.tbl1"
       val startPos = sqlStatement.indexOf(tbl)
 
       sql(s"CREATE TABLE $catalogName.tbl1 (col1 INT, col2 INT)")
       sql(s"INSERT INTO $catalogName.tbl1 VALUES (1, 2)")
-      val df = sql(s"SELECT * FROM $catalogName.tbl1")
+      val df = sql(sqlStatement)
       val row = df.collect()
       assert(row.length === 1)
 
@@ -1066,7 +1067,7 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
 
       checkError(
         exception = intercept[AnalysisException] {
-          sql(s"SELECT * FROM $catalogName.tbl1").collect()
+          sql(sqlStatement).collect()
         },
         condition = "TABLE_OR_VIEW_NOT_FOUND",
         parameters = Map("relationName" -> s"`$catalogName`.`tbl1`"),

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -1057,15 +1057,13 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
       val df = sql(s"SELECT * FROM $catalogName.tbl1")
       val row = df.collect()
       assert(row.length === 1)
-      assert(row(0).getDecimal(0).intValue() === 1)
-      assert(row(0).getDecimal(1).intValue() === 2)
 
       // Drop the table
       sql(s"DROP TABLE IF EXISTS $catalogName.tbl1")
 
       checkError(
         exception = intercept[AnalysisException] {
-          sql(s"SELECT * FROM $catalogName.tbl1")
+          sql(s"SELECT * FROM $catalogName.tbl1").collect()
         },
         condition = "TABLE_OR_VIEW_NOT_FOUND",
         parameters = Map("relationName" -> s"`$catalogName`.`tbl1`")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -76,7 +76,7 @@ object JdbcUtils extends Logging with SQLConfHelper {
 
     executionResult match {
       case Success(_) => true
-      case Failure(e: SQLException) if dialect.isTableNotFoundException(e) => false
+      case Failure(e: SQLException) if dialect.isObjectNotFoundException(e) => false
       case Failure(e) => throw e  // Re-throw unexpected exceptions
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -81,21 +81,6 @@ object JdbcUtils extends Logging with SQLConfHelper {
     }
   }
 
-  // Helper to identify table-not-found errors across common databases
-  private def isTableNotFoundException(e: SQLException): Boolean = {
-    // Check SQLState codes for common databases
-    val tableNotFoundStates = Set(
-      "42P01",   // PostgreSQL: undefined_table
-      "42S02",   // MySQL/H2: base table or view not found
-      "42X05",   // Derby: table/view does not exist
-      "S0002",   // SQL Server: object not found
-      "42Y55"    // Apache Derby: table does not exist
-    )
-
-    // Check error code for SQLite (uses error code 1 for missing table)
-    e.getErrorCode == 1 || tableNotFoundStates.contains(e.getSQLState)
-  }
-
   /**
    * Drops a table from the JDBC database.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
@@ -47,12 +47,8 @@ private case class DB2Dialect() extends JdbcDialect with SQLConfHelper with NoLe
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)
 
-  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
-    e match {
-      case sqlException: java.sql.SQLException =>
-        sqlException.getErrorCode == -204
-      case _ => false
-    }
+  override def isObjectNotFoundException(e: SQLException): Boolean = {
+    e.getErrorCode == -204
   }
 
   class DB2SQLBuilder extends JDBCSQLBuilder {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
@@ -47,6 +47,14 @@ private case class DB2Dialect() extends JdbcDialect with SQLConfHelper with NoLe
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)
 
+  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
+    e match {
+      case sqlException: java.sql.SQLException =>
+        sqlException.getErrorCode == -204
+      case _ => false
+    }
+  }
+
   class DB2SQLBuilder extends JDBCSQLBuilder {
 
     override def visitAggregateFunction(

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DatabricksDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DatabricksDialect.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.Connection
+import java.sql.{Connection, SQLException}
 
 import scala.collection.mutable.ArrayBuilder
 
@@ -31,12 +31,8 @@ private case class DatabricksDialect() extends JdbcDialect with NoLegacyJDBCErro
     url.startsWith("jdbc:databricks")
   }
 
-  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
-    e match {
-      case sqlException: java.sql.SQLException =>
-        sqlException.getSQLState == "42P01"
-      case _ => false
-    }
+  override def isObjectNotFoundException(e: SQLException): Boolean = {
+    e.getSQLState == "42P01" || e.getSQLState == "42704"
   }
 
   override def getCatalystType(

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DatabricksDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DatabricksDialect.scala
@@ -31,6 +31,14 @@ private case class DatabricksDialect() extends JdbcDialect with NoLegacyJDBCErro
     url.startsWith("jdbc:databricks")
   }
 
+  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
+    e match {
+      case sqlException: java.sql.SQLException =>
+        sqlException.getSQLState == "42P01"
+      case _ => false
+    }
+  }
+
   override def getCatalystType(
       sqlType: Int, typeName: String, size: Int, md: MetadataBuilder): Option[DataType] = {
     sqlType match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DerbyDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DerbyDialect.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.Types
+import java.sql.{SQLException, Types}
 import java.util.Locale
 
 import org.apache.spark.sql.connector.catalog.Identifier
@@ -38,13 +38,10 @@ private case class DerbyDialect() extends JdbcDialect with NoLegacyJDBCError {
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)
 
-  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
-    e match {
-      case sqlException: java.sql.SQLException =>
-        sqlException.getMessage.contains("Table/View") &&
-        sqlException.getMessage.contains("does not exist")
-      case _ => false
-    }
+  override def isObjectNotFoundException(e: SQLException): Boolean = {
+    e.getSQLState.equalsIgnoreCase("42Y07") ||
+      e.getSQLState.equalsIgnoreCase("42X05") ||
+      e.getSQLState.equalsIgnoreCase("X0X05")
   }
 
   override def getCatalystType(

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DerbyDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DerbyDialect.scala
@@ -38,6 +38,15 @@ private case class DerbyDialect() extends JdbcDialect with NoLegacyJDBCError {
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)
 
+  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
+    e match {
+      case sqlException: java.sql.SQLException =>
+        sqlException.getMessage.contains("Table/View") &&
+        sqlException.getMessage.contains("does not exist")
+      case _ => false
+    }
+  }
+
   override def getCatalystType(
       sqlType: Int, typeName: String, size: Int, md: MetadataBuilder): Option[DataType] = {
     if (sqlType == Types.REAL) Option(FloatType) else None

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
@@ -57,12 +57,8 @@ private[sql] case class H2Dialect() extends JdbcDialect with NoLegacyJDBCError {
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)
 
-  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
-    e match {
-      case sqlException: java.sql.SQLException =>
-        Set(42102, 42013, 42014).contains(sqlException.getErrorCode)
-      case _ => false
-    }
+  override def isObjectNotFoundException(e: SQLException): Boolean = {
+    Set(42102, 42103, 42104, 90079).contains(e.getErrorCode)
   }
 
   override def getCatalystType(

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
@@ -57,6 +57,14 @@ private[sql] case class H2Dialect() extends JdbcDialect with NoLegacyJDBCError {
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)
 
+  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
+    e match {
+      case sqlException: java.sql.SQLException =>
+        Set(42102, 42013, 42014).contains(sqlException.getErrorCode)
+      case _ => false
+    }
+  }
+
   override def getCatalystType(
       sqlType: Int, typeName: String, size: Int, md: MetadataBuilder): Option[DataType] = {
     sqlType match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -759,7 +759,7 @@ abstract class JdbcDialect extends Serializable with Logging {
   }
 
   @Since("4.1.0")
-  def isTableNotFoundException(e: SQLException): Boolean = true
+  def isObjectNotFoundException(e: SQLException): Boolean = true
 
   /**
    * Gets a dialect exception, classifies it and wraps it by `AnalysisException`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.{Connection, Date, Driver, ResultSetMetaData, Statement, Timestamp}
+import java.sql.{Connection, Date, Driver, ResultSetMetaData, SQLException, Statement, Timestamp}
 import java.time.{Instant, LocalDate, LocalDateTime}
 import java.util
 import java.util.ServiceLoader
@@ -757,6 +757,9 @@ abstract class JdbcDialect extends Serializable with Logging {
       options: JDBCOptions): Array[TableIndex] = {
     throw new SparkUnsupportedOperationException("_LEGACY_ERROR_TEMP_3182")
   }
+
+  @Since("4.1.0")
+  def isTableNotFoundException(e: SQLException): Boolean = true
 
   /**
    * Gets a dialect exception, classifies it and wraps it by `AnalysisException`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -38,12 +38,8 @@ private case class MsSqlServerDialect() extends JdbcDialect with NoLegacyJDBCErr
   override def canHandle(url: String): Boolean =
     url.toLowerCase(Locale.ROOT).startsWith("jdbc:sqlserver")
 
-  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
-    e match {
-      case sqlException: java.sql.SQLException =>
-        sqlException.getErrorCode == 208
-      case _ => false
-    }
+  override def isObjectNotFoundException(e: SQLException): Boolean = {
+    e.getErrorCode == 208
   }
 
   // Microsoft SQL Server does not have the boolean type.

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -38,6 +38,14 @@ private case class MsSqlServerDialect() extends JdbcDialect with NoLegacyJDBCErr
   override def canHandle(url: String): Boolean =
     url.toLowerCase(Locale.ROOT).startsWith("jdbc:sqlserver")
 
+  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
+    e match {
+      case sqlException: java.sql.SQLException =>
+        sqlException.getErrorCode == 208
+      case _ => false
+    }
+  }
+
   // Microsoft SQL Server does not have the boolean type.
   // Compile the boolean value to the bit data type instead.
   // scalastyle:off line.size.limit

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -50,12 +50,8 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)
 
-  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
-    e match {
-      case sqlException: java.sql.SQLException =>
-        sqlException.getErrorCode == 1146
-      case _ => false
-    }
+  override def isObjectNotFoundException(e: SQLException): Boolean = {
+    e.getErrorCode == 1146
   }
 
   class MySQLSQLBuilder extends JDBCSQLBuilder {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -50,6 +50,14 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)
 
+  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
+    e match {
+      case sqlException: java.sql.SQLException =>
+        sqlException.getErrorCode == 1146
+      case _ => false
+    }
+  }
+
   class MySQLSQLBuilder extends JDBCSQLBuilder {
 
     override def visitExtract(extract: Extract): String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -49,6 +49,14 @@ private case class OracleDialect() extends JdbcDialect with SQLConfHelper with N
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)
 
+  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
+    e match {
+      case sqlException: java.sql.SQLException =>
+        sqlException.getMessage.contains("ORA-00942")
+      case _ => false
+    }
+  }
+
   class OracleSQLBuilder extends JDBCSQLBuilder {
 
     override def visitAggregateFunction(

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -49,12 +49,9 @@ private case class OracleDialect() extends JdbcDialect with SQLConfHelper with N
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)
 
-  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
-    e match {
-      case sqlException: java.sql.SQLException =>
-        sqlException.getMessage.contains("ORA-00942")
-      case _ => false
-    }
+  override def isObjectNotFoundException(e: SQLException): Boolean = {
+    e.getMessage.contains("ORA-00942") ||
+      e.getMessage.contains("ORA-39165")
   }
 
   class OracleSQLBuilder extends JDBCSQLBuilder {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -54,6 +54,14 @@ private case class PostgresDialect()
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)
 
+  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
+    e match {
+      case sqlException: java.sql.SQLException =>
+        sqlException.getSQLState == "42P01"
+      case _ => false
+    }
+  }
+
   override def getCatalystType(
       sqlType: Int, typeName: String, size: Int, md: MetadataBuilder): Option[DataType] = {
     sqlType match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -54,12 +54,10 @@ private case class PostgresDialect()
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)
 
-  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
-    e match {
-      case sqlException: java.sql.SQLException =>
-        sqlException.getSQLState == "42P01"
-      case _ => false
-    }
+  override def isObjectNotFoundException(e: SQLException): Boolean = {
+    e.getSQLState == "42P01" ||
+      e.getSQLState == "3F000" ||
+      e.getSQLState == "42704"
   }
 
   override def getCatalystType(

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/SnowflakeDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/SnowflakeDialect.scala
@@ -26,6 +26,14 @@ private case class SnowflakeDialect() extends JdbcDialect with NoLegacyJDBCError
   override def canHandle(url: String): Boolean =
     url.toLowerCase(Locale.ROOT).startsWith("jdbc:snowflake")
 
+  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
+    e match {
+      case sqlException: java.sql.SQLException =>
+        sqlException.getSQLState == "002003"
+      case _ => false
+    }
+  }
+
   override def getJDBCType(dt: DataType): Option[JdbcType] = dt match {
     case BooleanType =>
       // By default, BOOLEAN is mapped to BIT(1).

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/SnowflakeDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/SnowflakeDialect.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.jdbc
 
+import java.sql.SQLException
 import java.util.Locale
 
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
@@ -26,12 +27,8 @@ private case class SnowflakeDialect() extends JdbcDialect with NoLegacyJDBCError
   override def canHandle(url: String): Boolean =
     url.toLowerCase(Locale.ROOT).startsWith("jdbc:snowflake")
 
-  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
-    e match {
-      case sqlException: java.sql.SQLException =>
-        sqlException.getSQLState == "002003"
-      case _ => false
-    }
+  override def isObjectNotFoundException(e: SQLException): Boolean = {
+    e.getSQLState == "002003"
   }
 
   override def getJDBCType(dt: DataType): Option[JdbcType] = dt match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/TeradataDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/TeradataDialect.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.Types
+import java.sql.{SQLException, Types}
 import java.util.Locale
 
 import org.apache.spark.sql.connector.catalog.Identifier
@@ -39,12 +39,8 @@ private case class TeradataDialect() extends JdbcDialect with NoLegacyJDBCError 
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)
 
-  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
-    e match {
-      case sqlException: java.sql.SQLException =>
-        sqlException.getErrorCode == 3807
-      case _ => false
-    }
+  override def isObjectNotFoundException(e: SQLException): Boolean = {
+    e.getErrorCode == 3807
   }
 
   override def getJDBCType(dt: DataType): Option[JdbcType] = dt match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/TeradataDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/TeradataDialect.scala
@@ -39,6 +39,14 @@ private case class TeradataDialect() extends JdbcDialect with NoLegacyJDBCError 
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)
 
+  override def isTableNotFoundException(e: java.sql.SQLException): Boolean = {
+    e match {
+      case sqlException: java.sql.SQLException =>
+        sqlException.getErrorCode == 3807
+      case _ => false
+    }
+  }
+
   override def getJDBCType(dt: DataType): Option[JdbcType] = dt match {
     case StringType => Some(JdbcType("VARCHAR(255)", java.sql.Types.VARCHAR))
     case BooleanType => Option(JdbcType("CHAR(1)", java.sql.Types.CHAR))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

In this PR, I propose that we rethrow exception when we are doing table existence check in jdbc dialect, if exception is not related to table/schema not being found. I propose this because currently all exceptions get swallowed and method returns false. From the perspective of the system its as if table doesn't exist, which is a wrong message (e.g, we can get table does not exist even if it was network failure).

This issue is mostly exposed when TableCatalog API is used,

```
  override def loadTable(ident: Identifier): Table = {
    if (!tableExists(ident)) {
      throw QueryCompilationErrors.noSuchTableError(ident)
    }

```

Error code links:
 - https://www.ibm.com/docs/en/db2-for-zos/12.0.0?topic=codes-error-sql
 - https://db.apache.org/derby/docs/10.4/ref/rrefexcept71493.html
 - https://docs.databricks.com/aws/en/error-messages/sqlstates
 - https://www.h2database.com/javadoc/org/h2/api/ErrorCode.html
 - https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors-0-to-999?view=sql-server-ver16
 - https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
 - https://www.postgresql.org/docs/current/errcodes-appendix.html

How its implemented today, tableExist cannot throw anything, so every exception gets converted to noSuchTableError which is wrong.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Customers will get proper error messages.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generetad by: COPILOT