### PR TITLE
[SPARK-52400][SQL][TESTS][FOLLOWUP] Regenerate `nonansi/try_arithmetic.sql.out` for Java 21

### DIFF
--- a/sql/core/src/test/resources/sql-tests/results/nonansi/try_arithmetic.sql.out.java21
+++ b/sql/core/src/test/resources/sql-tests/results/nonansi/try_arithmetic.sql.out.java21
@@ -80,6 +80,14 @@ NULL
 
 
 -- !query
+SELECT try_add(sum(1), 1) GROUP BY ALL
+-- !query schema
+struct<try_add(sum(1), 1):bigint>
+-- !query output
+2
+
+
+-- !query
 SELECT try_add(date'2021-01-01', 1)
 -- !query schema
 struct<try_add(DATE '2021-01-01', 1):date>
@@ -282,6 +290,14 @@ NULL
 
 
 -- !query
+SELECT try_divide(sum(1), 1) GROUP BY ALL
+-- !query schema
+struct<try_divide(sum(1), 1):double>
+-- !query output
+1.0
+
+
+-- !query
 SELECT try_divide(interval 2 year, 2)
 -- !query schema
 struct<try_divide(INTERVAL '2' YEAR, 2):interval year to month>
@@ -410,6 +426,14 @@ NULL
 
 
 -- !query
+SELECT try_subtract(sum(1), 1) GROUP BY ALL
+-- !query schema
+struct<try_subtract(sum(1), 1):bigint>
+-- !query output
+0
+
+
+-- !query
 SELECT try_subtract(interval 2 year, interval 3 year)
 -- !query schema
 struct<try_subtract(INTERVAL '2' YEAR, INTERVAL '3' YEAR):interval year>
@@ -519,6 +543,14 @@ SELECT try_multiply(1, 1.0 / 0.0)
 struct<try_multiply(1, (1.0 / 0.0)):decimal(10,6)>
 -- !query output
 NULL
+
+
+-- !query
+SELECT try_multiply(sum(1), 1) GROUP BY ALL
+-- !query schema
+struct<try_multiply(sum(1), 1):bigint>
+-- !query output
+1
 
 
 -- !query


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to regenerate `nonansi/try_arithmetic.sql.out.java21` for Java 21

### Why are the changes needed?
To restore Java 21 daily test:
- https://github.com/apache/spark/actions/runs/15482545651/job/43590926620

![image](https://github.com/user-attachments/assets/967b3c6a-86af-44a5-8a57-54138af9400b)

- https://github.com/apache/spark/actions/runs/15482545651/job/43590924259

![image](https://github.com/user-attachments/assets/3ae51ba3-8efa-4a16-bf4f-b78266c71c9a)



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions
- Manually checked `SQLQueryTestSuite` and `ThriftServerQueryTestSuite` using Java 21 with this pr


### Was this patch authored or co-authored using generative AI tooling?
No
