### PR TITLE
[SPARK-52384][CONNECT] Fix bug Connect should insensitive for JDBC options

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1516,20 +1516,20 @@ class SparkConnectPlanner(
 
       case proto.Read.ReadTypeCase.DATA_SOURCE if !rel.getIsStreaming =>
         val reader = session.read
+        val localMap = CaseInsensitiveMap[String](rel.getDataSource.getOptionsMap.asScala.toMap)
         if (rel.getDataSource.getFormat == "jdbc" && rel.getDataSource.getPredicatesCount > 0) {
-          if (!rel.getDataSource.getOptionsMap.containsKey(JDBCOptions.JDBC_URL) ||
-            !rel.getDataSource.getOptionsMap.containsKey(JDBCOptions.JDBC_TABLE_NAME)) {
+          if (!localMap.contains(JDBCOptions.JDBC_URL) ||
+            !localMap.contains(JDBCOptions.JDBC_TABLE_NAME)) {
             throw InvalidInputErrors.invalidJdbcParams()
           }
 
-          val url = rel.getDataSource.getOptionsMap.get(JDBCOptions.JDBC_URL)
-          val table = rel.getDataSource.getOptionsMap.get(JDBCOptions.JDBC_TABLE_NAME)
+          val url = localMap.get(JDBCOptions.JDBC_URL).get
+          val table = localMap.get(JDBCOptions.JDBC_TABLE_NAME).get
           val predicates = rel.getDataSource.getPredicatesList.asScala.toArray
           val properties = new Properties()
           properties.putAll(rel.getDataSource.getOptionsMap)
           reader.jdbc(url, table, predicates, properties).queryExecution.analyzed
         } else if (rel.getDataSource.getPredicatesCount == 0) {
-          val localMap = CaseInsensitiveMap[String](rel.getDataSource.getOptionsMap.asScala.toMap)
           if (rel.getDataSource.hasFormat) {
             reader.format(rel.getDataSource.getFormat)
           }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix bug Connect should insensitive for JDBC options.
Please refer to the comments. https://github.com/apache/spark/pull/50059#discussion_r2111071577
In fact, the built-in Scala API ensures these parameters are lowercase.
https://github.com/apache/spark/blob/b18b956f967038db4b751a3845154f2b1d4f5f79/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/DataFrameReader.scala#L126


### Why are the changes needed?
Fix bug Connect should insensitive for JDBC options.


### Does this PR introduce _any_ user-facing change?
'Yes'.
Restore the original behavior.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
