### PR TITLE
[SPARK-52412][INFRA][FOLLOW-UP] Escape special characters when redacting the logs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,8 +237,8 @@ jobs:
             cp "$file" "$file.bak"
             for pattern in "${PATTERNS[@]}"; do
               [ -n "$pattern" ] || continue  # Skip empty patterns
-              regex="${pattern//\*/.*}"
-              sed -i "s|$regex|***|g" "$file"
+              escaped_pattern=$(printf '%s\n' "$pattern" | sed 's/[\/&]/\\&/g')
+              sed -i "s/${escaped_pattern}/***/g" "$file"
             done
           done
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is another followup of https://github.com/apache/spark/pull/51118 that escapes special characters when redacting the logs

### Why are the changes needed?

So it won't fail unexpectedly for special characters.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.