### PR TITLE
[SPARK-52114][PYTHON][TESTS] Test UDF evaluation type under useArrow with session-level Arrow config

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
@@ -221,6 +221,28 @@ class ArrowPythonUDFTestsMixin(BaseUDFTestsMixin):
             ):
                 super().test_udf_with_udt()
 
+    def test_udf_use_arrow_and_session_conf(self):
+        with self.sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"}):
+            self.assertEqual(
+                udf(lambda x: str(x), useArrow=None).evalType, PythonEvalType.SQL_ARROW_BATCHED_UDF
+            )
+            self.assertEqual(
+                udf(lambda x: str(x), useArrow=True).evalType, PythonEvalType.SQL_ARROW_BATCHED_UDF
+            )
+            self.assertEqual(
+                udf(lambda x: str(x), useArrow=False).evalType, PythonEvalType.SQL_BATCHED_UDF
+            )
+        with self.sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "false"}):
+            self.assertEqual(
+                udf(lambda x: str(x), useArrow=None).evalType, PythonEvalType.SQL_BATCHED_UDF
+            )
+            self.assertEqual(
+                udf(lambda x: str(x), useArrow=True).evalType, PythonEvalType.SQL_ARROW_BATCHED_UDF
+            )
+            self.assertEqual(
+                udf(lambda x: str(x), useArrow=False).evalType, PythonEvalType.SQL_BATCHED_UDF
+            )
+
 
 class ArrowPythonUDFTests(ArrowPythonUDFTestsMixin, ReusedSQLTestCase):
     @classmethod


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add test for useArrow behavior under session-level Arrow config

### Why are the changes needed?
To verify that when determining the UDF evaluation type (with Arrow enabled or not), `useArrow` behaves correctly with the session-level configuration `spark.sql.execution.pythonUDF.arrow.enabled` .

Part of https://issues.apache.org/jira/browse/SPARK-52093

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Test changes only.

### Was this patch authored or co-authored using generative AI tooling?
No.
