### PR TITLE
[SPARK-52240][SQL] Fix VectorizedDeltaLengthByteArrayReader.readBinary to handle current row

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaLengthByteArrayReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaLengthByteArrayReader.java
@@ -56,7 +56,7 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
     ByteBufferOutputWriter outputWriter = ByteBufferOutputWriter::writeArrayByteBuffer;
     int length;
     for (int i = 0; i < total; i++) {
-      length = lengthsVector.getInt(rowId + i);
+      length = lengthsVector.getInt(currentRow + i);
       try {
         buffer = in.slice(length);
       } catch (EOFException e) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix VectorizedDeltaLengthByteArrayReader.readBinary to use `currentRow` to read the length of binary.

### Why are the changes needed?

VectorizedDeltaLengthByteArrayReader.readBinary should use `currentRow` instead of `rowId` to read from the internal data stream. The variable `rowId` is the destination of the output column vector not the position to read binary data from input. This causes dirty read and throws ParquetDecodingException.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Pass all existing test cases.


### Was this patch authored or co-authored using generative AI tooling?

No.
