### PR TITLE
[SPARK-52077][PYTHON][CONNECT][TEST] Skip ArrowUDTFParityTests in Spark Connect compatibility test

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_udtf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udtf.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
 import unittest
 
 from pyspark.testing.connectutils import should_test_connect
@@ -122,6 +123,10 @@ class LegacyArrowUDTFParityTests(LegacyUDTFArrowTestsMixin, UDTFParityTests):
             TestUDTF().collect()
 
 
+@unittest.skipIf(
+    os.environ.get("SPARK_SKIP_CONNECT_COMPAT_TESTS") == "1",
+    "Python UDTF with Arrow is still under development.",
+)
 class ArrowUDTFParityTests(UDTFArrowTestsMixin, UDTFParityTests):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip ArrowUDTFParityTests in Spark Connect compatibility test for now.

### Why are the changes needed?

After https://github.com/apache/spark/pull/50099, the compatibility test fails https://github.com/apache/spark/actions/runs/14959668798/job/42019945629

In fact, UDTF with Arrow is still under development so we can skip the tests for now

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Will monitor the build.

### Was this patch authored or co-authored using generative AI tooling?

No.