### PR TITLE
[SPARK-52174][CORE] Enable `spark.checkpoint.compress` by default

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1358,7 +1358,7 @@ package object config {
         "spark.io.compression.codec.")
       .version("2.2.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   private[spark] val CACHE_CHECKPOINT_PREFERRED_LOCS_EXPIRE_TIME =
     ConfigBuilder("spark.rdd.checkpoint.cachePreferredLocsExpireTime")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1840,7 +1840,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.checkpoint.compress</code></td>
-  <td>false</td>
+  <td>true</td>
   <td>
     Whether to compress RDD checkpoints. Generally a good idea.
     Compression will use <code>spark.io.compression.codec</code>.

--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -25,6 +25,7 @@ license: |
 ## Upgrading from Core 4.0 to 4.1
 
 - Since Spark 4.1, Spark Master deamon provides REST API by default. To restore the behavior before Spark 4.1, you can set `spark.master.rest.enabled` to `false`.
+- Since Spark 4.1, Spark will compress RDD checkpoints by default. To restore the behavior before Spark 4.1, you can set `spark.checkpoint.compress` to `false`.
 
 ## Upgrading from Core 3.5 to 4.0
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `spark.checkpoint.compress` by default at Apache Spark 4.1.0.

### Why are the changes needed?

Apache Spark 4.0.0 added `spark.checkpoint.dir` configuration officially.

https://github.com/apache/spark/blob/781031cd716039e7e3034e462e3292f79c000ff6/core/src/main/scala/org/apache/spark/internal/config/package.scala#L1354-L1361

In line with that, `spark.checkpoint.compress` was introduced at Apache Spark 2.2.0 and has been serving well. It would be great if can enable this by default to save the space for checkpointing location.

https://github.com/apache/spark/blob/781031cd716039e7e3034e462e3292f79c000ff6/core/src/main/scala/org/apache/spark/internal/config/package.scala#L1363-L1369

### Does this PR introduce _any_ user-facing change?

Yes only for the users who use RDD checkpoints.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.