### PR TITLE
[SPARK-52383][CONNECT] Improve errors in SparkConnectPlanner

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/InvalidInputErrors.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/InvalidInputErrors.scala
@@ -19,6 +19,10 @@ package org.apache.spark.sql.connect.planner
 
 import scala.collection.mutable
 
+import com.google.protobuf.Descriptors.Descriptor
+import com.google.protobuf.Internal.EnumLite
+import com.google.protobuf.ProtocolMessageEnum
+
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.connect.common.InvalidPlanInput
 import org.apache.spark.sql.errors.DataTypeErrors.{quoteByDefault, toSQLType}
@@ -26,14 +30,8 @@ import org.apache.spark.sql.types.DataType
 
 object InvalidInputErrors {
 
-  def unknownRelationNotSupported(rel: proto.Relation): InvalidPlanInput =
-    InvalidPlanInput(s"${rel.getUnknown} not supported.")
-
   def noHandlerFoundForExtension(): InvalidPlanInput =
     InvalidPlanInput("No handler found for extension")
-
-  def catalogTypeNotSupported(catType: proto.Catalog.CatTypeCase): InvalidPlanInput =
-    InvalidPlanInput(s"$catType not supported.")
 
   def invalidSQLWithReferences(query: proto.WithRelations): InvalidPlanInput =
     InvalidPlanInput(s"$query is not a valid relation for SQL with references")
@@ -60,9 +58,6 @@ object InvalidInputErrors {
 
   def functionEvalTypeNotSupported(evalType: Int): InvalidPlanInput =
     InvalidPlanInput(s"Function with EvalType: $evalType is not supported")
-
-  def functionIdNotSupported(functionId: Int): InvalidPlanInput =
-    InvalidPlanInput(s"Function with ID: $functionId is not supported")
 
   def groupingExpressionAbsentForKeyValueGroupedDataset(): InvalidPlanInput =
     InvalidPlanInput("The grouping expression cannot be absent for KeyValueGroupedDataset")
@@ -101,14 +96,30 @@ object InvalidInputErrors {
   def multiplePathsNotSupportedForStreamingSource(): InvalidPlanInput =
     InvalidPlanInput("Multiple paths are not supported for streaming source")
 
-  def doesNotSupport(what: String): InvalidPlanInput =
-    InvalidPlanInput(s"Does not support $what")
+  def invalidEnum(protoEnum: Enum[_] with ProtocolMessageEnum): InvalidPlanInput =
+    InvalidPlanInput(
+      s"This enum value of ${protoEnum.getDescriptorForType.getFullName}" +
+        s" is invalid: ${protoEnum.name()}(${protoEnum.getNumber})")
+
+  def invalidOneOfField(
+      enumCase: Enum[_] with EnumLite,
+      descriptor: Descriptor): InvalidPlanInput = {
+    // If the oneOf field is not set, the enum number will be 0.
+    if (enumCase.getNumber == 0) {
+      InvalidPlanInput(
+        s"This oneOf field in ${descriptor.getFullName} is not set: ${enumCase.name()}")
+    } else {
+      InvalidPlanInput(
+        s"This oneOf field message in ${descriptor.getFullName} is not supported: " +
+          s"${enumCase.name()}(${enumCase.getNumber})")
+    }
+  }
+
+  def cannotBeEmpty(fieldName: String, descriptor: Descriptor): InvalidPlanInput =
+    InvalidPlanInput(s"$fieldName in ${descriptor.getFullName} cannot be empty")
 
   def invalidSchemaTypeNonStruct(dataType: DataType): InvalidPlanInput =
     InvalidPlanInput("INVALID_SCHEMA_TYPE_NON_STRUCT", Map("dataType" -> toSQLType(dataType)))
-
-  def expressionIdNotSupported(exprId: Int): InvalidPlanInput =
-    InvalidPlanInput(s"Expression with ID: $exprId is not supported")
 
   def lambdaFunctionArgumentCountInvalid(got: Int): InvalidPlanInput =
     InvalidPlanInput(s"LambdaFunction requires 1 ~ 3 arguments, but got $got ones!")
@@ -127,17 +138,8 @@ object InvalidInputErrors {
   def windowFunctionRequired(): InvalidPlanInput =
     InvalidPlanInput("WindowFunction is required in WindowExpression")
 
-  def unknownFrameType(
-      frameType: proto.Expression.Window.WindowFrame.FrameType): InvalidPlanInput =
-    InvalidPlanInput(s"Unknown FrameType $frameType")
-
   def lowerBoundRequiredInWindowFrame(): InvalidPlanInput =
     InvalidPlanInput("LowerBound is required in WindowFrame")
-
-  def unknownFrameBoundary(
-      boundary: proto.Expression.Window.WindowFrame.FrameBoundary.BoundaryCase)
-      : InvalidPlanInput =
-    InvalidPlanInput(s"Unknown FrameBoundary $boundary")
 
   def upperBoundRequiredInWindowFrame(): InvalidPlanInput =
     InvalidPlanInput("UpperBound is required in WindowFrame")
@@ -151,35 +153,17 @@ object InvalidInputErrors {
   def intersectDoesNotSupportUnionByName(): InvalidPlanInput =
     InvalidPlanInput("Intersect does not support union_by_name")
 
-  def unsupportedSetOperation(op: Int): InvalidPlanInput =
-    InvalidPlanInput(s"Unsupported set operation $op")
-
-  def joinTypeNotSupported(t: proto.Join.JoinType): InvalidPlanInput =
-    InvalidPlanInput(s"Join type $t is not supported")
-
   def aggregateNeedsPlanInput(): InvalidPlanInput =
     InvalidPlanInput("Aggregate needs a plan input")
 
   def aggregateWithPivotRequiresPivot(): InvalidPlanInput =
     InvalidPlanInput("Aggregate with GROUP_TYPE_PIVOT requires a Pivot")
 
-  def runnerCannotBeEmptyInExecuteExternalCommand(): InvalidPlanInput =
-    InvalidPlanInput("runner cannot be empty in executeExternalCommand")
-
-  def commandCannotBeEmptyInExecuteExternalCommand(): InvalidPlanInput =
-    InvalidPlanInput("command cannot be empty in executeExternalCommand")
-
-  def unexpectedForeachBatchFunction(): InvalidPlanInput =
-    InvalidPlanInput("Unexpected foreachBatch function")
-
   def invalidWithRelationReference(): InvalidPlanInput =
     InvalidPlanInput("Invalid WithRelation reference")
 
   def assertionFailure(message: String): InvalidPlanInput =
     InvalidPlanInput(message)
-
-  def unsupportedMergeActionType(actionType: proto.MergeAction.ActionType): InvalidPlanInput =
-    InvalidPlanInput(s"Unsupported merge action type $actionType")
 
   def unresolvedNamedLambdaVariableRequiresNamePart(): InvalidPlanInput =
     InvalidPlanInput("UnresolvedNamedLambdaVariable requires at least one name part!")
@@ -190,15 +174,6 @@ object InvalidInputErrors {
   def sqlCommandExpectsSqlOrWithRelations(other: proto.Relation.RelTypeCase): InvalidPlanInput =
     InvalidPlanInput(s"SQL command expects either a SQL or a WithRelations, but got $other")
 
-  def unknownGroupType(groupType: proto.Aggregate.GroupType): InvalidPlanInput =
-    InvalidPlanInput(s"Unknown group type $groupType")
-
-  def dataSourceIdNotSupported(dataSourceId: Int): InvalidPlanInput =
-    InvalidPlanInput(s"Data source id $dataSourceId is not supported")
-
-  def unknownSubqueryType(subqueryType: proto.SubqueryExpression.SubqueryType): InvalidPlanInput =
-    InvalidPlanInput(s"Unknown subquery type $subqueryType")
-
   def reduceShouldCarryScalarScalaUdf(got: mutable.Buffer[proto.Expression]): InvalidPlanInput =
     InvalidPlanInput(s"reduce should carry a scalar scala udf, but got $got")
 
@@ -207,4 +182,15 @@ object InvalidInputErrors {
 
   def unsupportedUserDefinedFunctionImplementation(clazz: Class[_]): InvalidPlanInput =
     InvalidPlanInput(s"Unsupported UserDefinedFunction implementation: ${clazz}")
+
+  def streamingQueryRunIdMismatch(
+      id: String,
+      runId: String,
+      serverRunId: String): InvalidPlanInput =
+    InvalidPlanInput(
+      s"Run id mismatch for query id $id. Run id in the request $runId " +
+        s"does not match one on the server $serverRunId. The query might have restarted.")
+
+  def streamingQueryNotFound(id: String): InvalidPlanInput =
+    InvalidPlanInput(s"Streaming query $id is not found")
 }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -32,7 +32,7 @@ import io.grpc.{Context, Status, StatusRuntimeException}
 import io.grpc.stub.StreamObserver
 import org.apache.commons.lang3.exception.ExceptionUtils
 
-import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.{SparkClassNotFoundException, SparkEnv, SparkException, TaskContext}
 import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.api.python.{PythonEvalType, SimplePythonFunction}
 import org.apache.spark.connect.proto
@@ -98,7 +98,7 @@ class SparkConnectPlanner(
   }
 
   if (!executeHolderOpt.forall { e => e.sessionHolder == sessionHolder }) {
-    throw new IllegalArgumentException("executeHolder does not belong to sessionHolder")
+    throw SparkException.internalError("executeHolder does not belong to sessionHolder")
   }
 
   @Since("4.0.0")
@@ -113,7 +113,7 @@ class SparkConnectPlanner(
   private[connect] def sessionId: String = sessionHolder.sessionId
 
   private lazy val executeHolder = executeHolderOpt.getOrElse {
-    throw new IllegalArgumentException("executeHolder is not set")
+    throw SparkException.internalError("executeHolder is not set")
   }
 
   private lazy val pythonExec =
@@ -220,8 +220,6 @@ class SparkConnectPlanner(
         case proto.Relation.RelTypeCase.COLLECT_METRICS =>
           transformCollectMetrics(rel.getCollectMetrics, rel.getCommon.getPlanId)
         case proto.Relation.RelTypeCase.PARSE => transformParse(rel.getParse)
-        case proto.Relation.RelTypeCase.RELTYPE_NOT_SET =>
-          throw new IndexOutOfBoundsException("Expected Relation to be set, but is empty.")
 
         // Catalog API (internal-only)
         case proto.Relation.RelTypeCase.CATALOG => transformCatalog(rel.getCatalog)
@@ -233,7 +231,9 @@ class SparkConnectPlanner(
         // Handle plugins for Spark Connect Relation types.
         case proto.Relation.RelTypeCase.EXTENSION =>
           transformRelationPlugin(rel.getExtension)
-        case _ => throw InvalidInputErrors.unknownRelationNotSupported(rel)
+
+        case other =>
+          throw InvalidInputErrors.invalidOneOfField(other, rel.getDescriptorForType)
       }
       if (rel.hasCommon && rel.getCommon.hasPlanId) {
         plan.setTagValue(LogicalPlan.PLAN_ID_TAG, rel.getCommon.getPlanId)
@@ -297,7 +297,8 @@ class SparkConnectPlanner(
         transformSetCurrentCatalog(catalog.getSetCurrentCatalog)
       case proto.Catalog.CatTypeCase.LIST_CATALOGS =>
         transformListCatalogs(catalog.getListCatalogs)
-      case other => throw InvalidInputErrors.catalogTypeNotSupported(other)
+      case other =>
+        throw InvalidInputErrors.invalidOneOfField(other, catalog.getDescriptorForType)
     }
   }
 
@@ -610,8 +611,8 @@ class SparkConnectPlanner(
           case _ =>
             throw InvalidInputErrors.functionEvalTypeNotSupported(pythonUdf.evalType)
         }
-      case _ =>
-        throw InvalidInputErrors.functionIdNotSupported(commonUdf.getFunctionCase.getNumber)
+      case other =>
+        throw InvalidInputErrors.invalidOneOfField(other, commonUdf.getDescriptorForType)
     }
   }
 
@@ -667,8 +668,8 @@ class SparkConnectPlanner(
             throw InvalidInputErrors.functionEvalTypeNotSupported(pythonUdf.evalType)
         }
 
-      case _ =>
-        throw InvalidInputErrors.functionIdNotSupported(commonUdf.getFunctionCase.getNumber)
+      case other =>
+        throw InvalidInputErrors.invalidOneOfField(other, commonUdf.getDescriptorForType)
     }
   }
 
@@ -871,8 +872,8 @@ class SparkConnectPlanner(
             throw InvalidInputErrors.functionEvalTypeNotSupported(pythonUdf.evalType)
         }
 
-      case _ =>
-        throw InvalidInputErrors.functionIdNotSupported(commonUdf.getFunctionCase.getNumber)
+      case other =>
+        throw InvalidInputErrors.invalidOneOfField(other, commonUdf.getDescriptorForType)
     }
   }
 
@@ -1180,8 +1181,8 @@ class SparkConnectPlanner(
         function.builder(
           fun.getArgumentsList.asScala.map(transformExpression).toSeq,
           session.sessionState.sqlParser)
-      case _ =>
-        throw InvalidInputErrors.functionIdNotSupported(fun.getFunctionCase.getNumber)
+      case other =>
+        throw InvalidInputErrors.invalidOneOfField(other, fun.getDescriptorForType)
     }
   }
 
@@ -1568,7 +1569,8 @@ class SparkConnectPlanner(
 
         streamDF.queryExecution.analyzed
 
-      case _ => throw InvalidInputErrors.doesNotSupport(rel.getReadTypeCase.name())
+      case other =>
+        throw InvalidInputErrors.invalidOneOfField(other, rel.getDescriptorForType)
     }
   }
 
