### PR TITLE
[SPARK-52547][INFRA] Build dry runs against master branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,8 @@ on:
     inputs:
       branch:
         description: 'Branch to release. Leave it empty to launch a dryrun. Dispatch this workflow only in the forked repository.'
-        required: false
+        required: true
+        default: master
       release-version:
         description: 'Release version. Leave it empty to launch a dryrun.'
         required: false
@@ -132,18 +133,8 @@ jobs:
             sleep 60
           fi
 
-          empty_count=0
-          non_empty_count=0
-          for val in "$GIT_BRANCH" "$RELEASE_VERSION" "$SPARK_RC_COUNT"; do
-            if [ -z "$val" ]; then
-              empty_count=$((empty_count+1))
-            else
-              non_empty_count=$((non_empty_count+1))
-            fi
-          done
-
-          if [ "$empty_count" -gt 0 ] && [ "$non_empty_count" -gt 0 ]; then
-            echo "Error: Either provide all inputs or leave them all empty for a dryrun."
+          if { [ -n "$RELEASE_VERSION" ] && [ -z "$SPARK_RC_COUNT" ]; } || { [ -z "$RELEASE_VERSION" ] && [ -n "$SPARK_RC_COUNT" ]; }; then
+            echo "Error: Either provide both 'Release version' and 'RC number', or leave both empty for a dryrun."
             exit 1
           fi
 
@@ -155,7 +146,6 @@ jobs:
             GPG_PASSPHRASE="not_used"
             ASF_USERNAME="gurwls223"
             export SKIP_TAG=1
-            unset GIT_BRANCH
             unset RELEASE_VERSION
           else
             echo "Full release mode enabled"
@@ -163,7 +153,7 @@ jobs:
           fi
 
           export ASF_PASSWORD GPG_PRIVATE_KEY GPG_PASSPHRASE ASF_USERNAME
-          [ -n "$GIT_BRANCH" ] && export GIT_BRANCH
+          export GIT_BRANCH
           [ -n "$RELEASE_VERSION" ] && export RELEASE_VERSION
 
           if [ "$DRYRUN_MODE" = "1" ]; then


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to use `master` branch in dry runs in CI at https://github.com/apache/spark/actions/workflows/release.yml

### Why are the changes needed?

To check the health of the master branch when releasing.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Will monitor the build.

### Was this patch authored or co-authored using generative AI tooling?

No.