### PR TITLE
[SPARK-52565] [SQL] Enforce ordinal resolution before other sort order expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5971,6 +5971,17 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val PRIORITIZE_ORDINAL_RESOLUTION_IN_SORT =
+    buildConf("spark.sql.prioritizeOrdinalResolutionInSort.enabled")
+      .internal()
+      .doc(
+        "When set to true, we prioritize ordinal resolution in Sort over other expressions. " +
+        "Otherwise, no order is enforced."
+      )
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(true)
+
   /**
    * Holds information about keys that have been deprecated.
    *

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/order-by-ordinal.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/order-by-ordinal.sql.out
@@ -151,6 +151,284 @@ Sort [a#x DESC NULLS LAST], false
 
 
 -- !query
+set spark.sql.prioritizeOrdinalResolutionInSort.enabled=true
+-- !query analysis
+SetCommand (spark.sql.prioritizeOrdinalResolutionInSort.enabled,Some(true))
+
+
+-- !query
+SELECT a FROM data ORDER BY 2, b
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "2",
+    "size" : "1"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 29,
+    "stopIndex" : 29,
+    "fragment" : "2"
+  } ]
+}
+
+
+-- !query
+SELECT a FROM data ORDER BY b, 2
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "2",
+    "size" : "1"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 32,
+    "stopIndex" : 32,
+    "fragment" : "2"
+  } ]
+}
+
+
+-- !query
+SELECT a FROM data ORDER BY 'b', 2
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "2",
+    "size" : "1"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 34,
+    "stopIndex" : 34,
+    "fragment" : "2"
+  } ]
+}
+
+
+-- !query
+SELECT a FROM data ORDER BY `b`, 2
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "2",
+    "size" : "1"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 34,
+    "stopIndex" : 34,
+    "fragment" : "2"
+  } ]
+}
+
+
+-- !query
+SELECT a FROM data ORDER BY a, 2
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "2",
+    "size" : "1"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 32,
+    "stopIndex" : 32,
+    "fragment" : "2"
+  } ]
+}
+
+
+-- !query
+SELECT a FROM data ORDER BY b, 3
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "3",
+    "size" : "1"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 32,
+    "stopIndex" : 32,
+    "fragment" : "3"
+  } ]
+}
+
+
+-- !query
+SELECT a, a + 1 FROM data ORDER BY b, 3
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "3",
+    "size" : "2"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 39,
+    "stopIndex" : 39,
+    "fragment" : "3"
+  } ]
+}
+
+
+-- !query
+set spark.sql.prioritizeOrdinalResolutionInSort.enabled=false
+-- !query analysis
+SetCommand (spark.sql.prioritizeOrdinalResolutionInSort.enabled,Some(false))
+
+
+-- !query
+SELECT a FROM data ORDER BY 2, b
+-- !query analysis
+Project [a#x]
++- Sort [b#x ASC NULLS FIRST, b#x ASC NULLS FIRST], true
+   +- Project [a#x, b#x]
+      +- SubqueryAlias data
+         +- View (`data`, [a#x, b#x])
+            +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+               +- Project [a#x, b#x]
+                  +- SubqueryAlias data
+                     +- LocalRelation [a#x, b#x]
+
+
+-- !query
+SELECT a FROM data ORDER BY b, 2
+-- !query analysis
+Project [a#x]
++- Sort [b#x ASC NULLS FIRST, b#x ASC NULLS FIRST], true
+   +- Project [a#x, b#x]
+      +- SubqueryAlias data
+         +- View (`data`, [a#x, b#x])
+            +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+               +- Project [a#x, b#x]
+                  +- SubqueryAlias data
+                     +- LocalRelation [a#x, b#x]
+
+
+-- !query
+SELECT a FROM data ORDER BY 'b', 2
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "2",
+    "size" : "1"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 34,
+    "stopIndex" : 34,
+    "fragment" : "2"
+  } ]
+}
+
+
+-- !query
+SELECT a FROM data ORDER BY `b`, 2
+-- !query analysis
+Project [a#x]
++- Sort [b#x ASC NULLS FIRST, b#x ASC NULLS FIRST], true
+   +- Project [a#x, b#x]
+      +- SubqueryAlias data
+         +- View (`data`, [a#x, b#x])
+            +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+               +- Project [a#x, b#x]
+                  +- SubqueryAlias data
+                     +- LocalRelation [a#x, b#x]
+
+
+-- !query
+SELECT a FROM data ORDER BY a, 2
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "2",
+    "size" : "1"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 32,
+    "stopIndex" : 32,
+    "fragment" : "2"
+  } ]
+}
+
+
+-- !query
+SELECT a FROM data ORDER BY b, 3
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "3",
+    "size" : "2"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 32,
+    "stopIndex" : 32,
+    "fragment" : "3"
+  } ]
+}
+
+
+-- !query
+SELECT a, a + 1 FROM data ORDER BY b, 3
+-- !query analysis
+Project [a#x, (a + 1)#x]
++- Sort [b#x ASC NULLS FIRST, b#x ASC NULLS FIRST], true
+   +- Project [a#x, (a#x + 1) AS (a + 1)#x, b#x]
+      +- SubqueryAlias data
+         +- View (`data`, [a#x, b#x])
+            +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x]
+               +- Project [a#x, b#x]
+                  +- SubqueryAlias data
+                     +- LocalRelation [a#x, b#x]
+
+
+-- !query
 set spark.sql.orderByOrdinal=false
 -- !query analysis
 SetCommand (spark.sql.orderByOrdinal,Some(false))

--- a/sql/core/src/test/resources/sql-tests/inputs/order-by-ordinal.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/order-by-ordinal.sql
@@ -28,6 +28,25 @@ select * from data order by 3;
 -- sort by ordinal
 select * from data sort by 1 desc;
 
+-- SPARK-52565: Enforce ordinal resolution before other sort order expressions
+set spark.sql.prioritizeOrdinalResolutionInSort.enabled=true;
+SELECT a FROM data ORDER BY 2, b;
+SELECT a FROM data ORDER BY b, 2;
+SELECT a FROM data ORDER BY 'b', 2;
+SELECT a FROM data ORDER BY `b`, 2;
+SELECT a FROM data ORDER BY a, 2;
+SELECT a FROM data ORDER BY b, 3;
+SELECT a, a + 1 FROM data ORDER BY b, 3;
+
+set spark.sql.prioritizeOrdinalResolutionInSort.enabled=false;
+SELECT a FROM data ORDER BY 2, b;
+SELECT a FROM data ORDER BY b, 2;
+SELECT a FROM data ORDER BY 'b', 2;
+SELECT a FROM data ORDER BY `b`, 2;
+SELECT a FROM data ORDER BY a, 2;
+SELECT a FROM data ORDER BY b, 3;
+SELECT a, a + 1 FROM data ORDER BY b, 3;
+
 -- turn off order by ordinal
 set spark.sql.orderByOrdinal=false;
 

--- a/sql/core/src/test/resources/sql-tests/results/order-by-ordinal.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/order-by-ordinal.sql.out
@@ -149,6 +149,304 @@ struct<a:int,b:int>
 
 
 -- !query
+set spark.sql.prioritizeOrdinalResolutionInSort.enabled=true
+-- !query schema
+struct<key:string,value:string>
+-- !query output
+spark.sql.prioritizeOrdinalResolutionInSort.enabled	true
+
+
+-- !query
+SELECT a FROM data ORDER BY 2, b
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "2",
+    "size" : "1"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 29,
+    "stopIndex" : 29,
+    "fragment" : "2"
+  } ]
+}
+
+
+-- !query
+SELECT a FROM data ORDER BY b, 2
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "2",
+    "size" : "1"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 32,
+    "stopIndex" : 32,
+    "fragment" : "2"
+  } ]
+}
+
+
+-- !query
+SELECT a FROM data ORDER BY 'b', 2
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "2",
+    "size" : "1"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 34,
+    "stopIndex" : 34,
+    "fragment" : "2"
+  } ]
+}
+
+
+-- !query
+SELECT a FROM data ORDER BY `b`, 2
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "2",
+    "size" : "1"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 34,
+    "stopIndex" : 34,
+    "fragment" : "2"
+  } ]
+}
+
+
+-- !query
+SELECT a FROM data ORDER BY a, 2
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "2",
+    "size" : "1"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 32,
+    "stopIndex" : 32,
+    "fragment" : "2"
+  } ]
+}
+
+
+-- !query
+SELECT a FROM data ORDER BY b, 3
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "3",
+    "size" : "1"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 32,
+    "stopIndex" : 32,
+    "fragment" : "3"
+  } ]
+}
+
+
+-- !query
+SELECT a, a + 1 FROM data ORDER BY b, 3
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "3",
+    "size" : "2"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 39,
+    "stopIndex" : 39,
+    "fragment" : "3"
+  } ]
+}
+
+
+-- !query
+set spark.sql.prioritizeOrdinalResolutionInSort.enabled=false
+-- !query schema
+struct<key:string,value:string>
+-- !query output
+spark.sql.prioritizeOrdinalResolutionInSort.enabled	false
+
+
+-- !query
+SELECT a FROM data ORDER BY 2, b
+-- !query schema
+struct<a:int>
+-- !query output
+1
+2
+3
+1
+2
+3
+
+
+-- !query
+SELECT a FROM data ORDER BY b, 2
+-- !query schema
+struct<a:int>
+-- !query output
+1
+2
+3
+1
+2
+3
+
+
+-- !query
+SELECT a FROM data ORDER BY 'b', 2
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "2",
+    "size" : "1"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 34,
+    "stopIndex" : 34,
+    "fragment" : "2"
+  } ]
+}
+
+
+-- !query
+SELECT a FROM data ORDER BY `b`, 2
+-- !query schema
+struct<a:int>
+-- !query output
+1
+2
+3
+1
+2
+3
+
+
+-- !query
+SELECT a FROM data ORDER BY a, 2
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "2",
+    "size" : "1"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 32,
+    "stopIndex" : 32,
+    "fragment" : "2"
+  } ]
+}
+
+
+-- !query
+SELECT a FROM data ORDER BY b, 3
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42805",
+  "messageParameters" : {
+    "index" : "3",
+    "size" : "2"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 32,
+    "stopIndex" : 32,
+    "fragment" : "3"
+  } ]
+}
+
+
+-- !query
+SELECT a, a + 1 FROM data ORDER BY b, 3
+-- !query schema
+struct<a:int,(a + 1):int>
+-- !query output
+1	2
+2	3
+3	4
+1	2
+2	3
+3	4
+
+
+-- !query
 set spark.sql.orderByOrdinal=false
 -- !query schema
 struct<key:string,value:string>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The following query passes, but should fail:
```
SELECT col2 FROM values(1,2) ORDER BY 2,col1
```
As it can be seen in the query, we try to order by 2 which is an ordinal in this case and it should fail with `ORDER_BY_POS_OUT_OF_RANGE`. It doesn't because of Analyzer rule ordering issue.
We first resolve the sort order `col1` using the `ResolveReferencesInSort` rule. It turns out to be a missing input and thus we add it to the `Project` below and add another `Project` on top of sort to retain original output. At that point, plan looks like:
```
Project[col1#x]
+- Sort['UnresolvedOrdinal(2), col1#x]
     +- Project[col2#x, col1#x]
          ...
 ```
Then we go to `ResolveOrdinalInOrderByAndGroupBy` and successfully resolve the `UnresolvedOrdinal` because there are two elements in the `Project` below. This shouldn't happen and we should fail.

In this issue I propose that we fix it by enforcing ordinal resolution before other sort order expressions.

### Why are the changes needed?
To correct behavior of explained query patterns.

### Does this PR introduce _any_ user-facing change?
Yes, query that passed will fail (as it should).

### How was this patch tested?
Added tests.

### Was this patch authored or co-authored using generative AI tooling?
No.