### PR TITLE
[SPARK-52418][CORE] Add a `noElements ` state variable to the `PercentileHeap` to avoid repetitive calculations of `isEmpty()`

### DIFF
--- a/core/benchmarks/PercentileHeapBenchmark-jdk21-results.txt
+++ b/core/benchmarks/PercentileHeapBenchmark-jdk21-results.txt
@@ -6,36 +6,36 @@ OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 PercentileHeap Operations - Input Size: 10000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Percentile: 0.5                                           59             59           0          0.2        5916.3       1.0X
-Percentile: 0.9                                           59             59           0          0.2        5871.2       1.0X
-Percentile: 0.95                                          59             59           0          0.2        5866.8       1.0X
-Percentile: 0.99                                          59             59           1          0.2        5861.6       1.0X
+Percentile: 0.5                                            1              1           0         10.2          98.3       1.0X
+Percentile: 0.9                                            1              1           0         17.4          57.3       1.7X
+Percentile: 0.95                                           0              0           0         22.8          43.9       2.2X
+Percentile: 0.99                                           0              0           0         30.4          32.9       3.0X
 
 OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 PercentileHeap Operations - Input Size: 50000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Percentile: 0.5                                         1465           1466           1          0.0       29294.4       1.0X
-Percentile: 0.9                                         1459           1461           3          0.0       29170.8       1.0X
-Percentile: 0.95                                        1456           1458           2          0.0       29127.4       1.0X
-Percentile: 0.99                                        1455           1458           2          0.0       29106.2       1.0X
+Percentile: 0.5                                            5              5           0          9.6         104.6       1.0X
+Percentile: 0.9                                            3              3           0         16.8          59.6       1.8X
+Percentile: 0.95                                           2              2           0         20.8          48.1       2.2X
+Percentile: 0.99                                           2              2           0         29.3          34.2       3.1X
 
 OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 PercentileHeap Operations - Input Size: 100000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Percentile: 0.5                                          5834           5836           2          0.0       58336.8       1.0X
-Percentile: 0.9                                          5830           5838           9          0.0       58295.2       1.0X
-Percentile: 0.95                                         5830           5832           2          0.0       58302.2       1.0X
-Percentile: 0.99                                         5819           5822           3          0.0       58190.4       1.0X
+Percentile: 0.5                                            12             12           0          8.2         121.5       1.0X
+Percentile: 0.9                                             6              7           0         15.6          64.1       1.9X
+Percentile: 0.95                                            5              5           0         19.9          50.1       2.4X
+Percentile: 0.99                                            4              4           0         28.3          35.3       3.4X
 
 OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 PercentileHeap Operations - Input Size: 200000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Percentile: 0.5                                         23300          23326          31          0.0      116497.8       1.0X
-Percentile: 0.9                                         23303          23336          31          0.0      116515.2       1.0X
-Percentile: 0.95                                        23297          23328          35          0.0      116483.0       1.0X
-Percentile: 0.99                                        23276          23292          15          0.0      116381.6       1.0X
+Percentile: 0.5                                            26             26           0          7.8         128.2       1.0X
+Percentile: 0.9                                            14             14           0         14.5          68.8       1.9X
+Percentile: 0.95                                           11             11           0         19.0          52.7       2.4X
+Percentile: 0.99                                            7              7           0         27.1          36.9       3.5X
 
 

--- a/core/benchmarks/PercentileHeapBenchmark-results.txt
+++ b/core/benchmarks/PercentileHeapBenchmark-results.txt
@@ -6,36 +6,36 @@ OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 PercentileHeap Operations - Input Size: 10000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Percentile: 0.5                                            1              1           0         10.0         100.4       1.0X
-Percentile: 0.9                                            1              1           0         18.0          55.6       1.8X
-Percentile: 0.95                                           0              0           0         23.2          43.2       2.3X
-Percentile: 0.99                                           0              0           0         31.1          32.1       3.1X
+Percentile: 0.5                                            1              1           0          9.9         101.1       1.0X
+Percentile: 0.9                                            1              1           0         17.2          58.3       1.7X
+Percentile: 0.95                                           0              0           0         22.9          43.6       2.3X
+Percentile: 0.99                                           0              0           0         30.5          32.8       3.1X
 
 OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 PercentileHeap Operations - Input Size: 50000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Percentile: 0.5                                            5              6           0          9.2         108.2       1.0X
-Percentile: 0.9                                            3              3           0         15.7          63.8       1.7X
-Percentile: 0.95                                           2              2           0         20.4          49.0       2.2X
-Percentile: 0.99                                           2              2           0         29.4          34.0       3.2X
+Percentile: 0.5                                            5              6           0          9.3         107.0       1.0X
+Percentile: 0.9                                            3              3           0         16.8          59.4       1.8X
+Percentile: 0.95                                           2              2           0         21.8          45.9       2.3X
+Percentile: 0.99                                           2              2           0         28.8          34.8       3.1X
 
 OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 PercentileHeap Operations - Input Size: 100000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Percentile: 0.5                                            12             13           0          8.2         122.5       1.0X
-Percentile: 0.9                                             6              7           0         15.6          64.3       1.9X
-Percentile: 0.95                                            5              5           0         20.9          47.7       2.6X
-Percentile: 0.99                                            4              4           0         27.9          35.8       3.4X
+Percentile: 0.5                                            12             12           0          8.2         122.2       1.0X
+Percentile: 0.9                                             6              7           0         15.8          63.5       1.9X
+Percentile: 0.95                                            5              5           0         20.4          49.0       2.5X
+Percentile: 0.99                                            3              3           0         28.7          34.9       3.5X
 
 OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 PercentileHeap Operations - Input Size: 200000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Percentile: 0.5                                            26             26           1          7.7         129.7       1.0X
-Percentile: 0.9                                            13             14           1         14.9          67.3       1.9X
-Percentile: 0.95                                           10             10           0         19.6          51.0       2.5X
-Percentile: 0.99                                            7              7           0         28.4          35.2       3.7X
+Percentile: 0.5                                            26             26           0          7.7         130.1       1.0X
+Percentile: 0.9                                            14             14           0         14.4          69.4       1.9X
+Percentile: 0.95                                           10             11           1         19.3          51.8       2.5X
+Percentile: 0.99                                            7              7           0         27.6          36.2       3.6X
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr adds a `noElements ` state variable to the `PercentileHeap` to avoid repetitive calculations of `isEmpty()`.

### Why are the changes needed?
Ensure that `PercentileHeapBenchmark` exhibits the same performance when using Java 21 as it does when using Java 17. Previously, there was a significant performance gap in `PercentileHeap` when running on Java 21 compared to Java 17.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Pass Github Actions
- Update the benchmark results of `PercentileHeapBenchmark`, and we can see that the test results for Java 21 and Java 17 have now become largely comparable or nearly identical.


### Was this patch authored or co-authored using generative AI tooling?
No