### PR TITLE
[SPARK-52235][SQL] Add implicit cast to DefaultValue V2 Expressions passed to DSV2

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
@@ -78,6 +78,7 @@ object AnsiTypeCoercion extends TypeCoercionBase {
     UnpivotCoercion ::
     WidenSetOperationTypes ::
     ProcedureArgumentCoercion ::
+    DefaultValueExpressionCoercion ::
     new AnsiCombinedTypeCoercionRule(
       CollationTypeCasts ::
       InConversion ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -50,6 +50,7 @@ object TypeCoercion extends TypeCoercionBase {
     UnpivotCoercion ::
     WidenSetOperationTypes ::
     ProcedureArgumentCoercion ::
+    DefaultValueExpressionCoercion ::
     new CombinedTypeCoercionRule(
       CollationTypeCasts ::
       InConversion ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionBase.scala
@@ -102,8 +102,7 @@ abstract class TypeCoercionBase extends TypeCoercionHelper {
               c.dataType,
               "CREATE TABLE",
               c.name,
-              d.originalSQL,
-              castWiderOnlyLiterals = false))))
+              d.originalSQL))))
         }
         createTable.copy(columns = newCols)
 
@@ -116,8 +115,7 @@ abstract class TypeCoercionBase extends TypeCoercionHelper {
               c.dataType,
               "REPLACE TABLE",
               c.name,
-              d.originalSQL,
-              castWiderOnlyLiterals = false))))
+              d.originalSQL))))
         }
         replaceTable.copy(columns = newCols)
 
@@ -130,8 +128,7 @@ abstract class TypeCoercionBase extends TypeCoercionHelper {
               c.dataType,
               "ALTER TABLE ADD COLUMNS",
               c.colName,
-              d.originalSQL,
-              castWiderOnlyLiterals = false))))
+              d.originalSQL))))
         }
         addColumns.copy(columnsToAdd = newCols)
 
@@ -145,8 +142,7 @@ abstract class TypeCoercionBase extends TypeCoercionHelper {
               dataType,
               "ALTER TABLE ALTER COLUMN",
               c.column.name.quoted,
-              d.originalSQL,
-              castWiderOnlyLiterals = false))))
+              d.originalSQL))))
         }
         alterColumns.copy(specs = newSpecs)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionBase.scala
@@ -87,6 +87,10 @@ abstract class TypeCoercionBase extends TypeCoercionHelper {
     }
   }
 
+  /**
+   * A type coercion rule that implicitly casts default value expression in DDL statements
+   * to expected types.
+   */
   object DefaultValueExpressionCoercion extends Rule[LogicalPlan] {
     override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
       case createTable @ CreateTable(_, cols, _, _, _) if createTable.resolved &&
@@ -130,6 +134,7 @@ abstract class TypeCoercionBase extends TypeCoercionHelper {
               castWiderOnlyLiterals = false))))
         }
         addColumns.copy(columnsToAdd = newCols)
