### PR TITLE
[SPARK-52544][SQL] Allow configuring Json datasource string length limit through SQLConf

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -55,7 +55,7 @@ class JSONOptions(
   private val maxStringLen: Int = parameters
     .get("maxStringLen")
     .map(_.toInt)
-    .getOrElse(StreamReadConstraints.DEFAULT_MAX_STRING_LEN)
+    .getOrElse(SQLConf.get.getConf(SQLConf.JSON_MAX_STRING_LENGTH))
 
   def this(
     parameters: Map[String, String],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5016,6 +5016,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val JSON_MAX_STRING_LENGTH =
+    buildConf("spark.sql.json.defaultMaxStringLength")
+      .doc("Global default maximum string length limit when reading JSON data. It will be " +
+        "overridden if a JSONOption maxStringLen is provided.")
+      .version("3.5.0")
+      .intConf
+      .createWithDefault(Int.MaxValue)
+
   val VARIANT_ALLOW_DUPLICATE_KEYS =
     buildConf("spark.sql.variant.allowDuplicateKeys")
       .internal()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
In https://issues.apache.org/jira/browse/SPARK-43263, Spark upgraded Jackson to 2.15.0. This brought in a breaking change that set string max length to 20,000 which Json data source picked up. Before the upgrade, there was no limit. The limit could only be modified through Json option "maxStringLen".

This PR attempts to restore the old no limit behavior, by introducing a new JSON_MAX_STRING_LENGTH feature flag that sets the string length limit globally.

### Why are the changes needed?
To restore the old string length limit behavior of Json connector, prior to the upgrade to Jackson 2.15.0.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, added a new user configurable config for specifying max string length for Json connector.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit tests.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.