### PR TITLE
[SPARK-52470][ML][PYTHON][FOLLOW-UP] Further fix GRPC import

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,7 +41,7 @@ on:
         description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false
         type: string
-        default: '{"PYSPARK_IMAGE_TO_TEST": "python-311-classic-only", "PYTHON_TO_TEST": "python3.11"}'
+        default: '{"PYSPARK_IMAGE_TO_TEST": "python-311", "PYTHON_TO_TEST": "python3.11"}'
       jobs:
         description: >-
           Jobs to run, and should be in JSON format. The values should be matched with the job's key defined

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,7 +41,7 @@ on:
         description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false
         type: string
-        default: '{"PYSPARK_IMAGE_TO_TEST": "python-311", "PYTHON_TO_TEST": "python3.11"}'
+        default: '{"PYSPARK_IMAGE_TO_TEST": "python-311-classic-only", "PYTHON_TO_TEST": "python3.11"}'
       jobs:
         description: >-
           Jobs to run, and should be in JSON format. The values should be matched with the job's key defined

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -278,47 +278,46 @@ def try_remote_call(f: FuncT) -> FuncT:
 
     @functools.wraps(f)
     def wrapped(self: "JavaWrapper", name: str, *args: Any) -> Any:
-        import pyspark.sql.connect.proto as pb2
-        from pyspark.sql.connect.session import SparkSession
-
-        session = SparkSession.getActiveSession()
-
-        def remote_call() -> Any:
-            from pyspark.ml.connect.util import _extract_id_methods
-            from pyspark.ml.connect.serialize import serialize, deserialize
-            from pyspark.ml.wrapper import JavaModel
-
-            assert session is not None
-            if self._java_obj == ML_CONNECT_HELPER_ID:
-                obj_id = ML_CONNECT_HELPER_ID
-            else:
-                if isinstance(self, JavaModel):
-                    assert isinstance(self._java_obj, RemoteModelRef)
-                    obj_id = self._java_obj.ref_id
-                else:
-                    # model summary
-                    obj_id = self._java_obj  # type: ignore
-            methods, obj_ref = _extract_id_methods(obj_id)
-            methods.append(pb2.Fetch.Method(method=name, args=serialize(session.client, *args)))
-            command = pb2.Command()
-            command.ml_command.fetch.CopyFrom(
-                pb2.Fetch(obj_ref=pb2.ObjectRef(id=obj_ref), methods=methods)
-            )
-            (_, properties, _) = session.client.execute_command(command)
-            ml_command_result = properties["ml_command_result"]
-            if ml_command_result.HasField("summary"):
-                summary = ml_command_result.summary
-                return summary
-            elif ml_command_result.HasField("operator_info"):
-                model_info = deserialize(properties)
-                # get a new model ref id from the existing model,
-                # it is up to the caller to build the model
-                return model_info.obj_ref.id
-            else:
-                return deserialize(properties)
-
         if is_remote() and "PYSPARK_NO_NAMESPACE_SHARE" not in os.environ:
             from pyspark.errors.exceptions.connect import SparkException
+            import pyspark.sql.connect.proto as pb2
+            from pyspark.sql.connect.session import SparkSession
+
+            session = SparkSession.getActiveSession()
+
+            def remote_call() -> Any:
+                from pyspark.ml.connect.util import _extract_id_methods
+                from pyspark.ml.connect.serialize import serialize, deserialize
+                from pyspark.ml.wrapper import JavaModel
+
+                assert session is not None
+                if self._java_obj == ML_CONNECT_HELPER_ID:
+                    obj_id = ML_CONNECT_HELPER_ID
+                else:
+                    if isinstance(self, JavaModel):
+                        assert isinstance(self._java_obj, RemoteModelRef)
+                        obj_id = self._java_obj.ref_id
+                    else:
+                        # model summary
+                        obj_id = self._java_obj  # type: ignore
+                methods, obj_ref = _extract_id_methods(obj_id)
+                methods.append(pb2.Fetch.Method(method=name, args=serialize(session.client, *args)))
+                command = pb2.Command()
+                command.ml_command.fetch.CopyFrom(
+                    pb2.Fetch(obj_ref=pb2.ObjectRef(id=obj_ref), methods=methods)
+                )
+                (_, properties, _) = session.client.execute_command(command)
+                ml_command_result = properties["ml_command_result"]
+                if ml_command_result.HasField("summary"):
+                    summary = ml_command_result.summary
+                    return summary
+                elif ml_command_result.HasField("operator_info"):
+                    model_info = deserialize(properties)
+                    # get a new model ref id from the existing model,
+                    # it is up to the caller to build the model
+                    return model_info.obj_ref.id
+                else:
+                    return deserialize(properties)
 
             try:
                 return remote_call()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
to fix GRPC import


### Why are the changes needed?
to fix https://github.com/apache/spark/actions/runs/15801182350/job/44539663472

PySpark Classic should not depends on PySpark Connect


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
PR builder with
```
default: '{"PYSPARK_IMAGE_TO_TEST": "python-311-classic-only", "PYTHON_TO_TEST": "python3.11"}'
```

see https://github.com/zhengruifeng/spark/actions/runs/15840250226/job/44652627469

### Was this patch authored or co-authored using generative AI tooling?
No
