### PR TITLE
[SPARK-52454][BUILD] Automatically remove old releases from the mirror

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -180,6 +180,24 @@ if [[ "$1" == "finalize" ]]; then
   echo "KEYS sync'ed"
   rm -rf svn-spark
 
+  # TODO: Test it in the actual official release
+  # Remove old releases from the mirror
+  # Extract major.minor prefix
+  RELEASE_SERIES=$(echo "$RELEASE_VERSION" | cut -d. -f1-2)
+  
+  # Fetch existing dist URLs
+  OLD_VERSION=$(svn ls https://dist.apache.org/repos/dist/release/spark/ | \
+    grep "^spark-$RELEASE_SERIES" | \
+    grep -v "^spark-$RELEASE_VERSION/" | \
+    sed 's#/##' | sed 's/^spark-//' | \
+    sort -V | tail -n 1)
+  
+  if [[ -n "$OLD_VERSION" ]]; then
+    echo "Removing old version: spark-$OLD_VERSION"
+    svn rm "https://dist.apache.org/repos/dist/release/spark/spark-$OLD_VERSION" -m "Remove older $RELEASE_SERIES release after $RELEASE_VERSION"
+  else
+    echo "No previous $RELEASE_SERIES version found to remove. Manually remove it if there is."
+  fi
   exit 0
 fi
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds the automated step for "Remove old releases from Mirror Network" in https://spark.apache.org/release-process.html

### Why are the changes needed?

To make the release easier.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested the commands but it needs to be tested in the official release.

### Was this patch authored or co-authored using generative AI tooling?

No.