### PR TITLE
[MINOR] Ensure structured_logging_style runs out of correct directory

### DIFF
--- a/dev/structured_logging_style.py
+++ b/dev/structured_logging_style.py
@@ -41,7 +41,7 @@ def main():
 
     nonmigrated_files = {}
 
-    scala_files = glob.glob(os.path.join("../", "**", "*.scala"), recursive=True)
+    scala_files = glob.glob(os.path.join(__file__, "../", "**", "*.scala"), recursive=True)
 
     for file in scala_files:
         skip_file = False

--- a/dev/structured_logging_style.py
+++ b/dev/structured_logging_style.py
@@ -41,9 +41,7 @@ def main():
 
     nonmigrated_files = {}
 
-    scala_files = glob.glob(
-        os.path.join(__file__, "../", "**", "*.scala"), recursive=True
-    )
+    scala_files = glob.glob(os.path.join(__file__, "../", "**", "*.scala"), recursive=True)
 
     for file in scala_files:
         skip_file = False

--- a/dev/structured_logging_style.py
+++ b/dev/structured_logging_style.py
@@ -41,7 +41,9 @@ def main():
 
     nonmigrated_files = {}
 
-    scala_files = glob.glob(os.path.join(__file__, "../", "**", "*.scala"), recursive=True)
+    scala_files = glob.glob(
+        os.path.join(__file__, "../", "**", "*.scala"), recursive=True
+    )
 
     for file in scala_files:
         skip_file = False


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, `structured_logging_style.py` assumes that it's being run from the `dev` directory. If it's run from the project root, it will scan all files in the parent directory, i.e. outside the project root. I encountered this and was surprised that it was taking minutes just in the globbing step.

This change avoids that assumption, so `python dev/structured_logging_style.py` will still produce correct results.

### Why are the changes needed?

Make it easier for developers to run the structured logging checks locally.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

```
dev/structured_logging_style.py
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No