@@ -1592,7 +1594,7 @@ class SparkConnectPlanner(
         dataFrameReader.csv(ds).queryExecution.analyzed
       case ParseFormat.PARSE_FORMAT_JSON =>
         dataFrameReader.json(ds).queryExecution.analyzed
-      case _ => throw InvalidInputErrors.doesNotSupport(rel.getFormat.name())
+      case other => throw InvalidInputErrors.invalidEnum(other)
     }
   }
 
@@ -1773,8 +1775,8 @@ class SparkConnectPlanner(
         transformTypedAggregateExpression(exp.getTypedAggregateExpression, baseRelationOpt)
       case proto.Expression.ExprTypeCase.SUBQUERY_EXPRESSION =>
         transformSubqueryExpression(exp.getSubqueryExpression)
-      case _ =>
-        throw InvalidInputErrors.expressionIdNotSupported(exp.getExprTypeCase.getNumber)
+      case other =>
+        throw InvalidInputErrors.invalidOneOfField(other, exp.getDescriptorForType)
     }
   }
 
@@ -1880,8 +1882,8 @@ class SparkConnectPlanner(
         transformPythonFuncExpression(fun)
       case proto.CommonInlineUserDefinedFunction.FunctionCase.SCALAR_SCALA_UDF =>
         transformScalaUDF(fun)
-      case _ =>
-        throw InvalidInputErrors.functionIdNotSupported(fun.getFunctionCase.getNumber)
+      case other =>
+        throw InvalidInputErrors.invalidOneOfField(other, fun.getDescriptorForType)
     }
   }
 
