### PR TITLE
[SPARK-52299][CORE] replace deprecated JsonNode.fields

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -1023,14 +1023,14 @@ private[spark] class JsonProtocol(sparkConf: SparkConf) extends JsonUtils {
   }
 
   def taskResourceRequestMapFromJson(json: JsonNode): Map[String, TaskResourceRequest] = {
-    json.fields().asScala.collect { case field =>
+    json.properties().asScala.collect { case field =>
       val req = taskResourceRequestFromJson(field.getValue)
       (field.getKey, req)
     }.toMap
   }
 
   def executorResourceRequestMapFromJson(json: JsonNode): Map[String, ExecutorResourceRequest] = {
-    json.fields().asScala.collect { case field =>
+    json.properties().asScala.collect { case field =>
       val req = executorResourceRequestFromJson(field.getValue)
       (field.getKey, req)
     }.toMap
@@ -1543,7 +1543,7 @@ private[spark] class JsonProtocol(sparkConf: SparkConf) extends JsonUtils {
 
   def resourcesMapFromJson(json: JsonNode): Map[String, ResourceInformation] = {
     assert(json.isObject, s"expected object, got ${json.getNodeType}")
-    json.fields.asScala.map { field =>
+    json.properties.asScala.map { field =>
       val resourceInfo = ResourceInformation.parseJson(field.getValue.toString)
       (field.getKey, resourceInfo)
     }.toMap
@@ -1555,7 +1555,7 @@ private[spark] class JsonProtocol(sparkConf: SparkConf) extends JsonUtils {
 
   def mapFromJson(json: JsonNode): Map[String, String] = {
     assert(json.isObject, s"expected object, got ${json.getNodeType}")
-    json.fields.asScala.map { field =>
+    json.properties.asScala.map { field =>
       (field.getKey, field.getValue.extractString)
     }.toMap
   }

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -1356,7 +1356,7 @@ private[spark] object jsonProtocolSuite extends Assertions {
       case ((key1, values1: scala.collection.Seq[(String, String)]),
         (key2, values2: scala.collection.Seq[(String, String)])) =>
         assert(key1 === key2)
-        values1.zip(values2).foreach { case (v1, v2) => assert(v1 === v2) }
+        assert(values1.toMap == values2.toMap)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
JsonNode.fields is deprecated, and is supposed to be replaced as JsonNode.properties.


### Why are the changes needed?
Without the fix, there're warning during compile:

[warn] /path/to/spark/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala:1026:10: method fields in class JsonNode is deprecated
[warn] Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=deprecation, site=org.apache.spark.util.JsonProtocol.taskResourceRequestMapFromJson, origin=com.fasterxml.jackson.databind.JsonNode.fields
[warn]     json.fields().asScala.collect { case field =>
[warn]          ^


### Does this PR introduce _any_ user-facing change?
No, it only fixes compilation warning.


### How was this patch tested?
after the fix, no such warning during compilation. all ut passes.


### Was this patch authored or co-authored using generative AI tooling?
No
