### PR TITLE
[SPARK-52460][SQL][FOLLOWUP] Fix names and test ranges of TIME values

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -108,8 +108,8 @@ object DateTimeUtils extends SparkDateTimeUtils {
   /**
    * Returns the hour value of a given TIME (TimeType) value.
    */
-  def getHoursOfTime(micros: Long): Int = {
-    nanosToLocalTime(micros).getHour
+  def getHoursOfTime(nanos: Long): Int = {
+    nanosToLocalTime(nanos).getHour
   }
 
   /**
@@ -123,8 +123,8 @@ object DateTimeUtils extends SparkDateTimeUtils {
   /**
    * Returns the minute value of a given TIME (TimeType) value.
    */
-  def getMinutesOfTime(micros: Long): Int = {
-    nanosToLocalTime(micros).getMinute
+  def getMinutesOfTime(nanos: Long): Int = {
+    nanosToLocalTime(nanos).getMinute
   }
 
   /**
@@ -138,8 +138,8 @@ object DateTimeUtils extends SparkDateTimeUtils {
   /**
    * Returns the second value of a given TIME (TimeType) value.
    */
-  def getSecondsOfTime(micros: Long): Int = {
-    nanosToLocalTime(micros).getSecond
+  def getSecondsOfTime(nanos: Long): Int = {
+    nanosToLocalTime(nanos).getSecond
   }
   /**
    * Returns the seconds part and its fractional part with microseconds.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
@@ -292,7 +292,7 @@ object RandomDataGenerator {
         randomNumeric[LocalTime](
           rand,
           (rand: Random) => {
-            DateTimeUtils.nanosToLocalTime(rand.between(0, 24 * 60 * 60 * 1000 * 1000L))
+            DateTimeUtils.nanosToLocalTime(rand.between(0, 24 * 60 * 60 * 1000 * 1000L) * 1000L)
           },
           specialTimes.map(LocalTime.parse)
         )

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
@@ -449,8 +449,9 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
       43200999999L,
       86399000000L,
       86399999999L).foreach { us =>
-      val localTime = DateTimeUtils.nanosToLocalTime(us)
-      assert(CatalystTypeConverters.createToScalaConverter(TimeType())(us) === localTime)
+      val nanos = us * 1000L
+      val localTime = DateTimeUtils.nanosToLocalTime(nanos)
+      assert(CatalystTypeConverters.createToScalaConverter(TimeType())(nanos) === localTime)
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralGenerator.scala
@@ -24,8 +24,9 @@ import java.util.concurrent.TimeUnit
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.Assertions._
 
-import org.apache.spark.sql.catalyst.util.DateTimeConstants.{MICROS_PER_MILLIS, MILLIS_PER_DAY}
+import org.apache.spark.sql.catalyst.util.DateTimeConstants.{MICROS_PER_MILLIS, MILLIS_PER_DAY, NANOS_PER_MICROS}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.{localTimeToNanos, nanosToMicros}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.CalendarInterval
 
@@ -125,8 +126,8 @@ object LiteralGenerator {
 
   lazy val timeLiteralGen: Gen[Literal] = {
     // Valid range for TimeType is [00:00:00, 23:59:59.999999]
-    val minTime = DateTimeUtils.localTimeToNanos(LocalTime.MIN)
-    val maxTime = DateTimeUtils.localTimeToNanos(LocalTime.MAX)
+    val minTime = nanosToMicros(localTimeToNanos(LocalTime.MIN)) * NANOS_PER_MICROS
+    val maxTime = nanosToMicros(localTimeToNanos(LocalTime.MAX)) * NANOS_PER_MICROS
     for { t <- Gen.choose(minTime, maxTime) }
       yield Literal(t, TimeType())
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -1118,9 +1118,9 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     assert(nanosToLocalTime(24L * 60 * 60 * 1000 * 1000 * 1000 - 1) ===
       LocalTime.of(23, 59, 59, 999999999))
 
-    Seq(-1, 24L * 60 * 60 * 1000 * 1000 * 1000L).foreach { invalidMicros =>
+    Seq(-1, 24L * 60 * 60 * 1000 * 1000 * 1000L).foreach { invalidNanos =>
       val msg = intercept[DateTimeException] {
-        nanosToLocalTime(invalidMicros)
+        nanosToLocalTime(invalidNanos)
       }.getMessage
       assert(msg.contains("Invalid value"))
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to rename TIME vars/vals from micros to nanos, and extend the test ranges in random generators by taking into account nanos precision of TIME values. 

### Why are the changes needed?
To improve code maintenance.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the affected test suites:
```
$ build/sbt "test:testOnly *DateTimeUtilsSuite"
$ build/sbt "test:testOnly *CatalystTypeConvertersSuite"
$ build/sbt "test:testOnly *CastWithAnsiOnSuite"
$ build/sbt "test:testOnly *ParquetV1QuerySuite"
```


### Was this patch authored or co-authored using generative AI tooling?
No.
