### PR TITLE
[SPARK-52102] [SQL] Normalize correlated aggregate function names in HAVING condition

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -4157,6 +4157,17 @@ object UpdateOuterReferences extends Rule[LogicalPlan] {
       plan: LogicalPlan,
       refExprs: Seq[Expression]): LogicalPlan = {
     plan resolveExpressions { case e =>
+      e match {
+        case alias: Alias =>
+          if (refExprs.exists { ref =>
+            stripOuterReference(alias).exists { expr =>
+              stripAlias(ref).semanticEquals(expr)
+            }
+          }) {
+            alias.setTagValue(NormalizePlan.NORMALIZE_CORRELATED_AGGREGATE_FUNCTION, ())
+          }
+        case _ =>
+      }
       val outerAlias =
         refExprs.find(stripAlias(_).semanticEquals(stripOuterReference(e)))
       outerAlias match {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the following query we would have `min(outer(t2.t2a))` as a name for `min(t2a)` expression.
```
SELECT t1a 
FROM   t1
WHERE  t1a IN (SELECT t2a 
               FROM   t2
               WHERE  EXISTS (SELECT min(t2a) 
                              FROM   t3))
```
This is a problem in compatibility between single-pass resolver and fixed-point analyzer because names in single-pass are generated after we finish resolution of aggregate expression `min(t2a)` (bottom-up manner) and at that point we have `OuterReference` wrapped around aggregate expression (name looks like `outer(min(t2a))`).
I propose that we fix it by normalizing `Alias` names for correlated aggregate functions in HAVING condition.

### Why are the changes needed?
To ease development of single-pass analyzer.

### Does this PR introduce _any_ user-facing change?
`Explain extended` of affected plans would be different.

### How was this patch tested?
Existing tests (regenerated golden files).

### Was this patch authored or co-authored using generative AI tooling?
No.