### PR TITLE
[SPARK-52329][SS] Remove private sql scoping tags for new transformWithState API

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
@@ -566,7 +566,7 @@ abstract class KeyValueGroupedDataset[K, V] extends Serializable {
    * See [[org.apache.spark.sql.Encoder]] for more details on what types are encodable to Spark
    * SQL.
    */
-  private[sql] def transformWithState[U: Encoder](
+  def transformWithState[U: Encoder](
       statefulProcessor: StatefulProcessor[K, V, U],
       timeMode: TimeMode,
       outputMode: OutputMode): Dataset[U]
@@ -595,7 +595,7 @@ abstract class KeyValueGroupedDataset[K, V] extends Serializable {
    * See [[org.apache.spark.sql.Encoder]] for more details on what types are encodable to Spark
    * SQL.
    */
-  private[sql] def transformWithState[U: Encoder](
+  def transformWithState[U: Encoder](
       statefulProcessor: StatefulProcessor[K, V, U],
       eventTimeColumnName: String,
       outputMode: OutputMode): Dataset[U]
@@ -621,7 +621,7 @@ abstract class KeyValueGroupedDataset[K, V] extends Serializable {
    * See [[org.apache.spark.sql.Encoder]] for more details on what types are encodable to Spark
    * SQL.
    */
-  private[sql] def transformWithState[U: Encoder](
+  def transformWithState[U: Encoder](
       statefulProcessor: StatefulProcessor[K, V, U],
       timeMode: TimeMode,
       outputMode: OutputMode,
@@ -657,7 +657,7 @@ abstract class KeyValueGroupedDataset[K, V] extends Serializable {
    * See [[org.apache.spark.sql.Encoder]] for more details on what types are encodable to Spark
    * SQL.
    */
-  private[sql] def transformWithState[U: Encoder](
+  def transformWithState[U: Encoder](
       statefulProcessor: StatefulProcessor[K, V, U],
       eventTimeColumnName: String,
       outputMode: OutputMode,
@@ -686,7 +686,7 @@ abstract class KeyValueGroupedDataset[K, V] extends Serializable {
    * See [[org.apache.spark.sql.Encoder]] for more details on what types are encodable to Spark
    * SQL.
    */
-  private[sql] def transformWithState[U: Encoder, S: Encoder](
+  def transformWithState[U: Encoder, S: Encoder](
       statefulProcessor: StatefulProcessorWithInitialState[K, V, U, S],
       timeMode: TimeMode,
       outputMode: OutputMode,
@@ -719,7 +719,7 @@ abstract class KeyValueGroupedDataset[K, V] extends Serializable {
    * See [[org.apache.spark.sql.Encoder]] for more details on what types are encodable to Spark
    * SQL.
    */
-  private[sql] def transformWithState[U: Encoder, S: Encoder](
+  def transformWithState[U: Encoder, S: Encoder](
       statefulProcessor: StatefulProcessorWithInitialState[K, V, U, S],
       eventTimeColumnName: String,
       outputMode: OutputMode,
@@ -751,7 +751,7 @@ abstract class KeyValueGroupedDataset[K, V] extends Serializable {
    * See [[org.apache.spark.sql.Encoder]] for more details on what types are encodable to Spark
    * SQL.
    */
-  private[sql] def transformWithState[U: Encoder, S: Encoder](
+  def transformWithState[U: Encoder, S: Encoder](
       statefulProcessor: StatefulProcessorWithInitialState[K, V, U, S],
       timeMode: TimeMode,
       outputMode: OutputMode,
@@ -793,7 +793,7 @@ abstract class KeyValueGroupedDataset[K, V] extends Serializable {
    * See [[org.apache.spark.sql.Encoder]] for more details on what types are encodable to Spark
    * SQL.
    */
-  private[sql] def transformWithState[U: Encoder, S: Encoder](
+  def transformWithState[U: Encoder, S: Encoder](
       statefulProcessor: StatefulProcessorWithInitialState[K, V, U, S],
       outputMode: OutputMode,
       initialState: KeyValueGroupedDataset[K, S],

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/KeyValueGroupedDataset.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/KeyValueGroupedDataset.scala
@@ -137,14 +137,14 @@ class KeyValueGroupedDataset[K, V] private[sql] () extends sql.KeyValueGroupedDa
   }
 
   /** @inheritdoc */
-  private[sql] def transformWithState[U: Encoder](
+  def transformWithState[U: Encoder](
       statefulProcessor: StatefulProcessor[K, V, U],
       timeMode: TimeMode,
       outputMode: OutputMode): Dataset[U] =
     transformWithStateHelper(statefulProcessor, timeMode, outputMode)
 
   /** @inheritdoc */
-  private[sql] def transformWithState[U: Encoder, S: Encoder](
+  def transformWithState[U: Encoder, S: Encoder](
       statefulProcessor: StatefulProcessorWithInitialState[K, V, U, S],
       timeMode: TimeMode,
       outputMode: OutputMode,
@@ -152,7 +152,7 @@ class KeyValueGroupedDataset[K, V] private[sql] () extends sql.KeyValueGroupedDa
     transformWithStateHelper(statefulProcessor, timeMode, outputMode, Some(initialState))
 
   /** @inheritdoc */
-  override private[sql] def transformWithState[U: Encoder](
+  override def transformWithState[U: Encoder](
       statefulProcessor: StatefulProcessor[K, V, U],
       eventTimeColumnName: String,
       outputMode: OutputMode): Dataset[U] =
@@ -163,7 +163,7 @@ class KeyValueGroupedDataset[K, V] private[sql] () extends sql.KeyValueGroupedDa
       eventTimeColumnName = eventTimeColumnName)
 
   /** @inheritdoc */
-  override private[sql] def transformWithState[U: Encoder, S: Encoder](
+  override def transformWithState[U: Encoder, S: Encoder](
       statefulProcessor: StatefulProcessorWithInitialState[K, V, U, S],
       eventTimeColumnName: String,
       outputMode: OutputMode,
@@ -261,29 +261,29 @@ class KeyValueGroupedDataset[K, V] private[sql] () extends sql.KeyValueGroupedDa
     initialState)
 
   /** @inheritdoc */
-  override private[sql] def transformWithState[U: Encoder](
+  override def transformWithState[U: Encoder](
       statefulProcessor: StatefulProcessor[K, V, U],
       timeMode: TimeMode,
       outputMode: OutputMode,
-      outputEncoder: Encoder[U]) =
+      outputEncoder: Encoder[U]): Dataset[U] =
     super.transformWithState(statefulProcessor, timeMode, outputMode, outputEncoder)
 
   /** @inheritdoc */
-  override private[sql] def transformWithState[U: Encoder](
+  override def transformWithState[U: Encoder](
       statefulProcessor: StatefulProcessor[K, V, U],
       eventTimeColumnName: String,
       outputMode: OutputMode,
-      outputEncoder: Encoder[U]) =
+      outputEncoder: Encoder[U]): Dataset[U] =
     super.transformWithState(statefulProcessor, eventTimeColumnName, outputMode, outputEncoder)
 
   /** @inheritdoc */
-  override private[sql] def transformWithState[U: Encoder, S: Encoder](
+  override def transformWithState[U: Encoder, S: Encoder](
       statefulProcessor: StatefulProcessorWithInitialState[K, V, U, S],
       timeMode: TimeMode,
       outputMode: OutputMode,
       initialState: sql.KeyValueGroupedDataset[K, S],
       outputEncoder: Encoder[U],
-      initialStateEncoder: Encoder[S]) = super.transformWithState(
+      initialStateEncoder: Encoder[S]): Dataset[U] = super.transformWithState(
     statefulProcessor,
     timeMode,
     outputMode,
@@ -292,13 +292,13 @@ class KeyValueGroupedDataset[K, V] private[sql] () extends sql.KeyValueGroupedDa
     initialStateEncoder)
 
   /** @inheritdoc */
-  override private[sql] def transformWithState[U: Encoder, S: Encoder](
+  override def transformWithState[U: Encoder, S: Encoder](
       statefulProcessor: StatefulProcessorWithInitialState[K, V, U, S],
       outputMode: OutputMode,
       initialState: sql.KeyValueGroupedDataset[K, S],
       eventTimeColumnName: String,
       outputEncoder: Encoder[U],
-      initialStateEncoder: Encoder[S]) = super.transformWithState(
+      initialStateEncoder: Encoder[S]): Dataset[U] = super.transformWithState(
     statefulProcessor,
     outputMode,
     initialState,

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/KeyValueGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/KeyValueGroupedDataset.scala
@@ -444,29 +444,29 @@ class KeyValueGroupedDataset[K, V] private[sql](
       initialState)
 
   /** @inheritdoc */
-  override private[sql] def transformWithState[U: Encoder](
+  override def transformWithState[U: Encoder](
       statefulProcessor: StatefulProcessor[K, V, U],
       timeMode: TimeMode,
       outputMode: OutputMode,
-      outputEncoder: Encoder[U]) =
+      outputEncoder: Encoder[U]): Dataset[U] =
     super.transformWithState(statefulProcessor, timeMode, outputMode, outputEncoder)
 
   /** @inheritdoc */
-  override private[sql] def transformWithState[U: Encoder](
+  override def transformWithState[U: Encoder](
       statefulProcessor: StatefulProcessor[K, V, U],
       eventTimeColumnName: String,
       outputMode: OutputMode,
-      outputEncoder: Encoder[U]) =
+      outputEncoder: Encoder[U]): Dataset[U] =
     super.transformWithState(statefulProcessor, eventTimeColumnName, outputMode, outputEncoder)
 
   /** @inheritdoc */
-  override private[sql] def transformWithState[U: Encoder, S: Encoder](
+  override def transformWithState[U: Encoder, S: Encoder](
       statefulProcessor: StatefulProcessorWithInitialState[K, V, U, S],
       timeMode: TimeMode,
       outputMode: OutputMode,
       initialState: sql.KeyValueGroupedDataset[K, S],
       outputEncoder: Encoder[U],
-      initialStateEncoder: Encoder[S]) = super.transformWithState(
+      initialStateEncoder: Encoder[S]): Dataset[U] = super.transformWithState(
     statefulProcessor,
     timeMode,
     outputMode,
@@ -475,13 +475,13 @@ class KeyValueGroupedDataset[K, V] private[sql](
     initialStateEncoder)
 
   /** @inheritdoc */
-  override private[sql] def transformWithState[U: Encoder, S: Encoder](
+  override def transformWithState[U: Encoder, S: Encoder](
       statefulProcessor: StatefulProcessorWithInitialState[K, V, U, S],
       outputMode: OutputMode,
       initialState: sql.KeyValueGroupedDataset[K, S],
       eventTimeColumnName: String,
       outputEncoder: Encoder[U],
-      initialStateEncoder: Encoder[S]) = super.transformWithState(
+      initialStateEncoder: Encoder[S]): Dataset[U] = super.transformWithState(
     statefulProcessor,
     outputMode,
     initialState,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove private sql scoping tags for new transformWithState API


### Why are the changes needed?
To allow users to use the new operator in their queries without scoping explicitly to sql


### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?
Existing unit tests


### Was this patch authored or co-authored using generative AI tooling?
No
