### PR TITLE
[SPARK-52562][INFRA] Automatically create the base of release notes and push

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -363,11 +363,21 @@ EOF
     else
       CURRENT_TARGET=""
     fi
-    if [[ "$CURRENT_TARGET" != "$RELEASE_VERSION" ]]; then
-      ln -sfn "$RELEASE_VERSION" "$LINK_PATH"
-      echo "Updated symlink $LINK_PATH -> $RELEASE_VERSION"
+
+    if [[ "$CURRENT_TARGET" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      IFS='.' read -r cur_maj cur_min cur_patch <<< "$CURRENT_TARGET"
+
+      if [[ "$rel_maj" -gt "$cur_maj" ]]; then
+        ln -sfn "$RELEASE_VERSION" "$LINK_PATH"
+        echo "Updated symlink $LINK_PATH -> $RELEASE_VERSION (major version increased)"
+      elif [[ "$rel_maj" -eq "$cur_maj" && "$rel_min" -gt "$cur_min" ]]; then
+        ln -sfn "$RELEASE_VERSION" "$LINK_PATH"
+        echo "Updated symlink $LINK_PATH -> $RELEASE_VERSION (minor version increased)"
+      else
+        echo "Symlink $LINK_PATH points to $CURRENT_TARGET with equal or newer major.minor, no change"
+      fi
     else
-      echo "Symlink $LINK_PATH already points to $RELEASE_VERSION, no change"
+      echo "No valid existing version target."
     fi
   else
     echo "Patch release detected ($RELEASE_VERSION), not updating symlink"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add the automatic release note process. Here is what it does:

1. Add download link to docs
  Inserts the new release version link into `documentation.md`, keeping versions sorted by recency.

2. Add download link to spark-website
  Updates `js/downloads.js` with the new version's metadata for the downloads page. Replaces existing entry if it's a patch; inserts new entry otherwise. Uses different package lists for Spark 3 vs. Spark 4.

3. Generate news & release notes
  Creates a news post and release notes file as below. Note that I skipped the short link generation step here.
    - For minor/major releases (x.y.0), describes new features
    - For patch/maintenance releases (x.y.z, z > 0), mentions stability fixes and encourages upgrades.

4. Build the Website
  Runs Jekyll to generate updated HTML files for the website.

5. Update latest symlink (only for major/minor)
  Updates the `site/docs/latest` symlink to point to the new version only if it's a major or minor release (x.y.0), so maintenance releases don’t affect the default documentation version.

If the release manager needs to have better release notes, they can create a separate PR to update this.

### Why are the changes needed?

To make the release process easier.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

I manually tested them in my Mac for now, and checked that they are compatible with Ubuntu. It has to be tested in the official release later again.

### Was this patch authored or co-authored using generative AI tooling?

No.
