### PR TITLE
[SPARK-52447][SQL] Move GetViewColumnByNameAndOrdinal normalization to SessionCatalogSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -749,6 +749,13 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
     Project(projectList, CatalystSqlParser.parsePlan(metadata.viewText.get))
   }
 
+  private def stripViewDDLFromGetViewColumbByNameAndOrdinal(plan: LogicalPlan): LogicalPlan = {
+    plan.transformAllExpressions {
+      case getViewColumnByNameAndOrdinal: GetViewColumnByNameAndOrdinal =>
+        getViewColumnByNameAndOrdinal.copy(viewDDL = None)
+    }
+  }
+
   test("look up view relation") {
     withBasicCatalog { catalog =>
       val props = CatalogTable.catalogAndNamespaceToProps("cat1", Seq("ns1"))
@@ -762,11 +769,17 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
       // Look up a view.
       catalog.setCurrentDatabase("default")
       val view = View(desc = metadata, isTempView = false, child = getViewPlan(metadata))
-      comparePlans(catalog.lookupRelation(TableIdentifier("view1", Some("db3"))),
+      comparePlans(
+        stripViewDDLFromGetViewColumbByNameAndOrdinal(
+          catalog.lookupRelation(TableIdentifier("view1", Some("db3")))
+        ),
         SubqueryAlias(Seq(CatalogManager.SESSION_CATALOG_NAME, "db3", "view1"), view))
       // Look up a view using current database of the session catalog.
       catalog.setCurrentDatabase("db3")
-      comparePlans(catalog.lookupRelation(TableIdentifier("view1")),
+      comparePlans(
+        stripViewDDLFromGetViewColumbByNameAndOrdinal(
+          catalog.lookupRelation(TableIdentifier("view1"))
+        ),
         SubqueryAlias(Seq(CatalogManager.SESSION_CATALOG_NAME, "db3", "view1"), view))
     }
   }
@@ -781,7 +794,10 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
       assert(metadata.viewCatalogAndNamespace == Seq(CatalogManager.SESSION_CATALOG_NAME, "db2"))
 
       val view = View(desc = metadata, isTempView = false, child = getViewPlan(metadata))
-      comparePlans(catalog.lookupRelation(TableIdentifier("view2", Some("db3"))),
+      comparePlans(
+        stripViewDDLFromGetViewColumbByNameAndOrdinal(
+          catalog.lookupRelation(TableIdentifier("view2", Some("db3")))
+        ),
         SubqueryAlias(Seq(CatalogManager.SESSION_CATALOG_NAME, "db3", "view2"), view))
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Move `GetViewColumnByNameAndOrdinal` normalization to `SessionCatalogSuite`. This normalization is not universal and is only relevant for that suite.

### Why are the changes needed?

To avoid dropping coverage when comparing single-pass and fixed-point Analyzer logical plans.

### Does this PR introduce _any_ user-facing change?

Test-only change.

### How was this patch tested?

Updated `SessionCatalogSuite`.

### Was this patch authored or co-authored using generative AI tooling?

No.