### PR TITLE
[SPARK-48353][FOLLOW UP][SQL] Exception handling improvements

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
@@ -292,6 +292,7 @@ case class SimpleCaseStatement(
     conditionExpressions: Seq[Expression],
     conditionalBodies: Seq[CompoundBody],
     elseBody: Option[CompoundBody]) extends CompoundPlanStatement {
+  assert(conditionExpressions.nonEmpty)
   assert(conditionExpressions.length == conditionalBodies.length)
 
   override def output: Seq[Attribute] = Seq.empty

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionContext.scala
@@ -206,6 +206,15 @@ class SqlScriptingExecutionScope(
     errorHandler = triggerToExceptionHandlerMap.getHandlerForCondition(uppercaseCondition)
 
     if (errorHandler.isEmpty) {
+      if (uppercaseCondition.contains('.')) {
+        // If the condition contains a dot, it has a main error class and a subclass.
+        // Check if the error class is defined in the triggerToExceptionHandlerMap.
+        val errorClass = uppercaseCondition.split('.').head
+        errorHandler = triggerToExceptionHandlerMap.getHandlerForCondition(errorClass)
+      }
+    }
+
+    if (errorHandler.isEmpty) {
       // Check if there is a specific handler for the given SQLSTATE.
       errorHandler = triggerToExceptionHandlerMap.getHandlerForSqlState(uppercaseSqlState)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -58,6 +58,9 @@ trait LeafStatementExec extends CompoundStatementExec
  */
 trait NonLeafStatementExec extends CompoundStatementExec {
 
+  /** Pointer to the current statement - i.e. the statement that should be iterated next. */
+  protected[scripting] var curr: Option[CompoundStatementExec]
+
   /**
    * Construct the iterator to traverse the tree rooted at this node in an in-order traversal.
    * @return
@@ -244,7 +247,7 @@ class CompoundBodyExec(
   }
 
   private var localIterator = statements.iterator
-  private[scripting] var curr: Option[CompoundStatementExec] =
+  protected[scripting] var curr: Option[CompoundStatementExec] =
     if (localIterator.hasNext) Some(localIterator.next()) else None
   private var scopeStatus = ScopeStatus.NOT_ENTERED
 
@@ -406,7 +409,7 @@ class IfElseStatementExec(
   }
 
   private var state = IfElseState.Condition
-  private var curr: Option[CompoundStatementExec] = Some(conditions.head)
+  protected[scripting] var curr: Option[CompoundStatementExec] = Some(conditions.head)
 
   private var clauseIdx: Int = 0
   private val conditionsCount = conditions.length
@@ -418,6 +421,13 @@ class IfElseStatementExec(
 
       override def next(): CompoundStatementExec = state match {
         case IfElseState.Condition =>
+          if (curr.exists(_.isInstanceOf[LeaveStatementExec])) {
+            // Handling the case when condition evaluation throws an exception. Exception handling
+            //   mechanism will replace condition with the appropriate LEAVE statement if the
+            //   relevant condition handler was found.
+            return curr.get
+          }
+
           val condition = curr.get.asInstanceOf[SingleStatementExec]
           if (evaluateBooleanCondition(session, condition)) {
             state = IfElseState.Body
@@ -479,7 +489,7 @@ class WhileStatementExec(
   }
 
   private var state = WhileState.Condition
-  private var curr: Option[CompoundStatementExec] = Some(condition)
+  protected[scripting] var curr: Option[CompoundStatementExec] = Some(condition)
 
   private lazy val treeIterator: Iterator[CompoundStatementExec] =
     new Iterator[CompoundStatementExec] {
@@ -487,25 +497,32 @@ class WhileStatementExec(
 
       override def next(): CompoundStatementExec = state match {
           case WhileState.Condition =>
-            val condition = curr.get.asInstanceOf[SingleStatementExec]
-            if (evaluateBooleanCondition(session, condition)) {
-              state = WhileState.Body
-              curr = Some(body)
-              body.reset()
-            } else {
-              curr = None
+            curr match {
+              case Some(leaveStatement: LeaveStatementExec) =>
+                // Handling the case when condition evaluation throws an exception. Exception
+                //   handling mechanism will replace condition with the appropriate LEAVE statement
+                //   if the relevant condition handler was found.
+                handleLeaveStatement(leaveStatement)
+                leaveStatement
+              case Some(condition: SingleStatementExec) =>
+                if (evaluateBooleanCondition(session, condition)) {
+                  state = WhileState.Body
+                  curr = Some(body)
+                  body.reset()
+                } else {
+                  curr = None
+                }
+                condition
+              case _ =>
+                throw SparkException.internalError("Unexpected statement type in WHILE condition.")
             }
-            condition
           case WhileState.Body =>
             val retStmt = body.getTreeIterator.next()
 
             // Handle LEAVE or ITERATE statement if it has been encountered.
             retStmt match {
               case leaveStatementExec: LeaveStatementExec if !leaveStatementExec.hasBeenMatched =>
-                if (label.contains(leaveStatementExec.label)) {
-                  leaveStatementExec.hasBeenMatched = true
-                }
-                curr = None
+                handleLeaveStatement(leaveStatementExec)
                 return retStmt
               case iterStatementExec: IterateStatementExec if !iterStatementExec.hasBeenMatched =>
                 if (label.contains(iterStatementExec.label)) {
@@ -535,6 +552,13 @@ class WhileStatementExec(
     condition.reset()
     body.reset()
   }
+
+  private def handleLeaveStatement(leaveStatement: LeaveStatementExec): Unit = {
+    if (label.contains(leaveStatement.label)) {
+      leaveStatement.hasBeenMatched = true
+    }
+    curr = None
+  }
 }
 
 /**
@@ -555,7 +579,7 @@ class SearchedCaseStatementExec(
   }
 
   private var state = CaseState.Condition
-  private var curr: Option[CompoundStatementExec] = Some(conditions.head)
+  protected[scripting] var curr: Option[CompoundStatementExec] = Some(conditions.head)
 
   private var clauseIdx: Int = 0
   private val conditionsCount = conditions.length
@@ -566,6 +590,13 @@ class SearchedCaseStatementExec(
 
       override def next(): CompoundStatementExec = state match {
         case CaseState.Condition =>
+          if (curr.exists(_.isInstanceOf[LeaveStatementExec])) {
+            // Handling the case when condition evaluation throws an exception. Exception handling
+            //   mechanism will replace condition with the appropriate LEAVE statement if the
+            //   relevant condition handler was found.
+            return curr.get
+          }
+
           val condition = curr.get.asInstanceOf[SingleStatementExec]
           if (evaluateBooleanCondition(session, condition)) {
             state = CaseState.Body
@@ -633,6 +664,8 @@ class SimpleCaseStatementExec(
   private var state = CaseState.Condition
   private var bodyExec: Option[CompoundBodyExec] = None
 
+  protected[scripting] var curr: Option[CompoundStatementExec] = None
+
   private var conditionBodyTupleIterator: Iterator[(SingleStatementExec, CompoundBodyExec)] = _
   private var caseVariableLiteral: Literal = _
 
@@ -661,22 +694,45 @@ class SimpleCaseStatementExec(
   private lazy val treeIterator: Iterator[CompoundStatementExec] =
     new Iterator[CompoundStatementExec] {
       override def hasNext: Boolean = state match {
-        case CaseState.Condition => cachedConditionBodyIterator.hasNext || elseBody.isDefined
+        case CaseState.Condition =>
+          // Equivalent to the "iteration hasn't started yet" - to avoid computing cache
+          //   before the first actual iteration.
+          curr.isEmpty ||
+          // Special case when condition computation throws an exception.
+          curr.exists(_.isInstanceOf[LeaveStatementExec]) ||
+          // Regular conditions.
+          cachedConditionBodyIterator.hasNext ||
+          elseBody.isDefined
         case CaseState.Body => bodyExec.exists(_.getTreeIterator.hasNext)
       }
 
       override def next(): CompoundStatementExec = state match {
         case CaseState.Condition =>
-          cachedConditionBodyIterator.nextOption()
+          if (curr.exists(_.isInstanceOf[LeaveStatementExec])) {
+            // Handling the case when condition evaluation throws an exception. Exception handling
+            //   mechanism will replace condition with the appropriate LEAVE statement if the
+            //   relevant condition handler was found.
+            return curr.get
+          }
+
+          val nextOption = if (cachedConditionBodyIterator.hasNext) {
+            Some(cachedConditionBodyIterator.next())
+          } else {
+            None
+          }
+          nextOption
             .map { case (condStmt, body) =>
+              curr = Some(condStmt)
               if (evaluateBooleanCondition(session, condStmt)) {
                 bodyExec = Some(body)
+                curr = bodyExec
                 state = CaseState.Body
               }
               condStmt
             }
             .orElse(elseBody.map { body => {
               bodyExec = Some(body)
+              curr = bodyExec
               state = CaseState.Body
               next()
             }})
@@ -714,6 +770,8 @@ class SimpleCaseStatementExec(
 
   override def reset(): Unit = {
     state = CaseState.Condition
+    bodyExec = None
+    curr = None
     isCacheValid = false
     caseVariableExec.reset()
     conditionalBodies.foreach(b => b.reset())
@@ -740,7 +798,7 @@ class RepeatStatementExec(
   }
 
   private var state = RepeatState.Body
-  private var curr: Option[CompoundStatementExec] = Some(body)
+  protected[scripting] var curr: Option[CompoundStatementExec] = Some(body)
 
   private lazy val treeIterator: Iterator[CompoundStatementExec] =
     new Iterator[CompoundStatementExec] {
@@ -748,24 +806,31 @@ class RepeatStatementExec(
 
       override def next(): CompoundStatementExec = state match {
         case RepeatState.Condition =>
-          val condition = curr.get.asInstanceOf[SingleStatementExec]
-          if (!evaluateBooleanCondition(session, condition)) {
-            state = RepeatState.Body
-            curr = Some(body)
-            body.reset()
-          } else {
-            curr = None
+          curr match {
+            case Some(leaveStatement: LeaveStatementExec) =>
+              // Handling the case when condition evaluation throws an exception. Exception
+              //   handling mechanism will replace condition with the appropriate LEAVE statement
+              //   if the relevant condition handler was found.
+              handleLeaveStatement(leaveStatement)
+              leaveStatement
+            case Some(condition: SingleStatementExec) =>
+              if (!evaluateBooleanCondition(session, condition)) {
+                state = RepeatState.Body
+                curr = Some(body)
+                body.reset()
+              } else {
+                curr = None
+              }
+              condition
+            case _ =>
+              throw SparkException.internalError("Unexpected statement type in REPEAT condition.")
           }
-          condition
         case RepeatState.Body =>
           val retStmt = body.getTreeIterator.next()
 
           retStmt match {
             case leaveStatementExec: LeaveStatementExec if !leaveStatementExec.hasBeenMatched =>
-              if (label.contains(leaveStatementExec.label)) {
-                leaveStatementExec.hasBeenMatched = true
-              }
-              curr = None
+              handleLeaveStatement(leaveStatementExec)
               return retStmt
             case iterStatementExec: IterateStatementExec if !iterStatementExec.hasBeenMatched =>
               if (label.contains(iterStatementExec.label)) {
@@ -794,6 +859,13 @@ class RepeatStatementExec(
     curr = Some(body)
     body.reset()
     condition.reset()
+  }
+
+  private def handleLeaveStatement(leaveStatement: LeaveStatementExec): Unit = {
+    if (label.contains(leaveStatement.label)) {
+      leaveStatement.hasBeenMatched = true
+    }
+    curr = None
   }
 }
 
@@ -845,6 +917,8 @@ class IterateStatementExec(val label: String) extends LeafStatementExec {
 class LoopStatementExec(
     body: CompoundBodyExec,
     val label: Option[String]) extends NonLeafStatementExec {
+
+  protected[scripting] var curr: Option[CompoundStatementExec] = Some(body)
 
   /**
    * Loop can be interrupted by LeaveStatementExec
@@ -927,7 +1001,9 @@ class ForStatementExec(
     queryResult
   }
 
-  private var bodyWithVariables: CompoundBodyExec = null
+  protected[scripting] var curr: Option[CompoundStatementExec] = None
+
+  private var bodyWithVariables: Option[CompoundBodyExec] = None
 
   /**
    * For can be interrupted by LeaveStatementExec
@@ -943,15 +1019,29 @@ class ForStatementExec(
     new Iterator[CompoundStatementExec] {
 
       override def hasNext: Boolean = !interrupted && (state match {
-          case ForState.VariableAssignment => cachedQueryResult().hasNext || firstIteration
-          case ForState.Body => bodyWithVariables.getTreeIterator.hasNext
-        })
+        // `firstIteration` NEEDS to be the first condition! This is to handle edge-cases when
+        //   query fails with an exception. If the `cachedQueryResult().hasNext` is first, this
+        //   would mean that exception would be thrown before the scope of the parent (which is
+        //   of CompoundBodyExec type) of the FOR statement is entered (required for proper
+        //   exception handling). This can happen in a case when FOR statement is a first
+        //   statement in the compound.
+        case ForState.VariableAssignment => firstIteration || cachedQueryResult().hasNext
+        case ForState.Body => bodyWithVariables.exists(_.getTreeIterator.hasNext)
+      })
 
-      @scala.annotation.tailrec
       override def next(): CompoundStatementExec = state match {
 
         case ForState.VariableAssignment =>
-          // If result set is empty and we are on the first iteration, we return NO-OP statement
+          if (curr.exists(_.isInstanceOf[LeaveStatementExec])) {
+            // Handling the case when condition evaluation throws an exception. Exception handling
+            //   mechanism will replace condition with the appropriate LEAVE statement if the
+            //   relevant condition handler was found.
+            val leaveStatement = curr.get.asInstanceOf[LeaveStatementExec]
+            handleLeaveStatement(leaveStatement)
+            return leaveStatement
+          }
+
+          // If result set is empty, and we are on the first iteration, we return NO-OP statement
           // to prevent compound statements from not having anything to return. For example,
           // if a FOR statement is nested in REPEAT, REPEAT will assume that FOR has at least
           // one statement to return. In the case the result set is empty, FOR doesn't have
@@ -979,7 +1069,7 @@ class ForStatementExec(
             }
           ).orElse(Some(UUID.randomUUID().toString.toLowerCase(Locale.ROOT)))
 
-          bodyWithVariables = new CompoundBodyExec(
+          bodyWithVariables = Some(new CompoundBodyExec(
             // NoOpStatementExec appended to end of body to prevent
             // dropping variables before last statement is executed.
             // This is necessary because we are calling exitScope before returning the last
@@ -991,26 +1081,23 @@ class ForStatementExec(
             isScope = true,
             context = context,
             triggerToExceptionHandlerMap = TriggerToExceptionHandlerMap.createEmptyMap()
-          )
+          ))
 
           state = ForState.Body
-          bodyWithVariables.reset()
-          bodyWithVariables.enterScope()
+          bodyWithVariables.foreach(_.reset())
+          bodyWithVariables.foreach(_.enterScope())
+          curr = bodyWithVariables
           next()
 
         case ForState.Body =>
-          val retStmt = bodyWithVariables.getTreeIterator.next()
+          // `bodyWithVariables` must be defined at this point.
+          assert(bodyWithVariables.isDefined)
+          val retStmt = bodyWithVariables.get.getTreeIterator.next()
 
           // Handle LEAVE or ITERATE statement if it has been encountered.
           retStmt match {
             case leaveStatementExec: LeaveStatementExec if !leaveStatementExec.hasBeenMatched =>
-              if (label.contains(leaveStatementExec.label)) {
-                leaveStatementExec.hasBeenMatched = true
-              }
-              interrupted = true
-              // If this for statement encounters LEAVE, we need to exit the scope, as
-              // we will not reach the point where we usually exit it.
-              bodyWithVariables.exitScope()
+              handleLeaveStatement(leaveStatementExec)
               return retStmt
             case iterStatementExec: IterateStatementExec if !iterStatementExec.hasBeenMatched =>
               if (label.contains(iterStatementExec.label)) {
@@ -1018,19 +1105,30 @@ class ForStatementExec(
               } else {
                 // If an outer loop is being iterated, we need to exit the scope, as
                 // we will not reach the point where we usually exit it.
-                bodyWithVariables.exitScope()
+                bodyWithVariables.foreach(_.exitScope())
               }
               state = ForState.VariableAssignment
               return retStmt
             case _ =>
           }
 
-          if (!bodyWithVariables.getTreeIterator.hasNext) {
-            bodyWithVariables.exitScope()
+          if (!bodyWithVariables.exists(_.getTreeIterator.hasNext)) {
+            bodyWithVariables.foreach(_.exitScope())
+            curr = None
             state = ForState.VariableAssignment
           }
           retStmt
       }
+    }
+
+    private def handleLeaveStatement(leaveStatement: LeaveStatementExec): Unit = {
+      if (label.contains(leaveStatement.label)) {
+        leaveStatement.hasBeenMatched = true
+      }
+      interrupted = true
+      // If this for statement encounters LEAVE, we need to exit the scope, as
+      // we will not reach the point where we usually exit it.
+      bodyWithVariables.foreach(_.exitScope())
     }
 
   /**
@@ -1093,7 +1191,8 @@ class ForStatementExec(
     state = ForState.VariableAssignment
     isResultCacheValid = false
     interrupted = false
-    bodyWithVariables = null
+    curr = None
+    bodyWithVariables = None
     firstIteration = true
   }
 }
@@ -1108,6 +1207,8 @@ class ExceptionHandlerExec(
     val body: CompoundBodyExec,
     val handlerType: ExceptionHandlerType,
     val scopeLabel: Option[String]) extends NonLeafStatementExec {
+
+  protected[scripting] var curr: Option[CompoundStatementExec] = body.curr
 
   override def getTreeIterator: Iterator[CompoundStatementExec] = body.getTreeIterator
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -694,6 +694,195 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  test("handler - exit resolve when if condition fails") {
+    val sqlScript =
+      """
+        |BEGIN
+        |  DECLARE VARIABLE flag INT = -1;
+        |  scope_to_exit: BEGIN
+        |    DECLARE EXIT HANDLER FOR SQLSTATE '22012'
+        |    BEGIN
+        |      SELECT flag;
+        |      SET flag = 1;
+        |    END;
+        |    IF 1 > 1/0 THEN
+        |      SELECT 10;
+        |    END IF;
+        |    SELECT 4;
+        |    SELECT 5;
+        |  END;
+        |  SELECT flag;
+        |END
+        |""".stripMargin
+    val expected = Seq(
+      Seq(Row(-1)),   // select flag
+      Seq(Row(1))     // select flag from the outer body
+    )
+    verifySqlScriptResult(sqlScript, expected = expected)
+  }
+
+  test("handler - exit resolve when simple case variable computation fails") {
+    val sqlScript =
+      """
+        |BEGIN
+        |  DECLARE VARIABLE flag INT = -1;
+        |  scope_to_exit: BEGIN
+        |    DECLARE EXIT HANDLER FOR SQLSTATE '22012'
+        |    BEGIN
+        |      SELECT flag;
+        |      SET flag = 1;
+        |    END;
+        |    CASE 1/0
+        |      WHEN flag THEN SELECT 10;
+        |    END CASE;
+        |    SELECT 4;
+        |    SELECT 5;
+        |  END;
+        |  SELECT flag;
+        |END
+        |""".stripMargin
+    val expected = Seq(
+      Seq(Row(-1)),   // select flag
+      Seq(Row(1))     // select flag from the outer body
+    )
+    verifySqlScriptResult(sqlScript, expected = expected)
+  }
+
+  test("handler - exit resolve when simple case condition computation fails") {
+    val sqlScript =
+      """
+        |BEGIN
+        |  DECLARE VARIABLE flag INT = -1;
+        |  scope_to_exit: BEGIN
+        |    DECLARE EXIT HANDLER FOR SQLSTATE '22012'
+        |    BEGIN
+        |      SELECT flag;
+        |      SET flag = 1;
+        |    END;
+        |    CASE flag
+        |      WHEN 1/0 THEN SELECT 10;
+        |    END CASE;
+        |    SELECT 4;
+        |    SELECT 5;
+        |  END;
+        |  SELECT flag;
+        |END
+        |""".stripMargin
+    val expected = Seq(
+      Seq(Row(-1)),   // select flag
+      Seq(Row(1))     // select flag from the outer body
+    )
+    verifySqlScriptResult(sqlScript, expected = expected)
+  }
+
+  test("handler - exit resolve when simple case condition types are mismatch") {
+    val sqlScript =
+      """
+        |BEGIN
+        |  DECLARE VARIABLE flag INT = -1;
+        |  scope_to_exit: BEGIN
+        |    DECLARE EXIT HANDLER FOR CAST_INVALID_INPUT
+        |    BEGIN
+        |      SELECT flag;
+        |      SET flag = 1;
+        |    END;
+        |    CASE flag
+        |      WHEN 'teststr' THEN SELECT 10;
+        |    END CASE;
+        |    SELECT 4;
+        |    SELECT 5;
+        |  END;
+        |  SELECT flag;
+        |END
+        |""".stripMargin
+    val expected = Seq(
+      Seq(Row(-1)),   // select flag
+      Seq(Row(1))     // select flag from the outer body
+    )
+    verifySqlScriptResult(sqlScript, expected = expected)
+  }
+
+  test("handler - exit resolve when searched case condition fails") {
+    val sqlScript =
+      """
+        |BEGIN
+        |  DECLARE VARIABLE flag INT = -1;
+        |  scope_to_exit: BEGIN
+        |    DECLARE EXIT HANDLER FOR SQLSTATE '22012'
+        |    BEGIN
+        |      SELECT flag;
+        |      SET flag = 1;
+        |    END;
+        |    CASE
+        |      WHEN flag = 1/0 THEN SELECT 10;
+        |    END CASE;
+        |    SELECT 4;
+        |    SELECT 5;
+        |  END;
+        |  SELECT flag;
+        |END
+        |""".stripMargin
+    val expected = Seq(
+      Seq(Row(-1)),   // select flag
+      Seq(Row(1))     // select flag from the outer body
+    )
+    verifySqlScriptResult(sqlScript, expected = expected)
+  }
+
+  test("handler - exit resolve when while condition fails") {
+    val sqlScript =
+      """
+        |BEGIN
+        |  DECLARE VARIABLE flag INT = -1;
+        |  scope_to_exit: BEGIN
+        |    DECLARE EXIT HANDLER FOR SQLSTATE '22012'
+        |    BEGIN
+        |      SELECT flag;
+        |      SET flag = 1;
+        |    END;
+        |    WHILE 1 > 1/0 DO
+        |      SELECT 10;
+        |    END WHILE;
+        |    SELECT 4;
+        |    SELECT 5;
+        |  END;
+        |  SELECT flag;
+        |END
+        |""".stripMargin
+    val expected = Seq(
+      Seq(Row(-1)),   // select flag
+      Seq(Row(1))     // select flag from the outer body
+    )
+    verifySqlScriptResult(sqlScript, expected = expected)
+  }
+
+  test("handler - exit resolve when select fails in FOR statement") {
+    val sqlScript =
+      """
+        |BEGIN
+        |  DECLARE VARIABLE flag INT = -1;
+        |  scope_to_exit: BEGIN
+        |    DECLARE EXIT HANDLER FOR SQLSTATE '22012'
+        |    BEGIN
+        |      SELECT flag;
+        |      SET flag = 1;
+        |    END;
+        |    FOR iter AS (SELECT 1/0) DO
+        |      SELECT 10;
+        |    END FOR;
+        |    SELECT 4;
+        |    SELECT 5;
+        |  END;
+        |  SELECT flag;
+        |END
+        |""".stripMargin
+    val expected = Seq(
+      Seq(Row(-1)),   // select flag
+      Seq(Row(1))     // select flag from the outer body
+    )
+    verifySqlScriptResult(sqlScript, expected = expected)
+  }
+
   // Tests
   test("multi statement - simple") {
     withTable("t") {
@@ -2553,5 +2742,59 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
       Seq(Row(1))
     )
     verifySqlScriptResult(sqlScript, expected = expected)
+  }
+
+  test("ES-1406131: Exception handler in a FOR loop - with condition") {
+    withTable("t") {
+      withView("v") {
+        val sqlScript =
+          """
+            |BEGIN
+            |  DECLARE cnt = 0;
+            |  CREATE TABLE t (a INT, b STRING, c DOUBLE) USING parquet;
+            |  CREATE VIEW v AS SELECT a, b FROM t WHERE c > 0;
+            |  FOR tables AS (SELECT * FROM VALUES ('v'), ('v') AS tbl(name)) DO
+            |    lbl: BEGIN
+            |      DECLARE EXIT HANDLER FOR EXPECT_TABLE_NOT_VIEW.NO_ALTERNATIVE
+            |         BEGIN SET cnt = cnt + 1; END;
+            |      ALTER TABLE IDENTIFIER(tables.name) DEFAULT COLLATION UTF8_LCASE;
+            |    END;
+            |  END FOR;
+            |  SELECT cnt;
+            |END
+            |""".stripMargin
+        val expected = Seq(
+          Seq(Row(2)) // select cnt
+        )
+        verifySqlScriptResult(sqlScript, expected)
+      }
+    }
+  }
+
+  test("ES-1406131: Exception handler in a FOR loop - with SQL state") {
+    withTable("t") {
+      withView("v") {
+        val sqlScript =
+          """
+            |BEGIN
+            |  DECLARE cnt = 0;
+            |  CREATE TABLE t (a INT, b STRING, c DOUBLE) USING parquet;
+            |  CREATE VIEW v AS SELECT a, b FROM t WHERE c > 0;
+            |  FOR tables AS (SELECT * FROM VALUES ('v'), ('v') AS tbl(name)) DO
+            |    BEGIN
+            |      DECLARE EXIT HANDLER FOR SQLSTATE '42809'
+            |         BEGIN SET cnt = cnt + 1; END;
+            |      ALTER TABLE IDENTIFIER(tables.name) DEFAULT COLLATION UTF8_LCASE;
+            |    END;
+            |  END FOR;
+            |  SELECT cnt;
+            |END
+            |""".stripMargin
+        val expected = Seq(
+          Seq(Row(2)) // select cnt
+        )
+        verifySqlScriptResult(sqlScript, expected)
+      }
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This pull request proposes an improvement in how conditions are matched with exception handlers. Previously, condition would match with an exception handler only if the match was full/complete - i.e. condition `<MAIN>.<SUBCLASS>` would match only to the handler defined for `<MAIN>.<SUBCLASS>`. With this improvement, `<MAIN>.<SUBCLASS>` condition would match to the handlers defined for `<MAIN>` condition as well, with correct precedence.

This pull requests also proposes a number of fixes for different missing things:
- `CompoundBodyExec.reset()` is not resetting the `scopeStatus` field.
- Exception handler body is never reset (this includes internal iterator reset). This causes issues if the handler is defined in a loop and gets matched multiple times.
- When searching for a place to inject `LEAVE` statement, after the `EXIT` handler has been executed, the logic considered only `CompoundBodyExec` nodes, whereas it should have included all non-leaf statements.
- Exception handling for exceptions that happen in conditions (for each statement type - if/else, while, case, etc) is not working properly because the injected `LEAVE` statement is not recognized properly.
- Exception handling for exceptions that happen in the last statement of the body of if/else and searched case statement is not working properly because the injected `LEAVE` statement is not recognized properly.
- `hasNext()` in `ForStatementExec` is executing the query. This causes the issues in cases when `FOR` is the first statement in the compound and the query fails. It means that exception would happen during the `hasNext()` checks instead of the actual iteration. In such case, the parent compound (of the `FOR` statement) is not entered (because that happens during the iteration) and call stack is not properly setup for exception handling.

Changes corresponding to this problems, in the same order:
- Reset the `scopeStatus` field in `CompoundBodyExec.reset()`.
- Call `reset()` on handler before starting its execution in `SqlScriptingExecution.handleException()`.
- Move `curr` pointer to `NonLeafStatementExec` and use that in `SqlScriptingExecution. getNextStatement()` in case when `EXIT` handler is finished and removed from the stack.
- Add special case handling for `LeaveStatementExec` in `*.Condition` cases in all of the relevant statement types. When exception happens during the condition execution, the `LeaveStatementExec` is injected into `curr` field, but the state hasn't changed. This means that when the `LEAVE` statement is to be executed, the state would correspond to the condition. **I don't know how to do this better, so any suggestions are more than welcome!**
- Add special case handling for `LeaveStatementExec` in `*Body` cases of if/else and searched case statement - equivalent to the previous bullet.
- Reorder conditions in `ForStatementExec.hasNext()`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
These changes are fixing wrong logic and improving some of the already existing exception handling mechanisms.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit tests are added for to test/guard all of the introduced improvements.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.