### PR TITLE
[SPARK-52403][SQL] Add metric to MergeRowExec for rows that do not match condition

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -199,7 +199,7 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
     // as the last MATCHED and NOT MATCHED BY SOURCE instruction
     // this logic is specific to data sources that replace groups of data
     val carryoverRowsOutput = Literal(WRITE_WITH_METADATA_OPERATION) +: targetTable.output
-    val keepCarryoverRowsInstruction = Keep(TrueLiteral, carryoverRowsOutput)
+    val keepCarryoverRowsInstruction = Keep(TrueLiteral, carryoverRowsOutput, isSystem = true)
 
     val matchedInstructions = matchedActions.map { action =>
       toInstruction(action, metadataAttrs)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -199,7 +199,8 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
     // as the last MATCHED and NOT MATCHED BY SOURCE instruction
     // this logic is specific to data sources that replace groups of data
     val carryoverRowsOutput = Literal(WRITE_WITH_METADATA_OPERATION) +: targetTable.output
-    val keepCarryoverRowsInstruction = Keep(TrueLiteral, carryoverRowsOutput, isSystem = true)
+    val keepCarryoverRowsInstruction = Keep(TrueLiteral, carryoverRowsOutput,
+      systemPredicate = true)
 
     val matchedInstructions = matchedActions.map { action =>
       toInstruction(action, metadataAttrs)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLite
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.{FullOuter, Inner, JoinType, LeftAnti, LeftOuter, RightOuter}
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, DeleteAction, Filter, HintInfo, InsertAction, Join, JoinHint, LogicalPlan, MergeAction, MergeIntoTable, MergeRows, NO_BROADCAST_AND_REPLICATION, Project, ReplaceData, UpdateAction, WriteDelta}
-import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{CarryOver, Discard, Instruction, Keep, ROW_ID, Split}
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Copy, Discard, Instruction, Keep, ROW_ID, Split}
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils.{OPERATION_COLUMN, WRITE_OPERATION, WRITE_WITH_METADATA_OPERATION}
 import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
 import org.apache.spark.sql.connector.write.{RowLevelOperationTable, SupportsDelta}
@@ -199,7 +199,7 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
     // as the last MATCHED and NOT MATCHED BY SOURCE instruction
     // this logic is specific to data sources that replace groups of data
     val carryoverRowsOutput = Literal(WRITE_WITH_METADATA_OPERATION) +: targetTable.output
-    val keepCarryoverRowsInstruction = CarryOver(carryoverRowsOutput)
+    val keepCarryoverRowsInstruction = Copy(carryoverRowsOutput)
 
     val matchedInstructions = matchedActions.map { action =>
       toInstruction(action, metadataAttrs)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLite
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.{FullOuter, Inner, JoinType, LeftAnti, LeftOuter, RightOuter}
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, DeleteAction, Filter, HintInfo, InsertAction, Join, JoinHint, LogicalPlan, MergeAction, MergeIntoTable, MergeRows, NO_BROADCAST_AND_REPLICATION, Project, ReplaceData, UpdateAction, WriteDelta}
-import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Discard, Instruction, Keep, ROW_ID, Split}
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{CarryOver, Discard, Instruction, Keep, ROW_ID, Split}
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils.{OPERATION_COLUMN, WRITE_OPERATION, WRITE_WITH_METADATA_OPERATION}
 import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
 import org.apache.spark.sql.connector.write.{RowLevelOperationTable, SupportsDelta}
@@ -199,8 +199,7 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
     // as the last MATCHED and NOT MATCHED BY SOURCE instruction
     // this logic is specific to data sources that replace groups of data
     val carryoverRowsOutput = Literal(WRITE_WITH_METADATA_OPERATION) +: targetTable.output
