### PR TITLE
[SPARK-52312][SQL] Ignore V2WriteCommand when caching DataFrame

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -56,7 +56,11 @@ trait KeepAnalyzedQuery extends Command {
 /**
  * Base trait for DataSourceV2 write commands
  */
-trait V2WriteCommand extends UnaryCommand with KeepAnalyzedQuery with CTEInChildren {
+trait V2WriteCommand
+    extends UnaryCommand
+    with KeepAnalyzedQuery
+    with CTEInChildren
+    with IgnoreCachedData {
   def table: NamedRelation
   def query: LogicalPlan
   def isByName: Boolean

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -125,13 +125,13 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
       storageLevel: StorageLevel): Unit = {
     if (storageLevel == StorageLevel.NONE) {
       // Do nothing for StorageLevel.NONE since it will not actually cache any data.
-    } else if (lookupCachedDataInternal(normalizedPlan).nonEmpty) {
-      logWarning("Asked to cache already cached data.")
     } else if (unnormalizedPlan.isInstanceOf[IgnoreCachedData]) {
       logWarning(
         log"Asked to cache a plan that is inapplicable for caching: " +
         log"${MDC(LOGICAL_PLAN, unnormalizedPlan)}"
       )
+    } else if (lookupCachedDataInternal(normalizedPlan).nonEmpty) {
+      logWarning("Asked to cache already cached data.")
     } else {
       val sessionWithConfigsOff = getOrCloneSessionWithConfigsOff(spark)
       val inMemoryRelation = sessionWithConfigsOff.withActive {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -94,13 +94,20 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
       query: Dataset[_],
       tableName: Option[String],
       storageLevel: StorageLevel): Unit = {
-    cacheQueryInternal(
-      query.sparkSession,
-      query.queryExecution.analyzed,
-      query.queryExecution.normalized,
-      tableName,
-      storageLevel
-    )
+    if (query.queryExecution.analyzed.isInstanceOf[IgnoreCachedData]) {
+      logWarning(
+        log"Asked to cache a plan that is inapplicable for caching: " +
+        log"${MDC(LOGICAL_PLAN, query.queryExecution.analyzed)}"
+      )
+    } else {
+      cacheQueryInternal(
+        query.sparkSession,
+        query.queryExecution.analyzed,
+        query.queryExecution.normalized,
+        tableName,
+        storageLevel
+      )
+    }
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
@@ -886,42 +886,4 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
     insertDF.cache()
     checkAnswer(spark.table("testcat.table_name"), Seq(Row(1, "a"), Row(2, "b")))
   }
-
-  test(
-    "SPARK-52312: caching dataframe created from INSERT OVERWRITE shouldn't re-execute the command"
-  ) {
-    spark.sql("CREATE TABLE testcat.table_name (c1 int, c2 string) USING foo")
-
-    val insertDF = spark.sql("INSERT OVERWRITE testcat.table_name VALUES (1, 'a'), (2, 'b')")
-    checkAnswer(spark.table("testcat.table_name"), Seq(Row(1, "a"), Row(2, "b")))
-
-    // Insert one more row after the INSERT OVERWRITE
-    spark.sql("INSERT INTO testcat.table_name VALUES (3, 'c')")
-    checkAnswer(spark.table("testcat.table_name"), Seq(Row(1, "a"), Row(2, "b"), Row(3, "c")))
-
-    // Caching the DataFrame created from INSERT should not re-execute the command
-    insertDF.cache()
-    checkAnswer(spark.table("testcat.table_name"), Seq(Row(1, "a"), Row(2, "b"), Row(3, "c")))
-  }
-
-  test(
-    "SPARK-52312: " +
-    "caching dataframe created from dynamic INSERT OVERWRITE shouldn't re-execute the command"
-  ) {
-    // Create a table partitioned by c1
-    spark.sql("CREATE TABLE testcat.table_name (c1 int, c2 string) USING foo PARTITIONED BY (c1)")
-
-    spark.sql(s"SET spark.sql.sources.partitionOverwriteMode = DYNAMIC")
-
-    val insertDF = sql("INSERT OVERWRITE testcat.table_name VALUES (1, 'a'), (2, 'b')")
-    checkAnswer(spark.table("testcat.table_name"), Seq(Row(1, "a"), Row(2, "b")))
-
-    // Insert one more row after the dynamic INSERT OVERWRITE, in the existing partition c1 = 1
-    spark.sql("INSERT INTO testcat.table_name VALUES (1, 'c')")
-    checkAnswer(spark.table("testcat.table_name"), Seq(Row(1, "a"), Row(2, "b"), Row(1, "c")))
-
-    // Caching the DataFrame created from INSERT should not re-execute the command
-    insertDF.cache()
-    checkAnswer(spark.table("testcat.table_name"), Seq(Row(1, "a"), Row(2, "b"), Row(1, "c")))
-  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

We found an issue that `V2WriteCommand` plans were not properly excluded from `DataFrame` caching, which can cause unintended side effects.

For example, when `cache()` is called on a `DataFrame` created from an `INSERT` SQL statement, the `INSERT` command gets re-executed during the caching process because the underlying plan is not being ignored.


This PR fixes this by 

- making `V2WriteCommand` extend the `IgnoreCachedData` trait
- updating the caching logic to skip plans that extend `IgnoreCachedData`, preventing inapplicable plans from being cached

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This is a bug, since calling `cache()` on a `DataFrame` shouldn't re-execute the command that created it.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

New tests were added.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.