@@ -1922,16 +1924,20 @@ class SparkConnectPlanner(
       case t: Throwable =>
         Throwables.getRootCause(t) match {
           case nsm: NoSuchMethodException =>
-            throw new ClassNotFoundException(
-              s"Failed to load class correctly due to $nsm. " +
-                "Make sure the artifact where the class is defined is installed by calling" +
-                " session.addArtifact.")
+            throw new SparkClassNotFoundException(
+              "INTERNAL_ERROR",
+              Map[String, String](
+                "message" -> (s"Failed to load class correctly due to $nsm. " +
+                  "Make sure the artifact where the class is defined is installed by calling" +
+                  " session.addArtifact.")))
           case cnf: ClassNotFoundException =>
-            throw new ClassNotFoundException(
-              s"Failed to load class: ${cnf.getMessage}. " +
-                "Make sure the artifact where the class is defined is installed by calling" +
-                " session.addArtifact.")
-          case _ => throw t
+            throw new SparkClassNotFoundException(
+              "INTERNAL_ERROR",
+              Map[String, String](
+                "message" -> (s"Failed to load class: ${cnf.getMessage}. " +
+                  "Make sure the artifact where the class is defined is installed by calling" +
+                  " session.addArtifact.")))
+          case _ => throw SparkException.internalError("Failed to unpack scala udf.", t)
         }
     }
   }
