### PR TITLE
[SPARK-52096][SQL][SS] Reclassify kafka source offset assertion error

### DIFF
--- a/connector/kafka-0-10-sql/src/main/resources/error/kafka-error-conditions.json
+++ b/connector/kafka-0-10-sql/src/main/resources/error/kafka-error-conditions.json
@@ -97,5 +97,11 @@
       }
     },
     "sqlState" : "22000"
+  },
+  // todo yuchen: use this error
+  "SPECIFIED_START_OFFSET_GREATER_THAN_END_OFFSET" : {
+    "message" : [
+      "The specified <startOffsetType> <startOffset> is greater than the end offset <endOffsetType> <endOffset> for topic <topic> partition <partition>."
+    ]
   }
 }

--- a/connector/kafka-0-10-sql/src/main/resources/error/kafka-error-conditions.json
+++ b/connector/kafka-0-10-sql/src/main/resources/error/kafka-error-conditions.json
@@ -94,7 +94,7 @@
       "PARTITION_OFFSET_CHANGED" : {
         "message" : [
           "Partition <topicPartition> offset was changed from <prevOffset> to <newOffset>.",
-          "This could either be a user error that the start offset is set too high and this is the first batch, or the kafka topic-partition is broken, and some data may have been missed."
+          "This could be either 1) a user error that the start offset is set beyond available offset when starting query, or 2) the kafka topic-partition is deleted and re-created."
         ]
       },
       "START_OFFSET_RESET" : {
@@ -108,17 +108,17 @@
   "RESOLVED_START_OFFSET_GREATER_THAN_END_OFFSET" : {
     "message" : [
       "The resolved start offset <startOffset> is greater than the resolved end offset <endOffset> for topic <topic> partition <partition>.",
-      "There may be multiple reasons:",
-      "1. Start offset is set to too big a value that after resolution, end offset is smaller than it. There are multiple input cases:",
-      "  (a) Start offset is set to a timestamp, and the end offset is set to an index.",
-      "  (b) Start offset is set to an index, and the end offset is set to a timestamp.",
+      "Please investigate in this order:",
+      "1. Check whether start offset is set beyond the end offset or the latest available offset after resolution. Possible inputs are:",
+      "  (a) Start offset is set to a timestamp, and the end offset is set to an index of offset.",
+      "  (b) Start offset is set to an index of offset, and the end offset is set to a timestamp.",
       "  (c) Start offset is set, and the end offset is set to latest.",
-      "2. The Kafka topic partition is broken."
+      "2. Check whether the Kafka topic-partition is deleted and re-created."
     ]
   },
   "UNRESOLVED_START_OFFSET_GREATER_THAN_END_OFFSET" : {
     "message" : [
-      "The specified start offset <startOffset> is greater than the end offset <endOffset> for topic <topic> partition <partition>."
+      "The specified start <offsetType> <startOffset> is greater than the end <offsetType> <endOffset> for topic <topic> partition <partition>."
     ]
   }
 }

--- a/connector/kafka-0-10-sql/src/main/resources/error/kafka-error-conditions.json
+++ b/connector/kafka-0-10-sql/src/main/resources/error/kafka-error-conditions.json
@@ -5,6 +5,12 @@
       "topic-partitions for pre-fetched offset: <tpsForPrefetched>, topic-partitions for end offset: <tpsForEndOffset>."
     ]
   },
+  "MISMATCHED_TOPIC_PARTITIONS_BETWEEN_START_OFFSET_AND_END_OFFSET" : {
+    "message" : [
+      "The specified start offset and end offset should have the same topic-partitions.",
+      "Topic-partitions for start offset: <tpsForStartOffset>, topic-partitions for end offset: <tpsForEndOffset>."
+    ]
+  },
   "END_OFFSET_HAS_GREATER_OFFSET_FOR_TOPIC_PARTITION_THAN_PREFETCHED" : {
     "message" : [
       "For Kafka data source with Trigger.AvailableNow, end offset should have lower or equal offset per each topic partition than pre-fetched offset. The error could be transient - restart your query, and report if you still see the same issue.",
@@ -99,17 +105,6 @@
     },
     "sqlState" : "22000"
   },
