### PR TITLE
[SPARK-52237][DOCS] Fix the documentation of hypot function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -1383,8 +1383,10 @@ case class ShiftRightUnsigned(left: Expression, right: Expression) extends BitSh
     copy(left = newLeft, right = newRight)
 }
 
+// scalastyle:off nonascii
 @ExpressionDescription(
-  usage = "_FUNC_(expr1, expr2) - Returns sqrt(`expr1`**2 + `expr2`**2).",
+  usage = "_FUNC_(expr1, expr2) - Returns sqrt(`expr1`\u00B2 + `expr2`\u00B2).",
+  // scalastyle:on nonascii
   examples = """
     Examples:
       > SELECT _FUNC_(3, 4);


### PR DESCRIPTION


### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes the documentation of hypot function

### Why are the changes needed?

These two square marks conflict emphasis signs of Markdown.
`**XX**`
![image](https://github.com/user-attachments/assets/3a823aa7-a99c-4f7f-9b60-38b359420526)


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?

![image](https://github.com/user-attachments/assets/7b19c85b-291b-4356-9870-c81a88a2ca0d)


![image](https://github.com/user-attachments/assets/7fe28ab9-3c36-483d-a1a8-c2fc5b3cf934)


### Was this patch authored or co-authored using generative AI tooling?
no
