### PR TITLE
[SPARK-52079][SQL][Followup] Normalize internal projections under Aggregate as well

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/NormalizePlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/NormalizePlan.scala
@@ -154,11 +154,17 @@ object NormalizePlan extends PredicateHelper {
             .getTagValue(DeduplicateRelations.PROJECT_FOR_EXPRESSION_ID_DEDUPLICATION)
             .isDefined =>
         project.child
+      case aggregate @ Aggregate(_, _, innerProject: Project, _) =>
+        val newInnerProject = Project(
+          innerProject.projectList.sortBy(_.name),
+          innerProject.child
+        )
+        aggregate.copy(child = newInnerProject)
       case Project(outerProjectList, innerProject: Project) =>
-        val normalizedInnerProjectList = normalizeProjectList(innerProject.projectList)
-        val orderedInnerProjectList = normalizedInnerProjectList.sortBy(_.name)
-        val newInnerProject =
-          Project(orderedInnerProjectList, innerProject.child)
+        val newInnerProject = Project(
+          innerProject.projectList.sortBy(_.name),
+          innerProject.child
+        )
         Project(normalizeProjectList(outerProjectList), newInnerProject)
       case Project(projectList, child) =>
         Project(normalizeProjectList(projectList), child)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
@@ -48,11 +48,21 @@ class NormalizePlanSuite extends SparkFunSuite with SQLConfHelper {
     assert(NormalizePlan(baselinePlan) == NormalizePlan(testPlan))
   }
 
-  test("Normalize ordering in a project list of an inner Project") {
+  test("Normalize ordering in a project list of an inner Project of Project") {
     val baselinePlan =
       LocalRelation($"col1".int, $"col2".string).select($"col1", $"col2").select($"col1")
     val testPlan =
       LocalRelation($"col1".int, $"col2".string).select($"col2", $"col1").select($"col1")
+
+    assert(baselinePlan != testPlan)
+    assert(NormalizePlan(baselinePlan) == NormalizePlan(testPlan))
+  }
+
+  test("Normalize ordering in a project list of an inner Project of Aggregate") {
+    val baselinePlan =
+      LocalRelation($"col1".int, $"col2".string).select($"col1", $"col2").groupBy($"col1")($"col1")
+    val testPlan =
+      LocalRelation($"col1".int, $"col2".string).select($"col2", $"col1").groupBy($"col1")($"col1")
 
     assert(baselinePlan != testPlan)
     assert(NormalizePlan(baselinePlan) == NormalizePlan(testPlan))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Normalize internal projections under `Aggregate` as well, same as for `Project`.

I removed extra `normalizeProjectList` call because we already do that while transforming the tree upwards.

### Why are the changes needed?

We need to make sure that single-pass and fixed-point Analyzer plans are the same except small differences like internal projection ordering.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New test.

### Was this patch authored or co-authored using generative AI tooling?

No.