### PR TITLE
[SPARK-52099][SQL] Enable overriding the recursion row limit by adding a LIMIT operator

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4636,7 +4636,7 @@
   },
   "RECURSION_ROW_LIMIT_EXCEEDED" : {
     "message" : [
-      "Recursion row limit <rowLimit> reached but query has not exhausted, try increasing 'spark.sql.cteRecursionRowLimit'"
+      "Recursion row limit <rowLimit> reached but query has not exhausted, try setting a custom LIMIT value."
     ],
     "sqlState" : "42836"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4636,7 +4636,7 @@
   },
   "RECURSION_ROW_LIMIT_EXCEEDED" : {
     "message" : [
-      "Recursion row limit <rowLimit> reached but query has not exhausted, try setting a custom LIMIT value."
+      "Recursion row limit <rowLimit> reached but query has not exhausted, try setting a larger LIMIT value when querying the CTE relation."
     ],
     "sqlState" : "42836"
   },

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
@@ -170,6 +170,70 @@ DropTempViewCommand ZeroAndOne
 
 
 -- !query
+CREATE TEMPORARY VIEW ZeroAndOne(current, next) AS VALUES
+    (0,0),
+    (0,1),
+    (1,0),
+    (1,1)
+-- !query analysis
+CreateViewCommand `ZeroAndOne`, [(current,None), (next,None)], VALUES
+    (0,0),
+    (0,1),
+    (1,0),
+    (1,1), false, false, LocalTempView, UNSUPPORTED, true
+   +- LocalRelation [col1#x, col2#x]
+
+
+-- !query
+SET spark.sql.cteRecursionRowLimit=25
+-- !query analysis
+SetCommand (spark.sql.cteRecursionRowLimit,Some(25))
+
+
+-- !query
+WITH RECURSIVE t(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT next FROM t LEFT JOIN ZeroAndOne ON n = current
+    )
+SELECT * FROM t LIMIT 30
+-- !query analysis
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t
+:     +- Project [1#x AS n#x]
+:        +- UnionLoop xxxx
+:           :- Project [1 AS 1#x]
+:           :  +- OneRowRelation
+:           +- Project [next#x]
+:              +- Join LeftOuter, (n#x = current#x)
+:                 :- SubqueryAlias t
+:                 :  +- Project [1#x AS n#x]
+:                 :     +- UnionLoopRef xxxx, [1#x], false
+:                 +- SubqueryAlias zeroandone
+:                    +- View (`ZeroAndOne`, [current#x, next#x])
+:                       +- Project [cast(col1#x as int) AS current#x, cast(col2#x as int) AS next#x]
+:                          +- LocalRelation [col1#x, col2#x]
++- GlobalLimit 30
+   +- LocalLimit 30
+      +- Project [n#x]
+         +- SubqueryAlias t
+            +- CTERelationRef xxxx, true, [n#x], false, false
+
+
+-- !query
+SET spark.sql.cteRecursionRowLimit=1000000
+-- !query analysis
+SetCommand (spark.sql.cteRecursionRowLimit,Some(1000000))
+
+
+-- !query
+DROP VIEW ZeroAndOne
+-- !query analysis
+DropTempViewCommand ZeroAndOne
+
+
+-- !query
 WITH RECURSIVE r(level) AS (
   VALUES 0
   UNION ALL

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
@@ -222,9 +222,9 @@ WithCTE
 
 
 -- !query
-SET spark.sql.cteRecursionRowLimit=1000000
+RESET spark.sql.cteRecursionRowLimit
 -- !query analysis
-SetCommand (spark.sql.cteRecursionRowLimit,Some(1000000))
+ResetCommand spark.sql.cteRecursionRowLimit
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
@@ -57,6 +57,27 @@ SELECT * FROM t;
 
 DROP VIEW ZeroAndOne;
 
+-- unlimited recursion stopped from failing by putting LIMIT
+CREATE TEMPORARY VIEW ZeroAndOne(current, next) AS VALUES
+    (0,0),
+    (0,1),
+    (1,0),
+    (1,1);
+
+SET spark.sql.cteRecursionRowLimit=25;
+
+WITH RECURSIVE t(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT next FROM t LEFT JOIN ZeroAndOne ON n = current
+    )
+SELECT * FROM t LIMIT 30;
+
+SET spark.sql.cteRecursionRowLimit=1000000;
+
+DROP VIEW ZeroAndOne;
+
+
 -- terminate recursion with LIMIT
 WITH RECURSIVE r(level) AS (
   VALUES 0

--- a/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
@@ -73,7 +73,7 @@ WITH RECURSIVE t(n) AS (
     )
 SELECT * FROM t LIMIT 30;
 
-SET spark.sql.cteRecursionRowLimit=1000000;
+UNSET spark.sql.cteRecursionRowLimit;
 
 DROP VIEW ZeroAndOne;
 

--- a/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
@@ -73,7 +73,7 @@ WITH RECURSIVE t(n) AS (
     )
 SELECT * FROM t LIMIT 30;
 
-UNSET spark.sql.cteRecursionRowLimit;
+RESET spark.sql.cteRecursionRowLimit;
 
 DROP VIEW ZeroAndOne;
 

--- a/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
@@ -215,11 +215,11 @@ struct<n:int>
 
 
 -- !query
-SET spark.sql.cteRecursionRowLimit=1000000
+RESET spark.sql.cteRecursionRowLimit
 -- !query schema
-struct<key:string,value:string>
+struct<>
 -- !query output
-spark.sql.cteRecursionRowLimit	1000000
+
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
@@ -153,6 +153,84 @@ struct<>
 
 
 -- !query
+CREATE TEMPORARY VIEW ZeroAndOne(current, next) AS VALUES
+    (0,0),
+    (0,1),
+    (1,0),
+    (1,1)
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+SET spark.sql.cteRecursionRowLimit=25
+-- !query schema
+struct<key:string,value:string>
+-- !query output
+spark.sql.cteRecursionRowLimit	25
+
+
+-- !query
+WITH RECURSIVE t(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT next FROM t LEFT JOIN ZeroAndOne ON n = current
+    )
+SELECT * FROM t LIMIT 30
+-- !query schema
+struct<n:int>
+-- !query output
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+
+
+-- !query
+SET spark.sql.cteRecursionRowLimit=1000000
+-- !query schema
+struct<key:string,value:string>
+-- !query output
+spark.sql.cteRecursionRowLimit	1000000
+
+
+-- !query
+DROP VIEW ZeroAndOne
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
 WITH RECURSIVE r(level) AS (
   VALUES 0
   UNION ALL


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removed the early stop error in rCTEs when a custom LIMIT operator is present. Also changed error message to reflect this change.

### Why are the changes needed?

This enables users to return arbitrarily large result sets without using flags.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added a golden file test in cte-recursion.sql that breaks the flag limit but has a LIMIT operator.

### Was this patch authored or co-authored using generative AI tooling?

No.