### PR TITLE
[SPARK-52079][SQL][Followup] Normalize internal projections under Aggregate as well

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/NormalizePlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/NormalizePlan.scala
@@ -154,11 +154,17 @@ object NormalizePlan extends PredicateHelper {
             .getTagValue(DeduplicateRelations.PROJECT_FOR_EXPRESSION_ID_DEDUPLICATION)
             .isDefined =>
         project.child
+      case aggregate @ Aggregate(_, _, innerProject: Project, _) =>
+        val newInnerProject = Project(
+          innerProject.projectList.sortBy(_.name),
+          innerProject.child
+        )
+        aggregate.copy(child = newInnerProject)
       case Project(outerProjectList, innerProject: Project) =>
-        val normalizedInnerProjectList = normalizeProjectList(innerProject.projectList)
-        val orderedInnerProjectList = normalizedInnerProjectList.sortBy(_.name)
-        val newInnerProject =
-          Project(orderedInnerProjectList, innerProject.child)
+        val newInnerProject = Project(
+          innerProject.projectList.sortBy(_.name),
+          innerProject.child
+        )
         Project(normalizeProjectList(outerProjectList), newInnerProject)
       case Project(projectList, child) =>
         Project(normalizeProjectList(projectList), child)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
@@ -48,11 +48,21 @@ class NormalizePlanSuite extends SparkFunSuite with SQLConfHelper {
     assert(NormalizePlan(baselinePlan) == NormalizePlan(testPlan))
   }
 
-  test("Normalize ordering in a project list of an inner Project") {
+  test("Normalize ordering in a project list of an inner Project under Project") {
     val baselinePlan =
       LocalRelation($"col1".int, $"col2".string).select($"col1", $"col2").select($"col1")
     val testPlan =
       LocalRelation($"col1".int, $"col2".string).select($"col2", $"col1").select($"col1")
+
+    assert(baselinePlan != testPlan)
+    assert(NormalizePlan(baselinePlan) == NormalizePlan(testPlan))
+  }
+
+  test("Normalize ordering in a project list of an inner Project under Aggregate") {
+    val baselinePlan =
+      LocalRelation($"col1".int, $"col2".string).select($"col1", $"col2").groupBy($"col1")($"col1")
+    val testPlan =
+      LocalRelation($"col1".int, $"col2".string).select($"col2", $"col1").groupBy($"col1")($"col1")
 
     assert(baselinePlan != testPlan)
     assert(NormalizePlan(baselinePlan) == NormalizePlan(testPlan))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Normalize internal projections under `Aggregate` as well, same as for `Project`.

I removed extra `normalizeProjectList` call because we already do that while transforming the tree upwards.

### Why are the changes needed?

We need to make sure that single-pass and fixed-point Analyzer plans are the same except small differences like internal projection ordering.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New test.

### Was this patch authored or co-authored using generative AI tooling?

No.