### PR TITLE
 [SPARK-52528][PS] Enable divide-by-zero for numeric mod with ANSI enabled

### DIFF
--- a/python/pyspark/pandas/tests/computation/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/computation/test_binary_ops.py
@@ -225,6 +225,7 @@ class FrameBinaryOpsMixin:
         psdf = ps.from_pandas(pdf)
 
         self.assert_eq(psdf["a"] % psdf["b"], pdf["a"] % pdf["b"])
+        self.assert_eq(psdf["a"] % 0, pdf["a"] % 0)
 
         # Negative
         psdf = ps.DataFrame({"a": ["x"], "b": [1]})

--- a/python/pyspark/pandas/tests/series/test_stat.py
+++ b/python/pyspark/pandas/tests/series/test_stat.py
@@ -443,7 +443,6 @@ class SeriesStatMixin:
         self.assert_eq(krdiv, prdiv)
         self.assert_eq(krmod, prmod)
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_mod(self):
         pser = pd.Series([100, None, -300, None, 500, -700], name="Koalas")
         psser = ps.from_pandas(pser)

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -132,7 +132,6 @@ class NumPyCompatTestsMixin:
         finally:
             reset_option("compute.ops_on_diff_frames")
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_np_spark_compat_frame(self):
         from pyspark.pandas.numpy_compat import unary_np_spark_mappings, binary_np_spark_mappings
 

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -132,6 +132,7 @@ class NumPyCompatTestsMixin:
         finally:
             reset_option("compute.ops_on_diff_frames")
 
+    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_np_spark_compat_frame(self):
         from pyspark.pandas.numpy_compat import unary_np_spark_mappings, binary_np_spark_mappings
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable divide-by-zero for numeric mod with ANSI enabled


### Why are the changes needed?
Ensure pandas on Spark works well with ANSI mode on.
Part of https://issues.apache.org/jira/browse/SPARK-52169.


### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?
Unit tests.

```
(dev3.10) spark (num_mod) % SPARK_ANSI_SQL_MODE=true  ./python/run-tests --python-executables=python3.10 --testnames  "pyspark.pandas.tests.computation.test_binary_ops FrameBinaryOpsTests.test_binary_operator_mod"
...
Finished test(python3.10): pyspark.pandas.tests.computation.test_binary_ops FrameBinaryOpsTests.test_binary_operator_mod (4s)
Tests passed in 4 seconds

(dev3.10) spark (num_mod) % SPARK_ANSI_SQL_MODE=true  ./python/run-tests --python-executables=python3.10 --testnames "pyspark.pandas.tests.series.test_stat SeriesStatTests.test_mod"
...
Finished test(python3.10): pyspark.pandas.tests.series.test_stat SeriesStatTests.test_mod (5s)
Tests passed in 5 seconds
```

### Was this patch authored or co-authored using generative AI tooling?
No.
