### PR TITLE
[SPARK-52515][SQL] Add approx_top_k function

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -92,13 +92,13 @@
   },
   "APPROX_TOP_K_MAX_ITEMS_TRACKED_EXCEEDS_LIMIT": {
     "message": [
-      "The max items tracked `maxItemsTracked` = <maxItemsTracked> of `approx_top_k` should be less than or equal to <limit>."
+      "The max items tracked `maxItemsTracked`(<maxItemsTracked>) of `approx_top_k` should be less than or equal to <limit>."
     ],
     "sqlState" : "22023"
   },
   "APPROX_TOP_K_MAX_ITEMS_TRACKED_LESS_THAN_K": {
     "message": [
-      "The max items tracked `maxItemsTracked` = <maxItemsTracked> of `approx_top_k` should be greater than or equal to `k` = <k>."
+      "The max items tracked `maxItemsTracked`(<maxItemsTracked>) of `approx_top_k` should be greater than or equal to `k`(<k>)."
     ],
     "sqlState" : "22023"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -90,6 +90,24 @@
     ],
     "sqlState" : "42000"
   },
+  "APPROX_TOP_K_MAX_ITEMS_TRACKED_LESS_THAN_K": {
+    "message": [
+      "`approx_top_k` must have `maxItemsTracked` greater than or equal to `k`, but got `maxItemsTracked` = <maxItemsTracked> and `k` = <k>."
+    ],
+    "sqlState" : "22023"
+  },
+  "APPROX_TOP_K_NON_POSITIVE_ARG" : {
+    "message" : [
+      "The value of <argName> in `approx_top_k` must be a positive integer, but got <argValue>."
+    ],
+    "sqlState" : "22023"
+  },
+  "APPROX_TOP_K_NULL_ARG" : {
+    "message" : [
+      "The value of <argName> in `approx_top_k` cannot be NULL."
+    ],
+    "sqlState" : "22004"
+  },
   "ARITHMETIC_OVERFLOW" : {
     "message" : [
       "<message>.<alternative> If necessary set <config> to \"false\" to bypass this error."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -90,9 +90,15 @@
     ],
     "sqlState" : "42000"
   },
+  "APPROX_TOP_K_MAX_ITEMS_TRACKED_EXCEEDS_LIMIT": {
+    "message": [
+      "The max items tracked `maxItemsTracked` = <maxItemsTracked> of `approx_top_k` should be less than or equal to <limit>."
+    ],
+    "sqlState" : "22023"
+  },
   "APPROX_TOP_K_MAX_ITEMS_TRACKED_LESS_THAN_K": {
     "message": [
-      "`approx_top_k` must have `maxItemsTracked` greater than or equal to `k`, but got `maxItemsTracked` = <maxItemsTracked> and `k` = <k>."
+      "The max items tracked `maxItemsTracked` = <maxItemsTracked> of `approx_top_k` should be greater than or equal to `k` = <k>."
     ],
     "sqlState" : "22023"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -90,14 +90,14 @@
     ],
     "sqlState" : "42000"
   },
