### PR TITLE
[SPARK-52092][PYTHON][TESTS] Add UDF tests for empty DataFrames

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_udf.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf.py
@@ -391,6 +391,18 @@ class PandasUDFTestsMixin:
             PythonException, "Invalid return type", df.select(upper("s")).collect
         )
 
+    def test_pandas_udf_empty_frame(self):
+        import pandas as pd
+
+        empty_df = self.spark.createDataFrame([], "id long")
+
+        @pandas_udf("long")
+        def add1(x: pd.Series) -> pd.Series:
+            return x + 1
+
+        result = empty_df.select(add1("id"))
+        self.assertEqual(result.collect(), [])
+
 
 class PandasUDFTests(PandasUDFTestsMixin, ReusedSQLTestCase):
     pass

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -1369,6 +1369,16 @@ class BaseUDFTestsMixin(object):
             with self.subTest(chain=chain):
                 assertDataFrameEqual(actual=actual, expected=expected)
 
+    def test_udf_empty_frame(self):
+        empty_df = self.spark.createDataFrame([], "id long")
+
+        @udf("long")
+        def add1(x):
+            return x + 1
+
+        result = empty_df.select(add1("id"))
+        self.assertEqual(result.collect(), [])
+
 
 class UDFTests(BaseUDFTestsMixin, ReusedSQLTestCase):
     @classmethod


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add UDF tests for empty DataFrames, including Classic Python UDFs, Arrow Python UDFs, and Pandas UDFs.

### Why are the changes needed?
To ensure UDFs behave correctly on empty inputs, which is a common edge case.
Part of https://issues.apache.org/jira/browse/SPARK-52093
 
### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Test change only.


### Was this patch authored or co-authored using generative AI tooling?
No.
