### PR TITLE
[SPARK-52263][CORE][TESTS] Move the benchmark code related to `Sorter` from `SorterSuite` to `SorterBenchmark`

### DIFF
--- a/core/benchmarks/SorterBenchmark-jdk21-results.txt
+++ b/core/benchmarks/SorterBenchmark-jdk21-results.txt
@@ -1,0 +1,26 @@
+================================================================================================
+key-value pairs sort
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1014-azure
+AMD EPYC 7763 64-Core Processor
+key-value pairs sort 25000000:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Tuple-sort using Arrays.sort()                    17292          17584         413          1.4         691.7       1.0X
+KV-sort using Sorter                              21245          21340         134          1.2         849.8       0.8X
+
+
+================================================================================================
+primitive int array sort
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1014-azure
+AMD EPYC 7763 64-Core Processor
+primitive int array sort 25000000:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------
+Java Arrays.sort() on non-primitive int array            14231          14561         468          1.8         569.2       1.0X
+Java Arrays.sort() on primitive int array                 2141           2145           6         11.7          85.6       6.6X
+Sorter without key reuse on primitive int array           8607           8612           7          2.9         344.3       1.7X
+Sorter with key reuse on primitive int array             10602          10621          27          2.4         424.1       1.3X
+
+

--- a/core/benchmarks/SorterBenchmark-results.txt
+++ b/core/benchmarks/SorterBenchmark-results.txt
@@ -1,0 +1,26 @@
+================================================================================================
+key-value pairs sort
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1014-azure
+AMD EPYC 7763 64-Core Processor
+key-value pairs sort 25000000:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Tuple-sort using Arrays.sort()                    20545          20560          21          1.2         821.8       1.0X
+KV-sort using Sorter                              26696          26797         143          0.9        1067.8       0.8X
+
+
+================================================================================================
+primitive int array sort
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1014-azure
+AMD EPYC 7763 64-Core Processor
+primitive int array sort 25000000:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------
+Java Arrays.sort() on non-primitive int array            15325          15510         263          1.6         613.0       1.0X
+Java Arrays.sort() on primitive int array                 2088           2141          76         12.0          83.5       7.3X
+Sorter without key reuse on primitive int array           8254           8262          10          3.0         330.2       1.9X
+Sorter with key reuse on primitive int array             10184          10186           3          2.5         407.3       1.5X
+
+

