### PR TITLE
[SPARK-52236][SQL] Standardize analyze exceptions for default value

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ColumnDefinition.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ColumnDefinition.scala
@@ -162,15 +162,7 @@ object ColumnDefinition {
         cmd.columns.foreach { col =>
           col.defaultValue.foreach { default =>
             checkDefaultColumnConflicts(col)
-            if (!default.resolved) {
-              throw QueryCompilationErrors.defaultValuesUnresolvedExprError(
-                statement, col.name, default.originalSQL, null)
-            }
             validateDefaultValueExpr(default, statement, col.name, col.dataType)
-            if (!default.deterministic) {
-              throw QueryCompilationErrors.defaultValueNonDeterministicError(
-                statement, col.name, default.originalSQL)
-            }
           }
         }
 
@@ -178,15 +170,7 @@ object ColumnDefinition {
         val statement = "ALTER TABLE ADD COLUMNS"
         cmd.columnsToAdd.foreach { c =>
           c.default.foreach { d =>
-            if (!d.resolved) {
-              throw QueryCompilationErrors.defaultValuesUnresolvedExprError(
-                statement, c.colName, d.originalSQL, null)
-            }
             validateDefaultValueExpr(d, statement, c.colName, c.dataType)
-            if (!d.deterministic) {
-              throw QueryCompilationErrors.defaultValueNonDeterministicError(
-                statement, c.colName, d.originalSQL)
-            }
           }
         }
 
@@ -194,16 +178,12 @@ object ColumnDefinition {
         val statement = "ALTER TABLE ALTER COLUMN"
         cmd.specs.foreach { c =>
           c.newDefaultExpression.foreach { d =>
+            // Eagerly check resolved, as accessing datatype requires it to be resolved
             if (!d.resolved) {
               throw QueryCompilationErrors.defaultValuesUnresolvedExprError(
                 statement, c.column.name.quoted, d.originalSQL, null)
             }
-            validateDefaultValueExpr(d, statement,
-              c.column.name.quoted, d.dataType)
-            if (!d.deterministic) {
-              throw QueryCompilationErrors.defaultValueNonDeterministicError(
-                statement, c.column.name.quoted, d.originalSQL)
-            }
+            validateDefaultValueExpr(d, statement, c.column.name.quoted, d.dataType)
           }
         }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -598,12 +598,22 @@ object ResolveDefaultColumns extends QueryErrorsBase
       // expression is `foldable` here, as the plan is not optimized yet.
     }
 
+    if (!default.resolved) {
+      throw QueryCompilationErrors.defaultValuesUnresolvedExprError(
+        statement, colName, default.originalSQL, null)
+    }
+
     if (default.references.nonEmpty || default.exists(_.isInstanceOf[VariableReference])) {
       // Ideally we should let the rest of `CheckAnalysis` report errors about why the default
       // expression is unresolved. But we should report a better error here if the default
       // expression references columns, which means it's not a constant for sure.
       // Note that, session variable should be considered as non-constant as well.
       throw QueryCompilationErrors.defaultValueNotConstantError(
+        statement, colName, default.originalSQL)
+    }
+
+    if (!default.deterministic) {
+      throw QueryCompilationErrors.defaultValueNonDeterministicError(
         statement, colName, default.originalSQL)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -583,25 +583,28 @@ object ResolveDefaultColumns extends QueryErrorsBase
       default: DefaultValueExpression,
       statement: String,
       colName: String,
-      targetType: DataType): Unit = {
+      targetTypeOption: Option[DataType]): Unit = {
     if (default.containsPattern(PLAN_EXPRESSION)) {
       throw QueryCompilationErrors.defaultValuesMayNotContainSubQueryExpressions(
         statement, colName, default.originalSQL)
     } else if (default.resolved) {
-      val dataType = CharVarcharUtils.replaceCharVarcharWithString(targetType)
-      if (!Cast.canUpCast(default.child.dataType, dataType) &&
-        defaultValueFromWiderTypeLiteral(default.child, dataType, colName).isEmpty) {
-        throw QueryCompilationErrors.defaultValuesDataTypeError(
-          statement, colName, default.originalSQL, targetType, default.child.dataType)
+      targetTypeOption match {
+        case Some(targetType) =>
+          CharVarcharUtils.replaceCharVarcharWithString(targetType)
+          if (!Cast.canUpCast(default.child.dataType, targetType) &&
+            defaultValueFromWiderTypeLiteral(default.child, targetType, colName).isEmpty) {
+            throw QueryCompilationErrors.defaultValuesDataTypeError(
+              statement, colName, default.originalSQL, targetType, default.child.dataType)
+          }
+        case _ => ()
       }
-      // Our analysis check passes here. We do not further inspect whether the
-      // expression is `foldable` here, as the plan is not optimized yet.
-    }
-
-    if (!default.resolved) {
+    } else {
       throw QueryCompilationErrors.defaultValuesUnresolvedExprError(
         statement, colName, default.originalSQL, null)
     }
+
+    // Our analysis check passes here. We do not further inspect whether the
+    // expression is `foldable` here, as the plan is not optimized yet.
 
     if (default.references.nonEmpty || default.exists(_.isInstanceOf[VariableReference])) {
       // Ideally we should let the rest of `CheckAnalysis` report errors about why the default

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTableTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTableTests.scala
@@ -374,7 +374,7 @@ trait AlterTableTests extends SharedSparkSession with QueryErrorsBase {
           },
           condition = "INVALID_DEFAULT_VALUE.UNRESOLVED_EXPRESSION",
           parameters = Map(
-            "statement" -> "ALTER TABLE",
+            "statement" -> "ALTER TABLE ADD COLUMNS",
             "colName" -> "`s`",
             "defaultValue" -> "badvalue"))
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
@@ -511,7 +511,7 @@ class DataSourceV2DataFrameSuite
               Array(LiteralValue(123, IntegerType), LiteralValue(56, IntegerType)))))
 
         val alterExecCol2 = executeAndKeepPhysicalPlan[AlterTableExec] {
-          sql(s"ALTER TABLE $tableName ALTER COLUMN salary SET DEFAULT ('r' || 'l')")
+          sql(s"ALTER TABLE $tableName ALTER COLUMN dep SET DEFAULT ('r' || 'l')")
         }
         checkDefaultValue(
           alterExecCol2.changes.collect {
@@ -526,7 +526,7 @@ class DataSourceV2DataFrameSuite
                 LiteralValue(UTF8String.fromString("l"), StringType)))))
 
         val alterExecCol3 = executeAndKeepPhysicalPlan[AlterTableExec] {
-          sql(s"ALTER TABLE $tableName ALTER COLUMN salary SET DEFAULT CAST(0 AS BOOLEAN)")
+          sql(s"ALTER TABLE $tableName ALTER COLUMN active SET DEFAULT CAST(0 AS BOOLEAN)")
         }
         checkDefaultValue(
           alterExecCol3.changes.collect {

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1170,7 +1170,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
         exception = intercept[AnalysisException] {
           sql("create table t(i boolean, s bigint default badvalue) using parquet")
         },
-        condition = "INVALID_DEFAULT_VALUE.NOT_CONSTANT",
+        condition = "INVALID_DEFAULT_VALUE.UNRESOLVED_EXPRESSION",
         parameters = Map(
           "statement" -> "CREATE TABLE",
           "colName" -> "`s`",


### PR DESCRIPTION


### What changes were proposed in this pull request?
Default values are checked for various things like resolved, and deterministic.  Standardize the errors for various statements (CREATE TABLE/REPLACE TABLE/ALTER TABLE ADD COLUMNS/ALTER TABLE ALTER COLUMNS).  This pr just fixes the ones that were not standard before.

### Why are the changes needed?
Cleanup some exceptions and messages.  This is from the comment of https://github.com/apache/spark/pull/50864/files#r2087361821


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add test in DatasourceV2SQLSuite


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
