### PR TITLE
[SPARK-52238][TESTS][FOLLOW-UP] Fix test failure in daily builds

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,7 +41,7 @@ on:
         description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false
         type: string
-        default: '{"PYSPARK_IMAGE_TO_TEST": "python-312", "PYTHON_TO_TEST": "python3.12"}'
+        default: '{"PYSPARK_IMAGE_TO_TEST": "python-311", "PYTHON_TO_TEST": "python3.11"}'
       jobs:
         description: >-
           Jobs to run, and should be in JSON format. The values should be matched with the job's key defined

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,7 +41,7 @@ on:
         description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false
         type: string
-        default: '{"PYSPARK_IMAGE_TO_TEST": "python-311", "PYTHON_TO_TEST": "python3.11"}'
+        default: '{"PYSPARK_IMAGE_TO_TEST": "python-312", "PYTHON_TO_TEST": "python3.12"}'
       jobs:
         description: >-
           Jobs to run, and should be in JSON format. The values should be matched with the job's key defined

--- a/python/pyspark/pipelines/tests/test_block_connect_access.py
+++ b/python/pyspark/pipelines/tests/test_block_connect_access.py
@@ -38,7 +38,7 @@ class BlockSparkConnectAccessTests(ReusedConnectTestCase):
         with block_spark_connect_execution_and_analysis():
             with self.assertRaises(PySparkException) as context:
                 df.schema
