### PR TITLE
pyspark: Improve SparkConf typing

### DIFF
--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -18,7 +18,8 @@
 __all__ = ["SparkConf"]
 
 import sys
-from typing import Dict, Iterable, List, Optional, Tuple, cast, overload, TYPE_CHECKING
+from collections.abc import Iterable
+from typing import Dict, List, Optional, Tuple, cast, overload, TYPE_CHECKING
 
 from pyspark.util import is_remote_only
 from pyspark.errors import PySparkRuntimeError

--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -18,7 +18,7 @@
 __all__ = ["SparkConf"]
 
 import sys
-from typing import Dict, List, Optional, Tuple, cast, overload, TYPE_CHECKING
+from typing import Dict, Iterable, List, Optional, Tuple, cast, overload, TYPE_CHECKING
 
 from pyspark.util import is_remote_only
 from pyspark.errors import PySparkRuntimeError
@@ -176,14 +176,14 @@ class SparkConf:
         ...
 
     @overload
-    def setExecutorEnv(self, *, pairs: List[Tuple[str, str]]) -> "SparkConf":
+    def setExecutorEnv(self, *, pairs: Iterable[Tuple[str, str]]) -> "SparkConf":
         ...
 
     def setExecutorEnv(
         self,
         key: Optional[str] = None,
         value: Optional[str] = None,
-        pairs: Optional[List[Tuple[str, str]]] = None,
+        pairs: Optional[Iterable[Tuple[str, str]]] = None,
     ) -> "SparkConf":
         """Set an environment variable to be passed to executors."""
         if (key is not None and pairs is not None) or (key is None and pairs is None):
@@ -198,7 +198,7 @@ class SparkConf:
                 self.set("spark.executorEnv.{}".format(k), v)
         return self
 
-    def setAll(self, pairs: List[Tuple[str, str]]) -> "SparkConf":
+    def setAll(self, pairs: Iterable[Tuple[str, str]]) -> "SparkConf":
         """
         Set multiple parameters, passed as a list of key-value pairs.
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Better type hints for `SparkConf` class for mypy and other python type checkers
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Right now SparkConf accepts any iterable, but the type annotation says it only accepts a list, so the following code works at runtime, but fails in mypy:

```python
from pyspark.conf import SparkConf

d = {"a": "b"}
SparkConf().setAll(d.items())
```
mypy output:
```
tmp.py:4: error: Argument 1 to "setAll" of "SparkConf" has incompatible type "dict_items[str, str]"; expected "list[tuple[str, str]]"  [arg-type]
Found 1 error in 1 file (checked 1 source file)
```

### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Manually, by running mypy
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
