### PR TITLE
[SPARK-52095][SQL] Alter table alter column to pass V2Expression to DSV2

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
@@ -22,12 +22,9 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.catalyst.plans.logical.DefaultValueExpression;
 import org.apache.spark.sql.connector.catalog.constraints.Constraint;
-import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.types.DataType;
-import scala.Option;
 
 /**
  * TableChange subclasses represent requested changes to a table. These are passed to
@@ -233,11 +230,11 @@ public interface TableChange {
    * If the field does not exist, the change will result in an {@link IllegalArgumentException}.
    *
    * @param fieldNames field names of the column to update
-   * @param newDefaultValue the new default value, or null if it is to be removed
+   * @param newDefaultValue the new default value SQL string (Spark SQL dialect).
    * @return a TableChange for the update
    *
-   * @deprecated This is deprecated. Please use {@link #updateColumnDefaultValue(String[], DefaultValue)}
-   * instead.
+   * @deprecated This is deprecated. Please use {@link #updateColumnDefaultValue(
+   * String[],DefaultValue)} instead.
    */
   @Deprecated(since = "4.1.0")
   static TableChange updateColumnDefaultValue(String[] fieldNames, String newDefaultValue) {
@@ -252,7 +249,8 @@ public interface TableChange {
    * If the field does not exist, the change will result in an {@link IllegalArgumentException}.
    *
    * @param fieldNames field names of the column to update
-   * @param newDefaultValue the new default value SQL string (Spark SQL dialect).
+   * @param newDefaultValue the new default value SQL (Spark SQL dialect and
+   *                        V2 expression representation if it can be converted).
    * @return a TableChange for the update
    */
   static TableChange updateColumnDefaultValue(String[] fieldNames, DefaultValue newDefaultValue) {
@@ -744,7 +742,7 @@ public interface TableChange {
     }
 
     /**
-     * Returns the column default value SQL string. The default value literal
+     * Returns the column default value SQL string (Spark SQL dialect). The default value literal
      * is not provided as updating column default values does not need to back-fill existing data.
      * Empty string means dropping the column default value.
      */
@@ -753,7 +751,9 @@ public interface TableChange {
     }
 
     /**
-     * Returns the column default value as {@link DefaultValue}.
+     * Returns the column default value as {@link DefaultValue}. The default value literal
+     * is not provided as updating column default values does not need to back-fill existing data.
+     * Empty string means dropping the column default value.
      */
     public DefaultValue newModelDefaultValue() { return newDefaultValue; }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
@@ -753,7 +753,7 @@ public interface TableChange {
     /**
      * Returns the column default value as {@link DefaultValue}. The default value literal
      * is not provided as updating column default values does not need to back-fill existing data.
-     * Empty string means dropping the column default value.
+     * Empty string and Null literal means dropping the column default value.
      */
     public DefaultValue newModelDefaultValue() { return newDefaultValue; }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
@@ -729,11 +729,11 @@ public interface TableChange {
    */
   final class UpdateColumnDefaultValue implements ColumnChange {
     private final String[] fieldNames;
-    private final DefaultValue newDefaultValue;
+    private final DefaultValue newCurrentDefault;
 
-    private UpdateColumnDefaultValue(String[] fieldNames, DefaultValue newDefaultValue) {
+    private UpdateColumnDefaultValue(String[] fieldNames, DefaultValue newCurrentDefault) {
       this.fieldNames = fieldNames;
-      this.newDefaultValue = newDefaultValue;
+      this.newCurrentDefault = newCurrentDefault;
     }
 
     @Override
@@ -747,7 +747,7 @@ public interface TableChange {
      * Empty string means dropping the column default value.
      */
     public String newDefaultValue() {
-      return newDefaultValue == null ? "" : newDefaultValue.getSql();
+      return newCurrentDefault == null ? "" : newCurrentDefault.getSql();
     }
 
     /**
@@ -755,22 +755,19 @@ public interface TableChange {
      * is not provided as updating column default values does not need to back-fill existing data.
      * Empty string and Null literal means dropping the column default value.
      */
-    public DefaultValue newModelDefaultValue() { return newDefaultValue; }
+    public DefaultValue newCurrentDefault() { return newCurrentDefault; }
 
     @Override
     public boolean equals(Object o) {
-      if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       UpdateColumnDefaultValue that = (UpdateColumnDefaultValue) o;
-      return Arrays.equals(fieldNames, that.fieldNames) &&
-        newDefaultValue.equals(that.newDefaultValue());
+      return Objects.deepEquals(fieldNames, that.fieldNames) &&
+        Objects.equals(newCurrentDefault, that.newCurrentDefault);
     }
 
     @Override
     public int hashCode() {
-      int result = Objects.hash(newDefaultValue);
-      result = 31 * result + Arrays.hashCode(fieldNames);
-      return result;
+      return Objects.hash(Arrays.hashCode(fieldNames), newCurrentDefault);
     }
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
@@ -751,9 +751,10 @@ public interface TableChange {
     }
 
     /**
-     * Returns the column default value as {@link DefaultValue}. The default value literal
+     * Returns the column default value as {@link DefaultValue} with a
+     * {@link org.apache.spark.sql.connector.expressions.Expression}.  The default value literal
      * is not provided as updating column default values does not need to back-fill existing data.
-     * Empty string and Null literal means dropping the column default value.
+     * Null means dropping the column default value.
      */
     public DefaultValue newCurrentDefault() { return newCurrentDefault; }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
@@ -233,8 +233,7 @@ public interface TableChange {
    * @param newDefaultValue the new default value SQL string (Spark SQL dialect).
    * @return a TableChange for the update
    *
-   * @deprecated This is deprecated. Please use {@link #updateColumnDefaultValue(
-   * String[],DefaultValue)} instead.
+   * @deprecated Please use {@link #updateColumnDefaultValue(String[], DefaultValue)} instead.
    */
   @Deprecated(since = "4.1.0")
   static TableChange updateColumnDefaultValue(String[] fieldNames, String newDefaultValue) {
@@ -251,6 +250,7 @@ public interface TableChange {
    * @param fieldNames field names of the column to update
    * @param newDefaultValue the new default value SQL (Spark SQL dialect and
    *                        V2 expression representation if it can be converted).
+   *                        Null indicates dropping column default value
    * @return a TableChange for the update
    */
   static TableChange updateColumnDefaultValue(String[] fieldNames, DefaultValue newDefaultValue) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
@@ -745,14 +745,16 @@ public interface TableChange {
      * Returns the column default value SQL string (Spark SQL dialect). The default value literal
      * is not provided as updating column default values does not need to back-fill existing data.
      * Empty string means dropping the column default value.
+     *
+     * @deprecated Use {@link #newCurrentDefault()} instead.
      */
+    @Deprecated(since = "4.1.0")
     public String newDefaultValue() {
       return newCurrentDefault == null ? "" : newCurrentDefault.getSql();
     }
 
     /**
-     * Returns the column default value as {@link DefaultValue} with a
-     * {@link org.apache.spark.sql.connector.expressions.Expression}.  The default value literal
+     * Returns the column default value as {@link DefaultValue}.  The default value literal
      * is not provided as updating column default values does not need to back-fill existing data.
      * Null means dropping the column default value.
      */
@@ -762,13 +764,15 @@ public interface TableChange {
     public boolean equals(Object o) {
       if (o == null || getClass() != o.getClass()) return false;
       UpdateColumnDefaultValue that = (UpdateColumnDefaultValue) o;
-      return Objects.deepEquals(fieldNames, that.fieldNames) &&
+      return Arrays.equals(fieldNames, that.fieldNames) &&
         Objects.equals(newCurrentDefault, that.newCurrentDefault);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(Arrays.hashCode(fieldNames), newCurrentDefault);
+      int result = Arrays.hashCode(fieldNames);
+      result = 31 * result + Objects.hashCode(newCurrentDefault);
+      return result;
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3927,7 +3927,8 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
 
       case a @ AlterColumns(table: ResolvedTable, specs) =>
         val resolvedSpecs = specs.map {
-          case s @ AlterColumnSpec(ResolvedFieldName(path, field), dataType, _, _, position, _) =>
+          case s @ AlterColumnSpec(
+              ResolvedFieldName(path, field), dataType, _, _, position, _, _) =>
             val newDataType = dataType.flatMap { dt =>
               // Hive style syntax provides the column type, even if it may not have changed.
               val existing = CharVarcharUtils.getRawType(field.metadata).getOrElse(field.dataType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -1063,7 +1063,7 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
           }
         }
         specs.foreach {
-          case AlterColumnSpec(col: ResolvedFieldName, dataType, nullable, _, _, _) =>
+          case AlterColumnSpec(col: ResolvedFieldName, dataType, nullable, _, _, _, _) =>
             val fieldName = col.name.quoted
             if (dataType.isDefined) {
               val field = CharVarcharUtils.getRawType(col.field.metadata)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -5243,11 +5243,11 @@ class AstBuilder extends DataTypeAstBuilder
       } else {
         None
       }
-      val setDefaultExpression: Option[String] =
+      val setDefaultExpression: Option[DefaultValueExpression] =
         if (action.defaultExpression != null) {
-          Option(action.defaultExpression()).map(visitDefaultExpression).map(_.originalSQL)
+          Option(action.defaultExpression()).map(visitDefaultExpression)
         } else if (action.dropDefault != null) {
-          Some("")
+          Some(DefaultValueExpression(Literal(""), ""))
         } else {
           None
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -5247,7 +5247,7 @@ class AstBuilder extends DataTypeAstBuilder
         if (action.defaultExpression != null) {
           Option(action.defaultExpression()).map(visitDefaultExpression)
         } else if (action.dropDefault != null) {
-          Some(DefaultValueExpression(Literal(""), ""))
+          Some(DefaultValueExpression(Literal(null), ""))
         } else {
           None
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ColumnDefinition.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ColumnDefinition.scala
@@ -25,7 +25,8 @@ import org.apache.spark.sql.catalyst.trees.TreePattern.{ANALYSIS_AWARE_EXPRESSIO
 import org.apache.spark.sql.catalyst.util.{GeneratedColumn, IdentityColumn, V2ExpressionBuilder}
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns.validateDefaultValueExpr
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumnsUtils.{CURRENT_DEFAULT_COLUMN_METADATA_KEY, EXISTS_DEFAULT_COLUMN_METADATA_KEY}
-import org.apache.spark.sql.connector.catalog.{Column => V2Column, ColumnDefaultValue, IdentityColumnSpec}
+import org.apache.spark.sql.connector.catalog.{Column => V2Column, ColumnDefaultValue, DefaultValue, IdentityColumnSpec}
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.MultipartIdentifierHelper
 import org.apache.spark.sql.connector.expressions.LiteralValue
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.connector.ColumnImpl
@@ -184,6 +185,18 @@ object ColumnDefinition {
           }
         }
 
+      case cmd: AlterColumns if cmd.specs.exists(_.newDefaultExpression.isDefined) =>
+        // Wrap analysis errors for default values in a more user-friendly message.
+        cmd.specs.foreach { c =>
+          c.newDefaultExpression.foreach { d =>
+            if (!d.resolved) {
+              throw QueryCompilationErrors.defaultValuesUnresolvedExprError(
+                "ALTER TABLE ALTER COLUMN", c.column.name.quoted, d.originalSQL, null)
+            }
+            validateDefaultValueExpr(d, "ALTER TABLE", c.column.name.quoted, d.dataType)
+          }
+        }
+
       case _ =>
     }
   }
@@ -238,6 +251,15 @@ case class DefaultValueExpression(
       val currentDefault = analyzedChild.flatMap(new V2ExpressionBuilder(_).build())
       val existsDefault = LiteralValue(value, dataType)
       new ColumnDefaultValue(originalSQL, currentDefault.orNull, existsDefault)
+    case _ =>
+      throw QueryCompilationErrors.defaultValueNotConstantError(statement, colName, originalSQL)
+  }
+
+  // Convert the default expression to DefaultValue, which is required by DS v2 APIs.
+  def toV2CurrentDefault(statement: String, colName: String): DefaultValue = child match {
+    case Literal(_, _) =>
+      val currentDefault = analyzedChild.flatMap(new V2ExpressionBuilder(_).build())
+      new DefaultValue(originalSQL, currentDefault.orNull)
     case _ =>
       throw QueryCompilationErrors.defaultValueNotConstantError(statement, colName, originalSQL)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ColumnDefinition.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ColumnDefinition.scala
@@ -193,7 +193,12 @@ object ColumnDefinition {
               throw QueryCompilationErrors.defaultValuesUnresolvedExprError(
                 "ALTER TABLE ALTER COLUMN", c.column.name.quoted, d.originalSQL, null)
             }
-            validateDefaultValueExpr(d, "ALTER TABLE", c.column.name.quoted, d.dataType)
+            validateDefaultValueExpr(d, "ALTER TABLE ALTER COLUMN",
+              c.column.name.quoted, d.dataType)
+            if (!d.deterministic) {
+              throw QueryCompilationErrors.defaultValueNonDeterministicError(
+                "ALTER TABLE ALTER COLUMN", c.column.name.quoted, d.originalSQL)
+            }
           }
         }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
@@ -218,13 +218,17 @@ case class AlterColumnSpec(
   override protected def withNewChildrenInternal(
       newChildren: IndexedSeq[Expression]): Expression = {
     val newColumn = newChildren(0).asInstanceOf[FieldName]
-    val newPosition = newChildren collectFirst {
-      case p: FieldPosition => p
+    val newPos = if (newPosition.isDefined) {
+      Some(newChildren(1).asInstanceOf[FieldPosition])
+    } else {
+      None
     }
-    val newDefault = newChildren collectFirst {
-      case d: DefaultValueExpression => d
+    val newDefault = if (newDefaultExpression.isDefined) {
+      Some(newChildren.last.asInstanceOf[DefaultValueExpression])
+    } else {
+      None
     }
-    copy(column = newColumn, newPosition = newPosition, newDefaultExpression = newDefault)
+    copy(column = newColumn, newPosition = newPos, newDefaultExpression = newDefault)
   }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
@@ -276,16 +276,14 @@ private[sql] object CatalogV2Util {
           }
 
         case update: UpdateColumnDefaultValue =>
-          replace(schema, update.fieldNames.toImmutableArraySeq, field =>
-            // The new DEFAULT value string will be non-empty for any DDL commands that set the
-            // default value, such as "ALTER TABLE t ALTER COLUMN c SET DEFAULT ..." (this is
-            // enforced by the parser). On the other hand, commands that drop the default value such
-            // as "ALTER TABLE t ALTER COLUMN c DROP DEFAULT" will set this string to empty.
-            if (update.newDefaultValue().nonEmpty) {
-              Some(field.withCurrentDefaultValue(update.newDefaultValue()))
+          replace(schema, update.fieldNames.toImmutableArraySeq, field => {
+            val newDefault = update.newCurrentDefault()
+            if (newDefault != null) {
+              Some(field.withCurrentDefaultValue(newDefault.getSql))
             } else {
               Some(field.clearCurrentDefaultValue())
-            })
+            }
+          })
 
         case delete: DeleteColumn =>
           replace(schema, delete.fieldNames.toImmutableArraySeq, _ => None, delete.ifExists)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2773,7 +2773,7 @@ class DDLParserSuite extends AnalysisTest {
           None,
           None,
           None,
-          Some(DefaultValueExpression(Literal(""), ""))))))
+          Some(DefaultValueExpression(Literal(null), ""))))))
     // Make sure that the parser returns an exception when the feature is disabled.
     withSQLConf(SQLConf.ENABLE_DEFAULT_COLUMNS.key -> "false") {
       val sql = "CREATE TABLE my_tab(a INT, b STRING NOT NULL DEFAULT \"abc\") USING parquet"

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2735,7 +2735,7 @@ class DDLParserSuite extends AnalysisTest {
           None,
           None,
           None,
-          Some("42")))))
+          Some(DefaultValueExpression(Literal(42), "42"))))))
     // It is possible to pass an empty string default value using quotes.
     comparePlans(
       parsePlan("ALTER TABLE t1 ALTER COLUMN a.b.c SET DEFAULT ''"),
@@ -2747,7 +2747,7 @@ class DDLParserSuite extends AnalysisTest {
           None,
           None,
           None,
-          Some("''")))))
+          Some(DefaultValueExpression(Literal(""), "''"))))))
     // It is not possible to pass an empty string default value without using quotes.
     // This results in a parsing error.
     val sql1 = "ALTER TABLE t1 ALTER COLUMN a.b.c SET DEFAULT "
