### PR TITLE
[SPARK-52491][INFRA] Add `Java 25-ea` build and install test pipeline

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -936,7 +936,7 @@ jobs:
       run: |
         export MAVEN_OPTS="-Xss64m -Xmx4g -Xms4g -XX:ReservedCodeCacheSize=128m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
         export MAVEN_CLI_OPTS="--no-transfer-progress"
-        ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pjvm-profiler -Pspark-ganglia-lgpl -Pkinesis-asl -Djava.version=${JAVA_VERSION/-ea} clean install
+        ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pjvm-profiler -Pspark-ganglia-lgpl -Pkinesis-asl clean install
 
   # Documentation build
   docs:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -122,6 +122,7 @@ jobs:
               \"tpcds-1g\": \"$tpcds\",
               \"docker-integration-tests\": \"$docker\",
               \"lint\" : \"true\",
+              \"java25\" : \"true\",
               \"docs\" : \"$docs\",
               \"yarn\" : \"$yarn\",
               \"k8s-integration-tests\" : \"$kubernetes\",
@@ -918,6 +919,24 @@ jobs:
       run: ./R/install-dev.sh
     - name: R linter
       run: ./dev/lint-r
+
+  java25:
+    needs: [precondition]
+    if: fromJson(needs.precondition.outputs.required).java25 == 'true'
+    name: Java 25 build with Maven
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: zulu
+        java-version: 25-ea
+    - name: Build with Maven
+      run: |
+        export MAVEN_OPTS="-Xss64m -Xmx4g -Xms4g -XX:ReservedCodeCacheSize=128m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
+        export MAVEN_CLI_OPTS="--no-transfer-progress"
+        ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pjvm-profiler -Pspark-ganglia-lgpl -Pkinesis-asl -Djava.version=${JAVA_VERSION/-ea} clean install
 
   # Documentation build
   docs:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Java 25-ea` build and install test pipeline to GitHub Action.

Note that this is a part of preparation for Java 25 LTS. Since this is an early stage, the following are not the scope yet in this PR. Those will be handled later before finalizing Apache Spark 4.1.0 release.
- Test on Java 25
- Use `-Djava.version` at compilation to enforce the versions.

### Why are the changes needed?

According to the following Java 25 release schedule, the early-access version is available already.

- 2025/06/05		[Rampdown Phase One](https://openjdk.org/jeps/3#rdp-1) (branch from main line)
- 2025/07/17		[Rampdown Phase Two](https://openjdk.org/jeps/3#rdp-2)
- 2025/08/07		[Initial Release Candidate](https://openjdk.org/jeps/3#rc)
- 2025/08/21		[Final Release Candidate](https://openjdk.org/jeps/3#rc)
- 2025/09/16		General Availability

We need to start to monitor this from now
- To prevent a future regression at Java 25 compilation
- To improve CI test coverage gradually

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a change on CI infra.

### How was this patch tested?

Pass the CIs. Manually check the log.

- https://github.com/dongjoon-hyun/spark/actions/runs/15686705169/job/44191907444

![Screenshot 2025-06-16 at 11 02 47](https://github.com/user-attachments/assets/e5bf1383-18d6-4d67-91ae-df8dcd6e51ac)

```
  Java configuration:
    Distribution: zulu
    Version: 25.0.0+23
    Path: /opt/hostedtoolcache/Java_Zulu_jdk/25.0.0-ea.23/x64
```

### Was this patch authored or co-authored using generative AI tooling?

No.