### PR TITLE
[SPARK-52122] [ML] [CONNECT] Fix DefaultParamsReader RCE vulnerability

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/Pipeline.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Pipeline.scala
@@ -297,7 +297,9 @@ object Pipeline extends MLReadable[Pipeline] {
       val stageUids: Array[String] = (metadata.params \ "stageUids").extract[Seq[String]].toArray
       val stages: Array[PipelineStage] = stageUids.zipWithIndex.map { case (stageUid, idx) =>
         val stagePath = SharedReadWrite.getStagePath(stageUid, idx, stageUids.length, stagesDir)
-        val reader = DefaultParamsReader.loadParamsInstanceReader[PipelineStage](stagePath, spark)
+        val reader = DefaultParamsReader.loadParamsInstanceReader[PipelineStage](
+          stagePath, spark, expectedClassName
+        )
         instr.withLoadInstanceEvent(reader, stagePath)(reader.load(stagePath))
       }
       (metadata.uid, stages)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -116,7 +116,9 @@ private[ml] object OneVsRestParams extends ClassifierTypeTrait {
 
     val metadata = DefaultParamsReader.loadMetadata(path, spark, expectedClassName)
     val classifierPath = new Path(path, "classifier").toString
-    val estimator = DefaultParamsReader.loadParamsInstance[ClassifierType](classifierPath, spark)
+    val estimator = DefaultParamsReader.loadParamsInstance[ClassifierType](
+      classifierPath, spark, expectedClassName
+    )
     (metadata, estimator)
   }
 }
