### PR TITLE
[SPARK-52424][TESTS] Add unit test to verify in Spark Connect, Column object defined outside of a function can be referenced properly.

### DIFF
--- a/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
@@ -20,7 +20,6 @@ import unittest
 from pyspark.sql.tests.streaming.test_streaming_foreach_batch import StreamingTestsForeachBatchMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase, should_test_connect
 from pyspark.errors import PySparkPicklingError
-from pyspark.sql.dataframe import DataFrame
 
 if should_test_connect:
     from pyspark.errors.exceptions.connect import StreamingPythonRunnerInitializationException

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
@@ -20,7 +20,6 @@ import unittest
 from pyspark.sql.tests.streaming.test_streaming_foreach_batch import StreamingTestsForeachBatchMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase, should_test_connect
 from pyspark.errors import PySparkPicklingError
-from pyspark.sql import functions as sf
 from pyspark.sql.dataframe import DataFrame
 
 if should_test_connect:
@@ -139,28 +138,7 @@ class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedCo
                 q.stop()
 
     def test_streaming_foreach_batch_external_column(self):
-        table_name = "testTable_foreach_batch_external_column"
-
-        def func(df: DataFrame, batch_id: int):
-            # Define 'col' outside the UDF below, so with Spark Connect it'd have to be serialized.
-            col = sf.lit(10)
-
-            @sf.udf("int")
-            def f(x):
-                return col._expr._value
-
-            result_df = df.select(f(sf.col("value")).alias("result"))
-            result_df.write.mode("append").saveAsTable(table_name)
-
-        df = self.spark.readStream.format("text").load("python/test_support/sql/streaming")
-        q = df.writeStream.foreachBatch(func).start()
-        q.processAllAvailable()
-        q.stop()
-
-        collected = self.spark.sql("select * from " + table_name).collect()
-        self.assertTrue(len(collected), 2)
-        for row in collected:
-            self.assertTrue(row["result"] == 10)
+        super().test_streaming_foreach_batch_external_column()
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
@@ -136,8 +136,6 @@ class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedCo
             if q:
                 q.stop()
 
-    def test_streaming_foreach_batch_external_column(self):
-        super().test_streaming_foreach_batch_external_column()
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/sql/tests/streaming/test_streaming_foreach_batch.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_foreach_batch.py
@@ -204,6 +204,27 @@ class StreamingTestsForeachBatchMixin:
             df = self.spark.read.format("text").load("python/test_support/sql/streaming")
             self.assertEqual(sorted(df.collect()), sorted(actual.collect()))
 
+    def test_streaming_foreach_batch_external_column(self):
+        from pyspark.sql import functions as sf
+
+        table_name = "testTable_foreach_batch_external_column"
+
+        # Define 'col' outside the `func` below, so it'd have to be serialized.
+        col = sf.col("value")
+
+        def func(df: DataFrame, batch_id: int):
+            result_df = df.select(col.alias("result"))
+            result_df.write.mode("append").saveAsTable(table_name)
+
+        df = self.spark.readStream.format("text").load("python/test_support/sql/streaming")
+        q = df.writeStream.foreachBatch(func).start()
+        q.processAllAvailable()
+        q.stop()
+
+        collected = self.spark.sql("select * from " + table_name).collect()
+        results = [row["result"] for row in collected]
+        self.assertEqual(sorted(results), ["hello", "this"])
+
 
 class StreamingTestsForeachBatch(StreamingTestsForeachBatchMixin, ReusedSQLTestCase):
     pass


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added a unit test to verify the case of a UDF referencing a Column object defined outside of it can be referenced from the UDF as intended.

### Why are the changes needed?

This isn't really an intended usage pattern, but there are users implicitly relying on this behavior.  So it'd cause issues for those users if this is unintentionally broken.  Here we add a new unit test to ensure this case is covered.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

This is a unit test only change.

### Was this patch authored or co-authored using generative AI tooling?

No