### PR TITLE
[SPARK-52426][CORE] Support redirecting stdout/stderr to logging system

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/ConsoleRedirectPlugin.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ConsoleRedirectPlugin.scala
@@ -35,7 +35,6 @@ import org.apache.spark.internal.config._
 class ConsoleRedirectPlugin extends SparkPlugin {
   override def driverPlugin(): DriverPlugin = new DriverConsoleRedirectPlugin()
 
-  // No-op
   override def executorPlugin(): ExecutorPlugin = new ExecConsoleRedirectPlugin()
 }
 

--- a/core/src/main/scala/org/apache/spark/deploy/ConsoleRedirectPlugin.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ConsoleRedirectPlugin.scala
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy
+
+import java.io.{ByteArrayOutputStream, PrintStream}
+import java.util.{Map => JMap}
+
+import scala.jdk.CollectionConverters._
+
+import org.slf4j.LoggerFactory
+
+import org.apache.spark.SparkContext
+import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config._
+
+/**
+ * A built-in plugin to allow redirecting stdout/stderr to logging system (SLF4J).
+ */
+class ConsoleRedirectPlugin extends SparkPlugin {
+  override def driverPlugin(): DriverPlugin = new DriverConsoleRedirectPlugin()
+
+  // No-op
+  override def executorPlugin(): ExecutorPlugin = new ExecConsoleRedirectPlugin()
+}
+
+class DriverConsoleRedirectPlugin extends DriverPlugin with Logging {
+
+  override def init(sc: SparkContext, ctx: PluginContext): JMap[String, String] = {
+    if (sc.conf.get(DRIVER_REDIRECT_STDOUT_TO_LOG_ENABLED)) {
+      logInfo("Redirect driver's stdout to logging system")
+      val stdoutLogger = LoggerFactory.getLogger("stdout")
+      System.setOut(new LoggingPrintStream(stdoutLogger.info))
+    }
+
+    if (sc.conf.get(DRIVER_REDIRECT_STDERR_TO_LOG_ENABLED)) {
+      logInfo("Redirect driver's stderr to logging system")
+      val stderrLogger = LoggerFactory.getLogger("stderr")
+      System.setErr(new LoggingPrintStream(stderrLogger.error))
+    }
+    Map.empty[String, String].asJava
+  }
+}
+
+class ExecConsoleRedirectPlugin extends ExecutorPlugin with Logging {
+
+  override def init(ctx: PluginContext, extraConf: JMap[String, String]): Unit = {
+    if (ctx.conf.get(EXEC_REDIRECT_STDOUT_TO_LOG_ENABLED)) {
+      logInfo("Redirect executor's stdout to logging system")
+      val stdoutLogger = LoggerFactory.getLogger("stdout")
+      System.setOut(new LoggingPrintStream(stdoutLogger.info))
+    }
+
+    if (ctx.conf.get(EXEC_REDIRECT_STDERR_TO_LOG_ENABLED)) {
+      logInfo("Redirect executor's stderr to logging system")
+      val stderrLogger = LoggerFactory.getLogger("stderr")
+      System.setErr(new LoggingPrintStream(stderrLogger.error))
+    }
+  }
+}
+
+private[spark] class LoggingPrintStream(
+    redirect: String => Unit,
+    lineMaxBytes: Long = 4 * 1024 * 1024)
+  extends PrintStream(new LineBuffer(lineMaxBytes)) {
+
+  override def write(b: Int): Unit = {
+    super.write(b)
+    tryLogCurrentLine()
+  }
+
+  override def write(buf: Array[Byte], off: Int, len: Int): Unit = {
+    super.write(buf, off, len)
+    tryLogCurrentLine()
+  }
+
+  private def tryLogCurrentLine(): Unit = this.synchronized {
+    out.asInstanceOf[LineBuffer].tryGenerateContext.foreach { logContext =>
+      redirect(logContext)
+    }
+  }
+}
+
+/**
+ * Cache bytes before line ending. When current line is ended or the bytes size reaches the
+ * threshold, it can generate the line.
+ */
+private[spark] object LineBuffer {
+  private val LF_BYTES = System.lineSeparator.getBytes
+  private val LF_LENGTH = LF_BYTES.length
+}
+
+private[spark] class LineBuffer(lineMaxBytes: Long) extends ByteArrayOutputStream {
+
+  import LineBuffer._
+
+  def tryGenerateContext: Option[String] =
+    if (isLineEnded) {
+      try Some(new String(buf, 0, count - LF_LENGTH)) finally reset()
+    } else if (count >= lineMaxBytes) {
+      try Some(new String(buf, 0, count)) finally reset()
+    } else {
+      None
+    }
+
+  private def isLineEnded: Boolean = {
+    if (count < LF_LENGTH) return false
+    // fast return in UNIX-like OS when LF is single char '\n'
+    if (LF_LENGTH == 1) return LF_BYTES(0) == buf(count - 1)
+
+    var i = 0
+    do {
+      if (LF_BYTES(i) != buf(count - LF_LENGTH + i)) {
+        return false
+      }
+      i = i + 1
+    } while (i < LF_LENGTH)
+    true
+  }
+}

