### PR TITLE
[SPARK-52104][CONNECT][SCALA] Validate column name eagerly in Spark Connect Scala Client

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/SparkSessionE2ESuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/SparkSessionE2ESuite.scala
@@ -26,6 +26,7 @@ import scala.util.{Failure, Success}
 import org.scalatest.concurrent.Eventually._
 
 import org.apache.spark.SparkException
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.StringEncoder
 import org.apache.spark.sql.connect.test.{ConnectFunSuite, RemoteSparkSession}
 import org.apache.spark.util.SparkThreadUtils.awaitResult
@@ -449,5 +450,12 @@ class SparkSessionE2ESuite extends ConnectFunSuite with RemoteSparkSession {
       "command",
       Map("one" -> "1", "two" -> "2"))
     assert(df.as(StringEncoder).collect().toSet == Set("one", "two"))
+  }
+
+  test("Non-existent columns throw exception") {
+    val e = intercept[AnalysisException] {
+      spark.range(10).col("nonexistent")
+    }
+    assert(e.getMessage.contains("UNRESOLVED_COLUMN.WITH_SUGGESTION"))
   }
 }

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/Dataset.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/Dataset.scala
@@ -37,12 +37,8 @@ import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoder
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders._
 import org.apache.spark.sql.catalyst.expressions.OrderUtils
-<<<<<<<
-import org.apache.spark.sql.connect.ColumnNodeToProtoConverter.{toExpr, toLiteral, toTypedExpr}
-=======
 import org.apache.spark.sql.catalyst.util.AttributeNameParser
-import org.apache.spark.sql.connect.ColumnNodeToProtoConverter.{toExpr, toTypedExpr}
->>>>>>>
+import org.apache.spark.sql.connect.ColumnNodeToProtoConverter.{toExpr, toLiteral, toTypedExpr}
 import org.apache.spark.sql.connect.ConnectConversions._
 import org.apache.spark.sql.connect.client.SparkResult
 import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, StorageLevelProtoConverter}
@@ -465,6 +461,11 @@ class Dataset[T] private[sql] (
     new Column(colName, getPlanId)
   }
 
+  /**
+   * Verify whether the input column name can be resolved with the given schema.
+   * Note that this method can not 100% match the analyzer behavior, it is designed to
+   * try the best to eliminate unnecessary validation RPCs.
+   */
   private def verifyColName(name: String, schema: StructType): Boolean = {
     val partsOpt = AttributeNameParser.parseAttributeName(name)
     if (partsOpt == null || partsOpt.isEmpty) return false

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/Dataset.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/Dataset.scala
@@ -462,9 +462,9 @@ class Dataset[T] private[sql] (
   }
 
   /**
-   * Verify whether the input column name can be resolved with the given schema.
-   * Note that this method can not 100% match the analyzer behavior, it is designed to
-   * try the best to eliminate unnecessary validation RPCs.
+   * Verify whether the input column name can be resolved with the given schema. Note that this
+   * method can not 100% match the analyzer behavior, it is designed to try the best to eliminate
+   * unnecessary validation RPCs.
    */
   private def verifyColName(name: String, schema: StructType): Boolean = {
     val partsOpt = AttributeNameParser.parseAttributeName(name)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, calling DataFrame.col(colName) with a non-existent column in the Scala Spark Connect client does not raise an error. In contrast, both PySpark (in either Spark Connect or Spark Classic) and Scala in Spark Classic do raise an exception in such cases. This leads to inconsistent behavior between Spark Connect and Spark Classic in Scala.

PySpark on Spark Classic:
```
> spark.range(10)['nonexistent']
[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column, variable, or function parameter with name `nonexistent` cannot be resolved. Did you mean one of the following? [`id`]. SQLSTATE: 42703
```

PySpark on Spark Connect:
```
> spark.range(10)['nonexistent']
[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column, variable, or function parameter with name `nonexistent` cannot be resolved. Did you mean one of the following? [`id`]. SQLSTATE: 42703
```

Scala on Spark Classic:
```
> spark.range(10).col("nonexistent")
AnalysisException: [UNRESOLVED_COLUMN.WITH_SUGGESTION] A column, variable, or function parameter with name `nonexistent` cannot be resolved. Did you mean one of the following? [`id`]. SQLSTATE: 42703
```

Scala on Spark Connect:
```
> spark.range(10).col("nonexistent")
res5: org.apache.spark.sql.Column = unresolved_attribute {
  unparsed_identifier: "nonexistent"
  plan_id: 2
}
```
it doesn't throw any exceptions.

In this PR, eager validation of column names has been implemented in the DataFrame.col(colName) method of the Scala client to ensure consistent behavior with both Spark Classic and PySpark. The implementation here is based on the [\_\_getitem\_\_](https://github.com/apache/spark/blob/727167acc30c7a50566dad0c030763e34b450cca/python/pyspark/sql/connect/dataframe.py#L1745-L1748) and [verify_col_name](https://github.com/apache/spark/blob/e70f39e9a67184c2595d3a091ca716dccd70e41f/python/pyspark/sql/connect/types.py#L353-L380) methods in PySpark.

Now, it will throw an error in Scala client on Spark Connect:
```
> spark.range(10).col("nonexistent")
AnalysisException: [UNRESOLVED_COLUMN.WITH_SUGGESTION] A column, variable, or function parameter with name `nonexistent` cannot be resolved. Did you mean one of the following? [`id`]. SQLSTATE: 42703
```

### Why are the changes needed?

This PR ensures consistent behavior between Spark Connect and Spark Classic in the scenario described above.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, referencing non-existent column in Scala client will now throw an error.



### How was this patch tested?

New test case.

### Was this patch authored or co-authored using generative AI tooling?
No.