-    val keepCarryoverRowsInstruction = Keep(TrueLiteral, carryoverRowsOutput,
-      systemPredicate = true)
+    val keepCarryoverRowsInstruction = CarryOver(carryoverRowsOutput)
 
     val matchedInstructions = matchedActions.map { action =>
       toInstruction(action, metadataAttrs)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeRows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeRows.scala
@@ -87,7 +87,11 @@ object MergeRows {
     override def dataType: DataType = NullType
   }
 
-  case class Keep(condition: Expression, output: Seq[Expression]) extends Instruction {
+  case class Keep(
+      condition: Expression,
+      output: Seq[Expression],
+      isSystem: Boolean = false)
+    extends Instruction {
     def children: Seq[Expression] = condition +: output
     override def outputs: Seq[Seq[Expression]] = Seq(output)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeRows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeRows.scala
@@ -89,7 +89,7 @@ object MergeRows {
   }
 
   // A special case of Keep where the row is kept as is.
-  case class CarryOver(output: Seq[Expression]) extends Instruction  {
+  case class Copy(output: Seq[Expression]) extends Instruction  {
     override def condition: Expression = TrueLiteral
     override def outputs: Seq[Seq[Expression]] = Seq(output)
     override def children: Seq[Expression] = output

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeRows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeRows.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expression, Unevaluable}
+import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Instruction, ROW_ID}
 import org.apache.spark.sql.catalyst.trees.UnaryLike
 import org.apache.spark.sql.catalyst.util.truncatedString
@@ -87,12 +88,21 @@ object MergeRows {
     override def dataType: DataType = NullType
   }
 
+  // A special case of Keep where the row is kept as is.
+  case class CarryOver(output: Seq[Expression]) extends Instruction  {
+    override def condition: Expression = TrueLiteral
+    override def outputs: Seq[Seq[Expression]] = Seq(output)
+    override def children: Seq[Expression] = output
+
+    override protected def withNewChildrenInternal(
+        newChildren: IndexedSeq[Expression]): Expression = {
+      copy(output = newChildren)
+    }
+  }
+
   case class Keep(
       condition: Expression,
-      output: Seq[Expression],
-      // flag marking that row should be considered not matching
-      // any user predicate for metric calculations
-      systemPredicate: Boolean = false)
+      output: Seq[Expression])
     extends Instruction {
     def children: Seq[Expression] = condition +: output
     override def outputs: Seq[Seq[Expression]] = Seq(output)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeRows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeRows.scala
@@ -90,7 +90,9 @@ object MergeRows {
   case class Keep(
       condition: Expression,
       output: Seq[Expression],
-      isSystem: Boolean = false)
+      // flag marking that row should be considered not matching
+      // any user predicate for metric calculations
+      systemPredicate: Boolean = false)
     extends Instruction {
     def children: Seq[Expression] = condition +: output
     override def outputs: Seq[Seq[Expression]] = Seq(output)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
@@ -49,7 +49,7 @@ case class MergeRowsExec(
 
   override lazy val metrics: Map[String, SQLMetric] = Map(
     "numTargetRowsCopied" -> SQLMetrics.createMetric(sparkContext,
-      "Number of target rows rewritten unmodified because they did not meet any condition."))
+      "Number of target rows copied unmodified because they did not match any action."))
 
   @transient override lazy val producedAttributes: AttributeSet = {
     AttributeSet(output.filterNot(attr => inputSet.contains(attr)))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
@@ -244,12 +244,8 @@ case class MergeRowsExec(
           instruction match {
             case copy: CopyExec =>
               // For GroupBased Merge, Spark inserts a Copy predicate
-              // for source + target present rows
-              // to retain the row if no other case matches
+              // to retain the row if it does not match any case
               longMetric("numTargetRowsCopied") += 1
-              if (sourcePresent) {
-                longMetric("numSourceRowsUnused") += 1
-              }
               return copy.apply(row)
 
             case keep: KeepExec =>
@@ -263,15 +259,6 @@ case class MergeRowsExec(
               return split.projectRow(row)
           }
         }
-      }
-
-      // no instructions matched, drop the row
-      if (targetPresent) {
-        longMetric("numTargetRowsUnused") += 1
-      }
-
-      if (sourcePresent) {
-        longMetric("numSourceRowsUnused") += 1
       }
 
       null

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
@@ -269,9 +269,11 @@ case class MergeRowsExec(
       if (targetPresent) {
         longMetric("numTargetRowsUnused") += 1
       }
+
       if (sourcePresent) {
         longMetric("numSourceRowsUnused") += 1
       }
+
       null
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
@@ -75,9 +75,7 @@ case class MergeRowsExec(
     "numTargetRowsCopied" -> SQLMetrics.createMetric(sparkContext,
       "Number of target rows rewritten unmodified because they did not meet any condition."),
     "numTargetRowsUnused" -> SQLMetrics.createMetric(sparkContext,
-      """Number of target rows processed that did not meet any condition.
-         |These will be dropped for delta-based merge and
-         |rewritten unmodified for group-based merge.""".stripMargin),
+      "Number of target rows dropped because they did not meet any condition."),
     "numSourceRowsUnused" -> SQLMetrics.createMetric(sparkContext,
       "Number of source rows processed that did not meet any condition."))
 
@@ -249,7 +247,6 @@ case class MergeRowsExec(
               // for source + target present rows
               // to retain the row if no other case matches
               longMetric("numTargetRowsCopied") += 1
-              longMetric("numTargetRowsUnused") += 1
               if (sourcePresent) {
                 longMetric("numSourceRowsUnused") += 1
               }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
@@ -246,6 +246,7 @@ case class MergeRowsExec(
           instruction match {
             case copy: CopyExec =>
               // For GroupBased Merge, Spark inserts a Copy predicate
+              // for source + target present rows
               // to retain the row if no other case matches
               longMetric("numTargetRowsCopied") += 1
               longMetric("numTargetRowsUnused") += 1
@@ -267,6 +268,7 @@ case class MergeRowsExec(
         }
       }
 
+      // no instructions matched, drop the row
       if (targetPresent) {
         longMetric("numTargetRowsUnused") += 1
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
@@ -237,8 +237,7 @@ case class MergeRowsExec(
         if (instruction.condition.eval(row)) {
           instruction match {
             case copy: CopyExec =>
-              // For GroupBased Merge, Spark inserts a Copy predicate
-              // to retain the row if it does not match any case
+              // group-based operations copy over target rows that didn't match any actions
               longMetric("numTargetRowsCopied") += 1
               return copy.apply(row)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
@@ -49,11 +49,7 @@ case class MergeRowsExec(
 
   override lazy val metrics: Map[String, SQLMetric] = Map(
     "numTargetRowsCopied" -> SQLMetrics.createMetric(sparkContext,
-      "Number of target rows rewritten unmodified because they did not meet any condition."),
-    "numTargetRowsUnused" -> SQLMetrics.createMetric(sparkContext,
-      "Number of target rows dropped because they did not meet any condition."),
-    "numSourceRowsUnused" -> SQLMetrics.createMetric(sparkContext,
-      "Number of source rows processed that did not meet any condition."))
+      "Number of target rows rewritten unmodified because they did not meet any condition."))
 
   @transient override lazy val producedAttributes: AttributeSet = {
     AttributeSet(output.filterNot(attr => inputSet.contains(attr)))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
@@ -219,11 +219,11 @@ case class MergeRowsExec(
 
       if (isTargetRowPresent && isSourceRowPresent) {
         cardinalityValidator.validate(row)
-        applyInstructions(row, matchedInstructions, sourcePresent = true, targetPresent = true)
+        applyInstructions(row, matchedInstructions)
       } else if (isSourceRowPresent) {
-        applyInstructions(row, notMatchedInstructions, sourcePresent = true)
+        applyInstructions(row, notMatchedInstructions)
       } else if (isTargetRowPresent) {
-        applyInstructions(row, notMatchedBySourceInstructions, targetPresent = true)
+        applyInstructions(row, notMatchedBySourceInstructions)
       } else {
         null
       }
@@ -231,9 +231,7 @@ case class MergeRowsExec(
 
     private def applyInstructions(
         row: InternalRow,
-        instructions: Seq[InstructionExec],
-        sourcePresent: Boolean = false,
-        targetPresent: Boolean = false): InternalRow = {
+        instructions: Seq[InstructionExec]): InternalRow = {
 
       for (instruction <- instructions) {
         if (instruction.condition.eval(row)) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableSuite.scala
@@ -24,6 +24,8 @@ class DeltaBasedMergeIntoTableSuite extends DeltaBasedMergeIntoTableSuiteBase {
 
   import testImplicits._
 
+  override protected def deltaMerge = true
+
   override protected lazy val extraTableProps: java.util.Map[String, String] = {
     val props = new java.util.HashMap[String, String]()
     props.put("supports-deltas", "true")

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableSuite.scala
@@ -24,8 +24,6 @@ class DeltaBasedMergeIntoTableSuite extends DeltaBasedMergeIntoTableSuiteBase {
 
   import testImplicits._
 
-  override protected def deltaMerge = true
-
   override protected lazy val extraTableProps: java.util.Map[String, String] = {
     val props = new java.util.HashMap[String, String]()
     props.put("supports-deltas", "true")

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableSuiteBase.scala
@@ -23,6 +23,8 @@ abstract class DeltaBasedMergeIntoTableSuiteBase extends MergeIntoTableSuiteBase
 
   import testImplicits._
 
+  override protected def deltaMerge = true
+
   test("merge into schema pruning with WHEN MATCHED clause (update)") {
     withTempView("source") {
       createAndInitTable("pk INT NOT NULL, salary INT, country STRING, dep STRING",

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
@@ -1810,6 +1810,46 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
     }
   }
 
+  test("Merge metrics with matched and not matched clause") {
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "dep": "software" }
+          |{ "pk": 3, "salary": 300, "dep": "hr" }
+          |""".stripMargin)
+
+      val sourceDF = Seq(
+        (4, 100, "marketing"),
+        (5, 400, "executive"),
+        (6, 100, "hr")
+      ).toDF("pk", "salary", "dep")
+      sourceDF.createOrReplaceTempView("source")
+
+      val mergeExec = findMergeExec {
+        s"""MERGE INTO $tableNameAsString t
+           |USING source s
+           |ON t.pk = s.pk
+           |WHEN MATCHED THEN
+           | UPDATE SET salary = 9999
+           |WHEN NOT MATCHED AND salary > 200 THEN
+           | INSERT *
+           |""".stripMargin
+      }
+
+      assertMetric(mergeExec, "numTargetRowsCopied", 0)
+      assertMetric(mergeExec, "numTargetRowsUnused", 0)
+      assertMetric(mergeExec, "numSourceRowsUnused", 2)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(1, 100, "hr"),
+          Row(2, 200, "software"),
+          Row(3, 300, "hr"),
+          Row(5, 400, "executive"))) // inserted
+    }
+  }
+
   test("Merge metrics with matched and not matched by source clauses") {
     withTempView("source") {
       createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
@@ -1796,11 +1796,7 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
            |""".stripMargin
       }
 
-      // group based merge does a outer join on target to retain the original rows
-      // so pulls in more rows than delta based merge
       assertMetric(mergeExec, "numTargetRowsCopied", if (deltaMerge) 0 else 2)
-      assertMetric(mergeExec, "numTargetRowsUnused", if (deltaMerge) 1 else 0)
-      assertMetric(mergeExec, "numSourceRowsUnused", 1)
 
       checkAnswer(
         sql(s"SELECT * FROM $tableNameAsString"),
@@ -1838,8 +1834,6 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
       }
 
       assertMetric(mergeExec, "numTargetRowsCopied", 0)
-      assertMetric(mergeExec, "numTargetRowsUnused", 0)
-      assertMetric(mergeExec, "numSourceRowsUnused", 2)
 
       checkAnswer(
         sql(s"SELECT * FROM $tableNameAsString"),
@@ -1877,8 +1871,6 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
 
 
       assertMetric(mergeExec, "numTargetRowsCopied", if (deltaMerge) 0 else 3)
-      assertMetric(mergeExec, "numTargetRowsUnused", if (deltaMerge) 3 else 0)
-      assertMetric(mergeExec, "numSourceRowsUnused", 1)
 
       checkAnswer(
         sql(s"SELECT * FROM $tableNameAsString"),
@@ -1918,8 +1910,6 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
       }
 
       assertMetric(mergeExec, "numTargetRowsCopied", if (deltaMerge) 0 else 3)
-      assertMetric(mergeExec, "numTargetRowsUnused", if (deltaMerge) 3 else 0)
-      assertMetric(mergeExec, "numSourceRowsUnused", 2)
 
       checkAnswer(
         sql(s"SELECT * FROM $tableNameAsString"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
@@ -1796,9 +1796,10 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
            |""".stripMargin
       }
 
-      assertMetric(mergeExec, "numTargetRowsCopied", 2, Some(0))
       // group based merge does a outer join on target to retain the original rows
-      assertMetric(mergeExec, "numTargetRowsUnused", 2, Some(1))
+      // so pulls in more rows than delta based merge
+      assertMetric(mergeExec, "numTargetRowsCopied", 2, Some(0))
+      assertMetric(mergeExec, "numTargetRowsUnused", 0, Some(1))
       assertMetric(mergeExec, "numSourceRowsUnused", 1)
 
       checkAnswer(
@@ -1876,7 +1877,7 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
 
 
       assertMetric(mergeExec, "numTargetRowsCopied", 3, Some(0))
-      assertMetric(mergeExec, "numTargetRowsUnused", 3)
+      assertMetric(mergeExec, "numTargetRowsUnused", 0, Some(3))
       assertMetric(mergeExec, "numSourceRowsUnused", 1)
 
       checkAnswer(
@@ -1917,7 +1918,7 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
       }
 
       assertMetric(mergeExec, "numTargetRowsCopied", 3, Some(0))
-      assertMetric(mergeExec, "numTargetRowsUnused", 3)
+      assertMetric(mergeExec, "numTargetRowsUnused", 0, Some(3))
       assertMetric(mergeExec, "numSourceRowsUnused", 2)
 
       checkAnswer(


### PR DESCRIPTION


### What changes were proposed in this pull request?
MergeRowsExec can record some useful information, like how many rows are not target of any action (doesn't match any condition), which can be emitted as metrics.


### Why are the changes needed?
Improve debuggability of MERGE INTO


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add test to MergeIntoTableSuiteBase


### Was this patch authored or co-authored using generative AI tooling?
No
