### PR TITLE
[MINOR][INFRA] Limit build_python_3.11_macos execution time to up to 2 hours

### DIFF
--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -59,6 +59,7 @@ jobs:
   build:
     name: "PySpark test on macos: ${{ matrix.modules }}"
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Limit build_python_3.11_macos execution time to up to 2 hours 


### Why are the changes needed?
avoid timeout like https://github.com/apache/spark/actions/runs/15172562256/job/42665938236


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no