@@ -2773,7 +2773,7 @@ class DDLParserSuite extends AnalysisTest {
           None,
           None,
           None,
-          Some("")))))
+          Some(DefaultValueExpression(Literal(""), ""))))))
     // Make sure that the parser returns an exception when the feature is disabled.
     withSQLConf(SQLConf.ENABLE_DEFAULT_COLUMNS.key -> "false") {
       val sql = "CREATE TABLE my_tab(a INT, b STRING NOT NULL DEFAULT \"abc\") USING parquet"

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2773,7 +2773,8 @@ class DDLParserSuite extends AnalysisTest {
           None,
           None,
           None,
-          Some(DefaultValueExpression(Literal(null), ""))))))
+          None,
+          dropDefault = true))))
     // Make sure that the parser returns an exception when the feature is disabled.
     withSQLConf(SQLConf.ENABLE_DEFAULT_COLUMNS.key -> "false") {
       val sql = "CREATE TABLE my_tab(a INT, b STRING NOT NULL DEFAULT \"abc\") USING parquet"

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -107,6 +107,10 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
       // Add the current default column value string (if any) to the column metadata.
       s.newDefaultExpression.map { c => builder.putString(CURRENT_DEFAULT_COLUMN_METADATA_KEY,
         c.originalSQL) }
+      if (s.dropDefault) {
+        // for legacy reasons, "" means clearing default value
+        builder.putString(CURRENT_DEFAULT_COLUMN_METADATA_KEY, "")
+      }
       val newColumn = StructField(
         colName,
         dataType,

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -105,7 +105,8 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
           }
       }
       // Add the current default column value string (if any) to the column metadata.
