### PR TITLE
[SPARK-52540][SQL] Make TIMESTAMP_NTZ from DATE and TIME

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -2586,7 +2586,7 @@ case class MakeTimestampNTZ(left: Expression, right: Expression)
   usage = """
     _FUNC_(year, month, day, hour, min, sec) - Create local date-time from year, month, day, hour, min, sec fields. If the configuration `spark.sql.ansi.enabled` is false, the function returns NULL on invalid inputs. Otherwise, it will throw an error instead.
 
-    _FUNC_(date, time) - Create timestamp from date, time and time zone.
+    _FUNC_(date, time) - Create a local date-time from date and time fields.
     """,
   arguments = """
     Arguments:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -2583,7 +2583,11 @@ case class MakeTimestampNTZ(left: Expression, right: Expression)
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(year, month, day, hour, min, sec) - Create local date-time from year, month, day, hour, min, sec fields. If the configuration `spark.sql.ansi.enabled` is false, the function returns NULL on invalid inputs. Otherwise, it will throw an error instead.",
+  usage = """
+    _FUNC_(year, month, day, hour, min, sec) - Create local date-time from year, month, day, hour, min, sec fields. If the configuration `spark.sql.ansi.enabled` is false, the function returns NULL on invalid inputs. Otherwise, it will throw an error instead.
+
+    _FUNC_(date, time) - Create timestamp from date, time and time zone.
+    """,
   arguments = """
     Arguments:
       * year - the year to represent, from 1 to 9999
@@ -2594,6 +2598,8 @@ case class MakeTimestampNTZ(left: Expression, right: Expression)
       * sec - the second-of-minute and its micro-fraction to represent, from
               0 to 60. If the sec argument equals to 60, the seconds field is set
               to 0 and 1 minute is added to the final timestamp.
+      * date - a date to represent, from 0001-01-01 to 9999-12-31
+      * time - a local time to represent, from 00:00:00 to 23:59:59.999999
   """,
   examples = """
     Examples:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -822,4 +822,8 @@ object DateTimeUtils extends SparkDateTimeUtils {
         throw QueryExecutionErrors.ansiDateTimeArgumentOutOfRangeWithoutSuggestion(e)
     }
   }
+
+  def makeTimestampNTZ(days: Int, nanos: Long): Long = {
+    localDateTimeToMicros(LocalDateTime.of(daysToLocalDate(days), nanosToLocalTime(nanos)))
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -823,6 +823,14 @@ object DateTimeUtils extends SparkDateTimeUtils {
     }
   }
 
+  /**
+   * Makes a timestamp without time zone from a date and a local time.
+   *
+   * @param days The number of days since the epoch. 1970-01-01.
+   *             Negative numbers represent earlier days.
+   * @param nanos The number of nanoseconds within the day since the midnight.
+   * @return The number of microseconds since the epoch of 1970-01-01 00:00:00Z.
+   */
   def makeTimestampNTZ(days: Int, nanos: Long): Long = {
     localDateTimeToMicros(LocalDateTime.of(daysToLocalDate(days), nanosToLocalTime(nanos)))
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.expressions
 
 import java.sql.{Date, Timestamp}
 import java.text.SimpleDateFormat
-import java.time.{DateTimeException, Duration, Instant, LocalDate, LocalDateTime, Period, ZoneId}
+import java.time.{DateTimeException, Duration, Instant, LocalDate, LocalDateTime, LocalTime, Period, ZoneId}
 import java.time.temporal.ChronoUnit
 import java.util.{Calendar, Locale, TimeZone}
 import java.util.concurrent.TimeUnit._
@@ -2139,5 +2139,21 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
           TimestampType, TimestampType)
       }
     }
+  }
+
+  test("make timestamp_ntz from date and time") {
+    def dateLit(d: String): Expression = Literal(LocalDate.parse(d))
+    def timeLit(t: String): Expression = Literal(LocalTime.parse(t))
+    def tsNtz(s: String): Long = localDateTimeToMicros(LocalDateTime.parse(s), UTC)
+
+    checkEvaluation(MakeTimestampNTZ(dateLit("1970-01-01"), timeLit("00:00:00")), 0L)
+    checkEvaluation(MakeTimestampNTZ(dateLit("2025-06-20"), timeLit("15:20:30.123456")),
+      tsNtz("2025-06-20T15:20:30.123456"))
+    checkEvaluation(MakeTimestampNTZ(Literal(null, DateType), timeLit("15:20:30.123456")),
+      null)
+    checkEvaluation(MakeTimestampNTZ(dateLit("2025-06-20"), Literal(null, TimeType())),
+      null)
+    checkEvaluation(MakeTimestampNTZ(Literal(null, DateType), Literal(null, TimeType())),
+      null)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -1216,4 +1216,18 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
           s"Invalid value for SecondOfMinute (valid values 0 - 59): ${invalidSecond.toLong}"))
     }
   }
