### PR TITLE
[SPARK-52131][INFRA] Upload the application directory when tests for the `yarn` module fail

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -389,11 +389,11 @@ jobs:
       with:
         name: unit-tests-log-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
         path: "**/target/*.log"
-    - name: Upload yarn App log files
+    - name: Upload yarn app log files
       if: ${{ !success() && contains(matrix.modules, 'yarn') }}
       uses: actions/upload-artifact@v4
       with:
-        name: yarn-app-log-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
+        name: yarn-app-log-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
         path: "**/target/test/data/"
 
   infra-image:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -389,6 +389,12 @@ jobs:
       with:
         name: unit-tests-log-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
         path: "**/target/*.log"
+    - name: Upload yarn App log files
+      if: ${{ !success() && contains(matrix.modules, 'yarn') }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: yarn-app-log-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
+        path: "**/target/test/data/"
 
   infra-image:
     name: "Base image build"

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnShuffleIntegrationSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnShuffleIntegrationSuite.scala
@@ -82,7 +82,7 @@ abstract class YarnShuffleIntegrationSuite extends BaseYarnClusterSuite {
     )
     checkResult(finalState, result)
 
-    assert(!YarnTestAccessor.getRegisteredExecutorFile(shuffleService).exists())
+    assert(YarnTestAccessor.getRegisteredExecutorFile(shuffleService).exists())
   }
 }
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnShuffleIntegrationSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnShuffleIntegrationSuite.scala
@@ -82,7 +82,7 @@ abstract class YarnShuffleIntegrationSuite extends BaseYarnClusterSuite {
     )
     checkResult(finalState, result)
 
-    assert(YarnTestAccessor.getRegisteredExecutorFile(shuffleService).exists())
+    assert(!YarnTestAccessor.getRegisteredExecutorFile(shuffleService).exists())
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr adds functionality to upload the contents of the `target/test/data/` directory when the `yarn` module tests fail in GitHub Actions. This directory stores information related to Yarn Applications, such as logs and job configurations. The upload of this directory's contents facilitates troubleshooting when `yarn` module tests encounter failures.

### Why are the changes needed?
This facilitates troubleshooting when tests for the `yarn` module fail.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Pass GitHub Actions
- It has been confirmed that the expected files can be downloaded when test failures occur in the `yarn` module. 
https://github.com/LuciferYang/spark/actions/runs/15019569409

![image](https://github.com/user-attachments/assets/fd22f7d9-64fd-4d6f-a0d8-5e13c70de272)
 
After unzipping, the contents of the folder are as follows:

![image](https://github.com/user-attachments/assets/a2dce30f-add2-4671-9f64-2c26a25a8bab)


### Was this patch authored or co-authored using generative AI tooling?
No
