### PR TITLE
[SPARK-52303][CORE] Promote `ExternalCommandRunner` to `Stable`

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/ExternalCommandRunner.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/ExternalCommandRunner.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connector;
 
-import org.apache.spark.annotation.Unstable;
+import org.apache.spark.annotation.Stable;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 /**
@@ -30,7 +30,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *
  * @since 3.0.0
  */
-@Unstable
+@Stable
 public interface ExternalCommandRunner {
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to promote `ExternalCommandRunner` to `Stable` API in Apache Spark 4.1.0.

### Why are the changes needed?

Since Apache Spark 3.0.0, `ExternalCommandRunner` has been serving without any change over five years.

- https://github.com/apache/spark/pull/27199

https://github.com/apache/spark/blob/70cfe7d42f6092f2e44f80fdb4e7ac352c02f0ba/sql/catalyst/src/main/java/org/apache/spark/sql/connector/ExternalCommandRunner.java#L31-L34

Since Apache Spark 4.0.0, `Spark Connect` provides this as one of the defined protocols

  - #49774

https://github.com/apache/spark/blob/70cfe7d42f6092f2e44f80fdb4e7ac352c02f0ba/sql/connect/common/src/main/protobuf/spark/connect/commands.proto#L541-L543

Given the above situation, we had better make `interface ExternalCommandRunner` `Stable` because we cannot change this in a breaking way in Apache Spark 4.x in another five years although it's marked `Unstable` as of now.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.