### PR TITLE
[SQL][MINOR] Fix error desription for RECURSION_LEVEL_LIMIT_EXCEEDED

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4644,7 +4644,7 @@
   },
   "RECURSION_LEVEL_LIMIT_EXCEEDED" : {
     "message" : [
-      "Recursion level limit <levelLimit> reached but query has not exhausted, try increasing it like 'WITH RECURSIVE t(col) MAX RECURSION DEPTH 200'."
+      "Recursion level limit <levelLimit> reached but query has not exhausted, try increasing it like 'WITH RECURSIVE t(col) MAX RECURSION LEVEL 200'."
     ],
     "sqlState" : "42836"
   },


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix error message in for RECURSION_LEVEL_LIMIT_EXCEEDED. To suggest changing MAX RECURSION LEVEL instead of MAX RECURSION DEPTH (which was incorrectly claimed before.)

### Why are the changes needed?

The error message is incorrect currently.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Manual test to see whether error message is correct.

### Was this patch authored or co-authored using generative AI tooling?

No.