--- a/core/src/main/scala/org/apache/spark/deploy/RedirectConsolePlugin.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/RedirectConsolePlugin.scala
@@ -22,10 +22,8 @@ import java.util.{Collections, Map => JMap}
 
 import org.apache.spark.SparkContext
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
-import org.apache.spark.internal.{Logging, MDC, SparkLoggerFactory}
-import org.apache.spark.internal.LogKeys._
+import org.apache.spark.internal.{Logging, SparkLoggerFactory}
 import org.apache.spark.internal.config._
-import org.apache.spark.internal.config.UI.UI_SHOW_CONSOLE_PROGRESS
 
 /**
  * A built-in plugin to allow redirecting stdout/stderr to logging system (SLF4J).
@@ -51,12 +49,6 @@ class DriverRedirectConsolePlugin extends DriverPlugin with Logging {
   override def init(sc: SparkContext, ctx: PluginContext): JMap[String, String] = {
     if (sc.conf.get(DRIVER_REDIRECT_CONSOLE_TO_LOG_ENABLED)) {
       logInfo("Redirect driver's stdout/stderr to logging system")
-      if (sc.conf.get(UI_SHOW_CONSOLE_PROGRESS)) {
-        logWarning(log"Redirect driver's stderr to logging system may affect " +
-          log"console progress bar, consider disabling either " +
-          log"${MDC(CONFIG, DRIVER_REDIRECT_CONSOLE_TO_LOG_ENABLED.key)} or " +
-          log"${MDC(CONFIG2, UI_SHOW_CONSOLE_PROGRESS.key)}.")
-      }
       RedirectConsolePlugin.redirectConsoleToLog()
     }
     Collections.emptyMap

--- a/core/src/main/scala/org/apache/spark/deploy/RedirectConsolePlugin.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/RedirectConsolePlugin.scala
@@ -38,15 +38,22 @@ class RedirectConsolePlugin extends SparkPlugin {
   override def executorPlugin(): ExecutorPlugin = new ExecRedirectConsolePlugin()
 }
 
+object RedirectConsolePlugin {
+
+  def redirectConsoleToLog(): Unit = {
+    val stdoutLogger = LoggerFactory.getLogger("stdout")
+    System.setOut(new LoggingPrintStream(stdoutLogger.info))
+    val stderrLogger = LoggerFactory.getLogger("stderr")
+    System.setErr(new LoggingPrintStream(stderrLogger.error))
+  }
+}
+
 class DriverRedirectConsolePlugin extends DriverPlugin with Logging {
 
   override def init(sc: SparkContext, ctx: PluginContext): JMap[String, String] = {
     if (sc.conf.get(DRIVER_REDIRECT_CONSOLE_TO_LOG_ENABLED)) {
       logInfo("Redirect driver's stdout/stderr to logging system")
-      val stdoutLogger = LoggerFactory.getLogger("stdout")
-      System.setOut(new LoggingPrintStream(stdoutLogger.info))
-      val stderrLogger = LoggerFactory.getLogger("stderr")
-      System.setErr(new LoggingPrintStream(stderrLogger.error))
+      RedirectConsolePlugin.redirectConsoleToLog()
     }
     Map.empty[String, String].asJava
   }
@@ -57,10 +64,7 @@ class ExecRedirectConsolePlugin extends ExecutorPlugin with Logging {
   override def init(ctx: PluginContext, extraConf: JMap[String, String]): Unit = {
     if (ctx.conf.get(EXEC_REDIRECT_CONSOLE_TO_LOG_ENABLED)) {
       logInfo("Redirect executor's stdout/stdout to logging system")
-      val stdoutLogger = LoggerFactory.getLogger("stdout")
-      System.setOut(new LoggingPrintStream(stdoutLogger.info))
-      val stderrLogger = LoggerFactory.getLogger("stderr")
-      System.setErr(new LoggingPrintStream(stderrLogger.error))
+      RedirectConsolePlugin.redirectConsoleToLog()
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/RedirectConsolePlugin.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/RedirectConsolePlugin.scala
@@ -36,9 +36,12 @@ class RedirectConsolePlugin extends SparkPlugin {
 
 object RedirectConsolePlugin {
 
-  def redirectConsoleToLog(): Unit = {
+  def redirectStdoutToLog(): Unit = {
     val stdoutLogger = SparkLoggerFactory.getLogger("stdout")
     System.setOut(new LoggingPrintStream(stdoutLogger.info))
+  }
+
+  def redirectStderrToLog(): Unit = {
     val stderrLogger = SparkLoggerFactory.getLogger("stderr")
     System.setErr(new LoggingPrintStream(stderrLogger.error))
   }
@@ -47,9 +50,14 @@ object RedirectConsolePlugin {
 class DriverRedirectConsolePlugin extends DriverPlugin with Logging {
 
   override def init(sc: SparkContext, ctx: PluginContext): JMap[String, String] = {
-    if (sc.conf.get(DRIVER_REDIRECT_CONSOLE_TO_LOG_ENABLED)) {
-      logInfo("Redirect driver's stdout/stderr to logging system")
-      RedirectConsolePlugin.redirectConsoleToLog()
+    val outputs = sc.conf.get(DRIVER_REDIRECT_CONSOLE_OUTPUTS)
+    if (outputs.contains("stdout")) {
+      logInfo("Redirect driver's stdout to logging system.")
+      RedirectConsolePlugin.redirectStdoutToLog()
+    }
+    if (outputs.contains("stderr")) {
+      logInfo("Redirect driver's stderr to logging system.")
+      RedirectConsolePlugin.redirectStderrToLog()
     }
     Collections.emptyMap
   }
@@ -58,9 +66,14 @@ class DriverRedirectConsolePlugin extends DriverPlugin with Logging {
 class ExecRedirectConsolePlugin extends ExecutorPlugin with Logging {
 
   override def init(ctx: PluginContext, extraConf: JMap[String, String]): Unit = {
-    if (ctx.conf.get(EXEC_REDIRECT_CONSOLE_TO_LOG_ENABLED)) {
-      logInfo("Redirect executor's stdout/stdout to logging system")
-      RedirectConsolePlugin.redirectConsoleToLog()
+    val outputs = ctx.conf.get(EXEC_REDIRECT_CONSOLE_OUTPUTS)
+    if (outputs.contains("stdout")) {
+      logInfo("Redirect executor's stdout to logging system.")
+      RedirectConsolePlugin.redirectStdoutToLog()
+    }
+    if (outputs.contains("stderr")) {
+      logInfo("Redirect executor's stderr to logging system.")
+      RedirectConsolePlugin.redirectStderrToLog()
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/RedirectConsolePlugin.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/RedirectConsolePlugin.scala
@@ -32,41 +32,33 @@ import org.apache.spark.internal.config._
 /**
  * A built-in plugin to allow redirecting stdout/stderr to logging system (SLF4J).
  */
