### PR TITLE
[SPARK-52864] [CORE] [Tests] Let LocalSparkContext clear active context in beforeAll

### DIFF
--- a/core/src/test/scala/org/apache/spark/LocalSparkContext.scala
+++ b/core/src/test/scala/org/apache/spark/LocalSparkContext.scala
@@ -32,6 +32,7 @@ trait LocalSparkContext extends BeforeAndAfterEach with BeforeAndAfterAll { self
   override def beforeAll(): Unit = {
     super.beforeAll()
     InternalLoggerFactory.setDefaultFactory(Slf4JLoggerFactory.INSTANCE)
+    SparkContext.clearActiveContext()
   }
 
   override def afterEach(): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This change is to ensure no active SparkContext remain from previous test runs. This prevents potential resource leaks by cleaning up any lingering context before test execution begins. By having this call in the trait, we stabilize all tests that mix in this trait.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran all unit tests on 3.5 branch and all passed.

### Was this patch authored or co-authored using generative AI tooling?

No.

