### PR TITLE
[SPARK-49110][SQL] Fix reading metadata columns for tables with CHAR columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyCharTypePaddingHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyCharTypePaddingHelper.scala
@@ -65,6 +65,13 @@ object ApplyCharTypePaddingHelper {
     }
   }
 
+  private[sql] def isReadSidePadding(p: Project): Boolean = {
+    p.projectList.exists {
+      case Alias(e, _) => CharVarcharUtils.containsPaddingForScan(e)
+      case _ => false
+    }
+  }
+
   private[sql] def paddingForStringComparison(
       plan: LogicalPlan,
       padCharCol: Boolean): LogicalPlan = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharUtils.scala
@@ -243,6 +243,14 @@ object CharVarcharUtils extends Logging with SparkCharVarcharUtils {
     }.getOrElse(attr)
   }
 
+  private[sql] def containsPaddingForScan(e: Expression): Boolean = e.exists {
+    case s: StaticInvoke =>
+      s.staticObject == classOf[CharVarcharCodegenUtils] &&
+      s.functionName == "readSidePadding"
+    case _ =>
+      false
+  }
+
   /**
    * Return expressions to apply char type padding for the string comparison between the given
    * attributes. When comparing two char type columns/fields, we need to pad the shorter one to


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR modifies `SubqueryAlias` to propagate the metadata output of its child if the is a `Project` injected by `ApplyCharTypePadding`.

### Why are the changes needed?

This is needed because with these changes it is not possible to read metadata columns when reading a table with a CHAR column when read-side padding is enabled. In the case the plan is `SubqueryAlias(Project(LeafNode)))`, so without this patch the metadata output is not propagated.

### Does this PR introduce _any_ user-facing change?

Yes, there will be more cases in which the metadata columns can be accessed, and users will no longer get an exception in these cases.

### How was this patch tested?

Added a case to `MetadataColumnSuite`.

### Was this patch authored or co-authored using generative AI tooling?

No
