### PR TITLE
[SPARK-52397][CONNECT] Idempotent ExecutePlan: the second ExecutePlan with same operationId and plan reattaches

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -381,4 +381,16 @@ object Connect {
       .internal()
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("10g")
+
+  val CONNECT_SESSION_IDEMPOTENT_EXECUTE_PLAN_ENABLED =
+    buildConf("spark.connect.session.idempotentExecutePlan.enabled")
+      .doc(
+        "When true, ExecutionPlan RPC is idempotent: when an ExecutePlan request with a " +
+          "previously seen operation_id is received, instead of throwing an " +
+          "INVALID_HANDLE.OPERATION_ALREADY_EXISTS error, the server now reattaches the response " +
+          "stream to the already running execution associated with that operation.")
+      .version("4.1.0")
+      .internal()
+      .booleanConf
+      .createWithDefault(true)
 }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -384,11 +384,10 @@ object Connect {
 
   val CONNECT_SESSION_IDEMPOTENT_EXECUTE_PLAN_ENABLED =
     buildConf("spark.connect.session.idempotentExecutePlan.enabled")
-      .doc(
-        "When true, ExecutionPlan RPC is idempotent: when an ExecutePlan request with a " +
-          "previously seen operation_id is received, instead of throwing an " +
-          "INVALID_HANDLE.OPERATION_ALREADY_EXISTS error, the server now reattaches the response " +
-          "stream to the already running execution associated with that operation.")
+      .doc("When true, ExecutionPlan RPC is idempotent: when an ExecutePlan request with a " +
+        "previously seen operation_id is received, instead of throwing an " +
+        "INVALID_HANDLE.OPERATION_ALREADY_EXISTS error, the server now reattaches the response " +
+        "stream to the already running execution associated with that operation.")
       .version("4.1.0")
       .internal()
       .booleanConf

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -381,15 +381,4 @@ object Connect {
       .internal()
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("10g")
-
-  val CONNECT_SESSION_IDEMPOTENT_EXECUTE_PLAN_ENABLED =
-    buildConf("spark.connect.session.idempotentExecutePlan.enabled")
-      .doc("When true, ExecutionPlan RPC is idempotent: when an ExecutePlan request with a " +
-        "previously seen operation_id is received, instead of throwing an " +
-        "INVALID_HANDLE.OPERATION_ALREADY_EXISTS error, the server now reattaches the response " +
-        "stream to the already running execution associated with that operation.")
-      .version("4.1.0")
-      .internal()
-      .booleanConf
-      .createWithDefault(true)
 }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutePlanHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutePlanHandler.scala
@@ -41,7 +41,7 @@ class SparkConnectExecutePlanHandler(responseObserver: StreamObserver[proto.Exec
         // Create a new execute holder and attach to it.
         SparkConnectService.executionManager
           .createExecuteHolderAndAttach(executeKey, v, sessionHolder, responseObserver)
-      case Some(executeHolder) && executeHolder.request.getPlan.equals(v.getPlan) =>
+      case Some(executeHolder) if executeHolder.request.getPlan.equals(v.getPlan) =>
         // If the execute holder already exists with the same plan, reattach to it.
         SparkConnectService.executionManager
           .reattachExecuteHolder(executeHolder, responseObserver, None)

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutePlanHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutePlanHandler.scala
@@ -22,7 +22,6 @@ import io.grpc.stub.StreamObserver
 import org.apache.spark.SparkSQLException
 import org.apache.spark.connect.proto
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.connect.config.Connect
 
 class SparkConnectExecutePlanHandler(responseObserver: StreamObserver[proto.ExecutePlanResponse])
     extends Logging {

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutePlanHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutePlanHandler.scala
@@ -56,7 +56,7 @@ class SparkConnectExecutePlanHandler(responseObserver: StreamObserver[proto.Exec
         throw new SparkSQLException(
           errorClass = "INVALID_HANDLE.OPERATION_ALREADY_EXISTS",
           messageParameters = Map("handle" -> executeKey.operationId))
-      case None =>
+      case _ =>
         // Create a new execute holder and attach to it.
         SparkConnectService.executionManager
           .createExecuteHolderAndAttach(executeKey, v, sessionHolder, responseObserver)

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutePlanHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutePlanHandler.scala
@@ -33,10 +33,7 @@ class SparkConnectExecutePlanHandler(responseObserver: StreamObserver[proto.Exec
       case false => None
     }
     val sessionHolder = SparkConnectService
-      .getOrCreateIsolatedSession(
-        v.getUserContext.getUserId,
-        v.getSessionId,
-        previousSessionId)
+      .getOrCreateIsolatedSession(v.getUserContext.getUserId, v.getSessionId, previousSessionId)
     val executeKey = ExecuteKey(v, sessionHolder)
     val idempotentExecutePlanEnabled =
       sessionHolder.session.conf.get(Connect.CONNECT_SESSION_IDEMPOTENT_EXECUTE_PLAN_ENABLED)

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
@@ -127,10 +127,7 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
       case false => None
     }
     val sessionHolder = SparkConnectService
-      .getOrCreateIsolatedSession(
-        v.getUserContext.getUserId,
-        v.getSessionId,
-        previousSessionId)
+      .getOrCreateIsolatedSession(v.getUserContext.getUserId, v.getSessionId, previousSessionId)
     val executeKey = ExecuteKey(v, sessionHolder)
     createExecuteHolder(executeKey, v, sessionHolder)
   }
@@ -172,39 +169,36 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
   }
 
   /**
-   * Create a new ExecuteHolder, register it with this global manager and with its session,
-   * and attach the given response observer to it.
+   * Create a new ExecuteHolder, register it with this global manager and with its session, and
+   * attach the given response observer to it.
    */
-   private[connect] def createExecuteHolderAndAttach(
-       executeKey: ExecuteKey,
-       request: proto.ExecutePlanRequest,
-       sessionHolder: SessionHolder,
-       responseObserver: StreamObserver[proto.ExecutePlanResponse]): ExecuteHolder = {
-     val executeHolder = SparkConnectService.executionManager
-       .createExecuteHolder(executeKey, request, sessionHolder)
-     try {
-       executeHolder.eventsManager.postStarted()
-       executeHolder.start()
-     } catch {
-       // Errors raised before the execution holder has finished spawning a thread are considered
-       // plan execution failure, and the client should not try reattaching it afterwards.
-       case t: Throwable =>
-         SparkConnectService.executionManager.removeExecuteHolder(executeHolder.key)
-         throw t
-     }
+  private[connect] def createExecuteHolderAndAttach(
+      executeKey: ExecuteKey,
+      request: proto.ExecutePlanRequest,
+      sessionHolder: SessionHolder,
+      responseObserver: StreamObserver[proto.ExecutePlanResponse]): ExecuteHolder = {
+    val executeHolder = SparkConnectService.executionManager
+      .createExecuteHolder(executeKey, request, sessionHolder)
+    try {
+      executeHolder.eventsManager.postStarted()
+      executeHolder.start()
+    } catch {
+      // Errors raised before the execution holder has finished spawning a thread are considered
+      // plan execution failure, and the client should not try reattaching it afterwards.
+      case t: Throwable =>
+        SparkConnectService.executionManager.removeExecuteHolder(executeHolder.key)
+        throw t
+    }
 
-     try {
-       val responseSender =
-         new ExecuteGrpcResponseSender[proto.ExecutePlanResponse](
-           executeHolder, responseObserver
-         )
-       executeHolder.runGrpcResponseSender(responseSender)
-     } finally {
-       executeHolder.afterInitialRPC()
-     }
-     executeHolder
-   }
-
+    try {
+      val responseSender =
+        new ExecuteGrpcResponseSender[proto.ExecutePlanResponse](executeHolder, responseObserver)
+      executeHolder.runGrpcResponseSender(responseSender)
+    } finally {
+      executeHolder.afterInitialRPC()
+    }
+    executeHolder
+  }
 
   /**
    * Reattach the given response observer to the given ExecuteHolder.

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
@@ -26,12 +26,14 @@ import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
 import com.google.common.cache.CacheBuilder
+import io.grpc.stub.StreamObserver
 
 import org.apache.spark.{SparkEnv, SparkSQLException}
 import org.apache.spark.connect.proto
 import org.apache.spark.internal.{Logging, LogKeys, MDC}
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.NANOS_PER_MILLIS
 import org.apache.spark.sql.connect.config.Connect.{CONNECT_EXECUTE_MANAGER_ABANDONED_TOMBSTONES_SIZE, CONNECT_EXECUTE_MANAGER_DETACHED_TIMEOUT, CONNECT_EXECUTE_MANAGER_MAINTENANCE_INTERVAL}
+import org.apache.spark.sql.connect.execution.ExecuteGrpcResponseSender
 import org.apache.spark.util.ThreadUtils
 
 // Unique key identifying execution by combination of user, session and operation id
@@ -83,17 +85,10 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
   /**
    * Create a new ExecuteHolder and register it with this global manager and with its session.
    */
-  private[connect] def createExecuteHolder(request: proto.ExecutePlanRequest): ExecuteHolder = {
-    val previousSessionId = request.hasClientObservedServerSideSessionId match {
-      case true => Some(request.getClientObservedServerSideSessionId)
-      case false => None
-    }
-    val sessionHolder = SparkConnectService
-      .getOrCreateIsolatedSession(
-        request.getUserContext.getUserId,
-        request.getSessionId,
-        previousSessionId)
-    val executeKey = ExecuteKey(request, sessionHolder)
+  private[connect] def createExecuteHolder(
+      executeKey: ExecuteKey,
+      request: proto.ExecutePlanRequest,
+      sessionHolder: SessionHolder): ExecuteHolder = {
     val executeHolder = executions.compute(
       executeKey,
       (executeKey, oldExecuteHolder) => {
@@ -121,6 +116,23 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
     schedulePeriodicChecks() // Starts the maintenance thread if it hasn't started.
 
     executeHolder
+  }
+
+  /**
+   * Create a new ExecuteHolder and register it with this global manager and with its session.
+   */
+  private[connect] def createExecuteHolder(v: proto.ExecutePlanRequest): ExecuteHolder = {
+    val previousSessionId = v.hasClientObservedServerSideSessionId match {
+      case true => Some(v.getClientObservedServerSideSessionId)
+      case false => None
+    }
+    val sessionHolder = SparkConnectService
+      .getOrCreateIsolatedSession(
+        v.getUserContext.getUserId,
+        v.getSessionId,
+        previousSessionId)
+    val executeKey = ExecuteKey(v, sessionHolder)
+    createExecuteHolder(executeKey, v, sessionHolder)
   }
 
   /**
@@ -157,6 +169,71 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
 
   private[connect] def getExecuteHolder(key: ExecuteKey): Option[ExecuteHolder] = {
     Option(executions.get(key))
+  }
+
+  /**
+   * Create a new ExecuteHolder, register it with this global manager and with its session,
+   * and attach the given response observer to it.
+   */
+   private[connect] def createExecuteHolderAndAttach(
+       executeKey: ExecuteKey,
+       request: proto.ExecutePlanRequest,
+       sessionHolder: SessionHolder,
+       responseObserver: StreamObserver[proto.ExecutePlanResponse]): ExecuteHolder = {
+     val executeHolder = SparkConnectService.executionManager
+       .createExecuteHolder(executeKey, request, sessionHolder)
+     try {
+       executeHolder.eventsManager.postStarted()
+       executeHolder.start()
+     } catch {
+       // Errors raised before the execution holder has finished spawning a thread are considered
+       // plan execution failure, and the client should not try reattaching it afterwards.
+       case t: Throwable =>
+         SparkConnectService.executionManager.removeExecuteHolder(executeHolder.key)
+         throw t
+     }
+
+     try {
+       val responseSender =
+         new ExecuteGrpcResponseSender[proto.ExecutePlanResponse](
+           executeHolder, responseObserver
+         )
+       executeHolder.runGrpcResponseSender(responseSender)
+     } finally {
+       executeHolder.afterInitialRPC()
+     }
+     executeHolder
+   }
+
+
+  /**
+   * Reattach the given response observer to the given ExecuteHolder.
+   */
+  private[connect] def reattachExecuteHolder(
+      executeHolder: ExecuteHolder,
+      responseObserver: StreamObserver[proto.ExecutePlanResponse],
+      lastConsumedResponseId: Option[String]): Unit = {
+    if (!executeHolder.reattachable) {
+      logWarning(log"Reattach to not reattachable operation.")
+      throw new SparkSQLException(
+        errorClass = "INVALID_CURSOR.NOT_REATTACHABLE",
+        messageParameters = Map.empty)
+    } else if (executeHolder.isOrphan()) {
+      logWarning(log"Reattach to an orphan operation.")
+      SparkConnectService.executionManager.removeExecuteHolder(executeHolder.key)
+      throw new IllegalStateException("Operation was orphaned because of an internal error.")
+    }
+
+    val responseSender =
+      new ExecuteGrpcResponseSender[proto.ExecutePlanResponse](executeHolder, responseObserver)
+    lastConsumedResponseId match {
+      case Some(lastResponseId) =>
+        // start from response after lastResponseId
+        executeHolder.runGrpcResponseSender(responseSender, lastResponseId)
+      case None =>
+        // start from the start of the stream.
+        executeHolder.runGrpcResponseSender(responseSender)
+    }
   }
 
   private[connect] def removeAllExecutionsForSession(key: SessionKey): Unit = {

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
@@ -177,8 +177,7 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
       request: proto.ExecutePlanRequest,
       sessionHolder: SessionHolder,
       responseObserver: StreamObserver[proto.ExecutePlanResponse]): ExecuteHolder = {
-    val executeHolder = SparkConnectService.executionManager
-      .createExecuteHolder(executeKey, request, sessionHolder)
+    val executeHolder = createExecuteHolder(executeKey, request, sessionHolder)
     try {
       executeHolder.eventsManager.postStarted()
       executeHolder.start()
@@ -186,7 +185,7 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
       // Errors raised before the execution holder has finished spawning a thread are considered
       // plan execution failure, and the client should not try reattaching it afterwards.
       case t: Throwable =>
-        SparkConnectService.executionManager.removeExecuteHolder(executeHolder.key)
+        removeExecuteHolder(executeHolder.key)
         throw t
     }
 
@@ -214,7 +213,7 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
         messageParameters = Map.empty)
     } else if (executeHolder.isOrphan()) {
       logWarning(log"Reattach to an orphan operation.")
-      SparkConnectService.executionManager.removeExecuteHolder(executeHolder.key)
+      removeExecuteHolder(executeHolder.key)
       throw new IllegalStateException("Operation was orphaned because of an internal error.")
     }
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectReattachExecuteHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectReattachExecuteHandler.scala
@@ -62,7 +62,6 @@ class SparkConnectReattachExecuteHandler(
       v.hasLastResponseId match {
         case true => Some(v.getLastResponseId)
         case false => None
-      }
-    )
+      })
   }
 }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectReattachExecuteHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectReattachExecuteHandler.scala
@@ -22,8 +22,6 @@ import io.grpc.stub.StreamObserver
 import org.apache.spark.SparkSQLException
 import org.apache.spark.connect.proto
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.connect.execution.ExecuteGrpcResponseSender
-import org.apache.spark.sql.connect.service.ExecuteKey
 
 class SparkConnectReattachExecuteHandler(
     responseObserver: StreamObserver[proto.ExecutePlanResponse])
@@ -57,25 +55,14 @@ class SparkConnectReattachExecuteHandler(
             messageParameters = Map("handle" -> v.getOperationId))
         }
       }