@@ -2177,7 +2183,7 @@ class SparkConnectPlanner(
 
         case proto.Expression.Window.WindowFrame.FrameType.FRAME_TYPE_RANGE => RangeFrame
 
-        case other => throw InvalidInputErrors.unknownFrameType(other)
+        case other => throw InvalidInputErrors.invalidEnum(other)
       }
 
       if (!protoFrameSpec.hasLower) {
@@ -2193,7 +2199,10 @@ class SparkConnectPlanner(
         case proto.Expression.Window.WindowFrame.FrameBoundary.BoundaryCase.VALUE =>
           transformExpression(protoFrameSpec.getLower.getValue)
 
-        case other => throw InvalidInputErrors.unknownFrameBoundary(other)
+        case other =>
+          throw InvalidInputErrors.invalidOneOfField(
+            other,
+            protoFrameSpec.getLower.getDescriptorForType)
       }
 
       if (!protoFrameSpec.hasUpper) {
@@ -2209,7 +2218,10 @@ class SparkConnectPlanner(
         case proto.Expression.Window.WindowFrame.FrameBoundary.BoundaryCase.VALUE =>
           transformExpression(protoFrameSpec.getUpper.getValue)
 
-        case other => throw InvalidInputErrors.unknownFrameBoundary(other)
+        case other =>
+          throw InvalidInputErrors.invalidOneOfField(
+            other,
+            protoFrameSpec.getUpper.getDescriptorForType)
       }
 
       SpecifiedWindowFrame(frameType = frameType, lower = lower, upper = upper)
@@ -2258,8 +2270,8 @@ class SparkConnectPlanner(
           logical.Distinct(union)
         }
 
-      case _ =>
-        throw InvalidInputErrors.unsupportedSetOperation(u.getSetOpTypeValue)
+      case other =>
+        throw InvalidInputErrors.invalidEnum(other)
     }
   }
 
