### PR TITLE
[SPARK-52179][INFRA][FOLLOW-UP] Do not quote wildcard in logs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,10 +190,10 @@ jobs:
 
           # Zip logs/output
           if [ "$DRYRUN_MODE" = "1" ]; then
-            zip logs.zip "$RELEASE_DIR/docker-build.log" "$OUTPUT_DIR/*.log"
+            zip logs.zip "$RELEASE_DIR/docker-build.log" "$OUTPUT_DIR/"*.log
             zip -9 output.zip -r "$OUTPUT_DIR"
           else
-            zip -P "$ASF_PASSWORD" logs.zip "$RELEASE_DIR/docker-build.log" "$OUTPUT_DIR/*.log"
+            zip -P "$ASF_PASSWORD" logs.zip "$RELEASE_DIR/docker-build.log" "$OUTPUT_DIR/"*.log
             zip -9 -P "$ASF_PASSWORD" output.zip -r "$OUTPUT_DIR"
           fi
       - name: Upload logs


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/50911 that does not quote wildcard in logs

### Why are the changes needed?

To correctly catch log files.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

In my forked repository.


### Was this patch authored or co-authored using generative AI tooling?

No.