### PR TITLE
[SPARK-52486][SQL] Fix Spark Driver Planning OOM issue due to unworthwhile dpp expression before Execution when enabling AQE

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -539,10 +539,10 @@ object QueryExecution {
       subquery: Boolean): Seq[Rule[SparkPlan]] = {
     // `AdaptiveSparkPlanExec` is a leaf node. If inserted, all the following rules will be no-op
     // as the original plan is hidden behind `AdaptiveSparkPlanExec`.
+    Seq(CoalesceBucketsInJoin,
+      PlanDynamicPruningFilters(sparkSession)) ++
     adaptiveExecutionRule.toSeq ++
     Seq(
-      CoalesceBucketsInJoin,
-      PlanDynamicPruningFilters(sparkSession),
       PlanSubqueries(sparkSession),
       RemoveRedundantProjects,
       EnsureRequirements(),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.catalyst.rules.{PlanChangeLogger, Rule}
 import org.apache.spark.sql.catalyst.util.StringUtils.PlanStringConcat
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.classic.SparkSession
-import org.apache.spark.sql.execution.adaptive.{AdaptiveExecutionContext, InsertAdaptiveSparkPlan, PlanAdaptiveInitDynamicPruningFilters, PlanInitDynamicPruningFilters}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveExecutionContext, InsertAdaptiveSparkPlan, PlanAdaptiveInitDynamicPruningFilters}
 import org.apache.spark.sql.execution.bucketing.{CoalesceBucketsInJoin, DisableUnnecessaryBucketedScan}
 import org.apache.spark.sql.execution.dynamicpruning.PlanDynamicPruningFilters
 import org.apache.spark.sql.execution.exchange.EnsureRequirements

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -20,8 +20,11 @@ package org.apache.spark.sql.execution
 import java.io.{BufferedWriter, OutputStreamWriter}
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
+
 import scala.util.control.NonFatal
+
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.SparkException
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys.EXTENDED_EXPLAIN_GENERATOR
@@ -47,8 +50,6 @@ import org.apache.spark.sql.scripting.SqlScriptingExecution
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.util.{LazyTry, Utils}
 import org.apache.spark.util.ArrayImplicits._
-
-import scala.collection.Seq
 
 /**
  * The primary workflow for executing relational queries using Spark.  Designed to allow easy
@@ -541,6 +542,8 @@ object QueryExecution {
     Seq(PlanAdaptiveInitDynamicPruningFilters(sparkSession))
     adaptiveExecutionRule.toSeq ++
     Seq(
+      CoalesceBucketsInJoin,
+      PlanDynamicPruningFilters(sparkSession),
       PlanSubqueries(sparkSession),
       RemoveRedundantProjects,
       EnsureRequirements(),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.adaptive
 
 import scala.collection.{mutable}
+
 import org.apache.spark.internal.LogKeys.{CONFIG, SUB_QUERY}
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.catalyst.expressions

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.command.{DataWritingCommandExec, ExecutedCommandExec}
 import org.apache.spark.sql.execution.datasources.V1WriteCommand
 import org.apache.spark.sql.execution.datasources.v2.V2CommandExec
-import org.apache.spark.sql.execution.dynamicpruning.PlanDynamicPruningFilters
 import org.apache.spark.sql.execution.exchange.Exchange
 import org.apache.spark.sql.internal.SQLConf
 
@@ -62,7 +61,7 @@ case class InsertAdaptiveSparkPlan(
           // Plan sub-queries recursively and pass in the shared stage cache for exchange reuse.
           // Fall back to non-AQE mode if AQE is not supported in any of the sub-queries.
           val subqueryMap = buildSubqueryMap(plan)
-          val planSubqueriesRule = PlanAdaptiveSubqueries(adaptiveExecutionContext, subqueryMap)
+          val planSubqueriesRule = PlanAdaptiveSubqueries(subqueryMap)
 
           val processingRules = Seq(
             planSubqueriesRule)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
@@ -17,8 +17,7 @@
 
 package org.apache.spark.sql.execution.adaptive
 
-import scala.collection.mutable
-
+import scala.collection.{mutable}
 import org.apache.spark.internal.LogKeys.{CONFIG, SUB_QUERY}
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.catalyst.expressions
@@ -65,11 +64,13 @@ case class InsertAdaptiveSparkPlan(
           val subqueryMap = buildSubqueryMap(plan)
           val planSubqueriesRule = PlanAdaptiveSubqueries(adaptiveExecutionContext, subqueryMap)
 
+          val processingRules = Seq(
+            planSubqueriesRule)
           val preprocessingRules = Seq(
-            PlanDynamicPruningFilters(adaptiveExecutionContext.session),
+            PlanAdaptivePreDynamicPruningFilters(adaptiveExecutionContext),
             planSubqueriesRule)
           // Run pre-processing rules.
-          val newPlan = AdaptiveSparkPlanExec.applyPhysicalRules(plan, preprocessingRules)
+          val newPlan = AdaptiveSparkPlanExec.applyPhysicalRules(plan, processingRules)
           logDebug(s"Adaptive execution enabled for plan: $plan")
           AdaptiveSparkPlanExec(newPlan, adaptiveExecutionContext, preprocessingRules, isSubquery)
         } catch {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.command.{DataWritingCommandExec, ExecutedCommandExec}
 import org.apache.spark.sql.execution.datasources.V1WriteCommand
 import org.apache.spark.sql.execution.datasources.v2.V2CommandExec
+import org.apache.spark.sql.execution.dynamicpruning.PlanDynamicPruningFilters
 import org.apache.spark.sql.execution.exchange.Exchange
 import org.apache.spark.sql.internal.SQLConf
 
@@ -62,8 +63,10 @@ case class InsertAdaptiveSparkPlan(
           // Plan sub-queries recursively and pass in the shared stage cache for exchange reuse.
           // Fall back to non-AQE mode if AQE is not supported in any of the sub-queries.
           val subqueryMap = buildSubqueryMap(plan)
-          val planSubqueriesRule = PlanAdaptiveSubqueries(subqueryMap)
+          val planSubqueriesRule = PlanAdaptiveSubqueries(adaptiveExecutionContext, subqueryMap)
+
           val preprocessingRules = Seq(
+            PlanDynamicPruningFilters(adaptiveExecutionContext.session),
             planSubqueriesRule)
           // Run pre-processing rules.
           val newPlan = AdaptiveSparkPlanExec.applyPhysicalRules(plan, preprocessingRules)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveInitDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveInitDynamicPruningFilters.scala
@@ -17,10 +17,8 @@
 
 package org.apache.spark.sql.execution.adaptive
 
-import org.apache.spark.sql.catalyst.expressions
-import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeSeq, BindReferences, DynamicPruningExpression, DynamicPruningSubquery, Expression, ListQuery, Literal}
+import org.apache.spark.sql.catalyst.expressions.{AttributeSeq, BindReferences, DynamicPruningExpression, DynamicPruningSubquery, Expression, Literal}
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
-import org.apache.spark.sql.catalyst.plans.logical.Aggregate
 import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.DYNAMIC_PRUNING_SUBQUERY
@@ -82,12 +80,13 @@ case class PlanAdaptiveInitDynamicPruningFilters(sparkSession: SparkSession)
           // it is not worthwhile to execute the query, so we fall-back to a true literal
           DynamicPruningExpression(Literal.TrueLiteral)
         } else {
-          // we need to apply an aggregate on the buildPlan in order to be column pruned
-          val aliases = broadcastKeyIndices.map(idx =>
-            Alias(buildKeys(idx), buildKeys(idx).toString)())
-          val aggregate = Aggregate(aliases, aliases, buildPlan)
-          DynamicPruningExpression(expressions.InSubquery(
-            Seq(value), ListQuery(aggregate, numCols = aggregate.output.length)))
+//          // we need to apply an aggregate on the buildPlan in order to be column pruned
+//          val aliases = broadcastKeyIndices.map(idx =>
+//            Alias(buildKeys(idx), buildKeys(idx).toString)())
+//          val aggregate = Aggregate(aliases, aliases, buildPlan)
+//          DynamicPruningExpression(expressions.InSubquery(
+//            Seq(value), ListQuery(aggregate, numCols = aggregate.output.length)))
+          dps
         }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveInitDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveInitDynamicPruningFilters.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.adaptive
+
+import org.apache.spark.sql.catalyst.expressions
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeSeq, BindReferences, DynamicPruningExpression, DynamicPruningSubquery, Expression, ListQuery, Literal}
+import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
+import org.apache.spark.sql.catalyst.plans.logical.Aggregate
+import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.DYNAMIC_PRUNING_SUBQUERY
+import org.apache.spark.sql.classic.SparkSession
+import org.apache.spark.sql.execution.{QueryExecution, SparkPlan}
+import org.apache.spark.sql.execution.joins._
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * This planner rule aims at rewriting dynamic pruning predicates in order to reuse the
+ * results of broadcast. For joins that are not planned as broadcast hash joins we keep
+ * the fallback mechanism with subquery duplicate.
+*/
+case class PlanAdaptiveInitDynamicPruningFilters(sparkSession: SparkSession)
+  extends Rule[SparkPlan] {
+
+  override def conf: SQLConf = sparkSession.sessionState.conf
+
+  /**
+   * Identify the shape in which keys of a given plan are broadcasted.
+   */
+  private def broadcastMode(keys: Seq[Expression], output: AttributeSeq): BroadcastMode = {
+    val packedKeys = BindReferences.bindReferences(HashJoin.rewriteKeyExpr(keys), output)
+    HashedRelationBroadcastMode(packedKeys)
+  }
+
+  override def apply(plan: SparkPlan): SparkPlan = {
+    if (!conf.dynamicPartitionPruningEnabled) {
+      return plan
+    }
+
+    plan.transformAllExpressionsWithPruning(_.containsPattern(DYNAMIC_PRUNING_SUBQUERY)) {
+      case dps @ DynamicPruningSubquery(
+          value, buildPlan, buildKeys, broadcastKeyIndices, onlyInBroadcast, exprId, _) =>
+        val sparkPlan = QueryExecution.createSparkPlan(sparkSession.sessionState.planner, buildPlan)
+        // Using `sparkPlan` is a little hacky as it is based on the assumption that this rule is
+        // the first to be applied (apart from `InsertAdaptiveSparkPlan`).
+        val canReuseExchange = conf.exchangeReuseEnabled && buildKeys.nonEmpty &&
+          plan.exists {
+            case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _) =>
+              left.sameResult(sparkPlan)
+            case BroadcastHashJoinExec(_, _, _, BuildRight, _, _, right, _) =>
+              right.sameResult(sparkPlan)
+            case _ => false
+          }
+
+        if (canReuseExchange) {
+//          val executedPlan = QueryExecution.prepareExecutedPlan(sparkSession, sparkPlan)
+//          val mode = broadcastMode(buildKeys, executedPlan.output)
+//          // plan a broadcast exchange of the build side of the join
+//          val exchange = BroadcastExchangeExec(mode, executedPlan)
+//          val name = s"dynamicpruning#${exprId.id}"
+//          // place the broadcast adaptor for reusing the broadcast results on the probe side
+//          val broadcastValues =
+//            SubqueryBroadcastExec(name, broadcastKeyIndices, buildKeys, exchange)
+//          DynamicPruningExpression(InSubqueryExec(value, broadcastValues, exprId))
+          dps
+        } else if (onlyInBroadcast) {
+          // it is not worthwhile to execute the query, so we fall-back to a true literal
+          DynamicPruningExpression(Literal.TrueLiteral)
+        } else {
+          // we need to apply an aggregate on the buildPlan in order to be column pruned
+          val aliases = broadcastKeyIndices.map(idx =>
+            Alias(buildKeys(idx), buildKeys(idx).toString)())
+          val aggregate = Aggregate(aliases, aliases, buildPlan)
+          DynamicPruningExpression(expressions.InSubquery(
+            Seq(value), ListQuery(aggregate, numCols = aggregate.output.length)))
+        }
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptivePreDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptivePreDynamicPruningFilters.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
-import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, HashJoin, HashedRelationBroadcastMode}
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, HashedRelationBroadcastMode, HashJoin}
 
 /**
  * A rule to insert dynamic pruning predicates in order to reuse the results of broadcast.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptivePreDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptivePreDynamicPruningFilters.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.adaptive
+
+import org.apache.spark.sql.catalyst.expressions
+import org.apache.spark.sql.catalyst.expressions.{Alias, BindReferences, DynamicPruningExpression, Literal}
+import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
+import org.apache.spark.sql.catalyst.plans.logical.Aggregate
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern._
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, HashJoin, HashedRelationBroadcastMode}
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * A rule to insert dynamic pruning predicates in order to reuse the results of broadcast.
+ */
+case class PlanAdaptivePreDynamicPruningFilters(
+    context: AdaptiveExecutionContext) extends Rule[SparkPlan] with AdaptiveSparkPlanHelper {
+
+  def apply(plan: SparkPlan): SparkPlan = {
+    if (!conf.dynamicPartitionPruningEnabled) {
+      return plan
+    }
+
+    plan.transformAllExpressionsWithPruning(_.containsPattern(DYNAMIC_PRUNING_SUBQUERY)) {
+      case expressions.DynamicPruningSubquery(value, buildPlan,
+      buildKeys, indices, onlyInBroadcast, exprId, _) =>
+        val name = s"dynamicpruning#${exprId.id}"
+        val sparkPlan = QueryExecution.prepareExecutedPlan(
+          buildPlan, context)
+        assert(sparkPlan.isInstanceOf[AdaptiveSparkPlanExec])
+        val adaptivePlan: AdaptiveSparkPlanExec = sparkPlan.asInstanceOf[AdaptiveSparkPlanExec]
+
+        val packedKeys = BindReferences.bindReferences(
+          HashJoin.rewriteKeyExpr(buildKeys), adaptivePlan.executedPlan.output)
+        val mode = HashedRelationBroadcastMode(packedKeys)
+        // plan a broadcast exchange of the build side of the join
+        val exchange = BroadcastExchangeExec(mode, adaptivePlan.executedPlan)
+
+        val canReuseExchange = conf.exchangeReuseEnabled && buildKeys.nonEmpty &&
+          plan.exists {
+            case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _) =>
+              left.sameResult(exchange)
+            case BroadcastHashJoinExec(_, _, _, BuildRight, _, _, right, _) =>
+              right.sameResult(exchange)
+            case _ => false
+          }
+
+        if (canReuseExchange) {
+          exchange.setLogicalLink(adaptivePlan.executedPlan.logicalLink.get)
+          val newAdaptivePlan = adaptivePlan.copy(inputPlan = exchange)
+
+          val broadcastValues = SubqueryBroadcastExec(
+            name, indices, buildKeys, newAdaptivePlan)
+          DynamicPruningExpression(InSubqueryExec(value, broadcastValues, exprId))
+        } else if (onlyInBroadcast) {
+          DynamicPruningExpression(Literal.TrueLiteral)
+        } else {
+          // we need to apply an aggregate on the buildPlan in order to be column pruned
+          val aliases = indices.map(idx => Alias(buildKeys(idx), buildKeys(idx).toString)())
+          val aggregate = Aggregate(aliases, aliases, buildPlan)
+
+          val sparkPlan = QueryExecution.prepareExecutedPlan(aggregate, adaptivePlan.context)
+          assert(sparkPlan.isInstanceOf[AdaptiveSparkPlanExec])
+          val newAdaptivePlan = sparkPlan.asInstanceOf[AdaptiveSparkPlanExec]
+          val values = SubqueryExec(name, newAdaptivePlan)
+          DynamicPruningExpression(InSubqueryExec(value, values, exprId))
+        }
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptivePreDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptivePreDynamicPruningFilters.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, HashJoin, HashedRelationBroadcastMode}
-import org.apache.spark.sql.internal.SQLConf
 
 /**
  * A rule to insert dynamic pruning predicates in order to reuse the results of broadcast.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveSubqueries.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveSubqueries.scala
@@ -49,7 +49,7 @@ case class PlanAdaptiveSubqueries(context: AdaptiveExecutionContext,
           subquery = SubqueryExec(s"subquery#${exprId.id}", subqueryMap(exprId.id))
         } else {
           val sparkPlan = QueryExecution.prepareExecutedPlan(
-            context.session, query, context)
+            query, context)
           assert(sparkPlan.isInstanceOf[AdaptiveSparkPlanExec])
           val newAdaptivePlan = sparkPlan.asInstanceOf[AdaptiveSparkPlanExec]
           subquery = SubqueryExec(s"subquery#${exprId.id}", newAdaptivePlan)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveSubqueries.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveSubqueries.scala
@@ -22,9 +22,9 @@ import org.apache.spark.sql.catalyst.expressions.{CreateNamedStruct, DynamicPrun
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.{DYNAMIC_PRUNING_SUBQUERY, IN_SUBQUERY, SCALAR_SUBQUERY}
 import org.apache.spark.sql.execution
-import org.apache.spark.sql.execution.{InSubqueryExec, SparkPlan, SubqueryAdaptiveBroadcastExec, SubqueryExec}
+import org.apache.spark.sql.execution.{InSubqueryExec, QueryExecution, SparkPlan, SubqueryAdaptiveBroadcastExec, SubqueryExec}
 
-case class PlanAdaptiveSubqueries(
+case class PlanAdaptiveSubqueries(context: AdaptiveExecutionContext,
     subqueryMap: Map[Long, SparkPlan]) extends Rule[SparkPlan] {
 
   def apply(plan: SparkPlan): SparkPlan = {
@@ -34,7 +34,7 @@ case class PlanAdaptiveSubqueries(
         val subquery = SubqueryExec.createForScalarSubquery(
           s"subquery#${exprId.id}", subqueryMap(exprId.id))
         execution.ScalarSubquery(subquery, exprId)
-      case expressions.InSubquery(values, ListQuery(_, _, exprId, _, _, _)) =>
+      case expressions.InSubquery(values, ListQuery(query, _, exprId, _, _, _)) =>
         val expr = if (values.length == 1) {
           values.head
         } else {
@@ -44,7 +44,16 @@ case class PlanAdaptiveSubqueries(
             }
           )
         }
-        val subquery = SubqueryExec(s"subquery#${exprId.id}", subqueryMap(exprId.id))
+        var subquery: SubqueryExec = null
+        if (subqueryMap.contains(exprId.id)) {
+          subquery = SubqueryExec(s"subquery#${exprId.id}", subqueryMap(exprId.id))
+        } else {
+          val sparkPlan = QueryExecution.prepareExecutedPlan(
+            context.session, query, context)
+          assert(sparkPlan.isInstanceOf[AdaptiveSparkPlanExec])
+          val newAdaptivePlan = sparkPlan.asInstanceOf[AdaptiveSparkPlanExec]
+          subquery = SubqueryExec(s"subquery#${exprId.id}", newAdaptivePlan)
+        }
         InSubqueryExec(expr, subquery, exprId, isDynamicPruning = false)
       case expressions.DynamicPruningSubquery(value, buildPlan,
           buildKeys, broadcastKeyIndices, onlyInBroadcast, exprId, _) =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Before generating SubQuery Physical Plans, we need to filtering dynamicpruning expression which is not worthwhile. 


### Why are the changes needed?

During the join operations of a dozen partitioned fact tables in Spark-SQL, 8w+ subqueries were generated, ultimately causing a Driver OOM (Out-Of-Memory) error.


### How was this patch tested?

Existing Unit Tests can cover this PR.

### Benefit of this patch

By using this reproducing sql case from the SPARK-52486;  This patch can avoid large memory consumption:

<img width="665" alt="Clipboard_Screenshot_1750231561" src="https://github.com/user-attachments/assets/98a71ca5-c878-402c-8d62-11189eb83828" />


