### PR TITLE
[SPARK-52234][SQL] Fix error on non-string input to schema_of_csv/xml

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
@@ -174,7 +174,12 @@ case class SchemaOfCsv(
     } else if (child.dataType != StringType) {
       DataTypeMismatch(
         errorSubClass = "UNEXPECTED_INPUT_TYPE",
-        messageParameters = Map("exprName" -> "csv"))
+        messageParameters = Map(
+          "paramIndex" -> ordinalNumber(0),
+          "inputSql" -> toSQLExpr(child),
+          "inputType" -> toSQLType(child.dataType),
+          "requiredType" -> toSQLType(StringType))
+      )
     } else {
       super.checkInputDataTypes()
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
@@ -160,20 +160,21 @@ case class SchemaOfCsv(
   private lazy val csv = child.eval().asInstanceOf[UTF8String]
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    def err(sub: String, kv: (String, String)*): DataTypeMismatch =
-      DataTypeMismatch(errorSubClass = sub, messageParameters = kv.toMap)
-
     if (!child.foldable) {
-      err("NON_FOLDABLE_INPUT",
-        "inputName" -> toSQLId("csv"),
-        "inputType" -> toSQLType(child.dataType),
-        "inputExpr" -> toSQLExpr(child))
-    } else if (child.dataType != StringType) {
-      err("NON_STRING_LITERAL",
-        "inputType" -> toSQLType(child.dataType),
-        "inputExpr" -> toSQLExpr(child))
+      DataTypeMismatch(
+        errorSubClass = "NON_FOLDABLE_INPUT",
+        messageParameters = Map(
+          "inputName" -> toSQLId("csv"),
+          "inputType" -> toSQLType(child.dataType),
+          "inputExpr" -> toSQLExpr(child)))
     } else if (child.eval() == null) {
-      err("UNEXPECTED_NULL", "exprName" -> "csv")
+      DataTypeMismatch(
+        errorSubClass = "UNEXPECTED_NULL",
+        messageParameters = Map("exprName" -> "csv"))
+    } else if (child.dataType != StringType) {
+      DataTypeMismatch(
+        errorSubClass = "UNEXPECTED_INPUT_TYPE",
+        messageParameters = Map("exprName" -> "csv"))
     } else {
       super.checkInputDataTypes()
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xmlExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xmlExpressions.scala
@@ -166,20 +166,21 @@ case class SchemaOfXml(
   private lazy val xml = child.eval().asInstanceOf[UTF8String]
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    def err(sub: String, kv: (String, String)*): DataTypeMismatch =
-      DataTypeMismatch(errorSubClass = sub, messageParameters = kv.toMap)
-
     if (!child.foldable) {
-      err("NON_FOLDABLE_INPUT",
-        "inputName" -> toSQLId("xml"),
-        "inputType" -> toSQLType(child.dataType),
-        "inputExpr" -> toSQLExpr(child))
-    } else if (child.dataType != StringType) {
-       err("NON_STRING_LITERAL",
-        "inputType" -> toSQLType(child.dataType),
-        "inputExpr" -> toSQLExpr(child))
+      DataTypeMismatch(
+        errorSubClass = "NON_FOLDABLE_INPUT",
+        messageParameters = Map(
+          "inputName" -> toSQLId("xml"),
+          "inputType" -> toSQLType(child.dataType),
+          "inputExpr" -> toSQLExpr(child)))
     } else if (child.eval() == null) {
-      err("UNEXPECTED_NULL", "exprName" -> "xml")
+      DataTypeMismatch(
+        errorSubClass = "UNEXPECTED_NULL",
+        messageParameters = Map("exprName" -> "xml"))
+    } else if (child.dataType != StringType) {
+      DataTypeMismatch(
+        errorSubClass = "UNEXPECTED_INPUT_TYPE",
+        messageParameters = Map("exprName" -> "xml"))
     } else {
       super.checkInputDataTypes()
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xmlExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xmlExpressions.scala
@@ -166,19 +166,22 @@ case class SchemaOfXml(
   private lazy val xml = child.eval().asInstanceOf[UTF8String]
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    if (child.foldable && xml != null) {
-      super.checkInputDataTypes()
-    } else if (!child.foldable) {
-      DataTypeMismatch(
-        errorSubClass = "NON_FOLDABLE_INPUT",
-        messageParameters = Map(
-          "inputName" -> toSQLId("xml"),
-          "inputType" -> toSQLType(child.dataType),
-          "inputExpr" -> toSQLExpr(child)))
+    def err(sub: String, kv: (String, String)*): DataTypeMismatch =
+      DataTypeMismatch(errorSubClass = sub, messageParameters = kv.toMap)
+
+    if (!child.foldable) {
+      err("NON_FOLDABLE_INPUT",
+        "inputName" -> toSQLId("xml"),
+        "inputType" -> toSQLType(child.dataType),
+        "inputExpr" -> toSQLExpr(child))
+    } else if (child.dataType != StringType) {
+       err("NON_STRING_LITERAL",
+        "inputType" -> toSQLType(child.dataType),
+        "inputExpr" -> toSQLExpr(child))
+    } else if (child.eval() == null) {
+      err("UNEXPECTED_NULL", "exprName" -> "xml")
     } else {
-      DataTypeMismatch(
-        errorSubClass = "UNEXPECTED_NULL",
-        messageParameters = Map("exprName" -> "xml"))
+      super.checkInputDataTypes()
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xmlExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xmlExpressions.scala
@@ -180,7 +180,12 @@ case class SchemaOfXml(
     } else if (child.dataType != StringType) {
       DataTypeMismatch(
         errorSubClass = "UNEXPECTED_INPUT_TYPE",
-        messageParameters = Map("exprName" -> "xml"))
+        messageParameters = Map(
+          "paramIndex" -> ordinalNumber(0),
+          "inputSql" -> toSQLExpr(child),
+          "inputType" -> toSQLType(child.dataType),
+          "requiredType" -> toSQLType(StringType))
+      )
     } else {
       super.checkInputDataTypes()
     }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/csv-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/csv-functions.sql.out
@@ -173,13 +173,24 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 -- !query
 select schema_of_csv(42)
 -- !query analysis
-org.apache.spark.SparkException
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
 {
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
+  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "sqlState" : "42K09",
   "messageParameters" : {
-    "message" : "Undefined error message parameter for error class: 'DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE', MessageTemplate: Cannot resolve <sqlExpr> due to data type mismatch: The <paramIndex> parameter requires the <requiredType> type, however <inputSql> has the type <inputType>., Parameters: Map(exprName -> csv, sqlExpr -> \"schema_of_csv(42)\")"
-  }
+    "inputSql" : "\"42\"",
+    "inputType" : "\"INT\"",
+    "paramIndex" : "first",
+    "requiredType" : "\"STRING\"",
+    "sqlExpr" : "\"schema_of_csv(42)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 24,
+    "fragment" : "schema_of_csv(42)"
+  } ]
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/csv-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/csv-functions.sql.out
@@ -171,6 +171,19 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 
 
 -- !query
+select schema_of_csv(42)
+-- !query analysis
+org.apache.spark.SparkException
+{
+  "errorClass" : "INTERNAL_ERROR",
+  "sqlState" : "XX000",
+  "messageParameters" : {
+    "message" : "Undefined error message parameter for error class: 'DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE', MessageTemplate: Cannot resolve <sqlExpr> due to data type mismatch: The <paramIndex> parameter requires the <requiredType> type, however <inputSql> has the type <inputType>., Parameters: Map(exprName -> csv, sqlExpr -> \"schema_of_csv(42)\")"
+  }
+}
+
+
+-- !query
 CREATE TEMPORARY VIEW csvTable(csvField, a) AS SELECT * FROM VALUES ('1,abc', 'a')
 -- !query analysis
 CreateViewCommand `csvTable`, [(csvField,None), (a,None)], SELECT * FROM VALUES ('1,abc', 'a'), false, false, LocalTempView, UNSUPPORTED, true

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/xml-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/xml-functions.sql.out
@@ -357,6 +357,30 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 
 
 -- !query
+select schema_of_xml(42)
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "inputSql" : "\"42\"",
+    "inputType" : "\"INT\"",
+    "paramIndex" : "first",
+    "requiredType" : "\"STRING\"",
+    "sqlExpr" : "\"schema_of_xml(42)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 24,
+    "fragment" : "schema_of_xml(42)"
+  } ]
+}
+
+
+-- !query
 CREATE TEMPORARY VIEW xmlTable(xmlField, a) AS SELECT * FROM VALUES ('<p><a>1</a><b>"2"</b></p>', 'a')
 -- !query analysis
 CreateViewCommand `xmlTable`, [(xmlField,None), (a,None)], SELECT * FROM VALUES ('<p><a>1</a><b>"2"</b></p>', 'a'), false, false, LocalTempView, UNSUPPORTED, true

--- a/sql/core/src/test/resources/sql-tests/inputs/csv-functions.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/csv-functions.sql
@@ -12,6 +12,7 @@ select from_csv();
 select from_csv('1,abc', schema_of_csv('1,abc'));
 select schema_of_csv('1|abc', map('delimiter', '|'));
 select schema_of_csv(null);
+select schema_of_csv(42);
 CREATE TEMPORARY VIEW csvTable(csvField, a) AS SELECT * FROM VALUES ('1,abc', 'a');
 SELECT schema_of_csv(csvField) FROM csvTable;
 -- Clean up

--- a/sql/core/src/test/resources/sql-tests/inputs/xml-functions.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/xml-functions.sql
@@ -53,6 +53,7 @@ select from_xml(
 
 -- infer schema of xml literal with options
 select schema_of_xml(null);
+select schema_of_xml(42);
 CREATE TEMPORARY VIEW xmlTable(xmlField, a) AS SELECT * FROM VALUES ('<p><a>1</a><b>"2"</b></p>', 'a');
 SELECT schema_of_xml(xmlField) FROM xmlTable;
 

--- a/sql/core/src/test/resources/sql-tests/results/csv-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/csv-functions.sql.out
@@ -193,13 +193,24 @@ select schema_of_csv(42)
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkException
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
 {
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
+  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "sqlState" : "42K09",
   "messageParameters" : {
-    "message" : "Undefined error message parameter for error class: 'DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE', MessageTemplate: Cannot resolve <sqlExpr> due to data type mismatch: The <paramIndex> parameter requires the <requiredType> type, however <inputSql> has the type <inputType>., Parameters: Map(exprName -> csv, sqlExpr -> \"schema_of_csv(42)\")"
-  }
+    "inputSql" : "\"42\"",
+    "inputType" : "\"INT\"",
+    "paramIndex" : "first",
+    "requiredType" : "\"STRING\"",
+    "sqlExpr" : "\"schema_of_csv(42)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 24,
+    "fragment" : "schema_of_csv(42)"
+  } ]
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/csv-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/csv-functions.sql.out
@@ -189,6 +189,21 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 
 
 -- !query
+select schema_of_csv(42)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkException
+{
+  "errorClass" : "INTERNAL_ERROR",
+  "sqlState" : "XX000",
+  "messageParameters" : {
+    "message" : "Undefined error message parameter for error class: 'DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE', MessageTemplate: Cannot resolve <sqlExpr> due to data type mismatch: The <paramIndex> parameter requires the <requiredType> type, however <inputSql> has the type <inputType>., Parameters: Map(exprName -> csv, sqlExpr -> \"schema_of_csv(42)\")"
+  }
+}
+
+
+-- !query
 CREATE TEMPORARY VIEW csvTable(csvField, a) AS SELECT * FROM VALUES ('1,abc', 'a')
 -- !query schema
 struct<>

--- a/sql/core/src/test/resources/sql-tests/results/xml-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/xml-functions.sql.out
@@ -397,6 +397,32 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 
 
 -- !query
+select schema_of_xml(42)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "inputSql" : "\"42\"",
+    "inputType" : "\"INT\"",
+    "paramIndex" : "first",
+    "requiredType" : "\"STRING\"",
+    "sqlExpr" : "\"schema_of_xml(42)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 24,
+    "fragment" : "schema_of_xml(42)"
+  } ]
+}
+
+
+-- !query
 CREATE TEMPORARY VIEW xmlTable(xmlField, a) AS SELECT * FROM VALUES ('<p><a>1</a><b>"2"</b></p>', 'a')
 -- !query schema
 struct<>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Fix the error thrown upon executing invalid command, such as `SELECT schema_of_csv(42)` from an invalid cast to data type mismatch `UNEXPECTED_INPUT_TYPE `. 


### Why are the changes needed?
Improved functionality and readability of the error.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
The user will see a more comprehensible error.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
SQLQueryTest (golden files additions)

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No