### PR TITLE
[SQL][MINOR] Inline recursive CTEs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTE.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTE.scala
@@ -61,10 +61,7 @@ case class InlineCTE(
     // 1) It is fine to inline a CTE if it references another CTE that is non-deterministic;
     // 2) Any `CTERelationRef` that contains `OuterReference` would have been inlined first.
     refCount == 1 ||
-      // Don't inline recursive CTEs if not necessary as recursion is very costly.
-      // The check if cteDef is recursive is performed by checking if it contains
-      // a UnionLoopRef with the same ID.
-      (cteDef.deterministic && !cteDef.hasSelfReferenceAsUnionLoopRef) ||
+      cteDef.deterministic ||
       cteDef.child.exists(_.expressions.exists(_.isInstanceOf[OuterReference]))
   }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
@@ -1854,3 +1854,160 @@ WithCTE
       +- Project [n#x]
          +- SubqueryAlias t1
             +- CTERelationRef xxxx, true, [n#x], false, false
+
+
+-- !query
+WITH RECURSIVE t1(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM t1 WHERE n < 5
+)
+SELECT (SELECT SUM(n) FROM (SELECT * FROM t1)), (SELECT SUM(n) FROM (SELECT * FROM t1 LIMIT 3))
+-- !query analysis
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t1
+:     +- Project [1#x AS n#x]
+:        +- UnionLoop xxxx
+:           :- Project [1 AS 1#x]
+:           :  +- OneRowRelation
+:           +- Project [(n#x + 1) AS (n + 1)#x]
+:              +- Filter (n#x < 5)
+:                 +- SubqueryAlias t1
+:                    +- Project [1#x AS n#x]
+:                       +- UnionLoopRef xxxx, [1#x], false
++- Project [scalar-subquery#x [] AS scalarsubquery()#xL, scalar-subquery#x [] AS scalarsubquery()#xL]
+   :  :- Aggregate [sum(n#x) AS sum(n)#xL]
+   :  :  +- SubqueryAlias __auto_generated_subquery_name
+   :  :     +- Project [n#x]
+   :  :        +- SubqueryAlias t1
+   :  :           +- CTERelationRef xxxx, true, [n#x], false, false
+   :  +- Aggregate [sum(n#x) AS sum(n)#xL]
+   :     +- SubqueryAlias __auto_generated_subquery_name
+   :        +- GlobalLimit 3
+   :           +- LocalLimit 3
+   :              +- Project [n#x]
+   :                 +- SubqueryAlias t1
+   :                    +- CTERelationRef xxxx, true, [n#x], false, false
+   +- OneRowRelation
+
+
+-- !query
+WITH RECURSIVE t1(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM t1
+)
+SELECT (SELECT SUM(n) FROM (SELECT * FROM t1 LIMIT 5)), (SELECT SUM(n) FROM (SELECT * FROM t1 LIMIT 3))
+-- !query analysis
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t1
+:     +- Project [1#x AS n#x]
+:        +- UnionLoop xxxx
+:           :- Project [1 AS 1#x]
+:           :  +- OneRowRelation
+:           +- Project [(n#x + 1) AS (n + 1)#x]
+:              +- SubqueryAlias t1
+:                 +- Project [1#x AS n#x]
+:                    +- UnionLoopRef xxxx, [1#x], false
++- Project [scalar-subquery#x [] AS scalarsubquery()#xL, scalar-subquery#x [] AS scalarsubquery()#xL]
+   :  :- Aggregate [sum(n#x) AS sum(n)#xL]
+   :  :  +- SubqueryAlias __auto_generated_subquery_name
+   :  :     +- GlobalLimit 5
+   :  :        +- LocalLimit 5
+   :  :           +- Project [n#x]
+   :  :              +- SubqueryAlias t1
+   :  :                 +- CTERelationRef xxxx, true, [n#x], false, false
+   :  +- Aggregate [sum(n#x) AS sum(n)#xL]
+   :     +- SubqueryAlias __auto_generated_subquery_name
+   :        +- GlobalLimit 3
+   :           +- LocalLimit 3
+   :              +- Project [n#x]
+   :                 +- SubqueryAlias t1
+   :                    +- CTERelationRef xxxx, true, [n#x], false, false
+   +- OneRowRelation
+
+
+-- !query
+WITH RECURSIVE t1(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM t1
+), t2(m) AS (
+    SELECT (SELECT SUM(n) FROM (SELECT n FROM t1 LIMIT 10) AS sums)
+    UNION ALL
+    SELECT m + (SELECT SUM(n) FROM (SELECT n FROM t1 LIMIT 3) AS sums) FROM t2
+)
+SELECT * FROM t2 LIMIT 20
+-- !query analysis
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t1
+:     +- Project [1#x AS n#x]
+:        +- UnionLoop xxxx
+:           :- Project [1 AS 1#x]
+:           :  +- OneRowRelation
+:           +- Project [(n#x + 1) AS (n + 1)#x]
+:              +- SubqueryAlias t1
+:                 +- Project [1#x AS n#x]
+:                    +- UnionLoopRef xxxx, [1#x], false
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t2
+:     +- Project [scalarsubquery()#xL AS m#xL]
+:        +- UnionLoop xxxx
+:           :- Project [scalar-subquery#x [] AS scalarsubquery()#xL]
+:           :  :  +- Aggregate [sum(n#x) AS sum(n)#xL]
+:           :  :     +- SubqueryAlias sums
+:           :  :        +- GlobalLimit 10
+:           :  :           +- LocalLimit 10
+:           :  :              +- Project [n#x]
+:           :  :                 +- SubqueryAlias t1
+:           :  :                    +- CTERelationRef xxxx, true, [n#x], false, false
+:           :  +- OneRowRelation
+:           +- Project [(m#xL + scalar-subquery#x []) AS (m + scalarsubquery())#xL]
+:              :  +- Aggregate [sum(n#x) AS sum(n)#xL]
+:              :     +- SubqueryAlias sums
+:              :        +- GlobalLimit 3
+:              :           +- LocalLimit 3
+:              :              +- Project [n#x]
+:              :                 +- SubqueryAlias t1
+:              :                    +- CTERelationRef xxxx, true, [n#x], false, false
+:              +- SubqueryAlias t2
+:                 +- Project [scalarsubquery()#xL AS m#xL]
+:                    +- UnionLoopRef xxxx, [scalarsubquery()#xL], false
++- GlobalLimit 20
+   +- LocalLimit 20
+      +- Project [m#xL]
+         +- SubqueryAlias t2
+            +- CTERelationRef xxxx, true, [m#xL], false, false
+
+
+-- !query
+WITH RECURSIVE t1(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM t1
+)
+    ((SELECT n FROM t1) UNION ALL (SELECT n FROM t1)) LIMIT 20
+-- !query analysis
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t1
+:     +- Project [1#x AS n#x]
+:        +- UnionLoop xxxx
+:           :- Project [1 AS 1#x]
+:           :  +- OneRowRelation
+:           +- Project [(n#x + 1) AS (n + 1)#x]
+:              +- SubqueryAlias t1
+:                 +- Project [1#x AS n#x]
+:                    +- UnionLoopRef xxxx, [1#x], false
++- GlobalLimit 20
+   +- LocalLimit 20
+      +- Union false, false
+         :- Project [n#x]
+         :  +- SubqueryAlias t1
+         :     +- CTERelationRef xxxx, true, [n#x], false, false
+         +- Project [n#x]
+            +- SubqueryAlias t1
+               +- CTERelationRef xxxx, true, [n#x], false, false

--- a/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
@@ -690,3 +690,39 @@ WITH RECURSIVE t1(n) AS (
     SELECT CASE WHEN n < 5 THEN n + 1 ELSE NULL END FROM t1
 )
 SELECT * FROM t1 LIMIT 25;
+
+-- Two calls to same rCTE with and without limit
+WITH RECURSIVE t1(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM t1 WHERE n < 5
+)
+SELECT (SELECT SUM(n) FROM (SELECT * FROM t1)), (SELECT SUM(n) FROM (SELECT * FROM t1 LIMIT 3));
+
+-- Two calls to same infinite rCTE with different limits
+WITH RECURSIVE t1(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM t1
+)
+SELECT (SELECT SUM(n) FROM (SELECT * FROM t1 LIMIT 5)), (SELECT SUM(n) FROM (SELECT * FROM t1 LIMIT 3));
+
+-- Two calls to same infinite rCTE from another rCTE
+WITH RECURSIVE t1(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM t1
+), t2(m) AS (
+    SELECT (SELECT SUM(n) FROM (SELECT n FROM t1 LIMIT 10) AS sums)
+    UNION ALL
+    SELECT m + (SELECT SUM(n) FROM (SELECT n FROM t1 LIMIT 3) AS sums) FROM t2
+)
+SELECT * FROM t2 LIMIT 20;
+
+-- Two calls to recursive CTE with single limit pushed to both
+WITH RECURSIVE t1(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM t1
+)
+    ((SELECT n FROM t1) UNION ALL (SELECT n FROM t1)) LIMIT 20

--- a/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
@@ -1710,3 +1710,97 @@ NULL
 NULL
 NULL
 NULL
+
+
+-- !query
+WITH RECURSIVE t1(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM t1 WHERE n < 5
+)
+SELECT (SELECT SUM(n) FROM (SELECT * FROM t1)), (SELECT SUM(n) FROM (SELECT * FROM t1 LIMIT 3))
+-- !query schema
+struct<scalarsubquery():bigint,scalarsubquery():bigint>
+-- !query output
+15	6
+
+
+-- !query
+WITH RECURSIVE t1(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM t1
+)
+SELECT (SELECT SUM(n) FROM (SELECT * FROM t1 LIMIT 5)), (SELECT SUM(n) FROM (SELECT * FROM t1 LIMIT 3))
+-- !query schema
+struct<scalarsubquery():bigint,scalarsubquery():bigint>
+-- !query output
+15	6
+
+
+-- !query
+WITH RECURSIVE t1(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM t1
+), t2(m) AS (
+    SELECT (SELECT SUM(n) FROM (SELECT n FROM t1 LIMIT 10) AS sums)
+    UNION ALL
+    SELECT m + (SELECT SUM(n) FROM (SELECT n FROM t1 LIMIT 3) AS sums) FROM t2
+)
+SELECT * FROM t2 LIMIT 20
+-- !query schema
+struct<m:bigint>
+-- !query output
+103
+109
+115
+121
+127
+133
+139
+145
+151
+157
+163
+169
+55
+61
+67
+73
+79
+85
+91
+97
+
+
+-- !query
+WITH RECURSIVE t1(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM t1
+)
+    ((SELECT n FROM t1) UNION ALL (SELECT n FROM t1)) LIMIT 20
+-- !query schema
+struct<n:int>
+-- !query output
+1
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+2
+20
+3
+4
+5
+6
+7
+8
+9


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove check that prevents recursive CTEs from being inlined.

### Why are the changes needed?

Because of LIMITs being able to stop recursive CTEs, we don't want to put repartition by expression above them so that that LocalLimit can be pushed down to UnionLoop.

This prevents infinite recursion when using LIMIT to stop infinite recursion for an rCTE called twice.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New golden file tests.

### Was this patch authored or co-authored using generative AI tooling?

No.