### PR TITLE
[SPARK-52569][SQL] Fix the class cast exception in `SecondsOfTimeWithFraction`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -317,9 +317,11 @@ object HourExpressionBuilder extends ExpressionBuilder {
 case class SecondsOfTimeWithFraction(child: Expression)
   extends RuntimeReplaceable
   with ExpectsInputTypes {
-
   override def replacement: Expression = {
-
+    val precision = child.dataType match {
+      case TimeType(p) => p
+      case _ => TimeType.MIN_PRECISION
+    }
     StaticInvoke(
       classOf[DateTimeUtils.type],
       DecimalType(8, 6),
@@ -327,10 +329,9 @@ case class SecondsOfTimeWithFraction(child: Expression)
       Seq(child, Literal(precision)),
       Seq(child.dataType, IntegerType))
   }
-  private val precision: Int = child.dataType.asInstanceOf[TimeType].precision
 
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(TimeType(precision))
+    Seq(TypeCollection(TimeType.MIN_PRECISION to TimeType.MAX_PRECISION map TimeType.apply: _*))
 
   override def children: Seq[Expression] = Seq(child)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -358,6 +358,8 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(
       SecondsOfTimeWithFraction(Literal.create(null, TimeType(TimeType.MICROS_PRECISION))),
       null)
+    assert(SecondsOfTimeWithFraction(Literal.create(null)).inputTypes.nonEmpty)
+
     checkConsistencyBetweenInterpretedAndCodegen(
       (child: Expression) => SecondsOfTimeWithFraction(child).replacement,
       TimeType())


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to avoid an assumption in the `SecondsOfTimeWithFraction` expression: the default constructor is called only on `TimeType` of `child`. The constructor can be called before the `inputTypes` method, and we cannot guarantee that input types are `TimeType(n)` only. The `child` expression can be `NullType`, for instance.

### Why are the changes needed?
To avoid the following exception while calling expression's methods:
```
class org.apache.spark.sql.types.NullType$ cannot be cast to class org.apache.spark.sql.types.TimeType (org.apache.spark.sql.types.NullType$ and org.apache.spark.sql.types.TimeType are in unnamed module of loader 'app')
```


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
By running new check:
```
$ build/sbt "test:testOnly *TimeExpressionsSuite"
```


### Was this patch authored or co-authored using generative AI tooling?
No.
