### PR TITLE
[SPARK-50137][SQL] Avoid fallback to Hive-incompatible ways when table creation fails by thrift exception

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -391,7 +391,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
           logInfo(message)
           saveTableIntoHive(table, ignoreIfExists)
         } catch {
-          case NonFatal(e) =>
+          case NonFatal(e) if !HiveUtils.causedByThrift(e) =>
             val warningMessage =
               log"Could not persist ${MDC(TABLE_NAME, table.identifier.quotedString)} in a Hive " +
                 log"compatible way. Persisting it into Hive metastore in Spark SQL specific format."

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -520,4 +520,19 @@ private[spark] object HiveUtils extends Logging {
       case PATTERN_FOR_KEY_EQ_VAL(_, v) => FileUtils.unescapePathName(v)
     }
   }
+
+  /**
+   * Determine if a Hive call exception is caused by thrift error.
+   */
+  def causedByThrift(e: Throwable): Boolean = {
+    var target = e
+    while (target != null) {
+      val msg = target.getMessage()
+      if (msg != null && msg.matches("(?s).*(TApplication|TProtocol|TTransport)Exception.*")) {
+        return true
+      }
+      target = target.getCause()
+    }
+    false
+  }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -228,7 +228,7 @@ private[hive] class HiveClientImpl(
       try {
         return f
       } catch {
-        case e: Exception if causedByThrift(e) =>
+        case e: Exception if HiveUtils.causedByThrift(e) =>
           caughtException = e
           logWarning(
             log"HiveClient got thrift exception, destroying client and retrying " +
@@ -241,18 +241,6 @@ private[hive] class HiveClientImpl(
       logWarning("Deadline exceeded")
     }
     throw caughtException
-  }
-
-  private def causedByThrift(e: Throwable): Boolean = {
-    var target = e
-    while (target != null) {
-      val msg = target.getMessage()
-      if (msg != null && msg.matches("(?s).*(TApplication|TProtocol|TTransport)Exception.*")) {
-        return true
-      }
-      target = target.getCause()
-    }
-    false
   }
 
   private def client: Hive = {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -246,7 +246,7 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
   test("SPARK-50137: Avoid fallback to Hive-incompatible ways on thrift exception") {
     val hadoopConf = new Configuration()
     // Use an unavailable uri to mock client connection timeout.
-    hadoopConf.set("hive.metastore.uris", "thrift://1.1.1.1:1111")
+    hadoopConf.set("hive.metastore.uris", "thrift://192.0.2.1:9083")
     hadoopConf.set("hive.metastore.client.connection.timeout", "1s")
     // Dummy HiveExternalCatalog to mock that the hive client is still available
     // when checking database and table.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enhance the datasource table creation, do not fallback to hive incompatible way if failure was caused by thrift exception.


### Why are the changes needed?
Thrift exception is unrelated to hive compatibility of datasource table, so fallback is unnecessary in this case.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Add a unit test:
```bash
mvn test -Dtest=none -Dsuites="org.apache.spark.sql.hive.HiveExternalCatalogSuite @SPARK-50137: Avoid fallback to Hive-incompatible ways on thrift exception" -pl :spark-hive_2.13
```


### Was this patch authored or co-authored using generative AI tooling?
No.