-      s.newDefaultExpression.map { c => builder.putString(CURRENT_DEFAULT_COLUMN_METADATA_KEY, c) }
+      s.newDefaultExpression.map { c => builder.putString(CURRENT_DEFAULT_COLUMN_METADATA_KEY,
+        c.originalSQL) }
       val newColumn = StructField(
         colName,
         dataType,

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
@@ -708,7 +708,7 @@ class DataSourceV2DataFrameSuite
       column: UpdateColumnDefaultValue,
       expectedDefault: DefaultValue): Unit = {
     assert(
-      column.newModelDefaultValue() == expectedDefault,
+      column.newCurrentDefault() == expectedDefault,
         s"Default value mismatch for column '${column.toString}': " +
         s"expected $expectedDefault but found ${column.newDefaultValue()}")
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
@@ -725,10 +725,6 @@ class DataSourceV2DataFrameSuite
       column.newCurrentDefault() == expectedDefault,
         s"Default value mismatch for column '${column.toString}': " +
         s"expected $expectedDefault but found ${column.newCurrentDefault()}")
-    assert(
-      column.newDefaultValue() == expectedDefault.getSql,
-      s"Default value mismatch for column '${column.toString}': " +
-        s"expected ${expectedDefault.getSql} but found ${column.newDefaultValue()}")
   }
 
   private def checkDropDefaultValue(
@@ -737,10 +733,5 @@ class DataSourceV2DataFrameSuite
       column.newCurrentDefault() == null,
       s"Default value mismatch for column '${column.toString}': " +
         s"expected empty but found ${column.newCurrentDefault()}")
