### PR TITLE
[SPARK-52536] Set AsyncProfilerLoader extractionDir to spark local dir

### DIFF
--- a/connector/profiler/src/main/scala/org/apache/spark/profiler/SparkAsyncProfiler.scala
+++ b/connector/profiler/src/main/scala/org/apache/spark/profiler/SparkAsyncProfiler.scala
@@ -66,9 +66,15 @@ private[spark] class SparkAsyncProfiler(conf: SparkConf, executorId: String) ext
   private var threadpool: ScheduledExecutorService = _
   @volatile private var writing: Boolean = false
 
+  lazy private val extractionDir =
+    Utils.createTempDir(Utils.getLocalDir(conf), "asyncProfiler").toPath
+
   val profiler: Option[AsyncProfiler] = {
     Option(
-      if (enableProfiler && AsyncProfilerLoader.isSupported) AsyncProfilerLoader.load() else null
+      if (enableProfiler && AsyncProfilerLoader.isSupported) {
+        AsyncProfilerLoader.setExtractionDirectory(extractionDir)
+        AsyncProfilerLoader.load()
+      } else null
     )
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set AsyncProfilerLoader extractionDir to spark local dir

### Why are the changes needed?

`AsyncProfilerLoader` uses `user.home` dir to store the extracted libraries by default . When `user.home` dir is not initialized, it will cause `AsyncProfilerLoader.load` to fail.

https://github.com/jvm-profiling-tools/ap-loader/blob/main/src/main/java/one/profiler/AsyncProfilerLoader.java#L139-L152

We can specify `AsyncProfilerLoader.extractionDir` to spark local dir to avoid this issue.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### How was this patch tested?

Tested manually in our internal yarn cluster

![image](https://github.com/user-attachments/assets/ac6786a4-d061-45e7-8599-00cd61949a1a)


### Was this patch authored or co-authored using generative AI tooling?

No
