### PR TITLE
[SPARK-52337][CONNECT] Make InvalidPlanInput a user-facing error

### DIFF
--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/InvalidPlanInput.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/InvalidPlanInput.scala
@@ -16,10 +16,38 @@
  */
 package org.apache.spark.sql.connect.common
 
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.{SparkThrowable, SparkThrowableHelper}
+
 /**
  * Error thrown when a connect plan is not valid.
  */
 final case class InvalidPlanInput(
-    private val message: String = "",
-    private val cause: Throwable = None.orNull)
-    extends Exception(message, cause)
+    private val errorCondition: String,
+    private val messageParameters: Map[String, String],
+    private val causeOpt: Option[Throwable])
+    extends Exception(
+      SparkThrowableHelper.getMessage(errorCondition, messageParameters),
+      causeOpt.orNull)
+    with SparkThrowable {
+
+  override def getCondition: String = errorCondition
+
+  override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
+}
+
+object InvalidPlanInput {
+
+  def apply(message: String): InvalidPlanInput =
+    InvalidPlanInput(
+      errorCondition = "INTERNAL_ERROR",
+      messageParameters = Map("message" -> message),
+      causeOpt = None)
+
+  def apply(errorCondition: String, messageParameters: Map[String, String]): InvalidPlanInput =
+    InvalidPlanInput(
+      errorCondition = errorCondition,
+      messageParameters = messageParameters,
+      causeOpt = None)
+}

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/InvalidInputErrors.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/InvalidInputErrors.scala
@@ -19,21 +19,12 @@ package org.apache.spark.sql.connect.planner
 
 import scala.collection.mutable
 
-import org.apache.spark.SparkThrowableHelper
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.connect.common.InvalidPlanInput
 import org.apache.spark.sql.errors.DataTypeErrors.{quoteByDefault, toSQLType}
 import org.apache.spark.sql.types.DataType
 
 object InvalidInputErrors {
-
-  // invalidPlanInput is a helper function to facilitate the migration of InvalidInputErrors
-  // to support NERF.
-  private def invalidPlanInput(
-      errorCondition: String,
-      messageParameters: Map[String, String] = Map.empty): InvalidPlanInput = {
-    InvalidPlanInput(SparkThrowableHelper.getMessage(errorCondition, messageParameters))
-  }
 
   def unknownRelationNotSupported(rel: proto.Relation): InvalidPlanInput =
     InvalidPlanInput(s"${rel.getUnknown} not supported.")
@@ -97,7 +88,7 @@ object InvalidInputErrors {
     InvalidPlanInput("Schema for LocalRelation is required when the input data is not provided.")
 
   def invalidSchemaStringNonStructType(schema: String, dataType: DataType): InvalidPlanInput =
-    invalidPlanInput(
+    InvalidPlanInput(
       "INVALID_SCHEMA.NON_STRUCT_TYPE",
       Map("inputSchema" -> quoteByDefault(schema), "dataType" -> toSQLType(dataType)))
 
@@ -114,7 +105,7 @@ object InvalidInputErrors {
     InvalidPlanInput(s"Does not support $what")
 
   def invalidSchemaTypeNonStruct(dataType: DataType): InvalidPlanInput =
-    invalidPlanInput("INVALID_SCHEMA_TYPE_NON_STRUCT", Map("dataType" -> toSQLType(dataType)))
+    InvalidPlanInput("INVALID_SCHEMA_TYPE_NON_STRUCT", Map("dataType" -> toSQLType(dataType)))
 
   def expressionIdNotSupported(exprId: Int): InvalidPlanInput =
     InvalidPlanInput(s"Expression with ID: $exprId is not supported")

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/InvalidInputErrorsSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/InvalidInputErrorsSuite.scala
@@ -95,6 +95,18 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
           .build()
 
         proto.Relation.newBuilder().setRead(read).build()
+      }),
+    TestCase(
+      name = "Deduplicate needs input",
+      expectedErrorCondition = "INTERNAL_ERROR",
+      expectedParameters = Map("message" -> "Deduplicate needs a plan input"),
+      invalidInput = {
+        val deduplicate = proto.Deduplicate
+          .newBuilder()
+          .setAllColumnsAsKeys(true)
+          .build()
+
+        proto.Relation.newBuilder().setDeduplicate(deduplicate).build()
       }))
 
   // Run all test cases


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR makes `InvalidPlanInput` a user-facing error by:
1. Refactoring `InvalidPlanInput` to implement `SparkThrowable` interface
2. Adding proper error condition (the default value is `INTERNAL_ERROR`) and message parameters support
3. Updating error creation in `InvalidInputErrors` to use the new error format
4. Adding test coverage for the new error handling

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The PR follows the pattern of other Spark errors by implementing the `SparkThrowable` interface, which provides a standardized way to handle and display errors to users. This makes error messages more consistent and easier to understand across the Spark ecosystem.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

`build/sbt "connect/testOnly *InvalidInputErrorsSuite"`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Cursor 0.50.7 (Universal)