### PR TITLE
[SPARK-52527][BUILD] Upgrade `junit` to 5.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,13 +219,13 @@
     <netty.version>4.1.122.Final</netty.version>
     <netty-tcnative.version>2.0.72.Final</netty-tcnative.version>
     <icu4j.version>77.1</icu4j.version>
-    <junit-jupiter.version>5.12.2</junit-jupiter.version>
-    <junit-platform.version>1.12.2</junit-platform.version>
+    <junit-jupiter.version>5.13.1</junit-jupiter.version>
+    <junit-platform.version>1.13.1</junit-platform.version>
     <!--
       SPARK-50299: When updating `sbt-jupiter-interface.version`,
       also need to update the version in `SparkBuild.scala` and `plugins.sbt`.
     -->
-    <sbt-jupiter-interface.version>0.14.0</sbt-jupiter-interface.version>
+    <sbt-jupiter-interface.version>0.15.0</sbt-jupiter-interface.version>
     <!--
     If you are changing Arrow version specification, please check
     ./python/pyspark/sql/pandas/utils.py, ./python/packaging/classic/setup.py,

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1723,7 +1723,7 @@ object TestSettings {
     (Test / testOptions) += Tests.Argument(TestFrameworks.ScalaTest, "-W", "120", "300"),
     (Test / testOptions) += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
     // Enable Junit testing.
-    libraryDependencies += "com.github.sbt.junit" % "jupiter-interface" % "0.14.0" % "test",
+    libraryDependencies += "com.github.sbt.junit" % "jupiter-interface" % "0.15.0" % "test",
     // `parallelExecutionInTest` controls whether test suites belonging to the same SBT project
     // can run in parallel with one another. It does NOT control whether tests execute in parallel
     // within the same JVM (which is controlled by `testForkedParallel`) or whether test cases

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -41,6 +41,6 @@ addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
 
 addSbtPlugin("com.github.sbt" % "sbt-pom-reader" % "2.4.0")
 
-addSbtPlugin("com.github.sbt.junit" % "sbt-jupiter-interface" % "0.14.0")
+addSbtPlugin("com.github.sbt.junit" % "sbt-jupiter-interface" % "0.15.0")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.7")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `junit` to 5.13.1.

### Why are the changes needed?

- https://github.com/sbt/sbt-jupiter-interface/releases/tag/v0.15.0
- https://github.com/junit-team/junit5/milestone/97?closed=1
  - https://junit.org/junit5/docs/snapshot/release-notes/index.html#release-notes-5.13.1
- https://github.com/junit-team/junit5/milestone/94?closed=1
  - https://github.com/junit-team/junit5/issues/4440
  - https://junit.org/junit5/docs/snapshot/release-notes/index.html#release-notes-5.13.0

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.