+
+  test("makeTimestampNTZ") {
+    assert(makeTimestampNTZ(0, 0) == 0)
+    assert(makeTimestampNTZ(0, localTime(23, 59, 59)) * NANOS_PER_MICROS == localTime(23, 59, 59))
+    assert(makeTimestampNTZ(-1, 0) == -1 * MICROS_PER_DAY)
+    assert(makeTimestampNTZ(-1, localTime(23, 59, 59, 999999)) == -1)
+    assert(makeTimestampNTZ(days(9999, 12, 31), localTime(23, 59, 59, 999999)) ==
+      date(9999, 12, 31, 23, 59, 59, 999999))
+    assert(makeTimestampNTZ(days(1, 1, 1), localTime(0, 0, 0)) == date(1, 1, 1, 0, 0, 0))
+    val msg = intercept[DateTimeException] {
+      makeTimestampNTZ(0, -1)
+    }.getMessage
+    assert(msg.contains("Invalid value"))
+  }
 }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz.sql.out
@@ -108,25 +108,25 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 
 
 -- !query
-SELECT make_timestamp_ntz(DATE'2025-06-20', TIMESTAMP'0:0:0')
+SELECT make_timestamp_ntz(DATE'2025-06-20', '0:0:0')
 -- !query analysis
 org.apache.spark.sql.catalyst.ExtendedAnalysisException
 {
   "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
   "sqlState" : "42K09",
   "messageParameters" : {
-    "inputSql" : "\"TIMESTAMP '2025-06-20 00:00:00'\"",
-    "inputType" : "\"TIMESTAMP\"",
+    "inputSql" : "\"0:0:0\"",
+    "inputType" : "\"STRING\"",
     "paramIndex" : "second",
     "requiredType" : "(\"TIME(0)\" or \"TIME(1)\" or \"TIME(2)\" or \"TIME(3)\" or \"TIME(4)\" or \"TIME(5)\" or \"TIME(6)\")",
-    "sqlExpr" : "\"make_timestamp_ntz(DATE '2025-06-20', TIMESTAMP '2025-06-20 00:00:00')\""
+    "sqlExpr" : "\"make_timestamp_ntz(DATE '2025-06-20', 0:0:0)\""
   },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
     "startIndex" : 8,
-    "stopIndex" : 61,
-    "fragment" : "make_timestamp_ntz(DATE'2025-06-20', TIMESTAMP'0:0:0')"
+    "stopIndex" : 52,
+    "fragment" : "make_timestamp_ntz(DATE'2025-06-20', '0:0:0')"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz.sql.out
@@ -44,7 +44,7 @@ org.apache.spark.sql.AnalysisException
   "messageParameters" : {
     "actualNum" : "7",
     "docroot" : "https://spark.apache.org/docs/latest",
-    "expectedNum" : "6",
+    "expectedNum" : "[2, 6]",
     "functionName" : "`make_timestamp_ntz`"
   },
   "queryContext" : [ {
@@ -62,6 +62,73 @@ SELECT make_timestamp_ntz(2021, 07, 11, 6, 30, 60.007)
 -- !query analysis
 Project [make_timestamp_ntz(2021, 7, 11, 6, 30, cast(60.007 as decimal(16,6)), None, Some(America/Los_Angeles), true, TimestampNTZType) AS make_timestamp_ntz(2021, 7, 11, 6, 30, 60.007)#x]
 +- OneRowRelation
+
+
+-- !query
+SELECT make_timestamp_ntz(make_date(2021, 07, 11), make_time(6, 30, 45.678))
+-- !query analysis
+Project [make_timestamp_ntz(make_date(2021, 7, 11, true), make_time(6, 30, cast(45.678 as decimal(16,6)))) AS make_timestamp_ntz(make_date(2021, 7, 11), make_time(6, 30, 45.678))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT make_timestamp_ntz(NULL, TIME'00:00:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+SELECT make_timestamp_ntz(DATE'1970-01-01', NULL)
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+SELECT make_timestamp_ntz(timestamp_ntz'2018-11-17 13:33:33', TIME'0:0:0')
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "inputSql" : "\"TIMESTAMP_NTZ '2018-11-17 13:33:33'\"",
+    "inputType" : "\"TIMESTAMP_NTZ\"",
+    "paramIndex" : "first",
+    "requiredType" : "\"DATE\"",
+    "sqlExpr" : "\"make_timestamp_ntz(TIMESTAMP_NTZ '2018-11-17 13:33:33', TIME '00:00:00')\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 74,
+    "fragment" : "make_timestamp_ntz(timestamp_ntz'2018-11-17 13:33:33', TIME'0:0:0')"
+  } ]
+}
+
+
+-- !query
+SELECT make_timestamp_ntz(DATE'2025-06-20', TIMESTAMP'0:0:0')
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "inputSql" : "\"TIMESTAMP '2025-06-20 00:00:00'\"",
+    "inputType" : "\"TIMESTAMP\"",
+    "paramIndex" : "second",
+    "requiredType" : "(\"TIME(0)\" or \"TIME(1)\" or \"TIME(2)\" or \"TIME(3)\" or \"TIME(4)\" or \"TIME(5)\" or \"TIME(6)\")",
+    "sqlExpr" : "\"make_timestamp_ntz(DATE '2025-06-20', TIMESTAMP '2025-06-20 00:00:00')\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 61,
+    "fragment" : "make_timestamp_ntz(DATE'2025-06-20', TIMESTAMP'0:0:0')"
+  } ]
+}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/inputs/timestamp-ntz.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/timestamp-ntz.sql
@@ -15,6 +15,11 @@ SELECT make_timestamp_ntz(2021, 07, 11, 6, 30, 45.678);
 -- make_timestamp_ntz should not accept time zone input
 SELECT make_timestamp_ntz(2021, 07, 11, 6, 30, 45.678, 'CET');
 SELECT make_timestamp_ntz(2021, 07, 11, 6, 30, 60.007);
