### PR TITLE
[SPARK-52186][SQL] Rewrite EXISTS to add Scalar Project

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -318,6 +318,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
       EliminateSQLFunctionNode,
       ReplaceExpressions,
       RewriteNonCorrelatedExists,
+      RewriteExistsAsScalarProject,
       PullOutGroupingExpressions,
       // Put `InsertMapSortInGroupingExpressions` after `PullOutGroupingExpressions`,
       // so the grouping keys can only be attribute and literal which makes

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/explain.txt
@@ -82,15 +82,15 @@ ReadSchema: struct<cs_warehouse_sk:int,cs_order_number:int>
 Input [3]: [cs_warehouse_sk#15, cs_order_number#16, cs_sold_date_sk#17]
 
 (9) Project [codegen id : 3]
-Output [2]: [cs_warehouse_sk#15, cs_order_number#16]
+Output [2]: [cs_order_number#16, cs_warehouse_sk#15]
 Input [3]: [cs_warehouse_sk#15, cs_order_number#16, cs_sold_date_sk#17]
 
 (10) Exchange
-Input [2]: [cs_warehouse_sk#15, cs_order_number#16]
+Input [2]: [cs_order_number#16, cs_warehouse_sk#15]
 Arguments: hashpartitioning(cs_order_number#16, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (11) Sort [codegen id : 4]
-Input [2]: [cs_warehouse_sk#15, cs_order_number#16]
+Input [2]: [cs_order_number#16, cs_warehouse_sk#15]
 Arguments: [cs_order_number#16 ASC NULLS FIRST], false, 0
 
 (12) SortMergeJoin [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/simplified.txt
@@ -64,7 +64,7 @@ WholeStageCodegen (12)
                                             InputAdapter
                                               Exchange [cs_order_number] #6
                                                 WholeStageCodegen (3)
-                                                  Project [cs_warehouse_sk,cs_order_number]
+                                                  Project [cs_order_number,cs_warehouse_sk]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.catalog_sales [cs_warehouse_sk,cs_order_number,cs_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16/explain.txt
@@ -82,15 +82,15 @@ ReadSchema: struct<cs_warehouse_sk:int,cs_order_number:int>
 Input [3]: [cs_warehouse_sk#9, cs_order_number#10, cs_sold_date_sk#11]
 
 (9) Project [codegen id : 3]
-Output [2]: [cs_warehouse_sk#9, cs_order_number#10]
+Output [2]: [cs_order_number#10, cs_warehouse_sk#9]
 Input [3]: [cs_warehouse_sk#9, cs_order_number#10, cs_sold_date_sk#11]
 
 (10) Exchange
-Input [2]: [cs_warehouse_sk#9, cs_order_number#10]
+Input [2]: [cs_order_number#10, cs_warehouse_sk#9]
 Arguments: hashpartitioning(cs_order_number#10, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (11) Sort [codegen id : 4]
-Input [2]: [cs_warehouse_sk#9, cs_order_number#10]
+Input [2]: [cs_order_number#10, cs_warehouse_sk#9]
 Arguments: [cs_order_number#10 ASC NULLS FIRST], false, 0
 
 (12) SortMergeJoin [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16/simplified.txt
@@ -34,7 +34,7 @@ WholeStageCodegen (12)
                                             InputAdapter
                                               Exchange [cs_order_number] #3
                                                 WholeStageCodegen (3)
-                                                  Project [cs_warehouse_sk,cs_order_number]
+                                                  Project [cs_order_number,cs_warehouse_sk]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.catalog_sales [cs_warehouse_sk,cs_order_number,cs_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/explain.txt
@@ -82,15 +82,15 @@ ReadSchema: struct<ws_warehouse_sk:int,ws_order_number:int>
 Input [3]: [ws_warehouse_sk#15, ws_order_number#16, ws_sold_date_sk#17]
 
 (9) Project [codegen id : 3]
-Output [2]: [ws_warehouse_sk#15, ws_order_number#16]
+Output [2]: [ws_order_number#16, ws_warehouse_sk#15]
 Input [3]: [ws_warehouse_sk#15, ws_order_number#16, ws_sold_date_sk#17]
 
 (10) Exchange
-Input [2]: [ws_warehouse_sk#15, ws_order_number#16]
+Input [2]: [ws_order_number#16, ws_warehouse_sk#15]
 Arguments: hashpartitioning(ws_order_number#16, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (11) Sort [codegen id : 4]
-Input [2]: [ws_warehouse_sk#15, ws_order_number#16]
+Input [2]: [ws_order_number#16, ws_warehouse_sk#15]
 Arguments: [ws_order_number#16 ASC NULLS FIRST], false, 0
 
 (12) SortMergeJoin [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/simplified.txt
@@ -64,7 +64,7 @@ WholeStageCodegen (12)
                                             InputAdapter
                                               Exchange [ws_order_number] #6
                                                 WholeStageCodegen (3)
-                                                  Project [ws_warehouse_sk,ws_order_number]
+                                                  Project [ws_order_number,ws_warehouse_sk]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.web_sales [ws_warehouse_sk,ws_order_number,ws_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94/explain.txt
@@ -82,15 +82,15 @@ ReadSchema: struct<ws_warehouse_sk:int,ws_order_number:int>
 Input [3]: [ws_warehouse_sk#9, ws_order_number#10, ws_sold_date_sk#11]
 
 (9) Project [codegen id : 3]
-Output [2]: [ws_warehouse_sk#9, ws_order_number#10]
+Output [2]: [ws_order_number#10, ws_warehouse_sk#9]
 Input [3]: [ws_warehouse_sk#9, ws_order_number#10, ws_sold_date_sk#11]
 
 (10) Exchange
-Input [2]: [ws_warehouse_sk#9, ws_order_number#10]
+Input [2]: [ws_order_number#10, ws_warehouse_sk#9]
 Arguments: hashpartitioning(ws_order_number#10, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (11) Sort [codegen id : 4]
-Input [2]: [ws_warehouse_sk#9, ws_order_number#10]
+Input [2]: [ws_order_number#10, ws_warehouse_sk#9]
 Arguments: [ws_order_number#10 ASC NULLS FIRST], false, 0
 
 (12) SortMergeJoin [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94/simplified.txt
@@ -34,7 +34,7 @@ WholeStageCodegen (12)
                                             InputAdapter
                                               Exchange [ws_order_number] #3
                                                 WholeStageCodegen (3)
-                                                  Project [ws_warehouse_sk,ws_order_number]
+                                                  Project [ws_order_number,ws_warehouse_sk]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.web_sales [ws_warehouse_sk,ws_order_number,ws_sold_date_sk]

--- a/sql/core/src/test/scala/org/apache/spark/sql/RewriteExistsAsScalarProjectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RewriteExistsAsScalarProjectSuite.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class RewriteExistsAsScalarProjectSuite extends QueryTest with SharedSparkSession {
+  test("SPARK-50873: Prune column after RewriteSubquery for DSV2") {
+    import org.apache.spark.sql.functions._
+    withTempPath { dir =>
+      spark.range(10)
+        .withColumn("userid", col("id") + 1)
+        .withColumn("price", col("id") + 2)
+        .write
+        .mode("overwrite")
+        .parquet(dir.getCanonicalPath + "/sales")
+      spark.range(5)
+        .withColumn("age", col("id") + 1)
+        .withColumn("address", col("id") + 2)
+        .write.mode("overwrite").parquet(dir.getCanonicalPath + "/customer")
+      withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key-> "") {
+        spark.read.parquet(dir.getCanonicalPath + "/sales").createOrReplaceTempView("sales")
+        spark.read.parquet(dir.getCanonicalPath + "/customer").createOrReplaceTempView("customer")
+
+        val df = sql(
+          """
+            |select * from sales
+            |where exists (select * from customer where sales.userid == customer.id)
+            |""".stripMargin)
+
+        withClue(df.queryExecution) {
+          val plan = df.queryExecution.optimizedPlan
+          val allRelationV2 = plan.collectWithSubqueries { case b: DataSourceV2ScanRelation => b }
+          val customerRelation = allRelationV2.find(_.relation.name.endsWith("customer"))
+          assert(customerRelation.isDefined, "Customer relation not found in the plan")
+
+          val columns = customerRelation.get.output
+          val columnNames = columns.map(_.name)
+          assert(columnNames == Seq("id"),
+            s"Expected only 'id' column in customer relation, " +
+              s"but found: ${columnNames.mkString(", ")}")
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR offers an optimize rule for Optimizer to rewrite EXISTS to add a Scalar Project on the plan top. 
Since EXISTS only returns True or False, it doesn't matter what is SELECTED. Therefore, an optimization rule can be added to check whether the EXISTS clause contains Project 1, If not, add a Project 1 on the EXISTS. 


### Why are the changes needed?
Prune unnecessary column for spark DSV2. 
For example,  it will prune t1.col2 in EXISTS when generate physical plan.
`  
test("Test exist join with v2 source plan") {
    import org.apache.spark.sql.functions._
    withTempPath { dir =>
      spark.range(100)
        .withColumn("col1", col("id") + 1)
        .withColumn("col2", col("id") + 2)
        .write
        .mode("overwrite")
        .parquet(dir.getCanonicalPath + "/t1")
      spark.range(10).write.mode("overwrite").parquet(dir.getCanonicalPath + "/t2")
      Seq("parquet", "").foreach { v1SourceList =>
        withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key-> v1SourceList) {
          spark.read.parquet(dir.getCanonicalPath + "/t1").createOrReplaceTempView("t1")
          spark.read.parquet(dir.getCanonicalPath + "/t2").createOrReplaceTempView("t2")
          spark.sql(
            """
              |select t2.id
              |from t2
              |where exists(select col2 from t1 where t1.id == t2.id  and t1.col1>5)
              |""".stripMargin).explain()
        }
      }
    }
  }
`





### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
Github Actions.



### Was this patch authored or co-authored using generative AI tooling?
NO
