### PR TITLE
[SPARK-52363][SQL][TESTS] Analyzer NameScope test for nested struct fields inside map values

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/NameScopeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/NameScopeSuite.scala
@@ -358,6 +358,23 @@ class NameScopeSuite extends PlanTest {
       )
     )
 
+    val matchedMapStructs = stack.resolveMultipartName(Seq("col11", "key", "field"))
+    assert(
+      matchedMapStructs == NameTarget(
+        candidates = Seq(
+          GetStructField(GetMapValue(col11MapWithStruct, Literal("key")), 0, Some("field"))),
+        aliasName = Some("field"),
+        output = Seq(
+          col8Struct,
+          col9NestedStruct,
+          col10Map,
+          col11MapWithStruct,
+          col12Array,
+          col13ArrayWithStruct
+        )
+      )
+    )
+
     var matchedArrays = stack.resolveMultipartName(Seq("col12", "element"))
     assert(
       matchedArrays == NameTarget(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds test coverage for resolving nested struct fields inside Map values which was missing in the original test suite.


### Why are the changes needed?
 The new test verifies that multi-part resolution like mapColumn['key'].nestedField works correctly, we already defined a field `col11MapWithStruct`, but we didn't test it properly.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unneeded


### Was this patch authored or co-authored using generative AI tooling?
No
