### PR TITLE
Put a patch on bleeding eyes

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -415,8 +415,7 @@ private[spark] class PythonWorkerFactory(
         self.synchronized {
           if (idleWorkers.isEmpty) {
             self.wait()
-          }
-          if (idleWorkers.nonEmpty) {
+          } else {
             val (_, idleAt) = idleWorkers.front
             val curNanos = System.nanoTime
             if ((idleAt + IDLE_WORKER_TIMEOUT_NS) >= curNanos) {


### PR DESCRIPTION
Idle workers should respect idle termination. 
At the moment code does not properly handle termination timeouts for idle workeres. 

In this PR there is an attempt to better handle timeouts without stepping every 10 seconds without any need. 