### PR TITLE
[SPARK-52130] [FOLLOW-UP] [ML] [CONNECT] Refine error message when model.summary is evicted

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
@@ -227,8 +227,9 @@ private[connect] object MLHandler extends Logging {
         val methods = mlCommand.getFetch.getMethodsList.asScala.toArray
         val obj = sessionHolder.mlCache.get(objRefId)
         if (
-          obj != null && obj.isInstanceOf[HasTrainingSummary] && methods(0).getMethod == "summary"
-          && !obj.asInstanceOf[HasTrainingSummary].hasSummary
+          obj != null && obj.isInstanceOf[HasTrainingSummary[_]]
+          && methods(0).getMethod == "summary"
+          && !obj.asInstanceOf[HasTrainingSummary[_]].hasSummary
         ) {
           throw MLCacheInvalidException(objRefId, sessionHolder.mlCache.getOffloadingTimeoutMinute)
         }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
@@ -28,7 +28,7 @@ import org.apache.spark.ml.{Estimator, EstimatorUtils, Model, Transformer}
 import org.apache.spark.ml.evaluation.Evaluator
 import org.apache.spark.ml.param.{ParamMap, Params}
 import org.apache.spark.ml.tree.TreeConfig
-import org.apache.spark.ml.util.{MLWritable, Summary}
+import org.apache.spark.ml.util.{HasTrainingSummary, MLWritable, Summary}
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.connect.common.LiteralValueProtoConverter
 import org.apache.spark.sql.connect.ml.Serializer.deserializeMethodArguments
@@ -223,10 +223,16 @@ private[connect] object MLHandler extends Logging {
           .build()
 
       case proto.MlCommand.CommandCase.FETCH =>
-        val helper = AttributeHelper(
-          sessionHolder,
-          mlCommand.getFetch.getObjRef.getId,
-          mlCommand.getFetch.getMethodsList.asScala.toArray)
+        val objRefId = mlCommand.getFetch.getObjRef.getId
+        val methods = mlCommand.getFetch.getMethodsList.asScala.toArray
+        val obj = sessionHolder.mlCache.get(objRefId)
+        if (
+          obj != null && obj.isInstanceOf[HasTrainingSummary] && methods(0).getMethod == "summary"
+          && !obj.asInstanceOf[HasTrainingSummary].hasSummary
+        ) {
+          throw MLCacheInvalidException(objRefId, sessionHolder.mlCache.getOffloadingTimeoutMinute)
+        }
+        val helper = AttributeHelper(sessionHolder, objRefId, methods)
         val attrResult = helper.getAttribute
         attrResult match {
           case s: Summary =>

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
@@ -226,12 +226,12 @@ private[connect] object MLHandler extends Logging {
         val objRefId = mlCommand.getFetch.getObjRef.getId
         val methods = mlCommand.getFetch.getMethodsList.asScala.toArray
         val obj = sessionHolder.mlCache.get(objRefId)
-        if (
-          obj != null && obj.isInstanceOf[HasTrainingSummary[_]]
+        if (obj != null && obj.isInstanceOf[HasTrainingSummary[_]]
           && methods(0).getMethod == "summary"
-          && !obj.asInstanceOf[HasTrainingSummary[_]].hasSummary
-        ) {
-          throw MLCacheInvalidException(objRefId, sessionHolder.mlCache.getOffloadingTimeoutMinute)
+          && !obj.asInstanceOf[HasTrainingSummary[_]].hasSummary) {
+          throw MLCacheInvalidException(
+            objRefId,
+            sessionHolder.mlCache.getOffloadingTimeoutMinute)
         }
         val helper = AttributeHelper(sessionHolder, objRefId, methods)
         val attrResult = helper.getAttribute


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Refine error message when model.summary is evicted.

In Spark Connect ML handler, `model.summary.XXX` invocation has different code path than `model.evaluate`, and it should raise readable error message when model.summary is evicted, otherwise the MLHandler will raise NullPointerException which is not friendly to end-users.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Refine error message.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Manually.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.