### PR TITLE
[SPARK-52262][SQL] swap order of withConnection and classifyException in loadTable

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.jdbc.v2
 
 import org.apache.logging.log4j.Level
 
+import org.apache.spark.TestUtils.withConf
 import org.apache.spark.sql.{AnalysisException, DataFrame}
 import org.apache.spark.sql.catalyst.analysis.{IndexAlreadyExistsException, NoSuchIndexException}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Sample, Sort}

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.jdbc.v2
 
 import org.apache.logging.log4j.Level
 
-import org.apache.spark.TestUtils.withConf
 import org.apache.spark.sql.{AnalysisException, DataFrame}
 import org.apache.spark.sql.catalyst.analysis.{IndexAlreadyExistsException, NoSuchIndexException}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Sample, Sort}
@@ -1126,7 +1125,7 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
     val invalidUrl = originalUrl.replace("localhost", "nonexistenthost")
       .replace("127.0.0.1", "1.2.3.4")
 
-    withConf(s"spark.sql.catalog.$catalogName.url", invalidUrl) {
+    withSqlConf(s"spark.sql.catalog.$catalogName.url" -> invalidUrl) {
       // We want to check that SQLException is thrown and not FAILED_JDBC.TABLE_EXISTS
       val e = intercept[java.sql.SQLException] {
         sql(s"SELECT * FROM $invalidTableName")

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -1130,7 +1130,7 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
       val e = intercept[AnalysisException] {
         sql(s"SELECT * FROM $invalidTableName")
       }
-      assert(e.getCondition !== FAILED_JDBC.TABLE_EXISTS)
+      assert(e.getCondition !== "FAILED_JDBC.TABLE_EXISTS")
     }
   }
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -1125,7 +1125,7 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
     val invalidUrl = originalUrl.replace("localhost", "nonexistenthost")
       .replace("127.0.0.1", "1.2.3.4")
 
-    withSqlConf(s"spark.sql.catalog.$catalogName.url" -> invalidUrl) {
+    withSQLConf(s"spark.sql.catalog.$catalogName.url" -> invalidUrl) {
       // We want to check that SQLException is thrown and not FAILED_JDBC.TABLE_EXISTS
       val e = intercept[java.sql.SQLException] {
         sql(s"SELECT * FROM $invalidTableName")

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -1119,7 +1119,7 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
     }
   }
 
-  test("SPARK-52262: FAILED_JDBC.TABLE_EXISTS not thrown on connecttion error") {
+  test("SPARK-52262: FAILED_JDBC.TABLE_EXISTS not thrown on connection error") {
     val invalidTableName = s"$catalogName.invalid"
     val originalUrl = spark.conf.get(s"spark.sql.catalog.$catalogName.url")
     val invalidUrl = originalUrl.replace("localhost", "nonexistenthost")

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -1126,10 +1126,11 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
       .replace("127.0.0.1", "1.2.3.4")
 
     withSQLConf(s"spark.sql.catalog.$catalogName.url" -> invalidUrl) {
-      // We want to check that SQLException is thrown and not FAILED_JDBC.TABLE_EXISTS
-      val e = intercept[java.sql.SQLException] {
+      // Ideally we would catch SQLException, but analyzer wraps it
+      val e = intercept[AnalysisException] {
         sql(s"SELECT * FROM $invalidTableName")
       }
+      assert(e.getCondition !== FAILED_JDBC.TABLE_EXISTS)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -94,15 +94,15 @@ class JDBCTableCatalog extends TableCatalog
     checkNamespace(ident.namespace())
     val writeOptions = new JdbcOptionsInWrite(
       options.parameters + (JDBCOptions.JDBC_TABLE_NAME -> getTableName(ident)))
-    JdbcUtils.classifyException(
-      condition = "FAILED_JDBC.TABLE_EXISTS",
-      messageParameters = Map(
-        "url" -> options.getRedactUrl(),
-        "tableName" -> toSQLId(ident)),
-      dialect,
-      description = s"Failed table existence check: $ident",
-      isRuntime = false) {
-      JdbcUtils.withConnection(options)(JdbcUtils.tableExists(_, writeOptions))
+    JdbcUtils.withConnection(options) {
+      JdbcUtils.classifyException(
+        condition = "FAILED_JDBC.TABLE_EXISTS",
+        messageParameters = Map(
+          "url" -> options.getRedactUrl(),
+          "tableName" -> toSQLId(ident)),
+        dialect,
+        description = s"Failed table existence check: $ident",
+        isRuntime = false)(JdbcUtils.tableExists(_, writeOptions))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Swap order of `withConnection` and `classifyException` in `loadTable` since connection errors were swallowed with `FAILED_JDBC.TABLE_EXISTS`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To not have misleading error message.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
User would not see wrong wrapped error.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added a unit test and used debugger locally.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
