### PR TITLE
[SDP] [SPARK-52576] Drop/recreate on full refresh and MV update

### DIFF
--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DatasetManager.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DatasetManager.scala
@@ -181,7 +181,6 @@ object DatasetManager extends Logging {
     val dropTable = (isFullRefresh || !table.isStreamingTable) && existingTableOpt.isDefined
     if (dropTable) {
       catalog.dropTable(identifier)
-//      context.spark.sql(s"DROP TABLE ${table.identifier.quotedString}")
     }
 
     // Alter the table if we need to

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
@@ -435,7 +435,7 @@ class MaterializeTablesSuite extends BaseCoreExecutionTest {
     val table2 = catalog.loadTable(identifier)
     assert(
       table2.columns() sameElements CatalogV2Util
-        .structTypeToV2Columns(new StructType().add("x", BooleanType).add("y", IntegerType))
+        .structTypeToV2Columns(new StructType().add("y", IntegerType).add("x", BooleanType))
     )
     assert(table2.partitioning().toSeq == Seq(Expressions.identity("x")))
 
@@ -456,8 +456,8 @@ class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
     val table3 = catalog.loadTable(identifier)
     assert(
-      table3.columns() sameElements  CatalogV2Util
-        .structTypeToV2Columns(new StructType().add("x", BooleanType).add("y", IntegerType))
+      table3.columns() sameElements CatalogV2Util
+        .structTypeToV2Columns(new StructType().add("y", IntegerType).add("x", BooleanType))
     )
     assert(table3.partitioning().toSeq == Seq(Expressions.identity("x")))
   }

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
@@ -434,9 +434,8 @@ class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
     val table2 = catalog.loadTable(identifier)
     assert(
-      table2.columns().toSet == CatalogV2Util
+      table2.columns() sameElements CatalogV2Util
         .structTypeToV2Columns(new StructType().add("x", BooleanType).add("y", IntegerType))
-        .toSet
     )
     assert(table2.partitioning().toSeq == Seq(Expressions.identity("x")))
 
@@ -457,9 +456,8 @@ class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
     val table3 = catalog.loadTable(identifier)
     assert(
-      table3.columns().toSet == CatalogV2Util
+      table3.columns() sameElements  CatalogV2Util
         .structTypeToV2Columns(new StructType().add("x", BooleanType).add("y", IntegerType))
-        .toSet
     )
     assert(table3.partitioning().toSeq == Seq(Expressions.identity("x")))
   }

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
@@ -434,8 +434,9 @@ class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
     val table2 = catalog.loadTable(identifier)
     assert(
-      table2.columns() sameElements CatalogV2Util
-        .structTypeToV2Columns(new StructType().add("y", IntegerType).add("x", BooleanType))
+      table2.columns().toSet == CatalogV2Util
+        .structTypeToV2Columns(new StructType().add("x", BooleanType).add("y", IntegerType))
+        .toSet
     )
     assert(table2.partitioning().toSeq == Seq(Expressions.identity("x")))
 
@@ -456,8 +457,9 @@ class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
     val table3 = catalog.loadTable(identifier)
     assert(
-      table3.columns() sameElements CatalogV2Util
-        .structTypeToV2Columns(new StructType().add("y", IntegerType).add("x", BooleanType))
+      table3.columns().toSet == CatalogV2Util
+        .structTypeToV2Columns(new StructType().add("x", BooleanType).add("y", IntegerType))
+        .toSet
     )
     assert(table3.partitioning().toSeq == Seq(Expressions.identity("x")))
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Some pipeline runs result in wiping out and replacing all the data for a table:
- Every run of a materialized view
- Runs of streaming tables that have the "full refresh" flag

In the current implementation, this "wipe out and replace" is implemented by:
- Truncating the table 
- Altering the table to drop/update/add columns that don't match the columns in the DataFrame for the current run

The reason that we want originally wanted to truncate + alter instead of drop / recreate is that dropping has some undesirable effects. E.g. it interrupts readers of the table and wipes away things like ACLs.

However, we discovered that not all catalogs support dropping columns (e.g. Hive does not), and there’s no way to tell whether a catalog supports dropping columns or not. So this PR changes the implementation to drop/recreate the table instead of truncate/alter.

### Why are the changes needed?

See section above.

### Does this PR introduce _any_ user-facing change?

Yes, see section above. No releases contained the old behavior.

### How was this patch tested?

- Tests in MaterializeTablesSuite
- Ran the tests in MaterializeTablesSuite with Hive instead of the default catalog

### Was this patch authored or co-authored using generative AI tooling?

No