### PR TITLE
[SPARK-52130] [ML] [CONNECT] Refine error message, and hide internal spark config

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -827,23 +827,21 @@
       "CACHE_INVALID" : {
         "message" : [
           "Cannot retrieve Summary object <objectName> from the ML cache.",
-          "The Summary object is evicted if it hasn't been used a specified period of time.",
-          "You can configure the timeout by setting Spark cluster configure 'spark.connect.session.connectML.mlCache.memoryControl.offloadingTimeout'."
+          "Because the Summary object is evicted if you don't use it for more than <evictTimeoutInMinutes> minutes.",
+          "In this case, you can call `model.evaluate(dataset)` to create a new Summary object."
         ]
       },
       "ML_CACHE_SIZE_OVERFLOW_EXCEPTION" : {
         "message" : [
           "The model cache size in current session is about to exceed",
           "<mlCacheMaxSize> bytes.",
-          "Please delete existing cached model by executing 'del model' in python client before fitting new model or loading new model,",
-          "or increase Spark config 'spark.connect.session.connectML.mlCache.memoryControl.maxStorageSize'."
+          "Please delete existing cached model by executing 'del model' in python client before fitting new model or loading new model"
         ]
       },
       "MODEL_SIZE_OVERFLOW_EXCEPTION" : {
         "message" : [
           "The fitted or loaded model size is about <modelSize> bytes.",
-          "Please fit or load a model smaller than <modelMaxSize> bytes,",
-          "or increase Spark config 'spark.connect.session.connectML.mlCache.memoryControl.maxModelSize'."
+          "Please fit or load a model smaller than <modelMaxSize> bytes."
         ]
       },
       "UNSUPPORTED_EXCEPTION" : {

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
@@ -60,7 +60,7 @@ private[connect] class MLCache(sessionHolder: SessionHolder) extends Logging {
       Connect.CONNECT_SESSION_CONNECT_ML_CACHE_MEMORY_CONTROL_MAX_IN_MEMORY_SIZE) / 1024
   }
 
-  private def getOffloadingTimeoutMinute: Long = {
+  private[ml] def getOffloadingTimeoutMinute: Long = {
     sessionHolder.session.conf.get(
       Connect.CONNECT_SESSION_CONNECT_ML_CACHE_MEMORY_CONTROL_OFFLOADING_TIMEOUT)
   }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLException.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLException.scala
@@ -35,8 +35,8 @@ private[spark] case class MLCacheInvalidException(objectName: String, evictTimeo
     extends SparkException(
       errorClass = "CONNECT_ML.CACHE_INVALID",
       messageParameters = Map(
-            "objectName" -> objectName, "evictTimeoutInMinutes" -> evictTimeoutInMinutes.toString
-      ),
+        "objectName" -> objectName,
+        "evictTimeoutInMinutes" -> evictTimeoutInMinutes.toString),
       cause = null)
 
 private[spark] case class MLModelSizeOverflowException(modelSize: Long, modelMaxSize: Long)

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLException.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLException.scala
@@ -31,10 +31,12 @@ private[spark] case class MLAttributeNotAllowedException(className: String, attr
       messageParameters = Map("className" -> className, "attribute" -> attribute),
       cause = null)
 
-private[spark] case class MLCacheInvalidException(objectName: String)
+private[spark] case class MLCacheInvalidException(objectName: String, evictTimeoutInMinutes: Long)
     extends SparkException(
       errorClass = "CONNECT_ML.CACHE_INVALID",
-      messageParameters = Map("objectName" -> objectName),
+      messageParameters = Map(
+            "objectName" -> objectName, "evictTimeoutInMinutes" -> evictTimeoutInMinutes.toString
+      ),
       cause = null)
 
 private[spark] case class MLModelSizeOverflowException(modelSize: Long, modelMaxSize: Long)

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
@@ -46,7 +46,7 @@ private class AttributeHelper(
   protected def instance(): Object = {
     val obj = sessionHolder.mlCache.get(objRef)
     if (obj == null) {
-      throw MLCacheInvalidException(s"object $objRef")
+      throw MLCacheInvalidException(objRef, sessionHolder.mlCache.getOffloadingTimeoutMinute)
     }
     obj
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Refine error message, and hide internal spark config.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Refine error message, when the summary object is evicted, we need to give clear error message and hint for user.
Hide internal spark configs which are not user-facing.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Manually.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.