+SELECT make_timestamp_ntz(make_date(2021, 07, 11), make_time(6, 30, 45.678));
+SELECT make_timestamp_ntz(NULL, TIME'00:00:00');
+SELECT make_timestamp_ntz(DATE'1970-01-01', NULL);
+SELECT make_timestamp_ntz(timestamp_ntz'2018-11-17 13:33:33', TIME'0:0:0');
+SELECT make_timestamp_ntz(DATE'2025-06-20', TIMESTAMP'0:0:0');
 
 SELECT convert_timezone('Europe/Moscow', 'America/Los_Angeles', timestamp_ntz'2022-01-01 00:00:00');
 SELECT convert_timezone('Europe/Brussels', timestamp_ntz'2022-03-23 00:00:00');

--- a/sql/core/src/test/resources/sql-tests/inputs/timestamp-ntz.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/timestamp-ntz.sql
@@ -19,7 +19,7 @@ SELECT make_timestamp_ntz(make_date(2021, 07, 11), make_time(6, 30, 45.678));
 SELECT make_timestamp_ntz(NULL, TIME'00:00:00');
 SELECT make_timestamp_ntz(DATE'1970-01-01', NULL);
 SELECT make_timestamp_ntz(timestamp_ntz'2018-11-17 13:33:33', TIME'0:0:0');
-SELECT make_timestamp_ntz(DATE'2025-06-20', TIMESTAMP'0:0:0');
+SELECT make_timestamp_ntz(DATE'2025-06-20', '0:0:0');
 
 SELECT convert_timezone('Europe/Moscow', 'America/Los_Angeles', timestamp_ntz'2022-01-01 00:00:00');
 SELECT convert_timezone('Europe/Brussels', timestamp_ntz'2022-03-23 00:00:00');

