### PR TITLE
[SPARK-52487][UI] Add Stage Submitted Time and Duration to StagePage Detail

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/StageDataUtil.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StageDataUtil.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ui.jobs
+
+import org.apache.spark.status.api.v1.StageData
+import org.apache.spark.ui.UIUtils
+
+object StageDataUtil {
+  def getDuration(stageData: StageData): Option[Long] = {
+    stageData.submissionTime.map { start =>
+      val end = stageData.completionTime.map(_.getTime).getOrElse(System.currentTimeMillis())
+      end - start.getTime
+    }
+  }
+
+  def getFormattedDuration(stageData: StageData): String = {
+    val duration = getDuration(stageData)
+    duration.map(d => UIUtils.formatDuration(d)).getOrElse("Unknown")
+  }
+
+  def getFormattedSubmissionTime(stageData: StageData): String = {
+    stageData.submissionTime.map(UIUtils.formatDate).getOrElse("Unknown")
+  }
+}

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -142,6 +142,14 @@ private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends We
       <div>
         <ul class="list-unstyled">
           <li>
+            <Strong>Submitted:</Strong>
+            {StageDataUtil.getFormattedSubmissionTime(stageData)}
+          </li>
+          <li>
+            <strong>Duration</strong>
+            {StageDataUtil.getFormattedDuration(stageData)}
+          </li>
+          <li>
             <strong>Resource Profile Id: </strong>
             {stageData.resourceProfileId}
           </li>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add Stage Submitted Time and Duration to the StagePage Detail

### Why are the changes needed?

UX improvements while looking into stage details

### Does this PR introduce _any_ user-facing change?
Yes, UI changes


### How was this patch tested?

build and test locally
![image](https://github.com/user-attachments/assets/f704dfbf-813d-46df-ab21-580fcd843ed1)


### Was this patch authored or co-authored using generative AI tooling?
no