-
-    assert(
-      column.newDefaultValue() == "",
-      s"Default value mismatch for column '${column.toString}': " +
-        s"expected empty but found ${column.newDefaultValue()}")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
@@ -23,8 +23,8 @@ import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SaveMode}
 import org.apache.spark.sql.QueryTest.withQueryExecutionsCaptured
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, CreateTableAsSelect, LogicalPlan, ReplaceTableAsSelect}
-import org.apache.spark.sql.connector.catalog.{Column, ColumnDefaultValue, Identifier, InMemoryTableCatalog}
-import org.apache.spark.sql.connector.catalog.TableChange.AddColumn
+import org.apache.spark.sql.connector.catalog.{Column, ColumnDefaultValue, DefaultValue, Identifier, InMemoryTableCatalog}
+import org.apache.spark.sql.connector.catalog.TableChange.{AddColumn, UpdateColumnDefaultValue}
 import org.apache.spark.sql.connector.expressions.{Cast => V2Cast, GeneralScalarExpression, LiteralValue, Transform}
 import org.apache.spark.sql.execution.{QueryExecution, SparkPlan}
 import org.apache.spark.sql.execution.ExplainUtils.stripAQEPlan
@@ -441,7 +441,7 @@ class DataSourceV2DataFrameSuite
     }
   }
 
