### PR TITLE
[SPARK-52300][SQL] Make SQL UDTVF resolution use consistent configurations with view resolution

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -243,8 +243,7 @@ object AnalysisContext {
 }
 
 object Analyzer {
-  // List of configurations that should be passed on when resolving views and User-Defined Table
-  // Valued functions
+  // List of configurations that should be passed on when resolving views and SQL UDF.
   private val RETAINED_ANALYSIS_FLAGS = Seq(
     // retainedHiveConfigs
     // TODO: remove these Hive-related configs after the `RelationConversions` is moved to

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.{AliasIdentifier, InternalRow, SQLConfHelper}
-import org.apache.spark.sql.catalyst.analysis.{AnsiTypeCoercion, MultiInstanceRelation, Resolver, TypeCoercion, TypeCoercionBase, UnresolvedUnaryNode}
+import org.apache.spark.sql.catalyst.analysis.{Analyzer, AnsiTypeCoercion, MultiInstanceRelation, Resolver, TypeCoercion, TypeCoercionBase, UnresolvedUnaryNode}
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable.VIEW_STORING_ANALYZED_PLAN
 import org.apache.spark.sql.catalyst.expressions._
@@ -853,33 +853,11 @@ object View {
     // For temporary view, we always use captured sql configs
     if (activeConf.useCurrentSQLConfigsForView && !isTempView) return activeConf
 
-    // We retain below configs from current session because they are not captured by view
-    // as optimization configs but they are still needed during the view resolution.
-    // TODO: remove this `retainedHiveConfigs` after the `RelationConversions` is moved to
-    // optimization phase.
-    val retainedHiveConfigs = Seq(
-      "spark.sql.hive.convertMetastoreParquet",
-      "spark.sql.hive.convertMetastoreOrc",
-      "spark.sql.hive.convertInsertingPartitionedTable",
-      "spark.sql.hive.convertInsertingUnpartitionedTable",
-      "spark.sql.hive.convertMetastoreCtas"
-    )
-
-    val retainedLoggingConfigs = Seq(
-      "spark.sql.planChangeLog.level",
-      "spark.sql.expressionTreeChangeLog.level"
-    )
-
-    val retainedConfigs = activeConf.getAllConfs.filter { case (key, _) =>
-      retainedHiveConfigs.contains(key) || retainedLoggingConfigs.contains(key) || key.startsWith(
-        "spark.sql.catalog."
-      )
-    }
-
     val sqlConf = new SQLConf()
-    for ((k, v) <- configs ++ retainedConfigs) {
+    for ((k, v) <- configs) {
       sqlConf.settings.put(k, v)
     }
+    Analyzer.retainResolutionConfigsForAnalysis(newConf = sqlConf, existingConf = activeConf)
     sqlConf
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2030,7 +2030,7 @@ object SQLConf {
   val APPLY_SESSION_CONF_OVERRIDES_TO_FUNCTION_RESOLUTION =
     buildConf("spark.sql.analyzer.sqlFunctionResolution.applyConfOverrides")
       .internal()
-      .version("4.1.0")
+      .version("4.0.1")
       .doc("When true, applies the conf overrides for certain feature flags during the " +
         "resolution of user-defined sql table valued functions, consistent with view resolution.")
       .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2027,6 +2027,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val APPLY_SESSION_CONF_OVERRIDES_TO_FUNCTION_RESOLUTION =
+    buildConf("spark.sql.analyzer.sqlFunctionResolution.applyConfOverrides")
+      .internal()
+      .version("4.1.0")
+      .doc("When true, applies the conf overrides for certain feature flags during the " +
+        "resolution of user-defined sql table valued functions, consistent with view resolution.")
+      .booleanConf
+      .createWithDefault(true)
+
   // Whether to retain group by columns or not in GroupedData.agg.
   val DATAFRAME_RETAIN_GROUP_COLUMNS = buildConf("spark.sql.retainGroupColumns")
     .version("1.4.0")

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/AnalysisConfOverrideSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/AnalysisConfOverrideSuite.scala
@@ -91,7 +91,7 @@ class AnalysisConfOverrideSuite extends SharedSparkSession {
     }
   }
 
-  testOverride("user defined functions") { case (key, value) =>
+  testOverride("user defined SQL functions") { case (key, value) =>
     withTable("test_table", "test_table2") {
       spark.sql("CREATE TABLE test_table AS SELECT id as a FROM range(10)")
       spark.sql("CREATE TABLE test_table2 AS SELECT id as a, (id + 1) as b FROM range(10)")
@@ -124,7 +124,7 @@ class AnalysisConfOverrideSuite extends SharedSparkSession {
     }
   }
 
-  testOverride("user defined functions - test conf disabled") { case (key, value) =>
+  testOverride("user defined SQL functions - test conf disabled") { case (key, value) =>
     withTable("test_table", "test_table2") {
       spark.sql("CREATE TABLE test_table AS SELECT id as a FROM range(10)")
       spark.sql("CREATE TABLE test_table2 AS SELECT id as a, (id + 1) as b FROM range(10)")

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/AnalysisConfOverrideSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/AnalysisConfOverrideSuite.scala
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.analysis
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSessionExtensions
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.test.SharedSparkSession
+
+class AnalysisConfOverrideSuite extends SharedSparkSession {
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.sql.extensions", "com.databricks.sql.ConfOverrideValidationExtensions")
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.sql("SELECT id as a FROM range(10)").createTempView("table")
+    spark.sql("SELECT id as a, (id + 1) as b FROM range(10)").createTempView("table2")
+  }
+
+  override def afterAll(): Unit = {
+    spark.sessionState.experimentalMethods.extraOptimizations = Nil
+    spark.catalog.dropTempView("table")
+    spark.catalog.dropTempView("table2")
+    super.afterAll()
+  }
+
+  private def testOverride(testName: String)(f: => Unit): Unit = {
+    test(testName) {
+      val key = "spark.sql.catalog.x.y"
+      val value = "true"
+      withSQLConf(key -> value) {
+        ValidateConfOverrideRule.withConfValidationEnabled(key, value) {
+          f
+        }
+      }
+    }
+  }
+
+  testOverride("simple plan") {
+    spark.sql("SELECT * FROM TaBlE")
+  }
+
+  testOverride("CTE") {
+    spark.sql("""WITH cte AS (SELECT * FROM TaBlE)
+                |SELECT * FROM cte
+                |""".stripMargin)
+  }
+
+  testOverride("Subquery") {
+    spark.sql("""
+                |SELECT * FROM TaBlE WHERE a in (SELECT a FROM table2)
+                |""".stripMargin)
+  }
+
+  testOverride("View") {
+    withTable("test_table", "test_table2") {
+      spark.sql("CREATE TABLE test_table AS SELECT id as a FROM range(10)")
+      spark.sql("CREATE TABLE test_table2 AS SELECT id as a, (id + 1) as b FROM range(10)")
+      withView("test_view") {
+        spark.sql("CREATE VIEW test_view AS " +
+          "SELECT * FROM test_table WHERE a in (SELECT a FROM test_table2)")
+        spark.sql("SELECT * FROM test_view")
+      }
+    }
+  }
+
+  testOverride("user defined table valued function") {
+    withTable("test_table", "test_table2") {
+      spark.sql("CREATE TABLE test_table AS SELECT id as a FROM range(10)")
+      spark.sql("CREATE TABLE test_table2 AS SELECT id as a, (id + 1) as b FROM range(10)")
+      withUserDefinedFunction("f1" -> true, "f2" -> false) {
+        spark.sql(
+          """CREATE OR REPLACE TEMPORARY FUNCTION f1() RETURNS TABLE (a bigint)
+            |RETURN SELECT * FROM test_table WHERE a in (SELECT a FROM test_table2)
+            |""".stripMargin
+        )
+        spark.sql(
+          """CREATE OR REPLACE FUNCTION f2() RETURNS TABLE (a bigint)
+            |RETURN SELECT * FROM test_table WHERE a in (SELECT a FROM test_table2)
+            |""".stripMargin
+        )
+        spark.sql("SELECT * FROM f1()")
+        spark.sql("SELECT * FROM f2()")
+      }
+    }
+  }
+}
+
+object ValidateConfOverrideRule {
+  private var confToCheck: Option[(String, String)] = None
+  private var isCalled: Boolean = false
+
+  def withConfValidationEnabled(key: String, value: String)(f: => Unit): Unit = {
+    try {
+      confToCheck = Some(key -> value)
+      f
+      assert(isCalled, "The rule was enabled, but not called. This is a test setup error.")
+    } finally {
+      isCalled = false
+      confToCheck = None
+    }
+  }
+}
+
+class ValidateConfOverrideRule extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    ValidateConfOverrideRule.confToCheck.foreach { case (k, v) =>
+      assert(conf.getConfString(k) == v,
+        s"The feature wasn't enabled within plan:\n$plan")
+      ValidateConfOverrideRule.isCalled = true
+    }
+    plan
+  }
+}
+
+class ConfOverrideValidationExtensions extends (SparkSessionExtensions => Unit) {
+  override def apply(extensions: SparkSessionExtensions): Unit = {
+    extensions.injectResolutionRule(_ => new ValidateConfOverrideRule)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

View resolution and SQL UDTVF resolution store behavior related SQL configurations at creation time. However, view resolution can pass on additional configurations set post-session creation time. This PR refactors the View resolution configurations into an Analyzer function and uses it consistently between View resolution and SQL UDTVF resolution.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When resolving SQL User-defined Table Valued Functions, the catalog options do not get registered correctly if the configurations were overridden after a session is created (that is, not available as an override at Spark startup). This is not a problem during View resolution.

 

This rift is unnecessary and the resolution rules should be consistent with regards to which SQL configurations get passed down during UDTVF resolution similar with view resolution.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

If a SQL configuration, such as a catalog option (prefixed by `spark.sql.catalog.`) is overridden during a session, these options were not being passed correctly down to SQL User-defined table valued functions during resolution. This PR fixes that.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests. Added a feature flag and tested the changes with the feature flag off to maintain old behavior.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
