### PR TITLE
[SPARK-52531][SQL] `OuterReference` in subquery aggregate is incorrectly tied to outer query aggregate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -4218,13 +4218,14 @@ object UpdateOuterReferences extends Rule[LogicalPlan] {
   private def updateOuterReferenceInSubquery(
       plan: LogicalPlan,
       refExprs: Seq[Expression]): LogicalPlan = {
-    plan resolveExpressions { case e =>
-      val outerAlias =
-        refExprs.find(stripAlias(_).semanticEquals(stripOuterReference(e)))
-      outerAlias match {
-        case Some(a: Alias) => OuterReference(a.toAttribute)
-        case _ => e
-      }
+    plan resolveExpressions {
+      case e if e.containsPattern(OUTER_REFERENCE) =>
+        val outerAlias =
+          refExprs.find(stripAlias(_).semanticEquals(stripOuterReference(e)))
+        outerAlias match {
+          case Some(a: Alias) => OuterReference(a.toAttribute)
+          case _ => e
+        }
     }
   }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/scalar-subquery/scalar-subquery-predicate.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/scalar-subquery/scalar-subquery-predicate.sql.out
@@ -1766,3 +1766,27 @@ Project [t0a#x, t0b#x]
       +- View (`t0`, [t0a#x, t0b#x])
          +- Project [cast(col1#x as int) AS t0a#x, cast(col2#x as int) AS t0b#x]
             +- LocalRelation [col1#x, col2#x]
+
+
+-- !query
+SELECT MAX(a.col1)
+FROM VALUES (1) AS a(col1)
+GROUP BY a.col1
+HAVING COUNT(*) = (
+        SELECT COUNT(*)
+        FROM VALUES (1),(1),(2),(2) AS c(col1)
+        WHERE c.col1 >= a.col1
+        LIMIT 1
+    )
+-- !query analysis
+Project [max(col1)#x]
++- Filter (count(1)#xL = scalar-subquery#x [col1#x])
+   :  +- GlobalLimit 1
+   :     +- LocalLimit 1
+   :        +- Aggregate [count(1) AS count(1)#xL]
+   :           +- Filter (col1#x >= outer(col1#x))
+   :              +- SubqueryAlias c
+   :                 +- LocalRelation [col1#x]
+   +- Aggregate [col1#x], [max(col1#x) AS max(col1)#x, count(1) AS count(1)#xL, col1#x]
+      +- SubqueryAlias a
+         +- LocalRelation [col1#x]

--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/scalar-subquery/scalar-subquery-predicate.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/scalar-subquery/scalar-subquery-predicate.sql
@@ -532,3 +532,14 @@ WHERE (SELECT max(t2c)
 
 
 SELECT * FROM t0 WHERE t0a = (SELECT distinct(t1c) FROM t1 WHERE t1a = t0a);
+
+-- SPARK-52531: Inner aggregate expressions are properly decorrelated from outer aggregate expressions
+SELECT MAX(a.col1)
+FROM VALUES (1) AS a(col1)
+GROUP BY a.col1
+HAVING COUNT(*) = (
+        SELECT COUNT(*)
+        FROM VALUES (1),(1),(2),(2) AS c(col1)
+        WHERE c.col1 >= a.col1
+        LIMIT 1
+    );

--- a/sql/core/src/test/resources/sql-tests/results/subquery/scalar-subquery/scalar-subquery-predicate.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/scalar-subquery/scalar-subquery-predicate.sql.out
@@ -914,3 +914,19 @@ SELECT * FROM t0 WHERE t0a = (SELECT distinct(t1c) FROM t1 WHERE t1a = t0a)
 struct<t0a:int,t0b:int>
 -- !query output
 
+
+
+-- !query
+SELECT MAX(a.col1)
+FROM VALUES (1) AS a(col1)
+GROUP BY a.col1
+HAVING COUNT(*) = (
+        SELECT COUNT(*)
+        FROM VALUES (1),(1),(2),(2) AS c(col1)
+        WHERE c.col1 >= a.col1
+        LIMIT 1
+    )
+-- !query schema
+struct<max(col1):int>
+-- !query output
+


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
In `UpdateOuterReferences`, don't update outer references to aggregate expressions in outer query, unless the aggregate expression contains outer reference. Current behavior always ties inner aggregate expressions to semantically equal outer aggregate expressions causing a correctness issue.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
For a query like:
```
SELECT
    MAX(a.col1)
FROM
    VALUES (7) AS a(col1)
GROUP BY
    a.col1
HAVING
    COUNT(*) = (
        SELECT
            COUNT(*)
        FROM
            VALUES (7),(7),(8),(8) AS c(col1)
        WHERE
            c.col1 >= a.col1
        GROUP BY
            c.col1
        LIMIT 1
    )
ORDER BY
    a.col1 DESC;
```

`UpdateOuterReferences` changes the plan to:
```
Project [max(col1)#3081747]
+- Sort [col1#3081725 DESC NULLS LAST], true
   +- Project [max(col1)#3081747, col1#3081725]
      +- Filter (count(1)#3081750L = scalar-subquery#3081727 [col1#3081725])
         :  +- GlobalLimit 1
         :     +- LocalLimit 1
         :        +- Aggregate [col1#3081726], [outer(count(1)#3081750L) AS count(1)#3081749L]
         :           +- Filter (col1#3081726 >= outer(col1#3081725))
         :              +- SubqueryAlias c
         :                 +- LocalRelation [col1#3081726]
         +- Aggregate [col1#3081725], [max(col1#3081725) AS max(col1)#3081747, count(1) AS count(1)#3081750L, col1#3081725]
            +- SubqueryAlias a
               +- LocalRelation [col1#3081725]
```

Inner `count(*)` is tied to the outer one causing the having condition to always be true. This result in Spark producing a result `7` instead of 0 rows returned.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Yes. Users now see a correct result for the query patterns similar to the one shown above.
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Added new tests.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