-  test("alter table with complex foldable default values") {
+  test("alter table add column with complex foldable default values") {
     val tableName = "testcat.ns1.ns2.tbl"
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
       withTable(tableName) {
@@ -481,6 +481,83 @@ class DataSourceV2DataFrameSuite
               new V2Cast(LiteralValue(1, IntegerType), IntegerType, BooleanType),
               LiteralValue(true, BooleanType))))
       }
+    }
+  }
+
+  test("alter table alter column with complex foldable default values") {
+    val tableName = "testcat.ns1.ns2.tbl"
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+      withTable(tableName) {
+        sql(
+          s"""
+             |CREATE TABLE $tableName (
+             |  salary INT DEFAULT (100 + 23),
+             |  dep STRING DEFAULT ('h' || 'r'),
+             |  active BOOLEAN DEFAULT CAST(1 AS BOOLEAN)
+             |) USING foo
+             |""".stripMargin)
+
+        val alterExecCol1 = executeAndKeepPhysicalPlan[AlterTableExec] {
+          sql(s"ALTER TABLE $tableName ALTER COLUMN salary SET DEFAULT (123 + 56)")
+        }
+        checkDefaultValue(
+          alterExecCol1.changes.collect {
+            case u: UpdateColumnDefaultValue => u
+          }.head,
+          new DefaultValue(
+            "(123 + 56)",
+            new GeneralScalarExpression(
+              "+",
+              Array(LiteralValue(123, IntegerType), LiteralValue(56, IntegerType)))))
+
+        val alterExecCol2 = executeAndKeepPhysicalPlan[AlterTableExec] {
+          sql(s"ALTER TABLE $tableName ALTER COLUMN salary SET DEFAULT ('r' || 'l')")
+        }
+        checkDefaultValue(
+          alterExecCol2.changes.collect {
+            case u: UpdateColumnDefaultValue => u
+          }.head,
+          new DefaultValue(
+            "('r' || 'l')",
+            new GeneralScalarExpression(
+              "CONCAT",
+              Array(
+                LiteralValue(UTF8String.fromString("r"), StringType),
+                LiteralValue(UTF8String.fromString("l"), StringType)))))
+
+        val alterExecCol3 = executeAndKeepPhysicalPlan[AlterTableExec] {
+          sql(s"ALTER TABLE $tableName ALTER COLUMN salary SET DEFAULT CAST(0 AS BOOLEAN)")
+        }
+        checkDefaultValue(
+          alterExecCol3.changes.collect {
+            case u: UpdateColumnDefaultValue => u
+          }.head,
+          new DefaultValue(
+            "CAST(0 AS BOOLEAN)",
+            new V2Cast(LiteralValue(0, IntegerType), IntegerType, BooleanType)))
+      }
+    }
+  }
+
+  test("alter table alter column drop default") {
+    val tableName = "testcat.ns1.ns2.tbl"
+    withTable(tableName) {
+      sql(
+        s"""
+           |CREATE TABLE $tableName (
+           |  salary INT DEFAULT (100 + 23)
+           |) USING foo
+           |""".stripMargin)
+
+      val alterExecCol = executeAndKeepPhysicalPlan[AlterTableExec] {
+        sql(s"ALTER TABLE $tableName ALTER COLUMN salary DROP DEFAULT")
+      }
+      checkDefaultValue(
+        alterExecCol.changes.collect {
+          case u: UpdateColumnDefaultValue => u
+        }.head,
+        new DefaultValue(
+          "", LiteralValue(UTF8String.fromString(""), StringType)))
     }
   }
 
