### PR TITLE
[SPARK-52126][SS][PYTHON] Revert rename for TWS utility classes for forward compatibility in Spark Connect

### DIFF
--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -374,10 +374,10 @@ class GroupedData:
         from pyspark.sql.connect.udf import UserDefinedFunction
         from pyspark.sql.connect.dataframe import DataFrame
         from pyspark.sql.streaming.stateful_processor_util import (
-            TransformWithStateInPySparkUdfUtils,
+            TransformWithStateInPandasUdfUtils,
         )
 
-        udf_util = TransformWithStateInPySparkUdfUtils(statefulProcessor, timeMode)
+        udf_util = TransformWithStateInPandasUdfUtils(statefulProcessor, timeMode)
         if initialState is None:
             udf_obj = UserDefinedFunction(
                 udf_util.transformWithStateUDF,
@@ -426,10 +426,10 @@ class GroupedData:
         from pyspark.sql.connect.udf import UserDefinedFunction
         from pyspark.sql.connect.dataframe import DataFrame
         from pyspark.sql.streaming.stateful_processor_util import (
-            TransformWithStateInPySparkUdfUtils,
+            TransformWithStateInPandasUdfUtils,
         )
 
-        udf_util = TransformWithStateInPySparkUdfUtils(statefulProcessor, timeMode)
+        udf_util = TransformWithStateInPandasUdfUtils(statefulProcessor, timeMode)
         if initialState is None:
             udf_obj = UserDefinedFunction(
                 udf_util.transformWithStateUDF,

--- a/python/pyspark/sql/pandas/group_ops.py
+++ b/python/pyspark/sql/pandas/group_ops.py
@@ -635,7 +635,7 @@ class PandasGroupedOpsMixin:
         from pyspark.sql import GroupedData
         from pyspark.sql.functions import pandas_udf
         from pyspark.sql.streaming.stateful_processor_util import (
-            TransformWithStateInPySparkUdfUtils,
+            TransformWithStateInPandasUdfUtils,
         )
 
         assert isinstance(self, GroupedData)
@@ -645,7 +645,7 @@ class PandasGroupedOpsMixin:
             outputStructType = cast(StructType, self._df._session._parse_ddl(outputStructType))
 
         df = self._df
-        udf_util = TransformWithStateInPySparkUdfUtils(statefulProcessor, timeMode)
+        udf_util = TransformWithStateInPandasUdfUtils(statefulProcessor, timeMode)
 
         # explicitly set the type to Any since it could match to various types (literals)
         functionType: Any = None

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -1258,7 +1258,7 @@ class TransformWithStateInPandasSerializer(ArrowStreamPandasUDFSerializer):
         """
         import pyarrow as pa
         from pyspark.sql.streaming.stateful_processor_util import (
-            TransformWithStateInPySparkFuncMode,
+            TransformWithStateInPandasFuncMode,
         )
 
         def generate_data_batches(batches):
@@ -1284,11 +1284,11 @@ class TransformWithStateInPandasSerializer(ArrowStreamPandasUDFSerializer):
         data_batches = generate_data_batches(_batches)
 
         for k, g in groupby(data_batches, key=lambda x: x[0]):
-            yield (TransformWithStateInPySparkFuncMode.PROCESS_DATA, k, g)
+            yield (TransformWithStateInPandasFuncMode.PROCESS_DATA, k, g)
 
-        yield (TransformWithStateInPySparkFuncMode.PROCESS_TIMER, None, None)
+        yield (TransformWithStateInPandasFuncMode.PROCESS_TIMER, None, None)
 
-        yield (TransformWithStateInPySparkFuncMode.COMPLETE, None, None)
+        yield (TransformWithStateInPandasFuncMode.COMPLETE, None, None)
 
     def dump_stream(self, iterator, stream):
         """
@@ -1326,7 +1326,7 @@ class TransformWithStateInPandasInitStateSerializer(TransformWithStateInPandasSe
     def load_stream(self, stream):
         import pyarrow as pa
         from pyspark.sql.streaming.stateful_processor_util import (
-            TransformWithStateInPySparkFuncMode,
+            TransformWithStateInPandasFuncMode,
         )
 
         def generate_data_batches(batches):
@@ -1388,11 +1388,11 @@ class TransformWithStateInPandasInitStateSerializer(TransformWithStateInPandasSe
         data_batches = generate_data_batches(_batches)
 
         for k, g in groupby(data_batches, key=lambda x: x[0]):
-            yield (TransformWithStateInPySparkFuncMode.PROCESS_DATA, k, g)
+            yield (TransformWithStateInPandasFuncMode.PROCESS_DATA, k, g)
 
-        yield (TransformWithStateInPySparkFuncMode.PROCESS_TIMER, None, None)
+        yield (TransformWithStateInPandasFuncMode.PROCESS_TIMER, None, None)
 
-        yield (TransformWithStateInPySparkFuncMode.COMPLETE, None, None)
+        yield (TransformWithStateInPandasFuncMode.COMPLETE, None, None)
 
 
 class TransformWithStateInPySparkRowSerializer(ArrowStreamUDFSerializer):
@@ -1420,7 +1420,7 @@ class TransformWithStateInPySparkRowSerializer(ArrowStreamUDFSerializer):
         this function works in overall.
         """
         from pyspark.sql.streaming.stateful_processor_util import (
-            TransformWithStateInPySparkFuncMode,
+            TransformWithStateInPandasFuncMode,
         )
         import itertools
 
@@ -1451,11 +1451,11 @@ class TransformWithStateInPySparkRowSerializer(ArrowStreamUDFSerializer):
         for k, g in groupby(data_batches, key=lambda x: x[0]):
             chained = itertools.chain(g)
             chained_values = map(lambda x: x[1], chained)
-            yield (TransformWithStateInPySparkFuncMode.PROCESS_DATA, k, chained_values)
+            yield (TransformWithStateInPandasFuncMode.PROCESS_DATA, k, chained_values)
 
-        yield (TransformWithStateInPySparkFuncMode.PROCESS_TIMER, None, None)
+        yield (TransformWithStateInPandasFuncMode.PROCESS_TIMER, None, None)
 
-        yield (TransformWithStateInPySparkFuncMode.COMPLETE, None, None)
+        yield (TransformWithStateInPandasFuncMode.COMPLETE, None, None)
 
     def dump_stream(self, iterator, stream):
         """
@@ -1503,7 +1503,7 @@ class TransformWithStateInPySparkRowInitStateSerializer(TransformWithStateInPySp
         import itertools
         import pyarrow as pa
         from pyspark.sql.streaming.stateful_processor_util import (
-            TransformWithStateInPySparkFuncMode,
+            TransformWithStateInPandasFuncMode,
         )
 
         def generate_data_batches(batches):
@@ -1592,8 +1592,8 @@ class TransformWithStateInPySparkRowInitStateSerializer(TransformWithStateInPySp
 
             ret_tuple = (chained_input_values_without_none, chained_init_state_values_without_none)
 
-            yield (TransformWithStateInPySparkFuncMode.PROCESS_DATA, k, ret_tuple)
+            yield (TransformWithStateInPandasFuncMode.PROCESS_DATA, k, ret_tuple)
 
-        yield (TransformWithStateInPySparkFuncMode.PROCESS_TIMER, None, None)
+        yield (TransformWithStateInPandasFuncMode.PROCESS_TIMER, None, None)
 
-        yield (TransformWithStateInPySparkFuncMode.COMPLETE, None, None)
+        yield (TransformWithStateInPandasFuncMode.COMPLETE, None, None)

--- a/python/pyspark/sql/streaming/transform_with_state_driver_worker.py
+++ b/python/pyspark/sql/streaming/transform_with_state_driver_worker.py
@@ -31,7 +31,7 @@ from pyspark.util import handle_worker_exception
 from typing import IO
 from pyspark.worker_util import check_python_version
 from pyspark.sql.streaming.stateful_processor_api_client import StatefulProcessorApiClient
-from pyspark.sql.streaming.stateful_processor_util import TransformWithStateInPySparkFuncMode
+from pyspark.sql.streaming.stateful_processor_util import TransformWithStateInPandasFuncMode
 from pyspark.sql.types import StructType
 
 if TYPE_CHECKING:
@@ -51,7 +51,7 @@ def main(infile: IO, outfile: IO) -> None:
 
     def process(
         processor: StatefulProcessorApiClient,
-        mode: TransformWithStateInPySparkFuncMode,
+        mode: TransformWithStateInPandasFuncMode,
         key: Any,
         input: Iterator["PandasDataFrameLike"],
     ) -> None:
@@ -83,7 +83,7 @@ def main(infile: IO, outfile: IO) -> None:
         stateful_processor_api_client = StatefulProcessorApiClient(state_server_port, key_schema)
         process(
             stateful_processor_api_client,
-            TransformWithStateInPySparkFuncMode.PRE_INIT,
+            TransformWithStateInPandasFuncMode.PRE_INIT,
             None,
             iter([]),
         )

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -34,7 +34,7 @@ from pyspark.accumulators import (
     _deserialize_accumulator,
 )
 from pyspark.sql.streaming.stateful_processor_api_client import StatefulProcessorApiClient
-from pyspark.sql.streaming.stateful_processor_util import TransformWithStateInPySparkFuncMode
+from pyspark.sql.streaming.stateful_processor_util import TransformWithStateInPandasFuncMode
 from pyspark.taskcontext import BarrierTaskContext, TaskContext
 from pyspark.resource import ResourceInformation
 from pyspark.util import PythonEvalType, local_connect_and_auth
@@ -589,7 +589,7 @@ def wrap_grouped_transform_with_state_udf(f, return_type, runner_conf):
 
 def wrap_grouped_transform_with_state_init_state_udf(f, return_type, runner_conf):
     def wrapped(stateful_processor_api_client, mode, key, values):
-        if mode == TransformWithStateInPySparkFuncMode.PROCESS_DATA:
+        if mode == TransformWithStateInPandasFuncMode.PROCESS_DATA:
             values_gen = values[0]
             init_states_gen = values[1]
         else:
@@ -2001,7 +2001,7 @@ def read_udfs(pickleSer, infile, eval_type):
         def mapper(a):
             mode = a[0]
 
-            if mode == TransformWithStateInPySparkFuncMode.PROCESS_DATA:
+            if mode == TransformWithStateInPandasFuncMode.PROCESS_DATA:
                 key = a[1]
 
                 def values_gen():
@@ -2038,7 +2038,7 @@ def read_udfs(pickleSer, infile, eval_type):
         def mapper(a):
             mode = a[0]
 
-            if mode == TransformWithStateInPySparkFuncMode.PROCESS_DATA:
+            if mode == TransformWithStateInPandasFuncMode.PROCESS_DATA:
                 key = a[1]
 
                 def values_gen():
@@ -2070,7 +2070,7 @@ def read_udfs(pickleSer, infile, eval_type):
         def mapper(a):
             mode = a[0]
 
-            if mode == TransformWithStateInPySparkFuncMode.PROCESS_DATA:
+            if mode == TransformWithStateInPandasFuncMode.PROCESS_DATA:
                 key = a[1]
                 values = a[2]
 
@@ -2103,7 +2103,7 @@ def read_udfs(pickleSer, infile, eval_type):
         def mapper(a):
             mode = a[0]
 
-            if mode == TransformWithStateInPySparkFuncMode.PROCESS_DATA:
+            if mode == TransformWithStateInPandasFuncMode.PROCESS_DATA:
                 key = a[1]
                 values = a[2]
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to revert the renaming of TWS utility classes since it broke forward compatibility in Spark Connect.

We sought to find the way to leave the refactor and make the new version to understand the old class, but there is Enumeration which does not support inheritance unfortunately, and to support both Enumeration classes it needs broader code change.

### Why are the changes needed?

Without this fix, Spark 4.0 client cannot work with Spark 4.1 server in Spark Connect.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs. W.r.t. compatibility test, we tested manually on internal system test.

### Was this patch authored or co-authored using generative AI tooling?

No.