### PR TITLE
[SPARK-52227][PROTOBUF][BUILD] Make packaging results of the `spark-protobuf` module generated by maven and sbt remain consistent

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -916,14 +916,13 @@ object SparkProtobuf {
     // Exclude `scala-library` from assembly.
     (assembly / assemblyPackageScala / assembleArtifact) := false,
 
-    // Exclude `pmml-model-*.jar`, `scala-collection-compat_*.jar`,
-    // `spark-tags_*.jar`, "guava-*.jar" and `unused-1.0.0.jar` from assembly.
+    // Include `spark-protobuf-*.jar`, `unused-*.jar`,`protobuf-*.jar`in assembly.
+    // This needs to be consistent with the content of `maven-shade-plugin`.
     (assembly / assemblyExcludedJars) := {
       val cp = (assembly / fullClasspath).value
-      cp filter { v =>
-        val name = v.data.getName
-        name.startsWith("pmml-model-") || name.startsWith("scala-collection-compat_") ||
-          name.startsWith("spark-tags_") || name.startsWith("guava-") || name == "unused-1.0.0.jar"
+      val validPrefixes = Set("spark-protobuf", "protobuf-")
+      cp filterNot { v =>
+        validPrefixes.exists(v.data.getName.startsWith)
       }
     },
 

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -916,7 +916,7 @@ object SparkProtobuf {
     // Exclude `scala-library` from assembly.
     (assembly / assemblyPackageScala / assembleArtifact) := false,
 
-    // Include `spark-protobuf-*.jar`, `unused-*.jar`,`protobuf-*.jar`in assembly.
+    // SPARK-52227: Include `spark-protobuf-*.jar`, `unused-*.jar`,`protobuf-*.jar`in assembly.
     // This needs to be consistent with the content of `maven-shade-plugin`.
     (assembly / assemblyExcludedJars) := {
       val cp = (assembly / fullClasspath).value


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr refactors the assembly rules for package `protobuf` module using sbt, aiming to ensure consistency in the output results with those generated by Maven's shade process. Based on the build logs from Maven shade, it is observed that for `protobuf`, only two jars namely `protobuf-java` and `protobuf-java-util`, undergo shading.

```
[INFO] --- shade:3.6.0:shade (default) @ spark-protobuf_2.13 ---
[INFO] Including com.google.protobuf:protobuf-java:jar:4.29.3 in the shaded jar.
[INFO] Including com.google.protobuf:protobuf-java-util:jar:4.29.3 in the shaded jar.
[INFO] Excluding org.apache.avro:avro:jar:1.12.0 from the shaded jar.
```

### Why are the changes needed?
Make packaging results of the `spark-protobuf` module generated by `Maven` and` sbt` remain consistent


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions
- Manually inspect the results of the sbt packaging of `protobuf` module


### Was this patch authored or co-authored using generative AI tooling?
No