@@ -529,7 +606,7 @@ class DataSourceV2DataFrameSuite
     }
   }
 
-  test("alter table with current like default values") {
+  test("alter table add columns with current like default values") {
     val tableName = "testcat.ns1.ns2.tbl"
     withTable(tableName) {
       sql(
@@ -550,6 +627,38 @@ class DataSourceV2DataFrameSuite
             "current_catalog()",
             null, /* no V2 expression */
             LiteralValue(UTF8String.fromString("spark_catalog"), StringType))))
+
+      val df1 = Seq(1).toDF("dummy")
+      df1.writeTo(tableName).append()
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableName"),
+        Seq(Row(1, "spark_catalog")))
+    }
+  }
+
+  test("alter table alter column with current like default values") {
+    val tableName = "testcat.ns1.ns2.tbl"
+    withTable(tableName) {
+      sql(
+        s"""
+           |CREATE TABLE $tableName (
+           |  dummy INT,
+           |  cat STRING
+           |) USING foo
+           |""".stripMargin)
+
+      val alterExec = executeAndKeepPhysicalPlan[AlterTableExec] {
+        sql(s"ALTER TABLE $tableName ALTER COLUMN cat SET DEFAULT current_catalog()")
+      }
+
+      checkDefaultValue(
+        alterExec.changes.collect {
+          case u: UpdateColumnDefaultValue => u
+        }.head,
+        new DefaultValue(
+          "current_catalog()",
+          null /* No V2 Expression */))
 
       val df1 = Seq(1).toDF("dummy")
       df1.writeTo(tableName).append()
@@ -593,5 +702,14 @@ class DataSourceV2DataFrameSuite
           s"Default value mismatch for column '${column.toString}': " +
           s"expected $expectedDefault but found ${column.defaultValue}")
     }
