### PR TITLE
[SPARK-52489][SQL] Forbid duplicate SQLEXCEPTION and NOT FOUND handlers inside SQL Script

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreter.scala
@@ -122,12 +122,21 @@ case class SqlScriptingInterpreter(session: SparkSession) {
 
       // Get NOT FOUND handler.
       notFoundHandler = if (handler.exceptionHandlerTriggers.notFound) {
-        Some(handlerExec)
+        if (notFoundHandler.isDefined) {
+          throw SqlScriptingErrors.duplicateHandlerForSameCondition(CurrentOrigin.get, "NOT FOUND")
+        } else {
+          Some(handlerExec)
+        }
       } else None
 
       // Get SQLEXCEPTION handler.
       sqlExceptionHandler = if (handler.exceptionHandlerTriggers.sqlException) {
-        Some(handlerExec)
+        if (sqlExceptionHandler.isDefined) {
+          throw SqlScriptingErrors
+            .duplicateHandlerForSameCondition(CurrentOrigin.get, "SQLEXCEPTION")
+        } else {
+          Some(handlerExec)
+        }
       } else None
     })
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -3498,7 +3498,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         runSqlScript(sqlScript)
       },
       condition = "DUPLICATE_EXCEPTION_HANDLER.CONDITION",
-      parameters = Map.empty
+      parameters = Map("condition" -> "SQLEXCEPTION")
     )
   }
 
@@ -3520,7 +3520,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         runSqlScript(sqlScript)
       },
       condition = "DUPLICATE_EXCEPTION_HANDLER.CONDITION",
-      parameters = Map.empty
+      parameters = Map("condition" -> "NOT FOUND")
     )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -3478,4 +3478,49 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
       verifySqlScriptResult(sqlScript, expected)
     }
   }
+
+  test("Duplicate SQLEXCEPTION Handler") {
+    val sqlScript =
+      """
+        |BEGIN
+        |  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+        |  BEGIN
+        |    SELECT 1;
+        |  END;
+        |  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+        |  BEGIN
+        |    SELECT 2;
+        |  END;
+        |
+        |END""".stripMargin
+    checkError(
+      exception = intercept[SqlScriptingException] {
+        runSqlScript(sqlScript)
+      },
+      condition = "DUPLICATE_EXCEPTION_HANDLER.CONDITION",
+      parameters = Map.empty
+    )
+  }
+
+  test("Duplicate NOT FOUND Handler") {
+    val sqlScript =
+      """
+        |BEGIN
+        |  DECLARE EXIT HANDLER FOR NOT FOUND
+        |  BEGIN
+        |    SELECT 1;
+        |  END;
+        |  DECLARE EXIT HANDLER FOR NOT FOUND
+        |  BEGIN
+        |    SELECT 2;
+        |  END;
+        |END""".stripMargin
+    checkError(
+      exception = intercept[SqlScriptingException] {
+        runSqlScript(sqlScript)
+      },
+      condition = "DUPLICATE_EXCEPTION_HANDLER.CONDITION",
+      parameters = Map.empty
+    )
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR we forbid duplicate SQLEXCEPTION or NOT FOUND exception handlers to be defined in the same scope. This was already done for different conditions and sqlstates but was not done for these 2 types of exception handlers. Code like this should fail:

```
BEGIN
  DECLARE EXIT HANDLER FOR NOT FOUND
  BEGIN
    SELECT 1;
  END;
  DECLARE EXIT HANDLER FOR NOT FOUND
  BEGIN
    SELECT 2;
  END;
END
```

### Why are the changes needed?
This is a bug fix.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New tests in `SqlScriptingInterpreterSuite`.

### Was this patch authored or co-authored using generative AI tooling?
No.
