### PR TITLE
[SPARK-52505][K8S] Allow to create executor kubernetes service

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1693,6 +1693,12 @@
     ],
     "sqlState" : "42702"
   },
+  "EXECUTOR_KUBERNETES_SERVICE_REQUIRES_BLOCK_MANAGER_PORT" : {
+    "message" : [
+      "Enabling the executor Kubernetes service requires <blockManagerPortConfigKey> to be set to a positive number, for instance <defaultShuffleServicePort>."
+    ],
+    "sqlState" : "42000"
+  },
   "EXEC_IMMEDIATE_DUPLICATE_ARGUMENT_ALIASES" : {
     "message" : [
       "The USING clause of this EXECUTE IMMEDIATE command contained multiple arguments with same alias (<aliases>), which is invalid; please update the command to specify unique aliases and then try it again."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1693,6 +1693,12 @@
     ],
     "sqlState" : "42702"
   },
+  "EXECUTOR_KUBERNETES_SERVICE_COOL_DOWN_PERIOD_INVALID" : {
+    "message" : [
+      "The executor Kubernetes service cool down period of <period> seconds configured via <key> must not be negative."
+    ],
+    "sqlState" : "42000"
+  },
   "EXECUTOR_KUBERNETES_SERVICE_REQUIRES_BLOCK_MANAGER_PORT" : {
     "message" : [
       "Enabling the executor Kubernetes service requires <blockManagerPortConfigKey> to be set to a positive number, for instance <defaultShuffleServicePort>."

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -466,8 +466,8 @@ private[spark] object Config extends Logging {
       .toSequence
       .createWithDefault(Nil)
 
-  val KUBERNETES_EXECUTOR_ENABLE_SERVICE =
-    ConfigBuilder("spark.kubernetes.executor.enableService")
+  val KUBERNETES_EXECUTOR_SERVICE_ENABLED =
+    ConfigBuilder("spark.kubernetes.executor.service.enabled")
       .doc("If true, a Kubernetes service is created for the executor. " +
         "An executor is usually connected to via the pod IP. Connecting to a decommissioned" +
         "executor fails after a 'connection timeout', which is set via NETWORK_TIMEOUT and " +

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -466,6 +466,18 @@ private[spark] object Config extends Logging {
       .toSequence
       .createWithDefault(Nil)
 
+  val KUBERNETES_EXECUTOR_ENABLE_SERVICE =
+    ConfigBuilder("spark.kubernetes.executor.enableService")
+      .doc("If true, a Kubernetes service is created for the executor. " +
+        "An executor is usually connected to via the pod IP. Connecting to a decommissioned" +
+        "executor fails after a 'connection timeout', which is set via NETWORK_TIMEOUT and " +
+        "defaults to 2 minutes. Connecting to the executor via a Kubernetes service instantly " +
+        "fails with 'connection refused' error. " +
+        "The kubernetes service provides access to the executors shuffle service.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val KUBERNETES_EXECUTOR_DECOMMISSION_LABEL =
     ConfigBuilder("spark.kubernetes.executor.decommissionLabel")
       .doc("Label to apply to a pod which is being decommissioned." +

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -473,7 +473,8 @@ private[spark] object Config extends Logging {
         "executor fails after a 'connection timeout', which is set via NETWORK_TIMEOUT and " +
         "defaults to 2 minutes. Connecting to the executor via a Kubernetes service instantly " +
         "fails with 'connection refused' error. " +
-        "The kubernetes service provides access to the executors shuffle service.")
+        "The executor kubernetes service provides access to the executor's block manager, so " +
+        "BLOCK_MANAGER_PORT has to be given a value greater than zero.")
       .version("4.1.0")
       .booleanConf
       .createWithDefault(false)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -466,6 +466,8 @@ private[spark] object Config extends Logging {
       .toSequence
       .createWithDefault(Nil)
 
+  val KUBERNETES_EXECUTOR_SERVICE_COOL_DOWN_PERIOD_KEY =
+    "spark.kubernetes.executor.service.coolDownPeriod"
   val KUBERNETES_EXECUTOR_SERVICE_ENABLED =
     ConfigBuilder("spark.kubernetes.executor.service.enabled")
       .doc("If true, a Kubernetes service is created for the executor. " +
@@ -473,12 +475,25 @@ private[spark] object Config extends Logging {
         "executor fails after a 'connection timeout', which is set via NETWORK_TIMEOUT and " +
         "defaults to 2 minutes. Connecting to the executor via a Kubernetes service instantly " +
         "fails with 'connection refused' error. " +
-        "The executor kubernetes service is owned by the driver pod and will survive until " +
-        "the driver pod is deleted. This kubernetes service provides access to the executor's " +
+        "For this to work, the executor kubernetes service outlives its executor pod by at least " +
+        KUBERNETES_EXECUTOR_SERVICE_COOL_DOWN_PERIOD_KEY + " seconds. " +
+        "This kubernetes service provides access to the executor's " +
         "block manager, so BLOCK_MANAGER_PORT has to be given a value greater than zero.")
       .version("4.2.0")
       .booleanConf
       .createWithDefault(false)
+
+  val KUBERNETES_EXECUTOR_SERVICE_COOL_DOWN_PERIOD =
+    ConfigBuilder(KUBERNETES_EXECUTOR_SERVICE_COOL_DOWN_PERIOD_KEY)
+      .doc(s"The number of seconds the executor kubernetes service enabled via " +
+        KUBERNETES_EXECUTOR_SERVICE_ENABLED.key + " lives beyond the lifetime of the " +
+        "corresponding executor pod. The service has to live longer than the executor, " +
+        "because connecting to a non-existing kubernetes service fails after a 'connection " +
+        "timeout', which defeats its very purpose. " +
+        s"See ${KUBERNETES_EXECUTOR_SERVICE_ENABLED.key} for more information.")
+      .version("4.2.0")
+      .intConf
+      .createWithDefault(300)
 
   val KUBERNETES_EXECUTOR_DECOMMISSION_LABEL =
     ConfigBuilder("spark.kubernetes.executor.decommissionLabel")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -473,8 +473,9 @@ private[spark] object Config extends Logging {
         "executor fails after a 'connection timeout', which is set via NETWORK_TIMEOUT and " +
         "defaults to 2 minutes. Connecting to the executor via a Kubernetes service instantly " +
         "fails with 'connection refused' error. " +
-        "The executor kubernetes service provides access to the executor's block manager, so " +
-        "BLOCK_MANAGER_PORT has to be given a value greater than zero.")
+        "The executor kubernetes service is owned by the driver pod and will survive until " +
+        "the driver pod is deleted. This kubernetes service provides access to the executor's " +
+        "block manager, so BLOCK_MANAGER_PORT has to be given a value greater than zero.")
       .version("4.2.0")
       .booleanConf
       .createWithDefault(false)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -475,7 +475,7 @@ private[spark] object Config extends Logging {
         "fails with 'connection refused' error. " +
         "The executor kubernetes service provides access to the executor's block manager, so " +
         "BLOCK_MANAGER_PORT has to be given a value greater than zero.")
-      .version("4.1.0")
+      .version("4.2.0")
       .booleanConf
       .createWithDefault(false)
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
@@ -37,6 +37,9 @@ object Constants {
   val SPARK_POD_DRIVER_ROLE = "driver"
   val SPARK_POD_EXECUTOR_ROLE = "executor"
   val SPARK_EXECUTOR_INACTIVE_LABEL = "spark-exec-inactive"
+  val SPARK_EXECUTOR_SERVICE_STATE_LABEL = "spark-exec-service-state"
+  val SPARK_EXECUTOR_SERVICE_ALIVE_STATE = "alive"
+  val SPARK_EXECUTOR_SERVICE_COOLDOWN_STATE = "cooldown"
 
   // Credentials secrets
   val DRIVER_CREDENTIALS_SECRETS_BASE_DIR =
@@ -113,6 +116,7 @@ object Constants {
   val OWNER_REFERENCE_ANNOTATION_DRIVER_VALUE = "driver"
   val OWNER_REFERENCE_ANNOTATION_EXECUTOR_VALUE = "executor"
   val COOLDOWN_PERIOD_ANNOTATION = "spark.cooldown-period"
+  val COOLDOWN_DEADLINE_ANNOTATION = "spark.cooldown-deadline"
 
   // Hadoop Configuration
   val HADOOP_CONF_VOLUME = "hadoop-properties"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
@@ -109,6 +109,9 @@ object Constants {
   val CONNECT_GRPC_BINDING_PORT = "spark.connect.grpc.binding.port"
   val EXIT_EXCEPTION_ANNOTATION = "spark.exit-exception"
   val POD_DELETION_COST = "controller.kubernetes.io/pod-deletion-cost"
+  val OWNER_REFERENCE_ANNOTATION = "spark.owner-reference"
+  val OWNER_REFERENCE_ANNOTATION_DRIVER_VALUE = "driver"
+  val OWNER_REFERENCE_ANNOTATION_EXECUTOR_VALUE = "executor"
 
   // Hadoop Configuration
   val HADOOP_CONF_VOLUME = "hadoop-properties"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
@@ -112,6 +112,7 @@ object Constants {
   val OWNER_REFERENCE_ANNOTATION = "spark.owner-reference"
   val OWNER_REFERENCE_ANNOTATION_DRIVER_VALUE = "driver"
   val OWNER_REFERENCE_ANNOTATION_EXECUTOR_VALUE = "executor"
+  val COOLDOWN_PERIOD_ANNOTATION = "spark.cooldown-period"
 
   // Hadoop Configuration
   val HADOOP_CONF_VOLUME = "hadoop-properties"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorServiceFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorServiceFeatureStep.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s.features
+
+import scala.jdk.CollectionConverters._
+
+import io.fabric8.kubernetes.api.model.{ContainerBuilder, HasMetadata, ServiceBuilder}
+
+import org.apache.spark.SparkException
+import org.apache.spark.deploy.k8s.{KubernetesExecutorConf, SparkPod}
+import org.apache.spark.internal.config.SHUFFLE_SERVICE_PORT
+
+class ExecutorServiceFeatureStep(conf: KubernetesExecutorConf) extends KubernetesFeatureConfigStep {
+  private val spark_app_selector_label = "spark-app-selector"
+  private val spark_exec_id_label = "spark-exec-id"
+  private val service_selector_labels = Set(spark_app_selector_label, spark_exec_id_label)
+
+  private lazy val sparkAppSelector = getLabel(spark_app_selector_label)
+  private lazy val sparkExecId = getLabel(spark_exec_id_label)
+  // name length is 8 + 38 + 6 + 10 = 62
+  // which fits in KUBERNETES_DNS_LABEL_NAME_MAX_LENGTH = 63
+  private lazy val serviceName = s"svc-$sparkAppSelector-exec-$sparkExecId"
+
+  private def getLabel(label: String): String = {
+    val value = conf.labels.get(label)
+    value.getOrElse(
+      throw new SparkException(s"This feature step requires label $label")
+    )
+  }
+
+  override def configurePod(pod: SparkPod): SparkPod = {
+    SparkPod(
+      pod.pod,
+      // tell the executor entry point its Kubernetes service name
+      new ContainerBuilder(pod.container)
+        .addNewEnv()
+        .withName("EXECUTOR_SERVICE_NAME")
+        .withValue(serviceName)
+        .endEnv()
+        .build())
+  }
+
+  override def getAdditionalKubernetesResources(): Seq[HasMetadata] = {
+    val selector = conf.labels
+      .filter { case (key, _) => service_selector_labels.contains(key) }
+
+    // kubernetes executor service provides access to the executor's shuffle service
+    val portName = "spark-shuffle-service"
+    val port = conf.sparkConf.get(SHUFFLE_SERVICE_PORT)
+
+    val service = new ServiceBuilder()
+      .withNewMetadata()
+      .withName(serviceName)
+      .endMetadata()
+      .withNewSpec()
+      .withSelector(selector.asJava)
+      .addNewPort()
+      .withName(portName)
+      .withPort(port)
+      .withNewTargetPort(port)
+      .endPort()
+      .endSpec()
+      .build()
+
+    Seq(service)
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorServiceFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorServiceFeatureStep.scala
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.{ContainerBuilder, HasMetadata, ServiceBu
 
 import org.apache.spark.SparkException
 import org.apache.spark.deploy.k8s.{KubernetesExecutorConf, SparkPod}
+import org.apache.spark.deploy.k8s.Constants.{OWNER_REFERENCE_ANNOTATION, OWNER_REFERENCE_ANNOTATION_DRIVER_VALUE}
 import org.apache.spark.internal.config.{BLOCK_MANAGER_PORT, SHUFFLE_SERVICE_PORT}
 
 class ExecutorServiceFeatureStep(conf: KubernetesExecutorConf) extends KubernetesFeatureConfigStep {
@@ -66,9 +67,11 @@ class ExecutorServiceFeatureStep(conf: KubernetesExecutorConf) extends Kubernete
   }
 
   override def getAdditionalKubernetesResources(): Seq[HasMetadata] = {
+    val annotation = Map(OWNER_REFERENCE_ANNOTATION -> OWNER_REFERENCE_ANNOTATION_DRIVER_VALUE)
     val service = new ServiceBuilder()
       .withNewMetadata()
       .withName(serviceName)
+      .withAnnotations(annotation.asJava)
       .endMetadata()
       .withNewSpec()
       .withSelector(selector.asJava)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorServiceFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorServiceFeatureStep.scala
@@ -23,13 +23,15 @@ import io.fabric8.kubernetes.api.model.{ContainerBuilder, HasMetadata, ServiceBu
 import org.apache.spark.SparkException
 import org.apache.spark.deploy.k8s.{KubernetesExecutorConf, SparkPod}
 import org.apache.spark.deploy.k8s.Config.KUBERNETES_EXECUTOR_SERVICE_COOL_DOWN_PERIOD
-import org.apache.spark.deploy.k8s.Constants.{COOLDOWN_PERIOD_ANNOTATION, OWNER_REFERENCE_ANNOTATION, OWNER_REFERENCE_ANNOTATION_DRIVER_VALUE, OWNER_REFERENCE_ANNOTATION_EXECUTOR_VALUE, SPARK_APP_ID_LABEL, SPARK_EXECUTOR_ID_LABEL}
+import org.apache.spark.deploy.k8s.Constants.{COOLDOWN_PERIOD_ANNOTATION, OWNER_REFERENCE_ANNOTATION, OWNER_REFERENCE_ANNOTATION_DRIVER_VALUE, OWNER_REFERENCE_ANNOTATION_EXECUTOR_VALUE, SPARK_APP_ID_LABEL, SPARK_EXECUTOR_ID_LABEL, SPARK_EXECUTOR_SERVICE_ALIVE_STATE, SPARK_EXECUTOR_SERVICE_STATE_LABEL}
 import org.apache.spark.internal.config.{BLOCK_MANAGER_PORT, SHUFFLE_SERVICE_PORT}
 
 class ExecutorServiceFeatureStep(conf: KubernetesExecutorConf) extends KubernetesFeatureConfigStep {
   private val service_selector_labels = Set(SPARK_APP_ID_LABEL, SPARK_EXECUTOR_ID_LABEL)
   private lazy val selector = conf.labels
     .filter { case (key, _) => service_selector_labels.contains(key) }
+  private lazy val labels = selector ++
+    Map(SPARK_EXECUTOR_SERVICE_STATE_LABEL -> SPARK_EXECUTOR_SERVICE_ALIVE_STATE)
 
   private lazy val sparkAppSelector = getLabel(SPARK_APP_ID_LABEL)
   private lazy val sparkExecId = getLabel(SPARK_EXECUTOR_ID_LABEL)
@@ -87,6 +89,7 @@ class ExecutorServiceFeatureStep(conf: KubernetesExecutorConf) extends Kubernete
     val service = new ServiceBuilder()
       .withNewMetadata()
       .withName(serviceName)
+      .withLabels(labels.asJava)
       .withAnnotations(annotation.asJava)
       .endMetadata()
       .withNewSpec()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorServiceFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorServiceFeatureStep.scala
@@ -22,18 +22,16 @@ import io.fabric8.kubernetes.api.model.{ContainerBuilder, HasMetadata, ServiceBu
 
 import org.apache.spark.SparkException
 import org.apache.spark.deploy.k8s.{KubernetesExecutorConf, SparkPod}
-import org.apache.spark.deploy.k8s.Constants.{OWNER_REFERENCE_ANNOTATION, OWNER_REFERENCE_ANNOTATION_DRIVER_VALUE}
+import org.apache.spark.deploy.k8s.Constants.{OWNER_REFERENCE_ANNOTATION, OWNER_REFERENCE_ANNOTATION_DRIVER_VALUE, SPARK_APP_ID_LABEL, SPARK_EXECUTOR_ID_LABEL}
 import org.apache.spark.internal.config.{BLOCK_MANAGER_PORT, SHUFFLE_SERVICE_PORT}
 
 class ExecutorServiceFeatureStep(conf: KubernetesExecutorConf) extends KubernetesFeatureConfigStep {
-  private val spark_app_selector_label = "spark-app-selector"
-  private val spark_exec_id_label = "spark-exec-id"
-  private val service_selector_labels = Set(spark_app_selector_label, spark_exec_id_label)
+  private val service_selector_labels = Set(SPARK_APP_ID_LABEL, SPARK_EXECUTOR_ID_LABEL)
   private lazy val selector = conf.labels
     .filter { case (key, _) => service_selector_labels.contains(key) }
 
-  private lazy val sparkAppSelector = getLabel(spark_app_selector_label)
-  private lazy val sparkExecId = getLabel(spark_exec_id_label)
+  private lazy val sparkAppSelector = getLabel(SPARK_APP_ID_LABEL)
+  private lazy val sparkExecId = getLabel(SPARK_EXECUTOR_ID_LABEL)
   // name length is 8 + 38 + 6 + 10 = 62
   // which fits in KUBERNETES_DNS_LABEL_NAME_MAX_LENGTH = 63
   private lazy val serviceName = s"svc-$sparkAppSelector-exec-$sparkExecId"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -463,6 +463,7 @@ class ExecutorPodsAllocator(
         kubernetesClient.pods().inNamespace(namespace).resource(podWithAttachedContainer).create()
       try {
         addOwnerReference(createdExecutorPod, resources)
+        kubernetesClient.resourceList(resources: _*).forceConflicts().serverSideApply()
         resources
           .filter(_.getKind == "PersistentVolumeClaim")
           .foreach { resource =>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -17,7 +17,8 @@
 package org.apache.spark.scheduler.cluster.k8s
 
 import java.time.Instant
-import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
+import java.util.Comparator
+import java.util.concurrent.{ConcurrentHashMap, PriorityBlockingQueue, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable
@@ -50,11 +51,12 @@ class ExecutorPodsAllocator(
 
   protected val PVC_COUNTER = new AtomicInteger(0)
 
-  protected val maxPVCs = if (Utils.isDynamicAllocationEnabled(conf)) {
+  protected val maxNumExecutors = if (Utils.isDynamicAllocationEnabled(conf)) {
     conf.get(DYN_ALLOCATION_MAX_EXECUTORS)
   } else {
     conf.getInt(EXECUTOR_INSTANCES.key, DEFAULT_NUMBER_EXECUTORS)
   }
+  protected val maxPVCs = maxNumExecutors
 
   protected val podAllocOnPVC = conf.get(KUBERNETES_DRIVER_OWN_PVC) &&
     conf.get(KUBERNETES_DRIVER_REUSE_PVC) && conf.get(KUBERNETES_DRIVER_WAIT_TO_REUSE_PVC)
@@ -113,6 +115,14 @@ class ExecutorPodsAllocator(
   // Executor IDs that have been requested from Kubernetes but have not been detected in any POD
   // snapshot yet but already known by the scheduler backend. Mapped to the ResourceProfile id.
   protected val schedulerKnownNewlyCreatedExecs = mutable.LinkedHashMap.empty[Long, Int]
+
+  // Kubernetes services annotated with COOLDOWN_PERIOD_ANNOTATION are deleted
+  // at least this number of seconds after the corresponding executor pod got deleted
+  // known cooldown periods and their services
+  protected[k8s] val aliveServicesWithCooldown = new ConcurrentHashMap[Long, (Int, HasMetadata)]()
+  // elements encode the UNIX timestamp to delete the service, as well as the pod
+  protected[k8s] val serviceDeletionQueue = new PriorityBlockingQueue[(Long, HasMetadata)](
+    maxNumExecutors, Comparator.comparingLong[(Long, HasMetadata)](t => t._1))
 
   protected val dynamicAllocationEnabled = Utils.isDynamicAllocationEnabled(conf)
 
@@ -231,6 +241,32 @@ class ExecutorPodsAllocator(
     if (snapshots.nonEmpty) {
       val existingExecs = lastSnapshot.executorPods.keySet
       _deletedExecutorIds = _deletedExecutorIds.intersect(existingExecs)
+
+      // schedule all services for deletion that have a cooldown period but no alive executor
+      val deletedExecutorsWithCooldownService =
+        aliveServicesWithCooldown.keySet().asScala
+          .diff(existingExecs)
+          .diff(newlyCreatedExecutors.keySet.diff(k8sKnownExecIds.toSet))
+      deletedExecutorsWithCooldownService.foreach { deletedExecId =>
+        val (cooldown, service) = aliveServicesWithCooldown.remove(deletedExecId)
+        logInfo(s"Executor with service got deleted, service removal scheduled in ${cooldown}s")
+        serviceDeletionQueue.put((currentTime + cooldown, service))
+      }
+    }
+
+    // delete services the meet their deadline
+    while (serviceDeletionQueue.peek() != null && serviceDeletionQueue.peek()._1 <= currentTime) {
+      // we might get a different service here than peek() returned above,
+      // but by definition, the deadline is less or equal to the one tested above
+      val (deadline, service) = serviceDeletionQueue.poll()
+      logInfo(s"Service deadline $deadline has passed current time $currentTime, " +
+        s"deleting service $service")
+      try {
+        kubernetesClient.resourceList(service).delete()
+      } catch {
+        case NonFatal(e) =>
+          logWarning(s"Failed to delete service $service", e)
+      }
     }
 
     val notDeletedPods = lastSnapshot.executorPods
@@ -459,11 +495,11 @@ class ExecutorPodsAllocator(
         .build()
       val resources = replacePVCsIfNeeded(
         podWithAttachedContainer, resolvedExecutorSpec.executorKubernetesResources, reusablePVCs)
-      val annotation = OWNER_REFERENCE_ANNOTATION
+      val refAnnotation = OWNER_REFERENCE_ANNOTATION
       val driverValue = OWNER_REFERENCE_ANNOTATION_DRIVER_VALUE
       val executorValue = OWNER_REFERENCE_ANNOTATION_EXECUTOR_VALUE
       val getOwnerReference = (r: HasMetadata) =>
-        r.getMetadata.getAnnotations.getOrDefault(annotation, executorValue)
+        r.getMetadata.getAnnotations.getOrDefault(refAnnotation, executorValue)
       val (driverResources, executorResources) =
         resources
           .filter(r => Set(driverValue, executorValue).contains(getOwnerReference(r)))
@@ -476,9 +512,22 @@ class ExecutorPodsAllocator(
           addOwnerReference(driverPod.get, driverResources)
         }
         kubernetesClient.resourceList(resources: _*).forceConflicts().serverSideApply()
-        resources
-          .filter(_.getKind == "PersistentVolumeClaim")
-          .foreach { resource =>
+
+        resources.foreach {
+          case resource if resource.getKind == "Service" &&
+            resource.getMetadata.getAnnotations.containsKey(COOLDOWN_PERIOD_ANNOTATION) =>
+              val cooldown =
+                resource.getMetadata.getAnnotations.get(COOLDOWN_PERIOD_ANNOTATION).toInt
+              logInfo(s"Memorizing executor service $newExecutorId with cooldown period $cooldown")
+              val (_, existing) = {
+                aliveServicesWithCooldown.computeIfAbsent(newExecutorId, _ => (cooldown, resource))
+              }
+              if (existing != resource) {
+                throw new SparkException(
+                  "Only one service with cool down period supported per executor")
+              }
+
+          case resource if resource.getKind == "PersistentVolumeClaim" =>
             if (conf.get(KUBERNETES_DRIVER_OWN_PVC) && driverPod.nonEmpty) {
               addOwnerReference(driverPod.get, Seq(resource))
             }
@@ -488,7 +537,9 @@ class ExecutorPodsAllocator(
               log"StorageClass ${MDC(LogKeys.CLASS_NAME, pvc.getSpec.getStorageClassName)}")
             kubernetesClient.persistentVolumeClaims().inNamespace(namespace).resource(pvc).create()
             PVC_COUNTER.incrementAndGet()
-          }
+
+          case _ =>
+        }
         newlyCreatedExecutors(newExecutorId) = (resourceProfileId, clock.getTimeMillis())
         logDebug(s"Requested executor with id $newExecutorId from Kubernetes.")
       } catch {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
@@ -65,6 +65,12 @@ private[spark] class KubernetesExecutorBuilder {
         }
       }
 
+    val optionalFeatures = Seq(
+      Some(conf.get(Config.KUBERNETES_EXECUTOR_ENABLE_SERVICE))
+        .filter(enabled => enabled)
+        .map(_ => new ExecutorServiceFeatureStep(conf))
+    ).flatten
+
     val allFeatures = Seq(
       new BasicExecutorFeatureStep(conf, secMgr, resourceProfile),
       new ExecutorKubernetesCredentialsFeatureStep(conf),
@@ -72,7 +78,7 @@ private[spark] class KubernetesExecutorBuilder {
       new EnvSecretsFeatureStep(conf),
       new MountVolumesFeatureStep(conf),
       new HadoopConfExecutorFeatureStep(conf),
-      new LocalDirsFeatureStep(conf)) ++ userFeatures
+      new LocalDirsFeatureStep(conf)) ++ optionalFeatures ++ userFeatures
 
     val features = allFeatures.filterNot(f =>
       conf.get(Config.KUBERNETES_EXECUTOR_POD_EXCLUDED_FEATURE_STEPS).contains(f.getClass.getName))

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
@@ -66,7 +66,7 @@ private[spark] class KubernetesExecutorBuilder {
       }
 
     val optionalFeatures = Seq(
-      Some(conf.get(Config.KUBERNETES_EXECUTOR_ENABLE_SERVICE))
+      Some(conf.get(Config.KUBERNETES_EXECUTOR_SERVICE_ENABLED))
         .filter(enabled => enabled)
         .map(_ => new ExecutorServiceFeatureStep(conf))
     ).flatten

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/ExecutorServiceFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/ExecutorServiceFeatureStepSuite.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s.features
+
+import scala.jdk.CollectionConverters.{CollectionHasAsScala, MapHasAsScala}
+
+import io.fabric8.kubernetes.api.model.{HasMetadata, Service}
+import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.{SparkConf, SparkFunSuite, SparkIllegalArgumentException}
+import org.apache.spark.deploy.k8s.{KubernetesTestConf, SparkPod}
+import org.apache.spark.internal.config.BLOCK_MANAGER_PORT
+
+
+class ExecutorServiceFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
+
+  private var baseConf: SparkConf = _
+
+  before {
+    baseConf = new SparkConf(false)
+    baseConf.set(BLOCK_MANAGER_PORT, 1234)
+  }
+
+  test("no block manager port") {
+    baseConf.remove(BLOCK_MANAGER_PORT)
+    intercept[SparkIllegalArgumentException] {
+      evaluateStep()
+    }
+  }
+
+  test("default configuration") {
+    val (sparkPod, resources) = evaluateStep()
+    assertSparkPod(sparkPod)
+    assertResources(resources)
+  }
+
+  private def assertSparkPod(sparkPod: SparkPod): Unit = {
+    val env = sparkPod.container.getEnv.asScala.map(v => v.getName -> v.getValue).toMap
+    assert(env.get("EXECUTOR_SERVICE_NAME") === Some("svc-appId-exec-1"))
+  }
+
+  private def assertResources(resources: Seq[HasMetadata]): Unit = {
+    assert(resources.size === 1)
+    assert(resources.head.getKind === "Service")
+    assertService(resources.head.asInstanceOf[Service])
+  }
+
+  private def assertService(service: Service): Unit = {
+    assert(service.getKind === "Service")
+    assert(service.getMetadata.getName === "svc-appId-exec-1")
+    assert(service.getMetadata.getAnnotations.asScala === Map(
+      "spark.owner-reference" -> "driver"
+    ))
+    assert(service.getSpec.getSelector.asScala ===
+      Map("spark-exec-id" -> "1", "spark-app-selector" -> "appId"))
+    assert(service.getSpec.getPorts.size() === 1)
+    val port = service.getSpec.getPorts.get(0)
+    assert(port.getName === "spark-block-manager")
+    assert(port.getPort === 1234)
+    assert(port.getTargetPort.getIntVal === 1234)
+  }
+
+  private def evaluateStep(): (SparkPod, Seq[HasMetadata]) = {
+    val executorConf = KubernetesTestConf.createExecutorConf(
+      sparkConf = baseConf)
+    val step = new ExecutorServiceFeatureStep(executorConf)
+    (step.configurePod(SparkPod.initialPod()), step.getAdditionalKubernetesResources())
+  }
+}

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/ExecutorServiceFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/ExecutorServiceFeatureStepSuite.scala
@@ -64,6 +64,7 @@ class ExecutorServiceFeatureStepSuite extends SparkFunSuite with BeforeAndAfter 
   }
 
   private def assertSparkPod(sparkPod: SparkPod): Unit = {
+    assert(sparkPod.pod.getSpec.getEnableServiceLinks === false)
     val env = sparkPod.container.getEnv.asScala.map(v => v.getName -> v.getValue).toMap
     assert(env.get("EXECUTOR_SERVICE_NAME") === Some("svc-appId-exec-1"))
   }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -988,53 +988,53 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     assert(podsAllocatorUnderTest.aliveServicesWithCooldown.size() == 1)
 
     // make pods allocator see an empty snapshot
-    waitForExecutorPodsClock.setTime(startTime + 10)
+    waitForExecutorPodsClock.setTime(startTime + 10*1000)
     snapshotsStore.removeDeletedExecutors()
     snapshotsStore.notifySubscribers()
     assert(podsAllocatorUnderTest.aliveServicesWithCooldown.size() == 1)
 
     // the executor is coming up
-    waitForExecutorPodsClock.setTime(startTime + 20)
+    waitForExecutorPodsClock.setTime(startTime + 20*1000)
     snapshotsStore.updatePod(pendingExecutor(1))
     snapshotsStore.notifySubscribers()
     assert(podsAllocatorUnderTest.aliveServicesWithCooldown.size() == 1)
 
     // ... and running
-    waitForExecutorPodsClock.setTime(startTime + 30)
+    waitForExecutorPodsClock.setTime(startTime + 30*1000)
     snapshotsStore.updatePod(runningExecutor(1))
     snapshotsStore.notifySubscribers()
     assert(podsAllocatorUnderTest.aliveServicesWithCooldown.size() == 1)
 
     // the executor gets unscheduled
-    waitForExecutorPodsClock.setTime(startTime + 40)
+    waitForExecutorPodsClock.setTime(startTime + 40*1000)
     podsAllocatorUnderTest.setTotalExpectedExecutors(
       Map(defaultProfile -> 0))
     snapshotsStore.notifySubscribers()
     assert(podsAllocatorUnderTest.aliveServicesWithCooldown.size() == 1)
 
     // the executor disappears, does not trigger anything
-    waitForExecutorPodsClock.setTime(startTime + 50)
+    waitForExecutorPodsClock.setTime(startTime + 50*1000)
     snapshotsStore.updatePod(deletedExecutor(1))
     snapshotsStore.notifySubscribers()
     assert(podsAllocatorUnderTest.aliveServicesWithCooldown.size() == 1)
     assert(podsAllocatorUnderTest.serviceDeletionQueue.size() == 0)
 
     // the executor disappears, this triggers scheduling service for deletion
-    waitForExecutorPodsClock.setTime(startTime + 60)
+    waitForExecutorPodsClock.setTime(startTime + 60*1000)
     snapshotsStore.removeDeletedExecutors()
     snapshotsStore.notifySubscribers()
     assert(podsAllocatorUnderTest.aliveServicesWithCooldown.size() == 0)
     assert(podsAllocatorUnderTest.serviceDeletionQueue.size() == 1)
 
     // one second passes by, cooldown period is two seconds
-    waitForExecutorPodsClock.setTime(startTime + 61)
+    waitForExecutorPodsClock.setTime(startTime + 61*1000)
     snapshotsStore.notifySubscribers()
     assert(podsAllocatorUnderTest.aliveServicesWithCooldown.size() == 0)
     assert(podsAllocatorUnderTest.serviceDeletionQueue.size() == 1)
     verify(resourceList, never()).delete()
 
     // two seconds passed by, service is being deleted
-    waitForExecutorPodsClock.setTime(startTime + 62)
+    waitForExecutorPodsClock.setTime(startTime + 62*1000)
     snapshotsStore.notifySubscribers()
     assert(podsAllocatorUnderTest.aliveServicesWithCooldown.size() == 0)
     assert(podsAllocatorUnderTest.serviceDeletionQueue.size() == 0)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -25,7 +25,7 @@ import scala.jdk.CollectionConverters._
 
 import io.fabric8.kubernetes.api.model._
 import io.fabric8.kubernetes.client.{KubernetesClient, KubernetesClientException}
-import io.fabric8.kubernetes.client.dsl.PodResource
+import io.fabric8.kubernetes.client.dsl.{NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable, PodResource, ServerSideApplicable}
 import org.mockito.{ArgumentCaptor, Mock, MockitoAnnotations}
 import org.mockito.ArgumentMatchers.{any, anyString, eq => meq}
 import org.mockito.Mockito.{never, times, verify, when}
@@ -153,6 +153,11 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
       conf, secMgr, executorBuilder, kubernetesClient, snapshotsStore, waitForExecutorPodsClock)
     when(schedulerBackend.getExecutorIds()).thenReturn(Seq.empty)
     podsAllocatorUnderTest.start(TEST_SPARK_APP_ID, schedulerBackend)
+    val apl = mock[NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable[HasMetadata]]
+    val ssa = mock[ServerSideApplicable[java.util.List[HasMetadata]]]
+    when(apl.forceConflicts()).thenReturn(ssa)
+    when(kubernetesClient.resourceList()).thenReturn(apl)
+    when(kubernetesClient.resourceList(any[HasMetadata]())).thenReturn(apl)
     when(kubernetesClient.persistentVolumeClaims()).thenReturn(persistentVolumeClaims)
     when(persistentVolumeClaims.inNamespace("default")).thenReturn(pvcWithNamespace)
     when(pvcWithNamespace.withLabel(any(), any())).thenReturn(labeledPersistentVolumeClaims)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -822,7 +822,7 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     // service is considered for creation
     // resources should have been created
     verify(kubernetesClient, times(1)).resourceList(meq(service))
-    verify(resourceList).serverSideApply()
+    verify(resourceList, times(1)).serverSideApply()
   }
 
   test("SPARK-55587: executor feature steps resources ownership") {
@@ -906,16 +906,6 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
   }
 
   test("SPARK-55587: executor feature steps resources deleted on failure") {
-    val executorMetadata = mock[ObjectMeta]
-    when(executorMetadata.getName).thenReturn("executor-name")
-    when(executorMetadata.getUid).thenReturn("executor-uid")
-
-    val executorPod = mock[Pod]
-    when(podResource.create()).thenReturn(executorPod)
-    when(executorPod.getMetadata).thenReturn(executorMetadata)
-    when(executorPod.getApiVersion).thenReturn("executor-version")
-    when(executorPod.getKind).thenReturn("executor-kind")
-
     val service = new ServiceBuilder()
       .withNewMetadata()
       .withName("service")
@@ -951,7 +941,7 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     verify(podsWithNamespace).resource(podWithAttachedContainerForId(1))
 
     // resources should have been deleted on failure
-    verify(resourceList).delete()
+    verify(resourceList, times(1)).delete()
   }
 
   test("SPARK-33262: pod allocator does not stall with pending pods") {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilderSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilderSuite.scala
@@ -70,7 +70,7 @@ class KubernetesExecutorBuilderSuite extends PodBuilderSuite {
     new KubernetesExecutorBuilder().buildFromFeatures(conf, secMgr, client, defaultProfile).pod
   }
 
-  test("SPARK-XXXXX: check executor kubernetes spec with service disabled by default") {
+  test("SPARK-52505: check executor kubernetes spec with service disabled by default") {
     val sparkConf = baseConf
     val conf = KubernetesTestConf.createExecutorConf(sparkConf = sparkConf)
     val secMgr = new SecurityManager(sparkConf)
@@ -84,7 +84,7 @@ class KubernetesExecutorBuilderSuite extends PodBuilderSuite {
     assert(spec.executorKubernetesResources.size === 0)
   }
 
-  test("SPARK-XXXXX: check executor kubernetes spec with service enabled") {
+  test("SPARK-52505: check executor kubernetes spec with service enabled") {
     val sparkConf = baseConf.clone
       .set(Config.KUBERNETES_EXECUTOR_ENABLE_SERVICE, true)
       .set(BLOCK_MANAGER_PORT, 1234)
@@ -110,7 +110,7 @@ class KubernetesExecutorBuilderSuite extends PodBuilderSuite {
     assert(port.getPort === 1234)
   }
 
-  test("SPARK-XXXXX: check executor kubernetes service requires block manager port") {
+  test("SPARK-52505: check executor kubernetes service requires block manager port") {
     val sparkConf = baseConf.clone.set(Config.KUBERNETES_EXECUTOR_ENABLE_SERVICE, true)
     val conf = KubernetesTestConf.createExecutorConf(sparkConf = sparkConf)
     val secMgr = new SecurityManager(sparkConf)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilderSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilderSuite.scala
@@ -22,10 +22,10 @@ import io.fabric8.kubernetes.api.model.Service
 import io.fabric8.kubernetes.client.KubernetesClient
 import org.mockito.Mockito.mock
 
-import org.apache.spark.{SecurityManager, SparkConf}
+import org.apache.spark.{SecurityManager, SparkConf, SparkIllegalArgumentException}
 import org.apache.spark.deploy.k8s._
 import org.apache.spark.deploy.k8s.features.KubernetesExecutorCustomFeatureConfigStep
-import org.apache.spark.internal.config.{ConfigEntry, SHUFFLE_SERVICE_PORT}
+import org.apache.spark.internal.config.{BLOCK_MANAGER_PORT, ConfigEntry}
 import org.apache.spark.resource.ResourceProfile
 
 class KubernetesExecutorBuilderSuite extends PodBuilderSuite {
@@ -85,29 +85,39 @@ class KubernetesExecutorBuilderSuite extends PodBuilderSuite {
   }
 
   test("SPARK-XXXXX: check executor kubernetes spec with service enabled") {
-    Seq(None, Some(1234)).foreach { somePort =>
-      val sparkConf = baseConf.clone.set(Config.KUBERNETES_EXECUTOR_ENABLE_SERVICE, true)
-      somePort.foreach(sparkConf.set(SHUFFLE_SERVICE_PORT, _))
-      val conf = KubernetesTestConf.createExecutorConf(sparkConf = sparkConf)
-      val secMgr = new SecurityManager(sparkConf)
-      val client = mock(classOf[KubernetesClient])
-      val profile = ResourceProfile.getOrCreateDefaultProfile(sparkConf)
-      val spec = new KubernetesExecutorBuilder().buildFromFeatures(conf, secMgr, client, profile)
+    val sparkConf = baseConf.clone
+      .set(Config.KUBERNETES_EXECUTOR_ENABLE_SERVICE, true)
+      .set(BLOCK_MANAGER_PORT, 1234)
+    val conf = KubernetesTestConf.createExecutorConf(sparkConf = sparkConf)
+    val secMgr = new SecurityManager(sparkConf)
+    val client = mock(classOf[KubernetesClient])
+    val profile = ResourceProfile.getOrCreateDefaultProfile(sparkConf)
+    val spec = new KubernetesExecutorBuilder().buildFromFeatures(conf, secMgr, client, profile)
 
-      val containerEnvs = spec.pod.container.getEnv.asScala
-      assert(containerEnvs.exists(_.getName === "EXECUTOR_SERVICE_NAME"))
-      val containerEnv = containerEnvs.filter(_.getName === "EXECUTOR_SERVICE_NAME").head
-      assert(containerEnv.getValue === "svc-appId-exec-1")
+    val containerEnvs = spec.pod.container.getEnv.asScala
+    assert(containerEnvs.exists(_.getName === "EXECUTOR_SERVICE_NAME"))
+    val containerEnv = containerEnvs.filter(_.getName === "EXECUTOR_SERVICE_NAME").head
+    assert(containerEnv.getValue === "svc-appId-exec-1")
 
-      assert(spec.executorKubernetesResources.size === 1)
-      val resource = spec.executorKubernetesResources.head
-      assert(resource.getKind === "Service")
-      val service = resource.asInstanceOf[Service]
-      assert(service.getMetadata.getName === "svc-appId-exec-1")
-      assert(service.getSpec.getPorts.size() === 1)
-      val port = service.getSpec.getPorts.get(0)
-      assert(port.getName === "spark-shuffle-service")
-      assert(port.getPort === somePort.getOrElse(SHUFFLE_SERVICE_PORT.defaultValue.get))
+    assert(spec.executorKubernetesResources.size === 1)
+    val resource = spec.executorKubernetesResources.head
+    assert(resource.getKind === "Service")
+    val service = resource.asInstanceOf[Service]
+    assert(service.getMetadata.getName === "svc-appId-exec-1")
+    assert(service.getSpec.getPorts.size() === 1)
+    val port = service.getSpec.getPorts.get(0)
+    assert(port.getName === "spark-block-manager")
+    assert(port.getPort === 1234)
+  }
+
+  test("SPARK-XXXXX: check executor kubernetes service requires block manager port") {
+    val sparkConf = baseConf.clone.set(Config.KUBERNETES_EXECUTOR_ENABLE_SERVICE, true)
+    val conf = KubernetesTestConf.createExecutorConf(sparkConf = sparkConf)
+    val secMgr = new SecurityManager(sparkConf)
+    val client = mock(classOf[KubernetesClient])
+    val profile = ResourceProfile.getOrCreateDefaultProfile(sparkConf)
+    assertThrows[SparkIllegalArgumentException] {
+      new KubernetesExecutorBuilder().buildFromFeatures(conf, secMgr, client, profile)
     }
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilderSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilderSuite.scala
@@ -16,12 +16,16 @@
  */
 package org.apache.spark.scheduler.cluster.k8s
 
+import scala.jdk.CollectionConverters.IterableHasAsScala
+
+import io.fabric8.kubernetes.api.model.Service
 import io.fabric8.kubernetes.client.KubernetesClient
+import org.mockito.Mockito.mock
 
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.deploy.k8s._
 import org.apache.spark.deploy.k8s.features.KubernetesExecutorCustomFeatureConfigStep
-import org.apache.spark.internal.config.ConfigEntry
+import org.apache.spark.internal.config.{ConfigEntry, SHUFFLE_SERVICE_PORT}
 import org.apache.spark.resource.ResourceProfile
 
 class KubernetesExecutorBuilderSuite extends PodBuilderSuite {
@@ -64,6 +68,47 @@ class KubernetesExecutorBuilderSuite extends PodBuilderSuite {
     val secMgr = new SecurityManager(sparkConf)
     val defaultProfile = ResourceProfile.getOrCreateDefaultProfile(sparkConf)
     new KubernetesExecutorBuilder().buildFromFeatures(conf, secMgr, client, defaultProfile).pod
+  }
+
+  test("SPARK-XXXXX: check executor kubernetes spec with service disabled by default") {
+    val sparkConf = baseConf
+    val conf = KubernetesTestConf.createExecutorConf(sparkConf = sparkConf)
+    val secMgr = new SecurityManager(sparkConf)
+    val client = mock(classOf[KubernetesClient])
+    val profile = ResourceProfile.getOrCreateDefaultProfile(sparkConf)
+    val spec = new KubernetesExecutorBuilder().buildFromFeatures(conf, secMgr, client, profile)
+
+    val containerEnvs = spec.pod.container.getEnv.asScala
+    assert(!containerEnvs.exists(_.getName === "EXECUTOR_SERVICE_NAME"))
+
+    assert(spec.executorKubernetesResources.size === 0)
+  }
+
+  test("SPARK-XXXXX: check executor kubernetes spec with service enabled") {
+    Seq(None, Some(1234)).foreach { somePort =>
+      val sparkConf = baseConf.clone.set(Config.KUBERNETES_EXECUTOR_ENABLE_SERVICE, true)
+      somePort.foreach(sparkConf.set(SHUFFLE_SERVICE_PORT, _))
+      val conf = KubernetesTestConf.createExecutorConf(sparkConf = sparkConf)
+      val secMgr = new SecurityManager(sparkConf)
+      val client = mock(classOf[KubernetesClient])
+      val profile = ResourceProfile.getOrCreateDefaultProfile(sparkConf)
+      val spec = new KubernetesExecutorBuilder().buildFromFeatures(conf, secMgr, client, profile)
+
+      val containerEnvs = spec.pod.container.getEnv.asScala
+      assert(containerEnvs.exists(_.getName === "EXECUTOR_SERVICE_NAME"))
+      val containerEnv = containerEnvs.filter(_.getName === "EXECUTOR_SERVICE_NAME").head
+      assert(containerEnv.getValue === "svc-appId-exec-1")
+
+      assert(spec.executorKubernetesResources.size === 1)
+      val resource = spec.executorKubernetesResources.head
+      assert(resource.getKind === "Service")
+      val service = resource.asInstanceOf[Service]
+      assert(service.getMetadata.getName === "svc-appId-exec-1")
+      assert(service.getSpec.getPorts.size() === 1)
+      val port = service.getSpec.getPorts.get(0)
+      assert(port.getName === "spark-shuffle-service")
+      assert(port.getPort === somePort.getOrElse(SHUFFLE_SERVICE_PORT.defaultValue.get))
+    }
   }
 }
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilderSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilderSuite.scala
@@ -86,7 +86,7 @@ class KubernetesExecutorBuilderSuite extends PodBuilderSuite {
 
   test("SPARK-52505: check executor kubernetes spec with service enabled") {
     val sparkConf = baseConf.clone
-      .set(Config.KUBERNETES_EXECUTOR_ENABLE_SERVICE, true)
+      .set(Config.KUBERNETES_EXECUTOR_SERVICE_ENABLED, true)
       .set(BLOCK_MANAGER_PORT, 1234)
     val conf = KubernetesTestConf.createExecutorConf(sparkConf = sparkConf)
     val secMgr = new SecurityManager(sparkConf)
@@ -111,7 +111,7 @@ class KubernetesExecutorBuilderSuite extends PodBuilderSuite {
   }
 
   test("SPARK-52505: check executor kubernetes service requires block manager port") {
-    val sparkConf = baseConf.clone.set(Config.KUBERNETES_EXECUTOR_ENABLE_SERVICE, true)
+    val sparkConf = baseConf.clone.set(Config.KUBERNETES_EXECUTOR_SERVICE_ENABLED, true)
     val conf = KubernetesTestConf.createExecutorConf(sparkConf = sparkConf)
     val secMgr = new SecurityManager(sparkConf)
     val client = mock(classOf[KubernetesClient])

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -102,7 +102,8 @@ case "$1" in
       --executor-id $SPARK_EXECUTOR_ID
       --cores $SPARK_EXECUTOR_CORES
       --app-id $SPARK_APPLICATION_ID
-      --hostname $SPARK_EXECUTOR_POD_IP
+      ${EXECUTOR_SERVICE_NAME:+--bind-address $SPARK_EXECUTOR_POD_IP}
+      --hostname ${EXECUTOR_SERVICE_NAME:-$SPARK_EXECUTOR_POD_IP}
       --resourceProfileId $SPARK_RESOURCE_PROFILE_ID
       --podName $SPARK_EXECUTOR_POD_NAME
     )


### PR DESCRIPTION
### What changes were proposed in this pull request?
This allows executors to register its block manager with the driver via a Kubernetes service name rather than the pod IP. The driver and executors then connect to the executor block managers via the service.

### Why are the changes needed?
In Kubernetes, connecting to an evicted (decommissioned) executor times out after 2 minutes (default). Executors connect to other executors synchronously (one at a time), so this time out accumulates for each executor peer. An executor that reads from many decommissioned executors blocks for a multiple of the timeout until it fails with a fetch failure.

This can be fixed by binding the block manager to a fixed port, defining a Kubernetes service for that block manager port and have the executor register that K8S service port with the driver. The driver and other executors then connect to the service name and instantly fail with a `connection refused` if the executor got decommissioned and the service removed.

Setting `spark.kubernetes.executor.enableService=true` and defining `spark.blockManager.port` will perform this setup for each executor.

Note this Kubernetes service has to live longer than the executor pod. Otherwise, connecting to the service observes the same timeout. For this, the service is owned by the driver. Extensive lifetime of the service is limited by a "cool-down period" that defaults to 300s.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Unit tests.

### Was this patch authored or co-authored using generative AI tooling?
No.