### PR TITLE
[SPARK-52046] [SQL] Prettify OuterReference on AggregateExpression names when using toPrettySQL

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5818,6 +5818,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val PRETTY_ALIAS_NAME_FOR_CORRELATED_AGGREGATE_FUNCTION =
+    buildConf("spark.sql.prettyAliasNameForCorrelatedAggFunc.enabled")
+      .internal()
+      .doc("When true, use prettified name for correlated aggregate functions.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(true)
+
   /**
    * Holds information about keys that have been deprecated.
    *


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR I propose that we remove backticks, qualifiers from `OuterReference` over `AggregateExpression` when creating name. In other words, name for `column` which is an outer reference would be `outer(min(column))` instead of `outer('min(col)')`.
We also introduce a flag to guard the behavior as it changes the schema of some specific `LATERAL JOIN` queries.

### Why are the changes needed?
To ease development of single-pass analyzer and improve names in fixed-point implementation.

### Does this PR introduce _any_ user-facing change?
Schema changes in a way that `OuterReference` over `AggregateExpression` name doesn't contain backticks and qualifiers.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.