+  }
+
+  private def checkDefaultValue(
+      column: UpdateColumnDefaultValue,
+      expectedDefault: DefaultValue): Unit = {
+    assert(
+      column.newModelDefaultValue() == expectedDefault,
+        s"Default value mismatch for column '${column.toString}': " +
+        s"expected $expectedDefault but found ${column.newDefaultValue()}")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.execution.{QueryExecution, SparkPlan}
 import org.apache.spark.sql.execution.ExplainUtils.stripAQEPlan
 import org.apache.spark.sql.execution.datasources.v2.{AlterTableExec, CreateTableExec, DataSourceV2Relation, ReplaceTableExec}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{BooleanType, CalendarIntervalType, IntegerType, StringType}
+import org.apache.spark.sql.types.{BooleanType, CalendarIntervalType, IntegerType, NullType, StringType}
 import org.apache.spark.sql.util.QueryExecutionListener
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -557,7 +557,7 @@ class DataSourceV2DataFrameSuite
           case u: UpdateColumnDefaultValue => u
         }.head,
         new DefaultValue(
-          "", LiteralValue(UTF8String.fromString(""), StringType)))
+          "", LiteralValue(null, NullType)))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat, 
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Cast, EqualTo, Expression, InSubquery, IntegerLiteral, ListQuery, Literal, StringLiteral}
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.parser.ParseException
-import org.apache.spark.sql.catalyst.plans.logical.{AlterColumns, AlterColumnSpec, AnalysisOnlyCommand, AppendData, Assignment, CreateTable, CreateTableAsSelect, DeleteAction, DeleteFromTable, DescribeRelation, DropTable, InsertAction, InsertIntoStatement, LocalRelation, LogicalPlan, MergeIntoTable, OneRowRelation, OverwriteByExpression, OverwritePartitionsDynamic, Project, SetTableLocation, SetTableProperties, ShowTableProperties, SubqueryAlias, UnsetTableProperties, UpdateAction, UpdateTable}
+import org.apache.spark.sql.catalyst.plans.logical.{AlterColumns, AlterColumnSpec, AnalysisOnlyCommand, AppendData, Assignment, CreateTable, CreateTableAsSelect, DefaultValueExpression, DeleteAction, DeleteFromTable, DescribeRelation, DropTable, InsertAction, InsertIntoStatement, LocalRelation, LogicalPlan, MergeIntoTable, OneRowRelation, OverwriteByExpression, OverwritePartitionsDynamic, Project, SetTableLocation, SetTableProperties, ShowTableProperties, SubqueryAlias, UnsetTableProperties, UpdateAction, UpdateTable}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLId
 import org.apache.spark.sql.connector.FakeV2Provider
