### PR TITLE
[SPARK-52591][SDP] Validate streaming-ness of DFs returned by SDP table and standalone flow definitions

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2744,7 +2744,8 @@
           "Streaming tables may only be defined by streaming relations, but the flow <flowIdentifier> attempts to write a batch relation to the streaming table <tableIdentifier>. Consider using the STREAM operator in Spark-SQL to convert the batch relation into a streaming relation, or populating the streaming table with an append once-flow instead."
         ]
       }
-    }
+    },
+    "sqlState" : "42000"
   },
   "INVALID_FORMAT" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2719,27 +2719,27 @@
     ],
     "sqlState" : "42000"
   },
-  "INVALID_FLOW_RELATION_TYPE" : {
+  "INVALID_FLOW_QUERY_TYPE" : {
     "message" : [
       "Flow <flowIdentifier> returns an invalid relation type."
     ],
     "subClass" : {
-      "FOR_MATERIALIZED_VIEW" : {
+      "STREAMING_RELATION_FOR_MATERIALIZED_VIEW" : {
         "message" : [
           "Materialized views may only be defined by a batch relation, but the flow <flowIdentifier> attempts to write a streaming relation to the materialized view <tableIdentifier>."
         ]
       },
-      "FOR_ONCE_FLOW" : {
+      "STREAMING_RELATION_FOR_ONCE_FLOW" : {
         "message" : [
           "<flowIdentifier> is an append once-flow that is defined by a streaming relation. Append once-flows may only be defined by or return a batch relation."
         ]
       },
-      "FOR_PERSISTED_VIEW" : {
+      "STREAMING_RELATION_FOR_PERSISTED_VIEW" : {
         "message" : [
           "Persisted views may only be defined by a batch relation, but the flow <flowIdentifier> attempts to write a streaming relation to the persisted view <viewIdentifier>."
         ]
       },
-      "FOR_STREAMING_TABLE" : {
+      "BATCH_RELATION_FOR_STREAMING_TABLE" : {
         "message" : [
           "Streaming tables may only be defined by streaming relations, but the flow <flowIdentifier> attempts to write a batch relation to the streaming table <tableIdentifier>. Consider using the STREAM operator in Spark-SQL to convert the batch relation into a streaming relation, or populating the streaming table with an append once-flow instead."
         ]

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2724,6 +2724,11 @@
       "Flow <flowIdentifier> returns an invalid relation type."
     ],
     "subClass" : {
+      "BATCH_RELATION_FOR_STREAMING_TABLE" : {
+        "message" : [
+          "Streaming tables may only be defined by streaming relations, but the flow <flowIdentifier> attempts to write a batch relation to the streaming table <tableIdentifier>. Consider using the STREAM operator in Spark-SQL to convert the batch relation into a streaming relation, or populating the streaming table with an append once-flow instead."
+        ]
+      },
       "STREAMING_RELATION_FOR_MATERIALIZED_VIEW" : {
         "message" : [
           "Materialized views may only be defined by a batch relation, but the flow <flowIdentifier> attempts to write a streaming relation to the materialized view <tableIdentifier>."
@@ -2737,11 +2742,6 @@
       "STREAMING_RELATION_FOR_PERSISTED_VIEW" : {
         "message" : [
           "Persisted views may only be defined by a batch relation, but the flow <flowIdentifier> attempts to write a streaming relation to the persisted view <viewIdentifier>."
-        ]
-      },
-      "BATCH_RELATION_FOR_STREAMING_TABLE" : {
-        "message" : [
-          "Streaming tables may only be defined by streaming relations, but the flow <flowIdentifier> attempts to write a batch relation to the streaming table <tableIdentifier>. Consider using the STREAM operator in Spark-SQL to convert the batch relation into a streaming relation, or populating the streaming table with an append once-flow instead."
         ]
       }
     },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2719,6 +2719,33 @@
     ],
     "sqlState" : "42000"
   },
+  "INVALID_FLOW_RELATION_TYPE" : {
+    "message" : [
+      "Flow <flowIdentifier> returns an invalid relation type."
+    ],
+    "subClass" : {
+      "FOR_MATERIALIZED_VIEW" : {
+        "message" : [
+          "Materialized views may only be defined by a batch relation, but the flow <flowIdentifier> attempts to write a streaming relation to the materialized view <tableIdentifier>."
+        ]
+      },
+      "FOR_ONCE_FLOW" : {
+        "message" : [
+          "<flowIdentifier> is an append once-flow that is defined by a streaming relation. Append once-flows may only be defined by or return a batch relation."
+        ]
+      },
+      "FOR_PERSISTED_VIEW" : {
+        "message" : [
+          "Persisted views may only be defined by a batch relation, but the flow <flowIdentifier> attempts to write a streaming relation to the persisted view <viewIdentifier>."
+        ]
+      },
+      "FOR_STREAMING_TABLE" : {
+        "message" : [
+          "Streaming tables may only be defined by streaming relations, but the flow <flowIdentifier> attempts to write a batch relation to the streaming table <tableIdentifier>. Consider using the STREAM operator in Spark-SQL to convert the batch relation into a streaming relation, or populating the streaming table with an append once-flow instead."
+        ]
+      }
+    }
+  },
   "INVALID_FORMAT" : {
     "message" : [
       "The format is invalid: <format>."

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
@@ -161,7 +161,7 @@ private[connect] object PipelinesHandler extends Logging {
               language = Option(Python())),
             format = Option.when(dataset.hasFormat)(dataset.getFormat),
             normalizedPath = None,
-            isStreamingTableOpt = None))
+            isStreamingTable = dataset.getDatasetType == proto.DatasetType.TABLE))
       case proto.DatasetType.TEMPORARY_VIEW =>
         val viewIdentifier =
           GraphIdentifierManager.parseTableIdentifier(dataset.getDatasetName, sparkSession)

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
@@ -90,8 +90,7 @@ class PythonPipelineSuite
   }
 
   test("basic") {
-    val graph = buildGraph(
-      """
+    val graph = buildGraph("""
         |@sdp.table
         |def table1():
         |    return spark.readStream.format("rate").load()

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
@@ -90,10 +90,11 @@ class PythonPipelineSuite
   }
 
   test("basic") {
-    val graph = buildGraph("""
+    val graph = buildGraph(
+      """
         |@sdp.table
         |def table1():
-        |    return spark.range(10)
+        |    return spark.readStream.format("rate").load()
         |""".stripMargin)
       .resolve()
       .validate()
@@ -112,11 +113,11 @@ class PythonPipelineSuite
         |def c():
         |  return spark.readStream.table("a")
         |
-        |@sdp.table()
+        |@sdp.materialized_view()
         |def d():
         |  return spark.read.table("a")
         |
-        |@sdp.table()
+        |@sdp.materialized_view()
         |def a():
         |  return spark.range(5)
         |""".stripMargin)
@@ -177,11 +178,11 @@ class PythonPipelineSuite
   test("referencing external datasets") {
     sql("CREATE TABLE spark_catalog.default.src AS SELECT * FROM RANGE(5)")
     val graph = buildGraph("""
-        |@sdp.table
+        |@sdp.materialized_view
         |def a():
         |  return spark.read.table("spark_catalog.default.src")
         |
-        |@sdp.table
+        |@sdp.materialized_view
         |def b():
         |  return spark.table("spark_catalog.default.src")
         |
@@ -230,11 +231,11 @@ class PythonPipelineSuite
         |def a():
         |  return spark.read.table("spark_catalog.default.src")
         |
-        |@sdp.table
+        |@sdp.materialized_view
         |def b():
         |  return spark.table("spark_catalog.default.src")
         |
-        |@sdp.table
+        |@sdp.materialized_view
         |def c():
         |  return spark.readStream.table("spark_catalog.default.src")
         |""".stripMargin).resolve()

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerSuite.scala
@@ -206,7 +206,7 @@ class SparkDeclarativePipelinesServerSuite
           sql = Some("SELECT * FROM STREAM tableA"))
         createTable(
           name = "tableC",
-          datasetType = DatasetType.TABLE,
+          datasetType = DatasetType.MATERIALIZED_VIEW,
           sql = Some("SELECT * FROM tableB"))
       }
 
@@ -238,7 +238,7 @@ class SparkDeclarativePipelinesServerSuite
         createView(name = "viewC", sql = "SELECT * FROM curr.tableB")
         createTable(
           name = "other.tableD",
-          datasetType = proto.DatasetType.TABLE,
+          datasetType = proto.DatasetType.MATERIALIZED_VIEW,
           sql = Some("SELECT * FROM viewC"))
       }
 

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/CoreDataflowNodeProcessor.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/CoreDataflowNodeProcessor.scala
@@ -80,12 +80,6 @@ class CoreDataflowNodeProcessor(rawGraph: DataflowGraph) {
         val resolvedFlowsToTable = flowsToTable.map { flow =>
           resolvedFlowNodesMap.get(flow.identifier)
         }
-
-        // Assign isStreamingTable (MV or ST) to the table based on the resolvedFlowsToTable
-        val tableWithType = table.copy(
-          isStreamingTableOpt = Option(resolvedFlowsToTable.exists(f => f.df.isStreaming))
-        )
-
         // We mark all tables as virtual to ensure resolution uses incoming flows
         // rather than previously materialized tables.
         val virtualTableInput = VirtualTableInput(
@@ -95,7 +89,7 @@ class CoreDataflowNodeProcessor(rawGraph: DataflowGraph) {
           availableFlows = resolvedFlowsToTable
         )
         resolvedInputs.put(table.identifier, virtualTableInput)
-        Seq(tableWithType)
+        Seq(table)
       case view: View =>
         // For view, add the flow to resolvedInputs and return empty.
         require(upstreamNodes.size == 1, "Found multiple flows to view")

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DataflowGraph.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DataflowGraph.scala
@@ -191,6 +191,7 @@ case class DataflowGraph(flows: Seq[Flow], tables: Seq[Table], views: Seq[View])
     validatePersistedViewSources()
     validateEveryDatasetHasFlow()
     validateTablesAreResettable()
+    validateFlowStreamingness()
     inferredSchema
   }.failed
 

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DatasetManager.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DatasetManager.scala
@@ -178,7 +178,7 @@ object DatasetManager extends Logging {
     }
 
     // Wipe the data if we need to
-    if ((isFullRefresh || !table.isStreamingTableOpt.get) && existingTableOpt.isDefined) {
+    if ((isFullRefresh || !table.isStreamingTable) && existingTableOpt.isDefined) {
       context.spark.sql(s"TRUNCATE TABLE ${table.identifier.quotedString}")
     }
 
@@ -186,7 +186,7 @@ object DatasetManager extends Logging {
     if (existingTableOpt.isDefined) {
       val existingSchema = existingTableOpt.get.schema()
 
-      val targetSchema = if (table.isStreamingTableOpt.get && !isFullRefresh) {
+      val targetSchema = if (table.isStreamingTable && !isFullRefresh) {
         SchemaMergingUtils.mergeSchemas(existingSchema, outputSchema)
       } else {
         outputSchema

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphValidations.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphValidations.scala
@@ -62,10 +62,9 @@ trait GraphValidations extends Logging {
    */
   protected[graph] def validateFlowStreamingness(): Unit = {
     flowsTo.foreach { case (destTableIdentifier, flowsToDataset) =>
+      // The identifier should correspond to exactly one of a table or view
       val destTableOpt = table.get(destTableIdentifier)
-
-      // If the destination identifier does not correspond to a table, it must be a view.
-      val destViewOpt = destTableOpt.fold(view.get(destTableIdentifier))(_ => None)
+      val destViewOpt = view.get(destTableIdentifier)
 
       val resolvedFlowsToDataset: Seq[ResolvedFlow] = flowsToDataset.collect {
         case rf: ResolvedFlow => rf

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphValidations.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphValidations.scala
@@ -55,6 +55,75 @@ trait GraphValidations extends Logging {
     multiQueryTables
   }
 
+  protected[graph] def validateFlowStreamingness(): Unit = {
+    flowsTo.foreach { case (destTableIdentifier, flows) =>
+      val destTableOpt = table.get(destTableIdentifier)
+
+      // If the destination identifier does not correspond to a table, it must be a view.
+      val destViewOpt = destTableOpt.fold(view.get(destTableIdentifier))(_ => None)
+
+      flows.foreach {
+        case resolvedFlow: ResolvedFlow =>
+          // A flow must be successfully analyzed, thus resolved, in order to determine if it is
+          // streaming or not. Unresolved flows will throw an exception anyway via
+          // [[validateSuccessfulFlowAnalysis]], so don't check them here.
+          if (resolvedFlow.once) {
+            // Once flows by definition should be batch flows, not streaming.
+            if (resolvedFlow.df.isStreaming) {
+              throw new AnalysisException(
+                errorClass = "INVALID_FLOW_RELATION_TYPE.FOR_ONCE_FLOW",
+                messageParameters = Map(
+                  "flowIdentifier" -> resolvedFlow.identifier.quotedString
+                )
+              )
+            }
+          } else {
+            destTableOpt.foreach { destTable =>
+              if (destTable.isStreamingTable) {
+                if (!resolvedFlow.df.isStreaming) {
+                  throw new AnalysisException(
+                    errorClass = "INVALID_FLOW_RELATION_TYPE.FOR_STREAMING_TABLE",
+                    messageParameters = Map(
+                      "flowIdentifier" -> resolvedFlow.identifier.quotedString,
+                      "tableIdentifier" -> destTableIdentifier.quotedString
+                    )
+                  )
+                }
+              } else {
+                if (resolvedFlow.df.isStreaming) {
+                  // This check intentionally does NOT prevent materialized views from reading from
+                  // a streaming table using a _batch_ read, which is still considered valid.
+                  throw new AnalysisException(
+                    errorClass = "INVALID_FLOW_RELATION_TYPE.FOR_MATERIALIZED_VIEW",
+                    messageParameters = Map(
+                      "flowIdentifier" -> resolvedFlow.identifier.quotedString,
+                      "tableIdentifier" -> destTableIdentifier.quotedString
+                    )
+                  )
+                }
+              }
+            }
+
+            destViewOpt.foreach {
+              case _: PersistedView =>
+                if (resolvedFlow.df.isStreaming) {
+                  throw new AnalysisException(
+                    errorClass = "INVALID_FLOW_RELATION_TYPE.FOR_PERSISTED_VIEW",
+                    messageParameters = Map(
+                      "flowIdentifier" -> resolvedFlow.identifier.quotedString,
+                      "viewIdentifier" -> destTableIdentifier.quotedString
+                    )
+                  )
+                }
+              case _: TemporaryView =>
+                // Temporary views' flows are allowed to be either streaming or batch, so no
+                // validation needs to be done for them
+            }
+          }
+      }
+    }
+  }
+
   /** Throws an exception if the flows in this graph are not topologically sorted. */
   protected[graph] def validateGraphIsTopologicallySorted(): Unit = {
     val visitedNodes = mutable.Set.empty[TableIdentifier] // Set of visited nodes

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/SqlGraphRegistrationContext.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/SqlGraphRegistrationContext.scala
@@ -199,7 +199,7 @@ class SqlGraphRegistrationContext(
           ),
           format = cst.tableSpec.provider,
           normalizedPath = None,
-          isStreamingTableOpt = None
+          isStreamingTable = true
         )
       )
     }
@@ -230,7 +230,7 @@ class SqlGraphRegistrationContext(
           ),
           format = cst.tableSpec.provider,
           normalizedPath = None,
-          isStreamingTableOpt = None
+          isStreamingTable = true
         )
       )
 
@@ -281,7 +281,7 @@ class SqlGraphRegistrationContext(
           ),
           format = cmv.tableSpec.provider,
           normalizedPath = None,
-          isStreamingTableOpt = None
+          isStreamingTable = false
         )
       )
 

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/elements.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/elements.scala
@@ -114,8 +114,7 @@ sealed trait TableInput extends Input {
  *                       path (if not defined, we will normalize a managed storage path for it).
  * @param properties Table Properties to set in table metadata.
  * @param comment User-specified comment that can be placed on the table.
- * @param isStreamingTableOpt if the table is a streaming table, will be None until we have resolved
- *                            flows into table
+ * @param isStreamingTable if the table is a streaming table, as defined by the source code.
  */
 case class Table(
     identifier: TableIdentifier,
@@ -125,7 +124,7 @@ case class Table(
     properties: Map[String, String] = Map.empty,
     comment: Option[String],
     baseOrigin: QueryOrigin,
-    isStreamingTableOpt: Option[Boolean],
+    isStreamingTable: Boolean,
     format: Option[String]
 ) extends TableInput
     with Output {
@@ -161,17 +160,6 @@ case class Table(
       throw GraphErrors.unresolvedTablePath(identifier)
     }
     normalizedPath.get
-  }
-
-  /**
-   * Tell if a table is a streaming table or not. This property is not set until we have resolved
-   * the flows into the table. The exception reminds engineers that they cant call at random time.
-   */
-  def isStreamingTable: Boolean = isStreamingTableOpt.getOrElse {
-    throw new IllegalStateException(
-      "Cannot identify whether the table is streaming table or not. You may need to resolve the " +
-      "flows into table."
-    )
   }
 
   /**

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectInvalidPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectInvalidPipelineSuite.scala
@@ -443,7 +443,7 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
 
     checkError(
       exception = ex,
-      condition = "INVALID_FLOW_RELATION_TYPE.FOR_STREAMING_TABLE",
+      condition = "INVALID_FLOW_QUERY_TYPE.BATCH_RELATION_FOR_STREAMING_TABLE",
       parameters = Map(
         "flowIdentifier" -> fullyQualifiedIdentifier("a").quotedString,
         "tableIdentifier" -> fullyQualifiedIdentifier("a").quotedString
@@ -465,7 +465,7 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
 
     checkError(
       exception = ex,
-      condition = "INVALID_FLOW_RELATION_TYPE.FOR_MATERIALIZED_VIEW",
+      condition = "INVALID_FLOW_QUERY_TYPE.STREAMING_RELATION_FOR_MATERIALIZED_VIEW",
       parameters = Map(
         "flowIdentifier" -> fullyQualifiedIdentifier("a").quotedString,
         "tableIdentifier" -> fullyQualifiedIdentifier("a").quotedString
@@ -493,7 +493,7 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
 
     checkError(
       exception = ex,
-      condition = "INVALID_FLOW_RELATION_TYPE.FOR_ONCE_FLOW",
+      condition = "INVALID_FLOW_QUERY_TYPE.STREAMING_RELATION_FOR_ONCE_FLOW",
       parameters = Map(
         "flowIdentifier" -> fullyQualifiedIdentifier("once_flow").quotedString
       )

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectInvalidPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectInvalidPipelineSuite.scala
@@ -429,6 +429,77 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
     )
   }
 
+  test("Streaming table backed by batch relation fails validation") {
+    val session = spark
+    import session.implicits._
+
+    val graph = new TestGraphRegistrationContext(spark) {
+      registerTable("a", query = Option(dfFlowFunc(Seq(1, 2).toDF())))
+    }.resolveToDataflowGraph()
+
+    val ex = intercept[AnalysisException] {
+      graph.validate()
+    }
+
+    checkError(
+      exception = ex,
+      condition = "INVALID_FLOW_RELATION_TYPE.FOR_STREAMING_TABLE",
+      parameters = Map(
+        "flowIdentifier" -> fullyQualifiedIdentifier("a").quotedString,
+        "tableIdentifier" -> fullyQualifiedIdentifier("a").quotedString
+      )
+    )
+  }
+
+  test("Materialized view backed by streaming relation fails validation") {
+    val session = spark
+    import session.implicits._
+
+    val graph = new TestGraphRegistrationContext(spark) {
+      registerMaterializedView("a", query = dfFlowFunc(MemoryStream[Int].toDF()))
+    }.resolveToDataflowGraph()
+
+    val ex = intercept[AnalysisException] {
+      graph.validate()
+    }
+
+    checkError(
+      exception = ex,
+      condition = "INVALID_FLOW_RELATION_TYPE.FOR_MATERIALIZED_VIEW",
+      parameters = Map(
+        "flowIdentifier" -> fullyQualifiedIdentifier("a").quotedString,
+        "tableIdentifier" -> fullyQualifiedIdentifier("a").quotedString
+      )
+    )
+  }
+
+  test("Once flow backed by streaming relation fails validation") {
+    val session = spark
+    import session.implicits._
+
+    val graph = new TestGraphRegistrationContext(spark) {
+      registerTable("a")
+      registerFlow(
+        destinationName = "a",
+        name = "once_flow",
+        query = dfFlowFunc(MemoryStream[Int].toDF()),
+        once = true
+      )
+    }.resolveToDataflowGraph()
+
+    val ex = intercept[AnalysisException] {
+      graph.validate()
+    }
+
+    checkError(
+      exception = ex,
+      condition = "INVALID_FLOW_RELATION_TYPE.FOR_ONCE_FLOW",
+      parameters = Map(
+        "flowIdentifier" -> fullyQualifiedIdentifier("once_flow").quotedString
+      )
+    )
+  }
+
   test("Inferred schema that isn't a subset of user-specified schema") {
     val session = spark
     import session.implicits._

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
@@ -39,19 +39,15 @@ class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
-        registerFlow(
-          "a",
-          "a",
-          query = dfFlowFunc(Seq((1, 1), (2, 3)).toDF("x", "x2"))
-        )
-        registerTable(
+        registerMaterializedView(
           "a",
           specifiedSchema = Option(
             new StructType()
               .add("x", IntegerType, nullable = false, "comment1")
               .add("x2", IntegerType, nullable = true, "comment2")
           ),
-          comment = Option("p-comment")
+          comment = Option("p-comment"),
+          query = dfFlowFunc(Seq((1, 1), (2, 3)).toDF("x", "x2"))
         )
       }.resolveToDataflowGraph()
     )
@@ -71,19 +67,15 @@ class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
-        registerFlow(
-          "a",
-          "a",
-          query = dfFlowFunc(Seq((1, 1), (2, 3)).toDF("x", "x2"))
-        )
-        registerTable(
+        registerMaterializedView(
           "a",
           specifiedSchema = Option(
             new StructType()
               .add("x", IntegerType, nullable = false, "comment3")
               .add("x2", IntegerType, nullable = true, "comment4")
           ),
-          comment = Option("p-comment")
+          comment = Option("p-comment"),
+          query = dfFlowFunc(Seq((1, 1), (2, 3)).toDF("x", "x2"))
         )
       }.resolveToDataflowGraph()
     )
@@ -99,19 +91,15 @@ class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
-        registerFlow(
-          "a",
-          "a",
-          query = dfFlowFunc(Seq((1, 1), (2, 3)).toDF("x", "x2"))
-        )
-        registerTable(
+        registerMaterializedView(
           "a",
           specifiedSchema = Option(
             new StructType()
               .add("x", IntegerType, nullable = false)
               .add("x2", IntegerType, nullable = true)
           ),
-          comment = Option("p-comment")
+          comment = Option("p-comment"),
+          query = dfFlowFunc(Seq((1, 1), (2, 3)).toDF("x", "x2"))
         )
       }.resolveToDataflowGraph()
     )
@@ -205,9 +193,9 @@ class MaterializeTablesSuite extends BaseCoreExecutionTest {
         query = Option(dfFlowFunc(spark.readStream.format("rate").load()))
       )
       // Defines a column called timestamp as `int`.
-      registerTable(
+      registerMaterializedView(
         "b",
-        query = Option(sqlFlowFunc(spark, "SELECT value AS timestamp FROM a"))
+        query = sqlFlowFunc(spark, "SELECT value AS timestamp FROM a")
       )
     }
     materializeGraph(new P1().resolveToDataflowGraph())
@@ -226,9 +214,9 @@ class MaterializeTablesSuite extends BaseCoreExecutionTest {
         query = Option(dfFlowFunc(spark.readStream.format("rate").load()))
       )
       // Defines a column called timestamp as `timestamp`.
-      registerTable(
+      registerMaterializedView(
         "b",
-        query = Option(sqlFlowFunc(spark, "SELECT timestamp FROM a"))
+        query = sqlFlowFunc(spark, "SELECT timestamp FROM a")
       )
     }
     materializeGraph(new P2().resolveToDataflowGraph())
@@ -313,14 +301,14 @@ class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
-        registerFlow("t4", "t4", query = dfFlowFunc(Seq[Short](1, 2).toDF("x")))
-        registerTable(
+        registerMaterializedView(
           "t4",
           specifiedSchema = Option(
             new StructType()
               .add("x", IntegerType, nullable = true, "this is column x")
               .add("z", LongType, nullable = true, "this is column z")
-          )
+          ),
+          query = dfFlowFunc(Seq[Short](1, 2).toDF("x"))
         )
       }.resolveToDataflowGraph()
     )
@@ -367,10 +355,10 @@ class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
     // Works fine for a complete table
     materializeGraph(new TestGraphRegistrationContext(spark) {
-      registerTable(
+      registerMaterializedView(
         "t6",
         specifiedSchema = Option(new StructType().add("x", IntegerType)),
-        query = Option(dfFlowFunc(Seq(1, 2).toDF("x")))
+        query = dfFlowFunc(Seq(1, 2).toDF("x"))
       )
     }.resolveToDataflowGraph())
     val table2 = catalog.loadTable(identifier)
@@ -585,7 +573,7 @@ class MaterializeTablesSuite extends BaseCoreExecutionTest {
       val rawGraph =
         new TestGraphRegistrationContext(spark) {
           registerView("a", query = dfFlowFunc(Seq((1, 2), (2, 3)).toDF("x", "y")))
-          registerTable("b", query = Option(sqlFlowFunc(spark, "SELECT x FROM a")))
+          registerMaterializedView("b", query = sqlFlowFunc(spark, "SELECT x FROM a"))
         }.resolveToDataflowGraph()
 
       val graph = materializeGraph(rawGraph)
@@ -619,7 +607,7 @@ class MaterializeTablesSuite extends BaseCoreExecutionTest {
       materializeGraph(
         new TestGraphRegistrationContext(spark) {
           registerView("a", query = dfFlowFunc(Seq((1, 2), (2, 3)).toDF("x", "y")))
-          registerTable("b", query = Option(sqlFlowFunc(spark, "SELECT y FROM a")))
+          registerMaterializedView("b", query = sqlFlowFunc(spark, "SELECT y FROM a"))
         }.resolveToDataflowGraph()
       )
       val table2 = catalog.loadTable(identifier)

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
@@ -17,24 +17,15 @@
 package org.apache.spark.sql.pipelines.graph
 
 import org.apache.spark.sql.{AnalysisException, Row}
-import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.pipelines.utils.{PipelineTest, TestGraphRegistrationContext}
 import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.sql.types.{LongType, StructType}
 import org.apache.spark.util.Utils
 
-class SqlPipelineSuite extends PipelineTest with SQLTestUtils {
-  private val externalTable1Ident = TableIdentifier(
-    table = "external_t1",
-    database = Option(TestGraphRegistrationContext.DEFAULT_DATABASE),
-    catalog = Option(TestGraphRegistrationContext.DEFAULT_CATALOG)
-  )
-  private val externalTable2Ident = TableIdentifier(
-    table = "external_t2",
-    database = Option(TestGraphRegistrationContext.DEFAULT_DATABASE),
-    catalog = Option(TestGraphRegistrationContext.DEFAULT_CATALOG)
-  )
+class SQLPipelineSuite extends PipelineTest with SQLTestUtils {
+  private val externalTable1Ident = fullyQualifiedIdentifier("external_t1")
+  private val externalTable2Ident = fullyQualifiedIdentifier("external_t2")
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -402,32 +393,41 @@ class SqlPipelineSuite extends PipelineTest with SQLTestUtils {
   gridTest(s"Pipeline dataset can read from file based data sources")(
     Seq("parquet", "orc", "json", "csv")
   ) { fileFormat =>
+    // TODO: streaming file data sources in SQL is not currently supported. If and when it is,
+    //  streaming tables should also be able to directly stream from file based data sources. Until
+    //  then, users must stream from a regular table that has loaded the file data. A streaming
+    //  table reading from a materialized view or temp view is not supported.
     val tmpDir = Utils.createTempDir().getAbsolutePath
     spark.sql("SELECT * FROM RANGE(3)").write.format(fileFormat).mode("overwrite").save(tmpDir)
 
-    val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
-      sqlText = s"""
-                   |CREATE MATERIALIZED VIEW a AS SELECT * FROM $fileFormat.`$tmpDir`;
-                   |CREATE STREAMING TABLE b AS SELECT * FROM STREAM($fileFormat.`$tmpDir`)
-                   |""".stripMargin
-    )
+    val externalTableIdent = fullyQualifiedIdentifier("t")
+    spark.sql(s"CREATE TABLE $externalTableIdent AS SELECT * FROM $fileFormat.`$tmpDir`")
 
-    startPipelineAndWaitForCompletion(unresolvedDataflowGraph)
-
-    Seq("a", "b").foreach { datasetName =>
-      val datasetFullyQualifiedName =
-        fullyQualifiedIdentifier(datasetName).quotedString
-      spark.sql(s"REFRESH TABLE $datasetFullyQualifiedName")
-      val expectedRows = if (fileFormat == "csv") {
-        // CSV values are read as strings
-        Seq("0", "1", "2")
-      } else {
-        Seq(0, 1, 2)
-      }
-      checkAnswer(
-        spark.sql(s"SELECT * FROM $datasetFullyQualifiedName"),
-        expectedRows.map(Row(_))
+    withTable(externalTableIdent.quotedString) {
+      val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
+        sqlText =
+          s"""
+             |CREATE MATERIALIZED VIEW a AS SELECT * FROM $fileFormat.`$tmpDir`;
+             |CREATE STREAMING TABLE b AS SELECT * FROM STREAM $externalTableIdent
+             |""".stripMargin
       )
+
+      startPipelineAndWaitForCompletion(unresolvedDataflowGraph)
+
+      Seq("a", "b").foreach { datasetName =>
+        val datasetFullyQualifiedName =
+          fullyQualifiedIdentifier(datasetName).quotedString
+        val expectedRows = if (fileFormat == "csv") {
+          // CSV values are read as strings
+          Set("0", "1", "2")
+        } else {
+          Set(0, 1, 2)
+        }
+        assert(
+          spark.sql(s"SELECT * FROM $datasetFullyQualifiedName").collect().toSet ==
+            expectedRows.map(Row(_))
+        )
+      }
     }
   }
 

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/TestGraphRegistrationContext.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/TestGraphRegistrationContext.scala
@@ -50,6 +50,7 @@ class TestGraphRegistrationContext(
 
   // scalastyle:off
   // Disable scalastyle to ignore argument count.
+  /** Registers a streaming table in this [[TestGraphRegistrationContext]] */
   def registerTable(
       name: String,
       query: Option[FlowFunction] = None,
@@ -62,6 +63,70 @@ class TestGraphRegistrationContext(
       format: Option[String] = None,
       catalog: Option[String] = None,
       database: Option[String] = None
+  ): Unit = registerTable(
+    name,
+    query,
+    sqlConf,
+    comment,
+    specifiedSchema,
+    partitionCols,
+    properties,
+    baseOrigin,
+    format,
+    catalog,
+    database,
+    isStreamingTable = true
+  )
+  // scalastyle:on
+
+  // scalastyle:off
+  // Disable scalastyle to ignore argument count.
+  /** Registers a materialized view in this [[TestGraphRegistrationContext]] */
+  def registerMaterializedView(
+      name: String,
+      // Unlike for streaming tables, a materialized view MUST be defined alongside a query
+      // function.
+      query: FlowFunction,
+      sqlConf: Map[String, String] = Map.empty,
+      comment: Option[String] = None,
+      specifiedSchema: Option[StructType] = None,
+      partitionCols: Option[Seq[String]] = None,
+      properties: Map[String, String] = Map.empty,
+      baseOrigin: QueryOrigin = QueryOrigin.empty,
+      format: Option[String] = None,
+      catalog: Option[String] = None,
+      database: Option[String] = None
+): Unit = registerTable(
+    name,
+    Option(query),
+    sqlConf,
+    comment,
+    specifiedSchema,
+    partitionCols,
+    properties,
+    baseOrigin,
+    format,
+    catalog,
+    database,
+    isStreamingTable = false
+  )
+  // scalastyle:on
+
+  // scalastyle:off
+  // Disable scalastyle to ignore argument count.
+  private def registerTable(
+      name: String,
+      query: Option[FlowFunction],
+      sqlConf: Map[String, String],
+      comment: Option[String],
+      specifiedSchema: Option[StructType],
+      partitionCols: Option[Seq[String]],
+      properties: Map[String, String],
+      baseOrigin: QueryOrigin,
+      format: Option[String],
+      catalog: Option[String],
+      database: Option[String],
+      isStreamingTable: Boolean
   ): Unit = {
     // scalastyle:on
     val tableIdentifier = GraphIdentifierManager.parseTableIdentifier(name, spark)
@@ -75,7 +140,7 @@ class TestGraphRegistrationContext(
         baseOrigin = baseOrigin,
         format = format.orElse(Some("parquet")),
         normalizedPath = None,
-        isStreamingTableOpt = None
+        isStreamingTable = isStreamingTable
       )
     )
 


### PR DESCRIPTION
### What changes were proposed in this pull request? 
Validate that streaming flows are actually backed by streaming sources, and batch flows are actually backed by batch sources. Also improve SDP test harnesses to be explicit about whether a streaming table or materialized view is being created, to match the Python/SQL API.

### Why are the changes needed?
This change helps prevent incorrect usage of streaming/batch flows, such as directly reading from a batch source from a streaming table's flow. In this case for example, the `STREAM` key word to mark a SQL batch source as streaming or `readStream` should be used in Python to stream read from an otherwise non-streaming file source.


### Does this PR introduce _any_ user-facing change?
No, as this impacts SDP which is not released in any Spark version yet.

### How was this patch tested?
Existing suites and added tests to `ConnectInvalidPipelineSuite`

### Was this patch authored or co-authored using generative AI tooling? 
No
