### PR TITLE
[SPARK-52548][CORE][TESTS] Add a test case for when shuffle manager is overridden by a SparkPlugin

### DIFF
--- a/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
@@ -422,7 +422,7 @@ class SetShuffleManagerPlugin extends SparkPlugin {
   }
 }
 
-object SetShuffleManagerPlugin {
+private object SetShuffleManagerPlugin {
   class MyShuffleManager(conf: SparkConf) extends SortShuffleManager(conf)
 }
 

--- a/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
@@ -42,6 +42,7 @@ import org.apache.spark.resource.ResourceInformation
 import org.apache.spark.resource.ResourceUtils.GPU
 import org.apache.spark.resource.TestResourceIDs.{DRIVER_GPU_ID, EXECUTOR_GPU_ID, WORKER_GPU_ID}
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
+import org.apache.spark.shuffle.sort.SortShuffleManager
 import org.apache.spark.util.Utils
 
 class PluginContainerSuite extends SparkFunSuite with LocalSparkContext {
@@ -292,6 +293,20 @@ class PluginContainerSuite extends SparkFunSuite with LocalSparkContext {
     // If the listener bus is stopped before the plugin is shutdown,
     // then the event will be dropped and won't be delivered to the listener.
   }
+
+  test("override shuffle manager in plugin") {
+    val conf = new SparkConf()
+      .setAppName(getClass().getName())
+      .set(SparkLauncher.SPARK_MASTER, "local[1]")
+      .set(SHUFFLE_MANAGER, "sort")
+      .set(PLUGINS, Seq(classOf[SetShuffleManagerPlugin].getName()))
+
+    sc = new SparkContext(conf)
+
+    // Ensures the shuffle manager specified in configuration was
+    // overridden by the Spark plugin.
+    assert(sc.env.shuffleManager.isInstanceOf[SetShuffleManagerPlugin.MyShuffleManager])
+  }
 }
 
 class MemoryOverridePlugin extends SparkPlugin {
@@ -389,6 +404,26 @@ object NonLocalModeSparkPlugin {
   def reset(): Unit = {
     driverContext = null
   }
+}
+
+class SetShuffleManagerPlugin extends SparkPlugin {
+  import SetShuffleManagerPlugin._
+  override def driverPlugin(): DriverPlugin = {
+    new DriverPlugin {
+      override def init(sc: SparkContext, ctx: PluginContext): JMap[String, String] = {
+        sc.conf.set(SHUFFLE_MANAGER, classOf[MyShuffleManager].getName)
+        Map.empty[String, String].asJava
+      }
+    }
+  }
+
+  override def executorPlugin(): ExecutorPlugin = {
+    new ExecutorPlugin {}
+  }
+}
+
+object SetShuffleManagerPlugin {
+  class MyShuffleManager(conf: SparkConf) extends SortShuffleManager(conf)
 }
 
 class TestSparkPlugin extends SparkPlugin {

--- a/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
@@ -294,7 +294,7 @@ class PluginContainerSuite extends SparkFunSuite with LocalSparkContext {
     // then the event will be dropped and won't be delivered to the listener.
   }
 
-  test("override shuffle manager in plugin") {
+  test("SPARK-52548: override shuffle manager in plugin") {
     val conf = new SparkConf()
       .setAppName(getClass().getName())
       .set(SparkLauncher.SPARK_MASTER, "local[1]")


### PR DESCRIPTION

### What changes were proposed in this pull request?

As title, adding a test case for when shuffle manager is overridden by a SparkPlugin.

### Why are the changes needed?

PR https://github.com/apache/spark/pull/43627 introduced a change to allow the shuffle manager specified in Spark configuration to be overridden in SparkPlugin, this change was not guarded by test though.

The change in PR https://github.com/apache/spark/pull/43627 also allows Spark plugins to configure a shuffle manager automatically for user, so user won't have to configure both `spark.plugins` and `spark.shuffle.manager` at the same time.

### Does this PR introduce _any_ user-facing change?

No.

### Was this patch authored or co-authored using generative AI tooling?

No.
