### PR TITLE
[SPARK-52178][BUILD] Make release scripts to respect SKIP_TAG and ANSWER when already set with DEBUG_MODE

### DIFF
--- a/dev/create-release/do-release-docker.sh
+++ b/dev/create-release/do-release-docker.sh
@@ -71,7 +71,9 @@ if [ -z "$WORKDIR" ] || [ ! -d "$WORKDIR" ]; then
 fi
 
 if [ -d "$WORKDIR/output" ]; then
-  read -p "Output directory already exists. Overwrite and continue? [y/n] " ANSWER
+  if [ -z "$ANSWER" ]; then
+    read -p "Output directory already exists. Overwrite and continue? [y/n] " ANSWER
+  fi
   if [ "$ANSWER" != "y" ]; then
     error "Exiting."
   fi
@@ -79,7 +81,9 @@ fi
 
 if [ ! -z "$RELEASE_STEP" ] && [ "$RELEASE_STEP" = "finalize" ]; then
   echo "THIS STEP IS IRREVERSIBLE! Make sure the vote has passed and you pick the right RC to finalize."
-  read -p "You must be a PMC member to run this step. Continue? [y/n] " ANSWER
+  if [ -z "$ANSWER" ]; then
+    read -p "You must be a PMC member to run this step. Continue? [y/n] " ANSWER
+  fi
   if [ "$ANSWER" != "y" ]; then
     error "Exiting."
   fi
@@ -146,6 +150,7 @@ PYPI_API_TOKEN=$PYPI_API_TOKEN
 GPG_PASSPHRASE=$GPG_PASSPHRASE
 RELEASE_STEP=$RELEASE_STEP
 USER=$USER
+DEBUG_MODE=$DEBUG_MODE
 EOF
 
 JAVA_VOL=


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes:
- Respect `SKIP_TAG` and `ANSWER` if they are already set in the release scripts.
- Add `DEBUG_MODE` which fails fast and print out the commands that this script runs

### Why are the changes needed?

In order to make the release easier without interactions in the middle of builds.
Also this is a part of release automation in https://github.com/apache/spark/pull/50884.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Tested in https://github.com/HyukjinKwon/spark/actions/runs/15059178395/job/42330938218

### Was this patch authored or co-authored using generative AI tooling?

No.
