### PR TITLE
[SPARK-52557][PS] Avoid CAST_INVALID_INPUT of to_numeric(errors='coerce') in ANSI mode

### DIFF
--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -3630,7 +3630,7 @@ def to_numeric(arg, errors="raise"):
     """
     if isinstance(arg, Series):
         if errors == "coerce":
-            return arg._with_new_scol(arg.spark.column.cast("float"))
+            return arg._with_new_scol(arg.spark.column.try_cast("float"))
         elif errors == "raise":
             scol = arg.spark.column
             scol_casted = scol.cast("float")

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -561,7 +561,6 @@ class NamespaceTestsMixin:
             lambda: read_delta("fake_path", version="0", timestamp="2021-06-22"),
         )
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_to_numeric(self):
         pser = pd.Series(["1", "2", None, "4", "hello"])
         psser = ps.from_pandas(pser)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Avoid CAST_INVALID_INPUT of to_numeric(errors='coerce') in ANSI mode

### Why are the changes needed?
Ensure pandas on Spark works well with ANSI mode on.
Part of https://issues.apache.org/jira/browse/SPARK-52556.

### Does this PR introduce _any_ user-facing change?
Yes, to_numeric functions 

### How was this patch tested?
Unit tests

### Was this patch authored or co-authored using generative AI tooling?
No
