### PR TITLE
[SPARK-52514][R][INFRA] Use R 4.5.1 in `windows` R GitHub Action Windows job

### DIFF
--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -28,7 +28,6 @@ jobs:
     name: "Build module: sparkr"
     runs-on: windows-2022
     timeout-minutes: 120
-    if: github.repository == 'apache/spark'
     steps:
     - name: Download winutils Hadoop binary
       uses: actions/checkout@v4

--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: "Build / SparkR-only (master, 4.4.3, windows-2022)"
+name: "Build / SparkR-only (master, 4.5.1, windows-2022)"
 
 on:
   schedule:
@@ -51,10 +51,10 @@ jobs:
       with:
         distribution: zulu
         java-version: 17
-    - name: Install R 4.4.3
+    - name: Install R 4.5.1
       uses: r-lib/actions/setup-r@v2
       with:
-        r-version: 4.4.3
+        r-version: 4.5.1
     - name: Install R dependencies
       run: |
         Rscript -e "install.packages(c('knitr', 'rmarkdown', 'testthat', 'e1071', 'survival', 'arrow', 'xml2'), repos='https://cloud.r-project.org/')"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use R 4.5.1 instead of 4.4.3 in `windows` R GitHub Action Windows job.

- https://github.com/apache/spark/actions/workflows/build_sparkr_window.yml

### Why are the changes needed?

[R version 4.5.1 (Great Square Root)](https://cran.r-project.org/src/base/R-4) has been released on 2025-06-13.

We had better have a test coverage for R 4.5.1.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Since `build_sparkr_window.yml` is a daily job, I triggered here in my local PR.
- https://github.com/dongjoon-hyun/spark/actions/runs/15714349537/job/44280216129

### Was this patch authored or co-authored using generative AI tooling?

No.