### PR TITLE
[SPARK-52422][PYTHON][FOLLOW-UP] Upgrade required pandas version in API doc gen

### DIFF
--- a/python/pyspark/pandas/supported_api_gen.py
+++ b/python/pyspark/pandas/supported_api_gen.py
@@ -38,7 +38,7 @@ from pyspark.pandas.exceptions import PandasNotImplementedError
 MAX_MISSING_PARAMS_SIZE = 5
 COMMON_PARAMETER_SET = {"kwargs", "args", "cls"}
 MODULE_GROUP_MATCH = [(pd, ps), (pdw, psw), (pdg, psg)]
-PANDAS_LATEST_VERSION = "2.2.3"
+PANDAS_LATEST_VERSION = "2.3.0"
 
 RST_HEADER = """
 =====================


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/51123 that upgrades required pandas version in API doc gen

### Why are the changes needed?

The documentation build fails: https://github.com/apache/spark/actions/runs/15588545220/job/43901202898

### Does this PR introduce _any_ user-facing change?

Yes, otherwise the documentation build fails.

### How was this patch tested?

I will monitor the build.

### Was this patch authored or co-authored using generative AI tooling?

No.