### PR TITLE
[WIP][PS] Enable divide-by-zero for boolean floordiv with ANSI enabled

### DIFF
--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -127,9 +127,7 @@ class BooleanOps(DataTypeOps):
 
         def safe_floordiv(left_col: PySparkColumn, right_val: Any) -> PySparkColumn:
             if is_ansi_mode_enabled(spark_session):
-                return F.when(F.lit(right_val == 0), F.lit(None)).otherwise(
-                    F.floor(left_col / right_val)
-                )
+                return F.floor(F.try_divide(left_col, F.lit(right_val)))
             else:
                 return F.floor(left_col / right_val)
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -100,7 +100,6 @@ class BooleanOpsTestsMixin:
             else:
                 self.assertRaises(TypeError, lambda: b_psser * psser)
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_truediv(self):
         pdf, psdf = self.pdf, self.psdf
 
@@ -116,14 +115,11 @@ class BooleanOpsTestsMixin:
         for col in self.non_numeric_df_cols:
             self.assertRaises(TypeError, lambda: b_psser / psdf[col])
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_floordiv(self):
         pdf, psdf = self.pdf, self.psdf
 
         b_pser, b_psser = pdf["bool"], psdf["bool"]
-
-        # float is always returned in pandas-on-Spark
-        self.assert_eq((b_pser // 1).astype("float"), b_psser // 1)
+        self.assert_eq(b_pser // 1, b_psser // 1)
 
         # in pandas, 1 // 0.1 = 9.0; in pandas-on-Spark, 1 // 0.1 = 10.0
         # self.assert_eq(b_pser // 0.1, b_psser // 0.1)
@@ -132,7 +128,7 @@ class BooleanOpsTestsMixin:
         self.assertRaises(TypeError, lambda: b_psser // b_psser)
         self.assertRaises(TypeError, lambda: b_psser // True)
 
-        self.assert_eq(b_pser // pdf["float"], b_psser // psdf["float"])
+        self.assert_eq((b_pser // pdf["float"]).astype("int"), b_psser // psdf["float"])
 
         for col in self.non_numeric_df_cols:
             self.assertRaises(TypeError, lambda: b_psser // psdf[col])


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable divide-by-zero for boolean floordiv with ANSI enabled

### Why are the changes needed?
Ensure pandas on Spark works well with ANSI mode on.
Part of https://issues.apache.org/jira/browse/SPARK-52169.

### Does this PR introduce _any_ user-facing change?
Yes

FROM
```py
>>> ps.Series([True, False]) // 0
org.apache.spark.SparkArithmeticException: [DIVIDE_BY_ZERO] Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set "spark.sql.ansi.enabled" to "false" to bypass this error. SQLSTATE: 22012
...
```

TO
```py
>>> ps.Series([True, False]) // 0
0   NaN
1   NaN
dtype: float64

```


### How was this patch tested?
Unit tests.
```py
(dev3.10) spark (booldiv) % SPARK_ANSI_SQL_MODE=false  ./python/run-tests --python-executables=python3.10 --testnames "pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests.test_floordiv"
...
Finished test(python3.10): pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests.test_floordiv (5s)
Tests passed in 5 seconds

(dev3.10) spark (booldiv) % SPARK_ANSI_SQL_MODE=true  ./python/run-tests --python-executables=python3.10 --testnames "pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests.test_floordiv"
...
Finished test(python3.10): pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests.test_floordiv (5s)
Tests passed in 5 seconds
```

### Was this patch authored or co-authored using generative AI tooling?
No