### PR TITLE
[SPARK-52087] [SQL] Add copying of tags and origin to AliasHelper.trimNonTopLevelAliases

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.analysis.MultiAlias
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Project}
+import org.apache.spark.sql.catalyst.trees.CurrentOrigin
 import org.apache.spark.sql.types.Metadata
 
 /**
@@ -95,22 +96,26 @@ trait AliasHelper {
   }
 
   protected def trimNonTopLevelAliases[T <: Expression](e: T): T = {
-    val res = e match {
-      case a: Alias =>
-        val metadata = if (a.metadata == Metadata.empty) {
-          None
-        } else {
-          Some(a.metadata)
-        }
-        a.copy(child = trimAliases(a.child))(
-          exprId = a.exprId,
-          qualifier = a.qualifier,
-          explicitMetadata = metadata,
-          nonInheritableMetadataKeys = a.nonInheritableMetadataKeys)
-      case a: MultiAlias =>
-        a.copy(child = trimAliases(a.child))
-      case other => trimAliases(other)
+    val res = CurrentOrigin.withOrigin(e.origin) {
+      e match {
+        case a: Alias =>
+          val metadata = if (a.metadata == Metadata.empty) {
+            None
+          } else {
+            Some(a.metadata)
+          }
+          a.copy(child = trimAliases(a.child))(
+            exprId = a.exprId,
+            qualifier = a.qualifier,
+            explicitMetadata = metadata,
+            nonInheritableMetadataKeys = a.nonInheritableMetadataKeys)
+        case a: MultiAlias =>
+          a.copy(child = trimAliases(a.child))
+        case other => trimAliases(other)
+      }
     }
+
+    res.copyTagsFrom(e)
 
     res.asInstanceOf[T]
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -799,7 +799,7 @@ class AnalysisSuite extends AnalysisTest with Matchers {
     assertAnalysisErrorCondition(parsePlan("SELECT 'length' (a)"),
       "MULTI_ALIAS_WITHOUT_GENERATOR",
       Map("expr" -> "\"length\"", "names" -> "a"),
-      Array(ExpectedContext("SELECT 'length' (a)", 0, 18))
+      Array(ExpectedContext("'length' (a)", 7, 18))
     )
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR I propose that we add copying of tags and origin to `AliasHelper.trimNonTopLevelAlias`.

### Why are the changes needed?
Without this change tags and origin are not copied properly when `AliasHelper.trimNonTopLevelAlias` is called.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.