### PR TITLE
[MINOR][DOCS] Fix broken link for Python Package Management

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -462,7 +462,7 @@ Lines with a: 46, Lines with b: 23
 
 </div>
 
-Other dependency management tools such as Conda and pip can be also used for custom classes or third-party libraries. See also [Python Package Management](api/python/user_guide/python_packaging.html).
+Other dependency management tools such as Conda and pip can be also used for custom classes or third-party libraries. See also [Python Package Management](api/python/tutorial/python_packaging.html).
 
 # Where to Go from Here
 Congratulations on running your first Spark application!

--- a/docs/submitting-applications.md
+++ b/docs/submitting-applications.md
@@ -36,7 +36,7 @@ script as shown here while passing your jar.
 For Python, you can use the `--py-files` argument of `spark-submit` to add `.py`, `.zip` or `.egg`
 files to be distributed with your application. If you depend on multiple Python files we recommend
 packaging them into a `.zip` or `.egg`. For third-party Python dependencies,
-see [Python Package Management](api/python/user_guide/python_packaging.html).
+see [Python Package Management](api/python/tutorial/python_packaging.html).
 
 # Launching Applications with spark-submit
 


### PR DESCRIPTION


### What changes were proposed in this pull request?

Use https://spark.apache.org/docs/latest/api/python/tutorial/python_packaging.html as the correct href


### Why are the changes needed?
docfix


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
view manually 

### Was this patch authored or co-authored using generative AI tooling?
no