-class ConsoleRedirectPlugin extends SparkPlugin {
-  override def driverPlugin(): DriverPlugin = new DriverConsoleRedirectPlugin()
+class RedirectConsolePlugin extends SparkPlugin {
+  override def driverPlugin(): DriverPlugin = new DriverRedirectConsolePlugin()
 
-  override def executorPlugin(): ExecutorPlugin = new ExecConsoleRedirectPlugin()
+  override def executorPlugin(): ExecutorPlugin = new ExecRedirectConsolePlugin()
 }
 
-class DriverConsoleRedirectPlugin extends DriverPlugin with Logging {
+class DriverRedirectConsolePlugin extends DriverPlugin with Logging {
 
   override def init(sc: SparkContext, ctx: PluginContext): JMap[String, String] = {
-    if (sc.conf.get(DRIVER_REDIRECT_STDOUT_TO_LOG_ENABLED)) {
-      logInfo("Redirect driver's stdout to logging system")
+    if (sc.conf.get(DRIVER_REDIRECT_CONSOLE_TO_LOG_ENABLED)) {
+      logInfo("Redirect driver's stdout/stderr to logging system")
       val stdoutLogger = LoggerFactory.getLogger("stdout")
-      System.setOut(new LoggingPrintStream(stdoutLogger.info))
-    }
-
-    if (sc.conf.get(DRIVER_REDIRECT_STDERR_TO_LOG_ENABLED)) {
-      logInfo("Redirect driver's stderr to logging system")
       val stderrLogger = LoggerFactory.getLogger("stderr")
+      System.setOut(new LoggingPrintStream(stdoutLogger.info))
       System.setErr(new LoggingPrintStream(stderrLogger.error))
     }
     Map.empty[String, String].asJava
   }
 }
 
-class ExecConsoleRedirectPlugin extends ExecutorPlugin with Logging {
+class ExecRedirectConsolePlugin extends ExecutorPlugin with Logging {
 
   override def init(ctx: PluginContext, extraConf: JMap[String, String]): Unit = {
-    if (ctx.conf.get(EXEC_REDIRECT_STDOUT_TO_LOG_ENABLED)) {
-      logInfo("Redirect executor's stdout to logging system")
+    if (ctx.conf.get(EXEC_REDIRECT_CONSOLE_TO_LOG_ENABLED)) {
+      logInfo("Redirect executor's stdout/stdout to logging system")
       val stdoutLogger = LoggerFactory.getLogger("stdout")
       System.setOut(new LoggingPrintStream(stdoutLogger.info))
-    }
-
-    if (ctx.conf.get(EXEC_REDIRECT_STDERR_TO_LOG_ENABLED)) {
-      logInfo("Redirect executor's stderr to logging system")
       val stderrLogger = LoggerFactory.getLogger("stderr")
       System.setErr(new LoggingPrintStream(stderrLogger.error))
     }

--- a/core/src/main/scala/org/apache/spark/deploy/RedirectConsolePlugin.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/RedirectConsolePlugin.scala
@@ -18,9 +18,7 @@
 package org.apache.spark.deploy
 
 import java.io.{ByteArrayOutputStream, PrintStream}
-import java.util.{Map => JMap}
-
-import scala.jdk.CollectionConverters._
+import java.util.{Collections, Map => JMap}
 
 import org.apache.spark.SparkContext
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
@@ -61,7 +59,7 @@ class DriverRedirectConsolePlugin extends DriverPlugin with Logging {
       }
       RedirectConsolePlugin.redirectConsoleToLog()
     }
-    Map.empty[String, String].asJava
+    Collections.emptyMap
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/deploy/RedirectConsolePlugin.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/RedirectConsolePlugin.scala
@@ -65,10 +65,8 @@ class ExecRedirectConsolePlugin extends ExecutorPlugin with Logging {
   }
 }
 
-private[spark] class LoggingPrintStream(
-    redirect: String => Unit,
-    lineMaxBytes: Long = 4 * 1024 * 1024)
-  extends PrintStream(new LineBuffer(lineMaxBytes)) {
+private[spark] class LoggingPrintStream(redirect: String => Unit)
+  extends PrintStream(new LineBuffer(4 * 1024 * 1024)) {
 
   override def write(b: Int): Unit = {
     super.write(b)

--- a/core/src/main/scala/org/apache/spark/deploy/RedirectConsolePlugin.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/RedirectConsolePlugin.scala
@@ -44,8 +44,8 @@ class DriverRedirectConsolePlugin extends DriverPlugin with Logging {
     if (sc.conf.get(DRIVER_REDIRECT_CONSOLE_TO_LOG_ENABLED)) {
       logInfo("Redirect driver's stdout/stderr to logging system")
       val stdoutLogger = LoggerFactory.getLogger("stdout")
-      val stderrLogger = LoggerFactory.getLogger("stderr")
       System.setOut(new LoggingPrintStream(stdoutLogger.info))
+      val stderrLogger = LoggerFactory.getLogger("stderr")
       System.setErr(new LoggingPrintStream(stderrLogger.error))
     }
     Map.empty[String, String].asJava

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2839,39 +2839,21 @@ package object config {
       .createWithDefault(
         if (sys.env.get("SPARK_CONNECT_MODE").contains("1")) "connect" else "classic")
 
-  private[spark] val DRIVER_REDIRECT_STDOUT_TO_LOG_ENABLED =
-    ConfigBuilder("spark.driver.log.redirectStdout.enabled")
-      .doc("Whether to redirect the driver's stdout to logging system. " +
+  private[spark] val DRIVER_REDIRECT_CONSOLE_TO_LOG_ENABLED =
+    ConfigBuilder("spark.driver.log.redirectConsole.enabled")
+      .doc("Whether to redirect the driver's stdout/stderr to logging system. " +
         s"It only takes affect when `${PLUGINS.key}` is configured with " +
-        "`org.apache.spark.deploy.ConsoleRedirectPlugin`.")
+        "`org.apache.spark.deploy.RedirectConsolePlugin`.")
       .version("4.1.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
-  private[spark] val DRIVER_REDIRECT_STDERR_TO_LOG_ENABLED =
-    ConfigBuilder("spark.driver.log.redirectStderr.enabled")
-      .doc("Whether to redirect the driver's stderr to logging system. " +
+  private[spark] val EXEC_REDIRECT_CONSOLE_TO_LOG_ENABLED =
+    ConfigBuilder("spark.executor.log.redirectConsole.enabled")
+      .doc("Whether to redirect the executor's stdout/stderr to logging system. " +
         s"It only takes affect when `${PLUGINS.key}` is configured with " +
-        "`org.apache.spark.deploy.ConsoleRedirectPlugin`.")
+        "`org.apache.spark.deploy.RedirectConsolePlugin`.")
       .version("4.1.0")
       .booleanConf
-      .createWithDefault(false)
-
-  private[spark] val EXEC_REDIRECT_STDOUT_TO_LOG_ENABLED =
-    ConfigBuilder("spark.executor.log.redirectStdout.enabled")
-      .doc("Whether to redirect the executor's stdout to logging system. " +
-        s"It only takes affect when `${PLUGINS.key}` is configured with " +
-        "`org.apache.spark.deploy.ConsoleRedirectPlugin`.")
-      .version("4.1.0")
-      .booleanConf
-      .createWithDefault(false)
-
-  private[spark] val EXEC_REDIRECT_STDERR_TO_LOG_ENABLED =
-    ConfigBuilder("spark.executor.log.redirectStderr.enabled")
-      .doc("Whether to redirect the executor's stderr to logging system. " +
-        s"It only takes affect when `${PLUGINS.key}` is configured with " +
-        "`org.apache.spark.deploy.ConsoleRedirectPlugin`.")
-      .version("4.1.0")
-      .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2839,21 +2839,29 @@ package object config {
       .createWithDefault(
         if (sys.env.get("SPARK_CONNECT_MODE").contains("1")) "connect" else "classic")
 
-  private[spark] val DRIVER_REDIRECT_CONSOLE_TO_LOG_ENABLED =
-    ConfigBuilder("spark.driver.log.redirectConsole.enabled")
-      .doc("Whether to redirect the driver's stdout/stderr to logging system. " +
-        s"It only takes affect when `${PLUGINS.key}` is configured with " +
-        "`org.apache.spark.deploy.RedirectConsolePlugin`.")
+  private[spark] val DRIVER_REDIRECT_CONSOLE_OUTPUTS =
+    ConfigBuilder("spark.driver.log.redirectConsoleOutputs")
+      .doc("Comma-separated list of the console output kind for driver that needs to redirect " +
+        "to logging system. Supported values are `stdout`, `stderr`. It only takes affect when " +
+        s"`${PLUGINS.key}` is configured with `org.apache.spark.deploy.RedirectConsolePlugin`.")
       .version("4.1.0")
-      .booleanConf
-      .createWithDefault(true)
+      .stringConf
+      .transform(_.toLowerCase(Locale.ROOT))
+      .toSequence
+      .checkValue(v => v.forall(Set("stdout", "stderr").contains),
+        "The value only can be one or more of 'stdout, stderr'.")
+      .createWithDefault(Seq("stdout", "stderr"))
 
-  private[spark] val EXEC_REDIRECT_CONSOLE_TO_LOG_ENABLED =
-    ConfigBuilder("spark.executor.log.redirectConsole.enabled")
-      .doc("Whether to redirect the executor's stdout/stderr to logging system. " +
-        s"It only takes affect when `${PLUGINS.key}` is configured with " +
-        "`org.apache.spark.deploy.RedirectConsolePlugin`.")
+  private[spark] val EXEC_REDIRECT_CONSOLE_OUTPUTS =
+    ConfigBuilder("spark.executor.log.redirectConsoleOutputs")
+      .doc("Comma-separated list of the console output kind for executor that needs to redirect " +
+        "to logging system. Supported values are `stdout`, `stderr`. It only takes affect when " +
+        s"`${PLUGINS.key}` is configured with `org.apache.spark.deploy.RedirectConsolePlugin`.")
       .version("4.1.0")
-      .booleanConf
-      .createWithDefault(true)
+      .stringConf
+      .transform(_.toLowerCase(Locale.ROOT))
+      .toSequence
+      .checkValue(v => v.forall(Set("stdout", "stderr").contains),
+        "The value only can be one or more of 'stdout, stderr'.")
+      .createWithDefault(Seq("stdout", "stderr"))
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2843,8 +2843,7 @@ package object config {
     ConfigBuilder("spark.driver.log.redirectConsole.enabled")
       .doc("Whether to redirect the driver's stdout/stderr to logging system. " +
         s"It only takes affect when `${PLUGINS.key}` is configured with " +
-        "`org.apache.spark.deploy.RedirectConsolePlugin`. Note, enabling this " +
-        "feature may affect the shell console progress bar.")
+        "`org.apache.spark.deploy.RedirectConsolePlugin`.")
       .version("4.1.0")
       .booleanConf
       .createWithDefault(true)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2838,4 +2838,40 @@ package object config {
       .checkValues(Set("connect", "classic"))
       .createWithDefault(
         if (sys.env.get("SPARK_CONNECT_MODE").contains("1")) "connect" else "classic")
+
+  private[spark] val DRIVER_REDIRECT_STDOUT_TO_LOG_ENABLED =
+    ConfigBuilder("spark.driver.log.redirectStdout.enabled")
+      .doc("Whether to redirect the driver's stdout to logging system. " +
+        s"It only takes affect when `${PLUGINS.key}` is configured with " +
+        "`org.apache.spark.deploy.ConsoleRedirectPlugin`.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  private[spark] val DRIVER_REDIRECT_STDERR_TO_LOG_ENABLED =
+    ConfigBuilder("spark.driver.log.redirectStderr.enabled")
+      .doc("Whether to redirect the driver's stderr to logging system. " +
+        s"It only takes affect when `${PLUGINS.key}` is configured with " +
+        "`org.apache.spark.deploy.ConsoleRedirectPlugin`.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  private[spark] val EXEC_REDIRECT_STDOUT_TO_LOG_ENABLED =
+    ConfigBuilder("spark.executor.log.redirectStdout.enabled")
+      .doc("Whether to redirect the executor's stdout to logging system. " +
+        s"It only takes affect when `${PLUGINS.key}` is configured with " +
+        "`org.apache.spark.deploy.ConsoleRedirectPlugin`.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  private[spark] val EXEC_REDIRECT_STDERR_TO_LOG_ENABLED =
+    ConfigBuilder("spark.executor.log.redirectStderr.enabled")
+      .doc("Whether to redirect the executor's stderr to logging system. " +
+        s"It only takes affect when `${PLUGINS.key}` is configured with " +
+        "`org.apache.spark.deploy.ConsoleRedirectPlugin`.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2843,7 +2843,8 @@ package object config {
     ConfigBuilder("spark.driver.log.redirectConsole.enabled")
       .doc("Whether to redirect the driver's stdout/stderr to logging system. " +
         s"It only takes affect when `${PLUGINS.key}` is configured with " +
-        "`org.apache.spark.deploy.RedirectConsolePlugin`.")
+        "`org.apache.spark.deploy.RedirectConsolePlugin`. Note, enabling this " +
+        "feature may affect the shell console progress bar.")
       .version("4.1.0")
       .booleanConf
       .createWithDefault(true)

--- a/core/src/main/scala/org/apache/spark/ui/ConsoleProgressBar.scala
+++ b/core/src/main/scala/org/apache/spark/ui/ConsoleProgressBar.scala
@@ -38,6 +38,8 @@ private[spark] class ConsoleProgressBar(sc: SparkContext) extends Logging {
   private val updatePeriodMSec = sc.conf.get(UI_CONSOLE_PROGRESS_UPDATE_INTERVAL)
   // Delay to show up a progress bar, in milliseconds
   private val firstDelayMSec = 500L
+  // Get the stderr (which is console for spark-shell) before installing RedirectConsolePlugin
+  private val console = System.err
 
   // The width of terminal
   private val TerminalWidth = sys.env.getOrElse("COLUMNS", "80").toInt
@@ -92,7 +94,7 @@ private[spark] class ConsoleProgressBar(sc: SparkContext) extends Logging {
     // only refresh if it's changed OR after 1 minute (or the ssh connection will be closed
     // after idle some time)
     if (bar != lastProgressBar || now - lastUpdateTime > 60 * 1000L) {
-      System.err.print(s"$CR$bar$CR")
+      console.print(s"$CR$bar$CR")
       lastUpdateTime = now
     }
     lastProgressBar = bar
@@ -103,7 +105,7 @@ private[spark] class ConsoleProgressBar(sc: SparkContext) extends Logging {
    */
   private def clear(): Unit = {
     if (!lastProgressBar.isEmpty) {
-      System.err.printf(s"$CR${" " * TerminalWidth}$CR")
+      console.printf(s"$CR${" " * TerminalWidth}$CR")
       lastProgressBar = ""
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Though directly printing messages to stdout/stderr is discouraged, but as a framework, Spark does not forbid users from doing that.

This PR adds a RedirectConsolePlugin to allow Spark to redirect stdout/stderr to the logging system (Log4J2 via Slf4J API).

Apache Flink also has the same capability, see [FLINK-31234](https://issues.apache.org/jira/browse/FLINK-31234)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is especially useful for integrating with external logging services, for example, use Kafka Log4J appender to send logs to Kafka, then drain to ElasticSearch.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, new feature.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
I don't write UT as it will affect other cases run in the same JVM, I test it manually.

```
$ cp conf/log4j2.properties.template conf/log4j2.properties
$ cat >> conf/log4j2.properties <<EOF
logger.stdout.name = stdout
logger.stdout.level = info
EOF

$ bin/spark-shell --conf spark.plugins=org.apache.spark.deploy.RedirectConsolePlugin
WARNING: Using incubator modules: jdk.incubator.vector
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 4.1.0-SNAPSHOT
      /_/
         
Using Scala version 2.13.16 (OpenJDK 64-Bit Server VM, Java 17.0.13)
Type in expressions to have them evaluated.
Type :help for more information.
25/06/13 17:28:23 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Spark context Web UI available at http://10.242.159.140:4040
Spark context available as 'sc' (master = local[*], app id = local-1749806903960).
Spark session available as 'spark'.

scala> System.out.println("driver stdout")
     | System.err.println("driver stderr")
     | sc.parallelize(Array(1, 2, 3)).foreach { x =>
     |   System.out.println(s"executor stdout: $x")
     |   System.err.println(s"executor stderr: $x")
     | }
warning: 1 deprecation (since 2.13.0); for details, enable `:setting -deprecation` or `:replay -deprecation`
25/06/13 17:28:50 INFO stdout: driver stdout
25/06/13 17:28:50 ERROR stderr: driver stderr
25/06/13 17:28:50 INFO stdout: executor stdout: 2
25/06/13 17:28:50 ERROR stderr: executor stderr: 2
25/06/13 17:28:50 INFO stdout: executor stdout: 1
25/06/13 17:28:50 ERROR stderr: executor stderr: 1
25/06/13 17:28:50 INFO stdout: executor stdout: 3
25/06/13 17:28:50 ERROR stderr: executor stderr: 3

scala>
```

Console progress bar (without console redirection)
```
$ bin/spark-shell
WARNING: Using incubator modules: jdk.incubator.vector
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 4.1.0-SNAPSHOT
      /_/
         
Using Scala version 2.13.16 (OpenJDK 64-Bit Server VM, Java 17.0.13)
Type in expressions to have them evaluated.
Type :help for more information.
25/06/13 19:49:05 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Spark context Web UI available at http://10.242.159.140:4040
Spark context available as 'sc' (master = local[*], app id = local-1749815345805).
Spark session available as 'spark'.

scala> import org.apache.spark._
     | 
     | System.out.println("driver stdout")
     | System.err.println("driver stderr")
     | sc.parallelize(Array(1, 2, 3)).foreach { x =>
     |   Thread.sleep(TaskContext.getPartitionId() * 10000)
     |   System.out.println(s"executor stdout: $x")
     |   System.err.println(s"executor stderr: $x")
     | }
warning: 1 deprecation (since 2.13.0); for details, enable `:setting -deprecation` or `:replay -deprecation`
driver stdout
driver stderr
executor stdout: 1===============================>                 (7 + 3) / 10]
executor stderr: 1
executor stdout: 2=====================================>           (8 + 2) / 10]
executor stderr: 2
executor stdout: 3===========================================>     (9 + 1) / 10]
executor stderr: 3
import org.apache.spark._                                                       

scala>
```

Console progress bar (with console redirection)
```
$ bin/spark-shell --conf spark.plugins=org.apache.spark.deploy.RedirectConsolePlugin
WARNING: Using incubator modules: jdk.incubator.vector
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 4.1.0-SNAPSHOT
      /_/
         
Using Scala version 2.13.16 (OpenJDK 64-Bit Server VM, Java 17.0.13)
Type in expressions to have them evaluated.
Type :help for more information.
25/06/13 19:54:14 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
25/06/13 19:54:14 WARN DriverRedirectConsolePlugin: Redirect driver's stderr to logging system may affect console progress bar, consider disabling either spark.driver.log.redirectConsole.enabled or spark.ui.showConsoleProgress.
Spark context Web UI available at http://10.242.159.140:4040
Spark context available as 'sc' (master = local[*], app id = local-1749815654458).
Spark session available as 'spark'.

scala> import org.apache.spark._
     | 
     | System.out.println("driver stdout")
     | System.err.println("driver stderr")
     | sc.parallelize(Array(1, 2, 3)).foreach { x =>
     |   Thread.sleep(TaskContext.getPartitionId() * 10000)
     |   System.out.println(s"executor stdout: $x")
     |   System.err.println(s"executor stderr: $x")
     | }
warning: 1 deprecation (since 2.13.0); for details, enable `:setting -deprecation` or `:replay -deprecation`
25/06/13 19:54:22 INFO stdout: driver stdout
25/06/13 19:54:22 ERROR stderr: driver stderr
25/06/13 19:54:52 INFO stdout: executor stdout: 1>                 (7 + 3) / 10]
25/06/13 19:54:52 ERROR stderr: executor stderr: 1
25/06/13 19:55:22 INFO stdout: executor stdout: 2======>           (8 + 2) / 10]
25/06/13 19:55:22 ERROR stderr: executor stderr: 2
25/06/13 19:55:52 INFO stdout: executor stdout: 3============>     (9 + 1) / 10]
25/06/13 19:55:52 ERROR stderr: executor stderr: 3
import org.apache.spark._                                                       

scala> 
```


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.