### PR TITLE
[SPARK-52433][PYTHON] Unify the string coercion in createDataFrame

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -255,7 +255,7 @@ class LocalDataToArrowConversion:
                     return None
                 else:
                     if isinstance(value, bool):
-                        # To match the PySpark which convert bool to string in
+                        # To match the PySpark Classic which convert bool to string in
                         # the JVM side (python.EvaluatePython.makeFromJava)
                         return str(value).lower()
                     else:

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1194,10 +1194,11 @@ class SparkSession(SparkConversionMixin):
         if not isinstance(data, list):
             data = list(data)
 
+        tupled_data: Iterable[Tuple]
         if schema is None or isinstance(schema, (list, tuple)):
             struct = self._inferSchemaFromList(data, names=schema)
             converter = _create_converter(struct)
-            tupled_data: Iterable[Tuple] = map(converter, data)
+            tupled_data = map(converter, data)
             if isinstance(schema, (list, tuple)):
                 for i, name in enumerate(schema):
                     struct.fields[i].name = name
@@ -1206,7 +1207,7 @@ class SparkSession(SparkConversionMixin):
         elif isinstance(schema, StructType):
             struct = schema
             converter = _create_converter(struct)
-            tupled_data: Iterable[Tuple] = map(converter, data)
+            tupled_data = map(converter, data)
 
         else:
             raise PySparkTypeError(

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -54,6 +54,7 @@ from pyspark.sql.types import (
     DataType,
     StructField,
     StructType,
+    VariantVal,
     _make_type_verifier,
     _infer_schema,
     _has_nulltype,
@@ -1193,6 +1194,9 @@ class SparkSession(SparkConversionMixin):
         # make sure data could consumed multiple times
         if not isinstance(data, list):
             data = list(data)
+
+        if any(isinstance(d, VariantVal) for d in data):
+            raise PySparkValueError("Rows cannot be of type VariantVal")
 
         tupled_data: Iterable[Tuple]
         if schema is None or isinstance(schema, (list, tuple)):

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1205,7 +1205,8 @@ class SparkSession(SparkConversionMixin):
 
         elif isinstance(schema, StructType):
             struct = schema
-            tupled_data = data
+            converter = _create_converter(struct)
+            tupled_data: Iterable[Tuple] = map(converter, data)
 
         else:
             raise PySparkTypeError(

--- a/python/pyspark/sql/tests/test_creation.py
+++ b/python/pyspark/sql/tests/test_creation.py
@@ -24,6 +24,9 @@ from typing import cast
 from pyspark.sql import Row
 import pyspark.sql.functions as F
 from pyspark.sql.types import (
+    StructType,
+    StructField,
+    StringType,
     DateType,
     TimestampType,
     TimestampNTZType,
@@ -42,6 +45,21 @@ from pyspark.testing.sqlutils import (
 
 
 class DataFrameCreationTestsMixin:
+    def test_create_str_from_dict(self):
+        data = [
+            {"broker": {"teamId": 3398, "contactEmail": "abc.xyz@123.ca"}},
+        ]
+
+        for schema in [
+            StructType([StructField("broker", StringType())]),
+            "broker: string",
+        ]:
+            df = self.spark.createDataFrame(data, schema=schema)
+            self.assertEqual(
+                df.first().broker,
+                """{'teamId': 3398, 'contactEmail': 'abc.xyz@123.ca'}""",
+            )
+
     def test_create_dataframe_from_array_of_long(self):
         import array
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2510,6 +2510,9 @@ def _need_converter(dataType: DataType) -> bool:
         return _need_converter(dataType.keyType) or _need_converter(dataType.valueType)
     elif isinstance(dataType, NullType):
         return True
+    elif isinstance(dataType, StringType):
+        # Coercion to StringType is allowed, e.g. dict -> str
+        return True
     else:
         return False
 
@@ -2530,6 +2533,10 @@ def _create_converter(dataType: DataType) -> Callable:
 
     elif isinstance(dataType, NullType):
         return lambda x: None
+
+    elif isinstance(dataType, StringType):
+        # Coercion to StringType is allowed, e.g. dict -> str
+        return lambda x: str(x) if x is not None else None
 
     elif not isinstance(dataType, StructType):
         return lambda x: x


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Unify the string coercion in createDataFrame


### Why are the changes needed?
currently there is behavior difference between PySpark Classic and PySpark Connect:

```python
from pyspark.sql.types import StructType, StructField, StringType, IntegerType

items = [{'id': '5558382', 'broker': {'teamId': 3398, 'contactEmail': 'abc.xyz@123.ca'}} ]


schema = StructType([
    StructField("id", StringType()),
    StructField("broker", StringType())
   
])

df = spark.createDataFrame(items, schema=schema)

df.show(truncate=False)
```

PySpark Classic:
```
+-------+------------------------------------------+
|id     |broker                                    |
+-------+------------------------------------------+
|5558382|{contactEmail=abc.xyz@123.ca, teamId=3398}|
+-------+------------------------------------------+
```

PySpark Connect:
```
+-------+--------------------------------------------------+
|id     |broker                                            |
+-------+--------------------------------------------------+
|5558382|{'teamId': 3398, 'contactEmail': 'abc.xyz@123.ca'}|
+-------+--------------------------------------------------+
```

The latter seems more reasonable, the dicts should be converted into strings in the python side.


### Does this PR introduce _any_ user-facing change?
yes, in the PySpark classic


### How was this patch tested?
new UT


### Was this patch authored or co-authored using generative AI tooling?
no