### PR TITLE
[SPARK-51903][SQL] Validate data on adding a CHECK constraint

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4120,6 +4120,12 @@
     ],
     "sqlState" : "07501"
   },
+  "NEW_CHECK_CONSTRAINT_VIOLATION" : {
+    "message" : [
+      "The new check constraint (<expression>) is violated by the existing data in the table <tableName>."
+    ],
+    "sqlState" : "23512"
+  },
   "NONEXISTENT_FIELD_NAME_IN_LIST" : {
     "message" : [
       "Field(s) <nonExistFields> do(es) not exist. Available fields: <fieldNames>"

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4122,7 +4122,7 @@
   },
   "NEW_CHECK_CONSTRAINT_VIOLATION" : {
     "message" : [
-      "The new check constraint (<expression>) is violated by the existing data in the table <tableName>."
+      "The new check constraint (<expression>) cannot be added because it would be violated by existing data in table <tableName>. Please ensure all existing rows satisfy the constraint before adding it."
     ],
     "sqlState" : "23512"
   },

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -736,6 +736,12 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
           case write: V2WriteCommand if write.resolved =>
             write.query.schema.foreach(f => TypeUtils.failWithIntervalType(f.dataType))
 
+          case a: AddCheckConstraint if !a.checkConstraint.deterministic =>
+            a.checkConstraint.child.failAnalysis(
+              errorClass = "NON_DETERMINISTIC_CHECK_CONSTRAINT",
+              messageParameters = Map("checkCondition" -> a.checkConstraint.condition)
+            )
+
           case alter: AlterTableCommand =>
             checkAlterTableCommand(alter)
 
@@ -1036,12 +1042,6 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
 
       case RenameColumn(table: ResolvedTable, col: ResolvedFieldName, newName) =>
         checkColumnNotExists("rename", col.path :+ newName, table.schema)
-
-      case a: AddCheckConstraint if !a.tableConstraint.deterministic =>
-        a.tableConstraint.child.failAnalysis(
-          errorClass = "NON_DETERMINISTIC_CHECK_CONSTRAINT",
-          messageParameters = Map("checkCondition" -> a.tableConstraint.condition)
-        )
 
       case AlterColumns(table: ResolvedTable, specs) =>
         val groupedColumns = specs.groupBy(_.column.name)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -1037,10 +1037,10 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
       case RenameColumn(table: ResolvedTable, col: ResolvedFieldName, newName) =>
         checkColumnNotExists("rename", col.path :+ newName, table.schema)
 
-      case AddConstraint(_: ResolvedTable, check: CheckConstraint) if !check.deterministic =>
-        check.child.failAnalysis(
+      case a: AddCheckConstraint if !a.tableConstraint.deterministic =>
+        a.tableConstraint.child.failAnalysis(
           errorClass = "NON_DETERMINISTIC_CHECK_CONSTRAINT",
-          messageParameters = Map("checkCondition" -> check.condition)
+          messageParameters = Map("checkCondition" -> a.tableConstraint.condition)
         )
 
       case AlterColumns(table: ResolvedTable, specs) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/constraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/constraints.scala
@@ -129,15 +129,13 @@ case class CheckConstraint(
     val predicate = new V2ExpressionBuilder(child, true).buildPredicate().orNull
     val enforced = userProvidedCharacteristic.enforced.getOrElse(true)
     val rely = userProvidedCharacteristic.rely.getOrElse(false)
-    // TODO(SPARK-51903): Change the status to VALIDATED when we support validation on ALTER TABLE
-    val validateStatus = Constraint.ValidationStatus.UNVALIDATED
     Constraint
       .check(name)
       .predicateSql(condition)
       .predicate(predicate)
       .rely(rely)
       .enforced(enforced)
-      .validationStatus(validateStatus)
+      .validationStatus(Constraint.ValidationStatus.VALID)
       .build()
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -5493,7 +5493,7 @@ class AstBuilder extends DataTypeAstBuilder
         val namedConstraint = tableConstraint.withTableName(identifiers.last)
         namedConstraint match {
           case c: CheckConstraint =>
-            val relation = createUnresolvedRelation(ctx.identifierReference())
+            val relation = createUnresolvedRelation(ctx.identifierReference)
             val child = Filter(Not(c.child), relation)
             AddCheckConstraint(child, c)
           case _ =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
@@ -317,7 +317,7 @@ case class AddCheckConstraint(
     child: LogicalPlan,
     checkConstraint: CheckConstraint) extends UnaryCommand {
 
-  def changes: Seq[TableChange] = {
+  def change: TableChange = {
     val constraint = checkConstraint.toV2Constraint
     val validatedTableVersion = child.find(_.isInstanceOf[DataSourceV2ScanRelation]) match {
       case Some(d: DataSourceV2ScanRelation) if constraint.enforced() =>
@@ -325,7 +325,7 @@ case class AddCheckConstraint(
       case _ =>
         null
     }
-    Seq(TableChange.addConstraint(constraint, validatedTableVersion))
+    TableChange.addConstraint(constraint, validatedTableVersion)
   }
 
   override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.catalyst.expressions.{CheckConstraint, Expression, T
 import org.apache.spark.sql.catalyst.util.{ResolveDefaultColumns, TypeUtils}
 import org.apache.spark.sql.connector.catalog.{TableCatalog, TableChange}
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.util.ArrayImplicits._
 
@@ -316,17 +315,6 @@ case class AddConstraint(
 case class AddCheckConstraint(
     child: LogicalPlan,
     checkConstraint: CheckConstraint) extends UnaryCommand {
-
-  def change: TableChange = {
-    val constraint = checkConstraint.toV2Constraint
-    val validatedTableVersion = child.find(_.isInstanceOf[DataSourceV2ScanRelation]) match {
-      case Some(d: DataSourceV2ScanRelation) if constraint.enforced() =>
-        d.relation.table.currentVersion()
-      case _ =>
-        null
-    }
-    TableChange.addConstraint(constraint, validatedTableVersion)
-  }
 
   override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan =
     copy(child = newChild)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.plans.logical
 
-import org.apache.spark.sql.catalyst.analysis.{FieldName, FieldPosition, ResolvedFieldName, ResolvedTable, UnresolvedException}
+import org.apache.spark.sql.catalyst.analysis.{FieldName, FieldPosition, ResolvedFieldName, UnresolvedException}
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.catalog.ClusterBySpec
 import org.apache.spark.sql.catalyst.expressions.{CheckConstraint, Expression, TableConstraint, Unevaluable}
@@ -300,13 +300,8 @@ case class AddConstraint(
 
   override def changes: Seq[TableChange] = {
     val constraint = tableConstraint.toV2Constraint
-    val validatedTableVersion = table match {
-      case t: ResolvedTable if constraint.enforced() =>
-        t.table.currentVersion()
-      case _ =>
-        null
-    }
-    Seq(TableChange.addConstraint(constraint, validatedTableVersion))
+    // The table version is null because the constraint is not enforced.
+    Seq(TableChange.addConstraint(constraint, null))
   }
 
   override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -3026,4 +3026,14 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       values: java.util.List[Any]): SparkRuntimeException = {
     checkViolation(constraintName, sqlStr, columns.asScala.zip(values.asScala).toMap)
   }
+
+  def newCheckViolation(sqlStr: String, tableName: String): SparkRuntimeException = {
+    new SparkRuntimeException(
+      errorClass = "NEW_CHECK_CONSTRAINT_VIOLATION",
+      messageParameters = Map(
+        "expression" -> sqlStr,
+        "tableName" -> tableName
+      )
+    )
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AlterTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AlterTableExec.scala
@@ -21,6 +21,7 @@ import org.apache.spark.SparkThrowable
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog, TableChange}
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.{IdentifierHelper, MultipartIdentifierHelper}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 
@@ -52,18 +53,19 @@ case class AlterTableExec(
 case class AddCheckConstraintExec(
     catalog: TableCatalog,
     ident: Identifier,
-    changes: Seq[TableChange],
+    change: TableChange,
     condition: String,
     child: SparkPlan) extends V2CommandExec with UnaryExecNode {
 
   override def output: Seq[Attribute] = Seq.empty
 
   override protected def run(): Seq[InternalRow] = {
+    if (child.executeTake(1).nonEmpty) {
+      throw QueryExecutionErrors.newCheckViolation(
+        condition, ident.toQualifiedNameParts(catalog).quoted)
+    }
     try {
-     if (child.executeTake(1).nonEmpty) {
-       throw QueryExecutionErrors.newCheckViolation(condition, ident.name())
-     }
-     catalog.alterTable(ident, changes: _*)
+     catalog.alterTable(ident, change)
     } catch {
       case e: IllegalArgumentException if !e.isInstanceOf[SparkThrowable] =>
         throw QueryExecutionErrors.unsupportedTableChangeError(e)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -534,6 +534,20 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       }
       UncacheTableExec(r.table, cascade = !isTempView(r.table)) :: Nil
 
+    case a: AddCheckConstraint if a.child.resolved =>
+      a.child match {
+        case Filter(_, d: DataSourceV2ScanRelation) =>
+          assert(d.relation.catalog.isDefined, "Catalog should be defined")
+          assert(d.relation.identifier.isDefined, "Identifier should be defined")
+          val catalog = d.relation.catalog.get.asTableCatalog
+          val identifier = d.relation.identifier.get
+          ResolveTableConstraints.validateCatalogForTableChange(a.changes, catalog, identifier)
+          AddCheckConstraintExec(
+            catalog, identifier, a.changes, a.tableConstraint.condition, planLater(a.child)) :: Nil
+        case other =>
+          throw SparkException.internalError("Unexpected child plan of AlterTableCommand:" + other)
+      }
+
     case a: AlterTableCommand if a.table.resolved =>
       val table = a.table.asInstanceOf[ResolvedTable]
       ResolveTableConstraints.validateCatalogForTableChange(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -539,9 +539,9 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       assert(d.relation.identifier.isDefined, "Identifier should be defined after analysis")
       val catalog = d.relation.catalog.get.asTableCatalog
       val identifier = d.relation.identifier.get
-      ResolveTableConstraints.validateCatalogForTableChange(a.changes, catalog, identifier)
+      ResolveTableConstraints.validateCatalogForTableChange(Seq(a.change), catalog, identifier)
       AddCheckConstraintExec(
-        catalog, identifier, a.changes, a.checkConstraint.condition, planLater(a.child)) :: Nil
+        catalog, identifier, a.change, a.checkConstraint.condition, planLater(a.child)) :: Nil
 
     case a: AlterTableCommand if a.table.resolved =>
       val table = a.table.asInstanceOf[ResolvedTable]

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.{toPrettySQL, GeneratedColumn, IdentityColumn, ResolveDefaultColumns, ResolveTableConstraints, V2ExpressionBuilder}
 import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.connector.catalog.{Identifier, StagingTableCatalog, SupportsDeleteV2, SupportsNamespaces, SupportsPartitionManagement, SupportsWrite, Table, TableCapability, TableCatalog, TruncatableTable}
+import org.apache.spark.sql.connector.catalog.TableChange
 import org.apache.spark.sql.connector.catalog.index.SupportsIndex
 import org.apache.spark.sql.connector.expressions.{FieldReference, LiteralValue}
 import org.apache.spark.sql.connector.expressions.filter.{And => V2And, Not => V2Not, Or => V2Or, Predicate}
@@ -534,14 +535,17 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       }
       UncacheTableExec(r.table, cascade = !isTempView(r.table)) :: Nil
 
-    case a @ AddCheckConstraint(PhysicalOperation(_, _, d: DataSourceV2ScanRelation), _) =>
+    case a @ AddCheckConstraint(PhysicalOperation(_, _, d: DataSourceV2ScanRelation), check) =>
       assert(d.relation.catalog.isDefined, "Catalog should be defined after analysis")
       assert(d.relation.identifier.isDefined, "Identifier should be defined after analysis")
       val catalog = d.relation.catalog.get.asTableCatalog
-      val identifier = d.relation.identifier.get
-      ResolveTableConstraints.validateCatalogForTableChange(Seq(a.change), catalog, identifier)
-      AddCheckConstraintExec(
-        catalog, identifier, a.change, a.checkConstraint.condition, planLater(a.child)) :: Nil
+      val ident = d.relation.identifier.get
+      val condition = a.checkConstraint.condition
+      val change = TableChange.addConstraint(
+        check.toV2Constraint,
+        d.relation.table.currentVersion)
+      ResolveTableConstraints.validateCatalogForTableChange(Seq(change), catalog, ident)
+      AddCheckConstraintExec(catalog, ident, change, condition, planLater(a.child)) :: Nil
 
     case a: AlterTableCommand if a.table.resolved =>
       val table = a.table.asInstanceOf[ResolvedTable]

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -541,7 +541,7 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       val identifier = d.relation.identifier.get
       ResolveTableConstraints.validateCatalogForTableChange(a.changes, catalog, identifier)
       AddCheckConstraintExec(
-        catalog, identifier, a.changes, a.tableConstraint.condition, planLater(a.child)) :: Nil
+        catalog, identifier, a.changes, a.checkConstraint.condition, planLater(a.child)) :: Nil
 
     case a: AlterTableCommand if a.table.resolved =>
       val table = a.table.asInstanceOf[ResolvedTable]

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CheckConstraintParseSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CheckConstraintParseSuite.scala
@@ -17,11 +17,11 @@
 
 package org.apache.spark.sql.execution.command
 
-import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedTable}
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser.parsePlan
 import org.apache.spark.sql.catalyst.parser.ParseException
-import org.apache.spark.sql.catalyst.plans.logical.{AddConstraint, ColumnDefinition, CreateTable, ReplaceTable, UnresolvedTableSpec}
+import org.apache.spark.sql.catalyst.plans.logical.{AddCheckConstraint, ColumnDefinition, CreateTable, Filter, ReplaceTable, UnresolvedTableSpec}
 import org.apache.spark.sql.types.StringType
 
 class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
@@ -187,11 +187,13 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
         |ALTER TABLE a.b.t ADD CONSTRAINT c1 CHECK (a > 0)
         |""".stripMargin
     val parsed = parsePlan(sql)
-    val expected = AddConstraint(
-      UnresolvedTable(
-        Seq("a", "b", "t"),
-        "ALTER TABLE ... ADD CONSTRAINT"),
-      constraint1)
+    val expected = AddCheckConstraint(
+      Filter(
+        Not(GreaterThan(UnresolvedAttribute("a"), Literal(0))),
+        UnresolvedRelation(Seq("a", "b", "t"))
+      ),
+      constraint1
+    )
     comparePlans(parsed, expected)
   }
 
@@ -224,17 +226,20 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
            |ALTER TABLE a.b.t ADD CONSTRAINT c1 CHECK (d > 0) $enforcedStr $relyStr
            |""".stripMargin
       val parsed = parsePlan(sql)
-      val expected = AddConstraint(
-        UnresolvedTable(
-          Seq("a", "b", "t"),
-          "ALTER TABLE ... ADD CONSTRAINT"),
-        CheckConstraint(
-          child = GreaterThan(UnresolvedAttribute("d"), Literal(0)),
-          condition = "d > 0",
-          userProvidedName = "c1",
-          tableName = "t",
-          userProvidedCharacteristic = characteristic
-        ))
+      val expectedConstraint = CheckConstraint(
+        child = GreaterThan(UnresolvedAttribute("d"), Literal(0)),
+        condition = "d > 0",
+        userProvidedName = "c1",
+        tableName = "t",
+        userProvidedCharacteristic = characteristic
+      )
+      val expected = AddCheckConstraint(
+        Filter(
+          Not(GreaterThan(UnresolvedAttribute("d"), Literal(0))),
+          UnresolvedRelation(Seq("a", "b", "t"))
+        ),
+        expectedConstraint
+      )
       comparePlans(parsed, expected)
     }
   }
@@ -305,9 +310,10 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
         |""".stripMargin
     val plan = parsePlan(sql)
     plan match {
-      case a: AddConstraint =>
-        val table = a.table.asInstanceOf[UnresolvedTable]
-        assert(table.multipartIdentifier == Seq("a", "b", "t"))
+      case a: AddCheckConstraint =>
+        comparePlans(a.table, Filter(
+          Not(GreaterThan(UnresolvedAttribute("a"), Literal(0))),
+          UnresolvedRelation(Seq("a", "b", "t"))))
         assert(a.tableConstraint == unnamedConstraint)
         assert(a.tableConstraint.name.matches("t_chk_[0-9a-f]{7}"))
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CheckConstraintParseSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CheckConstraintParseSuite.scala
@@ -311,11 +311,11 @@ class CheckConstraintParseSuite extends ConstraintParseSuiteBase {
     val plan = parsePlan(sql)
     plan match {
       case a: AddCheckConstraint =>
-        comparePlans(a.table, Filter(
+        comparePlans(a.child, Filter(
           Not(GreaterThan(UnresolvedAttribute("a"), Literal(0))),
           UnresolvedRelation(Seq("a", "b", "t"))))
-        assert(a.tableConstraint == unnamedConstraint)
-        assert(a.tableConstraint.name.matches("t_chk_[0-9a-f]{7}"))
+        assert(a.checkConstraint == unnamedConstraint)
+        assert(a.checkConstraint.name.matches("t_chk_[0-9a-f]{7}"))
 
       case other =>
         fail(s"Expected AddConstraint, but got: $other")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CheckConstraintSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CheckConstraintSuite.scala
@@ -204,11 +204,11 @@ class CheckConstraintSuite extends QueryTest with CommandSuiteBase with DDLComma
       withNamespaceAndTable("ns", "tbl", nonPartitionCatalog) { t =>
         sql(s"CREATE TABLE $t (id bigint, data string) $defaultUsing")
         assert(loadTable(nonPartitionCatalog, "ns", "tbl").constraints.isEmpty)
-
+        sql(s"INSERT INTO $t VALUES (1, 'a'), (null, 'b')")
         sql(s"ALTER TABLE $t ADD CONSTRAINT c1 CHECK (id > 0) $characteristic")
         val table = loadTable(nonPartitionCatalog, "ns", "tbl")
-        assert(table.currentVersion() == "1")
-        assert(table.validatedVersion() == "0")
+        assert(table.currentVersion() == "2")
+        assert(table.validatedVersion() == "1")
         val constraint = getCheckConstraint(table)
         assert(constraint.name() == "c1")
         assert(constraint.toDDL == s"CONSTRAINT c1 CHECK (id > 0) $expectedDDL")
@@ -216,7 +216,7 @@ class CheckConstraintSuite extends QueryTest with CommandSuiteBase with DDLComma
     }
   }
 
-  test("Alter table add check constraint -- violation") {
+  test("Alter table add new check constraint with violation") {
     getConstraintCharacteristics().foreach { case (characteristic, expectedDDL) =>
       withNamespaceAndTable("ns", "tbl", nonPartitionCatalog) { t =>
         sql(s"CREATE TABLE $t (id bigint, data string) $defaultUsing")
@@ -232,6 +232,90 @@ class CheckConstraintSuite extends QueryTest with CommandSuiteBase with DDLComma
         )
         assert(loadTable(nonPartitionCatalog, "ns", "tbl").constraints.isEmpty)
       }
+    }
+  }
+
+  test("Alter table add new check constraint with nested column") {
+    withNamespaceAndTable("ns", "tbl", nonPartitionCatalog) { t =>
+      sql(s"CREATE TABLE $t (id INT, s STRUCT<num INT, str STRING>) $defaultUsing")
+      sql(s"INSERT INTO $t VALUES (1, struct(-1, 'test')), (2, struct(5, 'valid'))")
+
+      // Add an invalid check constraint
+      val error = intercept[SparkRuntimeException] {
+        sql(s"ALTER TABLE $t ADD CONSTRAINT positive_num CHECK (s.num > 0)")
+      }
+      checkError(
+        exception = error,
+        condition = "NEW_CHECK_CONSTRAINT_VIOLATION",
+        parameters = Map("expression" -> "s.num > 0", "tableName" -> "tbl")
+      )
+      assert(loadTable(nonPartitionCatalog, "ns", "tbl").constraints.isEmpty)
+
+      // Add a valid check constraint
+      sql(s"ALTER TABLE $t ADD CONSTRAINT valid_positive_num CHECK (s.num >= -1)")
+      val table = loadTable(nonPartitionCatalog, "ns", "tbl")
+      assert(table.currentVersion() == "2")
+      assert(table.validatedVersion() == "1")
+      val constraint = getCheckConstraint(table)
+      assert(constraint.name() == "valid_positive_num")
+      assert(constraint.toDDL ==
+        "CONSTRAINT valid_positive_num CHECK (s.num >= -1) ENFORCED UNVALIDATED NORELY")
+    }
+  }
+
+  test("Alter table add new check constraint with violation - map type column") {
+    withNamespaceAndTable("ns", "tbl", nonPartitionCatalog) { t =>
+      sql(s"CREATE TABLE $t (id INT, m MAP<STRING, INT>) $defaultUsing")
+      sql(s"INSERT INTO $t VALUES (1, map('a', -1, 'b', 2)), (2, map('a', 5))")
+
+      // Add an invalid check constraint
+      val error = intercept[SparkRuntimeException] {
+        sql(s"ALTER TABLE $t ADD CONSTRAINT positive_map_val CHECK (m['a'] > 0)")
+      }
+      checkError(
+        exception = error,
+        condition = "NEW_CHECK_CONSTRAINT_VIOLATION",
+        parameters = Map("expression" -> "m['a'] > 0", "tableName" -> "tbl")
+      )
+      assert(loadTable(nonPartitionCatalog, "ns", "tbl").constraints.isEmpty)
+
+      // Add a valid check constraint
+      sql(s"ALTER TABLE $t ADD CONSTRAINT valid_map_val CHECK (m['a'] >= -1)")
+      val table = loadTable(nonPartitionCatalog, "ns", "tbl")
+      assert(table.currentVersion() == "2")
+      assert(table.validatedVersion() == "1")
+      val constraint = getCheckConstraint(table)
+      assert(constraint.name() == "valid_map_val")
+      assert(constraint.toDDL ==
+        "CONSTRAINT valid_map_val CHECK (m['a'] >= -1) ENFORCED UNVALIDATED NORELY")
+    }
+  }
+
+  test("Alter table add new check constraint with violation - array type column") {
+    withNamespaceAndTable("ns", "tbl", nonPartitionCatalog) { t =>
+      sql(s"CREATE TABLE $t (id INT, a ARRAY<INT>) $defaultUsing")
+      sql(s"INSERT INTO $t VALUES (1, array(1, -2, 3)), (2, array(5, 6, 7))")
+
+      // Add an invalid check constraint
+      val error = intercept[SparkRuntimeException] {
+        sql(s"ALTER TABLE $t ADD CONSTRAINT positive_array CHECK (a[1] > 0)")
+      }
+      checkError(
+        exception = error,
+        condition = "NEW_CHECK_CONSTRAINT_VIOLATION",
+        parameters = Map("expression" -> "a[1] > 0", "tableName" -> "tbl")
+      )
+      assert(loadTable(nonPartitionCatalog, "ns", "tbl").constraints.isEmpty)
+
+      // Add a valid check constraint
+      sql(s"ALTER TABLE $t ADD CONSTRAINT valid_array CHECK (a[1] >= -2)")
+      val table = loadTable(nonPartitionCatalog, "ns", "tbl")
+      assert(table.currentVersion() == "2")
+      assert(table.validatedVersion() == "1")
+      val constraint = getCheckConstraint(table)
+      assert(constraint.name() == "valid_map_val")
+      assert(constraint.toDDL ==
+        "CONSTRAINT valid_array CHECK (a[1] >= -2) ENFORCED UNVALIDATED NORELY")
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CheckConstraintSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CheckConstraintSuite.scala
@@ -227,7 +227,7 @@ class CheckConstraintSuite extends QueryTest with CommandSuiteBase with DDLComma
         checkError(
           exception = error,
           condition = "NEW_CHECK_CONSTRAINT_VIOLATION",
-          parameters = Map("expression" -> "id > 0", "tableName" -> "tbl")
+          parameters = Map("expression" -> "id > 0", "tableName" -> "non_part_test_catalog.ns.tbl")
         )
         assert(loadTable(nonPartitionCatalog, "ns", "tbl").constraints.isEmpty)
       }
@@ -246,7 +246,7 @@ class CheckConstraintSuite extends QueryTest with CommandSuiteBase with DDLComma
       checkError(
         exception = error,
         condition = "NEW_CHECK_CONSTRAINT_VIOLATION",
-        parameters = Map("expression" -> "s.num > 0", "tableName" -> "tbl")
+        parameters = Map("expression" -> "s.num > 0", "tableName" -> "non_part_test_catalog.ns.tbl")
       )
       assert(loadTable(nonPartitionCatalog, "ns", "tbl").constraints.isEmpty)
 
@@ -274,7 +274,9 @@ class CheckConstraintSuite extends QueryTest with CommandSuiteBase with DDLComma
       checkError(
         exception = error,
         condition = "NEW_CHECK_CONSTRAINT_VIOLATION",
-        parameters = Map("expression" -> "m['a'] > 0", "tableName" -> "tbl")
+        parameters = Map(
+          "expression" -> "m['a'] > 0",
+          "tableName" -> "non_part_test_catalog.ns.tbl")
       )
       assert(loadTable(nonPartitionCatalog, "ns", "tbl").constraints.isEmpty)
 
@@ -302,7 +304,7 @@ class CheckConstraintSuite extends QueryTest with CommandSuiteBase with DDLComma
       checkError(
         exception = error,
         condition = "NEW_CHECK_CONSTRAINT_VIOLATION",
-        parameters = Map("expression" -> "a[1] > 0", "tableName" -> "tbl")
+        parameters = Map("expression" -> "a[1] > 0", "tableName" -> "non_part_test_catalog.ns.tbl")
       )
       assert(loadTable(nonPartitionCatalog, "ns", "tbl").constraints.isEmpty)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CheckConstraintSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CheckConstraintSuite.scala
@@ -313,7 +313,7 @@ class CheckConstraintSuite extends QueryTest with CommandSuiteBase with DDLComma
       assert(table.currentVersion() == "2")
       assert(table.validatedVersion() == "1")
       val constraint = getCheckConstraint(table)
-      assert(constraint.name() == "valid_map_val")
+      assert(constraint.name() == "valid_array")
       assert(constraint.toDDL ==
         "CONSTRAINT valid_array CHECK (a[1] >= -2) ENFORCED UNVALIDATED NORELY")
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CheckConstraintSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CheckConstraintSuite.scala
@@ -134,21 +134,20 @@ class CheckConstraintSuite extends QueryTest with CommandSuiteBase with DDLComma
       val constraint = getCheckConstraint(table)
       assert(constraint.name() == "c1")
       assert(constraint.toDDL ==
-        "CONSTRAINT c1 CHECK (from_json(j, 'a INT').a > 1) ENFORCED UNVALIDATED NORELY")
+        "CONSTRAINT c1 CHECK (from_json(j, 'a INT').a > 1) ENFORCED VALID NORELY")
       assert(constraint.predicateSql() == "from_json(j, 'a INT').a > 1")
       assert(constraint.predicate() == null)
     }
   }
 
   def getConstraintCharacteristics(): Seq[(String, String)] = {
-    val validStatus = "UNVALIDATED"
     Seq(
-      ("", s"ENFORCED $validStatus NORELY"),
-      ("NORELY", s"ENFORCED $validStatus NORELY"),
-      ("RELY", s"ENFORCED $validStatus RELY"),
-      ("ENFORCED", s"ENFORCED $validStatus NORELY"),
-      ("ENFORCED NORELY", s"ENFORCED $validStatus NORELY"),
-      ("ENFORCED RELY", s"ENFORCED $validStatus RELY")
+      ("", s"ENFORCED VALID NORELY"),
+      ("NORELY", s"ENFORCED VALID NORELY"),
+      ("RELY", s"ENFORCED VALID RELY"),
+      ("ENFORCED", s"ENFORCED VALID NORELY"),
+      ("ENFORCED NORELY", s"ENFORCED VALID NORELY"),
+      ("ENFORCED RELY", s"ENFORCED VALID RELY")
     )
   }
 
@@ -177,7 +176,7 @@ class CheckConstraintSuite extends QueryTest with CommandSuiteBase with DDLComma
             val constraint = getCheckConstraint(table)
             assert(constraint.name() == "c1")
             assert(constraint.toDDL ==
-              s"CONSTRAINT c1 CHECK (LENGTH(name) > 0) ENFORCED UNVALIDATED NORELY")
+              s"CONSTRAINT c1 CHECK (LENGTH(name) > 0) ENFORCED VALID NORELY")
             assert(constraint.predicateSql() == "LENGTH(name) > 0")
           }
         }
@@ -259,7 +258,7 @@ class CheckConstraintSuite extends QueryTest with CommandSuiteBase with DDLComma
       val constraint = getCheckConstraint(table)
       assert(constraint.name() == "valid_positive_num")
       assert(constraint.toDDL ==
-        "CONSTRAINT valid_positive_num CHECK (s.num >= -1) ENFORCED UNVALIDATED NORELY")
+        "CONSTRAINT valid_positive_num CHECK (s.num >= -1) ENFORCED VALID NORELY")
     }
   }
 
@@ -287,7 +286,7 @@ class CheckConstraintSuite extends QueryTest with CommandSuiteBase with DDLComma
       val constraint = getCheckConstraint(table)
       assert(constraint.name() == "valid_map_val")
       assert(constraint.toDDL ==
-        "CONSTRAINT valid_map_val CHECK (m['a'] >= -1) ENFORCED UNVALIDATED NORELY")
+        "CONSTRAINT valid_map_val CHECK (m['a'] >= -1) ENFORCED VALID NORELY")
     }
   }
 
@@ -315,7 +314,7 @@ class CheckConstraintSuite extends QueryTest with CommandSuiteBase with DDLComma
       val constraint = getCheckConstraint(table)
       assert(constraint.name() == "valid_array")
       assert(constraint.toDDL ==
-        "CONSTRAINT valid_array CHECK (a[1] >= -2) ENFORCED UNVALIDATED NORELY")
+        "CONSTRAINT valid_array CHECK (a[1] >= -2) ENFORCED VALID NORELY")
     }
   }
 
@@ -335,7 +334,7 @@ class CheckConstraintSuite extends QueryTest with CommandSuiteBase with DDLComma
           condition = "CONSTRAINT_ALREADY_EXISTS",
           sqlState = "42710",
           parameters = Map("constraintName" -> "abc",
-            "oldConstraint" -> "CONSTRAINT abc CHECK (id > 0) ENFORCED UNVALIDATED NORELY")
+            "oldConstraint" -> "CONSTRAINT abc CHECK (id > 0) ENFORCED VALID NORELY")
         )
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds support for enforcing CHECK constraints when executing the `ALTER TABLE ... ADD CONSTRAINT` statement on V2 tables. Specifically, before adding a new CHECK constraint, Spark will validate the constraint against existing table data to ensure data integrity and compliance with the constraint definition.



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
CHECK constraint enforcement in the `ALTER TABLE ... ADD CONSTRAINT` statement is part of the ANSI SQL standard. Supporting this feature ensures Spark's compliance with ANSI SQL and enhances data integrity by preventing invalid constraints from being added to existing tables.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

New UT
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No