### PR TITLE
[SPARK-52313][SQL] Correctly resolve reference data type for Views with default collation

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.collation
 
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog.DEFAULT_DATABASE
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.Project
 import org.apache.spark.sql.catalyst.util.CollationFactory
 import org.apache.spark.sql.connector.DatasourceV2SQLBase
 import org.apache.spark.sql.internal.SQLConf
@@ -430,6 +432,21 @@ abstract class DefaultCollationTestSuite extends QueryTest with SharedSparkSessi
 }
 
 class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
+
+  test("Check AttributeReference dataType from View with default collation") {
+    withView(testView) {
+      sql(s"CREATE VIEW $testView DEFAULT COLLATION UTF8_LCASE AS SELECT 'a' AS c1")
+
+      val df = sql(s"SELECT * FROM $testView")
+      val analyzedPlan = df.queryExecution.analyzed
+      analyzedPlan match {
+        case Project(Seq(AttributeReference("c1", dataType, _, _)), _) =>
+          assert(dataType == StringType("UTF8_LCASE"))
+        case _ =>
+          assert(false)
+      }
+    }
+  }
 
   test("create/alter view created from a table") {
     withTable(testTable) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Correctly resolve reference data type for Views with default collation.
`CREATE VIEW v DEFAULT COLLATION UTF8_LCASE AS SELECT 'a' AS c1` will resolve `c1` as `AttributeReference` but with non-collated `dataType`. This is because `ResolveReferences` comes before `ApplyDefaultCollationToStringType` in order of rules. Queries were still working correctly because there is `Cast` to collated `dataType` on top of `c1`.

### Why are the changes needed?
Bug fix.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New test in `DefaultCollationTestSuite.scala`.


### Was this patch authored or co-authored using generative AI tooling?
No.
