### PR TITLE
[SPARK-52243][CONNECT] Add NERF support for schema-related InvalidPlanInput errors

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3198,6 +3198,12 @@
     },
     "sqlState" : "42K06"
   },
+  "INVALID_OUTPUT_SCHEMA_TYPE_FOR_TRANSFORM_WITH_STATE_IN_PANDAS_NON_STRUCT" : {
+    "message" : [
+      "Invalid user-defined output schema type for TransformWithStateInPandas. Expect a struct type, but got <dataType>."
+    ],
+    "sqlState" : "42K09"
+  },
   "INVALID_PANDAS_UDF_PLACEMENT" : {
     "message" : [
       "The group aggregate pandas UDF <functionList> cannot be invoked together with as other, non-pandas aggregate functions."
@@ -3354,6 +3360,12 @@
     ],
     "sqlState" : "42602"
   },
+  "INVALID_PYTHON_UDTF_RETURN_TYPE_NON_STRUCT" : {
+    "message" : [
+      "Invalid Python user-defined table function return type. Expect a struct type, but got <dataType>."
+    ],
+    "sqlState" : "42K09"
+  },
   "INVALID_QUERY_MIXED_QUERY_PARAMETERS" : {
     "message" : [
       "Parameterized query must either use positional, or named parameters, but not both."
@@ -3431,6 +3443,12 @@
       "<name> is not a valid name for tables/schemas. Valid names only contain alphabet characters, numbers and _."
     ],
     "sqlState" : "42602"
+  },
+  "INVALID_SCHEMA_TYPE_NON_STRUCT" : {
+    "message" : [
+      "Invalid schema type. Expect a struct type, but got <dataType>."
+    ],
+    "sqlState" : "42K09"
   },
   "INVALID_SET_SYNTAX" : {
     "message" : [
@@ -3641,6 +3659,12 @@
       "The statement or clause: <operation> is not valid."
     ],
     "sqlState" : "42601"
+  },
+  "INVALID_STATE_SCHEMA_TYPE_FOR_FLAT_MAP_GROUPS_WITH_STATE_NON_STRUCT" : {
+    "message" : [
+      "Invalid state schema type for flatMapGroupsWithState. Expect a struct type, but got <dataType>."
+    ],
+    "sqlState" : "42K09"
   },
   "INVALID_SUBQUERY_EXPRESSION" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3198,12 +3198,6 @@
     },
     "sqlState" : "42K06"
   },
