### PR TITLE
[SPARK-52399][Kubernetes] Support local ephemeral-storage resource

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1050,6 +1050,14 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>2.3.0</td>
 </tr>
 <tr>
+  <td><code>spark.kubernetes.driver.request.ephemeral.storage</code></td>
+  <td>(none)</td>
+  <td>
+    Specify ephemeral storage <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#local-ephemeral-storage">request and limit</a> for the driver pod.
+  </td>
+  <td>4.1.0</td>
+</tr>
+<tr>
   <td><code>spark.kubernetes.executor.request.cores</code></td>
   <td>(none)</td>
   <td>
@@ -1067,6 +1075,14 @@ See the [configuration page](configuration.html) for information on Spark config
     Specify a hard cpu <a href="https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container">limit</a> for each executor pod launched for the Spark Application.
   </td>
   <td>2.3.0</td>
+</tr>
+<tr>
+  <td><code>spark.kubernetes.executor.request.ephemeral.storage</code></td>
+  <td>(none)</td>
+  <td>
+    Specify ephemeral storage <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#local-ephemeral-storage">request and limit</a> for the executor pod.
+  </td>
+  <td>4.1.0</td>
 </tr>
 <tr>
   <td><code>spark.kubernetes.node.selector.[labelKey]</code></td>
@@ -1848,6 +1864,7 @@ The following affect the driver and executor containers. All other containers in
     The cpu limits are set by <code>spark.kubernetes.{driver,executor}.limit.cores</code>. The cpu is set by
     <code>spark.{driver,executor}.cores</code>. The memory request and limit are set by summing the values of
     <code>spark.{driver,executor}.memory</code> and <code>spark.{driver,executor}.memoryOverhead</code>.
+    The ephemeral-storage is set by <code>spark.kubernetes.{driver,executor}.request.ephemeral.storage</code>.
     Other resource limits are set by <code>spark.{driver,executor}.resources.{resourceName}.*</code> configs.
   </td>
 </tr>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -298,6 +298,13 @@ private[spark] object Config extends Logging {
       .stringConf
       .createOptional
 
+  val KUBERNETES_DRIVER_REQUEST_EPHEMERAL_STORAGE =
+    ConfigBuilder("spark.kubernetes.driver.request.ephemeral.storage")
+      .doc("Specify the ephemeral storage request for the driver pod")
+      .version("4.1.0")
+      .stringConf
+      .createOptional
+
   val KUBERNETES_DRIVER_SUBMIT_CHECK =
     ConfigBuilder("spark.kubernetes.submitInDriver")
     .internal()
@@ -339,6 +346,13 @@ private[spark] object Config extends Logging {
     ConfigBuilder("spark.kubernetes.executor.request.cores")
       .doc("Specify the cpu request for each executor pod")
       .version("2.4.0")
+      .stringConf
+      .createOptional
+
+  val KUBERNETES_EXECUTOR_REQUEST_EPHEMERAL_STORAGE =
+    ConfigBuilder("spark.kubernetes.executor.request.ephemeral.storage")
+      .doc("Specify the ephemeral storage request for the executor pod")
+      .version("4.1.0")
       .stringConf
       .createOptional
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStepSuite.scala
@@ -175,6 +175,20 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
     }
   }
 
+  test("Check driver pod respects kubernetes driver request ephemeral-storage") {
+    val sparkConf = new SparkConf()
+      .set(KUBERNETES_DRIVER_POD_NAME, "spark-driver-pod")
+      .set(CONTAINER_IMAGE, "spark-driver:latest")
+
+    val basePod = SparkPod.initialPod()
+    sparkConf.set(KUBERNETES_DRIVER_REQUEST_EPHEMERAL_STORAGE, "5Gi")
+    val requests1 = new BasicDriverFeatureStep(KubernetesTestConf.createDriverConf(sparkConf))
+      .configurePod(basePod)
+      .container.getResources
+      .getRequests.asScala
+    assert(amountAndFormat(requests1("ephemeral-storage")) === "5Gi")
+  }
+
   test("Check appropriate entrypoint rerouting for various bindings") {
     val javaSparkConf = new SparkConf()
       .set(DRIVER_MEMORY.key, "4g")

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -144,6 +144,21 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     }
   }
 
+  test("basic executor pod with ephemeral-storage") {
+    baseConf.set(KUBERNETES_EXECUTOR_REQUEST_EPHEMERAL_STORAGE, "5Gi")
+    initDefaultProfile(baseConf)
+    val step = new BasicExecutorFeatureStep(newExecutorConf(), new SecurityManager(baseConf),
+      defaultProfile)
+    val executor = step.configurePod(SparkPod.initialPod())
+
+    assert(executor.container.getResources.getRequests.size() === 3)
+    assert(executor.container.getResources.getLimits.size() === 2)
+    assert(amountAndFormat(executor.container.getResources
+      .getRequests.get("ephemeral-storage")) === "5Gi")
+    assert(amountAndFormat(executor.container.getResources
+      .getLimits.get("ephemeral-storage")) === "5Gi")
+  }
+
   test("basic executor pod has reasonable defaults") {
     val conf = newExecutorConf()
     val step = new BasicExecutorFeatureStep(conf, new SecurityManager(baseConf),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add capability to set the [local ephemeral-storage resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#local-ephemeral-storage) on driver and executor pods


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

On kubernetes when a node is low on ephemeral storage the kubelete will killed pods using too much ephemeral storage (more than the requested one). As driver and executor does not set any ephemeral storage they can be evicted even if the big usage comes from other pods
Being able to set the ephemeral storage requests will ensure pods are not evicted

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes added `spark.kubernetes.driver.request.ephemeral.storage` and `spark.kubernetes.executor.request.ephemeral.storage` those 2 new configs.
But if those configs are not set the spark jobs will works as it was before without setting the ephemeral storage


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added some unittest and also deployed a spark job on our kubernetes cluster using those parameters.
The ephemeral storage was well added to the driver and executor:
```
% k get po -o yaml test-nico-driver|grep -A 10 resources 
--
    resources:
      limits:
        cpu: "2"
        ephemeral-storage: 5Gi
        memory: 8692Mi
      requests:
        cpu: "2"
        ephemeral-storage: 5Gi
        memory: 8692Mi
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
% k get po -o yaml test-nico-0aeee3973a4d6156-exec-1|grep -A 10 resources
--
    resources:
      limits:
        cpu: "2"
        ephemeral-storage: 50Gi
        memory: 9716Mi
      requests:
        cpu: "2"
        ephemeral-storage: 50Gi
        memory: 9716Mi
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
```


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No