### PR TITLE
[SPARK-52153][SQL] Fix from_json and to_json with variant

### DIFF
--- a/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
@@ -316,9 +316,15 @@ public final class Variant {
       case STRING:
         sb.append(escapeJson(VariantUtil.getString(value, pos)));
         break;
-      case DOUBLE:
-        sb.append(VariantUtil.getDouble(value, pos));
+      case DOUBLE: {
+        double d = VariantUtil.getDouble(value, pos);
+        if (Double.isFinite(d)) {
+          sb.append(d);
+        } else {
+          appendQuoted(sb, Double.toString(d));
+        }
         break;
+      }
       case DECIMAL:
         sb.append(VariantUtil.getDecimal(value, pos).toPlainString());
         break;
@@ -333,9 +339,15 @@ public final class Variant {
         appendQuoted(sb, TIMESTAMP_NTZ_FORMATTER.format(
             microsToInstant(VariantUtil.getLong(value, pos)).atZone(ZoneOffset.UTC)));
         break;
-      case FLOAT:
-        sb.append(VariantUtil.getFloat(value, pos));
+      case FLOAT: {
+        float f = VariantUtil.getFloat(value, pos);
+        if (Float.isFinite(f)) {
+          sb.append(f);
+        } else {
+          appendQuoted(sb, Float.toString(f));
+        }
         break;
+      }
       case BINARY:
         appendQuoted(sb, Base64.getEncoder().encodeToString(VariantUtil.getBinary(value, pos)));
         break;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/json/JsonExpressionEvalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/json/JsonExpressionEvalUtils.scala
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.core.json.JsonReadFeature
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{ExprUtils, GenericInternalRow}
-import org.apache.spark.sql.catalyst.expressions.variant.VariantExpressionEvalUtils
 import org.apache.spark.sql.catalyst.json.{CreateJacksonParser, JacksonGenerator, JacksonParser, JsonInferSchema, JSONOptions}
 import org.apache.spark.sql.catalyst.util.{ArrayData, FailFastMode, FailureSafeParser, MapData, PermissiveMode}
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -123,6 +122,8 @@ case class JsonToStructsEvaluator(
       (rows: Iterator[InternalRow]) => if (rows.hasNext) rows.next().getArray(0) else null
     case _: MapType =>
       (rows: Iterator[InternalRow]) => if (rows.hasNext) rows.next().getMap(0) else null
+    case _: VariantType =>
+      (rows: Iterator[InternalRow]) => if (rows.hasNext) rows.next().getVariant(0) else null
   }
 
   @transient
@@ -152,13 +153,7 @@ case class JsonToStructsEvaluator(
 
   final def evaluate(json: UTF8String): Any = {
     if (json == null) return null
-    nullableSchema match {
-      case _: VariantType =>
-        VariantExpressionEvalUtils.parseJson(json,
-          allowDuplicateKeys = variantAllowDuplicateKeys)
-      case _ =>
-        converter(parser.parse(json))
-    }
+    converter(parser.parse(json))
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -108,6 +108,9 @@ class JacksonParser(
    */
   private def makeRootConverter(dt: DataType): JsonParser => Iterable[InternalRow] = {
     dt match {
+      case _: VariantType => (parser: JsonParser) => {
+        Some(InternalRow(parseVariant(parser)))
+      }
       case _: StructType if options.singleVariantColumn.isDefined => (parser: JsonParser) => {
         Some(InternalRow(parseVariant(parser)))
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

It fixes two minor issues with `from_json(variant)` and `to_json(variant)`.
- `from_json(variant)` currently ignores any JSON options. This is inconsistent with `from_json(nested type containing variant)`, which respects JSON options.
- `to_json(variant)`, when the variant contains special floating-point values (Infinity, NaN), the output is currently not wrapped in quotes. This is inconsistent with `to_json(nested type containing floating points)`.
  - For example, the result of `to_json(named_struct('a', cast('NaN' as double)))` is `{"a":"NaN"}`, while the result of `to_json(to_variant_object(named_struct('a', cast('NaN' as double))))` is `{"a":NaN}`
  - Although `{"a":NaN}` can be parsed by `from_json` when the `allowNonNumericNumbers` option is true, it is still not a valid JSON according to the spec. `to_json` should produce valid JSON.

### Why are the changes needed?

This makes variant-related JSON handling more consistent with non-variant JSON handling.

### Does this PR introduce _any_ user-facing change?

Yes, as stated above.

### How was this patch tested?

Unit test.

### Was this patch authored or co-authored using generative AI tooling?

No.