### PR TITLE
Revert SPARK-52046 and SPARK-52019: Strip outer references and prettify correlated aggregate functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/LiteralFunctionResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/LiteralFunctionResolution.scala
@@ -41,12 +41,12 @@ object LiteralFunctionResolution {
   // support CURRENT_DATE, CURRENT_TIMESTAMP, CURRENT_TIME,
   //  CURRENT_USER, USER, SESSION_USER and grouping__id
   private val literalFunctions: Seq[(String, () => Expression, Expression => String)] = Seq(
-    (CurrentDate().prettyName, () => CurrentDate(), e => toPrettySQL(e)),
-    (CurrentTimestamp().prettyName, () => CurrentTimestamp(), e => toPrettySQL(e)),
-    (CurrentTime().prettyName, () => CurrentTime(), e => toPrettySQL(e)),
-    (CurrentUser().prettyName, () => CurrentUser(), e => toPrettySQL(e)),
-    ("user", () => CurrentUser(), e => toPrettySQL(e)),
-    ("session_user", () => CurrentUser(), e => toPrettySQL(e)),
+    (CurrentDate().prettyName, () => CurrentDate(), toPrettySQL(_)),
+    (CurrentTimestamp().prettyName, () => CurrentTimestamp(), toPrettySQL(_)),
+    (CurrentTime().prettyName, () => CurrentTime(), toPrettySQL(_)),
+    (CurrentUser().prettyName, () => CurrentUser(), toPrettySQL(_)),
+    ("user", () => CurrentUser(), toPrettySQL(_)),
+    ("session_user", () => CurrentUser(), toPrettySQL(_)),
     (VirtualColumn.hiveGroupingIdName, () => GroupingID(Nil), _ => VirtualColumn.hiveGroupingIdName)
   )
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5818,14 +5818,6 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val PRETTY_ALIAS_NAME_FOR_CORRELATED_AGGREGATE_FUNCTION =
-    buildConf("spark.sql.prettyAliasNameForCorrelatedAggFunc.enabled")
-      .internal()
-      .doc("When true, use prettified name for correlated aggregate functions.")
-      .version("4.1.0")
-      .booleanConf
-      .createWithDefault(true)
-
   /**
    * Holds information about keys that have been deprecated.
    *

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/negative-cases/invalid-correlation.sql.out
@@ -159,7 +159,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.CORRELATED_REFERENCE",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "sqlExprs" : "\"min(t2a) AS `outer(min(t2a))`\""
+    "sqlExprs" : "\"min(t2a) AS `min(outer(t2.t2a))`\""
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
@@ -160,7 +160,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.CORRELATED_REFERENCE",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "sqlExprs" : "\"min(t2a) AS `outer(min(t2a))`\""
+    "sqlExprs" : "\"min(t2a) AS `min(outer(t2.t2a))`\""
   },
   "queryContext" : [ {
     "objectType" : "",


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR we revert changes made in https://github.com/apache/spark/pull/50804 and https://github.com/apache/spark/pull/50836. This is necessary because we also change the alias name for outer references in LATERAL JOIN which is incorrect.

### Why are the changes needed?
To fix the behavior for LATERAL JOIN.

### Does this PR introduce _any_ user-facing change?
No (we revert to the previous working state).

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.