### PR TITLE
[SPARK-52156][SQL] Put legacy CREATE TEMPORARY TABLE ... USING provider under the flag

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3522,6 +3522,11 @@
           "Cannot create a routine with both IF NOT EXISTS and REPLACE specified."
         ]
       },
+      "CREATE_TEMP_TABLE_USING_PROVIDER" : {
+        "message" : [
+          "CREATE TEMPORARY TABLE ... USING ... is a deprecated syntax. To overcome the issue, please use CREATE TEMPORARY VIEW instead."
+        ]
+      },
       "CREATE_TEMP_FUNC_WITH_DATABASE" : {
         "message" : [
           "CREATE TEMPORARY FUNCTION with specifying a database(<database>) is not allowed."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3522,11 +3522,6 @@
           "Cannot create a routine with both IF NOT EXISTS and REPLACE specified."
         ]
       },
-      "CREATE_TEMP_TABLE_USING_PROVIDER" : {
-        "message" : [
-          "CREATE TEMPORARY TABLE ... USING ... is a deprecated syntax. To overcome the issue, please use CREATE TEMPORARY VIEW instead."
-        ]
-      },
       "CREATE_TEMP_FUNC_WITH_DATABASE" : {
         "message" : [
           "CREATE TEMPORARY FUNCTION with specifying a database(<database>) is not allowed."
@@ -3535,6 +3530,11 @@
       "CREATE_TEMP_FUNC_WITH_IF_NOT_EXISTS" : {
         "message" : [
           "CREATE TEMPORARY FUNCTION with IF NOT EXISTS is not allowed."
+        ]
+      },
+      "CREATE_TEMP_TABLE_USING_PROVIDER" : {
+        "message" : [
+          "CREATE TEMPORARY TABLE ... USING ... is a deprecated syntax. To overcome the issue, please use CREATE TEMPORARY VIEW instead."
         ]
       },
       "EMPTY_PARTITION_VALUE" : {

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -654,6 +654,10 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
       ctx)
   }
 
+  def createTempTableUsingProviderError(ctx: CreateTableContext): Throwable = {
+    new ParseException(errorClass = "INVALID_SQL_SYNTAX.CREATE_TEMP_TABLE_USING_PROVIDER", ctx)
+  }
+
   def createFuncWithGeneratedColumnsError(ctx: ParserRuleContext): Throwable = {
     new ParseException(
       errorClass = "INVALID_SQL_SYNTAX.CREATE_FUNC_WITH_GENERATED_COLUMNS_AS_PARAMETERS",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -250,8 +250,8 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
-  val BLOCK_CREATE_TEMP_TABLE_WITH_PROVIDER =
-    buildConf("spark.sql.blockCreateTempTableWithProvider")
+  val BLOCK_CREATE_TEMP_TABLE_USING_PROVIDER =
+    buildConf("spark.sql.blockCreateTempTableUsingProvider")
       .doc("If enabled, we fail CREATE TEMPORARY TABLE ... USING provider during parsing.")
       .internal()
       .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -251,9 +251,10 @@ object SQLConf {
     .createWithDefault(true)
 
   val BLOCK_CREATE_TEMP_TABLE_USING_PROVIDER =
-    buildConf("spark.sql.blockCreateTempTableUsingProvider")
-      .doc("If enabled, we fail CREATE TEMPORARY TABLE ... USING provider during parsing.")
+    buildConf("spark.sql.legacy.blockCreateTempTableUsingProvider")
+      .doc("If enabled, we fail legacy CREATE TEMPORARY TABLE ... USING provider during parsing.")
       .internal()
+      .version("4.1.0")
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -250,6 +250,13 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val BLOCK_CREATE_TEMP_TABLE_WITH_PROVIDER =
+    buildConf("spark.sql.blockCreateTempTableWithProvider")
+      .doc("If enabled, we fail CREATE TEMPORARY TABLE ... USING provider during parsing.")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   val ANALYZER_MAX_ITERATIONS = buildConf("spark.sql.analyzer.maxIterations")
     .internal()
     .doc("The max number of iterations the analyzer runs.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -361,6 +361,11 @@ class SparkSqlAstBuilder extends AstBuilder {
         invalidStatement("CREATE TEMPORARY TABLE IF NOT EXISTS", ctx)
       }
 
+      if (ctx.tableProvider != null
+        && conf.getConf(SQLConf.BLOCK_CREATE_TEMP_TABLE_WITH_PROVIDER)) {
+        throw invalidStatement("CREATE TEMPORARY TABLE ... USING", ctx)
+      }
+
       val (_, _, _, _, options, location, _, _, _, _) =
         visitCreateTableClauses(ctx.createTableClauses())
       val provider = Option(ctx.tableProvider).map(_.multipartIdentifier.getText).getOrElse(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
@@ -814,14 +814,14 @@ class SparkSqlParserSuite extends AnalysisTest with SharedSparkSession {
   }
 
   test("CREATE TEMPORARY TABLE ... USING provider should be blocked under the flag") {
-    withSQLConf((SQLConf.BLOCK_CREATE_TEMP_TABLE_WITH_PROVIDER.key, "true")) {
+    withSQLConf((SQLConf.BLOCK_CREATE_TEMP_TABLE_USING_PROVIDER.key, "true")) {
       checkError(
         exception = intercept[ParseException](
           sql("CREATE TEMPORARY TABLE t (i int) USING parquet")
         ),
-        condition = s"INVALID_STATEMENT_OR_CLAUSE",
-        sqlState = Option.empty[String],
-        parameters = Map("operation" -> "CREATE TEMPORARY TABLE ... USING"),
+        condition = s"INVALID_SQL_SYNTAX.CREATE_TEMP_TABLE_USING_PROVIDER",
+        sqlState = Some("42000"),
+        parameters = Map(),
         context = ExpectedContext(
           fragment = "CREATE TEMPORARY TABLE t (i int) USING parquet",
           start = 0,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
@@ -813,6 +813,24 @@ class SparkSqlParserSuite extends AnalysisTest with SharedSparkSession {
         stop = 63))
   }
 
+  test("CREATE TEMPORARY TABLE ... USING provider should be blocked under the flag") {
+    withSQLConf((SQLConf.BLOCK_CREATE_TEMP_TABLE_WITH_PROVIDER.key, "true")) {
+      checkError(
+        exception = intercept[ParseException](
+          sql("CREATE TEMPORARY TABLE t (i int) USING parquet")
+        ),
+        condition = s"INVALID_STATEMENT_OR_CLAUSE",
+        sqlState = Option.empty[String],
+        parameters = Map("operation" -> "CREATE TEMPORARY TABLE ... USING"),
+        context = ExpectedContext(
+          fragment = "CREATE TEMPORARY TABLE t (i int) USING parquet",
+          start = 0,
+          stop = 45
+        )
+      )
+    }
+  }
+
   test("verify whitespace handling - standard whitespace") {
     parser.parsePlan("SELECT 1") // ASCII space
     parser.parsePlan("SELECT\r1") // ASCII carriage return


### PR DESCRIPTION
### What changes were proposed in this pull request?
Blocking legacy feature of CREATE TEMPORARY TABLE ... USING under the flag. The default keeps it enabled.


### Why are the changes needed?
CREATE TEMPORARY TABLE ... USING provider uses legacy path which creates views with LogicalPlan for storage instead of sqlText. This could pose a problem for systems that rely on sqlText being present and we want to provide users with the option to disable it.


### Does this PR introduce _any_ user-facing change?
No, just a guard for a legacy feature.


### How was this patch tested?
Test added to the relevant suite.


### Was this patch authored or co-authored using generative AI tooling?
No.
