### PR TITLE
[SPARK-52225][BUILD][FOLLOW-UP] Change -it to -ti in Docker execution in release script

### DIFF
--- a/dev/create-release/do-release-docker.sh
+++ b/dev/create-release/do-release-docker.sh
@@ -163,7 +163,7 @@ if [ -n "$JAVA" ]; then
 fi
 
 echo "Building $RELEASE_TAG; output will be at $WORKDIR/output"
-docker $([ -z "$GITHUB_ACTIONS" ] && echo "-it") run \
+docker $([ -z "$GITHUB_ACTIONS" ] && echo "-ti") run \
   --env-file "$ENVFILE" \
   --volume "$WORKDIR:/opt/spark-rm" \
   $JAVA_VOL \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/50945 that fixes it to -ti in Docker execution in release script.

### Why are the changes needed?

Typo of the option.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.