### PR TITLE
[SPARK-52040][PYTHON][SQL][CONNECT][4.0] ResolveLateralColumnAliasReference should retain the plan id

### DIFF
--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -141,6 +141,15 @@ class DataFrameTestsMixin:
         self.assertTrue(df3.columns, ["id", "value", "id", "value"])
         self.assertTrue(df3.count() == 20)
 
+    def test_lateral_column_alias(self):
+        df1 = self.spark.range(10).select(
+            (col("id") + lit(1)).alias("x"), (col("x") + lit(1)).alias("y")
+        )
+        df2 = self.spark.range(10).select(col("id").alias("x"))
+        df3 = df1.join(df2, df1.x == df2.x).select(df1.y)
+        self.assertTrue(df3.columns, ["y"])
+        self.assertTrue(df3.count() == 9)
+
     def test_self_join_IV(self):
         df1 = self.spark.range(10).withColumn("value", lit(1))
         df2 = df1.withColumn("value", lit(2)).union(df1.withColumn("value", lit(3)))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveLateralColumnAliasReference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveLateralColumnAliasReference.scala
@@ -190,10 +190,12 @@ object ResolveLateralColumnAliasReference extends Rule[LogicalPlan] {
             outerProjectList.update(idx, alias.toAttribute)
             innerProjectList += alias
           }
-          p.copy(
+          val newProject = p.copy(
             projectList = outerProjectList.toSeq,
             child = Project(innerProjectList.toSeq, child)
           )
+          newProject.copyTagsFrom(p)
+          newProject
         }
 
       case aggOriginal: Aggregate
@@ -264,10 +266,12 @@ object ResolveLateralColumnAliasReference extends Rule[LogicalPlan] {
           }
           val projectExprs = aggregateExpressions.map(
             extractExpressions(_).asInstanceOf[NamedExpression])
-          Project(
+          val newProject = Project(
             projectList = projectExprs,
             child = agg.copy(aggregateExpressions = newAggExprs.asScala.toSeq)
           )
+          newProject.copyTagsFrom(agg)
+          newProject
         }
 
       case p: LogicalPlan =>


### PR DESCRIPTION
cherry-pick https://github.com/apache/spark/pull/50831 to 4.0