### PR TITLE
[SPARK-52339][SQL][FOLLOWUP] Sort paths in InMemoryFileIndex#equal only when size matches

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -103,7 +103,8 @@ class InMemoryFileIndex(
   }
 
   override def equals(other: Any): Boolean = other match {
-    case hdfs: InMemoryFileIndex => rootPaths.sorted == hdfs.rootPaths.sorted
+    case hdfs: InMemoryFileIndex if rootPaths.size == hdfs.rootPaths.size =>
+      rootPaths.sorted == hdfs.rootPaths.sorted
     case _ => false
   }
 


### PR DESCRIPTION


### What changes were proposed in this pull request?

A follow-up for https://github.com/apache/spark/pull/51043 that sorts paths in InMemoryFileIndex#equal only when size matches


### Why are the changes needed?

Avoid potential perf regression.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

Existing test from #51043


### Was this patch authored or co-authored using generative AI tooling?
No