### PR TITLE
[SPARK-52032][SQL] Fix orc filter pushdown with null-safe equality operator

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilters.scala
@@ -202,6 +202,10 @@ private[sql] object OrcFilters extends OrcFiltersBase {
         val rhs = buildSearchArgument(dataTypeMap, right, lhs)
         rhs.end()
 
+      case Not(EqualNullSafe(name, value)) if dataTypeMap.contains(name) =>
+        val orFilter = Or(IsNull(name), Not(EqualTo(name, value)))
+        buildSearchArgument(dataTypeMap, orFilter, builder)
+
       case Not(child) =>
         buildSearchArgument(dataTypeMap, child, builder.startNot()).end()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
@@ -826,43 +826,22 @@ class OrcFilterSuite extends OrcTest with SharedSparkSession {
       )
       val df = spark.createDataFrame(data).toDF("id", "name", "email")
 
-      // Write data in both ORC and Parquet formats
+      // Write data in ORC format
       val orcPath = s"${dir.getCanonicalPath}/orc"
-      val parquetPath = s"${dir.getCanonicalPath}/parquet"
-
       df.write.mode("overwrite").orc(orcPath)
-      df.write.mode("overwrite").parquet(parquetPath)
 
-      // Read data back
-      val orcDf = spark.read.orc(orcPath)
-      val parquetDf = spark.read.parquet(parquetPath)
+      // Read data back and check for both enabled/disabled filter-pushdown
+      Seq(true, false).foreach { filterPushdown =>
+        withSQLConf("spark.sql.orc.filterPushdown" -> filterPushdown.toString) {
+          // Apply filter with null-safe equality operator
+          val df = spark.read.orc(orcPath).filter(!(col("name") <=> "dummy"))
 
-      // Apply filter with null-safe equality operator
-      val filteredOrcDf = orcDf.filter(!(col("name") <=> "dummy"))
-      val filteredParquetDf = parquetDf.filter(!(col("name") <=> "dummy"))
-
-      // Check results
-      // Both ORC and Parquet should correctly include both rows
-      checkAnswer(filteredOrcDf, Seq(
-        Row(1, "John", "john@example.com"),
-        Row(3, null, "bob@example.com")
-      ))
-
-      // Parquet should also correctly include both rows
-      checkAnswer(filteredParquetDf, Seq(
-        Row(1, "John", "john@example.com"),
-        Row(3, null, "bob@example.com")
-      ))
-
-      // Verify that disabling ORC filter pushdown fixes the issue
-      withSQLConf("spark.sql.orc.filterPushdown" -> "false") {
-        val orcDfNoPushdown = spark.read.orc(orcPath)
-        val filteredOrcDfNoPushdown = orcDfNoPushdown.filter(!(col("name") <=> "dummy"))
-
-        checkAnswer(filteredOrcDfNoPushdown, Seq(
-          Row(1, "John", "john@example.com"),
-          Row(3, null, "bob@example.com")
-        ))
+          // Check results
+          checkAnswer(df, Seq(
+            Row(1, "John", "john@example.com"),
+            Row(3, null, "bob@example.com")
+          ))
+        }
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Background：As stated in [SPARK-52032](https://issues.apache.org/jira/browse/SPARK-52032): When applying a filter using `eqNullSafe` (`<=>`, null-safe equality operator) to a DataFrame created from an ORC file, rows containing null values are incorrectly excluded, even though they should be retained.

Changes：1. Added a UT in OrcFilterSuite to reproduce the issue, 2. fix the logic in OrcFilter.

### Why are the changes needed?

As stated above, it's an unexpected issue

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

UT


### Was this patch authored or co-authored using generative AI tooling?

No