### PR TITLE
[SPARK-51987][SQL] DSv2 expressions in column defaults on write

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/types/Metadata.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/Metadata.scala
@@ -40,11 +40,13 @@ import org.apache.spark.util.ArrayImplicits._
  * @since 1.3.0
  */
 @Stable
-sealed class Metadata private[types] (private[types] val map: Map[String, Any])
+sealed class Metadata private[types] (
+    private[types] val map: Map[String, Any],
+    @transient private[types] val runtimeMap: Map[String, Any])
     extends Serializable {
 
   /** No-arg constructor for kryo. */
-  protected def this() = this(null)
+  protected def this() = this(null, null)
 
   /** Tests whether this Metadata contains a binding for a key. */
   def contains(key: String): Boolean = map.contains(key)
@@ -120,6 +122,12 @@ sealed class Metadata private[types] (private[types] val map: Map[String, Any])
     map(key).asInstanceOf[T]
   }
 
+  private[sql] def getExpression[E](key: String): (String, Option[E]) = {
+    val sql = getString(key)
+    val expr = Option(runtimeMap).flatMap(_.get(key).map(_.asInstanceOf[E]))
+    sql -> expr
+  }
+
   private[sql] def jsonValue: JValue = Metadata.toJsonValue(this)
 }
 
@@ -129,7 +137,7 @@ sealed class Metadata private[types] (private[types] val map: Map[String, Any])
 @Stable
 object Metadata {
 
-  private[this] val _empty = new Metadata(Map.empty)
+  private[this] val _empty = new Metadata(Map.empty, Map.empty)
 
   /** Returns an empty Metadata. */
   def empty: Metadata = _empty
@@ -248,6 +256,7 @@ object Metadata {
 class MetadataBuilder {
 
   private val map: mutable.Map[String, Any] = mutable.Map.empty
+  private val runtimeMap: mutable.Map[String, Any] = mutable.Map.empty
 
   /** Returns the immutable version of this map.  Used for java interop. */
   protected def getMap = map.toMap
@@ -255,6 +264,9 @@ class MetadataBuilder {
   /** Include the content of an existing [[Metadata]] instance. */
   def withMetadata(metadata: Metadata): this.type = {
     map ++= metadata.map
+    if (metadata.runtimeMap != null) {
+      runtimeMap ++= metadata.runtimeMap
+    }
     this
   }
 
@@ -293,7 +305,7 @@ class MetadataBuilder {
 
   /** Builds the [[Metadata]] instance. */
   def build(): Metadata = {
-    new Metadata(map.toMap)
+    new Metadata(map.toMap, runtimeMap.toMap)
   }
 
   private def put(key: String, value: Any): this.type = {
@@ -301,8 +313,15 @@ class MetadataBuilder {
     this
   }
 
+  private[sql] def putExpression[E](key: String, sql: String, expr: Option[E]): this.type = {
+    map.put(key, sql)
+    expr.foreach(runtimeMap.put(key, _))
+    this
+  }
+
   def remove(key: String): this.type = {
     map.remove(key)
+    runtimeMap.remove(key)
     this
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -263,7 +263,12 @@ object ResolveDefaultColumns extends QueryErrorsBase
       field: StructField,
       statementType: String,
       metadataKey: String = CURRENT_DEFAULT_COLUMN_METADATA_KEY): Expression = {
-    analyze(field.name, field.dataType, field.metadata.getString(metadataKey), statementType)
+    field.metadata.getExpression[Expression](metadataKey) match {
+      case (sql, Some(expr)) =>
+        analyze(field.name, field.dataType, expr, sql, statementType)
+      case (sql, _) =>
+        analyze(field.name, field.dataType, sql, statementType)
+    }
   }
 
   /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -50,7 +50,7 @@ import org.apache.spark.util.ArrayImplicits._
  */
 abstract class InMemoryBaseTable(
     val name: String,
-    val schema: StructType,
+    override val columns: Array[Column],
     override val partitioning: Array[Transform],
     override val properties: util.Map[String, String],
     override val constraints: Array[Constraint] = Array.empty,
@@ -113,6 +113,8 @@ abstract class InMemoryBaseTable(
       metadata.json
     }
   }
+
+  override val schema: StructType = CatalogV2Util.v2ColumnsToStructType(columns)
 
   // purposely exposes a metadata column that conflicts with a data column in some tests
   override val metadataColumns: Array[MetadataColumn] = Array(IndexColumn, PartitionKeyColumn)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
@@ -38,8 +38,13 @@ class InMemoryRowLevelOperationTable(
     partitioning: Array[Transform],
     properties: util.Map[String, String],
     constraints: Array[Constraint] = Array.empty)
-  extends InMemoryTable(name, schema, partitioning, properties, constraints)
-    with SupportsRowLevelOperations {
+  extends InMemoryTable(
+    name,
+    CatalogV2Util.structTypeToV2Columns(schema),
+    partitioning,
+    properties,
+    constraints)
+  with SupportsRowLevelOperations {
 
   private final val PARTITION_COLUMN_REF = FieldReference(PartitionKeyColumn.name)
   private final val INDEX_COLUMN_REF = FieldReference(IndexColumn.name)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
@@ -33,7 +33,7 @@ import org.apache.spark.util.ArrayImplicits._
  */
 class InMemoryTable(
     name: String,
-    schema: StructType,
+    columns: Array[Column],
     override val partitioning: Array[Transform],
     override val properties: util.Map[String, String],
     override val constraints: Array[Constraint] = Array.empty,
@@ -43,9 +43,21 @@ class InMemoryTable(
     advisoryPartitionSize: Option[Long] = None,
     isDistributionStrictlyRequired: Boolean = true,
     override val numRowsPerSplit: Int = Int.MaxValue)
-  extends InMemoryBaseTable(name, schema, partitioning, properties, constraints, distribution,
+  extends InMemoryBaseTable(name, columns, partitioning, properties, constraints, distribution,
     ordering, numPartitions, advisoryPartitionSize, isDistributionStrictlyRequired,
     numRowsPerSplit) with SupportsDelete {
+
+  def this(
+      name: String,
+      schema: StructType,
+      partitioning: Array[Transform],
+      properties: util.Map[String, String]) = {
+    this(
+      name,
+      CatalogV2Util.structTypeToV2Columns(schema),
+      partitioning,
+      properties)
+  }
 
   override def canDeleteWhere(filters: Array[Filter]): Boolean = {
     InMemoryTable.supportsFilters(filters)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
@@ -118,7 +118,6 @@ class BasicInMemoryTableCatalog extends TableCatalog {
       distributionStrictlyRequired: Boolean = true,
       numRowsPerSplit: Int = Int.MaxValue): Table = {
     // scalastyle:on argcount
-    val schema = CatalogV2Util.v2ColumnsToStructType(columns)
     if (tables.containsKey(ident)) {
       throw new TableAlreadyExistsException(ident.asMultipartIdentifier)
     }
@@ -126,7 +125,7 @@ class BasicInMemoryTableCatalog extends TableCatalog {
     InMemoryTableCatalog.maybeSimulateFailedTableCreation(properties)
 
     val tableName = s"$name.${ident.quoted}"
-    val table = new InMemoryTable(tableName, schema, partitions, properties, constraints,
+    val table = new InMemoryTable(tableName, columns, partitions, properties, constraints,
       distribution, ordering, requiredNumPartitions, advisoryPartitionSize,
       distributionStrictlyRequired, numRowsPerSplit)
     tables.put(ident, table)
@@ -154,7 +153,7 @@ class BasicInMemoryTableCatalog extends TableCatalog {
     val currentVersion = table.currentVersion()
     val newTable = new InMemoryTable(
       name = table.name,
-      schema = schema,
+      columns = CatalogV2Util.structTypeToV2Columns(schema),
       partitioning = finalPartitioning,
       properties = properties,
       constraints = constraints)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithV2Filter.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithV2Filter.scala
@@ -31,10 +31,10 @@ import org.apache.spark.util.ArrayImplicits._
 
 class InMemoryTableWithV2Filter(
     name: String,
-    schema: StructType,
+    columns: Array[Column],
     partitioning: Array[Transform],
     properties: util.Map[String, String])
-  extends InMemoryBaseTable(name, schema, partitioning, properties) with SupportsDeleteV2 {
+  extends InMemoryBaseTable(name, columns, partitioning, properties) with SupportsDeleteV2 {
 
   override def canDeleteWhere(predicates: Array[Predicate]): Boolean = {
     InMemoryTableWithV2Filter.supportsPredicates(predicates)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithV2FilterCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithV2FilterCatalog.scala
@@ -37,8 +37,7 @@ class InMemoryTableWithV2FilterCatalog extends InMemoryTableCatalog {
     InMemoryTableCatalog.maybeSimulateFailedTableCreation(properties)
 
     val tableName = s"$name.${ident.quoted}"
-    val schema = CatalogV2Util.v2ColumnsToStructType(columns)
-    val table = new InMemoryTableWithV2Filter(tableName, schema, partitions, properties)
+    val table = new InMemoryTableWithV2Filter(tableName, columns, partitions, properties)
     tables.put(ident, table)
     namespaces.putIfAbsent(ident.namespace.toList, Map())
     table

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/MetadataSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/MetadataSuite.scala
@@ -17,7 +17,9 @@
 
 package org.apache.spark.sql.types
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.serializer.{JavaSerializer, KryoSerializer, SerializerInstance}
+import org.apache.spark.sql.catalyst.expressions.{Add, Expression, Literal}
 
 class MetadataSuite extends SparkFunSuite {
   test("String Metadata") {
@@ -75,5 +77,80 @@ class MetadataSuite extends SparkFunSuite {
     assert(meta.contains("key"))
     assert(meta === Metadata.fromJson(meta.json))
     intercept[NoSuchElementException](meta.getLong("no_such_key"))
+  }
+
+  test("Kryo serialization for expressions") {
+    val conf = new SparkConf()
+    val serializer = new KryoSerializer(conf).newInstance()
+    checkMetadataExpressions(serializer)
+  }
+
+  test("Java serialization for expressions") {
+    val conf = new SparkConf()
+    val serializer = new JavaSerializer(conf).newInstance()
+    checkMetadataExpressions(serializer)
+  }
+
+  test("JSON representation with expressions") {
+    val meta = new MetadataBuilder()
+      .putString("key", "value")
+      .putExpression("expr", "1 + 3", Some(Add(Literal(1), Literal(3))))
+      .build()
+    assert(meta.json == """{"expr":"1 + 3","key":"value"}""")
+  }
+
+  test("equals and hashCode with expressions") {
+    val meta1 = new MetadataBuilder()
+      .putString("key", "value")
+      .putExpression("expr", "1 + 2", Some(Add(Literal(1), Literal(2))))
+      .build()
+
+    val meta2 = new MetadataBuilder()
+      .putString("key", "value")
+      .putExpression("expr", "1 + 2", Some(Add(Literal(1), Literal(2))))
+      .build()
+
+    val meta3 = new MetadataBuilder()
+      .putString("key", "value")
+      .putExpression("expr", "2 + 3", Some(Add(Literal(2), Literal(3))))
+      .build()
+
+    val meta4 = new MetadataBuilder()
+      .putString("key", "value")
+      .putExpression("expr", "1 + 2", None)
+      .build()
+
+    // meta1 and meta2 are equivalent
+    assert(meta1 === meta2)
+    assert(meta1.hashCode === meta2.hashCode)
+
+    // meta1 and meta3 are different as they contain different expressions
+    assert(meta1 !== meta3)
+    assert(meta1.hashCode !== meta3.hashCode)
+
+    // meta1 and meta4 are equivalent even though meta4 only includes the SQL string
+    assert(meta1 == meta4)
+    assert(meta1.hashCode == meta4.hashCode)
+  }
+
+  private def checkMetadataExpressions(serializer: SerializerInstance): Unit = {
+    val meta = new MetadataBuilder()
+      .putString("key", "value")
+      .putExpression("tempKey", "1", Some(Literal(1)))
+      .build()
+    assert(meta.contains("key"))
+    assert(meta.getString("key") == "value")
+    assert(meta.contains("tempKey"))
+    assert(meta.getExpression[Expression]("tempKey")._1 == "1")
+    assert(meta.getExpression[Expression]("tempKey")._2.contains(Literal(1)))
+
+    val deserializedMeta = serializer.deserialize[Metadata](serializer.serialize(meta))
+    assert(deserializedMeta == meta)
+    assert(deserializedMeta.hashCode == meta.hashCode)
+    assert(deserializedMeta.contains("key"))
+    assert(deserializedMeta.getString("key") == "value")
+    assert(deserializedMeta.contains("tempKey"))
+    assert(deserializedMeta.getExpression[Expression]("tempKey")._1 == "1")
+    assert(deserializedMeta.getExpression[Expression]("tempKey")._2.isEmpty)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.catalog.{Column => ColumnV2, _}
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.connector.catalog.CatalogV2Util.withDefaultOwnership
-import org.apache.spark.sql.connector.expressions.{LiteralValue, Transform}
+import org.apache.spark.sql.connector.expressions.{Cast => V2Cast, Expression, GeneralScalarExpression, LiteralValue, Transform}
 import org.apache.spark.sql.errors.QueryErrorsBase
 import org.apache.spark.sql.execution.FilterExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
@@ -645,8 +645,21 @@ class DataSourceV2SQLSuiteV1Filter
       assert(replaced.columns.length === 1,
         "Replaced table should have new schema.")
       val actual = replaced.columns.head
-      val expected = ColumnV2.create("id", LongType, false, null,
-        new ColumnDefaultValue("41 + 1", LiteralValue(42L, LongType)), null)
+      val expected = ColumnV2.create(
+        "id",
+        LongType,
+        false, /* not nullable */
+        null, /* no comment */
+        new ColumnDefaultValue(
+          "41 + 1",
+          new V2Cast(
+            new GeneralScalarExpression(
+              "+",
+              Array[Expression](LiteralValue(41, IntegerType), LiteralValue(1, IntegerType))),
+            IntegerType,
+            LongType),
+          LiteralValue(42L, LongType)),
+        null /* no metadata */)
       assert(actual === expected,
         "Replaced table should have new schema with DEFAULT column metadata.")
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR allows connectors to expose expression-based defaults on write.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

These changes are needed to avoid the requirement of producing Spark SQL dialect in connectors.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

This PR comes with tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.
