### PR TITLE
[SPARK-52052][CORE][FOLLOW-UP] Remove extra broadcast

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -96,7 +96,6 @@ case class JsonFileFormat() extends TextBasedFileFormat with DataSourceRegister 
       hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
     val broadcastedHadoopConf =
       SerializableConfiguration.broadcast(sparkSession.sparkContext, hadoopConf)
-      sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
 
     val parsedOptions = new JSONOptionsInRead(
       options,


### PR DESCRIPTION


### What changes were proposed in this pull request?
Remove an extra broadcast added in https://github.com/apache/spark/pull/50844

### Why are the changes needed?
Return value of broadcast is not used, so it seems it is not needed

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests


### Was this patch authored or co-authored using generative AI tooling?
No
