### PR TITLE
[SPARK-52049] Fix the bug that XML attributes can't be parsed as Variant

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
@@ -544,6 +544,11 @@ class StaxXmlParser(
         case ShortType => castTo(value, ShortType)
         case IntegerType => signSafeToInt(value)
         case dt: DecimalType => castTo(value, dt)
+        case VariantType =>
+          val builder = new VariantBuilder(false)
+          StaxXmlParser.appendXMLCharacterToVariant(builder, value, options)
+          val v = builder.result()
+          new VariantVal(v.getValue, v.getMetadata)
         case _ => throw new SparkIllegalArgumentException(
           errorClass = "_LEGACY_ERROR_TEMP_3246",
           messageParameters = Map("dataType" -> dataType.toString))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlVariantSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlVariantSuite.scala
@@ -418,7 +418,9 @@ class XmlVariantSuite extends QueryTest with SharedSparkSession with TestXmlData
     val df = createDSLDataFrame(
       fileName = "books-complicated.xml",
       schemaDDL = Some(
-        "_id variant, author string, title string, " +
+        "_id variant, " + // Attribute as variant
+        "author string, " +
+        "title string, " +
         "genre struct<genreid int, name variant>, " + // Struct with variant
         "price variant, " + // Scalar as variant
         "publish_dates struct<publish_date array<variant>>" // Array with variant

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlVariantSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlVariantSuite.scala
@@ -418,7 +418,7 @@ class XmlVariantSuite extends QueryTest with SharedSparkSession with TestXmlData
     val df = createDSLDataFrame(
       fileName = "books-complicated.xml",
       schemaDDL = Some(
-        "_id string, author string, title string, " +
+        "_id variant, author string, title string, " +
         "genre struct<genreid int, name variant>, " + // Struct with variant
         "price variant, " + // Scalar as variant
         "publish_dates struct<publish_date array<variant>>" // Array with variant
@@ -427,11 +427,16 @@ class XmlVariantSuite extends QueryTest with SharedSparkSession with TestXmlData
     )
     checkAnswer(
       df.select(
+        variant_get(col("_id"), "$", "string"),
         variant_get(col("genre.name"), "$", "string"),
         variant_get(col("price"), "$", "double"),
         variant_get(col("publish_dates.publish_date").getItem(0), "$.month", "int")
       ),
-      Seq(Row("Computer", 44.95, 10), Row("Fantasy", 5.95, 12), Row("Fantasy", null, 11))
+      Seq(
+        Row("bk101", "Computer", 44.95, 10),
+        Row("bk102", "Fantasy", 5.95, 12),
+        Row("bk103", "Fantasy", null, 11)
+      )
     )
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
It's found that when parsing an XML record with a user-defined schema that specifies attribute fields as Variant type, the parsing will fail. This PR fixes the bug in the `StaxXmlParser`


### Why are the changes needed?
Bug fix


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
New UTs

### Was this patch authored or co-authored using generative AI tooling?
No.