### PR TITLE
[SPARK-48660][SQL] Fix explain result for CreateTableAsSelect

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -419,15 +419,12 @@ trait V2CreateTableAsSelectPlan
   def query: LogicalPlan
 
   /**
-   * For EXPLAIN, we want to show the optimized query plan without actually executing the CTAS.
-   * This method returns the query part for optimization and physical planning.
+   * SPARK-48660: Override to return the optimized query plan for explain
    */
   override def stageForExplain(): LogicalPlan = query
 
   /**
-   * SPARK-48660: Override stats to propagate statistics from the inner query
-   * instead of returning dummy statistics like other commands.
-   * This ensures consistency with CreateDataSourceTableAsSelectCommand behavior.
+   * SPARK-48660: Override to return the optimized query plan for explain
    */
   override def stats: Statistics = query.stats
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -414,19 +414,8 @@ case class WriteDelta(
 trait V2CreateTableAsSelectPlan
   extends V2CreateTablePlan
     with AnalysisOnlyCommand
-    with CTEInChildren
-    with ExecutableDuringAnalysis {
+    with CTEInChildren {
   def query: LogicalPlan
-
-  /**
-   * SPARK-48660: Override to return the optimized query plan for explain
-   */
-  override def stageForExplain(): LogicalPlan = query
-
-  /**
-   * SPARK-48660: Override to return the optimized query plan for explain
-   */
-  override def stats: Statistics = query.stats
 
   override def withCTEDefs(cteDefs: Seq[CTERelationDef]): LogicalPlan = {
     withNameAndQuery(newName = name, newQuery = WithCTE(query, cteDefs))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
@@ -93,9 +93,7 @@ case class ExecutedCommandExec(cmd: RunnableCommand) extends LeafExecNode {
     cmd match {
       case cmd: CreateDataSourceTableAsSelectCommand =>
         executedQuery.toSeq
-      case _ =>
-        // For other commands, delegate to the command's innerChildren
-        cmd.innerChildren
+      case _ => cmd :: Nil
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -23,7 +23,7 @@ import org.apache.spark.internal.LogKeys._
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.{AnalysisException, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.catalog._
-import org.apache.spark.sql.catalyst.plans.logical.{CTEInChildren, CTERelationDef, LogicalPlan, WithCTE}
+import org.apache.spark.sql.catalyst.plans.logical.{CTEInChildren, CTERelationDef, LogicalPlan, Statistics, WithCTE}
 import org.apache.spark.sql.catalyst.util.{removeInternalMetadata, CharVarcharUtils}
 import org.apache.spark.sql.classic.ClassicConversions.castToImpl
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -148,6 +148,9 @@ case class CreateDataSourceTableAsSelectCommand(
   extends LeafRunnableCommand with CTEInChildren {
   assert(query.resolved)
   override def innerChildren: Seq[LogicalPlan] = query :: Nil
+
+  // Override stats to return stats from the inner query
+  override def stats: Statistics = query.stats
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     assert(table.tableType != CatalogTableType.VIEW)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -22,7 +22,6 @@ import java.net.URI
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.{AnalysisException, Row, SaveMode, SparkSession}
-import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.plans.logical.{CTEInChildren, CTERelationDef, LogicalPlan, Statistics, WithCTE}
 import org.apache.spark.sql.catalyst.util.{removeInternalMetadata, CharVarcharUtils}
@@ -148,11 +147,7 @@ case class CreateDataSourceTableAsSelectCommand(
     outputColumnNames: Seq[String])
   extends LeafRunnableCommand with CTEInChildren {
   assert(query.resolved)
-
-  // Override to return the eliminated query as innerChildren to help correct the explain result.
-  override def innerChildren: Seq[LogicalPlan] = {
-    Seq(EliminateSubqueryAliases(query))
-  }
+  override def innerChildren: Seq[LogicalPlan] = query :: Nil
 
   // Override stats to return stats from the inner query
   override def stats: Statistics = query.stats

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
@@ -320,7 +320,9 @@ class CreateTableAsSelectSuite extends DataSourceTest with SharedSparkSession {
       """).collect()
 
       val explainOutput = explainResult.map(_.getString(0)).mkString("\n")
-      println(explainOutput)
+
+      assert(explainOutput.contains("CreateDataSourceTableAsSelectCommand"),
+        s"EXPLAIN COST output should contain createtableasselect. Output: $explainOutput")
 
       // The explain output should contain statistics information
       assert(explainOutput.contains("Statistics"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
@@ -301,7 +301,7 @@ class CreateTableAsSelectSuite extends DataSourceTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-48660: EXPLAIN COST should show statistics") {
+  test("SPARK-48660: EXPLAIN COST should exclude SubqueryAlias") {
     withTable("source_table") {
       // Create source table with data
       sql("""

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
@@ -321,14 +321,13 @@ class CreateTableAsSelectSuite extends DataSourceTest with SharedSparkSession {
 
       val explainOutput = explainResult.map(_.getString(0)).mkString("\n")
 
-      assert(explainOutput.contains("CreateDataSourceTableAsSelectCommand"),
-        s"EXPLAIN COST output should contain createtableasselect. Output: $explainOutput")
-
-      // The explain output should contain statistics information
+      // The explain output should not eliminate SubqueryAlias
+      assert(!explainOutput.contains("SubqueryAlias"),
+        s"EXPLAIN COST output should not contain SubqueryAlias. Output: $explainOutput")
       assert(explainOutput.contains("Statistics"),
         s"EXPLAIN COST output should contain statistics information. Output: $explainOutput")
 
-      // The explain output should contain pushdown information
+      // The explain output should contain pushdown
       assert(explainOutput.contains("PushedFilters"),
         s"EXPLAIN COST output should contain pushdown information. Output: $explainOutput")
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

To fix the explain result of 'CreateTableAsSelect', according to how ExplainCommand processes, I find out the following work is needed
- CreateDataSourceTableAsSelectCommand should implement stats
- ExecutedCommandExec should also implement innerChildren for CreateDataSourceTableAsSelectCommand

Here's why:
- As to 'CREATE TABLE ... AS SELECT'
- CreateDataSourceTableAsSelectCommand will finally be the LogicPlan
- ExecutedCommandExec(cmd=CreateDataSourceTableAsSelectCommand) will finally be the PhysicalPlan

Thus , to have the expected output
- CreateDataSourceTableAsSelectCommand adds stats implementation
- ExecutedCommandExec adds innerChildren for QueryExecution.stringWithStats

### Why are the changes needed?

as reported in SPARK-48660, explain result of 'CreateTableAsSelect' is incorrect. It's missing stats for logic plan and optimization for physical plan.


### Does this PR introduce _any_ user-facing change?

Yes, it affects the explain result.


### How was this patch tested?

UT.


### Was this patch authored or co-authored using generative AI tooling?

No