-    if (!executeHolder.reattachable) {
-      logWarning(s"Reattach to not reattachable operation.")
-      throw new SparkSQLException(
-        errorClass = "INVALID_CURSOR.NOT_REATTACHABLE",
-        messageParameters = Map.empty)
-    } else if (executeHolder.isOrphan()) {
-      logWarning("Reattach to an orphan operation.")
-      SparkConnectService.executionManager.removeExecuteHolder(executeHolder.key)
-      throw new IllegalStateException("Operation was orphaned because of an internal error.")
-    }
 
-    val responseSender =
-      new ExecuteGrpcResponseSender[proto.ExecutePlanResponse](executeHolder, responseObserver)
-    if (v.hasLastResponseId) {
-      // start from response after lastResponseId
-      executeHolder.runGrpcResponseSender(responseSender, v.getLastResponseId)
-    } else {
-      // start from the start of the stream.
-      executeHolder.runGrpcResponseSender(responseSender)
-    }
+    SparkConnectService.executionManager.reattachExecuteHolder(
+      executeHolder,
+      responseObserver,
+      v.hasLastResponseId match {
+        case true => Some(v.getLastResponseId)
+        case false => None
+      }
+    )
   }
 }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/execution/ReattachableExecuteSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/execution/ReattachableExecuteSuite.scala
