### PR TITLE
[SPARK-52225][BUILD][4.0][3.5] Avoid using interactive TTY mode in release scripts for branch-3.5 and 4.0

### DIFF
--- a/dev/create-release/do-release-docker.sh
+++ b/dev/create-release/do-release-docker.sh
@@ -160,7 +160,7 @@ if [ -n "$JAVA" ]; then
 fi
 
 echo "Building $RELEASE_TAG; output will be at $WORKDIR/output"
-docker run -ti \
+docker $([ -z "$GITHUB_ACTIONS" ] && echo "-it") run \
   --env-file "$ENVFILE" \
   --volume "$WORKDIR:/opt/spark-rm" \
   $JAVA_VOL \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a partial backport of https://github.com/apache/spark/pull/50884 so that GitHub Actions can run the automatic releases

### Why are the changes needed?

So we can make Apache Spark releases via GitHub Actions.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.