### PR TITLE
[SPARK-51983][PS][TESTS][FOLLOW-UP] Replace `assertEquals` with `assertEqual` for python 3.12+

### DIFF
--- a/python/pyspark/testing/pandasutils.py
+++ b/python/pyspark/testing/pandasutils.py
@@ -478,13 +478,11 @@ class PandasOnSparkTestCase(ReusedSQLTestCase, PandasOnSparkTestUtils):
 
     def setUp(self):
         super().setUp()
-        self.assertEquals(
-            is_ansi_mode_test, self.spark.conf.get("spark.sql.ansi.enabled") == "true"
-        )
+        self.assertEqual(is_ansi_mode_test, self.spark.conf.get("spark.sql.ansi.enabled") == "true")
 
     def tearDown(self):
         try:
-            self.assertEquals(
+            self.assertEqual(
                 is_ansi_mode_test, self.spark.conf.get("spark.sql.ansi.enabled") == "true"
             )
         finally:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Replace `assertEquals` with `assertEqual' for python 3.12+


### Why are the changes needed?

`assertEquals` was removed in 3.12, see https://docs.python.org/3/whatsnew/3.12.html#id3


tests in python 3.12+ was broken https://github.com/apache/spark/actions/runs/14914041146/job/41895320048


```
======================================================================
ERROR: test_align (pyspark.pandas.tests.diff_frames_ops.test_align.DiffFramesAlignTests.test_align)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/spark/spark/python/pyspark/testing/pandasutils.py", line 482, in setUp
    self.assertEquals(
    ^^^^^^^^^^^^^^^^^
AttributeError: 'DiffFramesAlignTests' object has no attribute 'assertEquals'. Did you mean: 'assertEqual'?

======================================================================
ERROR: test_assert_classic_mode (pyspark.pandas.tests.diff_frames_ops.test_align.DiffFramesAlignTests.test_assert_classic_mode)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/spark/spark/python/pyspark/testing/pandasutils.py", line 482, in setUp
    self.assertEquals(
    ^^^^^^^^^^^^^^^^^
AttributeError: 'DiffFramesAlignTests' object has no attribute 'assertEquals'. Did you mean: 'assertEqual'?

======================================================================
ERROR: test_assert_classic_mode (pyspark.testing.pandasutils.PandasOnSparkTestCase.test_assert_classic_mode)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/spark/spark/python/pyspark/testing/pandasutils.py", line 482, in setUp
    self.assertEquals(
    ^^^^^^^^^^^^^^^^^
AttributeError: 'PandasOnSparkTestCase' object has no attribute 'assertEquals'. Did you mean: 'assertEqual'?
```


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
manually test


### Was this patch authored or co-authored using generative AI tooling?
no