### PR TITLE
[SPARK-52178][BUILD][FOLLOW-UP] Respect ANSWER for checking tags

### DIFF
--- a/dev/create-release/do-release.sh
+++ b/dev/create-release/do-release.sh
@@ -52,9 +52,13 @@ function should_build {
 if should_build "tag" && [ $SKIP_TAG = 0 ]; then
   run_silent "Creating release tag $RELEASE_TAG..." "tag.log" \
     "$SELF/release-tag.sh"
-  echo "It may take some time for the tag to be synchronized to github."
-  echo "Press enter when you've verified that the new tag ($RELEASE_TAG) is available."
-  read
+  if [ -z "$ANSWER" ]; then
+    echo "It may take some time for the tag to be synchronized to github."
+    echo "Press enter when you've verified that the new tag ($RELEASE_TAG) is available."
+    read
+  else
+    sleep 10
+  fi
 else
   echo "Skipping tag creation for $RELEASE_TAG."
 fi


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of SPARK-52178 that makes release scripts respects `ANSWER` variable.

### Why are the changes needed?

So we can release automaticlaly.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested.


### Was this patch authored or co-authored using generative AI tooling?

No.