### PR TITLE
[SPARK-52238][PYTHON][TESTS][FOLLOW-UP] Avoid importing grpc before checking to skip

### DIFF
--- a/python/pyspark/pipelines/tests/test_block_connect_access.py
+++ b/python/pyspark/pipelines/tests/test_block_connect_access.py
@@ -18,12 +18,14 @@ import unittest
 
 from pyspark.errors import PySparkException
 from pyspark.testing.connectutils import ReusedConnectTestCase
-from pyspark.pipelines.block_connect_access import block_spark_connect_execution_and_analysis
 from pyspark.testing.connectutils import (
     ReusedConnectTestCase,
     should_test_connect,
     connect_requirement_message,
 )
+
+if should_test_connect:
+    from pyspark.pipelines.block_connect_access import block_spark_connect_execution_and_analysis
 
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/50963 that avoids importing grpc before checking to skip.

### Why are the changes needed?

To make the tests without dependencies. Now it fails: https://github.com/apache/spark/actions/runs/15519775218/job/43691466959

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Will monitor the broken build.

### Was this patch authored or co-authored using generative AI tooling?

No.