@@ -309,7 +311,9 @@ object OneVsRestModel extends MLReadable[OneVsRestModel] {
       val numClasses = (metadata.metadata \ "numClasses").extract[Int]
       val models = Range(0, numClasses).toArray.map { idx =>
         val modelPath = new Path(path, s"model_$idx").toString
-        DefaultParamsReader.loadParamsInstance[ClassificationModel[_, _]](modelPath, sparkSession)
+        DefaultParamsReader.loadParamsInstance[ClassificationModel[_, _]](
+          modelPath, sparkSession, className
+        )
       }
       val ovrModel = new OneVsRestModel(metadata.uid, labelMetadata, models)
       metadata.getAndSetParams(ovrModel)

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/CrossValidator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/CrossValidator.scala
@@ -445,7 +445,9 @@ object CrossValidatorModel extends MLReadable[CrossValidatorModel] {
         ValidatorParams.loadImpl(path, sparkSession, className)
       val numFolds = (metadata.params \ "numFolds").extract[Int]
       val bestModelPath = new Path(path, "bestModel").toString
-      val bestModel = DefaultParamsReader.loadParamsInstance[Model[_]](bestModelPath, sparkSession)
+      val bestModel = DefaultParamsReader.loadParamsInstance[Model[_]](
+        bestModelPath, sparkSession, className
+      )
       val avgMetrics = (metadata.metadata \ "avgMetrics").extract[Seq[Double]].toArray
       val persistSubModels = (metadata.metadata \ "persistSubModels")
         .extractOrElse[Boolean](false)
@@ -459,7 +461,7 @@ object CrossValidatorModel extends MLReadable[CrossValidatorModel] {
           for (paramIndex <- estimatorParamMaps.indices) {
             val modelPath = new Path(splitPath, paramIndex.toString).toString
             _subModels(splitIndex)(paramIndex) =
-              DefaultParamsReader.loadParamsInstance(modelPath, sparkSession)
+              DefaultParamsReader.loadParamsInstance(modelPath, sparkSession, className)
           }
         }
         Some(_subModels)

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
@@ -406,7 +406,9 @@ object TrainValidationSplitModel extends MLReadable[TrainValidationSplitModel] {
       val (metadata, estimator, evaluator, estimatorParamMaps) =
         ValidatorParams.loadImpl(path, sparkSession, className)
       val bestModelPath = new Path(path, "bestModel").toString
-      val bestModel = DefaultParamsReader.loadParamsInstance[Model[_]](bestModelPath, sparkSession)
+      val bestModel = DefaultParamsReader.loadParamsInstance[Model[_]](
+        bestModelPath, sparkSession, className
+      )
       val validationMetrics = (metadata.metadata \ "validationMetrics").extract[Seq[Double]].toArray
       val persistSubModels = (metadata.metadata \ "persistSubModels")
         .extractOrElse[Boolean](false)
@@ -417,7 +419,7 @@ object TrainValidationSplitModel extends MLReadable[TrainValidationSplitModel] {
         for (paramIndex <- estimatorParamMaps.indices) {
           val modelPath = new Path(subModelsPath, paramIndex.toString).toString
           _subModels(paramIndex) =
-            DefaultParamsReader.loadParamsInstance(modelPath, sparkSession)
+            DefaultParamsReader.loadParamsInstance(modelPath, sparkSession, className)
         }
         Some(_subModels)
       } else None

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/ValidatorParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/ValidatorParams.scala
@@ -182,9 +182,13 @@ private[ml] object ValidatorParams {
 
     implicit val format = DefaultFormats
     val evaluatorPath = new Path(path, "evaluator").toString
-    val evaluator = DefaultParamsReader.loadParamsInstance[Evaluator](evaluatorPath, spark)
+    val evaluator = DefaultParamsReader.loadParamsInstance[Evaluator](
+      evaluatorPath, spark, expectedClassName
+    )
     val estimatorPath = new Path(path, "estimator").toString
-    val estimator = DefaultParamsReader.loadParamsInstance[Estimator[M]](estimatorPath, spark)
+    val estimator = DefaultParamsReader.loadParamsInstance[Estimator[M]](
+      estimatorPath, spark, expectedClassName
+    )
 
     val uidToParams = Map(evaluator.uid -> evaluator) ++ MetaAlgorithmReadWrite.getUidMap(estimator)
 
@@ -202,7 +206,9 @@ private[ml] object ValidatorParams {
             } else {
               val relativePath = param.jsonDecode(pInfo("value")).toString
               val value = DefaultParamsReader
-                .loadParamsInstance[MLWritable](new Path(path, relativePath).toString, spark)
+                .loadParamsInstance[MLWritable](
+                  new Path(path, relativePath).toString, spark, expectedClassName
+                )
               param -> value
             }
           }

--- a/mllib/src/test/scala/org/apache/spark/ml/PipelineSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/PipelineSuite.scala
@@ -254,7 +254,9 @@ class WritableStage(override val uid: String) extends Transformer with MLWritabl
 
 object WritableStage extends MLReadable[WritableStage] {
 
-  override def read: MLReader[WritableStage] = new DefaultParamsReader[WritableStage]
+  override def read: MLReader[WritableStage] = new DefaultParamsReader[WritableStage](
+    "org.apache.spark.ml.WritableStage"
+  )
 
   override def load(path: String): WritableStage = super.load(path)
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/util/DefaultReadWriteTest.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/DefaultReadWriteTest.scala
@@ -200,7 +200,9 @@ class MyParams(override val uid: String) extends Params with MLWritable {
 
 object MyParams extends MLReadable[MyParams] {
 
-  override def read: MLReader[MyParams] = new DefaultParamsReader[MyParams]
+  override def read: MLReader[MyParams] = new DefaultParamsReader[MyParams](
+    "org.apache.spark.ml.util.MyParams"
+  )
 
   override def load(path: String): MyParams = super.load(path)
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/util/DefaultReadWriteTest.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/DefaultReadWriteTest.scala
@@ -241,7 +241,9 @@ class DefaultReadWriteSuite extends SparkFunSuite with MLlibTestSparkContext
       |"timestamp":1518852502761,"sparkVersion":"2.3.0",
       |"uid":"my_params",
       |"paramMap":{"intParamWithDefault":0}}""".stripMargin
-    val parsedMetadata = DefaultParamsReader.parseMetadata(metadata)
+    val parsedMetadata = DefaultParamsReader.parseMetadata(
+      metadata, "org.apache.spark.ml.util.MyParams"
+    )
     val myParams = new MyParams("my_params")
     assert(!myParams.isSet(myParams.intParamWithDefault))
     parsedMetadata.getAndSetParams(myParams)
@@ -257,7 +259,9 @@ class DefaultReadWriteSuite extends SparkFunSuite with MLlibTestSparkContext
       |"timestamp":1518852502761,"sparkVersion":"2.4.0",
       |"uid":"my_params",
       |"paramMap":{"intParamWithDefault":0}}""".stripMargin
-    val parsedMetadata1 = DefaultParamsReader.parseMetadata(metadata1)
+    val parsedMetadata1 = DefaultParamsReader.parseMetadata(
+      metadata1, "org.apache.spark.ml.util.MyParams"
+    )
     val err1 = intercept[IllegalArgumentException] {
       parsedMetadata1.getAndSetParams(myParams)
     }
@@ -267,7 +271,9 @@ class DefaultReadWriteSuite extends SparkFunSuite with MLlibTestSparkContext
       |"timestamp":1518852502761,"sparkVersion":"3.0.0",
       |"uid":"my_params",
       |"paramMap":{"intParamWithDefault":0}}""".stripMargin
-    val parsedMetadata2 = DefaultParamsReader.parseMetadata(metadata2)
+    val parsedMetadata2 = DefaultParamsReader.parseMetadata(
+      metadata2, "org.apache.spark.ml.util.MyParams"
+    )
     val err2 = intercept[IllegalArgumentException] {
       parsedMetadata2.getAndSetParams(myParams)
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix DefaultParamsReader RCE vulnerability:
The metadata loading https://github.com/apache/spark/blob/18aebd8eb86b554e7aab38baca1e5de24df19a57/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala#L565 does not verify the class,

and then the reflection invocation https://github.com/apache/spark/blob/18aebd8eb86b554e7aab38baca1e5de24df19a57/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala#L568 will trigger arbitrary code execution if malicious class name is written to a designed metadata file.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
SparkConnect RCE fix.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Manually.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.