### PR TITLE
[SPARK-52546][SQL] check sparkContext if has stopped when running catch code block in execute(), otherwise, it will return wrong state.

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -248,7 +248,7 @@ private[hive] class SparkExecuteStatementOperation(
         // then they may both call cleanup() before Spark Jobs are started. But before background
         // task interrupted, it may have started some spark job, so we need to cancel again to
         // make sure job was cancelled when background thread was interrupted
-        if (statementId != null) {
+        if (!sparkContext.isStopped && statementId != null) {
           sparkContext.cancelJobGroup(statementId,
             "The corresponding Thriftserver query has failed.")
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

When running execute() in SparkExecuteStatementOperation.scala, SparkContext crashes, and runs into catch code block, we should check SparkContext if has stopped, otherwise, running cancelJobGroup() in a stopped SparkContext will result in an uncaught IllegalStateException being thrown, which will run into finally code block and return wrong state "FINISHED".
<img width="944" alt="image" src="https://github.com/user-attachments/assets/fe3cbda0-8d0a-422b-850a-5a2ee3179685" />

### Why are the changes needed?

When SparkContext crashes in executing sql, state in Operation.scala should be set "error", but eventually return "finished”,which needs to be fixed.

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
Test in spark environment

### Was this patch authored or co-authored using generative AI tooling?
No