### PR TITLE
[SPARK-52507][CORE] Attempt to read missing block from fallback storage

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -23,7 +23,7 @@ import org.apache.spark._
 import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.serializer.SerializerManager
-import org.apache.spark.storage.{BlockId, BlockManager, BlockManagerId, ShuffleBlockFetcherIterator}
+import org.apache.spark.storage.{BlockId, BlockManager, BlockManagerId, FallbackStorage, ShuffleBlockFetcherIterator}
 import org.apache.spark.util.CompletionIterator
 import org.apache.spark.util.collection.ExternalSorter
 
@@ -88,7 +88,8 @@ private[spark] class BlockStoreShuffleReader[K, C](
       SparkEnv.get.conf.get(config.SHUFFLE_CHECKSUM_ENABLED),
       SparkEnv.get.conf.get(config.SHUFFLE_CHECKSUM_ALGORITHM),
       readMetrics,
-      fetchContinuousBlocksInBatch).toCompletionIterator
+      fetchContinuousBlocksInBatch,
+      FallbackStorage.getFallbackStorage(SparkEnv.get.conf)).toCompletionIterator
 
     val serializerInstance = dep.serializer.newInstance()
 

--- a/core/src/main/scala/org/apache/spark/storage/FallbackStorage.scala
+++ b/core/src/main/scala/org/apache/spark/storage/FallbackStorage.scala
@@ -90,6 +90,11 @@ private[storage] class FallbackStorage(conf: SparkConf) extends Logging {
     }
   }
 
+  /**
+   * Read a ManagedBuffer.
+   */
+  def read(blockId: BlockId): ManagedBuffer = FallbackStorage.read(conf, blockId)
+
   def exists(shuffleId: Int, filename: String): Boolean = {
     val hash = JavaUtils.nonNegativeHash(filename)
     fallbackFileSystem.exists(new Path(fallbackPath, s"$appId/$shuffleId/$hash/$filename"))

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -361,13 +361,16 @@ final class ShuffleBlockFetcherIterator(
 
             case _ =>
               val block = BlockId(blockId)
+              remainingBlocks -= blockId
               if (block.isShuffleChunk) {
-                remainingBlocks -= blockId
                 updateMergedReqsDuration(wasReqForMergedChunks = true)
                 results.put(FallbackOnPushMergedFailureResult(
                   block, address, infoMap(blockId)._1, remainingBlocks.isEmpty))
               } else {
-                results.putFirst(FailureFetchResult(block, infoMap(blockId)._2, address, e))
+                results.putFirst(FailureFetchResult(block, infoMap(blockId)._2, address, e,
+                  // we might want to recover from this fetch failure using fallback storage
+                  // so we need to be able to decrement reqsInFlight and bytesInFlight correctly
+                  isNetworkReqDone = remainingBlocks.isEmpty))
               }
           }
         }
@@ -979,14 +982,15 @@ final class ShuffleBlockFetcherIterator(
             }
           }
 
