### PR TITLE
[SPARK-47404][SQL] Add configurable size limits for ANTLR DFA cache

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -209,6 +209,7 @@ private[spark] object LogKeys {
   case object DIFF_DELTA extends LogKey
   case object DIVISIBLE_CLUSTER_INDICES_SIZE extends LogKey
   case object DRIVER_ID extends LogKey
+  case object DRIVER_JVM_MEMORY extends LogKey
   case object DRIVER_MEMORY_SIZE extends LogKey
   case object DRIVER_STATE extends LogKey
   case object DROPPED_PARTITIONS extends LogKey

--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -71,6 +71,8 @@ private[spark] object LogKeys {
   case object ALIGNED_TO_TIME extends LogKey
   case object ALPHA extends LogKey
   case object ANALYSIS_ERROR extends LogKey
+  case object ANTLR_DFA_CACHE_DELTA extends LogKey
+  case object ANTLR_DFA_CACHE_SIZE extends LogKey
   case object APP_ATTEMPT_ID extends LogKey
   case object APP_ATTEMPT_SHUFFLE_MERGE_ID extends LogKey
   case object APP_DESC extends LogKey
@@ -916,6 +918,4 @@ private[spark] object LogKeys {
   case object YARN_RESOURCE extends LogKey
   case object YOUNG_GENERATION_GC extends LogKey
   case object ZERO_TIME extends LogKey
-  case object ANTLR_DFA_CACHE_DELTA extends LogKey
-  case object ANTLR_DFA_CACHE_SIZE extends LogKey
 }

--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -915,4 +915,6 @@ private[spark] object LogKeys {
   case object YARN_RESOURCE extends LogKey
   case object YOUNG_GENERATION_GC extends LogKey
   case object ZERO_TIME extends LogKey
+  case object ANTLR_DFA_CACHE_DELTA extends LogKey
+  case object ANTLR_DFA_CACHE_SIZE extends LogKey
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/parsers.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/parsers.scala
@@ -106,8 +106,7 @@ abstract class AbstractParser extends DataTypeParserInterface with Logging {
           errorClass = e.getCondition,
           messageParameters = e.getMessageParameters.asScala.toMap,
           queryContext = e.getQueryContext)
-    }
-    finally {
+    } finally {
       // Antlr4 uses caches to make parsing faster but its caches are unbounded and never purged,
       // which can cause OOMs when parsing a huge number of SQL queries. Clearing these caches too
       // often will slow down parsing and cause performance regressions, but will prevent OOMs
@@ -465,7 +464,8 @@ object AbstractParser extends Logging {
   private val DRIVER_MEMORY = Runtime.getRuntime.maxMemory()
 
   private case class AntlrCaches(atn: ATN) {
-    private[parser] val predictionContextCache: PredictionContextCache = new PredictionContextCache
+    private[parser] val predictionContextCache: PredictionContextCache =
+      new PredictionContextCache
     private[parser] val decisionToDFACache: Array[DFA] = AntlrCaches.makeDecisionToDFACache(atn)
 
     def installManagedParserCaches(parser: SqlBaseParser): Unit = {
@@ -475,9 +475,6 @@ object AbstractParser extends Logging {
   }
 
   private object AntlrCaches {
-    /**
-     * Based off of `ParserATNSimulator.clearDFA` in ANTLR4.
-     */
     private def makeDecisionToDFACache(atn: ATN): Array[DFA] = {
       val decisionToDFA = new Array[DFA](atn.getNumberOfDecisions)
       for (i <- 0 until atn.getNumberOfDecisions) {
@@ -503,8 +500,8 @@ object AbstractParser extends Logging {
 
   /**
    * Install the managed parser caches into the given parser. Configuring the parser to use the
-   * managed `AntlrCaches` enables us to manage the size of the cache and clear it when required as
-   * the parser caches are unbounded by default.
+   * managed `AntlrCaches` enables us to manage the size of the cache and clear it when required
+   * as the parser caches are unbounded by default.
    *
    * This method should be called before parsing any input.
    */
@@ -515,12 +512,12 @@ object AbstractParser extends Logging {
   /**
    * Drop the existing parser caches and create a new one.
    *
-   * ANTLR retains caches in its parser that are never released.  This speeds up parsing of future
+   * ANTLR retains caches in its parser that are never released. This speeds up parsing of future
    * input, but it can consume a lot of memory depending on the input seen so far.
    *
-   * This method provides a mechanism to free the retained caches, which can be useful after parsing
-   * very large SQL inputs, especially if those large inputs are unlikely to be similar to future
-   * inputs seen by the driver.
+   * This method provides a mechanism to free the retained caches, which can be useful after
+   * parsing very large SQL inputs, especially if those large inputs are unlikely to be similar to
+   * future inputs seen by the driver.
    */
   private[parser] def clearParserCaches(parser: SqlBaseParser): Unit = {
     parserCaches.set(AntlrCaches(SqlBaseParser._ATN))
@@ -530,9 +527,9 @@ object AbstractParser extends Logging {
   }
 
   /**
-   * Check cache size and config values to determine if we should clear the parser caches.
-   * Also logs the current cache size and the delta since the last check.
-   * This method should be called after parsing each input.
+   * Check cache size and config values to determine if we should clear the parser caches. Also
+   * logs the current cache size and the delta since the last check. This method should be called
+   * after parsing each input.
    */
   private[parser] def maybeClearParserCaches(parser: SqlBaseParser, conf: SqlApiConf): Unit = {
     if (!conf.manageParserCaches) {

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/parsers.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/parsers.scala
@@ -16,15 +16,18 @@
  */
 package org.apache.spark.sql.catalyst.parser
 
+import java.util.concurrent.atomic.AtomicReference
+
 import scala.jdk.CollectionConverters._
 
 import org.antlr.v4.runtime._
-import org.antlr.v4.runtime.atn.PredictionMode
+import org.antlr.v4.runtime.atn.{ATN, ParserATNSimulator, PredictionContextCache, PredictionMode}
+import org.antlr.v4.runtime.dfa.DFA
 import org.antlr.v4.runtime.misc.{Interval, ParseCancellationException}
 import org.antlr.v4.runtime.tree.TerminalNodeImpl
 
 import org.apache.spark.{QueryContext, SparkException, SparkThrowable, SparkThrowableHelper}
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.{Logging, LogKeys, MDC}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin, SQLQueryContext, WithOrigin}
 import org.apache.spark.sql.catalyst.util.SparkParserUtils
@@ -62,6 +65,7 @@ abstract class AbstractParser extends DataTypeParserInterface with Logging {
 
     val tokenStream = new CommonTokenStream(lexer)
     val parser = new SqlBaseParser(tokenStream)
+    if (conf.manageParserCaches) AbstractParser.installCaches(parser)
     parser.addParseListener(PostProcessor)
     parser.addParseListener(UnclosedCommentProcessor(command, tokenStream))
     parser.removeErrorListeners()
@@ -102,6 +106,19 @@ abstract class AbstractParser extends DataTypeParserInterface with Logging {
           errorClass = e.getCondition,
           messageParameters = e.getMessageParameters.asScala.toMap,
           queryContext = e.getQueryContext)
+    }
+    finally {
+      // Antlr4 uses caches to make parsing faster but its caches are unbounded and never purged,
+      // which can cause OOMs when parsing a huge number of SQL queries. Clearing these caches too
+      // often will slow down parsing and cause performance regressions, but will prevent OOMs
+      // caused by the parser cache. We use a heuristic and clear the cache if the number of states
+      // in the DFA cache has exceeded the threshold
+      // configured by `spark.sql.parser.parserDfaCacheFlushThreshold`. These states generally
+      // represent the bulk of the memory consumed by the parser, and the size of a single state
+      // is approximately 7KB.
+      //
+      // Negative values mean we should never clear the cache
+      AbstractParser.maybeClearParserCaches(parser, conf)
     }
   }
 
@@ -438,4 +455,96 @@ case class UnclosedCommentProcessor(command: String, tokenStream: CommonTokenStr
 
 object DataTypeParser extends AbstractParser {
   override protected def astBuilder: DataTypeAstBuilder = new DataTypeAstBuilder
+}
+
+object AbstractParser extends Logging {
+  private case class AntlrCaches(atn: ATN) {
+    private[parser] val predictionContextCache: PredictionContextCache = new PredictionContextCache
+    private[parser] val decisionToDFACache: Array[DFA] = AntlrCaches.makeDecisionToDFACache(atn)
+
+    def installManagedParserCaches(parser: SqlBaseParser): Unit = {
+      parser.setInterpreter(
+        new ParserATNSimulator(parser, atn, decisionToDFACache, predictionContextCache))
+    }
+  }
+
+  private object AntlrCaches {
+    /**
+     * Based off of `ParserATNSimulator.clearDFA` in ANTLR4.
+     */
+    private def makeDecisionToDFACache(atn: ATN): Array[DFA] = {
+      val decisionToDFA = new Array[DFA](atn.getNumberOfDecisions)
+      for (i <- 0 until atn.getNumberOfDecisions) {
+        decisionToDFA(i) = new DFA(atn.getDecisionState(i), i)
+      }
+      decisionToDFA
+    }
+  }
+
+  private val parserCaches = new AtomicReference[AntlrCaches](AntlrCaches(SqlBaseParser._ATN))
+
+  private var numDFACacheStates: Int = 0
+  def getDFACacheNumStates: Int = numDFACacheStates
+
+  /**
+   * Returns the number of DFA states in the DFA cache.
+   *
+   * DFA states empirically consume about 7KB of memory each.
+   */
+  private def computeDFACacheNumStates: Int = {
+    parserCaches.get().decisionToDFACache.map(_.states.size).sum
+  }
+
+  /**
+   * Install the managed parser caches into the given parser. Configuring the parser to use the
+   * managed `AntlrCaches` enables us to manage the size of the cache and clear it when required as
+   * the parser caches are unbounded by default.
+   *
+   * This method should be called before parsing any input.
+   */
+  private[parser] def installCaches(parser: SqlBaseParser): Unit = {
+    parserCaches.get().installManagedParserCaches(parser)
+  }
+
+  /**
+   * Drop the existing parser caches and create a new one.
+   *
+   * ANTLR retains caches in its parser that are never released.  This speeds up parsing of future
+   * input, but it can consume a lot of memory depending on the input seen so far.
+   *
+   * This method provides a mechanism to free the retained caches, which can be useful after parsing
+   * very large SQL inputs, especially if those large inputs are unlikely to be similar to future
+   * inputs seen by the driver.
+   */
+  private[parser] def clearParserCaches(parser: SqlBaseParser): Unit = {
+    parserCaches.set(AntlrCaches(SqlBaseParser._ATN))
+    logInfo(log"ANTLR parser caches cleared")
+    numDFACacheStates = 0
+    installCaches(parser)
+  }
+
+  /**
+   * Check cache size and config values to determine if we should clear the parser caches.
+   * Also logs the current cache size and the delta since the last check.
+   * This method should be called after parsing each input.
+   */
+  private[parser] def maybeClearParserCaches(parser: SqlBaseParser, conf: SqlApiConf): Unit = {
+    if (!conf.manageParserCaches) {
+      return
+    }
+
+    val numDFACacheStatesCurrent = computeDFACacheNumStates
+    val numDFACacheStatesDelta = numDFACacheStatesCurrent - numDFACacheStates
+    numDFACacheStates = numDFACacheStatesCurrent
+    logInfo(
+      log"EXPERIMENTAL: Query cached " +
+        log"${MDC(LogKeys.ANTLR_DFA_CACHE_DELTA, numDFACacheStatesDelta)} " +
+        log"DFA states in the parser. Total cached DFA states: " +
+        log"${MDC(LogKeys.ANTLR_DFA_CACHE_SIZE, numDFACacheStatesCurrent)}.")
+
+    if (0 <= conf.parserDfaCacheFlushThreshold &&
+        conf.parserDfaCacheFlushThreshold <= numDFACacheStatesCurrent) {
+      AbstractParser.clearParserCaches(parser)
+    }
+  }
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
@@ -47,6 +47,8 @@ private[sql] trait SqlApiConf {
   def stackTracesInDataFrameContext: Int
   def dataFrameQueryContextEnabled: Boolean
   def legacyAllowUntypedScalaUDFs: Boolean
+  def manageParserCaches: Boolean
+  def parserDfaCacheFlushThreshold: Int
 }
 
 private[sql] object SqlApiConf {
@@ -60,6 +62,9 @@ private[sql] object SqlApiConf {
   val LOCAL_RELATION_CACHE_THRESHOLD_KEY: String = {
     SqlApiConfHelper.LOCAL_RELATION_CACHE_THRESHOLD_KEY
   }
+  val PARSER_DFA_CACHE_FLUSH_THRESHOLD_KEY: String =
+    SqlApiConfHelper.PARSER_DFA_CACHE_FLUSH_THRESHOLD_KEY
+  val MANAGE_PARSER_CACHES_KEY: String = SqlApiConfHelper.MANAGE_PARSER_CACHES_KEY
 
   def get: SqlApiConf = SqlApiConfHelper.getConfGetter.get()()
 
@@ -88,4 +93,6 @@ private[sql] object DefaultSqlApiConf extends SqlApiConf {
   override def stackTracesInDataFrameContext: Int = 1
   override def dataFrameQueryContextEnabled: Boolean = true
   override def legacyAllowUntypedScalaUDFs: Boolean = false
+  override def manageParserCaches: Boolean = false
+  override def parserDfaCacheFlushThreshold: Int = -1
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
@@ -49,6 +49,7 @@ private[sql] trait SqlApiConf {
   def legacyAllowUntypedScalaUDFs: Boolean
   def manageParserCaches: Boolean
   def parserDfaCacheFlushThreshold: Int
+  def parserDfaCacheFlushRatio: Double
 }
 
 private[sql] object SqlApiConf {
@@ -64,6 +65,8 @@ private[sql] object SqlApiConf {
   }
   val PARSER_DFA_CACHE_FLUSH_THRESHOLD_KEY: String =
     SqlApiConfHelper.PARSER_DFA_CACHE_FLUSH_THRESHOLD_KEY
+  val PARSER_DFA_CACHE_FLUSH_RATIO_KEY: String =
+    SqlApiConfHelper.PARSER_DFA_CACHE_FLUSH_RATIO_KEY
   val MANAGE_PARSER_CACHES_KEY: String = SqlApiConfHelper.MANAGE_PARSER_CACHES_KEY
 
   def get: SqlApiConf = SqlApiConfHelper.getConfGetter.get()()
@@ -95,4 +98,5 @@ private[sql] object DefaultSqlApiConf extends SqlApiConf {
   override def legacyAllowUntypedScalaUDFs: Boolean = false
   override def manageParserCaches: Boolean = false
   override def parserDfaCacheFlushThreshold: Int = -1
+  override def parserDfaCacheFlushRatio: Double = -1.0
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConfHelper.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConfHelper.scala
@@ -36,7 +36,7 @@ private[sql] object SqlApiConfHelper {
   val PARSER_DFA_CACHE_FLUSH_THRESHOLD_KEY: String =
     "spark.sql.parser.parserDfaCacheFlushThreshold"
   val PARSER_DFA_CACHE_FLUSH_RATIO_KEY: String = "spark.sql.parser.parserDfaCacheFlushRatio"
-  val MANAGE_PARSER_CACHES_KEY: String = "spark.sql.parser.manageParserCachesKillSwitch"
+  val MANAGE_PARSER_CACHES_KEY: String = "spark.sql.parser.manageParserCaches"
 
   val confGetter: AtomicReference[() => SqlApiConf] = {
     new AtomicReference[() => SqlApiConf](() => DefaultSqlApiConf)

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConfHelper.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConfHelper.scala
@@ -34,7 +34,8 @@ private[sql] object SqlApiConfHelper {
   val LOCAL_RELATION_CACHE_THRESHOLD_KEY: String = "spark.sql.session.localRelationCacheThreshold"
   val ARROW_EXECUTION_USE_LARGE_VAR_TYPES = "spark.sql.execution.arrow.useLargeVarTypes"
   val PARSER_DFA_CACHE_FLUSH_THRESHOLD_KEY: String = "spark.sql.parser.parserDfaCacheFlushThreshold"
-  val MANAGE_PARSER_CACHES_KEY: String = "spark.sql.parser.manageParserCaches"
+  val PARSER_DFA_CACHE_FLUSH_RATIO_KEY: String = "spark.sql.parser.parserDfaCacheFlushRatio"
+  val MANAGE_PARSER_CACHES_KEY: String = "spark.sql.parser.manageParserCachesKillSwitch"
 
   val confGetter: AtomicReference[() => SqlApiConf] = {
     new AtomicReference[() => SqlApiConf](() => DefaultSqlApiConf)

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConfHelper.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConfHelper.scala
@@ -33,6 +33,8 @@ private[sql] object SqlApiConfHelper {
   val SESSION_LOCAL_TIMEZONE_KEY: String = "spark.sql.session.timeZone"
   val LOCAL_RELATION_CACHE_THRESHOLD_KEY: String = "spark.sql.session.localRelationCacheThreshold"
   val ARROW_EXECUTION_USE_LARGE_VAR_TYPES = "spark.sql.execution.arrow.useLargeVarTypes"
+  val PARSER_DFA_CACHE_FLUSH_THRESHOLD_KEY: String = "spark.sql.parser.parserDfaCacheFlushThreshold"
+  val MANAGE_PARSER_CACHES_KEY: String = "spark.sql.parser.manageParserCaches"
 
   val confGetter: AtomicReference[() => SqlApiConf] = {
     new AtomicReference[() => SqlApiConf](() => DefaultSqlApiConf)

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConfHelper.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConfHelper.scala
@@ -33,7 +33,8 @@ private[sql] object SqlApiConfHelper {
   val SESSION_LOCAL_TIMEZONE_KEY: String = "spark.sql.session.timeZone"
   val LOCAL_RELATION_CACHE_THRESHOLD_KEY: String = "spark.sql.session.localRelationCacheThreshold"
   val ARROW_EXECUTION_USE_LARGE_VAR_TYPES = "spark.sql.execution.arrow.useLargeVarTypes"
-  val PARSER_DFA_CACHE_FLUSH_THRESHOLD_KEY: String = "spark.sql.parser.parserDfaCacheFlushThreshold"
+  val PARSER_DFA_CACHE_FLUSH_THRESHOLD_KEY: String =
+    "spark.sql.parser.parserDfaCacheFlushThreshold"
   val PARSER_DFA_CACHE_FLUSH_RATIO_KEY: String = "spark.sql.parser.parserDfaCacheFlushRatio"
   val MANAGE_PARSER_CACHES_KEY: String = "spark.sql.parser.manageParserCachesKillSwitch"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -6544,11 +6544,11 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def escapedStringLiterals: Boolean = getConf(ESCAPED_STRING_LITERALS)
 
-  def manageParserCaches: Boolean = getConf(MANAGE_PARSER_CACHES)
-
   def parserDfaCacheFlushRatio: Double = getConf(PARSER_DFA_CACHE_FLUSH_RATIO)
 
   def parserDfaCacheFlushThreshold: Int = getConf(PARSER_DFA_CACHE_FLUSH_THRESHOLD)
+
+  def manageParserCaches: Boolean = getConf(MANAGE_PARSER_CACHES)
 
   def fileCompressionFactor: Double = getConf(FILE_COMPRESSION_FACTOR)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1212,9 +1212,9 @@ object SQLConf {
           |Active values should be in the range 0-100, and a negative value disables the feature.
           |If both this config and `spark.sql.parser.parserDfaCacheFlushThreshold` are set, the
           |cache is flushed if either condition is met.
-          |Requires `spark.sql.parser.manageParserCachesKillSwitch` to be true to take effect.
+          |Requires `spark.sql.parser.manageParserCaches` to be true to take effect.
           |""".stripMargin)
-      .version("4.0.0")
+      .version("4.1.0")
       .doubleConf
       .checkValue(_ <= 100.0, "The ratio must be less than 100%")
       .createWithDefault(-1.0)
@@ -1235,22 +1235,22 @@ object SQLConf {
           |If this config is set to a negative value, it is ignored.
           |If both this config and `spark.sql.parser.parserDfaCacheFlushRatio` are set, the
           |cache is flushed if either condition is met.
-          |Requires `spark.sql.parser.manageParserCachesKillSwitch` to be true to take effect.
+          |Requires `spark.sql.parser.manageParserCaches` to be true to take effect.
           |
           |Can significantly slow down parsing in exchange for better memory stability.
           |""".stripMargin)
-      .version("4.0.0")
+      .version("4.1.0")
       .intConf
       .createWithDefault(-1)
 
   val MANAGE_PARSER_CACHES =
-    buildConf("spark.sql.parser.manageParserCachesKillSwitch")
+    buildConf("spark.sql.parser.manageParserCaches")
       .internal()
       .doc(
         """When true, we install our own ANTLR caches to manage memory usage. When false, we use the
           |default ANTLR caches. Dependency for
           |`spark.sql.parser.parserDfaCacheFlushThreshold`.""".stripMargin)
-      .version("4.0.0")
+      .version("4.1.0")
       .booleanConf
       .createWithDefault(true)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1225,7 +1225,7 @@ object SQLConf {
       .doc(
         """When positive, release ANTLR caches after parsing a SQL query when the number of states
           |in the DFA cache exceeds the value of the config. DFA states empirically consume about
-          |7KB of memory each.
+          |`AbstractParser.BYTES_PER_DFA_STATE` bytes of memory each.
           |
           |ANTLR parsers retain a DFA cache designed to speed up parsing future input. However,
           |there is no limit to how large this cache can become. Parsing large SQL statements can

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1252,7 +1252,7 @@ object SQLConf {
           |`spark.sql.parser.parserDfaCacheFlushThreshold`.""".stripMargin)
       .version("4.1.0")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val FILE_COMPRESSION_FACTOR = buildConf("spark.sql.sources.fileCompressionFactor")
     .internal()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -1034,51 +1034,53 @@ class AnalysisSuite extends AnalysisTest with Matchers {
 
   test("SPARK-30886 Deprecate two-parameter TRIM/LTRIM/RTRIM") {
     Seq("trim", "ltrim", "rtrim").foreach { f =>
-      val logAppender = new LogAppender("deprecated two-parameter TRIM/LTRIM/RTRIM functions")
-      def check(count: Int): Unit = {
-        val message = "Two-parameter TRIM/LTRIM/RTRIM function signatures are deprecated."
-        assert(logAppender.loggingEvents.size == count)
-        assert(logAppender.loggingEvents.exists(
-          e => e.getLevel == Level.WARN &&
-            e.getMessage.getFormattedMessage.contains(message)))
-      }
+      withSQLConf(SQLConf.MANAGE_PARSER_CACHES.key -> "false") {
+        val logAppender = new LogAppender("deprecated two-parameter TRIM/LTRIM/RTRIM functions")
+        def check(count: Int): Unit = {
+          val message = "Two-parameter TRIM/LTRIM/RTRIM function signatures are deprecated."
+          assert(logAppender.loggingEvents.size == count)
+          assert(logAppender.loggingEvents.exists(
+            e => e.getLevel == Level.WARN &&
+              e.getMessage.getFormattedMessage.contains(message)))
+        }
 
-      withLogAppender(logAppender) {
-        val testAnalyzer1 = new Analyzer(
-          new SessionCatalog(new InMemoryCatalog, FunctionRegistry.builtin))
+        withLogAppender(logAppender) {
+          val testAnalyzer1 = new Analyzer(
+            new SessionCatalog(new InMemoryCatalog, FunctionRegistry.builtin))
 
-        val plan1 = testRelation2.select(
-          UnresolvedFunction(f, $"a" :: Nil, isDistinct = false))
-        testAnalyzer1.execute(plan1)
-        // One-parameter is not deprecated.
-        assert(logAppender.loggingEvents.isEmpty)
+          val plan1 = testRelation2.select(
+            UnresolvedFunction(f, $"a" :: Nil, isDistinct = false))
+          testAnalyzer1.execute(plan1)
+          // One-parameter is not deprecated.
+          assert(logAppender.loggingEvents.isEmpty)
 
-        val plan2 = testRelation2.select(
-          UnresolvedFunction(f, $"a" :: $"b" :: Nil, isDistinct = false))
-        testAnalyzer1.execute(plan2)
-        // Deprecation warning is printed out once.
-        check(1)
+          val plan2 = testRelation2.select(
+            UnresolvedFunction(f, $"a" :: $"b" :: Nil, isDistinct = false))
+          testAnalyzer1.execute(plan2)
+          // Deprecation warning is printed out once.
+          check(1)
 
-        val plan3 = testRelation2.select(
-          UnresolvedFunction(f, $"b" :: $"a" :: Nil, isDistinct = false))
-        testAnalyzer1.execute(plan3)
-        // There is no change in the log.
-        check(1)
+          val plan3 = testRelation2.select(
+            UnresolvedFunction(f, $"b" :: $"a" :: Nil, isDistinct = false))
+          testAnalyzer1.execute(plan3)
+          // There is no change in the log.
+          check(1)
 
-        // New analyzer from new SessionState
-        val testAnalyzer2 = new Analyzer(
-          new SessionCatalog(new InMemoryCatalog, FunctionRegistry.builtin))
-        val plan4 = testRelation2.select(
-          UnresolvedFunction(f, $"c" :: $"d" :: Nil, isDistinct = false))
-        testAnalyzer2.execute(plan4)
-        // Additional deprecation warning from new analyzer
-        check(2)
+          // New analyzer from new SessionState
+          val testAnalyzer2 = new Analyzer(
+            new SessionCatalog(new InMemoryCatalog, FunctionRegistry.builtin))
+          val plan4 = testRelation2.select(
+            UnresolvedFunction(f, $"c" :: $"d" :: Nil, isDistinct = false))
+          testAnalyzer2.execute(plan4)
+          // Additional deprecation warning from new analyzer
+          check(2)
 
-        val plan5 = testRelation2.select(
-          UnresolvedFunction(f, $"c" :: $"d" :: Nil, isDistinct = false))
-        testAnalyzer2.execute(plan5)
-        // There is no change in the log.
-        check(2)
+          val plan5 = testRelation2.select(
+            UnresolvedFunction(f, $"c" :: $"d" :: Nil, isDistinct = false))
+          testAnalyzer2.execute(plan5)
+          // There is no change in the log.
+          check(2)
+        }
       }
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -1034,7 +1034,7 @@ class AnalysisSuite extends AnalysisTest with Matchers {
 
   test("SPARK-30886 Deprecate two-parameter TRIM/LTRIM/RTRIM") {
     Seq("trim", "ltrim", "rtrim").foreach { f =>
-      withSQLConf(SQLConf.MANAGE_PARSER_CACHES.key -> "false") {
+      withSQLConf(SQLConf.MANAGE_PARSER_CACHES.key -> "false") { // Avoid additional logging
         val logAppender = new LogAppender("deprecated two-parameter TRIM/LTRIM/RTRIM functions")
         def check(count: Int): Unit = {
           val message = "Two-parameter TRIM/LTRIM/RTRIM function signatures are deprecated."


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add hooks to release the ANTLR DFA cache after parsing SQL

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

ANTLR builds a DFA cache while parsing to speed up parsing of similar future inputs. However, this cache is never cleared and can only grow. Extremely large SQL inputs can lead to very large DFA caches (>20GiB in one extreme case I've seen).

Spark’s ANTLR SQL parser is derived from the Presto ANTLR SQL Parser (see [SPARK-13713](https://issues.apache.org/jira/browse/SPARK-13713) and https://github.com/apache/spark/pull/11557), and Presto has added hooks to be able to clear this DFA cache (https://github.com/trinodb/trino/pull/3186). I think Spark should have similar hooks.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

New `SQLConf`s to control the behavior:
- `spark.sql.parser.manageParserCachesKillSwitch`: turns feature and logging on/off
- `spark.sql.parser.parserDfaCacheFlushThreshold`: sets a limit on the absolute size of the DFA cache
- `spark.sql.parser.parserDfaCacheFlushRatio`: sets a limit on the ratio of the (estimated) DFA cache size to the total driver memory



### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

New unit tests



### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No