### PR TITLE
[SPARK-37940][SQL]upgrade to new error class in QueryCompilationErrors.

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1216,6 +1216,12 @@
     ],
     "sqlState" : "42K01"
   },
+  "DATATYPE_OPERATION_UNSUPPORTED" : {
+    "message" : [
+      "The operation `dataType` is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
   "DATA_SOURCE_ALREADY_EXISTS" : {
     "message" : [
       "Data source '<provider>' already exists. Please choose a different name for the new data source."
@@ -1296,6 +1302,12 @@
       "Failed to execute <statementType> command because DEFAULT values are not supported for target data source with table provider: \"<dataSource>\"."
     ],
     "sqlState" : "42623"
+  },
+  "DEPRECATED_METHOD_CALL" : {
+    "message" : [
+      "The method `<oldMethod>` is deprecated, please use `<newMethod>` instead."
+    ],
+    "sqlState" : "01000"
   },
   "DESCRIBE_JSON_NOT_EXTENDED" : {
     "message" : [
@@ -4072,6 +4084,12 @@
     ],
     "sqlState" : "42803"
   },
+  "MISSING_STATIC_PARTITION_COLUMN" : {
+    "message" : [
+      "Unknown static partition column: <staticName>."
+    ],
+    "sqlState" : "42703"
+  },
   "MISSING_TIMEOUT_CONFIGURATION" : {
     "message" : [
       "The operation has timed out, but no timeout duration is configured. To set a processing time-based timeout, use 'GroupState.setTimeoutDuration()' in your 'mapGroupsWithState' or 'flatMapGroupsWithState' operation. For event-time-based timeout, use 'GroupState.setTimeoutTimestamp()' and define a watermark using 'Dataset.withWatermark()'."
@@ -4125,6 +4143,12 @@
       "Not allowed to implement multiple UDF interfaces, UDF class <className>."
     ],
     "sqlState" : "0A000"
+  },
+  "MUST_OVERRIDE_METHOD" : {
+    "message" : [
+      "You must override one `<methodName>`. It's preferred to not override the deprecated one."
+    ],
+    "sqlState" : "01000"
   },
   "NAMED_PARAMETERS_NOT_SUPPORTED" : {
     "message" : [
@@ -5446,6 +5470,12 @@
   "UNEXPECTED_POSITIONAL_ARGUMENT" : {
     "message" : [
       "Cannot invoke routine <routineName> because it contains positional argument(s) following the named argument assigned to <parameterName>; please rearrange them so the positional arguments come first and then retry the query again."
+    ],
+    "sqlState" : "4274K"
+  },
+  "UNEXPECTED_REQUIRED_PARAMETER" : {
+    "message" : [
+      "Routine <routineName> has an unexpected required argument for the provided routine signature <parameters>. All required arguments should come before optional arguments."
     ],
     "sqlState" : "4274K"
   },


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
As stated in https://issues.apache.org/jira/browse/SPARK-37940, migrate the following errors to new error mechanism:

1. unexpectedRequiredParameter→UNEXPECTED_REQUIRED_PARAMETER
2. missingStaticPartitionColumn→MISSING_STATIC_PARTITION_COLUMN
3. dataTypeOperationUnsupportedError→DATATYPE_OPERATION_UNSUPPORTED
4. callDeprecatedMethodError→DEPRECATED_METHOD_CALL
5. mustOverrideOneMethodError→MUST_OVERRIDE_METHOD


### Why are the changes needed?
see https://issues.apache.org/jira/browse/SPARK-37935 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT


### Was this patch authored or co-authored using generative AI tooling?
No