-        case FailureFetchResult(blockId, mapIndex, address, e) =>
+        case FailureFetchResult(blockId, mapIndex, address, e, isNetworkReqDone) =>
           var error = e
           var errorMsg: String = null
           if (fallbackStorage.isDefined) {
             try {
               val buf = fallbackStorage.get.read(blockId)
               results.put(SuccessFetchResult(blockId, mapIndex, address, buf.size(), buf,
-                isNetworkReqDone = false))
+                // the original fetch request that we recovered has to be accounted for
+                isNetworkReqDone = isNetworkReqDone))
               result = null
               error = null
             } catch {
@@ -1618,7 +1622,8 @@ object ShuffleBlockFetcherIterator {
       blockId: BlockId,
       mapIndex: Int,
       address: BlockManagerId,
-      e: Throwable)
+      e: Throwable,
+      isNetworkReqDone: Boolean = false)
     extends FetchResult
 
   /**

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -982,12 +982,7 @@ final class ShuffleBlockFetcherIterator(
         case FailureFetchResult(blockId, mapIndex, address, e) =>
           var error = e
           var errorMsg: String = null
-          if (e.isInstanceOf[OutOfDirectMemoryError]) {
-            val logMessage = log"Block ${MDC(BLOCK_ID, blockId)} fetch failed after " +
-              log"${MDC(MAX_ATTEMPTS, maxAttemptsOnNettyOOM)} retries due to Netty OOM"
-            logError(logMessage)
-            errorMsg = logMessage.message
-          } else if (fallbackStorage.isDefined) {
+          if (fallbackStorage.isDefined) {
             try {
               val buf = fallbackStorage.get.read(blockId)
               results.put(SuccessFetchResult(blockId, mapIndex, address, buf.size(), buf,
@@ -1000,6 +995,12 @@ final class ShuffleBlockFetcherIterator(
             }
           }
           if (error != null) {
+            if (error.isInstanceOf[OutOfDirectMemoryError]) {
+              val logMessage = log"Block ${MDC(BLOCK_ID, blockId)} fetch failed after " +
+                log"${MDC(MAX_ATTEMPTS, maxAttemptsOnNettyOOM)} retries due to Netty OOM"
+              logError(logMessage)
+              errorMsg = logMessage.message
+            }
             throwFetchFailedException(blockId, mapIndex, address, error, Some(errorMsg))
           }
 

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -32,10 +32,10 @@ import scala.util.{Failure, Success}
 import io.netty.util.internal.OutOfDirectMemoryError
 import org.roaringbitmap.RoaringBitmap
 
-import org.apache.spark.{MapOutputTracker, SparkException, TaskContext}
+import org.apache.spark.{MapOutputTracker, SparkEnv, SparkException, TaskContext}
 import org.apache.spark.MapOutputTracker.SHUFFLE_PUSH_MAP_ID
 import org.apache.spark.errors.SparkCoreErrors
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.network.buffer.{FileSegmentManagedBuffer, ManagedBuffer}
 import org.apache.spark.network.shuffle._
@@ -979,14 +979,29 @@ final class ShuffleBlockFetcherIterator(
           }
 
         case FailureFetchResult(blockId, mapIndex, address, e) =>
+          var error = e
           var errorMsg: String = null
           if (e.isInstanceOf[OutOfDirectMemoryError]) {
             val logMessage = log"Block ${MDC(BLOCK_ID, blockId)} fetch failed after " +
               log"${MDC(MAX_ATTEMPTS, maxAttemptsOnNettyOOM)} retries due to Netty OOM"
             logError(logMessage)
             errorMsg = logMessage.message
+          } else if (
+            SparkEnv.get.conf.get(config.STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH).isDefined) {
+            try {
+              val buf = FallbackStorage.read(SparkEnv.get.conf, blockId)
+              results.put(SuccessFetchResult(blockId, mapIndex, address, buf.size(), buf,
+                isNetworkReqDone = false))
+              result = null
+              error = null
+            } catch {
+              case t: Throwable =>
+                logInfo(s"Failed to read block from fallback storage: $blockId", t)
+            }
           }
-          throwFetchFailedException(blockId, mapIndex, address, e, Some(errorMsg))
+          if (error != null) {
+            throwFetchFailedException(blockId, mapIndex, address, error, Some(errorMsg))
+          }
 
         case DeferFetchRequestResult(request) =>
           val address = request.address

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -32,10 +32,10 @@ import scala.util.{Failure, Success}
 import io.netty.util.internal.OutOfDirectMemoryError
 import org.roaringbitmap.RoaringBitmap
 
-import org.apache.spark.{MapOutputTracker, SparkEnv, SparkException, TaskContext}
+import org.apache.spark.{MapOutputTracker, SparkException, TaskContext}
 import org.apache.spark.MapOutputTracker.SHUFFLE_PUSH_MAP_ID
 import org.apache.spark.errors.SparkCoreErrors
-import org.apache.spark.internal.{config, Logging}
+import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.network.buffer.{FileSegmentManagedBuffer, ManagedBuffer}
 import org.apache.spark.network.shuffle._
@@ -101,6 +101,7 @@ final class ShuffleBlockFetcherIterator(
     checksumAlgorithm: String,
     shuffleMetrics: ShuffleReadMetricsReporter,
     doBatchFetch: Boolean,
+    fallbackStorage: Option[FallbackStorage],
   clock: Clock = new SystemClock())
   extends Iterator[(BlockId, InputStream)] with DownloadFileManager with Logging {
 
@@ -986,10 +987,9 @@ final class ShuffleBlockFetcherIterator(
               log"${MDC(MAX_ATTEMPTS, maxAttemptsOnNettyOOM)} retries due to Netty OOM"
             logError(logMessage)
             errorMsg = logMessage.message
-          } else if (
-            SparkEnv.get.conf.get(config.STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH).isDefined) {
+          } else if (fallbackStorage.isDefined) {
             try {
-              val buf = FallbackStorage.read(SparkEnv.get.conf, blockId)
+              val buf = fallbackStorage.get.read(blockId)
               results.put(SuccessFetchResult(blockId, mapIndex, address, buf.size(), buf,
                 isNetworkReqDone = false))
               result = null


### PR DESCRIPTION
### What changes were proposed in this pull request?
On the presence of a fallback storage, `ShuffleBlockFetcherIterator` seeing a fetch failure can optimistically try to read a block from the fallback storage, as it might have been migrated from a decommissioned executor to the fallback storage. If storage migration happens **only** to the fallback storage (#51201), then this assumption is even more optimistic.

Note: This optimistic attempt to find the missing shuffle data on the fallback storage would collide with some replication delay handled in #51200.

### Why are the changes needed?
In a Kubernetes environment, executors may be decommissioned. With a fallback storage configured, shuffle data will be migrated to other executors or the fallback storage. Tasks that start during a decommissioning phase of another executor might read blocks from that executor after it has been decommissioned. The task does not know the new location of the migrated block. Given a fallback storage is configured, it could optimistically try to read the block from the fallback storage and thus recover from the fetch failure.

This avoids a stage retry, which otherwise is an expensive way to fetch the current block address after a block migration.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit test and manual testing in a [Kubernetes setup](https://gist.github.com/EnricoMi/e9daa1176bce4c1211af3f3c5848112a).

### Was this patch authored or co-authored using generative AI tooling?
No