### PR TITLE
[SPARK-52355][PYTHON] Infer `VariantVal` object type as `VariantType` when creating a `DataFrame`

### DIFF
--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -478,21 +478,22 @@ class TypesTestsMixin:
         )
 
     def test_infer_variant_type(self):
-        VariantRow = Row("f1", "f2", "f3")
+        # SPARK-52355: Test inferring variant type
         value = VariantVal.parseJson('{"a": 1}')
 
-        data = [
-            VariantRow(value, [value], Row(value=value))
-        ]
+        data = [Row(f1=value)]
         df = self.spark.createDataFrame(data)
+        actual = df.first()["f1"]
+
+        # As of writing VariantVan can also include bytearray
         self.assertEqual(
-            Row(
-                f1=value,
-                f2=[value],
-                f3=Row(value=value),
-            ),
-            df.first(),
+            bytes(actual.value),
+            bytes(value.value),
         )
+        self.assertEqual(
+            bytes(actual.metadata),
+            bytes(value.metadata),
+        ]
 
     def test_create_dataframe_from_dict_respects_schema(self):
         df = self.spark.createDataFrame([{"a": 1}], ["b"])

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -485,10 +485,7 @@ class TypesTestsMixin:
         df = self.spark.createDataFrame(data)
         actual = df.first()["f1"]
 
-        self.assertEqual(
-            type(df.schema["f1"].dataType),
-            VariantType
-        )
+        self.assertEqual(type(df.schema["f1"].dataType), VariantType)
         # As of writing VariantVal can also include bytearray
         self.assertEqual(
             bytes(actual.value),

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -493,7 +493,7 @@ class TypesTestsMixin:
         self.assertEqual(
             bytes(actual.metadata),
             bytes(value.metadata),
-        ]
+        )
 
     def test_create_dataframe_from_dict_respects_schema(self):
         df = self.spark.createDataFrame([{"a": 1}], ["b"])

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -485,7 +485,11 @@ class TypesTestsMixin:
         df = self.spark.createDataFrame(data)
         actual = df.first()["f1"]
 
-        # As of writing VariantVan can also include bytearray
+        self.assertEqual(
+            type(df.schema["f1"].dataType),
+            VariantType
+        )
+        # As of writing VariantVal can also include bytearray
         self.assertEqual(
             bytes(actual.value),
             bytes(value.value),

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -477,6 +477,23 @@ class TypesTestsMixin:
             df.first(),
         )
 
+    def test_infer_variant_type(self):
+        VariantRow = Row("f1", "f2", "f3")
+        value = VariantVal.parseJson('{"a": 1}')
+
+        data = [
+            VariantRow(value, [value], Row(value=value))
+        ]
+        df = self.spark.createDataFrame(data)
+        self.assertEqual(
+            Row(
+                f1=value,
+                f2=[value],
+                f3=Row(value=value),
+            ),
+            df.first(),
+        )
+
     def test_create_dataframe_from_dict_respects_schema(self):
         df = self.spark.createDataFrame([{"a": 1}], ["b"])
         self.assertEqual(df.columns, ["b"])

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2307,6 +2307,8 @@ def _infer_type(
                 errorClass="UNSUPPORTED_DATA_TYPE",
                 messageParameters={"data_type": f"array({obj.typecode})"},
             )
+    elif isinstance(obj, VariantVal):
+       return VariantType()
     else:
         try:
             return _infer_schema(

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2308,7 +2308,7 @@ def _infer_type(
                 messageParameters={"data_type": f"array({obj.typecode})"},
             )
     elif isinstance(obj, VariantVal):
-       return VariantType()
+        return VariantType()
     else:
         try:
             return _infer_schema(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When creating a `DataFrame` from Python using `spark.createDataFrame`, infer the type of any `VariantVal` objects as `VariantType`. This is implemented by adding a case mapping `VariantVal` to `VariantType` in the `pyspark.sql.types._infer_type` function.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, when creating a `DataFrame` that includes locally-instantiated `VariantVal` objects in Python, the type is inferred as `struct<metadata:binary,value:binary>` rather than `VariantType`. This leads to unintended behavior when creating a `DataFrame` locally, or in certain situations like `df.rdd.map(...).toDF` which call `createDataFrame` under the hood. The bug only occurs when the schema of the `DataFrame` is not passed explicitly.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, fixes the bug described above.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added a test in `python/pyspark/sql/tests/test_types.py` that checks the inferred type is `VariantType`, as well as ensuring the `VariantVal` has the correct `value` and `metadata` after inference.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
