### PR TITLE
[SPARK-52272][SQL] HiveExternalCatalog alter table should update column comments

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -3392,4 +3392,21 @@ class HiveDDLSuite
       )
     }
   }
+
+  test("SPARK-52272: alter table should update column comments") {
+    val tabName = "tab1"
+    withTable(tabName) {
+      val catalog = spark.sessionState.catalog
+
+      sql(s"CREATE TABLE $tabName (col int COMMENT 'comment1') USING PARQUET")
+      val identifier = TableIdentifier(tabName, Some("default"))
+
+      val table = catalog.getTableMetadata(identifier)
+      val newTable = table.copy(schema =
+        new StructType().add("col", IntegerType, nullable = true, "comment2"))
+      catalog.alterTable(newTable)
+      val fetchedTable = catalog.getTableMetadata(identifier)
+      assert(fetchedTable.schema == newTable.schema)
+    }
+  }
 }


### PR DESCRIPTION
This bug was noticed by @gengliangwang , thanks!

### What changes were proposed in this pull request?
Improve HiveExternalCatalog.alterTable to update column comments if they are changed in the schema.

### Why are the changes needed?
Users use this method assuming comments should be updated.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add test to HiveDDLSuite

### Was this patch authored or co-authored using generative AI tooling?
No