@@ -478,12 +478,13 @@ class ReattachableExecuteSuite extends SparkConnectServerTest {
 
       // the second iterator should be able to continue
       while (iter2.hasNext) {
-          iter2.next()
+        iter2.next()
       }
     }
   }
 
-  test("When ExecutePlan idempotency is disabled, second ExecutePlan with same operationId fails") {
+  test(
+    "When ExecutePlan idempotency is disabled, second ExecutePlan with same operationId fails") {
     withRawBlockingStub { stub =>
       // Disable ExecutePlan idempotency
       val configCommand =


### PR DESCRIPTION
### What changes were proposed in this pull request?

In Spark Connect, queries can fail with the error INVALID_HANDLE.OPERATION_ALREADY_EXISTS, when a client retries an ExecutePlan RPC—often due to transient network issues—causing the server to receive the same request multiple times. Since each ExecutePlan request includes an operation_id, the server interprets the duplicate as an attempt to create an already existing operation, which results in the OPERATION_ALREADY_EXISTS exception. This behavior interrupts query execution and breaks the user experience under otherwise recoverable conditions.

To resolve this, the PR introduces idempotent handling of ExecutePlan on the server side. When a request with a previously seen operation_id and the same plan is received, instead of returning an error, the server now reattaches the response stream to the already running execution associated with that operation. This ensures that retries due to network flakiness no longer result in failed queries, thereby improving the resilience and robustness of query executions.

### Why are the changes needed?

It will improve the stability of Spark Connect in case of transient network issues.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Yes, new tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
