### PR TITLE
[SPARK-52488] [SQL] Strip alias before wrapping outer references under HAVING

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -210,7 +210,11 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
         case u @ UnresolvedHaving(_, agg: Aggregate) =>
           agg.resolveChildren(nameParts, conf.resolver)
             .orElse(u.resolveChildren(nameParts, conf.resolver))
-            .map(wrapOuterReference)
+            .map {
+              case alias: Alias =>
+                wrapOuterReference(alias.child)
+              case other => wrapOuterReference(other)
+            }
         case other =>
           other.resolveChildren(nameParts, conf.resolver).map(wrapOuterReference)
       }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/having.sql.out
@@ -426,3 +426,63 @@ Project [((sum(v) + 1) + min(v))#xL]
                +- Project [k#x, v#x]
                   +- SubqueryAlias hav
                      +- LocalRelation [k#x, v#x]
+
+
+-- !query
+SELECT col1 AS alias
+FROM values(1)
+GROUP BY col1
+HAVING (
+    SELECT col1 = 1
+)
+-- !query analysis
+Filter cast(scalar-subquery#x [alias#x] as boolean)
+:  +- Project [(outer(alias#x) = 1) AS (outer(col1) = 1)#x]
+:     +- OneRowRelation
++- Aggregate [col1#x], [col1#x AS alias#x]
+   +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT col1 AS alias
+FROM values(named_struct('a', 1))
+GROUP BY col1
+HAVING (
+    SELECT col1.a = 1
+)
+-- !query analysis
+Filter cast(scalar-subquery#x [alias#x] as boolean)
+:  +- Project [(outer(alias#x).a = 1) AS (outer(col1).a = 1)#x]
+:     +- OneRowRelation
++- Aggregate [col1#x], [col1#x AS alias#x]
+   +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT col1 AS alias
+FROM values(array(1))
+GROUP BY col1
+HAVING (
+    SELECT col1[0] = 1
+)
+-- !query analysis
+Filter cast(scalar-subquery#x [alias#x] as boolean)
+:  +- Project [(outer(alias#x)[0] = 1) AS (outer(col1)[0] = 1)#x]
+:     +- OneRowRelation
++- Aggregate [col1#x], [col1#x AS alias#x]
+   +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT col1 AS alias
+FROM values(map('a', 1))
+GROUP BY col1
+HAVING (
+    SELECT col1[0] = 1
+)
+-- !query analysis
+Filter cast(scalar-subquery#x [alias#x] as boolean)
+:  +- Project [(outer(alias#x)[cast(0 as string)] = 1) AS (outer(col1)[0] = 1)#x]
+:     +- OneRowRelation
++- Aggregate [col1#x], [col1#x AS alias#x]
+   +- LocalRelation [col1#x]

--- a/sql/core/src/test/resources/sql-tests/inputs/having.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/having.sql
@@ -62,3 +62,32 @@ SELECT 1 + SUM(v) FROM hav HAVING SUM(v) + 1;
 SELECT SUM(v) + 1 FROM hav HAVING 1 + SUM(v);
 SELECT MAX(v) + SUM(v) FROM hav HAVING SUM(v) + MAX(v);
 SELECT SUM(v) + 1 + MIN(v) FROM hav HAVING 1 + 1 + 1 + MIN(v) + 1 + SUM(v);
+
+-- HAVING with outer reference to alias in outer project list
+SELECT col1 AS alias
+FROM values(1)
+GROUP BY col1
+HAVING (
+    SELECT col1 = 1
+);
+
+SELECT col1 AS alias
+FROM values(named_struct('a', 1))
+GROUP BY col1
+HAVING (
+    SELECT col1.a = 1
+);
+
+SELECT col1 AS alias
+FROM values(array(1))
+GROUP BY col1
+HAVING (
+    SELECT col1[0] = 1
+);
+
+SELECT col1 AS alias
+FROM values(map('a', 1))
+GROUP BY col1
+HAVING (
+    SELECT col1[0] = 1
+);

--- a/sql/core/src/test/resources/sql-tests/results/having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/having.sql.out
@@ -291,3 +291,55 @@ SELECT SUM(v) + 1 + MIN(v) FROM hav HAVING 1 + 1 + 1 + MIN(v) + 1 + SUM(v)
 struct<((sum(v) + 1) + min(v)):bigint>
 -- !query output
 13
+
+
+-- !query
+SELECT col1 AS alias
+FROM values(1)
+GROUP BY col1
+HAVING (
+    SELECT col1 = 1
+)
+-- !query schema
+struct<alias:int>
+-- !query output
+1
+
+
+-- !query
+SELECT col1 AS alias
+FROM values(named_struct('a', 1))
+GROUP BY col1
+HAVING (
+    SELECT col1.a = 1
+)
+-- !query schema
+struct<alias:struct<a:int>>
+-- !query output
+{"a":1}
+
+
+-- !query
+SELECT col1 AS alias
+FROM values(array(1))
+GROUP BY col1
+HAVING (
+    SELECT col1[0] = 1
+)
+-- !query schema
+struct<alias:array<int>>
+-- !query output
+[1]
+
+
+-- !query
+SELECT col1 AS alias
+FROM values(map('a', 1))
+GROUP BY col1
+HAVING (
+    SELECT col1[0] = 1
+)
+-- !query schema
+struct<alias:map<string,int>>
+-- !query output
+


### PR DESCRIPTION
### What changes were proposed in this pull request?
For the following query:
```
SELECT col1 AS alias
FROM values(named_struct('a', 1))
GROUP BY col1
HAVING (
SELECT col1.a = 1
);
```
this is the resulting analyzed plan:
```
Filter cast(scalar-subquery#8847 [alias#8846] as boolean)
:  +- Project [(outer(alias#8846).a = 1) AS (outer(col1).a AS a = 1)#8867]
:     +- OneRowRelation
+- Aggregate [col1#8865], [col1#8865 AS alias#8846]
   +- LocalRelation [col1#8865]
```
As it can be seen, we have outer(col1).a AS a in the Alias name for col1.a = 1 which is redundant and should be removed. It doesn't affect the output schema so changing the Alias name here is safe.

After the change, plan looks like:
```
Filter cast(scalar-subquery#x [alias#x] as boolean)
:  +- Project [(outer(alias#x).a = 1) AS (outer(col1).a = 1)#x]
:     +- OneRowRelation
+- Aggregate [col1#x], [col1#x AS alias#x]
   +- LocalRelation [col1#x]
```

### Why are the changes needed?
To keep the compatibility between fixed-point and single-pass implementations. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Tests added in this PR.

### Was this patch authored or co-authored using generative AI tooling?
No.