### PR TITLE
[SPARK-52211][CONNECT] Strip `$` suffix from `SparkConnectServer` INFO log

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -409,7 +409,8 @@ object SparkConnectService extends Logging {
     }
 
     val maxRetries: Int = SparkEnv.get.conf.get(CONNECT_GRPC_PORT_MAX_RETRIES)
-    Utils.startServiceOnPort[Server](startPort, startServiceFn, maxRetries, getClass.getName)
+    Utils.startServiceOnPort[Server](
+      startPort, startServiceFn, maxRetries, getClass.getName.stripSuffix("$"))
   }
 
   // Starts the service

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -410,7 +410,10 @@ object SparkConnectService extends Logging {
 
     val maxRetries: Int = SparkEnv.get.conf.get(CONNECT_GRPC_PORT_MAX_RETRIES)
     Utils.startServiceOnPort[Server](
-      startPort, startServiceFn, maxRetries, getClass.getName.stripSuffix("$"))
+      startPort,
+      startServiceFn,
+      maxRetries,
+      getClass.getName.stripSuffix("$"))
   }
 
   // Starts the service


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a trivial improvement to strip `$` suffix from `SparkConnectServer` INFO log.

### Why are the changes needed?

**BEFORE (Apache Spark 4.0.0 RC6)**

```
25/05/18 14:19:52 INFO Utils: Successfully started service 
'org.apache.spark.sql.connect.service.SparkConnectService$' on port 15002.
```

**AFTER**

```
25/05/18 14:15:31 INFO Utils: Successfully started service 
'org.apache.spark.sql.connect.service.SparkConnectService' on port 15002.
```

### Does this PR introduce _any_ user-facing change?

No, this is a log message improvement.

### How was this patch tested?

Manual review.

```
$ sbin/start-connect-server.sh --wait
```

### Was this patch authored or co-authored using generative AI tooling?

No.