-            self.assertEquals(
+            self.assertEqual(
                 context.exception.getCondition(), "ATTEMPT_ANALYSIS_IN_PIPELINE_QUERY_FUNCTION"
             )
 
@@ -48,7 +48,7 @@ class BlockSparkConnectAccessTests(ReusedConnectTestCase):
         with block_spark_connect_execution_and_analysis():
             with self.assertRaises(PySparkException) as context:
                 df.collect()
-            self.assertEquals(
+            self.assertEqual(
                 context.exception.getCondition(), "ATTEMPT_ANALYSIS_IN_PIPELINE_QUERY_FUNCTION"
             )
 

--- a/python/pyspark/pipelines/tests/test_decorators.py
+++ b/python/pyspark/pipelines/tests/test_decorators.py
@@ -55,10 +55,10 @@ class DecoratorsTest(unittest.TestCase):
             with self.assertRaises(PySparkTypeError) as context:
                 decorator("table1")
 
-            self.assertEquals(context.exception.getCondition(), "DECORATOR_ARGUMENT_NOT_CALLABLE")
+            self.assertEqual(context.exception.getCondition(), "DECORATOR_ARGUMENT_NOT_CALLABLE")
             message_parameters = context.exception.getMessageParameters()
             assert message_parameters is not None
-            self.assertEquals(message_parameters["decorator_name"], decorator.__name__)
+            self.assertEqual(message_parameters["decorator_name"], decorator.__name__)
             assert message_parameters["example_usage"].startswith(f"@{decorator.__name__}(")
 
 

--- a/python/pyspark/pipelines/tests/test_graph_element_registry.py
+++ b/python/pyspark/pipelines/tests/test_graph_element_registry.py
@@ -46,41 +46,41 @@ class GraphElementRegistryTest(unittest.TestCase):
             def flow2():
                 raise NotImplementedError()
 
-        self.assertEquals(len(registry.datasets), 3)
-        self.assertEquals(len(registry.flows), 4)
+        self.assertEqual(len(registry.datasets), 3)
+        self.assertEqual(len(registry.flows), 4)
 
         mv_obj = registry.datasets[0]
-        self.assertEquals(mv_obj.name, "mv")
+        self.assertEqual(mv_obj.name, "mv")
         assert mv_obj.source_code_location.filename.endswith("test_graph_element_registry.py")
 
         mv_flow_obj = registry.flows[0]
-        self.assertEquals(mv_flow_obj.name, "mv")
-        self.assertEquals(mv_flow_obj.target, "mv")
+        self.assertEqual(mv_flow_obj.name, "mv")
+        self.assertEqual(mv_flow_obj.target, "mv")
         assert mv_flow_obj.source_code_location.filename.endswith("test_graph_element_registry.py")
 
         st_obj = registry.datasets[1]
-        self.assertEquals(st_obj.name, "st")
+        self.assertEqual(st_obj.name, "st")
         assert st_obj.source_code_location.filename.endswith("test_graph_element_registry.py")
 
         st_flow_obj = registry.flows[1]
-        self.assertEquals(st_flow_obj.name, "st")
-        self.assertEquals(st_flow_obj.target, "st")
+        self.assertEqual(st_flow_obj.name, "st")
+        self.assertEqual(st_flow_obj.target, "st")
         assert mv_flow_obj.source_code_location.filename.endswith("test_graph_element_registry.py")
 
         st2_obj = registry.datasets[2]
-        self.assertEquals(st2_obj.name, "st2")
+        self.assertEqual(st2_obj.name, "st2")
         assert st2_obj.source_code_location.filename.endswith("test_graph_element_registry.py")
 
         st2_flow1_obj = registry.flows[2]
-        self.assertEquals(st2_flow1_obj.name, "flow1")
-        self.assertEquals(st2_flow1_obj.target, "st2")
-        self.assertEquals(st2_flow1_obj.once, True)
+        self.assertEqual(st2_flow1_obj.name, "flow1")
+        self.assertEqual(st2_flow1_obj.target, "st2")
+        self.assertEqual(st2_flow1_obj.once, True)
         assert mv_flow_obj.source_code_location.filename.endswith("test_graph_element_registry.py")
 
         st2_flow1_obj = registry.flows[3]
-        self.assertEquals(st2_flow1_obj.name, "flow2")
-        self.assertEquals(st2_flow1_obj.target, "st2")
-        self.assertEquals(st2_flow1_obj.once, False)
+        self.assertEqual(st2_flow1_obj.name, "flow2")
+        self.assertEqual(st2_flow1_obj.target, "st2")
+        self.assertEqual(st2_flow1_obj.once, False)
         assert mv_flow_obj.source_code_location.filename.endswith("test_graph_element_registry.py")
 
     def test_definition_without_graph_element_registry(self):
@@ -91,7 +91,7 @@ class GraphElementRegistryTest(unittest.TestCase):
                 def a():
                     raise NotImplementedError()
 
-            self.assertEquals(
+            self.assertEqual(
                 context.exception.getCondition(),
                 "GRAPH_ELEMENT_DEFINED_OUTSIDE_OF_DECLARATIVE_PIPELINE",
             )
@@ -99,7 +99,7 @@ class GraphElementRegistryTest(unittest.TestCase):
         with self.assertRaises(PySparkException) as context:
             sdp.create_streaming_table("st")
 
-        self.assertEquals(
+        self.assertEqual(
             context.exception.getCondition(),
             "GRAPH_ELEMENT_DEFINED_OUTSIDE_OF_DECLARATIVE_PIPELINE",
         )
@@ -110,7 +110,7 @@ class GraphElementRegistryTest(unittest.TestCase):
             def b():
                 raise NotImplementedError()
 
-        self.assertEquals(
+        self.assertEqual(
             context.exception.getCondition(),
             "GRAPH_ELEMENT_DEFINED_OUTSIDE_OF_DECLARATIVE_PIPELINE",
         )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
python 3.12/3.13 were broken:

```
======================================================================
ERROR [0.019s]: test_collect_blocked (__main__.BlockSparkConnectAccessTests.test_collect_blocked)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/spark/spark/python/pyspark/pipelines/tests/test_block_connect_access.py", line 51, in test_collect_blocked
    self.assertEquals(
    ^^^^^^^^^^^^^^^^^
AttributeError: 'BlockSparkConnectAccessTests' object has no attribute 'assertEquals'. Did you mean: 'assertEqual'?

======================================================================
ERROR [0.016s]: test_schema_access_blocked (__main__.BlockSparkConnectAccessTests.test_schema_access_blocked)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/spark/spark/python/pyspark/pipelines/tests/test_block_connect_access.py", line 41, in test_schema_access_blocked
    self.assertEquals(
    ^^^^^^^^^^^^^^^^^
AttributeError: 'BlockSparkConnectAccessTests' object has no attribute 'assertEquals'. Did you mean: 'assertEqual'?

----------------------------------------------------------------------
Ran 5 tests in 7.175s
```


### Why are the changes needed?
to make CI happy

### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
PR build with 
```
default: '{"PYSPARK_IMAGE_TO_TEST": "python-312", "PYTHON_TO_TEST": "python3.12"}'
```

https://github.com/zhengruifeng/spark/actions/runs/15407621295/job/43353257681

### Was this patch authored or co-authored using generative AI tooling?
no