### PR TITLE
[SPARK-52535][SQL] Improve code readability of rule ApplyColumnarRulesAndInsertTransitions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
@@ -503,7 +503,7 @@ case class ApplyColumnarRulesAndInsertTransitions(
     if (!plan.supportsColumnar) {
       // The tree feels kind of backwards
       // Columnar Processing will start here, so transition from row to columnar
-      RowToColumnarExec(insertTransitions(plan, outputsColumnar = false))
+      RowToColumnarExec(ensureOutputsRowBased(plan))
     } else if (!plan.isInstanceOf[RowToColumnarTransition]) {
       plan.withNewChildren(plan.children.map(ensureOutputsColumnar))
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
@@ -529,7 +529,7 @@ case class ApplyColumnarRulesAndInsertTransitions(
         // With planned write, the write command invokes child plan's `executeWrite` which is
         // neither columnar nor row-based.
         case write: DataWritingCommandExec
-          if write.cmd.isInstanceOf[V1WriteCommand] && conf.plannedWriteEnabled =>
+            if write.cmd.isInstanceOf[V1WriteCommand] && conf.plannedWriteEnabled =>
           write.child.supportsColumnar
         // If it is not required to output columnar (`outputsColumnar` is false), and the plan
         // supports row-based and columnar, we don't need to output row-based data on its children


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/SPARK-52535

### What changes were proposed in this pull request?

A minor cleanup on the code of `ApplyColumnarRulesAndInsertTransitions` to improve readability.

### Why are the changes needed?

The rule is important for 3rd SQL plugins and the code got messed up a bit during the development iterations back then.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.