### PR TITLE
[SPARK-52145][PYTHON][TESTS] Add tests for mapInPandas schema mismatch

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_map.py
@@ -459,7 +459,7 @@ class MapInPandasTestsMixin:
         df = self.spark.range(2).mapInPandas(func, "id int")
         with self.assertRaisesRegex(
             PythonException,
-            "PySparkTypeError: Exception thrown when converting pandas.Series \\(object\\) "
+            "PySparkValueError: Exception thrown when converting pandas.Series \\(object\\) "
             "with name 'id' to Arrow Array \\(int32\\)\\.",
         ):
             df.collect()
@@ -470,12 +470,7 @@ class MapInPandasTestsMixin:
                 yield pd.DataFrame({"b": [1], "a": [2]})
 
         df = self.spark.range(1)
-        with self.assertRaisesRegex(
-            PythonException,
-            "PySparkTypeError: Exception thrown when converting pandas.Series \\(int64\\) "
-            "with name 'a' to Arrow Array \\(int32\\)\\.",
-        ):
-            df.mapInPandas(func, "a int, b int").collect()
+        self.assertEqual([Row(a=2, b=1)], df.mapInPandas(func, "a int, b int").collect())
 
 
 class MapInPandasTests(ReusedSQLTestCase, MapInPandasTestsMixin):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add tests for mapInPandas schema mismatch: type error and top-level column order


### Why are the changes needed?
To ensure mapInPandas raises consistent exceptions when the output DataFrame does not match the expected schema in type or column order

Part of https://issues.apache.org/jira/browse/SPARK-52093

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Test changes only.


### Was this patch authored or co-authored using generative AI tooling?
No
