### PR TITLE
[SPARK-52116][SQL] Improve exception for non-deterministic default values

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2518,6 +2518,11 @@
           "which requires <expectedType> type, but the statement provided a value of incompatible <actualType> type."
         ]
       },
+      "NON_DETERMINISTIC" : {
+        "message" : [
+          "which contains a non-deterministic expression."
+        ]
+      },
       "NOT_CONSTANT" : {
         "message" : [
           "which is not a constant expression whose equivalent value is known at query planning time."
@@ -2531,11 +2536,6 @@
       "UNRESOLVED_EXPRESSION" : {
         "message" : [
           "which fails to resolve as a valid expression."
-        ]
-      },
-      "NON_DETERMINISTIC" : {
-        "message" : [
-          "which contains a non-deterministic expression."
         ]
       }
     },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2532,6 +2532,11 @@
         "message" : [
           "which fails to resolve as a valid expression."
         ]
+      },
+      "NON_DETERMINISTIC" : {
+        "message" : [
+          "which contains a non-deterministic expression."
+        ]
       }
     },
     "sqlState" : "42623"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ColumnDefinition.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ColumnDefinition.scala
@@ -161,6 +161,10 @@ object ColumnDefinition {
           col.defaultValue.foreach { default =>
             checkDefaultColumnConflicts(col)
             validateDefaultValueExpr(default, statement, col.name, col.dataType)
+            if (!default.deterministic) {
+              throw QueryCompilationErrors.defaultValueNonDeterministicError(
+                "CREATE TABLE", col.name, default.originalSQL)
+            }
           }
         }
 
@@ -173,6 +177,10 @@ object ColumnDefinition {
                 "ALTER TABLE", c.colName, d.originalSQL, null)
             }
             validateDefaultValueExpr(d, "ALTER TABLE", c.colName, c.dataType)
+            if (!d.deterministic) {
+              throw QueryCompilationErrors.defaultValueNonDeterministicError(
+                "ALTER TABLE", c.colName, d.originalSQL)
+            }
           }
         }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3686,6 +3686,19 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       ))
   }
 
+  def defaultValueNonDeterministicError(
+      statement: String,
+      colName: String,
+      defaultValue: String): Throwable = {
+    new AnalysisException(
+      errorClass = "INVALID_DEFAULT_VALUE.NON_DETERMINISTIC",
+      messageParameters = Map(
+        "statement" -> toSQLStmt(statement),
+        "colName" -> toSQLId(colName),
+        "defaultValue" -> defaultValue
+      ))
+  }
+
   def nullableColumnOrFieldError(name: Seq[String]): Throwable = {
     new AnalysisException(
       errorClass = "NULLABLE_COLUMN_OR_FIELD",

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -3552,18 +3552,50 @@ class DataSourceV2SQLSuiteV1Filter
     }
   }
 
-  test("SPARK-48286: Add new column with default value which is not deterministic") {
+  test("SPARK-52116: Create table with default value which is not deterministic") {
+    withSQLConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS.key -> v2Source) {
+      withTable("tab") {
+        val exception = analysisException(
+          // Rand function is not deterministic
+          s"CREATE TABLE tab (col1 DOUBLE DEFAULT rand()) USING $v2Source")
+        assert(exception.getSqlState == "42623")
+        assert(exception.errorClass.get == "INVALID_DEFAULT_VALUE.NON_DETERMINISTIC")
+        assert(exception.messageParameters("statement") == "CREATE TABLE")
+        assert(exception.messageParameters("colName") == "`col1`")
+        assert(exception.messageParameters("defaultValue") == "rand()")
+      }
+    }
+  }
+
+  test("SPARK-52116: Replace table with default value which is not deterministic") {
+    withSQLConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS.key -> v2Source) {
+      withTable("tab") {
+        spark.sql(s"CREATE TABLE tab (col1 INT DEFAULT 100) USING $v2Source")
+        val exception = analysisException(
+          // Rand function is not deterministic
+          s"REPLACE TABLE tab (col1 DOUBLE DEFAULT rand()) USING $v2Source")
+        assert(exception.getSqlState == "42623")
+        assert(exception.errorClass.get == "INVALID_DEFAULT_VALUE.NON_DETERMINISTIC")
+        assert(exception.messageParameters("statement") == "CREATE TABLE")
+        assert(exception.messageParameters("colName") == "`col1`")
+        assert(exception.messageParameters("defaultValue") == "rand()")
+      }
+    }
+  }
+
+  test("SPARK-52116: Add new column with default value which is not deterministic") {
     val foldableExpressions = Seq("1", "2 + 1")
     withSQLConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS.key -> v2Source) {
       withTable("tab") {
         spark.sql(s"CREATE TABLE tab (col1 INT DEFAULT 100) USING $v2Source")
         val exception = analysisException(
-          // Rand function is not foldable
+          // Rand function is not deterministic
           s"ALTER TABLE tab ADD COLUMN col2 DOUBLE DEFAULT rand()")
-        assert(exception.getSqlState == "42K0E")
-        assert(exception.errorClass.get == "INVALID_NON_DETERMINISTIC_EXPRESSIONS")
-        assert(exception.messageParameters("sqlExprs") ==
-          "\"qualifiedcoltype(defaultvalueexpression(rand()))\"")
+        assert(exception.getSqlState == "42623")
+        assert(exception.errorClass.get == "INVALID_DEFAULT_VALUE.NON_DETERMINISTIC")
+        assert(exception.messageParameters("statement") == "ALTER TABLE")
+        assert(exception.messageParameters("colName") == "`col2`")
+        assert(exception.messageParameters("defaultValue") == "rand()")
       }
       foldableExpressions.foreach(expr => {
         withTable("tab") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add new exception subclass 'INVALID_DEFAULT_VALUE.NON_DETERMINISTIC', for Create/replace/alter table for column with non-deterministic default value.

### Why are the changes needed?
It was pointed out in https://github.com/apache/spark/pull/50701 that the existing test was wrongly asserting 'NOT_CONSTANT' for non-deterministic functions like rand().  Non-constant is not the same as non-deterministic, as there are some functions like current_xxx() that are deterministic but not-constant.  These are actually resolved later in FinishAnalysis (ReplaceCurrentLike rule), so they are constant in the end.

In https://github.com/apache/spark/pull/50701  we temporarily reverted back to the generic INVALID_NON_DETERMINISTIC_EXPRESSIONS exception in this case, and in this pr we are making a more user-friendly one for Default value. 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added unit test to DataSourceV2SQLSuite

### Was this patch authored or co-authored using generative AI tooling?
No