### PR TITLE
[SPARK-52547][INFRA][FOLLOW-UP] Check RELEASE_VERSION and SPARK_RC_COUNT for dryruns

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
             exit 1
           fi
 
-          if [ "$empty_count" -eq 3 ]; then
+          if [ -z "$RELEASE_VERSION" ] && [ -z "$SPARK_RC_COUNT" ]; then
             echo "Dry run mode enabled"
             export DRYRUN_MODE=1
             ASF_PASSWORD="not_used"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/51245 that switches the dryrun condition to check RELEASE_VERSION and SPARK_RC_COUNT.

### Why are the changes needed?

`empty_count` was removed in the original PR. This PR removes it out.

### Does this PR introduce _any_ user-facing change?

The build fails https://github.com/apache/spark/actions/runs/15843743201/job/44661165964

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.