### PR TITLE
[SPARK-52858][INFRA] Retry SBT compilation when OOM

### DIFF
--- a/python/pyspark/tests/test_util.py
+++ b/python/pyspark/tests/test_util.py
@@ -38,6 +38,9 @@ class KeywordOnlyTests(unittest.TestCase):
                 self._y = self._input_kwargs["y"]
             return x, y
 
+    def test_job_retry(self):
+        self.assertEqual(1, 2)
+
     def test_keywords(self):
         w = self.Wrapped()
         x, y = w.set(y=1)

--- a/python/pyspark/tests/test_util.py
+++ b/python/pyspark/tests/test_util.py
@@ -38,9 +38,6 @@ class KeywordOnlyTests(unittest.TestCase):
                 self._y = self._input_kwargs["y"]
             return x, y
 
-    def test_job_retry(self):
-        self.assertEqual(1, 2)
-
     def test_keywords(self):
         w = self.Wrapped()
         x, y = w.set(y=1)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Retry SBT compilation when OOM

### Why are the changes needed?
The CI is suffering SBT compilation OOM a lot in the last several months.


### Does this PR introduce _any_ user-facing change?
No, infra-only


### How was this patch tested?
Manually check following log

```
[info] Retrying command ['/__w/spark/spark/build/sbt', '-Phadoop-3', '-Phive', '-Pvolcano', '-Pkubernetes', '-Pjvm-profiler', '-Phive-thriftserver', '-Phadoop-cloud', '-Pyarn', '-Pspark-ganglia-lgpl', '-Pdocker-integration-tests', '-Pkinesis-asl', 'Test/package', 'streaming-kinesis-asl-assembly/assembly', 'connect/assembly'] ; attempt  2  of  3
Using /__t/Java_Zulu_jdk/17.0.16-8/x64 as default JAVA_HOME.
```

see https://github.com/zhengruifeng/spark/actions/runs/16343126445/job/46171805328

```
Warning: [732.595s][warning][gc,alloc] pool-6-thread-406: Retried waiting for GCLocker too often allocating 32391 words
[info] Compilation has been cancelled
[info] Compilation has been cancelled
[warn] javac exited with exit code -1
java.lang.OutOfMemoryError: Java heap space
	at java.base/java.lang.AbstractStringBuilder.<init>(AbstractStringBuilder.java:88)
	at java.base/java.lang.StringBuilder.<init>(StringBuilder.java:106)
	at

...

Error:  [launcher] error during sbt launcher: java.lang.OutOfMemoryError: Java heap space
[error] running /__w/spark/spark/build/sbt -Phadoop-3 -Phive -Pvolcano -Pkubernetes -Pjvm-profiler -Phive-thriftserver -Phadoop-cloud -Pyarn -Pspark-ganglia-lgpl -Pdocker-integration-tests -Pkinesis-asl Test/package streaming-kinesis-asl-assembly/assembly connect/assembly ; received return code 1
[info] Retrying command ['/__w/spark/spark/build/sbt', '-Phadoop-3', '-Phive', '-Pvolcano', '-Pkubernetes', '-Pjvm-profiler', '-Phive-thriftserver', '-Phadoop-cloud', '-Pyarn', '-Pspark-ganglia-lgpl', '-Pdocker-integration-tests', '-Pkinesis-asl', 'Test/package', 'streaming-kinesis-asl-assembly/assembly', 'connect/assembly'] ; attempt  2  of  3
Using /__t/Java_Zulu_jdk/17.0.16-8/x64 as default JAVA_HOME.
Note, this will be overridden by -java-home if it is set.
Using SPARK_LOCAL_IP=localhost
[info] welcome to sbt 1.9.3 (Azul Systems, Inc. Java 17.0.16)
[info] loading settings for project spark-build from plugins.sbt ...
[info] loading project definition from /__w/spark/spark/project
[info] resolving key references (48107 settings) ...
[info] set current project to spark-parent (in build file:/__w/spark/spark/)
[warn] there are 264 keys that are not used by any other settings/tasks:
```


### Was this patch authored or co-authored using generative AI tooling?
No