### PR TITLE
[SPARK-51856][FOLLOW-UP] Estimate ALS model size on one pass

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -778,8 +778,8 @@ class ALS(@Since("1.4.0") override val uid: String) extends Estimator[ALSModel] 
   override def copy(extra: ParamMap): ALS = defaultCopy(extra)
 
   override def estimateModelSize(dataset: Dataset[_]): Long = {
-    val userCount = dataset.select(getUserCol).distinct().count()
-    val itemCount = dataset.select(getItemCol).distinct().count()
+    val Row(userCount: Long, itemCount: Long) =
+      dataset.select(count_distinct(col(getUserCol)), count_distinct(col(getItemCol))).head()
     val rank = getRank
     (userCount + itemCount) * (rank + 1) * 4
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Estimate ALS model size on one pass


### Why are the changes needed?
existing implementation needs two passes


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no