### PR TITLE
[SPARK-52514][INFRA] Use `windows-2025` image in R GitHub Action job

### DIFF
--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: "Build / SparkR-only (master, 4.4.3, windows-2022)"
+name: "Build / SparkR-only (master, 4.4.3, windows-2025)"
 
 on:
   schedule:
@@ -26,7 +26,7 @@ on:
 jobs:
   build:
     name: "Build module: sparkr"
-    runs-on: windows-2022
+    runs-on: windows-2025
     timeout-minutes: 120
     if: github.repository == 'apache/spark'
     steps:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `windows-2025` image in R GitHub Action job for Apache Spark 4.1.0 while `windows-2022` image is used for `branch-4.0`.

### Why are the changes needed?

`Windows 2025` is added to the GitHub Action virtual environments.

- https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md

### Does this PR introduce _any_ user-facing change?

No behavior change because this is an infra PR.

### How was this patch tested?

This is tested manually because this is a daily CI job.
- https://github.com/dongjoon-hyun/spark/actions/runs/15717747421/job/44291608305

![Screenshot 2025-06-17 at 3 02 33 PM](https://github.com/user-attachments/assets/d47c6cbb-a9b5-4dd7-832f-b3a7a5ee4bce)

### Was this patch authored or co-authored using generative AI tooling?

No.