### PR TITLE
[SPARK-52567][SQL][HIVE][TEST] Refactor Hive_2_1_DDLSuite

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveIncompatibleColTypeChangeSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveIncompatibleColTypeChangeSuite.scala
@@ -31,7 +31,7 @@ class HiveIncompatibleColTypeChangeSuite extends SparkFunSuite with TestHiveSing
   private val catalog = spark.sessionState.catalog.externalCatalog
 
   override def beforeAll(): Unit = {
-    super.afterAll()
+    super.beforeAll()
     hiveClient.runSqlHive(
       "SET hive.metastore.disallow.incompatible.col.type.changes=true")
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveIncompatibleColTypeChangeSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveIncompatibleColTypeChangeSuite.scala
@@ -17,49 +17,23 @@
 
 package org.apache.spark.sql.hive.execution
 
-import org.apache.hadoop.conf.Configuration
-
-import org.apache.spark.{SparkConf, SparkFunSuite}
-import org.apache.spark.launcher.SparkLauncher
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.hive.{HiveExternalCatalog, HiveUtils}
 import org.apache.spark.sql.hive.test.TestHiveSingleton
-import org.apache.spark.sql.internal.StaticSQLConf._
 import org.apache.spark.sql.types._
-import org.apache.spark.tags.{ExtendedHiveTest, SlowHiveTest}
-import org.apache.spark.util.Utils
 
 /**
- * A separate set of DDL tests that uses Hive 2.1 libraries, which behave a little differently
- * from the built-in ones.
+ * A separate set of Hive DDL tests when setting
+ * `hive.metastore.disallow.incompatible.col.type.changes=true`
  */
-@SlowHiveTest
-@ExtendedHiveTest
-class Hive_2_1_DDLSuite extends SparkFunSuite with TestHiveSingleton {
+class HiveIncompatibleColTypeChangeSuite extends SparkFunSuite with TestHiveSingleton {
 
-  // Create a custom HiveExternalCatalog instance with the desired configuration. We cannot
-  // use SparkSession here since there's already an active on managed by the TestHive object.
-  private var catalog = {
-    val warehouse = Utils.createTempDir()
-    val metastore = Utils.createTempDir()
-    metastore.delete()
-    val sparkConf = new SparkConf()
-      .set(SparkLauncher.SPARK_MASTER, "local")
-      .set(WAREHOUSE_PATH.key, warehouse.toURI().toString())
-      .set(CATALOG_IMPLEMENTATION.key, "hive")
-      .set(HiveUtils.HIVE_METASTORE_VERSION.key, "2.1")
-      .set(HiveUtils.HIVE_METASTORE_JARS.key, "maven")
+  private val catalog = spark.sessionState.catalog.externalCatalog
 
-    val hadoopConf = new Configuration()
-    hadoopConf.set("hive.metastore.warehouse.dir", warehouse.toURI().toString())
-    hadoopConf.set("javax.jdo.option.ConnectionURL",
-      s"jdbc:derby:;databaseName=${metastore.getAbsolutePath()};create=true")
-    // These options are needed since the defaults in Hive 2.1 cause exceptions with an
-    // empty metastore db.
-    hadoopConf.set("datanucleus.schema.autoCreateAll", "true")
-    hadoopConf.set("hive.metastore.schema.verification", "false")
-
-    new HiveExternalCatalog(sparkConf, hadoopConf)
+  override def beforeAll(): Unit = {
+    super.afterAll()
+    hiveClient.runSqlHive(
+      "SET hive.metastore.disallow.incompatible.col.type.changes=true")
   }
 
   override def afterEach(): Unit = {
@@ -71,7 +45,8 @@ class Hive_2_1_DDLSuite extends SparkFunSuite with TestHiveSingleton {
 
   override def afterAll(): Unit = {
     try {
-      catalog = null
+      hiveClient.runSqlHive(
+        "SET hive.metastore.disallow.incompatible.col.type.changes=false")
     } finally {
       super.afterAll()
     }
@@ -122,7 +97,7 @@ class Hive_2_1_DDLSuite extends SparkFunSuite with TestHiveSingleton {
       updatedSchema: StructType,
       hiveCompatible: Boolean = true): Unit = {
     spark.sql(createTableStmt)
-    val oldTable = spark.sessionState.catalog.externalCatalog.getTable("default", tableName)
+    val oldTable = catalog.getTable("default", tableName)
     catalog.createTable(oldTable, true)
     catalog.alterTableDataSchema("default", tableName, updatedSchema)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Hive_2_1_DDLSuite was added in SPARK-21617 (2.3.0), in those days, the built-in Hive version was 1.2.1.

> A separate set of DDL tests that uses Hive 2.1 libraries, which behave a little differently from the built-in ones.

After a closer look, the real difference is, Hive enables `hive.metastore.disallow.incompatible.col.type.changes` since HIVE-12320 (2.0.0)

Now we upgraded the built-in Hive to 2.3.10, the comments become misleading and we can simply use the global `TestHiveSingleton` with overriding `hive.metastore.disallow.incompatible.col.type.changes` to achieve the same test purpose.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Simplify and speed up the test, and update the outdated comments for clarity.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

```
sbt:spark-hive> testOnly *HiveIncompatibleColTypeChangeSuite
...
[info] Run completed in 11 seconds, 429 milliseconds.
[info] Total number of tests run: 4
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 4, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 18 s, completed Jun 24, 2025, 11:26:07 PM
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.