### PR TITLE
[SPARK-52412][INFRA] Redact sensitive information in log files at release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,19 @@ jobs:
           wait $RELEASE_PID
           kill $TAIL_PID1 $TAIL_PID2 || true
 
+          # Redact sensitive information in log files
+          shopt -s globstar nullglob
+          FILES=("$RELEASE_DIR/docker-build.log" "$OUTPUT_DIR/"*.log)
+          PATTERNS=("$ASF_USERNAME" "$ASF_PASSWORD" "$GPG_PRIVATE_KEY" "$GPG_PASSPHRASE" "$PYPI_API_TOKEN")
+          for file in "${FILES[@]}"; do
+            [ -f "$file" ] || continue
+            cp "$file" "$file.bak"
+            for pattern in "${PATTERNS[@]}"; do
+              regex="${pattern//\*/.*}"
+              sed -i "s/$regex/***/g" "$file"
+            done
+          done
+
           # Zip logs/output
           if [ "$DRYRUN_MODE" = "1" ]; then
             zip logs.zip "$RELEASE_DIR/docker-build.log" "$OUTPUT_DIR/"*.log


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to redact sensitive information in log files at release workflow.

### Why are the changes needed?

The output files are already protected by ZipCrypto but this PR makes it even safer by redacting sensitive information in log files.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested in https://github.com/HyukjinKwon/spark/actions/runs/15481551209/job/43588217131

### Was this patch authored or co-authored using generative AI tooling?

No.