--- a/sql/core/src/test/resources/sql-tests/results/timestamp-ntz.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp-ntz.sql.out
@@ -51,7 +51,7 @@ org.apache.spark.sql.AnalysisException
   "messageParameters" : {
     "actualNum" : "7",
     "docroot" : "https://spark.apache.org/docs/latest",
-    "expectedNum" : "6",
+    "expectedNum" : "[2, 6]",
     "functionName" : "`make_timestamp_ntz`"
   },
   "queryContext" : [ {
@@ -76,6 +76,82 @@ org.apache.spark.SparkDateTimeException
   "messageParameters" : {
     "secAndMicros" : "60.007"
   }
+}
+
+
+-- !query
+SELECT make_timestamp_ntz(make_date(2021, 07, 11), make_time(6, 30, 45.678))
+-- !query schema
+struct<make_timestamp_ntz(make_date(2021, 7, 11), make_time(6, 30, 45.678)):timestamp_ntz>
+-- !query output
+2021-07-11 06:30:45.678
+
+
+-- !query
+SELECT make_timestamp_ntz(NULL, TIME'00:00:00')
+-- !query schema
+struct<make_timestamp_ntz(NULL, TIME '00:00:00'):timestamp_ntz>
+-- !query output
+NULL
+
+
+-- !query
+SELECT make_timestamp_ntz(DATE'1970-01-01', NULL)
+-- !query schema
+struct<make_timestamp_ntz(DATE '1970-01-01', NULL):timestamp_ntz>
+-- !query output
+NULL
+
+
+-- !query
+SELECT make_timestamp_ntz(timestamp_ntz'2018-11-17 13:33:33', TIME'0:0:0')
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "inputSql" : "\"TIMESTAMP_NTZ '2018-11-17 13:33:33'\"",
+    "inputType" : "\"TIMESTAMP_NTZ\"",
+    "paramIndex" : "first",
+    "requiredType" : "\"DATE\"",
+    "sqlExpr" : "\"make_timestamp_ntz(TIMESTAMP_NTZ '2018-11-17 13:33:33', TIME '00:00:00')\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 74,
+    "fragment" : "make_timestamp_ntz(timestamp_ntz'2018-11-17 13:33:33', TIME'0:0:0')"
+  } ]
+}
+
+
+-- !query
+SELECT make_timestamp_ntz(DATE'2025-06-20', TIMESTAMP'0:0:0')
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "inputSql" : "\"TIMESTAMP '2025-06-20 00:00:00'\"",
+    "inputType" : "\"TIMESTAMP\"",
+    "paramIndex" : "second",
+    "requiredType" : "(\"TIME(0)\" or \"TIME(1)\" or \"TIME(2)\" or \"TIME(3)\" or \"TIME(4)\" or \"TIME(5)\" or \"TIME(6)\")",
+    "sqlExpr" : "\"make_timestamp_ntz(DATE '2025-06-20', TIMESTAMP '2025-06-20 00:00:00')\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 61,
+    "fragment" : "make_timestamp_ntz(DATE'2025-06-20', TIMESTAMP'0:0:0')"
+  } ]
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/timestamp-ntz.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp-ntz.sql.out
@@ -130,7 +130,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 
 
 -- !query
-SELECT make_timestamp_ntz(DATE'2025-06-20', TIMESTAMP'0:0:0')
+SELECT make_timestamp_ntz(DATE'2025-06-20', '0:0:0')
 -- !query schema
 struct<>
 -- !query output
@@ -139,18 +139,18 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
   "sqlState" : "42K09",
   "messageParameters" : {
-    "inputSql" : "\"TIMESTAMP '2025-06-20 00:00:00'\"",
-    "inputType" : "\"TIMESTAMP\"",
+    "inputSql" : "\"0:0:0\"",
+    "inputType" : "\"STRING\"",
     "paramIndex" : "second",
     "requiredType" : "(\"TIME(0)\" or \"TIME(1)\" or \"TIME(2)\" or \"TIME(3)\" or \"TIME(4)\" or \"TIME(5)\" or \"TIME(6)\")",
-    "sqlExpr" : "\"make_timestamp_ntz(DATE '2025-06-20', TIMESTAMP '2025-06-20 00:00:00')\""
+    "sqlExpr" : "\"make_timestamp_ntz(DATE '2025-06-20', 0:0:0)\""
   },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
     "startIndex" : 8,
-    "stopIndex" : 61,
-    "fragment" : "make_timestamp_ntz(DATE'2025-06-20', TIMESTAMP'0:0:0')"
+    "stopIndex" : 52,
+    "fragment" : "make_timestamp_ntz(DATE'2025-06-20', '0:0:0')"
   } ]
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to extend the `make_timestamp_ntz` function, and accept a date and time fields.

#### Syntax
```sql
make_timestamp_ntz(date[, time])
```

#### Arguments

- date: A date expression
- time: A time expression

#### Returns
A TIMESTAMP_NTZ.

#### Examples

```sql
> SELECT make_timestamp_ntz(DATE'2014-12-28', TIME'6:30:45.887');
 2014-12-28 06:30:45.887
```

### Why are the changes needed?
Users will be able to create a timestamp without time zone by combining a time and a date. 


### Does this PR introduce _any_ user-facing change?
No, it just extends the existing API.


### How was this patch tested?
By running the affected test suites:
```
$ build/sbt "test:testOnly *ExpressionInfoSuite"
$ build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z timestamp-ntz.sql"
```


### Was this patch authored or co-authored using generative AI tooling?
No.

Closes #51179