### PR TITLE
[SPARK-52350][SS] Fix link for SS programming guide in 4.0

### DIFF
--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -19,4 +19,4 @@ license: |
   limitations under the License.
 ---
 
-As of Spark 4.0.0, the Structured Streaming Programming Guide has been broken apart into smaller, more readable pages. You can find these pages [here](/streaming).
+As of Spark 4.0.0, the Structured Streaming Programming Guide has been broken apart into smaller, more readable pages. You can find these pages [here](./streaming/index.html).


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix link for SS programming guide in 4.0


### Why are the changes needed?
Without this change, the doc link is broken


### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
Confirmed with manual test.


### Was this patch authored or co-authored using generative AI tooling?
No
