### PR TITLE
[SPARK-52111][SQL] Improve Length expression error messaging

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -2442,6 +2442,22 @@ case class Length(child: Expression)
       )
     )
 
+  override def checkInputDataTypes(): TypeCheckResult = {
+    child.dataType match {
+      case _: StringType => super.checkInputDataTypes()
+      case BinaryType => super.checkInputDataTypes()
+      case _ =>
+        DataTypeMismatch(
+          errorSubClass = "UNEXPECTED_INPUT_TYPE",
+          messageParameters = Map(
+            "paramIndex" -> ordinalNumber(0),
+            "requiredType" -> (toSQLType(StringType) + " or " + toSQLType(BinaryType)),
+            "inputSql" -> toSQLExpr(child),
+            "inputType" -> toSQLType(child.dataType)
+          )
+        )
+    }
+  }
   protected override def nullSafeEval(value: Any): Any = child.dataType match {
     case _: StringType => value.asInstanceOf[UTF8String].numChars
     case BinaryType => value.asInstanceOf[Array[Byte]].length

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -2444,8 +2444,7 @@ case class Length(child: Expression)
 
   override def checkInputDataTypes(): TypeCheckResult = {
     child.dataType match {
-      case _: StringType => super.checkInputDataTypes()
-      case BinaryType => super.checkInputDataTypes()
+      case _: StringType | BinaryType => super.checkInputDataTypes()
       case _ =>
         DataTypeMismatch(
           errorSubClass = "UNEXPECTED_INPUT_TYPE",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -1179,6 +1179,19 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(Length(Literal.create(null, BinaryType)), null, create_row(bytes))
     checkEvaluation(OctetLength(Literal.create(null, BinaryType)), null, create_row(bytes))
     checkEvaluation(BitLength(Literal.create(null, BinaryType)), null, create_row(bytes))
+
+    // type checking
+    assert(Length(Literal(Array("a"))).checkInputDataTypes() ==
+      DataTypeMismatch(
+        errorSubClass = "UNEXPECTED_INPUT_TYPE",
+        messageParameters = Map(
+          "paramIndex" -> ordinalNumber(0),
+          "requiredType" -> "\"STRING\" or \"BINARY\"",
+          "inputSql" -> "\"ARRAY('a')\"",
+          "inputType" -> "\"ARRAY<STRING>\""
+        )
+      )
+    )
   }
 
   test("format_number / FormatNumber") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Length expression uses datatype to decide evaluation path. Because of this we need to make sure we do not come to the evaluation with a different type.


### Why are the changes needed?
We do not want to expose scala match errors to the users.


### Does this PR introduce _any_ user-facing change?
Yes, we are now passing the proper error message.


### How was this patch tested?
Test added to `StringExpressionSuite`.


### Was this patch authored or co-authored using generative AI tooling?
No.
