### PR TITLE
[SPARK-52132][BUILD] Upgrade `arrow-java` to 18.3.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -15,11 +15,11 @@ antlr4-runtime/4.13.1//antlr4-runtime-4.13.1.jar
 aopalliance-repackaged/3.0.6//aopalliance-repackaged-3.0.6.jar
 arpack/3.0.3//arpack-3.0.3.jar
 arpack_combined_all/0.1//arpack_combined_all-0.1.jar
-arrow-format/18.2.0//arrow-format-18.2.0.jar
-arrow-memory-core/18.2.0//arrow-memory-core-18.2.0.jar
-arrow-memory-netty-buffer-patch/18.2.0//arrow-memory-netty-buffer-patch-18.2.0.jar
-arrow-memory-netty/18.2.0//arrow-memory-netty-18.2.0.jar
-arrow-vector/18.2.0//arrow-vector-18.2.0.jar
+arrow-format/18.3.0//arrow-format-18.3.0.jar
+arrow-memory-core/18.3.0//arrow-memory-core-18.3.0.jar
+arrow-memory-netty-buffer-patch/18.3.0//arrow-memory-netty-buffer-patch-18.3.0.jar
+arrow-memory-netty/18.3.0//arrow-memory-netty-18.3.0.jar
+arrow-vector/18.3.0//arrow-vector-18.3.0.jar
 audience-annotations/0.12.0//audience-annotations-0.12.0.jar
 avro-ipc/1.12.0//avro-ipc-1.12.0.jar
 avro-mapred/1.12.0//avro-mapred-1.12.0.jar
@@ -66,7 +66,7 @@ dropwizard-metrics-hadoop-metrics2-reporter/0.1.2//dropwizard-metrics-hadoop-met
 error_prone_annotations/2.36.0//error_prone_annotations-2.36.0.jar
 esdk-obs-java/3.20.4.2//esdk-obs-java-3.20.4.2.jar
 failureaccess/1.0.2//failureaccess-1.0.2.jar
-flatbuffers-java/24.3.25//flatbuffers-java-24.3.25.jar
+flatbuffers-java/25.2.10//flatbuffers-java-25.2.10.jar
 gcs-connector/hadoop3-2.2.26/shaded/gcs-connector-hadoop3-2.2.26-shaded.jar
 gmetric4j/1.0.10//gmetric4j-1.0.10.jar
 gson/2.11.0//gson-2.11.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
     ./python/pyspark/sql/pandas/utils.py, ./python/packaging/classic/setup.py,
     ./python/packaging/client/setup.py, and ./python/packaging/connect/setup.py too.
     -->
-    <arrow.version>18.2.0</arrow.version>
+    <arrow.version>18.3.0</arrow.version>
     <ammonite.version>3.0.1</ammonite.version>
     <jjwt.version>0.12.6</jjwt.version>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade `arrow-java` from 18.2.0 to 18.3.0.

### Why are the changes needed?
The new version bring some bug fixes, like:

- https://github.com/apache/arrow-java/pull/627
- https://github.com/apache/arrow-java/pull/654
- https://github.com/apache/arrow-java/pull/656
- https://github.com/apache/arrow-java/pull/693
- https://github.com/apache/arrow-java/pull/705
- https://github.com/apache/arrow-java/pull/707
- https://github.com/apache/arrow-java/pull/722

In addition, the new version introduces a cascading upgrade for flatbuffers-java([ from 24.3.25 to 25.1.24 ](https://github.com/apache/arrow-java/pull/600))

the full release note as follows:
- https://github.com/apache/arrow-java/releases/tag/v18.3.0


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Acitons



### Was this patch authored or co-authored using generative AI tooling?
No
