### PR TITLE
[SPARK-52179][INFRA][FOLLOW-UP] Skip dryruns in forked repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,9 @@ jobs:
     name: Release Apache Spark (dryrun and RC)
     runs-on: ubuntu-latest
     # Do not allow dispatching this workflow manually in the main repo.
-    if: ${{ !(github.repository == 'apache/spark' && inputs.branch != '' && inputs.release-version != '') }}
+    # and skip this workflow in forked repository when running as a
+    # scheduled job (dryrun).
+    if: ${{ (github.repository == 'apache/spark') != (inputs.branch != '' && inputs.release-version != '') }}
     steps:
       - name: Checkout Spark repository
         uses: actions/checkout@v4


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/50911 that skip dryruns in forked repository.

### Why are the changes needed?

To avoid using unnecessary resources in forked repository.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.
