### PR TITLE
[SPARK-52412][INFRA][FOLLOW-UP] Skip empty patterns when redacting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,8 +236,9 @@ jobs:
             [ -f "$file" ] || continue
             cp "$file" "$file.bak"
             for pattern in "${PATTERNS[@]}"; do
+              [ -n "$pattern" ] || continue  # Skip empty patterns
               regex="${pattern//\*/.*}"
-              sed -i "s/$regex/***/g" "$file"
+              sed -i "s|$regex|***|g" "$file"
             done
           done
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/51102 that skips empty strings.

### Why are the changes needed?

To make dry runs passing. It's broken https://github.com/apache/spark/actions/runs/15515989616/job/43682941208

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.