### PR TITLE
[SPARK-52047][PYTHON] Raise PySparkValueError for unsupported plot kinds

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -1150,6 +1150,11 @@
       "`<backend>` is not supported, it should be one of the values from <supported_backends>"
     ]
   },
+  "UNSUPPORTED_PLOT_KIND": {
+    "message": [
+      "`<plot_type>` is not supported, it should be one of the values from <supported_plot_types>"
+    ]
+  },
   "UNSUPPORTED_PLOT_BACKEND_PARAM": {
     "message": [
       "`<backend>` does not support `<param>` set to <value>, it should be one of the values from <supported_values>"

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -1150,14 +1150,14 @@
       "`<backend>` is not supported, it should be one of the values from <supported_backends>"
     ]
   },
-  "UNSUPPORTED_PLOT_KIND": {
-    "message": [
-      "`<plot_type>` is not supported, it should be one of the values from <supported_plot_types>"
-    ]
-  },
   "UNSUPPORTED_PLOT_BACKEND_PARAM": {
     "message": [
       "`<backend>` does not support `<param>` set to <value>, it should be one of the values from <supported_values>"
+    ]
+  },
+  "UNSUPPORTED_PLOT_KIND": {
+    "message": [
+      "`<plot_type>` is not supported, it should be one of the values from <supported_plot_types>"
     ]
   },
   "UNSUPPORTED_SIGNATURE": {

--- a/python/pyspark/sql/plot/plotly.py
+++ b/python/pyspark/sql/plot/plotly.py
@@ -43,6 +43,19 @@ def plot_pyspark(data: "DataFrame", kind: str, **kwargs: Any) -> "Figure":
         return plot_kde(data, **kwargs)
     if kind == "hist":
         return plot_histogram(data, **kwargs)
+    if kind not in PySparkPlotAccessor.plot_data_map:
+        raise PySparkValueError(
+            errorClass="UNSUPPORTED_PLOT_KIND",
+            messageParameters={
+                "plot_type": kind,
+                "supported_plot_types": ", ".join(
+                    sorted(
+                        list(PySparkPlotAccessor.plot_data_map.keys())
+                        + ["pie", "box", "kde", "density", "hist"]
+                    )
+                ),
+            },
+        )
 
     return plotly.plot(PySparkPlotAccessor.plot_data_map[kind](data), kind, **kwargs)
 

--- a/python/pyspark/sql/tests/plot/test_frame_plot.py
+++ b/python/pyspark/sql/tests/plot/test_frame_plot.py
@@ -51,8 +51,10 @@ class DataFramePlotTestsMixin:
     def test_unsupported_plot_kind(self):
         from pyspark.sql.plot.core import PySparkPlotAccessor
 
+        data = [Row(a=i, b=i + 1, c=i + 2, d=i + 3) for i in range(2000)]
+        sdf = self.spark.createDataFrame(data)
         with self.assertRaises(PySparkValueError) as pe:
-            self.sdf.plot(kind="bubble")
+            sdf.plot(kind="bubble")
 
         self.check_error(
             exception=pe.exception,

--- a/python/pyspark/sql/tests/plot/test_frame_plot.py
+++ b/python/pyspark/sql/tests/plot/test_frame_plot.py
@@ -48,9 +48,28 @@ class DataFramePlotTestsMixin:
             messageParameters={"backend": "matplotlib", "supported_backends": "plotly"},
         )
 
+    def test_unsupported_plot_kind(self):
+        from pyspark.sql.plot.core import PySparkPlotAccessor
+
+        with self.assertRaises(PySparkValueError) as pe:
+            self.sdf.plot(kind="bubble")
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="UNSUPPORTED_PLOT_KIND",
+            messageParameters={
+                "plot_type": "bubble",
+                "supported_plot_types": ", ".join(
+                    sorted(
+                        list(PySparkPlotAccessor.plot_data_map.keys())
+                        + ["pie", "box", "kde", "density", "hist"]
+                    )
+                ),
+            },
+        )
+
     def test_topn_max_rows(self):
         with self.sql_conf({"spark.sql.pyspark.plotting.max_rows": "1000"}):
-            self.spark.conf.set("spark.sql.pyspark.plotting.max_rows", "1000")
             sdf = self.spark.range(2500)
             pdf = PySparkTopNPlotBase().get_top_n(sdf)
             self.assertEqual(len(pdf), 1000)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Raise PySparkValueError for unsupported plot kinds


### Why are the changes needed?
Previously, unsupported plot kinds raised a raw KeyError, which was unclear. This change adds explicit validation and raises a descriptive PySparkValueError, improving user experience and debugging clarity.

### Does this PR introduce _any_ user-facing change?
Yes, when passing an invalid kind to DataFrame.plot, users now receive a clear PySparkValueError instead of a generic KeyError.

### How was this patch tested?
Unit tests.

### Was this patch authored or co-authored using generative AI tooling?
No.