### PR TITLE
Increase report interval of spaming logs to 10 seconds

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1017,7 +1017,7 @@ See the [configuration page](configuration.html) for information on Spark config
 </tr>
 <tr>
   <td><code>spark.kubernetes.report.interval</code></td>
-  <td><code>1s</code></td>
+  <td><code>10s</code></td>
   <td>
     Interval between reports of the current Spark job status in cluster mode.
   </td>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -625,7 +625,7 @@ To use a custom metrics.properties for the application master and executors, upd
 </tr>
 <tr>
   <td><code>spark.yarn.report.interval</code></td>
-  <td><code>1s</code></td>
+  <td><code>10s</code></td>
   <td>
     Interval between reports of the current Spark job status in cluster mode.
   </td>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -494,7 +494,7 @@ private[spark] object Config extends Logging {
       .version("2.3.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .checkValue(interval => interval > 0, s"Logging interval must be a positive time value.")
-      .createWithDefaultString("1s")
+      .createWithDefaultString("10s")
 
   val KUBERNETES_EXECUTOR_ENABLE_API_POLLING =
     ConfigBuilder("spark.kubernetes.executor.enableApiPolling")

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -214,7 +214,7 @@ package object config extends Logging {
     .doc("Interval between reports of the current app status.")
     .version("0.9.0")
     .timeConf(TimeUnit.MILLISECONDS)
-    .createWithDefaultString("1s")
+    .createWithDefaultString("10s")
 
   private[spark] val REPORT_LOG_FREQUENCY = {
     ConfigBuilder("spark.yarn.report.loggingFrequency")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

In this PR I want to increase the default report interval of both `K8S` and `Apache Yarn`
from `1s` to `10s`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Due to the logs of type:

> Application status for <app-id> (phase: <status>)

Being printed for every 1 seconds, the amount of logs made our `Airflow`'s UI slow,
it also takes too much space as we save the spark logs for future use.
I think the report interval should be increased to make a better balance between notifying the user
that the application is running and not spamming us.
I think it should be done globally to prevent other users to go what we went through:

1. Getting this bug.
2. Finding if there's a way to reduce the logs.
3. Finding this config (I went streight to the source code, only to find it's someplace at the docs).
4. Updating it in our applications.

If we would update the default, we would ease the use for many users in my opinion.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, in this PR we increase the report interval from 1 second to 10 seconds. 
The log of type:

> Application status for <app-id> (phase: <status>)

Would be printed every 10 seconds and not every 1 second by default.
But the users can change it if they want to, and they shouldn't be affected by it as it's just logging.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

I have tesed the patch manually,
I have an [`Airflow` Cluster with docker](https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html), a k8s cluster. With that, I have created a [spark submit connection](https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html),
and created a DAG that uses the [spark submit operator](https://airflow.apache.org/docs/apache-airflow-providers-apache-spark/stable/operators.html#sparksubmitoperator)
to run spark on my k8s.
The important thing that I have done is that I have added the config:

```json
{
"spark.kubernetes.report.interval": "10s"
}
```

To my spark application at the [spark submit operator conf](https://airflow.apache.org/docs/apache-airflow-providers-apache-spark/stable/_api/airflow/providers/apache/spark/operators/spark_submit/index.html#module-contents).
Which made the report interval to increase to 10 seconds from 1 second.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.

This is my first PR, if there's a problem, please notify me.