### PR TITLE
[SPARK-52195][PYTHON][SS] Fix initial state column dropping issue for Python TWS

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
@@ -760,6 +760,7 @@ class TransformWithStateTestsMixin:
         time_mode="None",
         checkpoint_path=None,
         initial_state=None,
+        with_extra_transformation=False,
     ):
         input_path = tempfile.mkdtemp()
         if checkpoint_path is None:
@@ -798,6 +799,15 @@ class TransformWithStateTestsMixin:
                 initialState=initial_state,
             )
 
+        if with_extra_transformation:
+            from pyspark.sql import functions as fn
+            import json
+
+            tws_df = tws_df.select(
+                fn.col("id").cast("string").alias("key"),
+                fn.to_json(fn.struct(fn.col("value"))).alias("value"),
+            )
+
         q = (
             tws_df.writeStream.queryName("this_query")
             .option("checkpointLocation", checkpoint_path)
@@ -833,6 +843,31 @@ class TransformWithStateTestsMixin:
 
         self._test_transform_with_state_init_state(
             SimpleStatefulProcessorWithInitialStateFactory(), check_results
+        )
+
+    def test_transform_with_state_init_state_with_extra_transformation(self):
+        def check_results(batch_df, batch_id):
+            if batch_id == 0:
+                # for key 0, initial state was processed and it was only processed once;
+                # for key 1, it did not appear in the initial state df;
+                # for key 3, it did not appear in the first batch of input keys
+                # so it won't be emitted
+                assert set(batch_df.sort("key").collect()) == {
+                    Row(key="0", value=f'{{"value":"{789 + 123 + 46}"}}'),
+                    Row(key="1", value=f'{{"value":"{146 + 346}"}}'),
+                }
+            else:
+                # for key 0, verify initial state was only processed once in the first batch;
+                # for key 3, verify init state was processed and reflected in the accumulated value
+                assert set(batch_df.sort("key").collect()) == {
+                    Row(key="0", value=f'{{"value":"{789 + 123 + 46 + 67}"}}'),
+                    Row(key="3", value=f'{{"value":"{987 + 12}"}}'),
+                }
+
+        self._test_transform_with_state_init_state(
+            SimpleStatefulProcessorWithInitialStateFactory(),
+            check_results,
+            with_extra_transformation=True,
         )
 
     def _test_transform_with_state_non_contiguous_grouping_cols(

--- a/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
@@ -801,7 +801,6 @@ class TransformWithStateTestsMixin:
 
         if with_extra_transformation:
             from pyspark.sql import functions as fn
-            import json
 
             tws_df = tws_df.select(
                 fn.col("id").cast("string").alias("key"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
@@ -226,7 +226,8 @@ case class TransformWithStateInPySpark(
     }
   }
 
-  def rightReferences: Seq[Attribute] = {
+  // Include the initial state columns in the references to avoid being column pruned.
+  private def rightReferences: Seq[Attribute] = {
     assert(resolved, "This method is expected to be called after resolution.")
     if (hasInitialState) {
       right.output

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
@@ -204,8 +204,7 @@ case class TransformWithStateInPySpark(
   override def producedAttributes: AttributeSet = AttributeSet(outputAttrs)
 
   override lazy val references: AttributeSet =
-    AttributeSet(leftAttributes ++ rightAttributes(true) ++ functionExpr.references) --
-      producedAttributes
+    AttributeSet(leftAttributes ++ rightReferences ++ functionExpr.references) -- producedAttributes
 
   override protected def withNewChildrenInternal(
       newLeft: LogicalPlan, newRight: LogicalPlan): TransformWithStateInPySpark =
@@ -216,15 +215,21 @@ case class TransformWithStateInPySpark(
     left.output.take(groupingAttributesLen)
   }
 
-  def rightAttributes(includesInitialStateColumns: Boolean = false): Seq[Attribute] = {
+  def rightAttributes: Seq[Attribute] = {
     assert(resolved, "This method is expected to be called after resolution.")
     if (hasInitialState) {
-      if (includesInitialStateColumns) {
-        // Include the initial state columns in the references to avoid being column pruned.
-        right.output
-      } else {
-        right.output.take(initGroupingAttrsLen)
-      }
+      right.output.take(initGroupingAttrsLen)
+    } else {
+      // Dummy variables for passing the distribution & ordering check
+      // in physical operators.
+      left.output.take(groupingAttributesLen)
+    }
+  }
+
+  def rightReferences: Seq[Attribute] = {
+    assert(resolved, "This method is expected to be called after resolution.")
+    if (hasInitialState) {
+      right.output
     } else {
       // Dummy variables for passing the distribution & ordering check
       // in physical operators.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -811,7 +811,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
           isStreaming = true,
           hasInitialState,
           planLater(initialState),
-          t.rightAttributes,
+          t.rightAttributes(),
           initialStateSchema
         )
 
@@ -982,7 +982,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         hasInitialState, initialState, _, initialStateSchema) =>
         TransformWithStateInPySparkExec.generateSparkPlanForBatchQueries(func,
           t.leftAttributes, outputAttrs, outputMode, timeMode, userFacingDataType,
-          planLater(child), hasInitialState, planLater(initialState), t.rightAttributes,
+          planLater(child), hasInitialState, planLater(initialState), t.rightAttributes(),
           initialStateSchema) :: Nil
 
       case _: FlatMapGroupsInPandasWithState =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -811,7 +811,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
           isStreaming = true,
           hasInitialState,
           planLater(initialState),
-          t.rightAttributes(),
+          t.rightAttributes,
           initialStateSchema
         )
 
@@ -982,7 +982,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         hasInitialState, initialState, _, initialStateSchema) =>
         TransformWithStateInPySparkExec.generateSparkPlanForBatchQueries(func,
           t.leftAttributes, outputAttrs, outputMode, timeMode, userFacingDataType,
-          planLater(child), hasInitialState, planLater(initialState), t.rightAttributes(),
+          planLater(child), hasInitialState, planLater(initialState), t.rightAttributes,
           initialStateSchema) :: Nil
 
       case _: FlatMapGroupsInPandasWithState =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix initial state column dropping issue for Python TWS. This may occur when user adds extra transformations after `TransformWithStateInPandas` operator and those initial state columns will get pruned during optimization.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This prevents users to use initial state with `TransformWithStateInPandas` if they require extra transformations.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added unit test case.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.