### PR TITLE
[SPARK-52551][SQL] Add a new v2 Predicate BOOLEAN_EXPRESSION

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/Predicate.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/Predicate.java
@@ -136,6 +136,12 @@ import org.apache.spark.sql.connector.expressions.GeneralScalarExpression;
  *    <li>Since version: 3.3.0</li>
  *   </ul>
  *  </li>
+ *  <li>Name: <code>BOOLEAN_EXPRESSION</code>
+ *   <ul>
+ *    <li>A simple wrapper for any expression that returns boolean type.</li>
+ *    <li>Since version: 4.1.0</li>
+ *   </ul>
+ *  </li>
  * </ol>
  *
  * @since 3.3.0
@@ -145,5 +151,8 @@ public class Predicate extends GeneralScalarExpression {
 
   public Predicate(String name, Expression[] children) {
     super(name, children);
+    if ("BOOLEAN_EXPRESSION".equals(name)) {
+      assert children.length == 1;
+    }
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -99,6 +99,8 @@ public class V2ExpressionSQLBuilder {
         case "CONTAINS" -> visitContains(build(e.children()[0]), build(e.children()[1]));
         case "=", "<>", "<=>", "<", "<=", ">", ">=" ->
           visitBinaryComparison(name, e.children()[0], e.children()[1]);
+        case "BOOLEAN_EXPRESSION" ->
+          build(expr.children()[0]);
         case "+", "*", "/", "%", "&", "|", "^" ->
           visitBinaryArithmetic(name, inputToSQL(e.children()[0]), inputToSQL(e.children()[1]));
         case "-" -> {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtils.scala
@@ -243,6 +243,7 @@ object V2ExpressionUtils extends SQLConfHelper with Logging {
       case "ENDS_WITH" => convertBinaryExpr(expr, EndsWith)
       case "CONTAINS" => convertBinaryExpr(expr, Contains)
       case "IN" => convertExpr(expr, children => In(children.head, children.tail))
+      case "BOOLEAN_EXPRESSION" => toCatalyst(expr.children().head)
       case _ => None
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -37,12 +37,21 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) extends L
   def build(): Option[V2Expression] = generateExpression(e, isPredicate)
 
   def buildPredicate(): Option[V2Predicate] = {
-
     if (isPredicate) {
-      val translated = build()
+      val translated0 = build()
+      val conf = SQLConf.get
+      val alwaysCreateV2Predicate = conf.getConf(SQLConf.DATA_SOURCE_ALWAYS_CREATE_V2_PREDICATE)
+      val translated = if (alwaysCreateV2Predicate && isPredicate && e.dataType == BooleanType) {
+        translated0.map {
+          case p: V2Predicate => p
+          case other => new V2Predicate("BOOLEAN_EXPRESSION", Array(other))
+        }
+      } else {
+        translated0
+      }
 
       val modifiedExprOpt = if (
-        SQLConf.get.getConf(SQLConf.DATA_SOURCE_DONT_ASSERT_ON_PREDICATE)
+        conf.getConf(SQLConf.DATA_SOURCE_DONT_ASSERT_ON_PREDICATE)
           && translated.isDefined
           && !translated.get.isInstanceOf[V2Predicate]) {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -41,7 +41,7 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) extends L
       val translated0 = build()
       val conf = SQLConf.get
       val alwaysCreateV2Predicate = conf.getConf(SQLConf.DATA_SOURCE_ALWAYS_CREATE_V2_PREDICATE)
-      val translated = if (alwaysCreateV2Predicate && isPredicate && e.dataType == BooleanType) {
+      val translated = if (alwaysCreateV2Predicate && e.dataType == BooleanType) {
         translated0.map {
           case p: V2Predicate => p
           case other => new V2Predicate("BOOLEAN_EXPRESSION", Array(other))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1695,8 +1695,18 @@ object SQLConf {
     buildConf("spark.sql.dataSource.skipAssertOnPredicatePushdown")
       .internal()
       .doc("Enable skipping assert when expression in not translated to predicate.")
+      .version("4.0.0")
       .booleanConf
       .createWithDefault(!Utils.isTesting)
+
+  val DATA_SOURCE_ALWAYS_CREATE_V2_PREDICATE =
+    buildConf("spark.sql.dataSource.alwaysCreateV2Predicate")
+      .internal()
+      .doc("When true, the v2 push-down framework always wraps the expression that returns " +
+        "boolean type with a v2 Predicate so that it can be pushed down.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(true)
 
   // This is used to set the default data source
   val DEFAULT_DATA_SOURCE_NAME = buildConf("spark.sql.sources.default")

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/PushablePredicateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/PushablePredicateSuite.scala
@@ -18,38 +18,71 @@
 package org.apache.spark.sql.connector
 
 import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.expressions.{Cast, Literal}
+import org.apache.spark.sql.connector.expressions.filter.{AlwaysTrue, Predicate => V2Predicate}
 import org.apache.spark.sql.execution.datasources.v2.PushablePredicate
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.BooleanType
 
 class PushablePredicateSuite extends QueryTest with SharedSparkSession {
 
-  test("PushablePredicate None returned - flag on") {
-    withSQLConf(SQLConf.DATA_SOURCE_DONT_ASSERT_ON_PREDICATE.key -> "true") {
-      val pushable = PushablePredicate.unapply(Literal.create("string"))
-      assert(!pushable.isDefined)
+  test("simple boolean expression should always return v2 Predicate") {
+    Seq(true, false).foreach { createV2Predicate =>
+      Seq(true, false).foreach { noAssert =>
+        withSQLConf(
+          SQLConf.DATA_SOURCE_ALWAYS_CREATE_V2_PREDICATE.key -> createV2Predicate.toString,
+          SQLConf.DATA_SOURCE_DONT_ASSERT_ON_PREDICATE.key -> noAssert.toString) {
+          val pushable = PushablePredicate.unapply(Literal.create(true))
+          assert(pushable.isDefined)
+          assert(pushable.get.isInstanceOf[AlwaysTrue])
+        }
+      }
     }
   }
 
-  test("PushablePredicate success - flag on") {
-    withSQLConf(SQLConf.DATA_SOURCE_DONT_ASSERT_ON_PREDICATE.key -> "true") {
-      val pushable = PushablePredicate.unapply(Literal.create(true))
-      assert(pushable.isDefined)
+  test("non-boolean expression") {
+    Seq(true, false).foreach { createV2Predicate =>
+      Seq(true, false).foreach { noAssert =>
+        withSQLConf(
+          SQLConf.DATA_SOURCE_ALWAYS_CREATE_V2_PREDICATE.key -> createV2Predicate.toString,
+          SQLConf.DATA_SOURCE_DONT_ASSERT_ON_PREDICATE.key -> noAssert.toString) {
+          val catalystExpr = Literal.create("string")
+          if (noAssert) {
+            val pushable = PushablePredicate.unapply(catalystExpr)
+            assert(pushable.isEmpty)
+          } else {
+            intercept[java.lang.AssertionError] {
+              PushablePredicate.unapply(catalystExpr)
+            }
+          }
+        }
+      }
     }
   }
 
-  test("PushablePredicate success") {
-    withSQLConf(SQLConf.DATA_SOURCE_DONT_ASSERT_ON_PREDICATE.key -> "false") {
-      val pushable = PushablePredicate.unapply(Literal.create(true))
-      assert(pushable.isDefined)
-    }
-  }
-
-  test("PushablePredicate throws") {
-    withSQLConf(SQLConf.DATA_SOURCE_DONT_ASSERT_ON_PREDICATE.key -> "false") {
-      intercept[java.lang.AssertionError] {
-        PushablePredicate.unapply(Literal.create("string"))
+  test("non-trivial boolean expression") {
+    Seq(true, false).foreach { createV2Predicate =>
+      Seq(true, false).foreach { noAssert =>
+        withSQLConf(
+          SQLConf.DATA_SOURCE_ALWAYS_CREATE_V2_PREDICATE.key -> createV2Predicate.toString,
+          SQLConf.DATA_SOURCE_DONT_ASSERT_ON_PREDICATE.key -> noAssert.toString) {
+          val catalystExpr = Cast(Literal.create("true"), BooleanType)
+          if (createV2Predicate) {
+            val pushable = PushablePredicate.unapply(catalystExpr)
+            assert(pushable.isDefined)
+            assert(pushable.get.isInstanceOf[V2Predicate])
+          } else {
+            if (noAssert) {
+              val pushable = PushablePredicate.unapply(catalystExpr)
+              assert(pushable.isEmpty)
+            } else {
+              intercept[java.lang.AssertionError] {
+                PushablePredicate.unapply(catalystExpr)
+              }
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is an extension of https://github.com/apache/spark/pull/47611 . It's impossible to translate all catalyst expressions returning boolean type into v2 `Predicate`, as the return type of a catalyst expression can be dynamic, and for example we can't make v2 `Cast` to extend `Predicate` only when it returns boolean type.

This PR adds a new type of v2 `Predicate`: `BOOLEAN_EXPRESSION`. It's a simple wrapper over any expression that returns boolean type. By doing so, Spark can push down any catalyst expression that returns boolean type as predicates.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To pushdown more v2 predicates.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
updated test cases in `PushablePredicateSuite`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no