@@ -1428,7 +1428,7 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
                     None,
                     None,
                     None,
-                    Some("'value'")))) =>
+                    Some(DefaultValueExpression(_, _, _))))) =>
               assert(column1.name == Seq("i"))
               assert(column2.name == Seq("s"))
             case _ => fail("expect AlterColumns")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -1391,7 +1391,8 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
                   None,
                   None,
                   None,
-                  None))) =>
+                  None,
+                  false))) =>
               assert(column.name == Seq("i"))
             case _ => fail("expect AlterColumns")
           }
@@ -1405,7 +1406,8 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
                   None,
                   Some("new comment"),
                   None,
-                  None))) =>
+                  None,
+                  false))) =>
               assert(column.name == Seq("i"))
             case _ => fail("expect AlterColumns")
           }
@@ -1421,14 +1423,16 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
                     None,
                     None,
                     None,
-                    None),
+                    None,
+                    false),
                   AlterColumnSpec(
                     column2: ResolvedFieldName,
                     None,
                     None,
                     None,
                     None,
-                    Some(DefaultValueExpression(_, _, _))))) =>
+                    Some(DefaultValueExpression(_, _, _)),
+                    false))) =>
               assert(column1.name == Seq("i"))
               assert(column2.name == Seq("s"))
             case _ => fail("expect AlterColumns")
@@ -1515,7 +1519,8 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
               None,
               Some(comment),
               None,
-              None))) =>
+              None,
+              false))) =>
           assert(comment == "an index")
         case _ => fail("expect AlterTableAlterColumn with comment change only")
       }
@@ -1529,7 +1534,8 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
               None,
               Some(comment),
               None,
-              None))) =>
+              None,
+              false))) =>
           assert(comment == "an index")
           assert(dataType == LongType)
         case _ => fail("expect AlterTableAlterColumn with type and comment changes")


### PR DESCRIPTION
### What changes were proposed in this pull request?
"Alter table alter column" to pass in V2 Expression to DSV2.
Like the similar changes (https://github.com/apache/spark/pull/50593) and (https://github.com/apache/spark/pull/50701), the existing logic is rewritten to use the main Analyzer loop to get this expression, instead of manual call to ResolveDefaultColumns to analyze.

We enhance the UpdateColumnValue (TableChanges API) to return DefaultValue (which contains the V2 Expression), in addition to the existing API returning String representation of the default value.

### Why are the changes needed?
DSV2 (example, Iceberg/Delta) should get modeled V2 Expression to set default value.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added tests in DataSourceV2DataFrameSuite

### Was this patch authored or co-authored using generative AI tooling?
No
