### PR TITLE
[SPARK-52238][TESTS][FOLLOW-UP] Fix test failure in classic-only envs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,14 +41,14 @@ on:
         description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false
         type: string
-        default: '{"PYSPARK_IMAGE_TO_TEST": "python-311-classic-only", "PYTHON_TO_TEST": "python3.11"}'
+        default: '{"PYSPARK_IMAGE_TO_TEST": "python-311", "PYTHON_TO_TEST": "python3.11"}'
       jobs:
         description: >-
           Jobs to run, and should be in JSON format. The values should be matched with the job's key defined
           in this file, e.g., build. See precondition job below.
         required: false
         type: string
-        default: '{"pyspark": "true", "pyspark-pandas": "true"}'
+        default: ''
     secrets:
       codecov_token:
         description: The upload token of codecov.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,14 +41,14 @@ on:
         description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false
         type: string
-        default: '{"PYSPARK_IMAGE_TO_TEST": "python-311", "PYTHON_TO_TEST": "python3.11"}'
+        default: '{"PYSPARK_IMAGE_TO_TEST": "python-311-classic-only", "PYTHON_TO_TEST": "python3.11"}'
       jobs:
         description: >-
           Jobs to run, and should be in JSON format. The values should be matched with the job's key defined
           in this file, e.g., build. See precondition job below.
         required: false
         type: string
-        default: ''
+        default: '{"pyspark": "true", "pyspark-pandas": "true"}'
     secrets:
       codecov_token:
         description: The upload token of codecov.

--- a/python/pyspark/pipelines/tests/test_block_connect_access.py
+++ b/python/pyspark/pipelines/tests/test_block_connect_access.py
@@ -18,12 +18,14 @@ import unittest
 
 from pyspark.errors import PySparkException
 from pyspark.testing.connectutils import ReusedConnectTestCase
-from pyspark.pipelines.block_connect_access import block_spark_connect_execution_and_analysis
 from pyspark.testing.connectutils import (
     ReusedConnectTestCase,
     should_test_connect,
     connect_requirement_message,
 )
+
+if should_test_connect:
+    from pyspark.pipelines.block_connect_access import block_spark_connect_execution_and_analysis
 
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)

--- a/python/pyspark/pipelines/tests/test_cli.py
+++ b/python/pyspark/pipelines/tests/test_cli.py
@@ -21,18 +21,25 @@ import textwrap
 from pathlib import Path
 
 from pyspark.errors import PySparkException
-from pyspark.pipelines.cli import (
-    change_dir,
-    find_pipeline_spec,
-    load_pipeline_spec,
-    register_definitions,
-    unpack_pipeline_spec,
-    DefinitionsGlob,
-    PipelineSpec,
+from pyspark.testing.connectutils import (
+    should_test_connect,
+    connect_requirement_message,
 )
-from pyspark.pipelines.tests.local_graph_element_registry import LocalGraphElementRegistry
+
+if should_test_connect:
+    from pyspark.pipelines.cli import (
+        change_dir,
+        find_pipeline_spec,
+        load_pipeline_spec,
+        register_definitions,
+        unpack_pipeline_spec,
+        DefinitionsGlob,
+        PipelineSpec,
+    )
+    from pyspark.pipelines.tests.local_graph_element_registry import LocalGraphElementRegistry
 
 
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
 class CLIUtilityTests(unittest.TestCase):
     def test_load_pipeline_spec(self):
         with tempfile.NamedTemporaryFile(mode="w") as tmpfile:

--- a/python/pyspark/pipelines/tests/test_init_cli.py
+++ b/python/pyspark/pipelines/tests/test_init_cli.py
@@ -18,18 +18,24 @@ import unittest
 import tempfile
 from pathlib import Path
 
-from pyspark.pipelines.cli import (
-    change_dir,
-    find_pipeline_spec,
-    load_pipeline_spec,
-    init,
-    register_definitions,
+from pyspark.testing.connectutils import (
+    ReusedConnectTestCase,
+    should_test_connect,
+    connect_requirement_message,
 )
-from pyspark.pipelines.tests.local_graph_element_registry import LocalGraphElementRegistry
-from pyspark.testing.sqlutils import ReusedSQLTestCase
+
+if should_test_connect:
+    from pyspark.pipelines.cli import (
+        change_dir,
+        find_pipeline_spec,
+        load_pipeline_spec,
+        init,
+        register_definitions,
+    )
+    from pyspark.pipelines.tests.local_graph_element_registry import LocalGraphElementRegistry
 
 
-class InitCLITests(ReusedSQLTestCase):
+class InitCLITests(ReusedConnectTestCase):
     def test_init(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             project_name = "test_project"

--- a/python/pyspark/pipelines/tests/test_init_cli.py
+++ b/python/pyspark/pipelines/tests/test_init_cli.py
@@ -35,6 +35,7 @@ if should_test_connect:
     from pyspark.pipelines.tests.local_graph_element_registry import LocalGraphElementRegistry
 
 
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
 class InitCLITests(ReusedConnectTestCase):
     def test_init(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
fix import error in classic-only envs:

- pypy3.10
- python3.11-classic-only
- python3.13-nogil

### Why are the changes needed?

https://github.com/apache/spark/actions/runs/15430761771/job/43428094456

```
Starting test(python3.11): pyspark.pipelines.tests.test_block_connect_access (temp output: /__w/spark/spark/python/target/e57e05b9-80f9-4149-9a9c-898cf497bd80/python3.11__pyspark.pipelines.tests.test_block_connect_access__wv66e6_5.log)
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/__w/spark/spark/python/pyspark/pipelines/tests/test_block_connect_access.py", line 21, in <module>
    from pyspark.pipelines.block_connect_access import block_spark_connect_execution_and_analysis
  File "/__w/spark/spark/python/pyspark/pipelines/block_connect_access.py", line 21, in <module>
    from pyspark.sql.connect.proto.base_pb2_grpc import SparkConnectServiceStub
  File "/__w/spark/spark/python/pyspark/sql/connect/proto/__init__.py", line 18, in <module>
    from pyspark.sql.connect.proto.base_pb2_grpc import *
  File "/__w/spark/spark/python/pyspark/sql/connect/proto/base_pb2_grpc.py", line 19, in <module>
    import grpc
ModuleNotFoundError: No module named 'grpc'
```

### Does this PR introduce _any_ user-facing change?
no, test-only

### How was this patch tested?
PR builder with
```
default: '{"PYSPARK_IMAGE_TO_TEST": "python-311-classic-only", "PYTHON_TO_TEST": "python3.11"}'
```

### Was this patch authored or co-authored using generative AI tooling?
No