-  "INVALID_OUTPUT_SCHEMA_TYPE_FOR_TRANSFORM_WITH_STATE_IN_PANDAS_NON_STRUCT" : {
-    "message" : [
-      "Invalid user-defined output schema type for TransformWithStateInPandas. Expect a struct type, but got <dataType>."
-    ],
-    "sqlState" : "42K09"
-  },
   "INVALID_PANDAS_UDF_PLACEMENT" : {
     "message" : [
       "The group aggregate pandas UDF <functionList> cannot be invoked together with as other, non-pandas aggregate functions."
@@ -3359,12 +3353,6 @@
       "<value> is an invalid property value, please use quotes, e.g. SET <key>=<value>"
     ],
     "sqlState" : "42602"
-  },
-  "INVALID_PYTHON_UDTF_RETURN_TYPE_NON_STRUCT" : {
-    "message" : [
-      "Invalid Python user-defined table function return type. Expect a struct type, but got <dataType>."
-    ],
-    "sqlState" : "42K09"
   },
   "INVALID_QUERY_MIXED_QUERY_PARAMETERS" : {
     "message" : [
@@ -3659,12 +3647,6 @@
       "The statement or clause: <operation> is not valid."
     ],
     "sqlState" : "42601"
-  },
-  "INVALID_STATE_SCHEMA_TYPE_FOR_FLAT_MAP_GROUPS_WITH_STATE_NON_STRUCT" : {
-    "message" : [
-      "Invalid state schema type for flatMapGroupsWithState. Expect a struct type, but got <dataType>."
-    ],
-    "sqlState" : "42K09"
   },
   "INVALID_SUBQUERY_EXPRESSION" : {
     "message" : [

--- a/python/pyspark/sql/tests/connect/test_parity_udtf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udtf.py
@@ -61,7 +61,7 @@ class UDTFParityTests(BaseUDTFTestsMixin, ReusedConnectTestCase):
                 yield a + 1,
 
         with self.assertRaisesRegex(
-            InvalidPlanInput, "Invalid Python user-defined table function return type."
+            InvalidPlanInput, "Invalid schema type. Expect a struct type, but got"
         ):
             TestUDTF(lit(1)).collect()
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/DataTypeErrorsBase.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/DataTypeErrorsBase.scala
@@ -85,7 +85,7 @@ private[sql] trait DataTypeErrorsBase {
     else value.toString
   }
 
-  protected def quoteByDefault(elem: String): String = {
+  protected[sql] def quoteByDefault(elem: String): String = {
     "\"" + elem + "\""
   }
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/InvalidInputErrors.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/InvalidInputErrors.scala
@@ -19,11 +19,21 @@ package org.apache.spark.sql.connect.planner
 
 import scala.collection.mutable
 
+import org.apache.spark.SparkThrowableHelper
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.connect.common.{InvalidCommandInput, InvalidPlanInput}
+import org.apache.spark.sql.errors.DataTypeErrors.{quoteByDefault, toSQLType}
 import org.apache.spark.sql.types.DataType
 
 object InvalidInputErrors {
+
+  // invalidPlanInput is a helper function to facilitate the migration of InvalidInputErrors
+  // to support NERF.
+  private def invalidPlanInput(
+      errorCondition: String,
+      messageParameters: Map[String, String] = Map.empty): InvalidPlanInput = {
+    InvalidPlanInput(SparkThrowableHelper.getMessage(errorCondition, messageParameters))
+  }
 
   def unknownRelationNotSupported(rel: proto.Relation): InvalidPlanInput =
     InvalidPlanInput(s"${rel.getUnknown} not supported.")
@@ -72,11 +82,6 @@ object InvalidInputErrors {
   def rowNotSupportedForUdf(errorType: String): InvalidPlanInput =
     InvalidPlanInput(s"Row is not a supported $errorType type for this UDF.")
 
-  def invalidUserDefinedOutputSchemaType(actualType: String): InvalidPlanInput =
-    InvalidPlanInput(
-      s"Invalid user-defined output schema type for TransformWithStateInPandas. " +
-        s"Expect a struct type, but got $actualType.")
-
   def notFoundCachedLocalRelation(hash: String, sessionUUID: String): InvalidPlanInput =
     InvalidPlanInput(
       s"Not found any cached local relation with the hash: " +
@@ -91,8 +96,10 @@ object InvalidInputErrors {
   def schemaRequiredForLocalRelation(): InvalidPlanInput =
     InvalidPlanInput("Schema for LocalRelation is required when the input data is not provided.")
 
-  def invalidSchema(schema: DataType): InvalidPlanInput =
-    InvalidPlanInput(s"Invalid schema $schema")
+  def invalidSchemaNonStructType(schema: String, dataType: DataType): InvalidPlanInput =
+    invalidPlanInput(
+      "INVALID_SCHEMA.NON_STRUCT_TYPE",
+      Map("inputSchema" -> quoteByDefault(schema), "dataType" -> toSQLType(dataType)))
 
   def invalidJdbcParams(): InvalidPlanInput =
     InvalidPlanInput("Invalid jdbc params, please specify jdbc url and table.")
@@ -106,8 +113,8 @@ object InvalidInputErrors {
   def doesNotSupport(what: String): InvalidPlanInput =
     InvalidPlanInput(s"Does not support $what")
 
-  def invalidSchemaDataType(dataType: DataType): InvalidPlanInput =
-    InvalidPlanInput(s"Invalid schema dataType $dataType")
+  def invalidSchemaType(dataType: DataType): InvalidPlanInput =
+    invalidPlanInput("INVALID_SCHEMA_TYPE_NON_STRUCT", Map("dataType" -> toSQLType(dataType)))
 
   def expressionIdNotSupported(exprId: Int): InvalidPlanInput =
     InvalidPlanInput(s"Expression with ID: $exprId is not supported")
@@ -189,8 +196,10 @@ object InvalidInputErrors {
   def usingColumnsOrJoinConditionSetInJoin(): InvalidPlanInput =
     InvalidPlanInput("Using columns or join conditions cannot be set at the same time in Join")
 
-  def invalidStateSchemaDataType(dataType: DataType): InvalidPlanInput =
-    InvalidPlanInput(s"Invalid state schema dataType $dataType for flatMapGroupsWithState")
+  def invalidStateSchemaTypeForFlatMapGroupsWithState(dataType: DataType): InvalidPlanInput =
+    invalidPlanInput(
+      "INVALID_STATE_SCHEMA_TYPE_FOR_FLAT_MAP_GROUPS_WITH_STATE_NON_STRUCT",
+      Map("dataType" -> toSQLType(dataType)))
 
   def sqlCommandExpectsSqlOrWithRelations(other: proto.Relation.RelTypeCase): InvalidPlanInput =
     InvalidPlanInput(s"SQL command expects either a SQL or a WithRelations, but got $other")
@@ -213,16 +222,15 @@ object InvalidInputErrors {
   def invalidBucketCount(numBuckets: Int): InvalidCommandInput =
     InvalidCommandInput("INVALID_BUCKET_COUNT", Map("numBuckets" -> numBuckets.toString))
 
-  def invalidPythonUdtfReturnType(actualType: String): InvalidPlanInput =
-    InvalidPlanInput(
-      s"Invalid Python user-defined table function return type. " +
-        s"Expect a struct type, but got $actualType.")
+  def invalidPythonUdtfReturnType(dataType: DataType): InvalidPlanInput =
+    invalidPlanInput(
+      "INVALID_PYTHON_UDTF_RETURN_TYPE_NON_STRUCT",
+      Map("dataType" -> toSQLType(dataType)))
 
-  def invalidUserDefinedOutputSchemaTypeForTransformWithState(
-      actualType: String): InvalidPlanInput =
-    InvalidPlanInput(
-      s"Invalid user-defined output schema type for TransformWithStateInPandas. " +
-        s"Expect a struct type, but got $actualType.")
+  def invalidOutputSchemaTypeForTransformWithStateInPandas(dataType: DataType): InvalidPlanInput =
+    invalidPlanInput(
+      "INVALID_OUTPUT_SCHEMA_TYPE_FOR_TRANSFORM_WITH_STATE_IN_PANDAS_NON_STRUCT",
+      Map("dataType" -> toSQLType(dataType)))
 
   def unsupportedUserDefinedFunctionImplementation(clazz: Class[_]): InvalidPlanInput =
     InvalidPlanInput(s"Unsupported UserDefinedFunction implementation: ${clazz}")

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/InvalidInputErrors.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/InvalidInputErrors.scala
@@ -96,7 +96,7 @@ object InvalidInputErrors {
   def schemaRequiredForLocalRelation(): InvalidPlanInput =
     InvalidPlanInput("Schema for LocalRelation is required when the input data is not provided.")
 
-  def invalidSchemaNonStructType(schema: String, dataType: DataType): InvalidPlanInput =
+  def invalidSchemaStringNonStructType(schema: String, dataType: DataType): InvalidPlanInput =
     invalidPlanInput(
       "INVALID_SCHEMA.NON_STRUCT_TYPE",
       Map("inputSchema" -> quoteByDefault(schema), "dataType" -> toSQLType(dataType)))
@@ -113,7 +113,7 @@ object InvalidInputErrors {
   def doesNotSupport(what: String): InvalidPlanInput =
     InvalidPlanInput(s"Does not support $what")
 
-  def invalidSchemaType(dataType: DataType): InvalidPlanInput =
+  def invalidSchemaTypeNonStruct(dataType: DataType): InvalidPlanInput =
     invalidPlanInput("INVALID_SCHEMA_TYPE_NON_STRUCT", Map("dataType" -> toSQLType(dataType)))
 
   def expressionIdNotSupported(exprId: Int): InvalidPlanInput =
@@ -196,11 +196,6 @@ object InvalidInputErrors {
   def usingColumnsOrJoinConditionSetInJoin(): InvalidPlanInput =
     InvalidPlanInput("Using columns or join conditions cannot be set at the same time in Join")
 
-  def invalidStateSchemaTypeForFlatMapGroupsWithState(dataType: DataType): InvalidPlanInput =
-    invalidPlanInput(
-      "INVALID_STATE_SCHEMA_TYPE_FOR_FLAT_MAP_GROUPS_WITH_STATE_NON_STRUCT",
-      Map("dataType" -> toSQLType(dataType)))
-
   def sqlCommandExpectsSqlOrWithRelations(other: proto.Relation.RelTypeCase): InvalidPlanInput =
     InvalidPlanInput(s"SQL command expects either a SQL or a WithRelations, but got $other")
 
@@ -221,16 +216,6 @@ object InvalidInputErrors {
 
   def invalidBucketCount(numBuckets: Int): InvalidCommandInput =
     InvalidCommandInput("INVALID_BUCKET_COUNT", Map("numBuckets" -> numBuckets.toString))
-
-  def invalidPythonUdtfReturnType(dataType: DataType): InvalidPlanInput =
-    invalidPlanInput(
-      "INVALID_PYTHON_UDTF_RETURN_TYPE_NON_STRUCT",
-      Map("dataType" -> toSQLType(dataType)))
-
-  def invalidOutputSchemaTypeForTransformWithStateInPandas(dataType: DataType): InvalidPlanInput =
-    invalidPlanInput(
-      "INVALID_OUTPUT_SCHEMA_TYPE_FOR_TRANSFORM_WITH_STATE_IN_PANDAS_NON_STRUCT",
-      Map("dataType" -> toSQLType(dataType)))
 
   def unsupportedUserDefinedFunctionImplementation(clazz: Class[_]): InvalidPlanInput =
     InvalidPlanInput(s"Unsupported UserDefinedFunction implementation: ${clazz}")

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -773,7 +773,7 @@ class SparkConnectPlanner(
       val stateSchema = DataTypeProtoConverter.toCatalystType(rel.getStateSchema) match {
         case s: StructType => s
         case other =>
-          throw InvalidInputErrors.invalidStateSchemaTypeForFlatMapGroupsWithState(other)
+          throw InvalidInputErrors.invalidSchemaTypeNonStruct(other)
       }
       val stateEncoder = TypedScalaUdf.encoderFor(
         // the state agnostic encoder is the second element in the input encoders.
@@ -1105,7 +1105,7 @@ class SparkConnectPlanner(
       transformDataType(twsInfo.getOutputSchema) match {
         case s: StructType => s
         case dt =>
-          throw InvalidInputErrors.invalidOutputSchemaTypeForTransformWithStateInPandas(dt)
+          throw InvalidInputErrors.invalidSchemaTypeNonStruct(dt)
       }
     }
 
@@ -1501,7 +1501,7 @@ class SparkConnectPlanner(
       StructType.fromDDL,
       fallbackParser = DataType.fromJson) match {
       case s: StructType => s
-      case other => throw InvalidInputErrors.invalidSchemaNonStructType(schema, other)
+      case other => throw InvalidInputErrors.invalidSchemaStringNonStructType(schema, other)
     }
   }
 
@@ -1579,7 +1579,7 @@ class SparkConnectPlanner(
       if (rel.hasSchema) {
         DataTypeProtoConverter.toCatalystType(rel.getSchema) match {
           case s: StructType => reader.schema(s)
-          case other => throw InvalidInputErrors.invalidSchemaType(other)
+          case other => throw InvalidInputErrors.invalidSchemaTypeNonStruct(other)
         }
       }
       localMap.foreach { case (key, value) => reader.option(key, value) }
@@ -2966,7 +2966,7 @@ class SparkConnectPlanner(
     val returnType = if (udtf.hasReturnType) {
       transformDataType(udtf.getReturnType) match {
         case s: StructType => Some(s)
-        case dt => throw InvalidInputErrors.invalidPythonUdtfReturnType(dt)
+        case dt => throw InvalidInputErrors.invalidSchemaTypeNonStruct(dt)
       }
     } else {
       None

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -773,7 +773,7 @@ class SparkConnectPlanner(
       val stateSchema = DataTypeProtoConverter.toCatalystType(rel.getStateSchema) match {
         case s: StructType => s
         case other =>
-          throw InvalidInputErrors.invalidStateSchemaDataType(other)
+          throw InvalidInputErrors.invalidStateSchemaTypeForFlatMapGroupsWithState(other)
       }
       val stateEncoder = TypedScalaUdf.encoderFor(
         // the state agnostic encoder is the second element in the input encoders.
@@ -1105,8 +1105,7 @@ class SparkConnectPlanner(
       transformDataType(twsInfo.getOutputSchema) match {
         case s: StructType => s
         case dt =>
-          throw InvalidInputErrors.invalidUserDefinedOutputSchemaTypeForTransformWithState(
-            dt.typeName)
+          throw InvalidInputErrors.invalidOutputSchemaTypeForTransformWithStateInPandas(dt)
       }
     }
 
@@ -1502,7 +1501,7 @@ class SparkConnectPlanner(
       StructType.fromDDL,
       fallbackParser = DataType.fromJson) match {
       case s: StructType => s
-      case other => throw InvalidInputErrors.invalidSchema(other)
+      case other => throw InvalidInputErrors.invalidSchemaNonStructType(schema, other)
     }
   }
 
@@ -1580,7 +1579,7 @@ class SparkConnectPlanner(
       if (rel.hasSchema) {
         DataTypeProtoConverter.toCatalystType(rel.getSchema) match {
           case s: StructType => reader.schema(s)
-          case other => throw InvalidInputErrors.invalidSchemaDataType(other)
+          case other => throw InvalidInputErrors.invalidSchemaType(other)
         }
       }
       localMap.foreach { case (key, value) => reader.option(key, value) }
@@ -2967,8 +2966,7 @@ class SparkConnectPlanner(
     val returnType = if (udtf.hasReturnType) {
       transformDataType(udtf.getReturnType) match {
         case s: StructType => Some(s)
-        case dt =>
-          throw InvalidInputErrors.invalidPythonUdtfReturnType(dt.typeName)
+        case dt => throw InvalidInputErrors.invalidPythonUdtfReturnType(dt)
       }
     } else {
       None

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/InvalidInputErrorsSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/InvalidInputErrorsSuite.scala
@@ -34,7 +34,7 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
 
   val testCases = Seq(
     TestCase(
-      name = "Invalid schema data type",
+      name = "Invalid schema data type non struct for Parse",
       expectedErrorCondition = "INVALID_SCHEMA_TYPE_NON_STRUCT",
       expectedParameters = Map("dataType" -> "\"ARRAY<INT>\""),
       invalidInput = {
@@ -47,31 +47,8 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
         proto.Relation.newBuilder().setParse(parse).build()
       }),
     TestCase(
-      name = "Invalid schema string non-struct type",
-      expectedErrorCondition = "INVALID_SCHEMA.NON_STRUCT_TYPE",
-      expectedParameters = Map(
-        "inputSchema" -> """"{"type":"array","elementType":"integer","containsNull":false}"""",
-        "dataType" -> "\"ARRAY<INT>\""),
-      invalidInput = {
-        val invalidSchema = """{"type":"array","elementType":"integer","containsNull":false}"""
-
-        val dataSource = proto.Read.DataSource
-          .newBuilder()
-          .setFormat("csv")
-          .setSchema(invalidSchema)
-          .build()
-
-        val read = proto.Read
-          .newBuilder()
-          .setDataSource(dataSource)
-          .build()
-
-        proto.Relation.newBuilder().setRead(read).build()
-      }),
-    TestCase(
-      name = "Invalid output schema type for TransformWithStateInPandas",
-      expectedErrorCondition =
-        "INVALID_OUTPUT_SCHEMA_TYPE_FOR_TRANSFORM_WITH_STATE_IN_PANDAS_NON_STRUCT",
+      name = "Invalid schema type non struct for TransformWithState",
+      expectedErrorCondition = "INVALID_SCHEMA_TYPE_NON_STRUCT",
       expectedParameters = Map("dataType" -> "\"ARRAY<INT>\""),
       invalidInput = {
         val pythonUdf = proto.CommonInlineUserDefinedFunction
@@ -96,6 +73,28 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
           .build()
 
         proto.Relation.newBuilder().setGroupMap(groupMap).build()
+      }),
+    TestCase(
+      name = "Invalid schema string non struct type",
+      expectedErrorCondition = "INVALID_SCHEMA.NON_STRUCT_TYPE",
+      expectedParameters = Map(
+        "inputSchema" -> """"{"type":"array","elementType":"integer","containsNull":false}"""",
+        "dataType" -> "\"ARRAY<INT>\""),
+      invalidInput = {
+        val invalidSchema = """{"type":"array","elementType":"integer","containsNull":false}"""
+
+        val dataSource = proto.Read.DataSource
+          .newBuilder()
+          .setFormat("csv")
+          .setSchema(invalidSchema)
+          .build()
+
+        val read = proto.Read
+          .newBuilder()
+          .setDataSource(dataSource)
+          .build()
+
+        proto.Relation.newBuilder().setRead(read).build()
       }))
 
   // Run all test cases

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/InvalidInputErrorsSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/InvalidInputErrorsSuite.scala
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.planner
+
+import org.apache.spark.SparkThrowableHelper
+import org.apache.spark.connect.proto
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, InvalidPlanInput}
+import org.apache.spark.sql.connect.planner.SparkConnectPlanTest
+import org.apache.spark.sql.types._
+
+class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
+
+  lazy val testLocalRelation =
+    createLocalRelationProto(
+      Seq(AttributeReference("id", IntegerType)(), AttributeReference("name", StringType)()),
+      Seq.empty)
+
+  val testCases = Seq(
+    TestCase(
+      name = "Invalid schema data type",
+      expectedErrorCondition = "INVALID_SCHEMA_TYPE_NON_STRUCT",
+      expectedParameters = Map("dataType" -> "\"ARRAY<INT>\""),
+      invalidInput = {
+        val parse = proto.Parse
+          .newBuilder()
+          .setSchema(DataTypeProtoConverter.toConnectProtoType(ArrayType(IntegerType)))
+          .setFormat(proto.Parse.ParseFormat.PARSE_FORMAT_CSV)
+          .build()
+
+        proto.Relation.newBuilder().setParse(parse).build()
+      }),
+    TestCase(
+      name = "Invalid schema string non-struct type",
+      expectedErrorCondition = "INVALID_SCHEMA.NON_STRUCT_TYPE",
+      expectedParameters = Map(
+        "inputSchema" -> """"{"type":"array","elementType":"integer","containsNull":false}"""",
+        "dataType" -> "\"ARRAY<INT>\""),
+      invalidInput = {
+        val invalidSchema = """{"type":"array","elementType":"integer","containsNull":false}"""
+
+        val dataSource = proto.Read.DataSource
+          .newBuilder()
+          .setFormat("csv")
+          .setSchema(invalidSchema)
+          .build()
+
+        val read = proto.Read
+          .newBuilder()
+          .setDataSource(dataSource)
+          .build()
+
+        proto.Relation.newBuilder().setRead(read).build()
+      }),
+    TestCase(
+      name = "Invalid output schema type for TransformWithStateInPandas",
+      expectedErrorCondition =
+        "INVALID_OUTPUT_SCHEMA_TYPE_FOR_TRANSFORM_WITH_STATE_IN_PANDAS_NON_STRUCT",
+      expectedParameters = Map("dataType" -> "\"ARRAY<INT>\""),
+      invalidInput = {
+        val pythonUdf = proto.CommonInlineUserDefinedFunction
+          .newBuilder()
+          .setPythonUdf(
+            proto.PythonUDF
+              .newBuilder()
+              .setEvalType(211)
+              .setOutputType(DataTypeProtoConverter.toConnectProtoType(ArrayType(IntegerType)))
+              .build())
+          .build()
+
+        val groupMap = proto.GroupMap
+          .newBuilder()
+          .setInput(testLocalRelation)
+          .setFunc(pythonUdf)
+          .setTransformWithStateInfo(
+            proto.TransformWithStateInfo
+              .newBuilder()
+              .setOutputSchema(DataTypeProtoConverter.toConnectProtoType(ArrayType(IntegerType)))
+              .build())
+          .build()
+
+        proto.Relation.newBuilder().setGroupMap(groupMap).build()
+      }))
+
+  // Run all test cases
+  testCases.foreach { testCase =>
+    test(s"${testCase.name}") {
+      val exception = intercept[InvalidPlanInput] {
+        transform(testCase.invalidInput)
+      }
+      val expectedMessage = SparkThrowableHelper.getMessage(
+        testCase.expectedErrorCondition,
+        testCase.expectedParameters)
+      assert(exception.getMessage == expectedMessage)
+    }
+  }
+
+  // Helper case class to define test cases
+  case class TestCase(
+      name: String,
+      expectedErrorCondition: String,
+      expectedParameters: Map[String, String],
+      invalidInput: proto.Relation)
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds NERF (New Error Framework) support for schema-related InvalidPlanInput errors in Spark Connect. The changes include:

1. Added a new error condition in error-conditions.json for schema validation:
   - INVALID_SCHEMA_TYPE_NON_STRUCT

2. Refactored error handling in InvalidInputErrors.scala to use the new NERF framework:
   - Added helper function invalidPlanInput for consistent error message generation
   - Updated schema validation error methods to use NERF error conditions
   - Made quoteByDefault method accessible to other packages

3. Added a test suite InvalidInputErrorsSuite.scala to verify error handling

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

These changes are needed to:
1. Standardize error reporting across Spark Connect using the NERF framework
2. Improve error messages with better parameterization and consistency
3. Ensure proper SQL state codes are associated with schema-related errors
4. Provide clearer error messages for users when schema validation fails

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

`build/sbt "connect/testOnly *InvalidInputErrorsSuite"`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Cursor 0.50.5 (Universal)