### PR TITLE
[SPARK-52404][SQL] Give a separate error class to failures in `BindReferences`

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2188,6 +2188,12 @@
     ],
     "sqlState" : "XX000"
   },
+  "INTERNAL_ERROR_ATTRIBUTE_NOT_FOUND" : {
+    "message" : [
+      "Could not find <missingAttr> in <inputAttrs>."
+    ],
+    "sqlState" : "XX000"
+  },
   "INTERNAL_ERROR_BROADCAST" : {
     "message" : [
       "<message>"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/BoundAttribute.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/BoundAttribute.scala
@@ -77,8 +77,7 @@ object BindReferences extends Logging {
         if (allowFailures) {
           a
         } else {
-          throw SparkException.internalError(
-            s"Couldn't find $a in ${input.attrs.mkString("[", ",", "]")}")
+          throw attributeNotFoundException(a, input.attrs)
         }
       } else {
         BoundReference(ordinal, a.dataType, input(ordinal).nullable)
@@ -94,4 +93,18 @@ object BindReferences extends Logging {
       input: AttributeSeq): Seq[A] = {
     expressions.map(BindReferences.bindReference(_, input))
   }
+
+  /**
+   * A helper function to produce an exception when binding a reference fails.
+   * Public for testing.
+   */
+  def attributeNotFoundException(
+      missingAttr: AttributeReference,
+      inputAttrs: Seq[Attribute]): SparkException =
+    new SparkException(
+      errorClass = "INTERNAL_ERROR_ATTRIBUTE_NOT_FOUND",
+      messageParameters = Map(
+        "missingAttr" -> missingAttr.toString,
+        "inputAttrs" -> inputAttrs.mkString("[", ",", "]")),
+      cause = null)
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/BindReferencesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/BindReferencesSuite.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.types.IntegerType
+
+class BindReferencesSuite extends SparkFunSuite{
+  test("attribute not found exception") {
+    val missing = AttributeReference("missing", IntegerType)(qualifier = Seq.empty)
+    val input1 = AttributeReference("one", IntegerType)(qualifier = Seq.empty)
+    val input2 = AttributeReference("two", IntegerType)(qualifier = Seq.empty)
+    val input3 = AttributeReference("three", IntegerType)(qualifier = Seq.empty)
+
+    val e = BindReferences.attributeNotFoundException(
+        missingAttr = missing,
+        inputAttrs = Seq(input1, input2, input3))
+
+    checkError(e,
+      condition = "INTERNAL_ERROR_ATTRIBUTE_NOT_FOUND",
+      sqlState = "XX000",
+      parameters = Map(
+        "missingAttr" -> s"$missing",
+        "inputAttrs" -> s"[$input1,$input2,$input3]"
+      )
+    )
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

We add a new error class to cover a distinct portion of the `INTERNAL_ERROR` class, that is, a situation where an attribute reference in the query plan cannot be bound. The error massage, once hardcoded in `BoundAttribute.scala` is now moved the the JSON file.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The error messages should be stored in the JSON files, and not hard-coded into the source. Failures in `BoundAttribute.scala` are a distinct and don't share much with the other `INTERNAL_ERROR` failures, yet they are currently bundled under the same error class.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Change of error class.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New test is added.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.