### PR TITLE
[SPARK-52294][INFRA] Add `sql/pipelines` to maven daily test module list

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1296,3 +1296,9 @@ jobs:
           cd ui-test
           npm install --save-dev
           node --experimental-vm-modules node_modules/.bin/jest
+
+  maven-test:
+    name: "Run Maven Test"
+    permissions:
+      packages: write
+    uses: ./.github/workflows/maven_test.yml

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1296,9 +1296,3 @@ jobs:
           cd ui-test
           npm install --save-dev
           node --experimental-vm-modules node_modules/.bin/jest
-
-  maven-test:
-    name: "Run Maven Test"
-    permissions:
-      packages: write
-    uses: ./.github/workflows/maven_test.yml

--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -71,7 +71,7 @@ jobs:
           - >-
             graphx,streaming,hadoop-cloud
           - >-
-            mllib-local,mllib
+            mllib-local,mllib,sql#pipelines
           - >-
             repl,sql#hive-thriftserver
           - >-


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr add `sql/pipelines` to maven daily test module list.

### Why are the changes needed?
Synchronize the modules to be tested in Maven daily test


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- test with maven and java 17: https://github.com/LuciferYang/spark/actions/runs/15228953786/job/42834451689, It has been confirmed in the logs that both `ConstructPipelineEventSuite` and `PipelineEventSuite` will be tested.


### Was this patch authored or co-authored using generative AI tooling?
No