-  "APPROX_TOP_K_MAX_ITEMS_TRACKED_EXCEEDS_LIMIT": {
-    "message": [
+  "APPROX_TOP_K_MAX_ITEMS_TRACKED_EXCEEDS_LIMIT" : {
+    "message" : [
       "The max items tracked `maxItemsTracked`(<maxItemsTracked>) of `approx_top_k` should be less than or equal to <limit>."
     ],
     "sqlState" : "22023"
   },
-  "APPROX_TOP_K_MAX_ITEMS_TRACKED_LESS_THAN_K": {
-    "message": [
+  "APPROX_TOP_K_MAX_ITEMS_TRACKED_LESS_THAN_K" : {
+    "message" : [
       "The max items tracked `maxItemsTracked`(<maxItemsTracked>) of `approx_top_k` should be greater than or equal to `k`(<k>)."
     ],
     "sqlState" : "22023"

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -765,66 +765,6 @@ object functions {
   }
 
   /**
-   * Aggregate function: returns approximate top k (i.e., k-most-frequent) items of a column,
-   * using Frequent Items Sketches from Apache DataSketches
-   *
-   * @group agg_funcs
-   * @since 4.1.0
-   */
-  def approx_top_k(e: Column, k: Int, maxItemsTracked: Int): Column =
-    Column.fn("approx_top_k", e, lit(k), lit(maxItemsTracked))
-
-  /**
-   * Aggregate function: returns approximate top k (i.e., k-most-frequent) items of a column,
-   * using Frequent Items Sketches from Apache DataSketches
-   *
-   * @group agg_funcs
-   * @since 4.1.0
-   */
-  def approx_top_k(columnName: String, k: Int, maxItemsTracked: Int): Column =
-    approx_top_k(Column(columnName), k, maxItemsTracked)
-
-  /**
-   * Aggregate function: returns approximate top k (i.e., k-most-frequent) items of a column,
-   * using Frequent Items Sketches from Apache DataSketches
-   *
-   * @group agg_funcs
-   * @since 4.1.0
-   */
-  def approx_top_k(e: Column, k: Int): Column =
-    Column.fn("approx_top_k", e, lit(k))
-
-  /**
-   * Aggregate function: returns approximate top k (i.e., k-most-frequent) items of a column,
-   * using Frequent Items Sketches from Apache DataSketches
-   *
-   * @group agg_funcs
-   * @since 4.1.0
-   */
-  def approx_top_k(columnName: String, k: Int): Column =
-    approx_top_k(Column(columnName), k)
-
-  /**
-   * Aggregate function: returns approximate top k (i.e., k-most-frequent) items of a column,
-   * using Frequent Items Sketches from Apache DataSketches
-   *
-   * @group agg_funcs
-   * @since 4.1.0
-   */
-  def approx_top_k(e: Column): Column =
-    Column.fn("approx_top_k", e)
-
-  /**
-   * Aggregate function: returns approximate top k (i.e., k-most-frequent) items of a column,
-   * using Frequent Items Sketches from Apache DataSketches
-   *
-   * @group agg_funcs
-   * @since 4.1.0
-   */
-  def approx_top_k(columnName: String): Column =
-    approx_top_k(Column(columnName))
-
-  /**
    * Aggregate function: returns the kurtosis of the values in a group.
    *
    * @group agg_funcs

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -765,6 +765,66 @@ object functions {
   }
 
   /**
+   * Aggregate function: returns approximate top k (i.e., k-most-frequent) items of a column,
+   * using Frequent Items Sketches from Apache DataSketches
+   *
+   * @group agg_funcs
+   * @since 4.1.0
+   */
+  def approx_top_k(e: Column, k: Int, maxItemsTracked: Int): Column =
+    Column.fn("approx_top_k", e, lit(k), lit(maxItemsTracked))
+
+  /**
+   * Aggregate function: returns approximate top k (i.e., k-most-frequent) items of a column,
+   * using Frequent Items Sketches from Apache DataSketches
+   *
+   * @group agg_funcs
+   * @since 4.1.0
+   */
+  def approx_top_k(columnName: String, k: Int, maxItemsTracked: Int): Column =
+    approx_top_k(Column(columnName), k, maxItemsTracked)
+
+  /**
+   * Aggregate function: returns approximate top k (i.e., k-most-frequent) items of a column,
+   * using Frequent Items Sketches from Apache DataSketches
+   *
+   * @group agg_funcs
+   * @since 4.1.0
+   */
+  def approx_top_k(e: Column, k: Int): Column =
+    Column.fn("approx_top_k", e, lit(k))
+
+  /**
+   * Aggregate function: returns approximate top k (i.e., k-most-frequent) items of a column,
+   * using Frequent Items Sketches from Apache DataSketches
+   *
+   * @group agg_funcs
+   * @since 4.1.0
+   */
+  def approx_top_k(columnName: String, k: Int): Column =
+    approx_top_k(Column(columnName), k)
+
+  /**
+   * Aggregate function: returns approximate top k (i.e., k-most-frequent) items of a column,
+   * using Frequent Items Sketches from Apache DataSketches
+   *
+   * @group agg_funcs
+   * @since 4.1.0
+   */
+  def approx_top_k(e: Column): Column =
+    Column.fn("approx_top_k", e)
+
+  /**
+   * Aggregate function: returns approximate top k (i.e., k-most-frequent) items of a column,
+   * using Frequent Items Sketches from Apache DataSketches
+   *
+   * @group agg_funcs
+   * @since 4.1.0
+   */
+  def approx_top_k(columnName: String): Column =
+    approx_top_k(Column(columnName))
+
+  /**
    * Aggregate function: returns the kurtosis of the values in a group.
    *
    * @group agg_funcs

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ArrayOfDecimalsSerDe.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ArrayOfDecimalsSerDe.java
@@ -90,21 +90,24 @@ public class ArrayOfDecimalsSerDe extends ArrayOfItemsSerDe<Decimal> {
     public Decimal[] deserializeFromMemory(Memory mem, long offsetBytes, int numItems) {
         Objects.requireNonNull(mem, "Memory must not be null");
         if (DecimalType.is32BitDecimalType(decimalType)) {
-            Number[] intArray = ((ArrayOfNumbersSerDe) delegate).deserializeFromMemory(mem, offsetBytes, numItems);
+            Number[] intArray = ((ArrayOfNumbersSerDe) delegate)
+                    .deserializeFromMemory(mem, offsetBytes, numItems);
             Decimal[] result = new Decimal[intArray.length];
             for (int i = 0; i < intArray.length; i++) {
                 result[i] = Decimal.createUnsafe((int) intArray[i], precision, scale);
             }
             return result;
         } else if (DecimalType.is64BitDecimalType(decimalType)) {
-            Long[] longArray = ((ArrayOfLongsSerDe) delegate).deserializeFromMemory(mem, offsetBytes, numItems);
+            Long[] longArray = ((ArrayOfLongsSerDe) delegate)
+                    .deserializeFromMemory(mem, offsetBytes, numItems);
             Decimal[] result = new Decimal[longArray.length];
             for (int i = 0; i < longArray.length; i++) {
                 result[i] = Decimal.createUnsafe(longArray[i], precision, scale);
             }
             return result;
         } else {
-            return ((ArrayOfDecimalByteArrSerDe) delegate).deserializeFromMemory(mem, offsetBytes, numItems);
+            return ((ArrayOfDecimalByteArrSerDe) delegate)
+                    .deserializeFromMemory(mem, offsetBytes, numItems);
         }
     }
 
@@ -151,7 +154,7 @@ public class ArrayOfDecimalsSerDe extends ArrayOfItemsSerDe<Decimal> {
         private final int precision;
         private final int scale;
 
-        public ArrayOfDecimalByteArrSerDe(DecimalType decimalType) {
+        ArrayOfDecimalByteArrSerDe(DecimalType decimalType) {
             assert DecimalType.isByteArrayDecimalType(decimalType);
             this.precision = decimalType.precision();
             this.scale = decimalType.scale();

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ArrayOfDecimalsSerDe.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ArrayOfDecimalsSerDe.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Objects;
+
+import org.apache.datasketches.common.ArrayOfItemsSerDe;
+import org.apache.datasketches.common.ArrayOfLongsSerDe;
+import org.apache.datasketches.common.ArrayOfNumbersSerDe;
+import org.apache.datasketches.common.Util;
+import org.apache.datasketches.memory.Memory;
+
+import org.apache.spark.sql.types.Decimal;
+
+import static org.apache.datasketches.common.ByteArrayUtil.copyBytes;
+import static org.apache.datasketches.common.ByteArrayUtil.putIntLE;
+
+public class ArrayOfDecimalsSerDe extends ArrayOfItemsSerDe<Decimal> {
+
+    private final int precision;
+    private final int scale;
+    private final ArrayOfItemsSerDe<?> delegate;
+
+    public ArrayOfDecimalsSerDe(int precision, int scale) {
+        this.precision = precision;
+        this.scale = scale;
+
+        if (precision <= Decimal.MAX_INT_DIGITS()) {
+            this.delegate = new ArrayOfNumbersSerDe();
+        } else if (precision <= Decimal.MAX_LONG_DIGITS()) {
+            this.delegate = new ArrayOfLongsSerDe();
+        } else {
+            this.delegate = new ArrayOfDecimalByteArrSerDe(precision, scale);
+        }
+    }
+
+    @Override
+    public byte[] serializeToByteArray(Decimal item) {
+        Objects.requireNonNull(item, "Item must not be null");
+        if (precision <= Decimal.MAX_INT_DIGITS()) {
+            return ((ArrayOfNumbersSerDe) delegate).serializeToByteArray(decimalToInt(item));
+        } else if (precision <= Decimal.MAX_LONG_DIGITS()) {
+            return ((ArrayOfLongsSerDe) delegate).serializeToByteArray(item.toUnscaledLong());
+        } else {
+            return ((ArrayOfDecimalByteArrSerDe) delegate).serializeToByteArray(item);
+        }
+    }
+
+    @Override
+    public byte[] serializeToByteArray(Decimal[] items) {
+        Objects.requireNonNull(items, "Item must not be null");
+        if (precision <= Decimal.MAX_INT_DIGITS()) {
+            Number[] intItems = new Number[items.length];
+            for (int i = 0; i < items.length; i++) {
+                intItems[i] = decimalToInt(items[i]);
+            }
+            return ((ArrayOfNumbersSerDe) delegate).serializeToByteArray(intItems);
+        } else if (precision <= Decimal.MAX_LONG_DIGITS()) {
+            Long[] longItems = new Long[items.length];
+            for (int i = 0; i < items.length; i++) {
+                longItems[i] = items[i].toUnscaledLong();
+            }
+            return ((ArrayOfLongsSerDe) delegate).serializeToByteArray(longItems);
+        } else {
+            return ((ArrayOfDecimalByteArrSerDe) delegate).serializeToByteArray(items);
+        }
+    }
+
+    @Override
+    public Decimal[] deserializeFromMemory(Memory mem, long offsetBytes, int numItems) {
+        Objects.requireNonNull(mem, "Memory must not be null");
+        if (precision <= Decimal.MAX_INT_DIGITS()) {
+            Number[] intArray = ((ArrayOfNumbersSerDe) delegate).deserializeFromMemory(mem, offsetBytes, numItems);
+            Decimal[] result = new Decimal[intArray.length];
+            for (int i = 0; i < intArray.length; i++) {
+                result[i] = Decimal.createUnsafe((int) intArray[i], precision, scale);
+            }
+            return result;
+        } else if (precision <= Decimal.MAX_LONG_DIGITS()) {
+            Long[] longArray = ((ArrayOfLongsSerDe) delegate).deserializeFromMemory(mem, offsetBytes, numItems);
+            Decimal[] result = new Decimal[longArray.length];
+            for (int i = 0; i < longArray.length; i++) {
+                result[i] = Decimal.createUnsafe(longArray[i], precision, scale);
+            }
+            return result;
+        } else {
+            return ((ArrayOfDecimalByteArrSerDe) delegate).deserializeFromMemory(mem, offsetBytes, numItems);
+        }
+    }
+
+    @Override
+    public int sizeOf(Decimal item) {
+        Objects.requireNonNull(item, "Item must not be null");
+        if (precision <= Decimal.MAX_INT_DIGITS()) {
+            return ((ArrayOfNumbersSerDe) delegate).sizeOf(decimalToInt(item));
+        } else if (precision <= Decimal.MAX_LONG_DIGITS()) {
+            return ((ArrayOfLongsSerDe) delegate).sizeOf(item.toUnscaledLong());
+        } else {
+            return ((ArrayOfDecimalByteArrSerDe) delegate).sizeOf(item);
+        }
+    }
+
+    @Override
+    public int sizeOf(Memory mem, long offsetBytes, int numItems) {
+        Objects.requireNonNull(mem, "Memory must not be null");
+        return delegate.sizeOf(mem, offsetBytes, numItems);
+    }
+
+    @Override
+    public String toString(Decimal item) {
+        if (item == null) {
+            return "null";
+        }
+        return item.toString();
+    }
+
+    @Override
+    public Class<Decimal> getClassOfT() {
+        return Decimal.class;
+    }
+
+    private int decimalToInt(Decimal item) {
+        return ((int) item.toUnscaledLong());
+    }
+
+
+    /**
+     * Serialize and deserialize Decimal as byte array.
+     */
+    private static class ArrayOfDecimalByteArrSerDe extends ArrayOfItemsSerDe<Decimal> {
+        private final int precision;
+        private final int scale;
+
+        public ArrayOfDecimalByteArrSerDe(int precision, int scale) {
+            assert precision > Decimal.MAX_LONG_DIGITS();
+            this.precision = precision;
+            this.scale = scale;
+        }
+
+        @Override
+        public byte[] serializeToByteArray(Decimal item) {
+            Objects.requireNonNull(item, "Item must not be null");
+            final byte[] decimalByteArr = item.toJavaBigDecimal().unscaledValue().toByteArray();
+            final int numBytes = decimalByteArr.length;
+            final byte[] out = new byte[numBytes + Integer.BYTES];
+            copyBytes(decimalByteArr, 0, out, 4, numBytes);
+            putIntLE(out, 0, numBytes);
+            return out;
+        }
+
+        @Override
+        public byte[] serializeToByteArray(Decimal[] items) {
+            Objects.requireNonNull(items, "Items must not be null");
+            if (items.length == 0) {
+                return new byte[0];
+            }
+            int totalBytes = 0;
+            final int numItems = items.length;
+            final byte[][] serialized2DArray = new byte[numItems][];
+            for (int i = 0; i < numItems; i++) {
+                serialized2DArray[i] = items[i].toJavaBigDecimal().unscaledValue().toByteArray();
+                totalBytes += serialized2DArray[i].length + Integer.BYTES;
+            }
+            final byte[] bytesOut = new byte[totalBytes];
+            int offset = 0;
+            for (int i = 0; i < numItems; i++) {
+                final int decimalLen = serialized2DArray[i].length;
+                putIntLE(bytesOut, offset, decimalLen);
+                offset += Integer.BYTES;
+                copyBytes(serialized2DArray[i], 0, bytesOut, offset, decimalLen);
+                offset += decimalLen;
+            }
+            return bytesOut;
+        }
+
+        @Override
+        public Decimal[] deserializeFromMemory(Memory mem, long offsetBytes, int numItems) {
+            Objects.requireNonNull(mem, "Memory must not be null");
+            if (numItems <= 0) {
+                return new Decimal[0];
+            }
+            final Decimal[] array = new Decimal[numItems];
+            long offset = offsetBytes;
+            for (int i = 0; i < numItems; i++) {
+                Util.checkBounds(offset, Integer.BYTES, mem.getCapacity());
+                final int decimalLength = mem.getInt(offset);
+                offset += Integer.BYTES;
+                final byte[] decimalBytes = new byte[decimalLength];
+                Util.checkBounds(offset, decimalLength, mem.getCapacity());
+                mem.getByteArray(offset, decimalBytes, 0, decimalLength);
+                offset += decimalLength;
+                BigInteger bigInteger = new BigInteger(decimalBytes);
+                BigDecimal javaDecimal = new BigDecimal(bigInteger, scale);
+                array[i] = Decimal.apply(javaDecimal, precision, scale);
+            }
+            return array;
+        }
+
+        @Override
+        public int sizeOf(Decimal item) {
+            Objects.requireNonNull(item, "Item must not be null");
+            return item.toJavaBigDecimal().unscaledValue().toByteArray().length + Integer.BYTES;
+        }
+
+        @Override
+        public int sizeOf(Memory mem, long offsetBytes, int numItems) {
+            Objects.requireNonNull(mem, "Memory must not be null");
+            if (numItems <= 0) {
+                return 0;
+            }
+            long offset = offsetBytes;
+            final long memCap = mem.getCapacity();
+            for (int i = 0; i < numItems; i++) {
+                Util.checkBounds(offset, Integer.BYTES, memCap);
+                final int itemLenBytes = mem.getInt(offset);
+                offset += Integer.BYTES;
+                Util.checkBounds(offset, itemLenBytes, memCap);
+                offset += itemLenBytes;
+            }
+            return (int) (offset - offsetBytes);
+        }
+
+        @Override
+        public String toString(Decimal item) {
+            if (item == null) {
+                return "null";
+            }
+            return item.toString();
+        }
+
+        @Override
+        public Class<Decimal> getClassOfT() {
+            return Decimal.class;
+        }
+    }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -527,6 +527,7 @@ object FunctionRegistry {
     expressionBuilder("mode", ModeBuilder),
     expression[HllSketchAgg]("hll_sketch_agg"),
     expression[HllUnionAgg]("hll_union_agg"),
+    expression[ApproxTopK]("approx_top_k"),
 
     // string functions
     expression[Ascii]("ascii"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproxTopKAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproxTopKAggregates.scala
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.spark.sql.catalyst.expressions.aggregate
+
+import org.apache.datasketches.common._
+import org.apache.datasketches.frequencies.{ErrorType, ItemsSketch}
+import org.apache.datasketches.memory.Memory
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, TypeCheckResult}
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{TypeCheckFailure, TypeCheckSuccess}
+import org.apache.spark.sql.catalyst.expressions.{ArrayOfDecimalsSerDe, Expression, ExpressionDescription, ImplicitCastInputTypes, Literal}
+import org.apache.spark.sql.catalyst.trees.TernaryLike
+import org.apache.spark.sql.catalyst.util.{CollationFactory, GenericArrayData}
+import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
+
+/**
+ * The ApproxTopK function (i.e., "approx_top_k") is an aggregate function that estimates
+ * the approximate top K (aka. k-most-frequent) items in a column.
+ *
+ * The result is an array of structs, each containing a frequent item and its estimated frequency.
+ * The items are sorted by their estimated frequency in descending order.
+ *
+ * The function uses the ItemsSketch from the DataSketches library to do the estimation.
+ *
+ * See [[https://datasketches.apache.org/docs/Frequency/FrequencySketches.html]]
+ * for more information.
+ *
+ * @param first  the child expression to estimate the top K items from
+ * @param second the number of top items to return (K)
+ * @param third  the maximum number of items to track in the sketch
+ */
+// scalastyle:off line.size.limit
+@ExpressionDescription(
+  usage =
+    """
+    _FUNC_(expr, k, maxItemsTracked) - Returns top k items with their frequency.
+      `k` An optional INTEGER literal greater than 0. If k is not specified, it defaults to 5.
+      `maxItemsTracked` An optional INTEGER literal greater than or equal to k. If maxItemsTracked is not specified, it defaults to 10000.
+    """,
+  examples =
+    """
+    Examples:
+      > SELECT approx_top_k(expr, 10, 100) FROM VALUES (0), (1), (1), (2), (2), (2) AS tab(expr);
+        [{'item':2,'count':3},{'item':1,'count':2},{'item':0,'count':1}]
+    """,
+  group = "agg_funcs",
+  since = "4.1.0")
+// scalastyle:on line.size.limit
+case class ApproxTopK(
+    first: Expression,
+    second: Expression,
+    third: Expression,
+    mutableAggBufferOffset: Int = 0,
+    inputAggBufferOffset: Int = 0)
+  extends TypedImperativeAggregate[ItemsSketch[Any]]
+  with ImplicitCastInputTypes
+  with TernaryLike[Expression] {
+
+  def this(child: Expression, topK: Expression, maxItemsTracked: Expression) =
+    this(child, topK, maxItemsTracked, 0, 0)
+
+  def this(child: Expression, topK: Int, maxItemsTracked: Int) =
+    this(child, Literal(topK), Literal(maxItemsTracked), 0, 0)
+
+  def this(child: Expression, topK: Expression) =
+    this(child, topK, Literal(ApproxTopK.DEFAULT_MAX_ITEMS_TRACKED), 0, 0)
+
+  def this(child: Expression, topK: Int) =
+    this(child, Literal(topK), Literal(ApproxTopK.DEFAULT_MAX_ITEMS_TRACKED), 0, 0)
+
+  def this(child: Expression) =
+    this(child, Literal(ApproxTopK.DEFAULT_K), Literal(ApproxTopK.DEFAULT_MAX_ITEMS_TRACKED), 0, 0)
+
+  private lazy val itemDataType: DataType = first.dataType
+  private lazy val k: Int = {
+    ApproxTopK.checkExpressionNotNull(second, "k")
+    val k = second.eval().asInstanceOf[Int]
+    ApproxTopK.checkK(k)
+    k
+  }
+  private lazy val maxItemsTracked: Int = {
+    ApproxTopK.checkExpressionNotNull(third, "maxItemsTracked")
+    val maxItemsTracked = third.eval().asInstanceOf[Int]
+    ApproxTopK.checkMaxItemsTracked(maxItemsTracked, k)
+    maxItemsTracked
+  }
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(AnyDataType, IntegerType, IntegerType)
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    val defaultCheck = super.checkInputDataTypes()
+    if (defaultCheck.isFailure) {
+      defaultCheck
+    } else if (!ApproxTopK.checkItemType(itemDataType)) {
+      TypeCheckFailure(f"${itemDataType.typeName} columns are not supported")
+    } else if (!second.foldable) {
+      TypeCheckFailure("K must be a constant literal")
+    } else if (!third.foldable) {
+      TypeCheckFailure("Number of items tracked must be a constant literal")
+    } else {
+      TypeCheckSuccess
+    }
+  }
+
+  override def dataType: DataType = ApproxTopK.getResultDataType(itemDataType)
+
+  override def createAggregationBuffer(): ItemsSketch[Any] = {
+    val maxMapSize = ApproxTopK.calMaxMapSize(maxItemsTracked)
+    ApproxTopK.createAggregationBuffer(first, maxMapSize)
+  }
+
+  override def update(buffer: ItemsSketch[Any], input: InternalRow): ItemsSketch[Any] =
+    ApproxTopK.updateSketchBuffer(first, buffer, input)
+
+  override def merge(buffer: ItemsSketch[Any], input: ItemsSketch[Any]): ItemsSketch[Any] =
+    buffer.merge(input)
+
+  override def eval(buffer: ItemsSketch[Any]): Any = {
+    ApproxTopK.genEvalResult(buffer, k, itemDataType)
+  }
+
+  override def serialize(buffer: ItemsSketch[Any]): Array[Byte] =
+    buffer.toByteArray(ApproxTopK.genSketchSerDe(itemDataType))
+
+  override def deserialize(storageFormat: Array[Byte]): ItemsSketch[Any] =
+    ItemsSketch.getInstance(Memory.wrap(storageFormat), ApproxTopK.genSketchSerDe(itemDataType))
+
+  override def withNewMutableAggBufferOffset(newMutableAggBufferOffset: Int): ImperativeAggregate =
+    copy(mutableAggBufferOffset = newMutableAggBufferOffset)
+
+  override def withNewInputAggBufferOffset(newInputAggBufferOffset: Int): ImperativeAggregate =
+    copy(inputAggBufferOffset = newInputAggBufferOffset)
+
+  override protected def withNewChildrenInternal(
+      newFirst: Expression,
+      newSecond: Expression,
+      newThird: Expression): Expression =
+    copy(first = newFirst, second = newSecond, third = newThird)
+
+  override def nullable: Boolean = false
+
+  override def prettyName: String =
+    getTagValue(FunctionRegistry.FUNC_ALIAS).getOrElse("approx_top_k")
+}
+
+object ApproxTopK {
+
+  private val DEFAULT_K: Int = 5
+  private val DEFAULT_MAX_ITEMS_TRACKED: Int = 10000
+
+  private def checkExpressionNotNull(expr: Expression, exprName: String): Unit = {
+    if (expr == null || expr.eval() == null) {
+      throw QueryExecutionErrors.approxTopKNullArg(exprName)
+    }
+  }
+
+  private def checkK(k: Int): Unit = {
+    if (k <= 0) {
+      throw QueryExecutionErrors.approxTopKNonPositiveValue("k", k)
+    }
+  }
+
+  private def checkMaxItemsTracked(maxItemsTracked: Int, k: Int): Unit = {
+    if (maxItemsTracked < k) {
+      throw QueryExecutionErrors.approxTopKMaxItemsTrackedLessThanK(maxItemsTracked, k)
+    }
+  }
+
+  private def getResultDataType(itemDataType: DataType): DataType = {
+    val resultEntryType = StructType(
+      StructField("Item", itemDataType, nullable = false) ::
+        StructField("Estimate", LongType, nullable = false) :: Nil)
+    ArrayType(resultEntryType, containsNull = false)
+  }
+
+  private def checkItemType(itemType: DataType): Boolean =
+    itemType match {
+      case _: BooleanType | _: ByteType | _: ShortType | _: IntegerType |
+           _: LongType | _: FloatType | _: DoubleType | _: DateType |
+           _: TimestampType | _: StringType | _: DecimalType => true
+      case _ => false
+    }
+
+  private def calMaxMapSize(maxItemsTracked: Int): Int = {
+    // The maximum capacity of this internal hash map has maxMapCap = 0.75 * maxMapSize
+    // Therefore, the maxMapSize must be at least ceil(maxItemsTracked / 0.75)
+    // https://datasketches.apache.org/docs/Frequency/FrequentItemsOverview.html
+    val ceilMaxMapSize = math.ceil(maxItemsTracked / 0.75).toInt
+    // The maxMapSize must be a power of 2 and greater than ceilMaxMapSize
+    math.pow(2, math.ceil(math.log(ceilMaxMapSize) / math.log(2))).toInt
+  }
+
+  def createAggregationBuffer(itemExpression: Expression, maxMapSize: Int): ItemsSketch[Any] = {
+    itemExpression.dataType match {
+      case _: BooleanType =>
+        new ItemsSketch[Boolean](maxMapSize).asInstanceOf[ItemsSketch[Any]]
+      case _: ByteType | _: ShortType | _: IntegerType | _: FloatType | _: DateType =>
+        new ItemsSketch[Number](maxMapSize).asInstanceOf[ItemsSketch[Any]]
+      case _: LongType | _: TimestampType =>
+        new ItemsSketch[Long](maxMapSize).asInstanceOf[ItemsSketch[Any]]
+      case _: DoubleType =>
+        new ItemsSketch[Double](maxMapSize).asInstanceOf[ItemsSketch[Any]]
+      case _: StringType =>
+        new ItemsSketch[String](maxMapSize).asInstanceOf[ItemsSketch[Any]]
+      case _: DecimalType =>
+        new ItemsSketch[Decimal](maxMapSize).asInstanceOf[ItemsSketch[Any]]
+    }
+  }
+
+  private def updateSketchBuffer(
+      itemExpression: Expression,
+      buffer: ItemsSketch[Any],
+      input: InternalRow): ItemsSketch[Any] = {
+    val v = itemExpression.eval(input)
+    if (v != null) {
+      itemExpression.dataType match {
+        case _: BooleanType => buffer.update(v.asInstanceOf[Boolean])
+        case _: ByteType => buffer.update(v.asInstanceOf[Byte])
+        case _: ShortType => buffer.update(v.asInstanceOf[Short])
+        case _: IntegerType => buffer.update(v.asInstanceOf[Int])
+        case _: LongType => buffer.update(v.asInstanceOf[Long])
+        case _: FloatType => buffer.update(v.asInstanceOf[Float])
+        case _: DoubleType => buffer.update(v.asInstanceOf[Double])
+        case _: DateType => buffer.update(v.asInstanceOf[Int])
+        case _: TimestampType => buffer.update(v.asInstanceOf[Long])
+        case st: StringType =>
+          val cKey = CollationFactory.getCollationKey(v.asInstanceOf[UTF8String], st.collationId)
+          buffer.update(cKey.toString)
+        case _: DecimalType => buffer.update(v.asInstanceOf[Decimal])
+      }
+    }
+    buffer
+  }
+
+  private def genEvalResult(itemsSketch: ItemsSketch[Any], k: Int, itemDataType: DataType): Any = {
+    val items = itemsSketch.getFrequentItems(ErrorType.NO_FALSE_POSITIVES)
+    val resultLength = math.min(items.length, k)
+    val result = new Array[AnyRef](resultLength)
+    for (i <- 0 until resultLength) {
+      val row = items(i)
+      itemDataType match {
+        case _: BooleanType | _: ByteType | _: ShortType | _: IntegerType | _: LongType |
+             _: FloatType | _: DoubleType | _: DateType | _: TimestampType | _: DecimalType =>
+          result(i) = InternalRow.apply(row.getItem, row.getEstimate)
+        case _: StringType =>
+          val item = UTF8String.fromString(row.getItem.asInstanceOf[String])
+          result(i) = InternalRow.apply(item, row.getEstimate)
+      }
+    }
+    new GenericArrayData(result)
+  }
+
+  private def genSketchSerDe(dataType: DataType): ArrayOfItemsSerDe[Any] = {
+    dataType match {
+      case _: BooleanType => new ArrayOfBooleansSerDe().asInstanceOf[ArrayOfItemsSerDe[Any]]
+      case _: ByteType | _: ShortType | _: IntegerType | _: FloatType | _: DateType =>
+        new ArrayOfNumbersSerDe().asInstanceOf[ArrayOfItemsSerDe[Any]]
+      case _: LongType | _: TimestampType =>
+        new ArrayOfLongsSerDe().asInstanceOf[ArrayOfItemsSerDe[Any]]
+      case _: DoubleType =>
+        new ArrayOfDoublesSerDe().asInstanceOf[ArrayOfItemsSerDe[Any]]
+      case _: StringType =>
+        new ArrayOfStringsSerDe().asInstanceOf[ArrayOfItemsSerDe[Any]]
+      case dt: DecimalType =>
+        new ArrayOfDecimalsSerDe(dt.precision, dt.scale).asInstanceOf[ArrayOfItemsSerDe[Any]]
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproxTopKAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproxTopKAggregates.scala
@@ -50,18 +50,22 @@ import org.apache.spark.unsafe.types.UTF8String
  */
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage =
-    """
+  usage = """
     _FUNC_(expr, k, maxItemsTracked) - Returns top k items with their frequency.
       `k` An optional INTEGER literal greater than 0. If k is not specified, it defaults to 5.
       `maxItemsTracked` An optional INTEGER literal greater than or equal to k. If maxItemsTracked is not specified, it defaults to 10000.
     """,
-  examples =
-    """
+  examples = """
     Examples:
-      > SELECT approx_top_k(expr, 10, 100) FROM VALUES (0), (1), (1), (2), (2), (2) AS tab(expr);
-        [{'item':2,'count':3},{'item':1,'count':2},{'item':0,'count':1}]
-    """,
+      > SELECT _FUNC_(expr) FROM VALUES (0), (0), (1), (1), (2), (3), (4), (4) AS tab(expr);
+       [{"item":0,"count":2},{"item":4,"count":2},{"item":1,"count":2},{"item":2,"count":1},{"item":3,"count":1}]
+
+      > SELECT _FUNC_(expr, 2) FROM VALUES 'a', 'b', 'c', 'c', 'c', 'c', 'd', 'd' AS tab(expr);
+       [{"item":"c","count":4},{"item":"d","count":2}]
+
+      > SELECT _FUNC_(expr, 10, 100) FROM VALUES (0), (1), (1), (2), (2), (2) AS tab(expr);
+       [{"item":2,"count":3},{"item":1,"count":2},{"item":0,"count":1}]
+  """,
   group = "agg_funcs",
   since = "4.1.0")
 // scalastyle:on line.size.limit
@@ -197,8 +201,8 @@ object ApproxTopK {
 
   private def getResultDataType(itemDataType: DataType): DataType = {
     val resultEntryType = StructType(
-      StructField("Item", itemDataType, nullable = false) ::
-        StructField("Estimate", LongType, nullable = false) :: Nil)
+      StructField("item", itemDataType, nullable = false) ::
+        StructField("count", LongType, nullable = false) :: Nil)
     ArrayType(resultEntryType, containsNull = false)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproxTopKAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproxTopKAggregates.scala
@@ -134,7 +134,7 @@ case class ApproxTopK(
   override def merge(buffer: ItemsSketch[Any], input: ItemsSketch[Any]): ItemsSketch[Any] =
     buffer.merge(input)
 
-  override def eval(buffer: ItemsSketch[Any]): Any = {
+  override def eval(buffer: ItemsSketch[Any]): GenericArrayData = {
     ApproxTopK.genEvalResult(buffer, k, itemDataType)
   }
 
@@ -251,7 +251,10 @@ object ApproxTopK {
     buffer
   }
 
-  private def genEvalResult(itemsSketch: ItemsSketch[Any], k: Int, itemDataType: DataType): Any = {
+  private def genEvalResult(
+      itemsSketch: ItemsSketch[Any],
+      k: Int,
+      itemDataType: DataType): GenericArrayData = {
     val items = itemsSketch.getFrequentItems(ErrorType.NO_FALSE_POSITIVES)
     val resultLength = math.min(items.length, k)
     val result = new Array[AnyRef](resultLength)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproxTopKAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproxTopKAggregates.scala
@@ -298,7 +298,7 @@ object ApproxTopK {
       case _: StringType =>
         new ArrayOfStringsSerDe().asInstanceOf[ArrayOfItemsSerDe[Any]]
       case dt: DecimalType =>
-        new ArrayOfDecimalsSerDe(dt.precision, dt.scale).asInstanceOf[ArrayOfItemsSerDe[Any]]
+        new ArrayOfDecimalsSerDe(dt).asInstanceOf[ArrayOfItemsSerDe[Any]]
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproxTopKAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproxTopKAggregates.scala
@@ -172,6 +172,7 @@ object ApproxTopK {
 
   private val DEFAULT_K: Int = 5
   private val DEFAULT_MAX_ITEMS_TRACKED: Int = 10000
+  private val MAX_ITEMS_TRACKED_LIMIT: Int = 1000000
 
   private def checkExpressionNotNull(expr: Expression, exprName: String): Unit = {
     if (expr == null || expr.eval() == null) {
@@ -186,6 +187,10 @@ object ApproxTopK {
   }
 
   private def checkMaxItemsTracked(maxItemsTracked: Int, k: Int): Unit = {
+    if (maxItemsTracked > MAX_ITEMS_TRACKED_LIMIT) {
+      throw QueryExecutionErrors.approxTopKMaxItemsTrackedExceedsLimit(
+        maxItemsTracked, MAX_ITEMS_TRACKED_LIMIT)
+    }
     if (maxItemsTracked < k) {
       throw QueryExecutionErrors.approxTopKMaxItemsTrackedLessThanK(maxItemsTracked, k)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproxTopKAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproxTopKAggregates.scala
@@ -202,13 +202,15 @@ object ApproxTopK {
     ArrayType(resultEntryType, containsNull = false)
   }
 
-  private def isDataTypeSupported(itemType: DataType): Boolean =
+  private def isDataTypeSupported(itemType: DataType): Boolean = {
     itemType match {
       case _: BooleanType | _: ByteType | _: ShortType | _: IntegerType |
            _: LongType | _: FloatType | _: DoubleType | _: DateType |
            _: TimestampType | _: TimestampNTZType | _: StringType | _: DecimalType => true
+      // BinaryType is not supported now, as ItemsSketch seems cannot count the frequency correctly
       case _ => false
     }
+  }
 
   private def calMaxMapSize(maxItemsTracked: Int): Int = {
     // The maximum capacity of this internal hash map has maxMapCap = 0.75 * maxMapSize

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2791,6 +2791,14 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
         "k" -> toSQLValue(k, IntegerType)))
   }
 
+  def approxTopKMaxItemsTrackedExceedsLimit(maxItemsTracked: Int, limit: Int): Throwable = {
+    new SparkRuntimeException(
+      errorClass = "APPROX_TOP_K_MAX_ITEMS_TRACKED_EXCEEDS_LIMIT",
+      messageParameters = Map(
+        "maxItemsTracked" -> toSQLValue(maxItemsTracked, IntegerType),
+        "limit" -> toSQLValue(limit, IntegerType)))
+  }
+
   def mergeCardinalityViolationError(): SparkRuntimeException = {
     new SparkRuntimeException(
       errorClass = "MERGE_CARDINALITY_VIOLATION",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -152,13 +152,13 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       s: UTF8String,
       fmt: UTF8String,
       hint: String): SparkIllegalArgumentException = {
-      new SparkIllegalArgumentException(
-        errorClass = "CONVERSION_INVALID_INPUT",
-        messageParameters = Map(
-          "str" -> toSQLValue(s, StringType),
-          "fmt" -> toSQLValue(fmt, StringType),
-          "targetType" -> toSQLType(to),
-          "suggestion" -> toSQLId(hint)))
+    new SparkIllegalArgumentException(
+      errorClass = "CONVERSION_INVALID_INPUT",
+      messageParameters = Map(
+        "str" -> toSQLValue(s, StringType),
+        "fmt" -> toSQLValue(fmt, StringType),
+        "targetType" -> toSQLType(to),
+        "suggestion" -> toSQLId(hint)))
   }
 
   def cannotCastFromNullTypeError(to: DataType): Throwable = {
@@ -249,7 +249,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def invalidBitmapPositionError(bitPosition: Long,
-                                 bitmapNumBytes: Long): ArrayIndexOutOfBoundsException = {
+      bitmapNumBytes: Long): ArrayIndexOutOfBoundsException = {
     new SparkArrayIndexOutOfBoundsException(
       errorClass = "INVALID_BITMAP_POSITION",
       messageParameters = Map(
@@ -346,7 +346,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       errorClass = "UNSUPPORTED_FEATURE.LITERAL_TYPE",
       messageParameters = Map(
         "value" -> v.toString,
-        "type" ->  v.getClass.toString))
+        "type" -> v.getClass.toString))
   }
 
   def pivotColumnUnsupportedError(v: Any, expr: Expression): RuntimeException = {
@@ -668,7 +668,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def withoutSuggestionIntervalArithmeticOverflowError(
-    context: QueryContext): SparkArithmeticException = {
+      context: QueryContext): SparkArithmeticException = {
     new SparkArithmeticException(
       errorClass = "INTERVAL_ARITHMETIC_OVERFLOW.WITHOUT_SUGGESTION",
       messageParameters = Map(),
@@ -728,7 +728,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
         "windowFunc" -> windowFuncList.map(toSQLStmt(_)).mkString(","),
         "columnName" -> columnNameList.map(toSQLId(_)).mkString(","),
         "windowSpec" -> windowSpecList.map(toSQLStmt(_)).mkString(",")),
-        origin = origin)
+      origin = origin)
   }
 
   def multiplePathsSpecifiedError(allPaths: Seq[String]): SparkIllegalArgumentException = {
@@ -1421,7 +1421,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def arrayFunctionWithElementsExceedLimitError(
-    prettyName: String, numberOfElements: Long): SparkRuntimeException = {
+      prettyName: String, numberOfElements: Long): SparkRuntimeException = {
     new SparkRuntimeException(
       errorClass = "COLLECTION_SIZE_LIMIT_EXCEEDED.FUNCTION",
       messageParameters = Map(
@@ -1432,7 +1432,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def createArrayWithElementsExceedLimitError(
-    prettyName: String, count: Any): SparkRuntimeException = {
+      prettyName: String, count: Any): SparkRuntimeException = {
     new SparkRuntimeException(
       errorClass = "COLLECTION_SIZE_LIMIT_EXCEEDED.PARAMETER",
       messageParameters = Map(
@@ -1547,7 +1547,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       errorClass = "_LEGACY_ERROR_TEMP_2176",
       messageParameters = Map(
         "numElements" -> numElements.toString(),
-        "maxRoundedArrayLength"-> ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH.toString(),
+        "maxRoundedArrayLength" -> ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH.toString(),
         "additionalErrorMessage" -> additionalErrorMessage))
   }
 
@@ -1742,7 +1742,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def stateNotDefinedOrAlreadyRemovedError(): Throwable = {
-      new NoSuchElementException("State is either not defined or has already been removed")
+    new NoSuchElementException("State is either not defined or has already been removed")
   }
 
   def statefulOperatorNotMatchInStateMetadataError(
@@ -1750,6 +1750,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       opsInCurBatchSeq: Map[Long, String]): SparkRuntimeException = {
     def formatPairString(pair: (Long, String)): String
     = s"(OperatorId: ${pair._1} -> OperatorName: ${pair._2})"
+
     new SparkRuntimeException(
       errorClass = s"STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA",
       messageParameters = Map(
@@ -2630,7 +2631,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       acquiredThreadInfo: String,
       timeWaitedMs: Long,
       stackTraceOutput: String): Throwable = {
-    new SparkException (
+    new SparkException(
       errorClass = "CANNOT_LOAD_STATE_STORE.UNRELEASED_THREAD_ERROR",
       messageParameters = Map(
         "loggingId" -> loggingId,
@@ -2643,7 +2644,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def cannotReadCheckpoint(expectedVersion: String, actualVersion: String): Throwable = {
-    new SparkException (
+    new SparkException(
       errorClass = "CANNOT_LOAD_STATE_STORE.CANNOT_READ_CHECKPOINT",
       messageParameters = Map(
         "expectedVersion" -> expectedVersion,
@@ -2652,7 +2653,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def cannotFindBaseSnapshotCheckpoint(lineage: String): Throwable = {
-    new SparkException (
+    new SparkException(
       errorClass =
         "CANNOT_LOAD_STATE_STORE.CANNOT_FIND_BASE_SNAPSHOT_CHECKPOINT",
       messageParameters = Map("lineage" -> lineage),
@@ -2769,6 +2770,28 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
         "function" -> toSQLId(function)))
   }
 
+  def approxTopKNonPositiveValue(argName: String, argValue: Int): Throwable = {
+    new SparkRuntimeException(
+      errorClass = "APPROX_TOP_K_NON_POSITIVE_ARG",
+      messageParameters = Map(
+        "argName" -> toSQLId(argName),
+        "argValue" -> toSQLValue(argValue, IntegerType)))
+  }
+
+  def approxTopKNullArg(argName: String): Throwable = {
+    new SparkRuntimeException(
+      errorClass = "APPROX_TOP_K_NULL_ARG",
+      messageParameters = Map("argName" -> toSQLId(argName)))
+  }
+
+  def approxTopKMaxItemsTrackedLessThanK(maxItemsTracked: Int, k: Int): Throwable = {
+    new SparkRuntimeException(
+      errorClass = "APPROX_TOP_K_MAX_ITEMS_TRACKED_LESS_THAN_K",
+      messageParameters = Map(
+        "maxItemsTracked" -> toSQLValue(maxItemsTracked, IntegerType),
+        "k" -> toSQLValue(k, IntegerType)))
+  }
+
   def mergeCardinalityViolationError(): SparkRuntimeException = {
     new SparkRuntimeException(
       errorClass = "MERGE_CARDINALITY_VIOLATION",
@@ -2795,7 +2818,11 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       val errorParmsMutable = collection.mutable.Map[String, String]()
       errorParms.foreach(StringType, StringType, { case (key, value) =>
         errorParmsMutable += (key.toString ->
-          (if (value == null) { "null" } else { value.toString } ))
+          (if (value == null) {
+            "null"
+          } else {
+            value.toString
+          }))
       })
       errorParmsMutable.toMap
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -152,13 +152,13 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       s: UTF8String,
       fmt: UTF8String,
       hint: String): SparkIllegalArgumentException = {
-    new SparkIllegalArgumentException(
-      errorClass = "CONVERSION_INVALID_INPUT",
-      messageParameters = Map(
-        "str" -> toSQLValue(s, StringType),
-        "fmt" -> toSQLValue(fmt, StringType),
-        "targetType" -> toSQLType(to),
-        "suggestion" -> toSQLId(hint)))
+      new SparkIllegalArgumentException(
+        errorClass = "CONVERSION_INVALID_INPUT",
+        messageParameters = Map(
+          "str" -> toSQLValue(s, StringType),
+          "fmt" -> toSQLValue(fmt, StringType),
+          "targetType" -> toSQLType(to),
+          "suggestion" -> toSQLId(hint)))
   }
 
   def cannotCastFromNullTypeError(to: DataType): Throwable = {
@@ -249,7 +249,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def invalidBitmapPositionError(bitPosition: Long,
-      bitmapNumBytes: Long): ArrayIndexOutOfBoundsException = {
+                                 bitmapNumBytes: Long): ArrayIndexOutOfBoundsException = {
     new SparkArrayIndexOutOfBoundsException(
       errorClass = "INVALID_BITMAP_POSITION",
       messageParameters = Map(
@@ -346,7 +346,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       errorClass = "UNSUPPORTED_FEATURE.LITERAL_TYPE",
       messageParameters = Map(
         "value" -> v.toString,
-        "type" -> v.getClass.toString))
+        "type" ->  v.getClass.toString))
   }
 
   def pivotColumnUnsupportedError(v: Any, expr: Expression): RuntimeException = {
@@ -668,7 +668,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def withoutSuggestionIntervalArithmeticOverflowError(
-      context: QueryContext): SparkArithmeticException = {
+    context: QueryContext): SparkArithmeticException = {
     new SparkArithmeticException(
       errorClass = "INTERVAL_ARITHMETIC_OVERFLOW.WITHOUT_SUGGESTION",
       messageParameters = Map(),
@@ -728,7 +728,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
         "windowFunc" -> windowFuncList.map(toSQLStmt(_)).mkString(","),
         "columnName" -> columnNameList.map(toSQLId(_)).mkString(","),
         "windowSpec" -> windowSpecList.map(toSQLStmt(_)).mkString(",")),
-      origin = origin)
+        origin = origin)
   }
 
   def multiplePathsSpecifiedError(allPaths: Seq[String]): SparkIllegalArgumentException = {
@@ -1421,7 +1421,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def arrayFunctionWithElementsExceedLimitError(
-      prettyName: String, numberOfElements: Long): SparkRuntimeException = {
+    prettyName: String, numberOfElements: Long): SparkRuntimeException = {
     new SparkRuntimeException(
       errorClass = "COLLECTION_SIZE_LIMIT_EXCEEDED.FUNCTION",
       messageParameters = Map(
@@ -1432,7 +1432,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def createArrayWithElementsExceedLimitError(
-      prettyName: String, count: Any): SparkRuntimeException = {
+    prettyName: String, count: Any): SparkRuntimeException = {
     new SparkRuntimeException(
       errorClass = "COLLECTION_SIZE_LIMIT_EXCEEDED.PARAMETER",
       messageParameters = Map(
@@ -1547,7 +1547,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       errorClass = "_LEGACY_ERROR_TEMP_2176",
       messageParameters = Map(
         "numElements" -> numElements.toString(),
-        "maxRoundedArrayLength" -> ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH.toString(),
+        "maxRoundedArrayLength"-> ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH.toString(),
         "additionalErrorMessage" -> additionalErrorMessage))
   }
 
@@ -1742,7 +1742,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def stateNotDefinedOrAlreadyRemovedError(): Throwable = {
-    new NoSuchElementException("State is either not defined or has already been removed")
+      new NoSuchElementException("State is either not defined or has already been removed")
   }
 
   def statefulOperatorNotMatchInStateMetadataError(
@@ -1750,7 +1750,6 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       opsInCurBatchSeq: Map[Long, String]): SparkRuntimeException = {
     def formatPairString(pair: (Long, String)): String
     = s"(OperatorId: ${pair._1} -> OperatorName: ${pair._2})"
-
     new SparkRuntimeException(
       errorClass = s"STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA",
       messageParameters = Map(
@@ -2631,7 +2630,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       acquiredThreadInfo: String,
       timeWaitedMs: Long,
       stackTraceOutput: String): Throwable = {
-    new SparkException(
+    new SparkException (
       errorClass = "CANNOT_LOAD_STATE_STORE.UNRELEASED_THREAD_ERROR",
       messageParameters = Map(
         "loggingId" -> loggingId,
@@ -2644,7 +2643,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def cannotReadCheckpoint(expectedVersion: String, actualVersion: String): Throwable = {
-    new SparkException(
+    new SparkException (
       errorClass = "CANNOT_LOAD_STATE_STORE.CANNOT_READ_CHECKPOINT",
       messageParameters = Map(
         "expectedVersion" -> expectedVersion,
@@ -2653,7 +2652,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def cannotFindBaseSnapshotCheckpoint(lineage: String): Throwable = {
-    new SparkException(
+    new SparkException (
       errorClass =
         "CANNOT_LOAD_STATE_STORE.CANNOT_FIND_BASE_SNAPSHOT_CHECKPOINT",
       messageParameters = Map("lineage" -> lineage),
@@ -2818,11 +2817,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       val errorParmsMutable = collection.mutable.Map[String, String]()
       errorParms.foreach(StringType, StringType, { case (key, value) =>
         errorParmsMutable += (key.toString ->
-          (if (value == null) {
-            "null"
-          } else {
-            value.toString
-          }))
+          (if (value == null) { "null" } else { value.toString } ))
       })
       errorParmsMutable.toMap
     } else {

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -400,9 +400,9 @@
 | org.apache.spark.sql.catalyst.expressions.ZeroIfNull | zeroifnull | SELECT zeroifnull(NULL) | struct<zeroifnull(NULL):int> |
 | org.apache.spark.sql.catalyst.expressions.ZipWith | zip_with | SELECT zip_with(array(1, 2, 3), array('a', 'b', 'c'), (x, y) -> (y, x)) | struct<zip_with(array(1, 2, 3), array(a, b, c), lambdafunction(named_struct(y, namedlambdavariable(), x, namedlambdavariable()), namedlambdavariable(), namedlambdavariable())):array<struct<y:string,x:int>>> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.AnyValue | any_value | SELECT any_value(col) FROM VALUES (10), (5), (20) AS tab(col) | struct<any_value(col):int> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.ApproxTopK | approx_top_k | SELECT approx_top_k(expr) FROM VALUES (0), (0), (1), (1), (2), (3), (4), (4) AS tab(expr) | struct<approx_top_k(expr, 5, 10000):array<struct<item:int,count:bigint>>> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile | approx_percentile | SELECT approx_percentile(col, array(0.5, 0.4, 0.1), 100) FROM VALUES (0), (1), (2), (10) AS tab(col) | struct<approx_percentile(col, array(0.5, 0.4, 0.1), 100):array<int>> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile | percentile_approx | SELECT percentile_approx(col, array(0.5, 0.4, 0.1), 100) FROM VALUES (0), (1), (2), (10) AS tab(col) | struct<percentile_approx(col, array(0.5, 0.4, 0.1), 100):array<int>> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.ApproxTopK | approx_top_k | SELECT approx_top_k(col) FROM VALUES (0), (0), (1), (1), (2), (3), (4), (4) AS tab(col) | struct<approx_top_k(col):array<struct<item:int,count:bigint>>> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.Average | avg | SELECT avg(col) FROM VALUES (1), (2), (3) AS tab(col) | struct<avg(col):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.Average | mean | SELECT mean(col) FROM VALUES (1), (2), (3) AS tab(col) | struct<mean(col):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.BitAndAgg | bit_and | SELECT bit_and(col) FROM VALUES (3), (5) AS tab(col) | struct<bit_and(col):int> |

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -402,6 +402,7 @@
 | org.apache.spark.sql.catalyst.expressions.aggregate.AnyValue | any_value | SELECT any_value(col) FROM VALUES (10), (5), (20) AS tab(col) | struct<any_value(col):int> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile | approx_percentile | SELECT approx_percentile(col, array(0.5, 0.4, 0.1), 100) FROM VALUES (0), (1), (2), (10) AS tab(col) | struct<approx_percentile(col, array(0.5, 0.4, 0.1), 100):array<int>> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile | percentile_approx | SELECT percentile_approx(col, array(0.5, 0.4, 0.1), 100) FROM VALUES (0), (1), (2), (10) AS tab(col) | struct<percentile_approx(col, array(0.5, 0.4, 0.1), 100):array<int>> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.ApproxTopK | approx_top_k | SELECT approx_top_k(col) FROM VALUES (0), (0), (1), (1), (2), (3), (4), (4) AS tab(col) | struct<approx_top_k(col):array<struct<item:int,count:bigint>>> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.Average | avg | SELECT avg(col) FROM VALUES (1), (2), (3) AS tab(col) | struct<avg(col):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.Average | mean | SELECT mean(col) FROM VALUES (1), (2), (3) AS tab(col) | struct<mean(col):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.BitAndAgg | bit_and | SELECT bit_and(col) FROM VALUES (3), (5) AS tab(col) | struct<bit_and(col):int> |

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -2769,6 +2769,16 @@ class DataFrameAggregateSuite extends QueryTest
     )
   }
 
+  test("SPARK-52515: invalid maxItemsTracked > 1000000") {
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        sql("SELECT approx_top_k(expr, 10, 1000001) FROM VALUES (0), (1) AS tab(expr);").collect()
+      },
+      condition = "APPROX_TOP_K_MAX_ITEMS_TRACKED_EXCEEDS_LIMIT",
+      parameters = Map("maxItemsTracked" -> "1000001", "limit" -> "1000000")
+    )
+  }
+
   test("SPARK-52515: invalid item type array") {
     checkError(
       exception = intercept[ExtendedAnalysisException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -2800,7 +2800,7 @@ class DataFrameAggregateSuite extends QueryTest
     )
   }
 
-  test("SPARK-52515null: does not count NULL values") {
+  test("SPARK-52515: does not count NULL values") {
     val res = sql(
       "SELECT approx_top_k(expr, 2)" +
         "FROM VALUES 'a', 'a', 'b', 'b', 'b', NULL, NULL, NULL AS tab(expr);")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -2712,6 +2712,18 @@ class DataFrameAggregateSuite extends QueryTest
       Row(Seq(Row(new java.math.BigDecimal("0.0"), 3), Row(new java.math.BigDecimal("1.0"), 2))))
   }
 
+  test("SPARK-52515: test of Decimal(4, 1) type") {
+    val res = sql(
+      "SELECT approx_top_k(expr, 2) AS top_k_result " +
+        "FROM VALUES CAST(0.0 AS DECIMAL(4, 1)), CAST(0.0 AS DECIMAL(4, 1)), " +
+        "CAST(0.0 AS DECIMAL(4, 1)), CAST(1.0 AS DECIMAL(4, 1)), " +
+        "CAST(1.0 AS DECIMAL(4, 1)), CAST(2.0 AS DECIMAL(4, 1)), " +
+        "CAST(3.0 AS DECIMAL(4, 1)), CAST(4.0 AS DECIMAL(4, 1)) AS tab(expr);")
+    checkAnswer(
+      res,
+      Row(Seq(Row(new java.math.BigDecimal("0.0"), 3), Row(new java.math.BigDecimal("1.0"), 2))))
+  }
+
   test("SPARK-52515: test of Decimal(10, 2) type") {
     val res = sql(
       "SELECT approx_top_k(expr, 2) AS top_k_result " +
@@ -2724,16 +2736,17 @@ class DataFrameAggregateSuite extends QueryTest
       Row(Seq(Row(new java.math.BigDecimal("0.00"), 3), Row(new java.math.BigDecimal("1.00"), 2))))
   }
 
-  test("SPARK-52515: test of Decimal(20, 1) type") {
+  test("SPARK-52515: test of Decimal(20, 3) type") {
     val res = sql(
       "SELECT approx_top_k(expr, 2) AS top_k_result " +
-        "FROM VALUES CAST(0.0 AS DECIMAL(20, 1)), CAST(0.0 AS DECIMAL(20, 1)), " +
-        "CAST(0.0 AS DECIMAL(20, 1)), CAST(1.0 AS DECIMAL(20, 1)), " +
-        "CAST(1.0 AS DECIMAL(20, 1)), CAST(2.0 AS DECIMAL(20, 1)), " +
-        "CAST(3.0 AS DECIMAL(20, 1)), CAST(4.0 AS DECIMAL(20, 1)) AS tab(expr);")
+        "FROM VALUES CAST(0.0 AS DECIMAL(20, 3)), CAST(0.0 AS DECIMAL(20, 3)), " +
+        "CAST(0.0 AS DECIMAL(20, 3)), CAST(1.0 AS DECIMAL(20, 3)), " +
+        "CAST(1.0 AS DECIMAL(20, 3)), CAST(2.0 AS DECIMAL(20, 3)), " +
+        "CAST(3.0 AS DECIMAL(20, 3)), CAST(4.0 AS DECIMAL(20, 3)) AS tab(expr);")
     checkAnswer(
       res,
-      Row(Seq(Row(new java.math.BigDecimal("0.0"), 3), Row(new java.math.BigDecimal("1.0"), 2))))
+      Row(Seq(Row(new java.math.BigDecimal("0.000"), 3),
+        Row(new java.math.BigDecimal("1.000"), 2))))
   }
 
   test("SPARK-52515: invalid k value") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -2843,6 +2843,21 @@ class DataFrameAggregateSuite extends QueryTest
     )
   }
 
+  test("SPARK-52515: invalid item type map") {
+    checkError(
+      exception = intercept[ExtendedAnalysisException] {
+        sql("SELECT approx_top_k(expr) FROM VALUES map('red', 1, 'green', 2) AS tab(expr);")
+      },
+      condition = "DATATYPE_MISMATCH.TYPE_CHECK_FAILURE_WITH_HINT",
+      parameters = Map(
+        "sqlExpr" -> "\"approx_top_k(expr, 5, 10000)\"",
+        "msg" -> "map columns are not supported",
+        "hint" -> ""
+      ),
+      queryContext = Array(ExpectedContext("approx_top_k(expr)", 7, 24))
+    )
+  }
+
   test("SPARK-52515: does not count NULL values") {
     val res = sql(
       "SELECT approx_top_k(expr, 2)" +

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -2686,6 +2686,23 @@ class DataFrameAggregateSuite extends QueryTest
         Row(Timestamp.valueOf("2023-01-05 00:00:00"), 2))))
   }
 
+  test("SPARK-52515: test of Timestamp_ntz type") {
+    val res = sql(
+      "SELECT approx_top_k(expr, 2) " +
+        "FROM VALUES TIMESTAMP_NTZ'2023-01-01 00:00:00', " +
+        "TIMESTAMP_NTZ'2023-01-01 00:00:00', " +
+        "TIMESTAMP_NTZ'2023-01-02 00:00:00', " +
+        "TIMESTAMP_NTZ'2023-01-02 00:00:00', " +
+        "TIMESTAMP_NTZ'2023-01-03 00:00:00', " +
+        "TIMESTAMP_NTZ'2023-01-04 00:00:00', " +
+        "TIMESTAMP_NTZ'2023-01-05 00:00:00', " +
+        "TIMESTAMP_NTZ'2023-01-05 00:00:00' AS tab(expr);")
+    checkAnswer(
+      res,
+      Row(Seq(Row(LocalDateTime.of(2023, 1, 5, 0, 0), 2),
+        Row(LocalDateTime.of(2023, 1, 1, 0, 0), 2))))
+  }
+
   test("SPARK-52515: test of Decimal type") {
     val res = sql(
       "SELECT approx_top_k(expr, 2) AS top_k_result " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -2729,6 +2729,22 @@ class DataFrameAggregateSuite extends QueryTest
     )
   }
 
+  test("SPARK-52515: invalid k value > Int.MaxValue") {
+    val k: Long = Int.MaxValue + 1L
+    checkError(
+      exception = intercept[SparkArithmeticException] {
+        sql(s"SELECT approx_top_k(expr, $k) FROM VALUES (0), (1), (2) AS tab(expr);").collect()
+      },
+      condition = "CAST_OVERFLOW",
+      parameters = Map(
+        "value" -> (k.toString + "L"),
+        "sourceType" -> "\"BIGINT\"",
+        "targetType" -> "\"INT\"",
+        "ansiConfig" -> "\"spark.sql.ansi.enabled\""
+      )
+    )
+  }
+
   test("SPARK-52515: invalid k value null") {
     checkError(
       exception = intercept[SparkRuntimeException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -2809,25 +2809,25 @@ class DataFrameAggregateSuite extends QueryTest
 
   test("SPARK-52515: Accepts literal and foldable inputs") {
     val agg = new ApproxTopK(
-      first = BoundReference(0, LongType, nullable = true),
-      second = Abs(Literal(10)),
-      third = Abs(Literal(-10))
+      expr = BoundReference(0, LongType, nullable = true),
+      k = Abs(Literal(10)),
+      maxItemsTracked = Abs(Literal(-10))
     )
     assert(agg.checkInputDataTypes().isSuccess)
   }
 
   test("SPARK-52515: Fail if parameters are not foldable") {
     val badAgg = new ApproxTopK(
-      first = BoundReference(0, LongType, nullable = true),
-      second = Sum(BoundReference(1, LongType, nullable = true)),
-      third = Literal(10)
+      expr = BoundReference(0, LongType, nullable = true),
+      k = Sum(BoundReference(1, LongType, nullable = true)),
+      maxItemsTracked = Literal(10)
     )
     assert(badAgg.checkInputDataTypes().isFailure)
 
     val badAgg2 = new ApproxTopK(
-      first = BoundReference(0, LongType, nullable = true),
-      second = Literal(10),
-      third = Sum(BoundReference(1, LongType, nullable = true))
+      expr = BoundReference(0, LongType, nullable = true),
+      k = Literal(10),
+      maxItemsTracked = Sum(BoundReference(1, LongType, nullable = true))
     )
     assert(badAgg2.checkInputDataTypes().isFailure)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql
 
+import java.sql.{Date, Timestamp}
 import java.time.{Duration, LocalDateTime, Period}
 
 import scala.util.Random
@@ -24,6 +25,7 @@ import scala.util.Random
 import org.scalatest.matchers.must.Matchers.the
 
 import org.apache.spark.{SparkArithmeticException, SparkRuntimeException}
+import org.apache.spark.sql.catalyst.ExtendedAnalysisException
 import org.apache.spark.sql.catalyst.plans.logical.Expand
 import org.apache.spark.sql.catalyst.util.AUTO_GENERATED_ALIAS
 import org.apache.spark.sql.errors.DataTypeErrors.toSQLId
@@ -2566,6 +2568,234 @@ class DataFrameAggregateSuite extends QueryTest
               |""".stripMargin)
       checkAnswer(df, Row(1.001d, 1, 1) :: Row(6.002d, 1, 1) :: Nil)
     }
+  }
+
+  test("SPARK-52515: test of 1 parameter") {
+    val res = sql(
+      "SELECT approx_top_k(expr) FROM VALUES (0), (0), (1), (1), (2), (3), (4), (4) AS tab(expr);"
+    )
+    checkAnswer(res, Row(Seq(Row(0, 2), Row(4, 2), Row(1, 2), Row(2, 1), Row(3, 1))))
+  }
+
+  test("SPARK-52515: test of 2 parameter") {
+    val res = sql(
+      "SELECT approx_top_k(expr, 2) " +
+        "FROM VALUES 'a', 'b', 'c', 'c', 'c', 'c', 'd', 'd' AS tab(expr);")
+    checkAnswer(res, Row(Seq(Row("c", 4), Row("d", 2))))
+  }
+
+  test("SPARK-52515: test of 3 parameter") {
+    val res = sql(
+      "SELECT approx_top_k(expr, 10, 100) FROM VALUES (0), (1), (1), (2), (2), (2) AS tab(expr);"
+    )
+    checkAnswer(res, Row(Seq(Row(2, 3), Row(1, 2), Row(0, 1))))
+  }
+
+  test("SPARK-52515: test of Integer type") {
+    val res = sql(
+      "SELECT approx_top_k(expr) FROM VALUES (0), (0), (1), (1), (2), (3), (4), (4) AS tab(expr);"
+    )
+    checkAnswer(res, Row(Seq(Row(0, 2), Row(4, 2), Row(1, 2), Row(2, 1), Row(3, 1))))
+  }
+
+  test("SPARK-52515: test of String type") {
+    val res = sql(
+      "SELECT approx_top_k(expr, 2)" +
+        "FROM VALUES 'a', 'b', 'c', 'c', 'c', 'c', 'd', 'd' AS tab(expr);")
+    checkAnswer(res, Row(Seq(Row("c", 4), Row("d", 2))))
+  }
+
+  test("SPARK-52515: test of Boolean type") {
+    Seq(true, true, false, true, true, false, false).toDF("expr").createOrReplaceTempView("t_bool")
+    val res = sql("SELECT approx_top_k(expr, 1) FROM t_bool;")
+    checkAnswer(res, Row(Seq(Row(true, 4))))
+  }
+
+  test("SPARK-52515: test of Byte type") {
+    val res = sql(
+      "SELECT approx_top_k(expr, 2) " +
+        "FROM VALUES cast(0 AS BYTE), cast(0 AS BYTE), cast(1 AS BYTE), cast(1 AS BYTE), " +
+        "cast(2 AS BYTE), cast(3 AS BYTE), cast(4 AS BYTE), cast(4 AS BYTE) AS tab(expr);")
+    checkAnswer(res, Row(Seq(Row(0, 2), Row(4, 2))))
+  }
+
+  test("SPARK-52515: test of Short type") {
+    val res = sql(
+      "SELECT approx_top_k(expr, 2) " +
+        "FROM VALUES cast(0 AS SHORT), cast(0 AS SHORT), cast(1 AS SHORT), cast(1 AS SHORT), " +
+        "cast(2 AS SHORT), cast(3 AS SHORT), cast(4 AS SHORT), cast(4 AS SHORT) AS tab(expr);")
+    checkAnswer(res, Row(Seq(Row(0, 2), Row(4, 2))))
+  }
+
+  test("SPARK-52515: test of Long type") {
+    val res = sql(
+      "SELECT approx_top_k(expr, 2) " +
+        "FROM VALUES cast(0 AS LONG), cast(0 AS LONG), cast(1 AS LONG), cast(1 AS LONG), " +
+        "cast(2 AS LONG), cast(3 AS LONG), cast(4 AS LONG), cast(4 AS LONG) AS tab(expr);")
+    checkAnswer(res, Row(Seq(Row(0, 2), Row(4, 2))))
+  }
+
+  test("SPARK-52515: test of Float type") {
+    val res = sql(
+      "SELECT approx_top_k(expr) " +
+        "FROM VALUES cast(0.0 AS FLOAT), cast(0.0 AS FLOAT), " +
+        "cast(1.0 AS FLOAT), cast(1.0 AS FLOAT), " +
+        "cast(2.0 AS FLOAT), cast(3.0 AS FLOAT), " +
+        "cast(4.0 AS FLOAT), cast(4.0 AS FLOAT) AS tab(expr);")
+    checkAnswer(res, Row(Seq(Row(0.0, 2), Row(1.0, 2), Row(4.0, 2), Row(2.0, 1), Row(3.0, 1))))
+  }
+
+  test("SPARK-52515: test of Double type") {
+    val res = sql(
+      "SELECT approx_top_k(expr, 2) " +
+        "FROM VALUES cast(0.0 AS DOUBLE), cast(0.0 AS DOUBLE), " +
+        "cast(1.0 AS DOUBLE), cast(1.0 AS DOUBLE), " +
+        "cast(2.0 AS DOUBLE), cast(3.0 AS DOUBLE), " +
+        "cast(4.0 AS DOUBLE), cast(4.0 AS DOUBLE) AS tab(expr);")
+    checkAnswer(res, Row(Seq(Row(0.0, 2), Row(4.0, 2))))
+  }
+
+  test("SPARK-52515: test of Date type") {
+    val res = sql(
+      "SELECT approx_top_k(expr, 2) " +
+        "FROM VALUES cast('2023-01-01' AS DATE), cast('2023-01-01' AS DATE), " +
+        "cast('2023-01-02' AS DATE), cast('2023-01-02' AS DATE), " +
+        "cast('2023-01-03' AS DATE), cast('2023-01-04' AS DATE), " +
+        "cast('2023-01-05' AS DATE), cast('2023-01-05' AS DATE) AS tab(expr);")
+    checkAnswer(
+      res,
+      Row(Seq(Row(Date.valueOf("2023-01-02"), 2), Row(Date.valueOf("2023-01-01"), 2))))
+  }
+
+  test("SPARK-52515: test of Timestamp type") {
+    val res = sql(
+      "SELECT approx_top_k(expr, 2) " +
+        "FROM VALUES cast('2023-01-01 00:00:00' AS TIMESTAMP), " +
+        "cast('2023-01-01 00:00:00' AS TIMESTAMP), " +
+        "cast('2023-01-02 00:00:00' AS TIMESTAMP), " +
+        "cast('2023-01-02 00:00:00' AS TIMESTAMP), " +
+        "cast('2023-01-03 00:00:00' AS TIMESTAMP), " +
+        "cast('2023-01-04 00:00:00' AS TIMESTAMP), " +
+        "cast('2023-01-05 00:00:00' AS TIMESTAMP), " +
+        "cast('2023-01-05 00:00:00' AS TIMESTAMP) AS tab(expr);")
+    checkAnswer(
+      res,
+      Row(Seq(Row(Timestamp.valueOf("2023-01-02 00:00:00"), 2),
+        Row(Timestamp.valueOf("2023-01-05 00:00:00"), 2))))
+  }
+
+  test("SPARK-52515: test of Decimal type") {
+    val res = sql(
+      "SELECT approx_top_k(expr, 2) AS top_k_result " +
+        "FROM VALUES (0.0), (0.0), (0.0) ,(1.0), (1.0), (2.0), (3.0), (4.0) AS tab(expr);")
+    checkAnswer(
+      res,
+      Row(Seq(Row(new java.math.BigDecimal("0.0"), 3), Row(new java.math.BigDecimal("1.0"), 2))))
+  }
+
+  test("SPARK-52515: test of Decimal(10, 2) type") {
+    val res = sql(
+      "SELECT approx_top_k(expr, 2) AS top_k_result " +
+        "FROM VALUES CAST(0.0 AS DECIMAL(10, 2)), CAST(0.0 AS DECIMAL(10, 2)), " +
+        "CAST(0.0 AS DECIMAL(10, 2)), CAST(1.0 AS DECIMAL(10, 2)), " +
+        "CAST(1.0 AS DECIMAL(10, 2)), CAST(2.0 AS DECIMAL(10, 2)), " +
+        "CAST(3.0 AS DECIMAL(10, 2)), CAST(4.0 AS DECIMAL(10, 2)) AS tab(expr);")
+    checkAnswer(
+      res,
+      Row(Seq(Row(new java.math.BigDecimal("0.00"), 3), Row(new java.math.BigDecimal("1.00"), 2))))
+  }
+
+  test("SPARK-52515: test of Decimal(20, 1) type") {
+    val res = sql(
+      "SELECT approx_top_k(expr, 2) AS top_k_result " +
+        "FROM VALUES CAST(0.0 AS DECIMAL(20, 1)), CAST(0.0 AS DECIMAL(20, 1)), " +
+        "CAST(0.0 AS DECIMAL(20, 1)), CAST(1.0 AS DECIMAL(20, 1)), " +
+        "CAST(1.0 AS DECIMAL(20, 1)), CAST(2.0 AS DECIMAL(20, 1)), " +
+        "CAST(3.0 AS DECIMAL(20, 1)), CAST(4.0 AS DECIMAL(20, 1)) AS tab(expr);")
+    checkAnswer(
+      res,
+      Row(Seq(Row(new java.math.BigDecimal("0.0"), 3), Row(new java.math.BigDecimal("1.0"), 2))))
+  }
+
+  test("SPARK-52515: invalid k value") {
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        sql("SELECT approx_top_k(expr, 0) FROM VALUES (0), (1), (2) AS tab(expr);").collect()
+      },
+      condition = "APPROX_TOP_K_NON_POSITIVE_ARG",
+      parameters = Map("argName" -> "`k`", "argValue" -> "0")
+    )
+  }
+
+  test("SPARK-52515: invalid k value null") {
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        sql("SELECT approx_top_k(expr, NULL) FROM VALUES (0), (1), (2) AS tab(expr);").collect()
+      },
+      condition = "APPROX_TOP_K_NULL_ARG",
+      parameters = Map("argName" -> "`k`")
+    )
+  }
+
+  test("SPARK-52515: invalid maxItemsTracked value") {
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        sql("SELECT approx_top_k(expr, 10, -1) FROM VALUES (0), (1), (2) AS tab(expr);").collect()
+      },
+      condition = "APPROX_TOP_K_MAX_ITEMS_TRACKED_LESS_THAN_K",
+      parameters = Map("maxItemsTracked" -> "-1", "k" -> "10")
+    )
+  }
+
+  test("SPARK-52515: invalid maxItemsTracked value null") {
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        sql("SELECT approx_top_k(expr, 10, NULL) FROM VALUES (0), (1), (2) AS tab(expr);").collect()
+      },
+      condition = "APPROX_TOP_K_NULL_ARG",
+      parameters = Map("argName" -> "`maxItemsTracked`")
+    )
+  }
+
+  test("SPARK-52515: invalid maxItemsTracked < k") {
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        sql("SELECT approx_top_k(expr, 10, 5) FROM VALUES (0), (1), (2) AS tab(expr);").collect()
+      },
+      condition = "APPROX_TOP_K_MAX_ITEMS_TRACKED_LESS_THAN_K",
+      parameters = Map("maxItemsTracked" -> "5", "k" -> "10")
+    )
+  }
+
+  test("SPARK-52515: invalid item type array") {
+    checkError(
+      exception = intercept[ExtendedAnalysisException] {
+        sql("SELECT approx_top_k(expr) FROM VALUES array(1, 2), array(2, 3) AS tab(expr);")
+      },
+      condition = "DATATYPE_MISMATCH.TYPE_CHECK_FAILURE_WITH_HINT",
+      parameters = Map(
+        "sqlExpr" -> "\"approx_top_k(expr, 5, 10000)\"",
+        "msg" -> "array columns are not supported",
+        "hint" -> ""
+      ),
+      queryContext = Array(ExpectedContext("approx_top_k(expr)", 7, 24))
+    )
+  }
+
+  test("SPARK-52515: invalid item type struct") {
+    sql("SELECT struct(1, 2) AS expr").createOrReplaceTempView("struct_table")
+    checkError(
+      exception = intercept[ExtendedAnalysisException] {
+        sql("SELECT approx_top_k(expr) FROM struct_table;")
+      },
+      condition = "DATATYPE_MISMATCH.TYPE_CHECK_FAILURE_WITH_HINT",
+      parameters = Map(
+        "sqlExpr" -> "\"approx_top_k(expr, 5, 10000)\"",
+        "msg" -> "struct columns are not supported",
+        "hint" -> ""
+      ),
+      queryContext = Array(ExpectedContext("approx_top_k(expr)", 7, 24))
+    )
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds a new SQL aggregation function `approx_top_k` which estimates the top-k (aka. k-most-frequent) items in an expression, using open source library [Apache DataSketches](https://datasketches.apache.org/) and specifically its [ItemsSketch](https://datasketches.apache.org/docs/Frequency/FrequencySketches.html#frequent-items-sketches).

**Syntax**
```sql
approx_top_k(expr[, k[, maxItemsTracked]])
```

**Arguments**
`expr`: An expression of BOOLEAN, BINARY, STRING, DATE, TIMESTAMP or numeric type.
`k`: An optional INTEGER literal greater than 0. If k is not specified, it defaults to 5. This is the number of most frequent items you want approximated.
`maxItemsTracked`: An optional INTEGER literal greater than or equal to k. If maxItemsTracked is not specified, it defaults to 10000. This is the maximum number of distinct values that can be tracked at a time during the estimation process.

**Returns**
Results are returned as an ARRAY of type STRUCT, where each STRUCT contains an item field for the value (with its original input type) and a count field (of type LONG) with the approximate number of occurrences. The array is sorted by count descending.

#### Summary of changes:

**Tests:** 

- [DataFrameAggregateSuite.scala](https://github.com/apache/spark/compare/master...yhuang-db:spark:SPARK-52515#diff-bd3d5c79ede5675f4bf10d2efb313db893d57443d6d6d67b1f8766e6ce741271)
  - Add test cases on different number of arguments, different expression types, and exception with invalid inputs. 

**Implementation:**

- [ApproxTopKAggregates.scala](https://github.com/apache/spark/compare/master...yhuang-db:spark:SPARK-52515#diff-4021e1ab8695d8d1d811954789c2121485ebdf92f322dcb0c0089a3c66c8b332)
  - Aggregation function implementation
- [functions.scala](https://github.com/apache/spark/compare/master...yhuang-db:spark:SPARK-52515#diff-6341a4097e7fb627fa94af493259fce6f158987e7791eff44258b06f32fe2c77) and [FunctionRegistry.scala](https://github.com/apache/spark/compare/master...yhuang-db:spark:SPARK-52515#diff-6c6ba3e220b9d155160e4e25305fdd3a4835b7ce9eba230a7ae70bdd97047313)
  - Function registration
- [ArrayOfDecimalsSerDe.java](https://github.com/apache/spark/compare/master...yhuang-db:spark:SPARK-52515#diff-afcd24d20d893509fbb3855d8b0e07f1ccbb22b2b7f8fcd50483c0c38070750f)
  - An implementation of Serializer and Deserializer for ItemsSketch of DecimalType, which is not provided by Apache DataSketches. 
- [error-conditions.json](https://github.com/apache/spark/compare/master...yhuang-db:spark:SPARK-52515#diff-2372d97e9baed2fb6732dd6e3c63136cda800952e1a1c8aa20f64144762e7c8d) and [QueryExecutionErrors.scala](https://github.com/apache/spark/compare/master...yhuang-db:spark:SPARK-52515#diff-fad3de9058d5ffc779a83700a6c6477d2d3caa03b00e167c4aa87413af4ba7cd)
  - New errors related to approx_top_k. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This PR proposes `approx_top_k`, which gives result orders-of magnitude faster exact top-k. This function is widely used in interactive analysis and streaming analysis.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, this PR introduces a new user-facing SQL function. See user examples as below. 

```SQL
> SELECT approx_top_k(expr) FROM VALUES (0), (0), (1), (1), (2), (3), (4), (4) AS tab(expr);
 [{'item':4,'count':2},{'item':1,'count':2},{'item':0,'count':2},{'item':3,'count':1},{'item':2,'count':1}]

> SELECT approx_top_k(expr, 2) FROM VALUES 'a', 'b', 'c', 'c', 'c', 'c', 'd', 'd' AS tab(expr);
 [{'item':'c','count',4},{'item':'d','count':2}]

> SELECT approx_top_k(expr, 10, 100) FROM VALUES (0), (1), (1), (2), (2), (2) AS tab(expr);
 [{'item':2,'count':3},{'item':1,'count':2},{'item':0,'count':1}]

```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

It is tested with unit tests of different combinations of arguments, different expression types, and exception with invalid inputs. 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.