### PR TITLE
[SPARK-52422][BUILD][FOLLOW-UP] Pin pandas as 2.2.3 for release build

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -98,10 +98,10 @@ RUN mkdir -p /usr/local/pypy/pypy3.10 && \
     ln -sf /usr/local/pypy/pypy3.10/bin/pypy /usr/local/bin/pypy3.10 && \
     ln -sf /usr/local/pypy/pypy3.10/bin/pypy /usr/local/bin/pypy3
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
-RUN pypy3 -m pip install numpy 'six==1.16.0' 'pandas==2.3.0' scipy coverage matplotlib lxml
+RUN pypy3 -m pip install numpy 'six==1.16.0' 'pandas==2.2.3' scipy coverage matplotlib lxml
 
 
-ARG BASIC_PIP_PKGS="numpy pyarrow>=18.0.0 six==1.16.0 pandas==2.3.0 scipy plotly<6.0.0 mlflow>=2.8.1 coverage matplotlib openpyxl memory-profiler>=0.61.0 scikit-learn>=1.3.2 twine==3.4.1"
+ARG BASIC_PIP_PKGS="numpy pyarrow>=18.0.0 six==1.16.0 pandas==2.2.3 scipy plotly<6.0.0 mlflow>=2.8.1 coverage matplotlib openpyxl memory-profiler>=0.61.0 scikit-learn>=1.3.2 twine==3.4.1"
 # Python deps for Spark Connect
 ARG CONNECT_PIP_PKGS="grpcio==1.67.0 grpcio-status==1.67.0 protobuf==5.29.1 googleapis-common-protos==1.65.0 graphviz==0.20.3"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is another followup of https://github.com/apache/spark/pull/51148 that pins pandas to 2.2.3. 

### Why are the changes needed?

The release build fails with:

```
...
2025-06-22T08:35:34.1301035Z *****************************
2025-06-22T08:35:34.1301288Z * Building Python API docs. *
2025-06-22T08:35:34.1301537Z *****************************
2025-06-22T08:35:34.3572377Z Running Sphinx v4.5.0
2025-06-22T08:35:35.4512673Z /opt/spark-rm/output/spark/python/pyspark/pandas/__init__.py:43: UserWarning: 'PYARROW_IGNORE_TIMEZONE' environment variable was not set. It is required to set this environment variable to '1' in both driver and executor sides if you use pyarrow>=2.0.0. pandas-on-Spark will set it for you but it does not work if there is a Spark context already launched.
2025-06-22T08:35:35.4513955Z   warnings.warn(
2025-06-22T08:35:35.6137194Z /opt/spark-rm/output/spark/python/pyspark/pandas/supported_api_gen.py:115: UserWarning: Warning: pandas 2.2.3 is required; your version is 2.3.0+4.g1dfc98e16a
2025-06-22T08:35:35.6137902Z   warnings.warn(msg, UserWarning)
2025-06-22T08:35:35.6158120Z 
2025-06-22T08:35:35.6158297Z Configuration error:
2025-06-22T08:35:35.6158689Z There is a programmable error in your configuration file:
2025-06-22T08:35:35.6158959Z 
2025-06-22T08:35:35.6159066Z Traceback (most recent call last):
2025-06-22T08:35:35.6159847Z   File "/usr/local/lib/python3.9/dist-packages/sphinx/config.py", line 332, in eval_config_file
2025-06-22T08:35:35.6160379Z     exec(code, namespace)
2025-06-22T08:35:35.6160803Z   File "/opt/spark-rm/output/spark/python/docs/source/conf.py", line 33, in <module>
2025-06-22T08:35:35.6161296Z     generate_supported_api(output_rst_file_path)
2025-06-22T08:35:35.6161959Z   File "/opt/spark-rm/output/spark/python/pyspark/pandas/supported_api_gen.py", line 102, in generate_supported_api
2025-06-22T08:35:35.6162673Z     _check_pandas_version()
2025-06-22T08:35:35.6163257Z   File "/opt/spark-rm/output/spark/python/pyspark/pandas/supported_api_gen.py", line 116, in _check_pandas_version
2025-06-22T08:35:35.6163872Z     raise ImportError(msg)
2025-06-22T08:35:35.6164275Z ImportError: Warning: pandas 2.2.3 is required; your version is 2.3.0+4.g1dfc98e16a
2025-06-22T08:35:35.6164634Z 
```

https://github.com/apache/spark/actions/workflows/release.yml

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Will monitor the build.

### Was this patch authored or co-authored using generative AI tooling?

No.