### PR TITLE
[SPARK-52022][PYTHON][FOLLOW-UP] Explicitly check thrown exceptions

### DIFF
--- a/python/pyspark/errors/exceptions/captured.py
+++ b/python/pyspark/errors/exceptions/captured.py
@@ -118,51 +118,68 @@ class CapturedException(PySparkException):
     def getMessageParameters(self) -> Optional[Dict[str, str]]:
         from pyspark import SparkContext
         from py4j.java_gateway import is_instance_of
+        from py4j.protocol import Py4JError
 
         assert SparkContext._gateway is not None
 
         gw = SparkContext._gateway
-        if (
-            self._origin is not None
-            and is_instance_of(gw, self._origin, "org.apache.spark.SparkThrowable")
-            and hasattr(self._origin, "getMessageParameters")
+        if self._origin is not None and is_instance_of(
+            gw, self._origin, "org.apache.spark.SparkThrowable"
         ):
-            return dict(self._origin.getMessageParameters())
+            try:
+                return dict(self._origin.getMessageParameters())
+            except Py4JError as e:
+                if "py4j.Py4JException" in str(e) and "Method getMessageParameters" in str(e):
+                    return None
+                raise e
         else:
             return None
 
     def getSqlState(self) -> Optional[str]:
         from pyspark import SparkContext
         from py4j.java_gateway import is_instance_of
+        from py4j.protocol import Py4JError
 
         assert SparkContext._gateway is not None
         gw = SparkContext._gateway
-        if (
-            self._origin is not None
-            and is_instance_of(gw, self._origin, "org.apache.spark.SparkThrowable")
-            and hasattr(self._origin, "getSqlState")
+        if self._origin is not None and is_instance_of(
+            gw, self._origin, "org.apache.spark.SparkThrowable"
         ):
-            return self._origin.getSqlState()
+            try:
+                return self._origin.getSqlState()
+            except Py4JError as e:
+                if "py4j.Py4JException" in str(e) and "Method getSqlState" in str(e):
+                    return None
+                raise e
         else:
             return None
 
     def getMessage(self) -> str:
         from pyspark import SparkContext
         from py4j.java_gateway import is_instance_of
+        from py4j.protocol import Py4JError
 
         assert SparkContext._gateway is not None
         gw = SparkContext._gateway
 
-        if (
-            self._origin is not None
-            and is_instance_of(gw, self._origin, "org.apache.spark.SparkThrowable")
-            and hasattr(self._origin, "getMessageParameters")
+        if self._origin is not None and is_instance_of(
+            gw, self._origin, "org.apache.spark.SparkThrowable"
         ):
-            errorClass = self._origin.getCondition()
-            messageParameters = self._origin.getMessageParameters()
+            try:
+                error_class = self._origin.getCondition()
+            except Py4JError as e:
+                if "py4j.Py4JException" in str(e) and "Method getCondition" in str(e):
+                    return ""
+                raise e
+            try:
+                message_parameters = self._origin.getMessageParameters()
+            except Py4JError as e:
+                if "py4j.Py4JException" in str(e) and "Method getMessageParameters" in str(e):
+                    return ""
+                raise e
 
             error_message = getattr(gw.jvm, "org.apache.spark.SparkThrowableHelper").getMessage(
-                errorClass, messageParameters
+                error_class, message_parameters
             )
 
             return error_message
@@ -172,17 +189,22 @@ class CapturedException(PySparkException):
     def getQueryContext(self) -> List[BaseQueryContext]:
         from pyspark import SparkContext
         from py4j.java_gateway import is_instance_of
+        from py4j.protocol import Py4JError
 
         assert SparkContext._gateway is not None
 
         gw = SparkContext._gateway
-        if (
-            self._origin is not None
-            and is_instance_of(gw, self._origin, "org.apache.spark.SparkThrowable")
-            and hasattr(self._origin, "getQueryContext")
+        if self._origin is not None and is_instance_of(
+            gw, self._origin, "org.apache.spark.SparkThrowable"
         ):
             contexts: List[BaseQueryContext] = []
-            for q in self._origin.getQueryContext():
+            try:
+                context = self._origin.getQueryContext()
+            except Py4JError as e:
+                if "py4j.Py4JException" in str(e) and "Method getQueryContext" in str(e):
+                    return []
+                raise e
+            for q in context:
                 if q.contextType().toString() == "SQL":
                     contexts.append(SQLQueryContext(q))
                 else:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/50807 that rather explicitly check thrown exceptions.

### Why are the changes needed?

Seems like `hasttr` thinks the method exists, but it fails when you actually invoke.

```
...
  File "/.../lib/python3.9/site-packages/pyspark/python/lib/pyspark.zip/pyspark/errors/exceptions/captured.py", line 184, in getQueryContext
    for q in self._origin.getQueryContext():
  File "/.../lib/python3.9/site-packages/pyspark/python/lib/py4j-0.10.9.9-src.zip/py4j/java_gateway.py", line 1362, in __call__
    return_value = get_return_value(
  File "/.../lib/python3.9/site-packages/pyspark/python/lib/pyspark.zip/pyspark/errors/exceptions/captured.py", line 260, in deco
    return f(*a, **kw)
  File "/.../lib/python3.9/site-packages/pyspark/python/lib/py4j-0.10.9.9-src.zip/py4j/protocol.py", line 331, in get_return_value
    raise Py4JError(
py4j.protocol.Py4JError: An error occurred while calling o91.getQueryContext. Trace:
py4j.Py4JException: Method getQueryContext([]) does not exist
	at py4j.reflection.ReflectionEngine.getMethod(ReflectionEngine.java:321)
	at py4j.reflection.ReflectionEngine.getMethod(ReflectionEngine.java:329)
	at py4j.Gateway.invoke(Gateway.java:274)
	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at py4j.commands.CallCommand.execute(CallCommand.java:79)
	at py4j.ClientServerConnection.waitForCommands(ClientServerConnection.java:184)
	at py4j.ClientServerConnection.run(ClientServerConnection.java:108)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

### Does this PR introduce _any_ user-facing change?

Yes. Seems like Py4J does not support default method access. So if `getQueryContext` is not explicitly overridden, it throws an exception.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.