@@ -2314,7 +2326,7 @@ class SparkConnectPlanner(
       case proto.Join.JoinType.JOIN_TYPE_RIGHT_OUTER => RightOuter
       case proto.Join.JoinType.JOIN_TYPE_LEFT_SEMI => LeftSemi
       case proto.Join.JoinType.JOIN_TYPE_CROSS => Cross
-      case _ => throw InvalidInputErrors.joinTypeNotSupported(t)
+      case other => throw InvalidInputErrors.invalidEnum(other)
     }
   }
 
@@ -2520,7 +2532,7 @@ class SparkConnectPlanner(
           aggregateExpressions = aliasedAgg,
           child = logicalPlan)
 
-      case other => throw InvalidInputErrors.unknownGroupType(other)
+      case other => throw InvalidInputErrors.invalidEnum(other)
     }
   }
 
@@ -2619,8 +2631,8 @@ class SparkConnectPlanner(
       case proto.MergeAction.ActionType.ACTION_TYPE_UPDATE_STAR =>
         assertPlan(assignments.isEmpty, "UpdateStar action should not have assignment.")
         UpdateStarAction(condition)
-      case _ =>
-        throw InvalidInputErrors.unsupportedMergeActionType(action.getActionType)
+      case other =>
+        throw InvalidInputErrors.invalidEnum(other)
     }
   }
 
@@ -2683,7 +2695,8 @@ class SparkConnectPlanner(
       case proto.Command.CommandTypeCase.EXECUTE_EXTERNAL_COMMAND =>
         handleExecuteExternalCommand(command.getExecuteExternalCommand, responseObserver)
 
-      case _ => throw new UnsupportedOperationException(s"$command not supported.")
+      case other =>
+        throw InvalidInputErrors.invalidOneOfField(other, command.getDescriptorForType)
     }
   }
 