--- a/core/src/test/scala/org/apache/spark/util/collection/SorterBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/SorterBenchmark.scala
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util.collection
+
+import java.lang.{Float => JFloat}
+import java.util
+
+import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
+import org.apache.spark.util.random.XORShiftRandom
+
+/**
+ * Benchmark for o.a.s.util.collection.Sorter.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class> <spark core test jar>
+ *   2. build/sbt "core/Test/runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "core/Test/runMain <this class>"
+ *      Results will be written to "benchmarks/SorterBenchmark-results.txt".
+ * }}}
+ * */
+object SorterBenchmark extends BenchmarkBase {
+
+  def keyValuePairsSortBenchmark(): Unit = {
+    val numElements = 25000000 // 25 mil
+    val rand = new XORShiftRandom(123)
+    val benchmark =
+      new Benchmark(s"key-value pairs sort $numElements", numElements, output = output)
+
+    // Test key-value pairs where each element is a Tuple2[Float, Integer]
+    val kvTuples = Array.tabulate(numElements) { i =>
+      (JFloat.valueOf(rand.nextFloat()), Integer.valueOf(i))
+    }
+
+    benchmark.addTimerCase("Tuple-sort using Arrays.sort()") { timer =>
+      val kvTupleArray = new Array[AnyRef](numElements)
+      System.arraycopy(kvTuples, 0, kvTupleArray, 0, numElements)
+      timer.startTiming()
+      util.Arrays.sort(kvTupleArray, (x: AnyRef, y: AnyRef) =>
+        x.asInstanceOf[(JFloat, _)]._1.compareTo(y.asInstanceOf[(JFloat, _)]._1))
+      timer.stopTiming()
+    }
+
+    // Test Sorter where each element alternates between Float and Integer, non-primitive
+    val keyValues = {
+      val data = new Array[AnyRef](numElements * 2)
+      var i = 0
+      while (i < numElements) {
+        data(2 * i) = kvTuples(i)._1
+        data(2 * i + 1) = kvTuples(i)._2
+        i += 1
+      }
+      data
+    }
+
+    benchmark.addTimerCase("KV-sort using Sorter") { timer =>
+      val keyValueArray = new Array[AnyRef](numElements * 2)
+      System.arraycopy(keyValues, 0, keyValueArray, 0, numElements * 2)
+      val sorter = new Sorter(new KVArraySortDataFormat[JFloat, AnyRef])
+      timer.startTiming()
+      sorter.sort(keyValueArray, 0, numElements, (x: JFloat, y: JFloat) => x.compareTo(y))
+      timer.stopTiming()
+    }
+
+    benchmark.run()
+  }
+
+  def primitiveIntArraySortBenchmark(): Unit = {
+    val numElements = 25000000 // 25 mil
+    val rand = new XORShiftRandom(123)
+    val benchmark =
+      new Benchmark(s"primitive int array sort $numElements", numElements, output = output)
+
+    val ints = Array.fill(numElements)(rand.nextInt())
+    val intObjects = {
+      val data = new Array[Integer](numElements)
+      var i = 0
+      while (i < numElements) {
+        data(i) = Integer.valueOf(ints(i))
+        i += 1
+      }
+      data
+    }
+
+    benchmark.addTimerCase("Java Arrays.sort() on non-primitive int array") { timer =>
+      val intObjectArray = new Array[Integer](numElements)
+      System.arraycopy(intObjects, 0, intObjectArray, 0, numElements)
+      timer.startTiming()
+      util.Arrays.sort(intObjectArray, (x: Integer, y: Integer) => x.compareTo(y))
+      timer.stopTiming()
+    }
+
+    benchmark.addTimerCase("Java Arrays.sort() on primitive int array") { timer =>
+      val intPrimitiveArray = new Array[Int](numElements)
+      System.arraycopy(ints, 0, intPrimitiveArray, 0, numElements)
+      timer.startTiming()
+      util.Arrays.sort(intPrimitiveArray)
+      timer.stopTiming()
+    }
+
+    benchmark.addTimerCase("Sorter without key reuse on primitive int array") { timer =>
+      val intPrimitiveArray = new Array[Int](numElements)
+      System.arraycopy(ints, 0, intPrimitiveArray, 0, numElements)
+      val sorterWithoutKeyReuse = new Sorter(new IntArraySortDataFormat)
+      timer.startTiming()
+      sorterWithoutKeyReuse.sort(intPrimitiveArray, 0, numElements, Ordering[Int])
+      timer.stopTiming()
+    }
+
+    benchmark.addTimerCase("Sorter with key reuse on primitive int array") { timer =>
+      val intPrimitiveArray = new Array[Int](numElements)
+      System.arraycopy(ints, 0, intPrimitiveArray, 0, numElements)
+      val sorterWithKeyReuse = new Sorter(new KeyReuseIntArraySortDataFormat)
+      timer.startTiming()
+      sorterWithKeyReuse.sort(intPrimitiveArray, 0, numElements, Ordering[IntWrapper])
+      timer.stopTiming()
+    }
+
+    benchmark.run()
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    runBenchmark("key-value pairs sort") {
+      keyValuePairsSortBenchmark()
+    }
+    runBenchmark("primitive int array sort") {
+      primitiveIntArraySortBenchmark()
+    }
+  }
+
+  /** Format to sort a simple Array[Int]. Could be easily generified and specialized. */
+  class IntArraySortDataFormat extends AbstractIntArraySortDataFormat[Int] {
+
+    override protected def getKey(data: Array[Int], pos: Int): Int = {
+      data(pos)
+    }
+  }
+
+  abstract class AbstractIntArraySortDataFormat[K] extends SortDataFormat[K, Array[Int]] {
+
+    override def swap(data: Array[Int], pos0: Int, pos1: Int): Unit = {
+      val tmp = data(pos0)
+      data(pos0) = data(pos1)
+      data(pos1) = tmp
+    }
+
+    override def copyElement(src: Array[Int], srcPos: Int, dst: Array[Int], dstPos: Int): Unit = {
+      dst(dstPos) = src(srcPos)
+    }
+
+    /** Copy a range of elements starting at src(srcPos) to dest, starting at destPos. */
+    override def copyRange(src: Array[Int], srcPos: Int,
+        dst: Array[Int], dstPos: Int, length: Int): Unit = {
+      System.arraycopy(src, srcPos, dst, dstPos, length)
+    }
+
+    /** Allocates a new structure that can hold up to 'length' elements. */
+    override def allocate(length: Int): Array[Int] = {
+      new Array[Int](length)
+    }
+  }
+
+  /** Wrapper of Int for key reuse. */
+  class IntWrapper(var key: Int = 0) extends Ordered[IntWrapper] {
+
+    override def compare(that: IntWrapper): Int = {
+      Ordering.Int.compare(key, that.key)
+    }
+  }
+
+  /** SortDataFormat for Array[Int] with reused keys. */
+  class KeyReuseIntArraySortDataFormat extends AbstractIntArraySortDataFormat[IntWrapper] {
+
+    override def newKey(): IntWrapper = {
+      new IntWrapper()
+    }
+
+    override def getKey(data: Array[Int], pos: Int, reuse: IntWrapper): IntWrapper = {
+      if (reuse == null) {
+        new IntWrapper(data(pos))
+      } else {
+        reuse.key = data(pos)
+        reuse
+      }
+    }
+
+    override protected def getKey(data: Array[Int], pos: Int): IntWrapper = {
+      getKey(data, pos, null)
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
@@ -18,10 +18,8 @@
 package org.apache.spark.util.collection
 
 import java.util.Arrays
-import java.util.concurrent.TimeUnit
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.util.Utils.timeIt
 import org.apache.spark.util.random.XORShiftRandom
 
 class SorterSuite extends SparkFunSuite {
@@ -169,28 +167,6 @@ class SorterSuite extends SparkFunSuite {
     } while (i < sizeOfArrayToSort)
     assert(sum === runLengths.length)
     */
-  }
-
-  /** Runs an experiment several times. */
-  def runExperiment(name: String, skip: Boolean = false)(f: => Unit, prepare: () => Unit): Unit = {
-    if (skip) {
-      logInfo(s"Skipped experiment $name.")
-      return
-    }
-
-    val firstTry = TimeUnit.NANOSECONDS.toMillis(timeIt(1)(f, Some(prepare)))
-    System.gc()
-
-    var i = 0
-    var next10: Long = 0
-    while (i < 10) {
-      val time = TimeUnit.NANOSECONDS.toMillis(timeIt(1)(f, Some(prepare)))
-      next10 += time
-      logInfo(s"$name: Took $time ms")
-      i += 1
-    }
-
-    logInfo(s"$name: ($firstTry ms first try, ${next10 / 10} ms average)")
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.util.collection
 
-import java.lang.{Float => JFloat}
 import java.util.Arrays
 import java.util.concurrent.TimeUnit
 
@@ -192,113 +191,6 @@ class SorterSuite extends SparkFunSuite {
     }
 
     logInfo(s"$name: ($firstTry ms first try, ${next10 / 10} ms average)")
-  }
-
-  /**
-   * This provides a simple benchmark for comparing the Sorter with Java internal sorting.
-   * Ideally these would be executed one at a time, each in their own JVM, so their listing
-   * here is mainly to have the code. Running multiple tests within the same JVM session would
-   * prevent JIT inlining overridden methods and hence hurt the performance.
-   *
-   * The goal of this code is to sort an array of key-value pairs, where the array physically
-   * has the keys and values alternating. The basic Java sorts work only on the keys, so the
-   * real Java solution is to make Tuple2s to store the keys and values and sort an array of
-   * those, while the Sorter approach can work directly on the input data format.
-   */
-  ignore("Sorter benchmark for key-value pairs") {
-    val numElements = 25000000 // 25 mil
-    val rand = new XORShiftRandom(123)
-
-    // Test our key-value pairs where each element is a Tuple2[Float, Integer].
-
-    val kvTuples = Array.tabulate(numElements) { i =>
-      (JFloat.valueOf(rand.nextFloat()), Integer.valueOf(i))
-    }
-
-    val kvTupleArray = new Array[AnyRef](numElements)
-    val prepareKvTupleArray = () => {
-      System.arraycopy(kvTuples, 0, kvTupleArray, 0, numElements)
-    }
-    runExperiment("Tuple-sort using Arrays.sort()")({
-      Arrays.sort(kvTupleArray, (x: AnyRef, y: AnyRef) =>
-        x.asInstanceOf[(JFloat, _)]._1.compareTo(y.asInstanceOf[(JFloat, _)]._1))
-    }, prepareKvTupleArray)
-
-    // Test our Sorter where each element alternates between Float and Integer, non-primitive
-
-    val keyValues = {
-      val data = new Array[AnyRef](numElements * 2)
-      var i = 0
-      while (i < numElements) {
-        data(2 * i) = kvTuples(i)._1
-        data(2 * i + 1) = kvTuples(i)._2
-        i += 1
-      }
-      data
-    }
-
-    val keyValueArray = new Array[AnyRef](numElements * 2)
-    val prepareKeyValueArray = () => {
-      System.arraycopy(keyValues, 0, keyValueArray, 0, numElements * 2)
-    }
-
-    val sorter = new Sorter(new KVArraySortDataFormat[JFloat, AnyRef])
-    runExperiment("KV-sort using Sorter")({
-      sorter.sort(keyValueArray, 0, numElements, (x: JFloat, y: JFloat) => x.compareTo(y))
-    }, prepareKeyValueArray)
-  }
-
-  /**
-   * Tests for sorting with primitive keys with/without key reuse. Java's Arrays.sort is used as
-   * reference, which is expected to be faster but it can only sort a single array. Sorter can be
-   * used to sort parallel arrays.
-   *
-   * Ideally these would be executed one at a time, each in their own JVM, so their listing
-   * here is mainly to have the code. Running multiple tests within the same JVM session would
-   * prevent JIT inlining overridden methods and hence hurt the performance.
-   */
-  ignore("Sorter benchmark for primitive int array") {
-    val numElements = 25000000 // 25 mil
-    val rand = new XORShiftRandom(123)
-
-    val ints = Array.fill(numElements)(rand.nextInt())
-    val intObjects = {
-      val data = new Array[Integer](numElements)
-      var i = 0
-      while (i < numElements) {
-        data(i) = Integer.valueOf(ints(i))
-        i += 1
-      }
-      data
-    }
-
-    val intObjectArray = new Array[Integer](numElements)
-    val prepareIntObjectArray = () => {
-      System.arraycopy(intObjects, 0, intObjectArray, 0, numElements)
-    }
-
-    runExperiment("Java Arrays.sort() on non-primitive int array")(
-      Arrays.sort(intObjectArray, (x: Integer, y: Integer) => x.compareTo(y)),
-      prepareIntObjectArray)
-
-    val intPrimitiveArray = new Array[Int](numElements)
-    val prepareIntPrimitiveArray = () => {
-      System.arraycopy(ints, 0, intPrimitiveArray, 0, numElements)
-    }
-
-    runExperiment("Java Arrays.sort() on primitive int array")({
-      Arrays.sort(intPrimitiveArray)
-    }, prepareIntPrimitiveArray)
-
-    val sorterWithoutKeyReuse = new Sorter(new IntArraySortDataFormat)
-    runExperiment("Sorter without key reuse on primitive int array")({
-      sorterWithoutKeyReuse.sort(intPrimitiveArray, 0, numElements, Ordering[Int])
-    }, prepareIntPrimitiveArray)
-
-    val sorterWithKeyReuse = new Sorter(new KeyReuseIntArraySortDataFormat)
-    runExperiment("Sorter with key reuse on primitive int array")({
-      sorterWithKeyReuse.sort(intPrimitiveArray, 0, numElements, Ordering[IntWrapper])
-    }, prepareIntPrimitiveArray)
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The main changes proposed in this pr are as follows:
1. Implemented `SorterBenchmark` by referring to the test cases named "Sorter benchmark for key-value pairs" and "Sorter benchmark for primitive int array" in `org.apache.spark.util.collection.SorterSuite`.
2. Updated the benchmark result files for `SorterBenchmark`.
3. Removed "Sorter benchmark for key-value pairs" and "Sorter benchmark for primitive int array" from `org.apache.spark.util.collection.SorterSuite`, as they were previously ignored.

### Why are the changes needed?
"Sorter benchmark for key-value pairs" and "Sorter benchmark for primitive int array" are more suitable to exist as micro-benchmarks.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
