### PR TITLE
[SPARK-52249][PS] Enable divide-by-zero for numeric truediv with ANSI enabled

### DIFF
--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -257,7 +257,7 @@ class IntegralOps(NumericOps):
                 ).otherwise(F.lit(np.inf).__div__(left))
             else:
                 return F.when(
-                    right == 0,
+                    F.lit(right == 0),
                     F.when(left < 0, F.lit(float("-inf")))
                     .when(left > 0, F.lit(float("inf")))
                     .otherwise(F.lit(np.nan)),
@@ -354,7 +354,7 @@ class FractionalOps(NumericOps):
                 )
             else:
                 return F.when(
-                    right == 0,
+                    F.lit(right == 0),
                     F.when(left < 0, F.lit(float("-inf")))
                     .when(left > 0, F.lit(float("inf")))
                     .otherwise(F.lit(np.nan)),

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -247,6 +247,7 @@ class IntegralOps(NumericOps):
         _sanitize_list_like(right)
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("True division can not be applied to given types.")
+        right = transform_boolean_operand_to_numeric(right, spark_type=left.spark.data_type)
 
         def truediv(left: PySparkColumn, right: Any) -> PySparkColumn:
             if not get_option("compute.ansi_mode_support"):
@@ -262,7 +263,6 @@ class IntegralOps(NumericOps):
                     .otherwise(F.lit(np.nan)),
                 ).otherwise(left / right)
 
-        right = transform_boolean_operand_to_numeric(right, spark_type=left.spark.data_type)
         return numpy_column_op(truediv)(left, right)
 
     def floordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
@@ -340,6 +340,7 @@ class FractionalOps(NumericOps):
         _sanitize_list_like(right)
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("True division can not be applied to given types.")
+        right = transform_boolean_operand_to_numeric(right, spark_type=left.spark.data_type)
 
         def truediv(left: PySparkColumn, right: Any) -> PySparkColumn:
             if not get_option("compute.ansi_mode_support"):
@@ -359,7 +360,6 @@ class FractionalOps(NumericOps):
                     .otherwise(F.lit(np.nan)),
                 ).otherwise(left / right)
 
-        right = transform_boolean_operand_to_numeric(right, spark_type=left.spark.data_type)
         return numpy_column_op(truediv)(left, right)
 
     def floordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -43,6 +43,7 @@ from pyspark.pandas.data_type_ops.base import (
     _is_boolean_type,
 )
 from pyspark.pandas.typedef.typehints import extension_dtypes, pandas_on_spark_type
