### PR TITLE
[SPARK-52469][CORE] Use JEP 223 API to process Java version

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -51,7 +51,7 @@ import com.google.common.net.InetAddresses
 import jakarta.ws.rs.core.UriBuilder
 import org.apache.commons.codec.binary.Hex
 import org.apache.commons.io.IOUtils
-import org.apache.commons.lang3.{JavaVersion, SystemUtils}
+import org.apache.commons.lang3.SystemUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, FileUtil, Path}
 import org.apache.hadoop.fs.audit.CommonAuditContext.currentAuditContext
@@ -1869,9 +1869,14 @@ private[spark] object Utils
   val isMac = SystemUtils.IS_OS_MAC_OSX
 
   /**
+   * Whether the underlying Java version is at most 17.
+   */
+  val isJavaVersionAtMost17 = Runtime.version().feature() <= 17
+
+  /**
    * Whether the underlying Java version is at least 21.
    */
-  val isJavaVersionAtLeast21 = SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_21)
+  val isJavaVersionAtLeast21 = Runtime.version().feature() >= 21
 
   /**
    * Whether the underlying operating system is Mac OS X and processor is Apple Silicon.

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -527,13 +527,11 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
 
     // The following 3 scenarios are only for the method: createDirectory(File)
     // 6. Symbolic link
-    // JAVA_RUNTIME_VERSION is like "17.0.14+7-LTS"
-    lazy val javaVersion = Runtime.Version.parse(SystemUtils.JAVA_RUNTIME_VERSION)
     val scenario6 = java.nio.file.Files.createSymbolicLink(new File(testDir, "scenario6")
       .toPath, scenario1.toPath).toFile
     if (Utils.isJavaVersionAtLeast21) {
       assert(Utils.createDirectory(scenario6))
-    } else if (javaVersion.feature() == 17 && javaVersion.update() >= 14) {
+    } else if (Runtime.version().feature() == 17 && Runtime.version().update() >= 14) {
       // SPARK-50946: Java 17.0.14 includes JDK-8294193, so scenario6 can succeed.
       assert(Utils.createDirectory(scenario6))
     } else {

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -183,6 +183,7 @@
         <module name="IllegalImport">
             <property name="illegalPkgs" value="org.apache.log4j" />
             <property name="illegalPkgs" value="org.apache.commons.lang" />
+            <property name="illegalClasses" value="org.apache.commons.lang3.JavaVersion" />
         </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="new URL\("/>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -288,6 +288,12 @@ This file is divided into 3 sections:
     of Commons Lang 2 (package org.apache.commons.lang.*)</customMessage>
   </check>
 
+  <check customId="commonslang3javaversion" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.lang3\.JavaVersion</parameter></parameters>
+    <customMessage>Use JEP 223 API (java.lang.Runtime.Version) instead of
+      Commons Lang 3 JavaVersion (org.apache.commons.lang3.JavaVersion)</customMessage>
+  </check>
+
   <check customId="uribuilder" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">UriBuilder\.fromUri</parameter></parameters>
     <customMessage>Use Utils.getUriBuilder instead.</customMessage>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -289,7 +289,7 @@ This file is divided into 3 sections:
   </check>
 
   <check customId="commonslang3javaversion" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
-    <parameters><parameter name="regex">org\.apache\.commons\.lang3\.JavaVersion</parameter></parameters>
+    <parameters><parameter name="regex">org\.apache\.commons\.lang3\..*JavaVersion</parameter></parameters>
     <customMessage>Use JEP 223 API (java.lang.Runtime.Version) instead of
       Commons Lang 3 JavaVersion (org.apache.commons.lang3.JavaVersion)</customMessage>
   </check>

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
@@ -264,7 +264,7 @@ object PROCESS_TABLES extends QueryTest with SQLTestUtils {
     "https://dist.apache.org/repos/dist/release")
   // Tests the latest version of every release line if Java version is at most 17.
   val testingVersions: Seq[String] = if (isPythonVersionAvailable &&
-    Utils.isJavaVersionAtMost17) {
+      Utils.isJavaVersionAtMost17) {
     import scala.io.Source
     val sparkVersionPattern = """<a href="spark-(\d.\d.\d)/">""".r
     try Utils.tryWithResource(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
@@ -24,7 +24,6 @@ import java.nio.file.{Files, Paths}
 import scala.sys.process._
 import scala.util.control.NonFatal
 
-import org.apache.commons.lang3.{JavaVersion, SystemUtils}
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
@@ -200,7 +199,7 @@ class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
 
     if (PROCESS_TABLES.testingVersions.isEmpty) {
       if (PROCESS_TABLES.isPythonVersionAvailable) {
-        if (SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17)) {
+        if (Utils.isJavaVersionAtMost17) {
           logError("Fail to get the latest Spark versions to test.")
         } else {
           logInfo("Skip tests because old Spark versions don't support Java 21.")
@@ -265,7 +264,7 @@ object PROCESS_TABLES extends QueryTest with SQLTestUtils {
     "https://dist.apache.org/repos/dist/release")
   // Tests the latest version of every release line if Java version is at most 17.
   val testingVersions: Seq[String] = if (isPythonVersionAvailable &&
-      SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17)) {
+    Utils.isJavaVersionAtMost17) {
     import scala.io.Source
     val sparkVersionPattern = """<a href="spark-(\d.\d.\d)/">""".r
     try Utils.tryWithResource(

--- a/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
@@ -27,7 +27,6 @@ import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.language.implicitConversions
 
-import org.apache.commons.lang3.{JavaVersion, SystemUtils}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.mockito.ArgumentCaptor
@@ -477,7 +476,7 @@ class BatchedWriteAheadLogSuite extends CommonWriteAheadLogTests(
     val batchedWal = new BatchedWriteAheadLog(wal, sparkConf)
 
     val e = intercept[SparkException] {
-      val buffer = if (SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17)) {
+      val buffer = if (Utils.isJavaVersionAtMost17) {
         mock[ByteBuffer]
       } else {
         // SPARK-40731: Use a 0 size `ByteBuffer` instead of `mock[ByteBuffer]`
@@ -553,7 +552,7 @@ class BatchedWriteAheadLogSuite extends CommonWriteAheadLogTests(
     batchedWal.close()
     verify(wal, times(1)).close()
 
-    val buffer = if (SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17)) {
+    val buffer = if (Utils.isJavaVersionAtMost17) {
       mock[ByteBuffer]
     } else {
       // SPARK-40731: Use a 0 size `ByteBuffer` instead of `mock[ByteBuffer]`


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Use [JEP 223](https://openjdk.org/jeps/223) API instead of `commons-lang3` to process Java version.

Checkstyle and Scalastyle configuration files are updated too to avoid future regression.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

[JEP 223](https://openjdk.org/jeps/223) API is available in modern JDKs, it provides simple and richer API compared to `org.apache.commons.lang3.JavaVersion` to process Java version.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GHA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.