### PR TITLE
[SPARK-52256][ML] Make Param.paramValueClassTag private

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -52,7 +52,7 @@ class Param[T: ClassTag](
 
   // Spark Connect ML needs T type information which has been erased when compiling,
   // Use classTag to preserve the T type.
-  val paramValueClassTag = implicitly[ClassTag[T]]
+  private[spark] val paramValueClassTag = implicitly[ClassTag[T]]
 
   def this(parent: Identifiable, name: String, doc: String, isValid: T => Boolean) =
     this(parent.uid, name, doc, isValid)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Make `Param.paramValueClassTag` private


### Why are the changes needed?
it is for internal implementation, should not be exposed

```
scala> import org.apache.spark.ml.classification.LogisticRegression
import org.apache.spark.ml.classification.LogisticRegression

scala> val lor = new LogisticRegression()
val lor: org.apache.spark.ml.classification.LogisticRegression = logreg_49c3f17e88cc

scala> lor.maxIter
val res0: org.apache.spark.ml.param.IntParam = logreg_49c3f17e88cc__maxIter

scala> lor.maxIter.paramValueClassTag
val res1: scala.reflect.ClassTag[Int] = Int
```


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
No