-  "MISMATCHED_TOPIC_PARTITIONS_BETWEEN_START_OFFSET_AND_END_OFFSET" : {
-    "message" : [
-      "The specified start offset and end offset should have the same topic-partitions.",
-      "Topic-partitions for start offset: <tpsForStartOffset>, topic-partitions for end offset: <tpsForEndOffset>."
-    ]
-  },
-  "UNRESOLVED_START_OFFSET_GREATER_THAN_END_OFFSET" : {
-    "message" : [
-      "The specified start offset <startOffset> is greater than the end offset <endOffset> for topic <topic> partition <partition>."
-    ]
-  },
   "RESOLVED_START_OFFSET_GREATER_THAN_END_OFFSET" : {
     "message" : [
       "The resolved start offset <startOffset> is greater than the resolved end offset <endOffset> for topic <topic> partition <partition>.",
@@ -119,6 +114,11 @@
       "  (b) Start offset is set to an index, and the end offset is set to a timestamp.",
       "  (c) Start offset is set, and the end offset is set to latest.",
       "2. The Kafka topic partition is broken."
+    ]
+  },
+  "UNRESOLVED_START_OFFSET_GREATER_THAN_END_OFFSET" : {
+    "message" : [
+      "The specified start offset <startOffset> is greater than the end offset <endOffset> for topic <topic> partition <partition>."
     ]
   }
 }

--- a/connector/kafka-0-10-sql/src/main/resources/error/kafka-error-conditions.json
+++ b/connector/kafka-0-10-sql/src/main/resources/error/kafka-error-conditions.json
@@ -87,7 +87,8 @@
       },
       "PARTITION_OFFSET_CHANGED" : {
         "message" : [
-          "Partition <topicPartition> offset was changed from <prevOffset> to <newOffset>."
+          "Partition <topicPartition> offset was changed from <prevOffset> to <newOffset>.",
+          "This could either be a user error that the start offset is set too high and this is the first batch, or the kafka topic-partition is broken, and some data may have been missed."
         ]
       },
       "START_OFFSET_RESET" : {
@@ -98,10 +99,26 @@
     },
     "sqlState" : "22000"
   },
-  // todo yuchen: use this error
-  "SPECIFIED_START_OFFSET_GREATER_THAN_END_OFFSET" : {
+  "MISMATCHED_TOPIC_PARTITIONS_BETWEEN_START_OFFSET_AND_END_OFFSET" : {
     "message" : [
-      "The specified <startOffsetType> <startOffset> is greater than the end offset <endOffsetType> <endOffset> for topic <topic> partition <partition>."
+      "The specified start offset and end offset should have the same topic-partitions.",
+      "Topic-partitions for start offset: <tpsForStartOffset>, topic-partitions for end offset: <tpsForEndOffset>."
+    ]
+  },
+  "UNRESOLVED_START_OFFSET_GREATER_THAN_END_OFFSET" : {
+    "message" : [
+      "The specified start offset <startOffset> is greater than the end offset <endOffset> for topic <topic> partition <partition>."
+    ]
+  },
+  "RESOLVED_START_OFFSET_GREATER_THAN_END_OFFSET" : {
+    "message" : [
+      "The resolved start offset <startOffset> is greater than the resolved end offset <endOffset> for topic <topic> partition <partition>.",
+      "There may be multiple reasons:",
+      "1. Start offset is set to too big a value that after resolution, end offset is smaller than it. There are multiple input cases:",
+      "  (a) Start offset is set to a timestamp, and the end offset is set to an index.",
+      "  (b) Start offset is set to an index, and the end offset is set to a timestamp.",
+      "  (c) Start offset is set, and the end offset is set to latest.",
+      "2. The Kafka topic partition is broken."
     ]
   }
 }

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaExceptions.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaExceptions.scala
@@ -183,6 +183,8 @@ object KafkaExceptions {
       errorClass = "KAFKA_NULL_TOPIC_IN_DATA",
       messageParameters = Map.empty)
   }
