### PR TITLE
[SPARK-52389][K8S][DOCS] Drop K8s v1.30 Support

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -44,7 +44,7 @@ Cluster administrators should use [Pod Security Policies](https://kubernetes.io/
 
 # Prerequisites
 
-* A running Kubernetes cluster at version >= 1.30 with access configured to it using
+* A running Kubernetes cluster at version >= 1.31 with access configured to it using
 [kubectl](https://kubernetes.io/docs/reference/kubectl/).  If you do not already have a working Kubernetes cluster,
 you may set up a test cluster on your local machine using
 [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/).


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update K8s docs to recommend K8s v1.31+ for Apache Spark 4.1.0.

### Why are the changes needed?

**1. K8s v1.30 entered the maintenance since 2025-04-28 and will reach the end of support on 2025-06-28**
- https://kubernetes.io/releases/patch-releases/#1-30

**2. Default K8s Versions in Public Cloud environments**

The default K8s versions of public cloud providers are already moving to K8s 1.31 like the following.

- EKS: v1.32 (Default), v1.33 (Available)
- GKE: v1.32 (Stable), v1.32 (Regular), v1.33 (Rapid)
- AKS: v1.32 (Default), v1.33 (GA)

**3. End Of Support**

In addition, K8s 1.30 reached or will reach the end of standard support around Apache Spark 4.1.0 release. 

| K8s  |   EKS   |  AKE  |  GKE  |
| ---- | ------- | ------- | ------- |
| 1.30 | 2025-07 | 2025-07 | 2025-09 |

- [EKS EOL Schedule](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar)
- [AKS EOL Schedule](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)
- [GKE EOL Schedule](https://cloud.google.com/kubernetes-engine/docs/release-schedule)

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only change about K8s versions.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.