### PR TITLE
[SPARK-52217] [SQL] Skip outer reference validation under Filter in single-pass resolver

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/SubqueryExpressionResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/SubqueryExpressionResolver.scala
@@ -195,6 +195,10 @@ class SubqueryExpressionResolver(expressionResolver: ExpressionResolver, resolve
    * logic is too sophisticated.
    */
   private def validateSubqueryExpression(subqueryExpression: SubqueryExpression): Unit = {
-    ValidateSubqueryExpression(traversals.current.parentOperator, subqueryExpression)
+    ValidateSubqueryExpression(
+      plan = traversals.current.parentOperator,
+      expr = subqueryExpression,
+      skipOuterReferenceValidationInFilter = true
+    )
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Validation for outer references in subquery expressions is done in the bottom up manner in single-pass resolver. In other words, we do the validation right after we resolve the subquery expression and at that moment missing attributes haven't been pushed down yet.
Because of that, we fail with `UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.MUST_AGGREGATE_CORRELATED_SCALAR_SUBQUERY`. With the validation disabled, we fail with `UNRESOLVED_COLUMN.WITH_SUGGESTION` on the unhappy path and pass on the happy path which was intended.

### Why are the changes needed?
To fix the single-pass analyzer.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.