### PR TITLE
[SPARK-52419][PYTHON][TESTS] Make Python Connect tests work with NumPy 2.3.0

### DIFF
--- a/python/pyspark/pandas/tests/test_typedef.py
+++ b/python/pyspark/pandas/tests/test_typedef.py
@@ -313,7 +313,6 @@ class TypeHintTestsMixin:
     def test_as_spark_type_pandas_on_spark_dtype(self):
         type_mapper = {
             # binary
-            np.character: (np.character, BinaryType()),
             np.bytes_: (np.bytes_, BinaryType()),
             bytes: (np.bytes_, BinaryType()),
             # integer
@@ -347,6 +346,9 @@ class TypeHintTestsMixin:
                 LongType(),
             ),
         }
+        if LooseVersion(np.__version__) < LooseVersion("2.3"):
+            # binary
+            type_mapper.update({np.character: (np.character, BinaryType())})
 
         for numpy_or_python_type, (dtype, spark_type) in type_mapper.items():
             self.assertEqual(as_spark_type(numpy_or_python_type), spark_type)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip a type definition test with NumPy 2.3 for now.

### Why are the changes needed?

To fix the build for Python Connect client (https://github.com/apache/spark/actions/runs/15521622757/job/43695591595). It fails after NumPy got upgraded to 2.3.0.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.