### PR TITLE
[SPARK-52493][SQL] Support TIMESTAMP WITHOUT TIME ZONE

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -1345,6 +1345,7 @@ dataType
       (TO to=(HOUR | MINUTE | SECOND))?                         #dayTimeIntervalDataType
     | TIME (LEFT_PAREN precision=INTEGER_VALUE RIGHT_PAREN)?
       (WITHOUT TIME ZONE)?                                      #timeDataType
+    | (TIMESTAMP_NTZ | TIMESTAMP WITHOUT TIME ZONE)             #timestampNtzDataType
     | type (LEFT_PAREN INTEGER_VALUE
       (COMMA INTEGER_VALUE)* RIGHT_PAREN)?                      #primitiveDataType
     ;

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/DataTypeAstBuilder.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/DataTypeAstBuilder.scala
@@ -78,6 +78,13 @@ class DataTypeAstBuilder extends SqlBaseParserBaseVisitor[AnyRef] {
   }
 
   /**
+   * Create the TIMESTAMP_NTZ primitive type.
+   */
+  override def visitTimestampNtzDataType(ctx: TimestampNtzDataTypeContext): DataType = {
+    withOrigin(ctx)(TimestampNTZType)
+  }
+
+  /**
    * Resolve/create a primitive type.
    */
   override def visitPrimitiveDataType(ctx: PrimitiveDataTypeContext): DataType = withOrigin(ctx) {
@@ -92,7 +99,6 @@ class DataTypeAstBuilder extends SqlBaseParserBaseVisitor[AnyRef] {
       case (DOUBLE, Nil) => DoubleType
       case (DATE, Nil) => DateType
       case (TIMESTAMP, Nil) => SqlApiConf.get.timestampType
-      case (TIMESTAMP_NTZ, Nil) => TimestampNTZType
       case (TIMESTAMP_LTZ, Nil) => TimestampType
       case (STRING, Nil) =>
         typeCtx.children.asScala.toSeq match {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DataTypeParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DataTypeParserSuite.scala
@@ -64,6 +64,7 @@ class DataTypeParserSuite extends SparkFunSuite with SQLHelper {
   checkDataType("TIME(6)", TimeType(6))
   checkDataType("TIME(6) WITHOUT TIME ZONE", TimeType(6))
   checkDataType("timestamp", TimestampType)
+  checkDataType("TIMESTAMP WITHOUT TIME ZONE", TimestampNTZType)
   checkDataType("timestamp_ntz", TimestampNTZType)
   checkDataType("timestamp_ltz", TimestampType)
   checkDataType("string", StringType)
@@ -160,6 +161,7 @@ class DataTypeParserSuite extends SparkFunSuite with SQLHelper {
     }
     withSQLConf(SQLConf.TIMESTAMP_TYPE.key -> TimestampTypes.TIMESTAMP_LTZ.toString) {
       assert(parse("timestamp") === TimestampType)
+      assert(parse("timestamp without time zone") === TimestampNTZType)
     }
   }
 
@@ -216,6 +218,21 @@ class DataTypeParserSuite extends SparkFunSuite with SQLHelper {
     checkError(
       exception = intercept[ParseException] {
         CatalystSqlParser.parseDataType("time(0) WITH TIME ZONE")
+      },
+      condition = "PARSE_SYNTAX_ERROR",
+      parameters = Map("error" -> "'WITH'", "hint" -> ""))
+  }
+
+  test("invalid TIMESTAMP suffix") {
+    checkError(
+      exception = intercept[ParseException] {
+        CatalystSqlParser.parseDataType("timestamp WITHOUT TIMEZONE")
+      },
+      condition = "PARSE_SYNTAX_ERROR",
+      parameters = Map("error" -> "'WITHOUT'", "hint" -> ""))
+    checkError(
+      exception = intercept[ParseException] {
+        CatalystSqlParser.parseDataType("timestamp WITH TIME ZONE")
       },
       condition = "PARSE_SYNTAX_ERROR",
       parameters = Map("error" -> "'WITH'", "hint" -> ""))


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to introduce a synonym for the existing type `TIMESTAMP_NTZ` as the SQL standard defines: `TIMESTAMP WITHOUT TIME ZONE`. 

### Why are the changes needed?
- To conform to the SQL standard
- To simplify migration from other systems that recognize the fully qualified type name. 
- To be consistent with the `TIME` type, see https://github.com/apache/spark/pull/51177

### Does this PR introduce _any_ user-facing change?
No, it just extends the existing syntax.


### How was this patch tested?
By running the modified test suite:
```
$ build/sbt "test:testOnly *DataTypeParserSuite"
```


### Was this patch authored or co-authored using generative AI tooling?
No.
