### PR TITLE
[SPARK-52521][SQL] `Right#replacement` should not access SQLConf dynamically

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -2354,7 +2354,7 @@ case class Right(str: Expression, len: Expression) extends RuntimeReplaceable
     If(
       LessThanOrEqual(len, Literal(0)),
       Literal(UTF8String.EMPTY_UTF8, str.dataType),
-      new Substring(str, UnaryMinus(len))
+      new Substring(str, UnaryMinus(len, failOnError = false))
     )
   )
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -1316,4 +1316,21 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
       assert(ts1._1.getTime < ts2._1.getTime)
     }
   }
+
+  test("view with ANSI expressions") {
+    withView("v1") {
+      withSQLConf(ANSI_ENABLED.key -> "true") {
+        sql(
+          """
+            |CREATE VIEW v1 AS
+            |SELECT RIGHT(CAST(id AS STRING), 1) AS c
+            |FROM range(1)
+            |GROUP BY RIGHT(CAST(id AS STRING), 1)
+            |""".stripMargin)
+      }
+      withSQLConf(ANSI_ENABLED.key -> "false") {
+        checkAnswer(sql("SELECT * FROM v1"), Row("0"))
+      }
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -1317,7 +1317,7 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
     }
   }
 
-  test("view with ANSI expressions") {
+  test("SPARK-52521: view with ANSI expressions") {
     withView("v1") {
       withSQLConf(ANSI_ENABLED.key -> "true") {
         sql(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
`Right#replacement` is a lazy val that has non-deterministic initialization timing. It's fragile to access SQLConf there as the conf value can be different with different lazy val initialization timing. For example, if we initialize the lazy val during view plan resolution, it will use the ANSI conf from the view's recorded SQL confs, which can be different from the current session's SQL conf. If the `Right` expression appears more than once in the query plan, and their lazy val initialization timing is different, it will lead to inconsistency issues that fail the analysis.

This PR fixes `Right#replacement` to always create `Substring` with `failOnError = false`. The length parameter is guaranteed to be positive here, so the `failOnError` flag doesn't matter. Setting it to false makes the generated java code simpler.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
bug fix

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, the query failed to analysis can now work

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
a new test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no