+from pyspark.pandas.utils import is_ansi_mode_enabled
 from pyspark.sql import functions as F, Column as PySparkColumn
 from pyspark.sql.types import (
     BooleanType,
@@ -52,7 +53,7 @@ from pyspark.sql.types import (
 from pyspark.errors import PySparkValueError
 
 # For Supporting Spark Connect
-from pyspark.sql.utils import pyspark_column_op, is_ansi_mode_enabled
+from pyspark.sql.utils import pyspark_column_op
 
 
 def _non_fractional_astype(
@@ -247,10 +248,11 @@ class IntegralOps(NumericOps):
         _sanitize_list_like(right)
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("True division can not be applied to given types.")
+        spark_session = left._internal.spark_frame.sparkSession
         right = transform_boolean_operand_to_numeric(right, spark_type=left.spark.data_type)
 
         def truediv(left: PySparkColumn, right: Any) -> PySparkColumn:
-            if is_ansi_mode_enabled():
+            if is_ansi_mode_enabled(spark_session):
                 return F.when(
                     F.lit(right == 0),
                     F.when(left < 0, F.lit(float("-inf")))
@@ -340,10 +342,11 @@ class FractionalOps(NumericOps):
         _sanitize_list_like(right)
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("True division can not be applied to given types.")
+        spark_session = left._internal.spark_frame.sparkSession
         right = transform_boolean_operand_to_numeric(right, spark_type=left.spark.data_type)
 
         def truediv(left: PySparkColumn, right: Any) -> PySparkColumn:
-            if is_ansi_mode_enabled():
+            if is_ansi_mode_enabled(spark_session):
                 return F.when(
                     F.lit(right == 0),
                     F.when(left < 0, F.lit(float("-inf")))

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -252,11 +252,11 @@ class IntegralOps(NumericOps):
 
         def truediv(left: PySparkColumn, right: Any) -> PySparkColumn:
             return F.when(
-                right_col == 0,
-                F.when(left_col < 0, F.lit(float("-inf")))
-                .when(left_col > 0, F.lit(float("inf")))
+                right == 0,
+                F.when(left < 0, F.lit(float("-inf")))
+                .when(left > 0, F.lit(float("inf")))
                 .otherwise(F.lit(np.nan)),
-            ).otherwise(left_col / right_col)
+            ).otherwise(left / right)
 
         return numpy_column_op(truediv)(left, right)
 
@@ -336,15 +336,13 @@ class FractionalOps(NumericOps):
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("True division can not be applied to given types.")
 
-        def truediv(left_col: PySparkColumn, right_val: Any) -> PySparkColumn:
+        def truediv(left: PySparkColumn, right: Any) -> PySparkColumn:
             return F.when(
-                F.lit(right_val != 0) | F.lit(right_val).isNull(),
-                left_col / right_val,
-            ).otherwise(
-                F.when(
-                    (left_col == float("inf")) | (left_col == float("-inf")), left_col
-                ).otherwise(float("inf") / left_col)
-            )
+                right == 0,
+                F.when(left < 0, F.lit(float("-inf")))
+                .when(left > 0, F.lit(float("inf")))
+                .otherwise(F.lit(np.nan)),
+            ).otherwise(left / right)
 
         right = transform_boolean_operand_to_numeric(right, spark_type=left.spark.data_type)
         return numpy_column_op(truediv)(left, right)

--- a/python/pyspark/pandas/tests/computation/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/computation/test_binary_ops.py
@@ -111,7 +111,6 @@ class FrameBinaryOpsMixin:
         psdf = ps.DataFrame({"a": ["x"], "b": ["y"]})
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] - psdf["b"])
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_divide_by_zero_behavior(self):
         # float / float
         # np.float32

--- a/python/pyspark/pandas/tests/computation/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/computation/test_binary_ops.py
@@ -189,6 +189,19 @@ class FrameBinaryOpsMixin:
         psdf = ps.from_pandas(pdf)
         self.assert_eq(psdf["a"] / psdf["b"], pdf["a"] / pdf["b"])
 
+        pdf = pd.DataFrame(
+            {
+                "a": [1, -1, 0],
+                "b": [0, 0, 0],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        # a / b: .. divide by zero
+        self.assert_eq(psdf["a"] / psdf["b"], pdf["a"] / pdf["b"])
+
+        # b / a: 0 divided by ..
+        self.assert_eq(psdf["b"] / psdf["a"], pdf["b"] / pdf["a"])
+
     def test_binary_operator_truediv(self):
         # Positive
         pdf = pd.DataFrame({"a": [3], "b": [2]})

--- a/python/pyspark/pandas/tests/computation/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/computation/test_binary_ops.py
@@ -188,19 +188,6 @@ class FrameBinaryOpsMixin:
         psdf = ps.from_pandas(pdf)
         self.assert_eq(psdf["a"] / psdf["b"], pdf["a"] / pdf["b"])
 
-        pdf = pd.DataFrame(
-            {
-                "a": [1, -1, 0],
-                "b": [0, 0, 0],
-            }
-        )
-        psdf = ps.from_pandas(pdf)
-        # a / b: .. divide by zero
-        self.assert_eq(psdf["a"] / psdf["b"], pdf["a"] / pdf["b"])
-
-        # b / a: 0 divided by ..
-        self.assert_eq(psdf["b"] / psdf["a"], pdf["b"] / pdf["a"])
-
     def test_binary_operator_truediv(self):
         # Positive
         pdf = pd.DataFrame({"a": [3], "b": [2]})

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -1070,8 +1070,7 @@ def xor(df1: PySparkDataFrame, df2: PySparkDataFrame) -> PySparkDataFrame:
     )
 
 
-def is_ansi_mode_enabled() -> bool:
-    spark = SparkSession.getActiveSession()
+def is_ansi_mode_enabled(spark: SparkSession) -> bool:
     return (
         ps.get_option("compute.ansi_mode_support", spark_session=spark)
         and spark.conf.get("spark.sql.ansi.enabled") == "true"

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -1070,6 +1070,14 @@ def xor(df1: PySparkDataFrame, df2: PySparkDataFrame) -> PySparkDataFrame:
     )
 
 
+def is_ansi_mode_enabled() -> bool:
+    spark = SparkSession.getActiveSession()
+    return (
+        ps.get_option("compute.ansi_mode_support", spark_session=spark)
+        and spark.conf.get("spark.sql.ansi.enabled") == "true"
+    )
+
+
 def _test() -> None:
     import os
     import doctest


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable divide-by-zero for truediv with ANSI enabled

### Why are the changes needed?
Part of https://issues.apache.org/jira/browse/SPARK-52169

### Does this PR introduce _any_ user-facing change?
Yes,  divide-by-zero for truediv is enabled with ANSI enabled

```py
>>> spark.conf.get("spark.sql.ansi.enabled")
'true'
>>> pdf = pd.DataFrame({"a": [1.0, -1.0, 0.0, np.nan], "b": [0.0, 0.0, 0.0, 0.0]})
>>> psdf = ps.from_pandas(pdf)
```

FROM
```py
>>> psdf["a"] / psdf["b"]
...
pyspark.errors.exceptions.captured.ArithmeticException: [DIVIDE_BY_ZERO] Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set "spark.sql.ansi.enabled" to "false" to bypass this error. SQLSTATE: 22012
== DataFrame ==
"__div__" was called from
<stdin>:1
```

TO
```py
>>> psdf["a"] / psdf["b"]
0    inf                                                                        
1   -inf
2    NaN
3    NaN
dtype: float64
```

### How was this patch tested?
Unit tests

### Was this patch authored or co-authored using generative AI tooling?
No