### PR TITLE
[SPARK-52420][PYTHON][TESTS] Make test_udtf_with_invalid_return_type compatible with Python only client

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_udtf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udtf.py
@@ -61,7 +61,7 @@ class UDTFParityTests(BaseUDTFTestsMixin, ReusedConnectTestCase):
                 yield a + 1,
 
         with self.assertRaisesRegex(
-            InvalidPlanInput, "Invalid schema type. Expect a struct type, but got"
+            InvalidPlanInput, "Invalid.*type"
         ):
             TestUDTF(lit(1)).collect()
 

--- a/python/pyspark/sql/tests/connect/test_parity_udtf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udtf.py
@@ -60,9 +60,7 @@ class UDTFParityTests(BaseUDTFTestsMixin, ReusedConnectTestCase):
             def eval(self, a: int):
                 yield a + 1,
 
-        with self.assertRaisesRegex(
-            InvalidPlanInput, "Invalid.*type"
-        ):
+        with self.assertRaisesRegex(InvalidPlanInput, "Invalid.*type"):
             TestUDTF(lit(1)).collect()
 
     @unittest.skip("Spark Connect does not support broadcast but the test depends on it.")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/50997 that backports the test changes into branch-3.5.

### Why are the changes needed?

To make the build pass (https://github.com/apache/spark/actions/runs/15522509263/job/43697654408).

```
======================================================================
FAIL [0.015s]: test_udtf_with_invalid_return_type (pyspark.sql.tests.connect.test_parity_udtf.UDTFParityTests.test_udtf_with_invalid_return_type)
----------------------------------------------------------------------
pyspark.errors.exceptions.connect.SparkConnectGrpcException: (org.apache.spark.sql.connect.common.InvalidPlanInput) [INVALID_SCHEMA_TYPE_NON_STRUCT] Invalid schema type. Expect a struct type, but got "INT". SQLSTATE: 42K09

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/work/spark/spark-3.5/python/pyspark/sql/tests/connect/test_parity_udtf.py", line 57, in test_udtf_with_invalid_return_type
    with self.assertRaisesRegex(
AssertionError: "Invalid Python user-defined table function return type." does not match "(org.apache.spark.sql.connect.common.InvalidPlanInput) [INVALID_SCHEMA_TYPE_NON_STRUCT] Invalid schema type. Expect a struct type, but got "INT". SQLSTATE: 42K09"

----------------------------------------------------------------------
```

Now that the error message has changed, the tests in branch-3.5 fails.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.