### PR TITLE
[SPARK-52356][PS] Enable divide-by-zero for boolean mod/rmod with ANSI enabled

### DIFF
--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -139,11 +139,11 @@ class BooleanOps(DataTypeOps):
             )
         spark_session = left._internal.spark_frame.sparkSession
 
-        def safe_mod(l: PySparkColumn, r: Any) -> PySparkColumn:
+        def safe_mod(left_col: PySparkColumn, right_val: Any) -> PySparkColumn:
             if is_ansi_mode_enabled(spark_session):
-                return F.when(F.lit(r == 0), F.lit(None)).otherwise(l % r)
+                return F.when(F.lit(right_val == 0), F.lit(None)).otherwise(left_col % right_val)
             else:
-                return l % r
+                return left_col % right_val
 
         if isinstance(right, numbers.Number):
             left = transform_boolean_operand_to_numeric(left, spark_type=as_spark_type(type(right)))

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -237,7 +237,7 @@ class BooleanOps(DataTypeOps):
             left = transform_boolean_operand_to_numeric(left, spark_type=as_spark_type(type(right)))
             spark_session = left._internal.spark_frame.sparkSession
 
-            def safe_rmod(left_col, right):
+            def safe_rmod(left_col: PySparkColumn, right: Any) -> PySparkColumn:
                 if is_ansi_mode_enabled(spark_session):
                     return F.when(left_col != 0, F.pmod(F.lit(right), left_col)).otherwise(
                         F.lit(None)

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -237,15 +237,16 @@ class BooleanOps(DataTypeOps):
             left = transform_boolean_operand_to_numeric(left, spark_type=as_spark_type(type(right)))
             spark_session = left._internal.spark_frame.sparkSession
 
-            def safe_rmod(left_col: PySparkColumn, right: Any) -> PySparkColumn:
-                if is_ansi_mode_enabled(spark_session):
-                    return F.when(left_col != 0, F.pmod(F.lit(right), left_col)).otherwise(
+            if is_ansi_mode_enabled(spark_session):
+
+                def safe_rmod(left_col: PySparkColumn, right_val: Any) -> PySparkColumn:
+                    return F.when(left_col != 0, F.pmod(F.lit(right_val), left_col)).otherwise(
                         F.lit(None)
                     )
-                else:
-                    return right % left
 
-            return numpy_column_op(safe_rmod)(left, right)
+                return numpy_column_op(safe_rmod)(left, right)
+            else:
+                return right % left
         else:
             raise TypeError(
                 "Modulo can not be applied to %s and the given type." % self.pretty_name

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -137,7 +137,6 @@ class BooleanOpsTestsMixin:
         for col in self.non_numeric_df_cols:
             self.assertRaises(TypeError, lambda: b_psser // psdf[col])
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_mod(self):
         pdf, psdf = self.pdf, self.psdf
 
@@ -237,7 +236,6 @@ class BooleanOpsTestsMixin:
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) ** b_psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) ** b_psser)
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_rmod(self):
         psdf = self.psdf
 
@@ -248,6 +246,7 @@ class BooleanOpsTestsMixin:
         self.assert_eq(
             pd.Series([0.10000000000000009, 0.10000000000000009, None], dtype=float, name="bool"),
             0.1 % b_psser,
+            check_exact=False,  # [0.1, 0.1, nan] for pandas-on-Spark
         )
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) % b_psser)
         self.assertRaises(TypeError, lambda: True % b_psser)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable divide-by-zero for boolean mod/rmod with ANSI enabled


### Why are the changes needed?
Ensure pandas on Spark works well with ANSI mode on.
Part of https://issues.apache.org/jira/browse/SPARK-52169.




### Does this PR introduce _any_ user-facing change?
Yes, divide-by-zero is enabled when ANSI is on, as shown below: 

```
>>> ps.set_option("compute.fail_on_ansi_mode", False)
>>> pser = pd.Series([True, False])
>>> psser = ps.from_pandas(pser)

>>> ps.set_option("compute.ansi_mode_support", True)
>>> spark.conf.set("spark.sql.ansi.enabled", True)
>>> 1 % psser
0    0.0
1    NaN
dtype: float64

# Same as ANSI off
>>> spark.conf.set("spark.sql.ansi.enabled", False)
>>> 1 % psser
0    0.0
1    NaN
dtype: float64

```

### How was this patch tested?
Unit tests, and

```py
(dev3.10) spark (divide_0_tests) % SPARK_ANSI_SQL_MODE=true  ./python/run-tests --python-executables=python3.10 --testnames "pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests.test_mod"

Running PySpark tests. Output is in /Users/xinrong.meng/spark/python/unit-tests.log
...
Finished test(python3.10): pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests.test_mod (5s)
Tests passed in 5 seconds


(dev3.10) spark (divide_0_tests) % SPARK_ANSI_SQL_MODE=true  ./python/run-tests --python-executables=python3.10 --testnames "pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests.test_rmod"
Running PySpark tests. Output is in /Users/xinrong.meng/spark/python/unit-tests.log
...
Finished test(python3.10): pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests.test_rmod (4s)
Tests passed in 4 seconds
```

### Was this patch authored or co-authored using generative AI tooling?
No