### PR TITLE
[SPARK-52441][INFRA] Skip testing `sql/pipelines` module in the Maven daily test when the input branch is branch-4.0

### DIFF
--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -190,6 +190,7 @@ jobs:
           export MAVEN_OPTS="-Xss64m -Xmx4g -Xms4g -XX:ReservedCodeCacheSize=128m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
           export MAVEN_CLI_OPTS="--no-transfer-progress"
           export JAVA_VERSION=${{ matrix.java }}
+          export INPUT_BRANCH=${{ inputs.branch }}
           export ENABLE_KINESIS_TESTS=0
           # Replace with the real module name, for example, connector#kafka-0-10 -> connector/kafka-0-10
           export TEST_MODULES=`echo "$MODULES_TO_TEST" | sed -e "s%#%/%g"`
@@ -209,6 +210,10 @@ jobs:
           elif [[ "$MODULES_TO_TEST" == *"sql#hive-thriftserver"* ]]; then
             # To avoid a compilation loop, for the `sql/hive-thriftserver` module, run `clean install` instead
             ./build/mvn $MAVEN_CLI_OPTS -pl "$TEST_MODULES" -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pjvm-profiler -Pspark-ganglia-lgpl -Pkinesis-asl -Djava.version=${JAVA_VERSION/-ea} clean install -fae
+          elif [[ "$MODULES_TO_TEST" == *"sql#pipelines"* && "$INPUT_BRANCH" == "branch-4.0" ]]; then
+            # SPARK-52441: Remove sql/pipelines from TEST_MODULES for branch-4.0, this branch can be deleted after the EOL of branch-4.0.
+            TEST_MODULES=${TEST_MODULES/,sql\/pipelines/}
+            ./build/mvn $MAVEN_CLI_OPTS -pl "$TEST_MODULES" -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Pspark-ganglia-lgpl -Phadoop-cloud -Pjvm-profiler -Pkinesis-asl -Djava.version=${JAVA_VERSION/-ea} test -fae
           else
             ./build/mvn $MAVEN_CLI_OPTS -pl "$TEST_MODULES" -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Pspark-ganglia-lgpl -Phadoop-cloud -Pjvm-profiler -Pkinesis-asl -Djava.version=${JAVA_VERSION/-ea} test -fae
           fi


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to skip testing `sql/pipelines` module in the Maven daily test when the input branch is branch-4.0 because branch-4.0 doesn't have this module

### Why are the changes needed?
Fix branch-4.0 maven daily test:
- https://github.com/apache/spark/actions/runs/15561695563/job/43815397047

![image](https://github.com/user-attachments/assets/583289f0-0fbf-4ff2-b45d-97de9e59bacf)



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Monitor the Maven daily tests for branch-4.0 after merged


### Was this patch authored or co-authored using generative AI tooling?
No
