### PR TITLE
[SPARK-52385] [SQL] Remove TempResolvedColumns from InheritAnalysisRules name

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/LiteralFunctionResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/LiteralFunctionResolution.scala
@@ -41,12 +41,12 @@ object LiteralFunctionResolution {
   // support CURRENT_DATE, CURRENT_TIMESTAMP, CURRENT_TIME,
   //  CURRENT_USER, USER, SESSION_USER and grouping__id
   private val literalFunctions: Seq[(String, () => Expression, Expression => String)] = Seq(
-    (CurrentDate().prettyName, () => CurrentDate(), toPrettySQL(_)),
-    (CurrentTimestamp().prettyName, () => CurrentTimestamp(), toPrettySQL(_)),
-    (CurrentTime().prettyName, () => CurrentTime(), toPrettySQL(_)),
-    (CurrentUser().prettyName, () => CurrentUser(), toPrettySQL(_)),
-    ("user", () => CurrentUser(), toPrettySQL(_)),
-    ("session_user", () => CurrentUser(), toPrettySQL(_)),
+    (CurrentDate().prettyName, () => CurrentDate(), e => toPrettySQL(e)),
+    (CurrentTimestamp().prettyName, () => CurrentTimestamp(), e => toPrettySQL(e)),
+    (CurrentTime().prettyName, () => CurrentTime(), e => toPrettySQL(e)),
+    (CurrentUser().prettyName, () => CurrentUser(), e => toPrettySQL(e)),
+    ("user", () => CurrentUser(), e => toPrettySQL(e)),
+    ("session_user", () => CurrentUser(), e => toPrettySQL(e)),
     (VirtualColumn.hiveGroupingIdName, () => GroupingID(Nil), _ => VirtualColumn.hiveGroupingIdName)
   )
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 import com.google.common.io.ByteStreams
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.analysis.TempResolvedColumn
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.connector.catalog.MetadataColumn
 import org.apache.spark.sql.types.{MetadataBuilder, NumericType, StringType, StructType}
@@ -91,22 +92,44 @@ package object util extends Logging {
 
   def stackTraceToString(t: Throwable): String = SparkErrorUtils.stackTraceToString(t)
 
-  // Replaces attributes, string literals, complex type extractors with their pretty form so that
-  // generated column names don't contain back-ticks or double-quotes.
-  def usePrettyExpression(e: Expression): Expression = e transform {
+  /**
+   * Replaces attributes, string literals, complex type extractors with their pretty form so that
+   * generated column names don't contain back-ticks or double-quotes.
+   * In case value of `shouldTrimTempResolvedColumn` is true, trim [[TempResolvedColumn]]s from the
+   * expression tree to avoid having it in an [[Alias]] name.
+   */
+  private def usePrettyExpression(
+      e: Expression,
+      shouldTrimTempResolvedColumn: Boolean = false): Expression = e transform {
     case a: Attribute => new PrettyAttribute(a)
     case Literal(s: UTF8String, StringType) => PrettyAttribute(s.toString, StringType)
     case Literal(v, t: NumericType) if v != null => PrettyAttribute(v.toString, t)
     case Literal(null, dataType) => PrettyAttribute("NULL", dataType)
     case e: GetStructField =>
       val name = e.name.getOrElse(e.childSchema(e.ordinal).name)
-      PrettyAttribute(usePrettyExpression(e.child).sql + "." + name, e.dataType)
+      PrettyAttribute(
+        usePrettyExpression(e.child, shouldTrimTempResolvedColumn).sql + "." + name,
+        e.dataType
+      )
     case e: GetArrayStructFields =>
-      PrettyAttribute(s"${usePrettyExpression(e.child)}.${e.field.name}", e.dataType)
+      PrettyAttribute(
+        s"${usePrettyExpression(e.child, shouldTrimTempResolvedColumn)}.${e.field.name}",
+        e.dataType
+      )
     case r: InheritAnalysisRules =>
-      PrettyAttribute(r.makeSQLString(r.parameters.map(toPrettySQL)), r.dataType)
+      val proposedParameters = if (shouldTrimTempResolvedColumn) {
+        r.parameters.map(trimTempResolvedColumn)
+      } else {
+        r.parameters
+      }
+      PrettyAttribute(
+        name = r.makeSQLString(
+          proposedParameters.map(parameter => toPrettySQL(parameter, shouldTrimTempResolvedColumn))
+        ),
+        dataType = r.dataType
+      )
     case c: Cast if c.getTagValue(Cast.USER_SPECIFIED_CAST).isEmpty =>
-      PrettyAttribute(usePrettyExpression(c.child).sql, c.dataType)
+      PrettyAttribute(usePrettyExpression(c.child, shouldTrimTempResolvedColumn).sql, c.dataType)
     case p: PythonFuncExpression => PrettyPythonUDF(p.name, p.dataType, p.children)
   }
 
@@ -122,7 +145,8 @@ package object util extends Logging {
     QuotingUtils.quoteIfNeeded(part)
   }
 
-  def toPrettySQL(e: Expression): String = usePrettyExpression(e).sql
+  def toPrettySQL(e: Expression, shouldTrimTempResolvedColumn: Boolean = false): String =
+    usePrettyExpression(e, shouldTrimTempResolvedColumn).sql
 
   def escapeSingleQuotedString(str: String): String = {
     QuotingUtils.escapeSingleQuotedString(str)
@@ -146,6 +170,14 @@ package object util extends Logging {
   /** Shorthand for calling truncatedString() without start or end strings. */
   def truncatedString[T](seq: Seq[T], sep: String, maxFields: Int): String = {
     SparkStringUtils.truncatedString(seq, "", sep, "", maxFields)
+  }
+
+  /**
+   * Helper method used to remove all the [[TempResolvedColumn]]s from the provided expression
+   * tree.
+   */
+  def trimTempResolvedColumn(input: Expression): Expression = input.transform {
+    case t: TempResolvedColumn => t.child
   }
 
   val METADATA_COL_ATTR_KEY = "__metadata_col"

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/having.sql.out
@@ -208,3 +208,115 @@ Project [k#x, sum(v)#xL]
                   +- Project [k#x, v#x]
                      +- SubqueryAlias hav
                         +- LocalRelation [k#x, v#x]
+
+
+-- !query
+SELECT sum(v) FROM hav HAVING avg(try_add(v, 1)) = 1
+-- !query analysis
+Project [sum(v)#xL]
++- Filter (avg(try_add(v, 1))#x = cast(1 as double))
+   +- Aggregate [sum(v#x) AS sum(v)#xL, avg(try_add(tempresolvedcolumn(v#x, v, false), 1)) AS avg(try_add(v, 1))#x]
+      +- SubqueryAlias hav
+         +- View (`hav`, [k#x, v#x])
+            +- Project [cast(k#x as string) AS k#x, cast(v#x as int) AS v#x]
+               +- Project [k#x, v#x]
+                  +- SubqueryAlias hav
+                     +- LocalRelation [k#x, v#x]
+
+
+-- !query
+SELECT sum(v) FROM hav HAVING sum(try_add(v, 1)) = 1
+-- !query analysis
+Project [sum(v)#xL]
++- Filter (sum(try_add(v, 1))#xL = cast(1 as bigint))
+   +- Aggregate [sum(v#x) AS sum(v)#xL, sum(try_add(tempresolvedcolumn(v#x, v, false), 1)) AS sum(try_add(v, 1))#xL]
+      +- SubqueryAlias hav
+         +- View (`hav`, [k#x, v#x])
+            +- Project [cast(k#x as string) AS k#x, cast(v#x as int) AS v#x]
+               +- Project [k#x, v#x]
+                  +- SubqueryAlias hav
+                     +- LocalRelation [k#x, v#x]
+
+
+-- !query
+SELECT sum(v) FROM hav HAVING sum(ifnull(v, 1)) = 1
+-- !query analysis
+Project [sum(v)#xL]
++- Filter (sum(ifnull(v, 1))#xL = cast(1 as bigint))
+   +- Aggregate [sum(v#x) AS sum(v)#xL, sum(ifnull(tempresolvedcolumn(v#x, v, false), 1)) AS sum(ifnull(v, 1))#xL]
+      +- SubqueryAlias hav
+         +- View (`hav`, [k#x, v#x])
+            +- Project [cast(k#x as string) AS k#x, cast(v#x as int) AS v#x]
+               +- Project [k#x, v#x]
+                  +- SubqueryAlias hav
+                     +- LocalRelation [k#x, v#x]
+
+
+-- !query
+SELECT sum(v) FROM hav GROUP BY ALL HAVING sum(ifnull(v, 1)) = 1
+-- !query analysis
+Project [sum(v)#xL]
++- Filter (sum(ifnull(v, 1))#xL = cast(1 as bigint))
+   +- Aggregate [sum(v#x) AS sum(v)#xL, sum(ifnull(tempresolvedcolumn(v#x, v, false), 1)) AS sum(ifnull(v, 1))#xL]
+      +- SubqueryAlias hav
+         +- View (`hav`, [k#x, v#x])
+            +- Project [cast(k#x as string) AS k#x, cast(v#x as int) AS v#x]
+               +- Project [k#x, v#x]
+                  +- SubqueryAlias hav
+                     +- LocalRelation [k#x, v#x]
+
+
+-- !query
+SELECT sum(v) FROM hav GROUP BY v HAVING sum(ifnull(v, 1)) = 1
+-- !query analysis
+Project [sum(v)#xL]
++- Filter (sum(ifnull(v, 1))#xL = cast(1 as bigint))
+   +- Aggregate [v#x], [sum(v#x) AS sum(v)#xL, sum(ifnull(tempresolvedcolumn(v#x, v, false), 1)) AS sum(ifnull(v, 1))#xL]
+      +- SubqueryAlias hav
+         +- View (`hav`, [k#x, v#x])
+            +- Project [cast(k#x as string) AS k#x, cast(v#x as int) AS v#x]
+               +- Project [k#x, v#x]
+                  +- SubqueryAlias hav
+                     +- LocalRelation [k#x, v#x]
+
+
+-- !query
+SELECT v + 1 FROM hav GROUP BY ALL HAVING avg(try_add(v, 1)) = 1
+-- !query analysis
+Project [(v + 1)#x]
++- Filter (avg(try_add(v, 1))#x = cast(1 as double))
+   +- Aggregate [(v#x + 1)], [(v#x + 1) AS (v + 1)#x, avg(try_add(tempresolvedcolumn(v#x, v, false), 1)) AS avg(try_add(v, 1))#x]
+      +- SubqueryAlias hav
+         +- View (`hav`, [k#x, v#x])
+            +- Project [cast(k#x as string) AS k#x, cast(v#x as int) AS v#x]
+               +- Project [k#x, v#x]
+                  +- SubqueryAlias hav
+                     +- LocalRelation [k#x, v#x]
+
+
+-- !query
+SELECT v + 1 FROM hav GROUP BY ALL HAVING avg(try_add(v, 1) + 1) = 1
+-- !query analysis
+Project [(v + 1)#x]
++- Filter (avg((try_add(v, 1) + 1))#x = cast(1 as double))
+   +- Aggregate [(v#x + 1)], [(v#x + 1) AS (v + 1)#x, avg((try_add(tempresolvedcolumn(v#x, v, false), 1) + 1)) AS avg((try_add(v, 1) + 1))#x]
+      +- SubqueryAlias hav
+         +- View (`hav`, [k#x, v#x])
+            +- Project [cast(k#x as string) AS k#x, cast(v#x as int) AS v#x]
+               +- Project [k#x, v#x]
+                  +- SubqueryAlias hav
+                     +- LocalRelation [k#x, v#x]
+
+
+-- !query
+SELECT sum(v) FROM hav GROUP BY ifnull(v, 1) + 1 order by ifnull(v, 1) + 1
+-- !query analysis
+Project [sum(v)#xL]
++- Sort [(ifnull(v, 1) + 1)#x ASC NULLS FIRST], true
+   +- Aggregate [(ifnull(v#x, 1) + 1)], [sum(v#x) AS sum(v)#xL, (ifnull(tempresolvedcolumn(v#x, v, false), 1) + 1) AS (ifnull(v, 1) + 1)#x]
+      +- SubqueryAlias hav
+         +- View (`hav`, [k#x, v#x])
+            +- Project [cast(k#x as string) AS k#x, cast(v#x as int) AS v#x]
+               +- Project [k#x, v#x]
+                  +- SubqueryAlias hav
+                     +- LocalRelation [k#x, v#x]

--- a/sql/core/src/test/resources/sql-tests/inputs/having.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/having.sql
@@ -39,3 +39,13 @@ SELECT k, sum(v) FROM hav GROUP BY k HAVING sum(v) > 2 ORDER BY sum(v);
 
 -- SPARK-28386: Resolve ORDER BY agg function with HAVING clause, while the agg function does not present on SELECT list
 SELECT k, sum(v) FROM hav GROUP BY k HAVING sum(v) > 2 ORDER BY avg(v);
+
+-- SPARK-52385: Remove TempResolvedColumns from InheritAnalysisRules name
+SELECT sum(v) FROM hav HAVING avg(try_add(v, 1)) = 1;
+SELECT sum(v) FROM hav HAVING sum(try_add(v, 1)) = 1;
+SELECT sum(v) FROM hav HAVING sum(ifnull(v, 1)) = 1;
+SELECT sum(v) FROM hav GROUP BY ALL HAVING sum(ifnull(v, 1)) = 1;
+SELECT sum(v) FROM hav GROUP BY v HAVING sum(ifnull(v, 1)) = 1;
+SELECT v + 1 FROM hav GROUP BY ALL HAVING avg(try_add(v, 1)) = 1;
+SELECT v + 1 FROM hav GROUP BY ALL HAVING avg(try_add(v, 1) + 1) = 1;
+SELECT sum(v) FROM hav GROUP BY ifnull(v, 1) + 1 order by ifnull(v, 1) + 1;

--- a/sql/core/src/test/resources/sql-tests/results/having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/having.sql.out
@@ -152,3 +152,70 @@ struct<k:string,sum(v):bigint>
 -- !query output
 one	6
 three	3
+
+
+-- !query
+SELECT sum(v) FROM hav HAVING avg(try_add(v, 1)) = 1
+-- !query schema
+struct<sum(v):bigint>
+-- !query output
+
+
+
+-- !query
+SELECT sum(v) FROM hav HAVING sum(try_add(v, 1)) = 1
+-- !query schema
+struct<sum(v):bigint>
+-- !query output
+
+
+
+-- !query
+SELECT sum(v) FROM hav HAVING sum(ifnull(v, 1)) = 1
+-- !query schema
+struct<sum(v):bigint>
+-- !query output
+
+
+
+-- !query
+SELECT sum(v) FROM hav GROUP BY ALL HAVING sum(ifnull(v, 1)) = 1
+-- !query schema
+struct<sum(v):bigint>
+-- !query output
+
+
+
+-- !query
+SELECT sum(v) FROM hav GROUP BY v HAVING sum(ifnull(v, 1)) = 1
+-- !query schema
+struct<sum(v):bigint>
+-- !query output
+1
+
+
+-- !query
+SELECT v + 1 FROM hav GROUP BY ALL HAVING avg(try_add(v, 1)) = 1
+-- !query schema
+struct<(v + 1):int>
+-- !query output
+
+
+
+-- !query
+SELECT v + 1 FROM hav GROUP BY ALL HAVING avg(try_add(v, 1) + 1) = 1
+-- !query schema
+struct<(v + 1):int>
+-- !query output
+
+
+
+-- !query
+SELECT sum(v) FROM hav GROUP BY ifnull(v, 1) + 1 order by ifnull(v, 1) + 1
+-- !query schema
+struct<sum(v):bigint>
+-- !query output
+1
+2
+3
+5


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this issue I propose to remove the `TempResolvedColumn` nodes when computing the name for `InheritAnalysisRules` nodes (they are not removed during the `ResolveAggregateFunctions` rule). This is the right behavior as `TempResolvedColumn` is an internal node and shouldn't be exposed to the users.

The following query:
```
SELECT sum(col1) FROM VALUES(1) GROUP BY ALL HAVING sum(ifnull(col1, 1)) = 1
```

Would have following analyzed plans:
Before the change:
```
Project [sum(col1)#2L]
+- Filter (sum(ifnull(tempresolvedcolumn(col1), 1))#4L = cast(1 as bigint))
   +- Aggregate [sum(col1#0) AS sum(col1)#2L, sum(ifnull(tempresolvedcolumn(col1#0, col1, false), 1)) AS sum(ifnull(tempresolvedcolumn(col1), 1))#4L]
      +- LocalRelation [col1#0]
```

After the change:
```
Project [sum(col1)#2L]
+- Filter (sum(ifnull(col1, 1))#4L = cast(1 as bigint))
   +- Aggregate [sum(col1#0) AS sum(col1)#2L, sum(ifnull(tempresolvedcolumn(col1#0, col1, false), 1)) AS sum(ifnull(col1, 1))#4L]
      +- LocalRelation [col1#0]
```

### Why are the changes needed?
To improve (correct) `Alias` names.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.