### PR TITLE
[MINOR][PYSPARK][SQL] fixed a typo in python/pyspark/sql/column.py

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -318,7 +318,7 @@ class Column(TableValuedFunctionArgument):
     def bitwiseOR(
         self, other: Union["Column", "LiteralType", "DecimalLiteral", "DateTimeLiteral"]
     ) -> "Column":
-        """ "
+        """
         Compute bitwise OR of this expression with another expression.
 
         .. versionchanged:: 3.4.0


### PR DESCRIPTION
**What changes were proposed in this pull request?**
Fixed a minor typo in the python/pyspark/sql/column.py, removing an unnecessary double quotation mark (").

**Why are the changes needed?**
To improve the clarity and professionalism of the documentation by correcting a typographical error.

**Does this PR introduce any user-facing change?**
No. This change only affects the documentation and does not alter any functionality.

**How was this patch tested?**
As this is a documentation-only change, no tests were required. 

**Was this patch authored or co-authored using generative AI tooling?**
No.



