### PR TITLE
[SPARK-52577][SDP]  Add tests for Declarative Pipelines DatasetManager with Hive catalog

### DIFF
--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -65,6 +65,18 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
+      <artifactId>spark-pipelines_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-pipelines_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
       <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
       <type>test-jar</type>
       <version>${project.version}</version>

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/pipelines/HiveMaterializeTablesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/pipelines/HiveMaterializeTablesSuite.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.pipelines.hive
+
+import org.apache.spark.sql.classic.SparkSession
+import org.apache.spark.sql.hive.test.{TestHive, TestHiveContext}
+import org.apache.spark.sql.pipelines.graph.MaterializeTablesSuite
+
+class HiveMaterializeTablesSuite extends MaterializeTablesSuite {
+  protected val hiveContext: TestHiveContext = TestHive
+
+  override def createAndInitializeSpark(): SparkSession = TestHive.sparkSession
+
+  override def afterAll(): Unit = {
+    try {
+      hiveContext.reset()
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  override def afterEach(): Unit = {
+    try {
+      spark.artifactManager.cleanUpResourcesForTesting()
+    } finally {
+      super.afterEach()
+    }
+  }
+}

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/pipelines/HiveMaterializeTablesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/pipelines/HiveMaterializeTablesSuite.scala
@@ -17,11 +17,41 @@
 
 package org.apache.spark.sql.pipelines.hive
 
+import scala.jdk.CollectionConverters._
+
 import org.apache.spark.sql.classic.SparkSession
+import org.apache.spark.sql.connector.catalog.{
+  CatalogV2Util,
+  Identifier,
+  TableCatalog,
+  TableChange,
+  TableInfo
+}
 import org.apache.spark.sql.hive.test.{TestHive, TestHiveContext}
 import org.apache.spark.sql.pipelines.graph.MaterializeTablesSuite
+import org.apache.spark.sql.types.{IntegerType, StructType}
 
 class HiveMaterializeTablesSuite extends MaterializeTablesSuite {
+  test("super basic") {
+    val catalogManager = spark.sessionState.catalogManager
+    val catalog = catalogManager.currentCatalog.asInstanceOf[TableCatalog]
+    val identifier = Identifier.of(Array("default"), "test_table")
+    val outputSchema =
+      new StructType().add("a", IntegerType, true, "comment1")
+    catalog.createTable(
+      identifier,
+      new TableInfo.Builder()
+        .withProperties(Map.empty.asJava)
+        .withColumns(CatalogV2Util.structTypeToV2Columns(outputSchema))
+        .withPartitions(Array.empty)
+        .build()
+    )
+
+    catalog.alterTable(identifier, TableChange.updateColumnComment(Array("a"), "comment2"))
+    val table = catalog.loadTable(identifier)
+    assert(table.schema() == new StructType().add("a", IntegerType, true, "comment2"))
+  }
+
   protected val hiveContext: TestHiveContext = TestHive
 
   override def createAndInitializeSpark(): SparkSession = TestHive.sparkSession

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/pipelines/HiveMaterializeTablesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/pipelines/HiveMaterializeTablesSuite.scala
@@ -15,20 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.pipelines.hive
+package org.apache.spark.sql.hive.pipelines
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.sql.classic.SparkSession
-import org.apache.spark.sql.connector.catalog.{
-  CatalogV2Util,
-  Identifier,
-  TableCatalog,
-  TableChange,
-  TableInfo
-}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, TableCatalog, TableChange, TableInfo}
 import org.apache.spark.sql.hive.test.{TestHive, TestHiveContext}
 import org.apache.spark.sql.pipelines.graph.MaterializeTablesSuite
+import org.apache.spark.sql.test.TestSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructType}
 
 class HiveMaterializeTablesSuite extends MaterializeTablesSuite {
@@ -54,7 +48,7 @@ class HiveMaterializeTablesSuite extends MaterializeTablesSuite {
 
   protected val hiveContext: TestHiveContext = TestHive
 
-  override def createAndInitializeSpark(): SparkSession = TestHive.sparkSession
+  override def createSparkSession: TestSparkSession = TestHive.sparkSession
 
   override def afterAll(): Unit = {
     try {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -45,7 +45,6 @@ import org.apache.spark.sql.hive._
 import org.apache.spark.sql.hive.client.HiveClient
 import org.apache.spark.sql.internal.{SessionState, SharedState, SQLConf, WithTestConf}
 import org.apache.spark.sql.internal.StaticSQLConf.{CATALOG_IMPLEMENTATION, RESULT_QUERY_STAGE_MAX_THREAD_THRESHOLD, SHUFFLE_EXCHANGE_MAX_THREAD_THRESHOLD, WAREHOUSE_PATH}
-import org.apache.spark.sql.test.TestSparkSession
 import org.apache.spark.util.{ShutdownHookManager, Utils}
 
 // SPARK-3729: Test key required to check for initialization errors with config.
@@ -182,7 +181,7 @@ private[hive] class TestHiveSparkSession(
     @transient private val existingSharedState: Option[TestHiveSharedState],
     @transient private val parentSessionState: Option[SessionState],
     private val loadTestTables: Boolean)
-  extends TestSparkSession(sc) with Logging { self =>
+  extends SparkSession(sc) with Logging { self =>
 
   def this(sc: SparkContext, loadTestTables: Boolean) = {
     this(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -45,6 +45,7 @@ import org.apache.spark.sql.hive._
 import org.apache.spark.sql.hive.client.HiveClient
 import org.apache.spark.sql.internal.{SessionState, SharedState, SQLConf, WithTestConf}
 import org.apache.spark.sql.internal.StaticSQLConf.{CATALOG_IMPLEMENTATION, RESULT_QUERY_STAGE_MAX_THREAD_THRESHOLD, SHUFFLE_EXCHANGE_MAX_THREAD_THRESHOLD, WAREHOUSE_PATH}
+import org.apache.spark.sql.test.TestSparkSession
 import org.apache.spark.util.{ShutdownHookManager, Utils}
 
 // SPARK-3729: Test key required to check for initialization errors with config.
@@ -181,7 +182,7 @@ private[hive] class TestHiveSparkSession(
     @transient private val existingSharedState: Option[TestHiveSharedState],
     @transient private val parentSessionState: Option[SessionState],
     private val loadTestTables: Boolean)
-  extends SparkSession(sc) with Logging { self =>
+  extends TestSparkSession(sc) with Logging { self =>
 
   def this(sc: SparkContext, loadTestTables: Boolean) = {
     this(

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectInvalidPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectInvalidPipelineSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.pipelines.graph
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.pipelines.utils.{PipelineTest, TestGraphRegistrationContext}
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructType}
 
 /**
@@ -27,7 +28,7 @@ import org.apache.spark.sql.types.{IntegerType, StructType}
  * examples are all semantically correct but contain logical errors which should be found
  * when connect is called and thrown when validate() is called.
  */
-class ConnectInvalidPipelineSuite extends PipelineTest {
+class ConnectInvalidPipelineSuite extends PipelineTest with SharedSparkSession {
 
   test("Missing source") {
     class P extends TestGraphRegistrationContext(spark) {

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectValidPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectValidPipelineSuite.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.plans.logical.Union
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.pipelines.utils.{PipelineTest, TestGraphRegistrationContext}
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -30,7 +31,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
  * examples are all semantically correct and logically correct and connect should not result in any
  * errors.
  */
-class ConnectValidPipelineSuite extends PipelineTest {
+class ConnectValidPipelineSuite extends PipelineTest with SharedSparkSession {
   test("Extra simple") {
     val session = spark
     import session.implicits._

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
@@ -25,14 +25,17 @@ import org.apache.spark.sql.connector.expressions.Expressions
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.pipelines.graph.DatasetManager.TableMaterializationException
 import org.apache.spark.sql.pipelines.utils.{BaseCoreExecutionTest, TestGraphRegistrationContext}
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils.exceptionString
+
+class DefaultMaterializeTablesSuite extends MaterializeTablesSuite with SharedSparkSession
 
 /**
  * Local integration tests for materialization of `Table`s in a `DataflowGraph` to make sure
  * tables are written with the appropriate schemas.
  */
-class MaterializeTablesSuite extends BaseCoreExecutionTest {
+abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   test("basic") {
     val session = spark
     import session.implicits._

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
@@ -19,11 +19,11 @@ package org.apache.spark.sql.pipelines.graph
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.pipelines.utils.{PipelineTest, TestGraphRegistrationContext}
-import org.apache.spark.sql.test.SQLTestUtils
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{LongType, StructType}
 import org.apache.spark.util.Utils
 
-class SQLPipelineSuite extends PipelineTest with SQLTestUtils {
+class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
   private val externalTable1Ident = fullyQualifiedIdentifier("external_t1")
   private val externalTable2Ident = fullyQualifiedIdentifier("external_t2")
 

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlQueryOriginSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlQueryOriginSuite.scala
@@ -18,8 +18,9 @@ package org.apache.spark.sql.pipelines.graph
 
 import org.apache.spark.sql.pipelines.Language
 import org.apache.spark.sql.pipelines.utils.PipelineTest
+import org.apache.spark.sql.test.SharedSparkSession
 
-class SqlQueryOriginSuite extends PipelineTest {
+class SqlQueryOriginSuite extends PipelineTest with SharedSparkSession {
   test("basic test") {
     val sqlQueryOrigins = SqlGraphRegistrationContext.splitSqlFileIntoQueries(
       spark,

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/TriggeredGraphExecutionSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/TriggeredGraphExecutionSuite.scala
@@ -28,9 +28,10 @@ import org.apache.spark.sql.pipelines.common.{FlowStatus, RunState}
 import org.apache.spark.sql.pipelines.graph.TriggeredGraphExecution.StreamState
 import org.apache.spark.sql.pipelines.logging.EventLevel
 import org.apache.spark.sql.pipelines.utils.{ExecutionTest, TestGraphRegistrationContext}
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
-class TriggeredGraphExecutionSuite extends ExecutionTest {
+class TriggeredGraphExecutionSuite extends ExecutionTest with SharedSparkSession {
 
   /** Returns a Dataset of Longs from the table with the given identifier. */
   private def getTable(identifier: TableIdentifier): Dataset[Long] = {

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/PipelineTest.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/PipelineTest.scala
@@ -26,29 +26,33 @@ import scala.util.control.NonFatal
 
 import org.scalactic.source
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Tag}
+import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.should.Matchers
 
-import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{Column, QueryTest, Row, TypedColumn}
+import org.apache.spark.sql.{Column, QueryTest, Row, SQLContext, TypedColumn}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.classic.{DataFrame, Dataset, SparkSession}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.pipelines.graph.{DataflowGraph, PipelineUpdateContextImpl, SqlGraphRegistrationContext}
 import org.apache.spark.sql.pipelines.utils.PipelineTest.{cleanupMetastore, createTempDir}
-import org.apache.spark.sql.test.SharedSparkSession
 
 abstract class PipelineTest
     extends SparkFunSuite
-    with SharedSparkSession
     with BeforeAndAfterAll
     with BeforeAndAfterEach
     with Matchers
     with SparkErrorTestMixin
     with TargetCatalogAndDatabaseMixin
-    with Logging {
+    with Logging
+    with Eventually {
 
   final protected val storageRoot = createTempDir()
+
+  protected def spark: SparkSession
+
+  protected implicit def sqlContext: SQLContext
 
   def sql(text: String): DataFrame = spark.sql(text)
 
@@ -57,15 +61,6 @@ abstract class PipelineTest
       unresolvedDataflowGraph, eventCallback = _ => ())
     updateContext.pipelineExecution.runPipeline()
     updateContext.pipelineExecution.awaitCompletion()
-  }
-
-  /**
-   * Spark confs set here will be the default spark confs for all spark sessions created in tests.
-   */
-  override def sparkConf: SparkConf = {
-    super.sparkConf
-      .set("spark.sql.shuffle.partitions", "2")
-      .set("spark.sql.session.timeZone", "UTC")
   }
 
   /** Returns the dataset name in the event log. */
@@ -126,7 +121,7 @@ abstract class PipelineTest
     )
   }
 
-  override def beforeEach(): Unit = {
+  protected override def beforeEach(): Unit = {
     super.beforeEach()
     cleanupMetastore(spark)
     (catalogInPipelineSpec, databaseInPipelineSpec) match {
@@ -137,7 +132,7 @@ abstract class PipelineTest
     }
   }
 
-  override def afterEach(): Unit = {
+  protected override def afterEach(): Unit = {
     cleanupMetastore(spark)
     super.afterEach()
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add tests to make sure that the code inside Declarative Pipelines that interacts with the catalog works with Hive in addition to the default catalog.

### Why are the changes needed?

To make sure that the code inside Declarative Pipelines that interacts with the catalog works with Hive in addition to the default catalog.


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

It's only tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
