### PR TITLE
[SPARK-52458][CORE] Support `spark.eventLog.excludedPatterns`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
@@ -43,6 +43,7 @@ import org.apache.spark.util.Utils
  *   spark.eventLog.compression.codec - The codec to compress logged events
  *   spark.eventLog.overwrite - Whether to overwrite any existing files
  *   spark.eventLog.buffer.kb - Buffer size to use when writing to output streams
+ *   spark.eventLog.excludedPatterns - Specifes a comma-separated event names to be excluded
  *
  * Note that descendant classes can maintain its own parameters: refer the javadoc of each class
  * for more details.
@@ -58,6 +59,8 @@ abstract class EventLogFileWriter(
 
   protected val shouldCompress = sparkConf.get(EVENT_LOG_COMPRESS) &&
       !sparkConf.get(EVENT_LOG_COMPRESSION_CODEC).equalsIgnoreCase("none")
+  protected val excludedPatterns = sparkConf.get(EVENT_LOG_EXCLUDED_PATTERNS)
+      .toSeq.flatMap(Utils.stringToSeq).map(name => s"""{"Event":"$name"""")
   protected val shouldOverwrite = sparkConf.get(EVENT_LOG_OVERWRITE)
   protected val outputBufferSize = sparkConf.get(EVENT_LOG_OUTPUT_BUFFER_SIZE).toInt * 1024
   protected val fileSystem = Utils.getHadoopFileSystem(logBaseDir, hadoopConf)
@@ -117,6 +120,7 @@ abstract class EventLogFileWriter(
   }
 
   protected def writeLine(line: String, flushLogger: Boolean = false): Unit = {
+    if (excludedPatterns.exists(line.startsWith(_))) return
     // scalastyle:off println
     writer.foreach(_.println(line))
     // scalastyle:on println

--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
@@ -60,7 +60,7 @@ abstract class EventLogFileWriter(
   protected val shouldCompress = sparkConf.get(EVENT_LOG_COMPRESS) &&
       !sparkConf.get(EVENT_LOG_COMPRESSION_CODEC).equalsIgnoreCase("none")
   protected val excludedPatterns = sparkConf.get(EVENT_LOG_EXCLUDED_PATTERNS)
-      .toSeq.flatMap(Utils.stringToSeq).map(name => s"""{"Event":"$name"""")
+      .map(name => s"""{"Event":"$name"""")
   protected val shouldOverwrite = sparkConf.get(EVENT_LOG_OVERWRITE)
   protected val outputBufferSize = sparkConf.get(EVENT_LOG_OUTPUT_BUFFER_SIZE).toInt * 1024
   protected val fileSystem = Utils.getHadoopFileSystem(logBaseDir, hadoopConf)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -226,10 +226,11 @@ package object config {
 
   private[spark] val EVENT_LOG_EXCLUDED_PATTERNS =
     ConfigBuilder("spark.eventLog.excludedPatterns")
-      .doc("Specifies a comma-separated event names to be excluded from the event logs.")
+      .doc("Specifies comma-separated event names to be excluded from the event logs.")
       .version("4.1.0")
       .stringConf
-      .createOptional
+      .toSequence
+      .createWithDefault(Nil)
 
   private[spark] val EVENT_LOG_ALLOW_EC =
     ConfigBuilder("spark.eventLog.erasureCoding.enabled")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -224,6 +224,13 @@ package object config {
       .booleanConf
       .createWithDefault(false)
 
+  private[spark] val EVENT_LOG_EXCLUDED_PATTERNS =
+    ConfigBuilder("spark.eventLog.excludedPatterns")
+      .doc("Specifies a comma-separated event names to be excluded from the event logs.")
+      .version("4.1.0")
+      .stringConf
+      .createOptional
+
   private[spark] val EVENT_LOG_ALLOW_EC =
     ConfigBuilder("spark.eventLog.erasureCoding.enabled")
       .version("3.0.0")

--- a/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileWritersSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileWritersSuite.scala
@@ -117,7 +117,7 @@ abstract class EventLogFileWritersSuite extends SparkFunSuite with LocalSparkCon
     val attemptId = None
 
     val conf = getLoggingConf(testDirPath, None)
-    conf.set(EVENT_LOG_EXCLUDED_PATTERNS, "B,C")
+    conf.set(EVENT_LOG_EXCLUDED_PATTERNS, Seq("B", "C"))
 
     val writer = createWriter(appId, attemptId, testDirPath.toUri, conf,
       SparkHadoopUtil.get.newConfiguration(conf))

--- a/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileWritersSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileWritersSuite.scala
@@ -112,6 +112,26 @@ abstract class EventLogFileWritersSuite extends SparkFunSuite with LocalSparkCon
     assert(writer.compressionCodecName === EVENT_LOG_COMPRESSION_CODEC.defaultValue)
   }
 
+  test("SPARK-52458: Support spark.eventLog.excludedPatterns") {
+    val appId = getUniqueApplicationId
+    val attemptId = None
+
+    val conf = getLoggingConf(testDirPath, None)
+    conf.set(EVENT_LOG_EXCLUDED_PATTERNS, "B,C")
+
+    val writer = createWriter(appId, attemptId, testDirPath.toUri, conf,
+      SparkHadoopUtil.get.newConfiguration(conf))
+
+    writer.start()
+    Seq("A", "B", "C", "D").foreach { name =>
+      writer.writeEvent(s"""{"Event":"$name"}""", flushLogger = true)
+    }
+    writer.stop()
+
+    verifyWriteEventLogFile(appId, attemptId, testDirPath.toUri,
+      None, Seq("""{"Event":"A"}""", """{"Event":"D"}"""))
+  }
+
   protected def readLinesFromEventLogFile(log: Path, fs: FileSystem): List[String] = {
     val logDataStream = EventLogFileReader.openEventLog(log, fs)
     try {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `spark.eventLog.excludedPatterns` to exclude specific `SparkEvent`s. This has two goals.
1. Save the cost of event log processing.
2. Provide a full control to save or not on top of the existing `logEvent`.

https://github.com/apache/spark/blob/68136fd50a5b635ed5f1a17984b79d86bdc357eb/common/utils/src/main/scala/org/apache/spark/scheduler/SparkListenerEvent.scala#L25-L28

### Why are the changes needed?

Historically, Apache Spark provides multiple ways to manage the event logs to save a storage cost.
- `spark.history.fs.cleaner.maxAge`: Delete old Spark jobs by age
- `spark.history.fs.cleaner.maxNum`: Delete old Spark jobs by the total number of jobs
- `spark.history.fs.eventLog.rolling.maxFilesToRetain`: Decompress + Compact + Compress back

For example, after compaction, Spark event logs only have the following.

```
// The extracted event names from a `compacted` event log file
"SparkListenerLogStart"
"SparkListenerResourceProfileAdded"
"org.apache.spark.sql.connect.service.SparkListenerConnectServiceStarted"
"SparkListenerBlockManagerAdded"
"SparkListenerEnvironmentUpdate"
"SparkListenerApplicationStart"
"SparkListenerExecutorAdded"
"SparkListenerBlockManagerAdded"
"SparkListenerExecutorAdded"
"SparkListenerBlockManagerAdded"
"SparkListenerJobStart"
"SparkListenerStageSubmitted"
"SparkListenerTaskStart"
"SparkListenerTaskEnd"
"SparkListenerStageCompleted"
```

This PR aims to provide a simple alternative to allow the users to skip specific Spark events completely.

```
org.apache.spark.sql.execution.ui.SparkListenerSQLAdaptiveExecutionUpdate
org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart
org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
org.apache.spark.sql.execution.ui.SparkListenerDriverAccumUpdates
```

### Does this PR introduce _any_ user-facing change?

No. This is a new feature.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.