### PR TITLE
[SPARK-52415][BUILD] Upgrade Maven to 3.9.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>17</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
-    <maven.version>3.9.9</maven.version>
+    <maven.version>3.9.10</maven.version>
     <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.8</asm.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Maven to 3.9.10.

### Why are the changes needed?

To bring the latest bug fixes and to improve `Java 24` support.
- https://maven.apache.org/docs/3.9.10/release-notes.html
  - https://issues.apache.org/jira/browse/MNG-8399 (JDK 24+ issues warning about usage of sun.misc.Unsafe)
> Maven 3.9.10 now has a far better support if you want to run your builds on Java 24.

However, please note that we have still a known remaining issue which is not a regression.
- https://issues.apache.org/jira/browse/MNG-8760 (WARNING: A terminally deprecated method in sun.misc.Unsafe has been called - staticFieldBase in guice)

Here is the complete list of resolved issues.
- https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12316922&version=12355010

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.