### PR TITLE
[SPARK-52430][SQL] Resolve bug with nullability of Union in rCTEs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveWithCTE.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveWithCTE.scala
@@ -306,7 +306,8 @@ object ResolveWithCTE extends Rule[LogicalPlan] {
       columnNames: Option[Seq[String]]) = {
     recursion.transformUpWithSubqueriesAndPruning(_.containsPattern(CTE)) {
       case r: CTERelationRef if r.recursive && r.cteId == cteDefId =>
-        val ref = UnionLoopRef(r.cteId, anchor.output.map(_.newInstance()), false)
+        val ref =
+          UnionLoopRef(r.cteId, anchor.output.map(_.newInstance().withNullability(true)), false)
         columnNames.map(UnresolvedSubqueryColumnAliases(_, ref)).getOrElse(ref)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveWithCTE.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveWithCTE.scala
@@ -306,6 +306,8 @@ object ResolveWithCTE extends Rule[LogicalPlan] {
       columnNames: Option[Seq[String]]) = {
     recursion.transformUpWithSubqueriesAndPruning(_.containsPattern(CTE)) {
       case r: CTERelationRef if r.recursive && r.cteId == cteDefId =>
+        // We mark the output of UnionLoopRef as nullable as it may become NULL in the following
+        // iterations.
         val ref =
           UnionLoopRef(r.cteId, anchor.output.map(_.newInstance().withNullability(true)), false)
         columnNames.map(UnresolvedSubqueryColumnAliases(_, ref)).getOrElse(ref)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveRecursiveCTESuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveRecursiveCTESuite.scala
@@ -53,7 +53,8 @@ class ResolveRecursiveCTESuite extends AnalysisTest {
     }
 
     def getAfterPlan(): LogicalPlan = {
-      val recursion = UnionLoopRef(cteId, anchor.output, accumulated = false).subquery("t")
+      val recursion = UnionLoopRef(cteId, anchor.output.map(_.withNullability(true)),
+        accumulated = false).subquery("t")
       val cteDef = CTERelationDef(UnionLoop(cteId, anchor, recursion,
         outputExprIds).subquery("t"), cteId)
       val cteRef = CTERelationRef(
@@ -97,8 +98,9 @@ class ResolveRecursiveCTESuite extends AnalysisTest {
     }
 
     def getAfterPlan(): LogicalPlan = {
-      val col = anchor.output.head
-      val recursion = UnionLoopRef(cteId, anchor.output, accumulated = false)
+      val col = anchor.output.head.withNullability(true)
+      val recursion = UnionLoopRef(cteId, anchor.output.map(_.withNullability(true)),
+        accumulated = false)
         .select(col.as("n"))
         .subquery("t")
       val cteDef = CTERelationDef(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/UnionLoopExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/UnionLoopExec.scala
@@ -135,7 +135,8 @@ case class UnionLoopExec(
         // reference any external tables, we are able to calculate everything in the optimizer,
         // using the ConvertToLocalRelation rule, which significantly improves runtime.
         if (count <= localRelationLimit) {
-          val local = LocalRelation.fromExternalRows(output, df.collect().toIndexedSeq)
+          val local = LocalRelation.fromExternalRows(df.logicalPlan.output,
+            df.collect().toIndexedSeq)
          (Dataset.ofRows(session, local), count)
         } else {
           (materializedDF, count)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/UnionLoopExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/UnionLoopExec.scala
@@ -135,7 +135,7 @@ case class UnionLoopExec(
         // reference any external tables, we are able to calculate everything in the optimizer,
         // using the ConvertToLocalRelation rule, which significantly improves runtime.
         if (count <= localRelationLimit) {
-          val local = LocalRelation.fromExternalRows(anchor.output, df.collect().toIndexedSeq)
+          val local = LocalRelation.fromExternalRows(output, df.collect().toIndexedSeq)
          (Dataset.ofRows(session, local), count)
         } else {
           (materializedDF, count)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
@@ -1812,3 +1812,29 @@ WITH RECURSIVE randoms(val) AS (
 SELECT val FROM randoms LIMIT 5
 -- !query analysis
 [Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+WITH RECURSIVE t1(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT CASE WHEN n < 5 THEN n + 1 ELSE NULL END FROM t1
+)
+SELECT * FROM t1 LIMIT 25
+-- !query analysis
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t1
+:     +- Project [1#x AS n#x]
+:        +- UnionLoop xxxx
+:           :- Project [1 AS 1#x]
+:           :  +- OneRowRelation
+:           +- Project [CASE WHEN (n#x < 5) THEN (n#x + 1) ELSE cast(null as int) END AS CASE WHEN (n < 5) THEN (n + 1) ELSE NULL END#x]
+:              +- SubqueryAlias t1
+:                 +- Project [1#x AS n#x]
+:                    +- UnionLoopRef xxxx, [1#x], false
++- GlobalLimit 25
+   +- LocalLimit 25
+      +- Project [n#x]
+         +- SubqueryAlias t1
+            +- CTERelationRef xxxx, true, [n#x], false, false

--- a/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
@@ -675,3 +675,10 @@ WITH RECURSIVE randoms(val) AS (
     FROM randoms
 )
 SELECT val FROM randoms LIMIT 5;
+
+WITH RECURSIVE t1(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT CASE WHEN n < 5 THEN n + 1 ELSE NULL END FROM t1
+)
+SELECT * FROM t1 LIMIT 25;

--- a/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
@@ -676,6 +676,7 @@ WITH RECURSIVE randoms(val) AS (
 )
 SELECT val FROM randoms LIMIT 5;
 
+-- Recursive CTE with nullable recursion and non-recursive anchor
 WITH RECURSIVE t1(n) AS (
     SELECT 1
     UNION ALL

--- a/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
@@ -1656,3 +1656,40 @@ struct<val:array<int>>
 [2,1,5,3,4]
 [4,3,2,5,1]
 [4,5,1,2,3]
+
+
+-- !query
+WITH RECURSIVE t1(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT CASE WHEN n < 5 THEN n + 1 ELSE NULL END FROM t1
+)
+SELECT * FROM t1 LIMIT 25
+-- !query schema
+struct<n:int>
+-- !query output
+1
+2
+3
+4
+5
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL

--- a/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
@@ -990,7 +990,7 @@ Output [1]: [col1#x]
 Accumulated: false
 
 (4) Filter
-Arguments: (col1#x < 9)
+Arguments: (isnotnull(col1#x) AND (col1#x < 9))
 
 (5) Project
 Arguments: [(col1#x + 1) AS (level + 1)#x]

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -885,7 +885,7 @@ Output [1]: [col1#x]
 Accumulated: false
 
 (4) Filter
-Arguments: (col1#x < 9)
+Arguments: (isnotnull(col1#x) AND (col1#x < 9))
 
 (5) Project
 Arguments: [(col1#x + 1) AS (level + 1)#x]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the output of UnionLoopRef to be nullable by default and use the correct output in Local Optimization optimization for small result sets. 

### Why are the changes needed?

Currently, we mark the nullability of UnionLoopRef with the nullability of the anchor. However, the NULL may occur because of the recursive step, leading to unexpected behavior (treating NULLs as 0s).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New golden file test with failing example.

### Was this patch authored or co-authored using generative AI tooling?

No.