### PR TITLE
Quiet "Unable to load native-hadoop library for your platform" message

### DIFF
--- a/common/utils/src/main/resources/org/apache/spark/log4j2-defaults.properties
+++ b/common/utils/src/main/resources/org/apache/spark/log4j2-defaults.properties
@@ -53,3 +53,7 @@ logger.parquet.name = org.apache.parquet.CorruptStatistics
 logger.parquet.level = error
 logger.parquet2.name = parquet.CorruptStatistics
 logger.parquet2.level = error
+
+# Quiet annoying "Unable to load native-hadoop library for your platform" message
+logger.hadoop_native_code_loader.name = org.apache.hadoop.util.NativeCodeLoader
+logger.hadoop_native_code_loader.level = error


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes suppressing this warning that gets logged at startup if native-hadoop libraries aren't installed:
```
25/06/09 10:16:45 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
```

### Why are the changes needed?

This warning (among others) provides a noisy experience to users getting started with Spark locally, who aren'y likely to care about this.

```
$ bin/pyspark
Python 3.9.21 (main, Apr 24 2025, 15:50:57)
[Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
WARNING: Using incubator modules: jdk.incubator.vector
Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
25/06/09 10:16:45 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
```

### Does this PR introduce _any_ user-facing change?

Yes

### How was this patch tested?

Ran `bin/pyspark` after making the change and observed that the message was not shown.

### Was this patch authored or co-authored using generative AI tooling?

No