### PR TITLE
[SPARK-52308][CORE] Fix the bug that the actual configs of the driver are overwritten

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -19,12 +19,14 @@ package org.apache.spark
 
 import java.util.{Map => JMap}
 import java.util.concurrent.ConcurrentHashMap
+
 import scala.collection.mutable.LinkedHashSet
 import scala.jdk.CollectionConverters._
+
 import org.apache.avro.{Schema, SchemaNormalization}
+
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys
-import org.apache.spark.internal.LogKeys.{CONFIG, VALUE}
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.History._
 import org.apache.spark.internal.config.Kryo._
@@ -340,9 +342,9 @@ class SparkConf(loadDefaults: Boolean)
     if (driverJvmStartupConfList.contains(key) && settings.containsKey(key)) {
       logWarning(
         log"Spark user should not overwrite spark driver JVM startup parameters in code:\n" +
-          log"key = ${MDC(CONFIG, key)} , " +
-          log"effective value = ${MDC(VALUE, settings.get(key))}, " +
-          log"user setting value = ${MDC(VALUE, value)}.")
+          log"key = ${MDC(LogKeys.CONFIG, key)} , " +
+          log"effective value = ${MDC(LogKeys.VALUE, settings.get(key))}, " +
+          log"user setting value = ${MDC(LogKeys.VALUE, value)}.")
       return this
     }
     settings.put(key, value)

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -19,14 +19,12 @@ package org.apache.spark
 
 import java.util.{Map => JMap}
 import java.util.concurrent.ConcurrentHashMap
-
 import scala.collection.mutable.LinkedHashSet
 import scala.jdk.CollectionConverters._
-
 import org.apache.avro.{Schema, SchemaNormalization}
-
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys
+import org.apache.spark.internal.LogKeys.{CONFIG, VALUE}
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.History._
 import org.apache.spark.internal.config.Kryo._
@@ -341,8 +339,10 @@ class SparkConf(loadDefaults: Boolean)
     }
     if (driverJvmStartupConfList.contains(key) && settings.containsKey(key)) {
       logWarning(
-        s"Spark user should not overwrite spark driver JVM startup parameters in code:\n" +
-          s"  key = $key, effective value = ${settings.get(key)}, user setting value = $value.")
+        log"Spark user should not overwrite spark driver JVM startup parameters in code:\n" +
+          log"key = ${MDC(CONFIG, key)} , " +
+          log"effective value = ${MDC(VALUE, settings.get(key))}, " +
+          log"user setting value = ${MDC(VALUE, value)}.")
       return this
     }
     settings.put(key, value)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2838,4 +2838,12 @@ package object config {
       .checkValues(Set("connect", "classic"))
       .createWithDefault(
         if (sys.env.get("SPARK_CONNECT_MODE").contains("1")) "connect" else "classic")
+
+  private[spark] val SPARK_DRIVER_JVM_CONFIG_BLACKLIST =
+    ConfigBuilder("spark.driver.jvm.config.blacklist")
+      .doc("Spark driver jvm startup blacklist conf list.")
+      .version("3.2.1")
+      .stringConf.toSequence
+      .createWithDefault(
+        DRIVER_MEMORY.key :: DRIVER_MEMORY_OVERHEAD.key :: DRIVER_CORES.key :: Nil)
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
After Spark Driver is started, it is not allowed to overwrite Driver-related configurations.


### Why are the changes needed?
Fix the problem that the driver-related configuration was overwritten by the user by mistake, resulting in the final spark UI display error.


### Does this PR introduce _any_ user-facing change?
Yes. The values ​​of driver-related configurations on the Spark UI will show the actual effective values


### How was this patch tested?
The manual test is as follows:
Test Scripts： 
`./bin/spark-submit  --conf spark.driver.memory=10g --conf spark.driver.memoryOverhead=2g  --queue dev  test_pyspark.py`

test_pyspark.py
``` 
from pyspark import SparkContext, SparkConf
from pyspark.sql import SQLContext, HiveContext, SparkSession

SPARK_CONF = SparkConf().set('spark.driver.memory','2.5G').set('spark.driver.memoryOverhead','2.5G')

sc = SparkContext(appName="test pyspark", conf=SPARK_CONF)

spark = SparkSession.builder.enableHiveSupport().getOrCreate()

df = spark.sql("select 1")
df.show()
spark.stop()
```

Spark UI display before repair：
![image](https://github.com/user-attachments/assets/fd1de505-f89c-4af4-84e4-ba2a330cad24)


Spark UI display after repair：
![image](https://github.com/user-attachments/assets/56d9f1b3-fb84-4b1c-a6bb-112eee630932)


BTW, Spark does not support double type values ​​for memory configuration ​​by default. So when we used Spark code to parse the event log, we encountered this problem. This PR is to avoid this kind of problem from the source.
![image](https://github.com/user-attachments/assets/070f9921-0950-4a88-bafd-69887bcd7f16)



### Was this patch authored or co-authored using generative AI tooling?
No
