### PR TITLE
[SPARK-52437][BUILD] Ensure `Annotation Processing` in Java compilation for Java 23+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2808,6 +2808,7 @@
               <javacArg>--release</javacArg>
               <javacArg>${java.version}</javacArg>
               <javacArg>-Xlint:all,-serial,-path,-try</javacArg>
+              <javacArg>-proc:full</javacArg>
             </javacArgs>
           </configuration>
         </plugin>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -313,6 +313,7 @@ object SparkBuild extends PomBuild {
     (Compile / javacOptions) ++= Seq(
       "-encoding", UTF_8.name(),
       "-g",
+      "-proc:full",
       "--release", javaVersion.value
     ),
     // This -target and Xlint:unchecked options cannot be set in the Compile configuration scope since


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ensure `Annotation Processing` in Java compilation.

### Why are the changes needed?

Since JDK 23, `Annotation Processing` is disabled by default. We need to enable it explicitly to be consistent across Java 17/21/25.
- [JDK 23: Changes Default Annotation Processing Policy](https://inside.java/2024/06/18/quality-heads-up/)

For example, `Launcher` fails without this.

### How was this patch tested?

Manual test since we didn't add JDK23+ CI yet.

**Java 25-EA**

```
$ java -version
openjdk version "25-ea" 2025-09-16
OpenJDK Runtime Environment (build 25-ea+26-3358)
OpenJDK 64-Bit Server VM (build 25-ea+26-3358, mixed mode, sharing)
```

**BEFORE**

```
$ mvn package
...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Spark Project Parent POM 4.1.0-SNAPSHOT:
[INFO]
[INFO] Spark Project Parent POM ........................... SUCCESS [  2.604 s]
[INFO] Spark Project Tags ................................. SUCCESS [  5.236 s]
[INFO] Spark Project Sketch ............................... SUCCESS [  9.123 s]
[INFO] Spark Project Common Utils ......................... SUCCESS [ 17.486 s]
[INFO] Spark Project Local DB ............................. SUCCESS [ 10.095 s]
[INFO] Spark Project Networking ........................... SUCCESS [01:01 min]
[INFO] Spark Project Shuffle Streaming Service ............ SUCCESS [ 11.162 s]
[INFO] Spark Project Variant .............................. SUCCESS [  2.899 s]
[INFO] Spark Project Unsafe ............................... SUCCESS [ 11.482 s]
[INFO] Spark Project Connect Shims ........................ SUCCESS [  2.701 s]
[INFO] Spark Project Launcher ............................. FAILURE [  5.519 s]
```

**AFTER**

```
$ mvn package
...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Spark Project Parent POM 4.1.0-SNAPSHOT:
[INFO]
[INFO] Spark Project Parent POM ........................... SUCCESS [  2.598 s]
[INFO] Spark Project Tags ................................. SUCCESS [  5.312 s]
[INFO] Spark Project Sketch ............................... SUCCESS [  9.437 s]
[INFO] Spark Project Common Utils ......................... SUCCESS [ 19.041 s]
[INFO] Spark Project Local DB ............................. SUCCESS [  9.419 s]
[INFO] Spark Project Networking ........................... SUCCESS [01:00 min]
[INFO] Spark Project Shuffle Streaming Service ............ SUCCESS [ 11.515 s]
[INFO] Spark Project Variant .............................. SUCCESS [  2.966 s]
[INFO] Spark Project Unsafe ............................... SUCCESS [ 11.876 s]
[INFO] Spark Project Connect Shims ........................ SUCCESS [  2.916 s]
[INFO] Spark Project Launcher ............................. SUCCESS [  6.806 s]
...
```

### Was this patch authored or co-authored using generative AI tooling?

No.