@@ -2705,10 +2718,10 @@ class SparkConnectPlanner(
       command: proto.ExecuteExternalCommand,
       responseObserver: StreamObserver[proto.ExecutePlanResponse]): Unit = {
     if (command.getRunner.isEmpty) {
-      throw InvalidInputErrors.runnerCannotBeEmptyInExecuteExternalCommand()
+      throw InvalidInputErrors.cannotBeEmpty("runner", command.getDescriptorForType)
     }
     if (command.getCommand.isEmpty) {
-      throw InvalidInputErrors.commandCannotBeEmptyInExecuteExternalCommand()
+      throw InvalidInputErrors.cannotBeEmpty("command", command.getDescriptorForType)
     }
     val executor = ExternalCommandExecutor(
       session,
@@ -2929,8 +2942,8 @@ class SparkConnectPlanner(
         handleRegisterJavaUDF(fun)
       case proto.CommonInlineUserDefinedFunction.FunctionCase.SCALAR_SCALA_UDF =>
         handleRegisterScalaUDF(fun)
-      case _ =>
-        throw InvalidInputErrors.functionIdNotSupported(fun.getFunctionCase.getNumber)
+      case other =>
+        throw InvalidInputErrors.invalidOneOfField(other, fun.getDescriptorForType)
     }
     executeHolder.eventsManager.postFinished()
   }
@@ -2941,8 +2954,8 @@ class SparkConnectPlanner(
       case proto.CommonInlineUserDefinedTableFunction.FunctionCase.PYTHON_UDTF =>
         val function = createPythonUserDefinedTableFunction(fun)
         session.udtf.registerPython(fun.getFunctionName, function)
-      case _ =>
-        throw InvalidInputErrors.functionIdNotSupported(fun.getFunctionCase.getNumber)
+      case other =>
+        throw InvalidInputErrors.invalidOneOfField(other, fun.getDescriptorForType)
     }
     executeHolder.eventsManager.postFinished()
   }
@@ -2954,8 +2967,8 @@ class SparkConnectPlanner(
         val ds = fun.getPythonDataSource
         val dataSource = UserDefinedPythonDataSource(transformPythonDataSource(ds))
         session.dataSource.registerPython(fun.getName, dataSource)
-      case _ =>
-        throw InvalidInputErrors.dataSourceIdNotSupported(fun.getDataSourceCase.getNumber)
+      case other =>
+        throw InvalidInputErrors.invalidOneOfField(other, fun.getDescriptorForType)
     }
     executeHolder.eventsManager.postFinished()
   }
@@ -3104,15 +3117,10 @@ class SparkConnectPlanner(
             w.saveAsTable(tableName)
           case proto.WriteOperation.SaveTable.TableSaveMethod.TABLE_SAVE_METHOD_INSERT_INTO =>
             w.insertInto(tableName)
-          case _ =>
-            throw new UnsupportedOperationException(
-              "WriteOperation:SaveTable:TableSaveMethod not supported "
-                + s"${writeOperation.getTable.getSaveMethodValue}")
+          case other => throw InvalidInputErrors.invalidEnum(other)
         }
-      case _ =>
-        throw new UnsupportedOperationException(
-          "WriteOperation:SaveTypeCase not supported "
-            + s"${writeOperation.getSaveTypeCase.getNumber}")
+      case other =>
+        throw InvalidInputErrors.invalidOneOfField(other, writeOperation.getDescriptorForType)
     }
     executeHolder.eventsManager.postFinished()
   }
@@ -3183,9 +3191,8 @@ class SparkConnectPlanner(
         } else {
           w.createOrReplace()
         }
-      case _ =>
-        throw new UnsupportedOperationException(
-          s"WriteOperationV2:ModeValue not supported ${writeOperation.getModeValue}")
+      case other =>
+        throw InvalidInputErrors.invalidEnum(other)
     }
     executeHolder.eventsManager.postFinished()
   }
@@ -3268,8 +3275,10 @@ class SparkConnectPlanner(
             writeOp.getForeachBatch.getScalaFunction.getPayload.toByteArray,
             sessionHolder)
 