+
       case alterColumns @ AlterColumns(_, specs) if alterColumns.resolved &&
         specs.exists(_.newDefaultExpression.isDefined) =>
         val newSpecs = specs.map { c =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionBase.scala
@@ -32,16 +32,22 @@ import org.apache.spark.sql.catalyst.expressions.{
   WindowSpecDefinition
 }
 import org.apache.spark.sql.catalyst.plans.logical.{
+  AddColumns,
+  AlterColumns,
   Call,
+  CreateTable,
   Except,
   Intersect,
   LogicalPlan,
   Project,
+  ReplaceTable,
   Union,
   Unpivot
 }
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.CurrentOrigin.withOrigin
+import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.MultipartIdentifierHelper
 import org.apache.spark.sql.connector.catalog.procedures.BoundProcedure
 import org.apache.spark.sql.types.DataType
 
@@ -78,6 +84,66 @@ abstract class TypeCoercionBase extends TypeCoercionHelper {
           case (arg, expectedType) => implicitCast(arg, expectedType).getOrElse(arg)
         }
         c.copy(args = coercedArgs)
+    }
+  }
+
+  object DefaultValueExpressionCoercion extends Rule[LogicalPlan] {
+    override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
+      case createTable @ CreateTable(_, cols, _, _, _) if createTable.resolved &&
+        cols.exists(_.defaultValue.isDefined) =>
+        val newCols = cols.map { c =>
+          c.copy(defaultValue = c.defaultValue.map(d =>
+            d.copy(child = ResolveDefaultColumns.coerceDefaultValue(
+              d.child,
+              c.dataType,
+              "CREATE TABLE",
+              c.name,
+              d.originalSQL,
+              castWiderOnlyLiterals = false))))
+        }
+        createTable.copy(columns = newCols)
+
+      case replaceTable @ ReplaceTable(_, cols, _, _, _) if replaceTable.resolved &&
+        cols.exists(_.defaultValue.isDefined) =>
+        val newCols = cols.map { c =>
+          c.copy(defaultValue = c.defaultValue.map(d =>
+            d.copy(child = ResolveDefaultColumns.coerceDefaultValue(
+              d.child,
+              c.dataType,
+              "REPLACE TABLE",
+              c.name,
+              d.originalSQL,
+              castWiderOnlyLiterals = false))))
+        }
+        replaceTable.copy(columns = newCols)
+
+      case addColumns @ AddColumns(_, cols) if addColumns.resolved &&
+        cols.exists(_.default.isDefined) =>
+        val newCols = cols.map { c =>
+          c.copy(default = c.default.map(d =>
+            d.copy(child = ResolveDefaultColumns.coerceDefaultValue(
+              d.child,
+              c.dataType,
+              "ALTER TABLE ADD COLUMNS",
+              c.colName,
+              d.originalSQL,
+              castWiderOnlyLiterals = false))))
+        }
+        addColumns.copy(columnsToAdd = newCols)
+      case alterColumns @ AlterColumns(_, specs) if alterColumns.resolved &&
+        specs.exists(_.newDefaultExpression.isDefined) =>
+        val newSpecs = specs.map { c =>
+          val dataType = c.column.asInstanceOf[ResolvedFieldName].field.dataType
+          c.copy(newDefaultExpression = c.newDefaultExpression.map(d =>
+            d.copy(child = ResolveDefaultColumns.coerceDefaultValue(
+              d.child,
+              dataType,
+              "ALTER TABLE ALTER COLUMN",
+              c.column.name.quoted,
+              d.originalSQL,
+              castWiderOnlyLiterals = false))))
+        }
+        alterColumns.copy(specs = newSpecs)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.util
 
 import scala.collection.mutable.ArrayBuffer
+import scala.util.control.NonFatal
 
 import org.apache.spark.{SparkException, SparkUnsupportedOperationException}
 import org.apache.spark.internal.{Logging, MDC}
@@ -440,7 +441,7 @@ object ResolveDefaultColumns extends QueryErrorsBase
         try {
           Option(casted.eval(EmptyRow)).map(Literal(_, targetType))
         } catch {
-          case ex: Exception =>
+          case NonFatal(ex) =>
             logWarning(log"Failed to cast default value '${MDC(COLUMN_DEFAULT_VALUE, e)}' " +
               log"for column ${MDC(COLUMN_NAME, colName)} " +
               log"from ${MDC(COLUMN_DATA_TYPE_SOURCE, e.dataType)} " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -432,23 +432,7 @@ object ResolveDefaultColumns extends QueryErrorsBase
       targetType: DataType,
       colName: String): Option[Expression] = {
     expr match {
-      case l: Literal => defaultValueFromWiderType(l, targetType, colName)
-      case _ => None
-    }
-  }
-
-  /**
-   * If the provided default value is a literal of a wider type than the target column,
-   * but the literal value fits within the narrower type, just coerce it for convenience.
-   * Exclude boolean/array/struct/map types from consideration for this type coercion to
-   * avoid surprising behavior like interpreting "false" as integer zero.
-   */
-  def defaultValueFromWiderType(
-      expr: Expression,
-      targetType: DataType,
-      colName: String): Option[Expression] = {
-    expr match {
-      case e if !Seq(targetType, e.dataType).exists(_ match {
+      case e if e.foldable && !Seq(targetType, e.dataType).exists(_ match {
         case _: BooleanType | _: ArrayType | _: StructType | _: MapType => true
         case _ => false
       }) =>
@@ -456,12 +440,12 @@ object ResolveDefaultColumns extends QueryErrorsBase
         try {
           Option(casted.eval(EmptyRow)).map(Literal(_, targetType))
         } catch {
-          case e @ ( _: SparkThrowable | _: RuntimeException) =>
+          case ex @ ( _: SparkThrowable | _: RuntimeException) =>
             logWarning(log"Failed to cast default value '${MDC(COLUMN_DEFAULT_VALUE, e)}' " +
               log"for column ${MDC(COLUMN_NAME, colName)} " +
-              log"from ${MDC(COLUMN_DATA_TYPE_SOURCE, expr.dataType)} " +
+              log"from ${MDC(COLUMN_DATA_TYPE_SOURCE, e.dataType)} " +
               log"to ${MDC(COLUMN_DATA_TYPE_TARGET, targetType)} " +
-              log"due to ${MDC(ERROR, e.getMessage)}", e)
+              log"due to ${MDC(ERROR, ex.getMessage)}", ex)
             None
         }
       case _ => None
@@ -477,8 +461,7 @@ object ResolveDefaultColumns extends QueryErrorsBase
       dataType: DataType,
       statementType: String,
       colName: String,
-      defaultSQL: String,
-      castWiderOnlyLiterals: Boolean = true): Expression = {
+      defaultSQL: String): Expression = {
     val supplanted = CharVarcharUtils.replaceCharVarcharWithString(dataType)
     // Perform implicit coercion from the provided expression type to the required column type.
     val ret = analyzed match {
@@ -487,12 +470,7 @@ object ResolveDefaultColumns extends QueryErrorsBase
       case canUpCast if Cast.canUpCast(canUpCast.dataType, supplanted) =>
         Cast(analyzed, supplanted, Some(conf.sessionLocalTimeZone))
       case other =>
-        val casted = if (castWiderOnlyLiterals) {
-          defaultValueFromWiderTypeLiteral(other, supplanted, colName)
-        } else {
-          defaultValueFromWiderType(other, supplanted, colName)
-        }
-        casted.getOrElse(
+        defaultValueFromWiderTypeLiteral(other, supplanted, colName).getOrElse(
           throw QueryCompilationErrors.defaultValuesDataTypeError(
             statementType, colName, defaultSQL, dataType, other.dataType))
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.util
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.spark.{SparkException, SparkThrowable, SparkUnsupportedOperationException}
+import org.apache.spark.{SparkException, SparkUnsupportedOperationException}
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.sql.AnalysisException
@@ -440,7 +440,7 @@ object ResolveDefaultColumns extends QueryErrorsBase
         try {
           Option(casted.eval(EmptyRow)).map(Literal(_, targetType))
         } catch {
-          case ex @ ( _: SparkThrowable | _: RuntimeException) =>
+          case ex: Exception =>
             logWarning(log"Failed to cast default value '${MDC(COLUMN_DEFAULT_VALUE, e)}' " +
               log"for column ${MDC(COLUMN_NAME, colName)} " +
               log"from ${MDC(COLUMN_DATA_TYPE_SOURCE, e.dataType)} " +


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add implicit cast to DefaultValue V2 expressions passed to DSV2, by adding rule to TypeCoercion.

### Why are the changes needed?

Now default values are passed as V2 Expressions to DSV2 in Create/Replace/Alter table DDL statements.

We should match what the normal default value analysis path does for sql strings (ie, implicit cast).


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add unit test to DatasourceV2DataFrameSuite


### Was this patch authored or co-authored using generative AI tooling?
No
