### PR TITLE
[SPARK-52570][PS] Enable divide-by-zero for numeric rmod with ANSI enabled

### DIFF
--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -160,12 +160,20 @@ class NumericOps(DataTypeOps):
         _sanitize_list_like(right)
         if not isinstance(right, numbers.Number):
             raise TypeError("Modulo can not be applied to given types.")
-
-        def rmod(left: PySparkColumn, right: Any) -> PySparkColumn:
-            return ((right % left) + left) % left
+        spark_session = left._internal.spark_frame.sparkSession
 
         right = transform_boolean_operand_to_numeric(right)
-        return column_op(rmod)(left, right)
+
+        def safe_rmod(left_col: PySparkColumn, right_val: Any) -> PySparkColumn:
+            if is_ansi_mode_enabled(spark_session):
+                result = F.when(left_col != 0, F.pmod(F.lit(right_val), left_col)).otherwise(
+                    F.lit(None)
+                )
+                return result
+            else:
+                return ((right % left) + left) % left
+
+        return column_op(safe_rmod)(left, right)
 
     def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
         return operand._with_new_scol(-operand.spark.column, field=operand._internal.data_fields[0])

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -166,9 +166,10 @@ class NumericOps(DataTypeOps):
 
         def safe_rmod(left_col: PySparkColumn, right_val: Any) -> PySparkColumn:
             if is_ansi_mode_enabled(spark_session):
-                result = F.when(left_col != 0, F.pmod(F.lit(right_val), left_col)).otherwise(
-                    F.lit(None)
-                )
+                # Java-style modulo -> Python-style modulo
+                result = F.when(
+                    left_col != 0, ((F.lit(right_val) % left_col) + left_col) % left_col
+                ).otherwise(F.lit(None))
                 return result
             else:
                 return ((right % left) + left) % left

--- a/python/pyspark/pandas/tests/computation/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/computation/test_binary_ops.py
@@ -225,11 +225,12 @@ class FrameBinaryOpsMixin:
 
     def test_binary_operator_mod(self):
         # Positive
-        pdf = pd.DataFrame({"a": [3], "b": [2]})
+        pdf = pd.DataFrame({"a": [3], "b": [2], "c": [0]})
         psdf = ps.from_pandas(pdf)
 
         self.assert_eq(psdf["a"] % psdf["b"], pdf["a"] % pdf["b"])
         self.assert_eq(psdf["a"] % 0, pdf["a"] % 0)
+        self.assert_eq(1 % psdf["c"], 1 % pdf["c"])
 
         # Negative
         psdf = ps.DataFrame({"a": ["x"], "b": [1]})

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -134,6 +134,7 @@ class BooleanOpsTestsMixin:
         for col in self.non_numeric_df_cols:
             self.assertRaises(TypeError, lambda: b_psser // psdf[col])
 
+    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_mod(self):
         pdf, psdf = self.pdf, self.psdf
 
@@ -233,6 +234,7 @@ class BooleanOpsTestsMixin:
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) ** b_psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) ** b_psser)
 
+    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_rmod(self):
         psdf = self.psdf
 
@@ -243,7 +245,6 @@ class BooleanOpsTestsMixin:
         self.assert_eq(
             pd.Series([0.10000000000000009, 0.10000000000000009, None], dtype=float, name="bool"),
             0.1 % b_psser,
-            check_exact=False,  # [0.1, 0.1, nan] for pandas-on-Spark
         )
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) % b_psser)
         self.assertRaises(TypeError, lambda: True % b_psser)

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -240,7 +240,8 @@ class BooleanOpsTestsMixin:
         b_psser = psdf["bool"]
         b_pser = pdf["bool"]
         self.assert_eq(1 % b_pser.astype(float), 1 % b_psser)
-        self.assert_eq(0.1 % b_pser, 0.1 % b_psser)
+        # # Allow float precision diff: pandas:  0.10000000000000009; pandas on spark: 0.1
+        self.assert_eq(0.1 % b_pser, 0.1 % b_psser, almost=True)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) % b_psser)
         self.assertRaises(TypeError, lambda: True % b_psser)
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -134,7 +134,6 @@ class BooleanOpsTestsMixin:
         for col in self.non_numeric_df_cols:
             self.assertRaises(TypeError, lambda: b_psser // psdf[col])
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_mod(self):
         pdf, psdf = self.pdf, self.psdf
 
@@ -234,18 +233,14 @@ class BooleanOpsTestsMixin:
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) ** b_psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) ** b_psser)
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_rmod(self):
         psdf = self.psdf
+        pdf = self.pdf
 
         b_psser = psdf["bool"]
-        # 1 % False is 0.0 in pandas
-        self.assert_eq(pd.Series([0, 0, None], dtype=float, name="bool"), 1 % b_psser)
-        # 0.1 / True is 0.1 in pandas
-        self.assert_eq(
-            pd.Series([0.10000000000000009, 0.10000000000000009, None], dtype=float, name="bool"),
-            0.1 % b_psser,
-        )
+        b_pser = pdf["bool"]
+        self.assert_eq(1 % b_pser.astype(float), 1 % b_psser)
+        self.assert_eq(0.1 % b_pser, 0.1 % b_psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) % b_psser)
         self.assertRaises(TypeError, lambda: True % b_psser)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable divide-by-zero for numeric rmod with ANSI enabled

### Why are the changes needed?
Part of https://issues.apache.org/jira/browse/SPARK-52169.

### Does this PR introduce _any_ user-facing change?
Yes.

```py
>>> ps.set_option("compute.fail_on_ansi_mode", False)
>>> ps.set_option("compute.ansi_mode_support", True)

>>> pdf = pd.DataFrame({"a": [0], "b": [False]})
>>> pdf.dtypes
a    int64
b     bool
dtype: object
>>> psdf = ps.from_pandas(pdf)
>>> 1 % psdf["a"]
0   NaN
Name: a, dtype: float64
>>> 1 % psdf["b"]
0   NaN
Name: b, dtype: float64
```


### How was this patch tested?
Unit tests.

```
(dev3.11) spark (bool_mod_new) % SPARK_ANSI_SQL_MODE=true  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_boolean_ops 
...
Tests passed in 4 seconds
```

### Was this patch authored or co-authored using generative AI tooling?
No.