### PR TITLE
[SPARK-52124] Actively Releasing Disk Space After Application Completio…

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Worker.scala
@@ -59,6 +59,12 @@ private[spark] object Worker {
     .timeConf(TimeUnit.MILLISECONDS)
     .createWithDefaultString("10s")
 
+  val WORKER_CLEANUP_WORKDIR_AFTER_FINISHED_APP_ENABLED =
+    ConfigBuilder("spark.worker.cleanupWorkDirAfterAppFinished.enabled")
+      .version("1.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val WORKER_CLEANUP_ENABLED = ConfigBuilder("spark.worker.cleanup.enabled")
     .version("1.0.0")
     .booleanConf

--- a/core/src/main/scala/org/apache/spark/internal/config/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Worker.scala
@@ -61,7 +61,7 @@ private[spark] object Worker {
 
   val WORKER_CLEANUP_WORKDIR_AFTER_FINISHED_APP_ENABLED =
     ConfigBuilder("spark.worker.cleanupWorkDirAfterAppFinished.enabled")
-      .version("1.0.0")
+      .version("4.0.0")
       .booleanConf
       .createWithDefault(false)
 


### PR DESCRIPTION
…n in Spark Standalone Mode

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In the spark standalone mode, actively release the disk space occupied by the application in the work directory

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When submitting applications using Spark in standalone mode, a folder is generated under the work directory on each node every time a application is submitted. The naming convention for these folders is, for example, app-20250212191730-0249. These folders contain the resource files that each node downloads from the master node when the application is submitted. Although there is a scheduled cleanup mechanism (spark.worker.cleanup.enabled), it is not immediate. If a large number of application are submitted in a short period of time, and each application depends on a significant amount of external resources, the disk space can be quickly exhausted.
 
Therefore, I suggest actively deleting the disk space occupied under the work directory after each application is completed.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