+
+  // todo yuchen: create error function
 }
 
 /**

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaExceptions.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaExceptions.scala
@@ -201,6 +201,21 @@ object KafkaExceptions {
     new KafkaIllegalArgumentException(
       errorClass = "UNRESOLVED_START_OFFSET_GREATER_THAN_END_OFFSET",
       messageParameters = Map(
+        "offsetType" -> "offset",
+        "startOffset" -> startOffset.toString,
+        "endOffset" -> endOffset.toString,
+        "topic" -> topicPartition.topic,
+        "partition" -> topicPartition.partition.toString))
+  }
+
+  def unresolvedStartTimestampGreaterThanEndTimestamp(
+      startOffset: Long,
+      endOffset: Long,
+      topicPartition: TopicPartition): KafkaIllegalArgumentException = {
+    new KafkaIllegalArgumentException(
+      errorClass = "UNRESOLVED_START_OFFSET_GREATER_THAN_END_OFFSET",
+      messageParameters = Map(
+        "offsetType" -> "timestamp",
         "startOffset" -> startOffset.toString,
         "endOffset" -> endOffset.toString,
         "topic" -> topicPartition.topic,

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderAdmin.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderAdmin.scala
@@ -401,6 +401,23 @@ private[kafka010] class KafkaOffsetReaderAdmin(
         throw new IllegalStateException(s"$tp doesn't have a from offset")
       )
       val untilOffset = untilPartitionOffsets(tp)
+      // todo yuchen: check if greater, maybe kafka broken (most likely) or bad input
+      // give different potential options
+      // (1) kafka broken
+      // (2) start is time, end is index ...
+      // (3) start is index, end is time ...
+      // (4) start is index (big), end is latest.
+      // 1 and 4 also applies to streaming (resolved offsets)
+      // todo put it to KafkaOffsetReaderConsumer as well
+      KafkaSourceProvider.checkStartOffsetNotGreaterThanEndOffset(
+        tp,
+        fromOffset,
+        untilOffset,
+        (tp, fromOffset, untilOffset) =>
+          throw new IllegalStateException(
+            s"2: Start offset $fromOffset is greater than end offset $untilOffset " +
+              s"for topic ${tp.topic()} partition ${tp.partition()}.")
+      )
       KafkaOffsetRange(tp, fromOffset, untilOffset, None)
     }.toSeq
 

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderAdmin.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderAdmin.scala
@@ -512,9 +512,9 @@ private[kafka010] class KafkaOffsetReaderAdmin(
       if (untilOffset < fromOffset) {
         reportDataLoss(
           s"Partition $tp's offset was changed from " +
-            s"$fromOffset to $untilOffset. This could either be a user error that the start " +
-            "offset is set too high and this is the first batch, or the kafka topic-partition " +
-            "is broken, and some data may have been missed.",
+            s"$fromOffset to $untilOffset. This could be either 1) a user error that the start " +
+            "offset is set beyond available offset when starting query, or 2) the kafka " +
+            "topic-partition is deleted and re-created.",
           () =>
             KafkaExceptions.partitionOffsetChanged(tp, fromOffset, untilOffset))
       }

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderConsumer.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderConsumer.scala
@@ -561,9 +561,9 @@ private[kafka010] class KafkaOffsetReaderConsumer(
       if (untilOffset < fromOffset) {
         reportDataLoss(
           s"Partition $tp's offset was changed from " +
-            s"$fromOffset to $untilOffset. This could either be a user error that the start " +
-            "offset is set too high and this is the first batch, or the kafka topic-partition " +
-            "is broken, and some data may have been missed.",
+            s"$fromOffset to $untilOffset. This could be either 1) a user error that the start " +
+            "offset is set beyond available offset when starting query, or 2) the kafka " +
+            "topic-partition is deleted and re-created.",
           () =>
             KafkaExceptions.partitionOffsetChanged(tp, fromOffset, untilOffset))
       }

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
@@ -466,6 +466,9 @@ private[kafka010] class KafkaSourceProvider extends DataSourceRegister
         ENDING_OFFSETS_BY_TIMESTAMP_OPTION_KEY, ENDING_OFFSETS_OPTION_KEY,
         LatestOffsetRangeLimit)
 
+      println("YuchenYuchen: startingRelationOffsets: " + startingRelationOffsets)
+      println("YuchenYuchen: endingRelationOffsets: " + endingRelationOffsets)
+
       checkOffsetLimitValidity(startingRelationOffsets, endingRelationOffsets)
 
       new KafkaBatch(

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
@@ -466,9 +466,6 @@ private[kafka010] class KafkaSourceProvider extends DataSourceRegister
         ENDING_OFFSETS_BY_TIMESTAMP_OPTION_KEY, ENDING_OFFSETS_OPTION_KEY,
         LatestOffsetRangeLimit)
 
-      println("YuchenYuchen: startingRelationOffsets: " + startingRelationOffsets)
-      println("YuchenYuchen: endingRelationOffsets: " + endingRelationOffsets)
-
       checkOffsetLimitValidity(startingRelationOffsets, endingRelationOffsets)
 
       new KafkaBatch(

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
@@ -618,7 +618,8 @@ private[kafka010] object KafkaSourceProvider extends Logging {
       endOffset: Long,
       topicPartition: TopicPartition,
       exception: (Long, Long, TopicPartition) => Exception): Unit = {
-    if (startOffset > endOffset && startOffset != -1 && endOffset != -1) {
+    // earliest or latest offsets are negative and should not be compared
+    if (startOffset > endOffset && startOffset >= 0 && endOffset >= 0) {
       throw exception(startOffset, endOffset, topicPartition)
     }
   }
@@ -634,7 +635,7 @@ private[kafka010] object KafkaSourceProvider extends Logging {
             start.partitionOffsets.keySet, end.partitionOffsets.keySet
           )
         }
-        start.partitionOffsets.foreach({
+        start.partitionOffsets.foreach {
           case (tp, startOffset) =>
             checkStartOffsetNotGreaterThanEndOffset(
               startOffset,
@@ -642,7 +643,7 @@ private[kafka010] object KafkaSourceProvider extends Logging {
               tp,
               KafkaExceptions.unresolvedStartOffsetGreaterThanEndOffset
             )
-        })
+        }
 
       case start: SpecificTimestampRangeLimit
         if endOffset.isInstanceOf[SpecificTimestampRangeLimit] =>
@@ -652,15 +653,15 @@ private[kafka010] object KafkaSourceProvider extends Logging {
             start.topicTimestamps.keySet, end.topicTimestamps.keySet
           )
         }
-        start.topicTimestamps.foreach({
+        start.topicTimestamps.foreach {
           case (tp, startOffset) =>
             checkStartOffsetNotGreaterThanEndOffset(
               startOffset,
               end.topicTimestamps(tp),
               tp,
-              KafkaExceptions.unresolvedStartOffsetGreaterThanEndOffset
+              KafkaExceptions.unresolvedStartTimestampGreaterThanEndTimestamp
             )
-        })
+        }
 
       case _ =>  // do nothing
     }

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
@@ -21,7 +21,7 @@ import java.{util => ju}
 
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
-import org.apache.spark.{Partition, SparkContext, SparkException, TaskContext}
+import org.apache.spark.{Partition, SparkContext, TaskContext}
 import org.apache.spark.internal.LogKeys.{FROM_OFFSET, PARTITION_ID, TOPIC}
 import org.apache.spark.internal.MDC
 import org.apache.spark.rdd.RDD

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
@@ -135,26 +135,14 @@ private[kafka010] class KafkaSourceRDD(
       } else {
         range.untilOffset
       }
-//      if (range.fromOffset > range.untilOffset) {
-//        // todo yuchen: check if greater, maybe kafka broken (most likely) or bad input
-//        // give different potential options
-//        // (1) kafka broken
-//        // (2) start is time, end is index ...
-//        // (3) start is index, end is time ...
-//        // (4) start is index (big), end is latest.
-//        // 1 and 4 also applies to streaming (resolved offsets)
-//        // todo yuchen: check how streaming uses getOffsetRangesFromResolvedOffsets
-//        throw new SparkIllegalArgumentException("")
-//      }
+
       KafkaSourceProvider.checkStartOffsetNotGreaterThanEndOffset(
-        range.topicPartition,
         fromOffset,
         untilOffset,
-        (tp, fromOffset, untilOffset) =>
-          throw new IllegalStateException(
-            s"3: Start offset $fromOffset is greater than end offset $untilOffset " +
-              s"for topic ${tp.topic()} partition ${tp.partition()}.")
+        range.topicPartition,
+        KafkaExceptions.resolvedStartOffsetGreaterThanEndOffset
       )
+
       KafkaOffsetRange(range.topicPartition,
         fromOffset, untilOffset, range.preferredLoc)
     } else {

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
@@ -21,7 +21,7 @@ import java.{util => ju}
 
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
-import org.apache.spark.{Partition, SparkContext, TaskContext}
+import org.apache.spark.{Partition, SparkContext, SparkException, TaskContext}
 import org.apache.spark.internal.LogKeys.{FROM_OFFSET, PARTITION_ID, TOPIC}
 import org.apache.spark.internal.MDC
 import org.apache.spark.rdd.RDD
@@ -75,9 +75,12 @@ private[kafka010] class KafkaSourceRDD(
       sourcePartition.offsetRange.topicPartition, executorKafkaParams)
 
     val range = resolveRange(consumer, sourcePartition.offsetRange)
-    assert(range.fromOffset != -1 && range.untilOffset != -1,
-      s"Should not have -1 offsets for topic ${range.topic} partition ${range.partition} " +
-        s"fromOffset ${range.fromOffset} untilOffset ${range.untilOffset}")
+    if (range.fromOffset < 0 || range.untilOffset < 0) {
+      throw SparkException.internalError(
+        s"Should not have negative offsets for topic ${range.topic} partition ${range.partition} " +
+          s"at this point: fromOffset ${range.fromOffset} untilOffset ${range.untilOffset}"
+      )
+    }
     if (range.fromOffset == range.untilOffset) {
       logInfo(log"Beginning offset ${MDC(FROM_OFFSET, range.fromOffset)} is the same as ending " +
         log"offset skipping ${MDC(TOPIC, range.topic)} ${MDC(PARTITION_ID, range.partition)}")

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
@@ -21,6 +21,8 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicInteger
 
+import scala.concurrent.duration.DurationInt
+
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 
@@ -673,6 +675,12 @@ abstract class KafkaRelationSuiteBase extends QueryTest with SharedSparkSession 
   test("resolved start offset greater than end offset (without latest)") {
     val topic = newTopic()
     testUtils.createTopic(topic, partitions = 3)
+    val timestamp1 =
+      testUtils.sendMessages(topic, Seq("0", "0").toArray, Some(0))(1)._2.timestamp()
+    val timestamp2 =
+      testUtils.sendMessages(topic, Seq("0", "0").toArray, Some(1))(1)._2.timestamp()
+    val timestamp3 =
+      testUtils.sendMessages(topic, Seq("0", "0").toArray, Some(2))(1)._2.timestamp()
     val df = spark.read
       .format("kafka")
       .option("kafka.bootstrap.servers", testUtils.brokerAddress)
@@ -680,22 +688,24 @@ abstract class KafkaRelationSuiteBase extends QueryTest with SharedSparkSession 
       .option(
         "startingOffsets",
         s"""
-          |{"$topic": {"0": 1, "1": 1, "2": 1}}
+          |{"$topic": {"0": 3, "1": 3, "2": 3}}
           |""".stripMargin
       )
       .option(
         "endingOffsetsByTimestamp",
         s"""
-          |{"$topic": {"0": 0, "1": 0, "2": 0}}
+          |{"$topic": {"0": $timestamp1, "1": $timestamp2, "2": $timestamp3}}
           |""".stripMargin
       )
       .load()
 
-    val e = intercept[IllegalStateException] {
-      df.collect()
+    eventually(timeout(60.seconds)) {
+      val e = intercept[IllegalStateException] {
+        df.collect()
+      }
+      assert(e.getMessage.contains(
+        "The resolved start offset 3 is greater than the resolved end offset 1 for"))
     }
-    assert(e.getMessage.contains(
-      "The resolved start offset 1 is greater than the resolved end offset 0 for"))
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR classifies the assertion error saying that the start offset of Kafka source is greater than end offset to either user error or Kafka internal error. There are different possible cases that can lead to this error. Here is a list in the time order that we can catch them:
1. If the user specifies startingOffset and endingOffset in a comparable way (either by index or timestamp), we can compare them before starting the query.
2. If the user provides startingOffset and endingOffset but they are incomparable initially, we should compare them as soon as they are resolved by contacting the kafka brokers.
3. If the user sets startingOffset to some value and endingOffset to latest, we should compare them after the query has started and the latest offset has been fetched.
4. It is a Kafka topic-partition is broken.
```
java.lang.AssertionError: assertion failed: Beginning offset 49041276637 is after the ending offset 48774253518 for topic xxx partition 1. You either provided an invalid fromOffset, or the Kafka topic has been damaged
	at scala.Predef$.assert(Predef.scala:223)
	at org.apache.spark.sql.kafka010.KafkaSourceRDD.compute(KafkaSourceRDD.scala:79)
	at org.apache.spark.rdd.RDD.$anonfun$computeOrReadCheckpoint$1(RDD.scala:409)
	at com.databricks.spark.util.ExecutorFrameProfiler$.record(ExecutorFrameProfiler.scala:110)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:406) 
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  5. If you fix a bug, you can clarify why it is a bug.
-->
Most of the time this assertion error is fired due to user errors, and we have the information to make it explicit. This PR tries to utilize all the information to separate user errors from system errors.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Creates some unit tests in `KafkaRelationSuiteBase`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.