-        case StreamingForeachFunction.FunctionCase.FUNCTION_NOT_SET =>
-          throw InvalidInputErrors.unexpectedForeachBatchFunction() // Unreachable
+        case other =>
+          throw InvalidInputErrors.invalidOneOfField(
+            other,
+            writeOp.getForeachBatch.getDescriptorForType)
       }
 
       writer.foreachBatch(foreachBatchFn)
@@ -3373,11 +3382,9 @@ class SparkConnectPlanner(
       case Some(query) if query.runId.toString == runId =>
         query
       case Some(query) =>
-        throw new IllegalArgumentException(
-          s"Run id mismatch for query id $id. Run id in the request $runId " +
-            s"does not match one on the server ${query.runId}. The query might have restarted.")
+        throw InvalidInputErrors.streamingQueryRunIdMismatch(id, runId, query.runId.toString)
       case None =>
-        throw new IllegalArgumentException(s"Streaming query $id is not found")
+        throw InvalidInputErrors.streamingQueryNotFound(id)
     }
 
     command.getCommandCase match {
@@ -3420,7 +3427,7 @@ class SparkConnectPlanner(
           case q: StreamingQueryWrapper =>
             q.streamingQuery.explainInternal(command.getExplain.getExtended)
           case _ =>
-            throw new IllegalStateException(s"Unexpected type for streaming query: $query")
+            throw SparkException.internalError(s"Unexpected type for streaming query: $query")
         }
         val explain = StreamingQueryCommandResult.ExplainResult
           .newBuilder()
@@ -3460,8 +3467,8 @@ class SparkConnectPlanner(
         val terminated = handleStreamingAwaitTermination(query, timeout)
         respBuilder.getAwaitTerminationBuilder.setTerminated(terminated)
 
-      case StreamingQueryCommand.CommandCase.COMMAND_NOT_SET =>
-        throw new IllegalArgumentException("Missing command in StreamingQueryCommand")
+      case other =>
+        throw InvalidInputErrors.invalidOneOfField(other, command.getDescriptorForType)
     }
 
     executeHolder.eventsManager.postFinished()
@@ -3598,8 +3605,8 @@ class SparkConnectPlanner(
         respBuilder.getListListenersBuilder
           .addAllListenerIds(sessionHolder.listListenerIds().asJava)
 
-      case StreamingQueryManagerCommand.CommandCase.COMMAND_NOT_SET =>
-        throw new IllegalArgumentException("Missing command in StreamingQueryManagerCommand")
+      case other =>
+        throw InvalidInputErrors.invalidOneOfField(other, command.getDescriptorForType)
     }
 
     executeHolder.eventsManager.postFinished()
@@ -4057,7 +4064,7 @@ class SparkConnectPlanner(
             transformExpression(value)
           }.toSeq,
           planId)
-      case other => throw InvalidInputErrors.unknownSubqueryType(other)
+      case other => throw InvalidInputErrors.invalidEnum(other)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR improves error handling in SparkConnectPlanner by:

1. Adding new error handling methods in `InvalidInputErrors.scala` for better error messages:
   - `invalidEnum` for handling invalid enum values
   - `invalidOneOfField` for handling invalid oneOf fields in protobuf messages
   - `cannotBeEmpty` for handling empty fields
   - `streamingQueryRunIdMismatch` and `streamingQueryNotFound` for streaming query errors

2. Replacing specific error messages with more generic ones. For examples:
   - Replacing `unknownRelationNotSupported` with `invalidOneOfField`
   - Replacing `catalogTypeNotSupported` with `invalidOneOfField`
   - Replacing `functionIdNotSupported` with `invalidOneOfField`
   - Replacing `expressionIdNotSupported` with `invalidOneOfField`
   - Replacing `dataSourceIdNotSupported` with `invalidOneOfField`

3. Improving error handling for protobuf-related issues:
   - Better handling of oneOf fields in protobuf messages
   - More descriptive error messages for invalid enum values
   - Better handling of empty fields

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

1. Provide more specific and descriptive error messages
2. Better handle protobuf-related issues that are common in the Connect API
3. Make error messages more consistent across different parts of the codebase

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

`build/sbt "connect/testOnly *SparkConnectPlannerSuite"`
`build/sbt "connect/testOnly *InvalidInputErrorsSuite"`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by: Cursor 0.50.7 (Universal)