### PR TITLE
[SPARK-52578][SQL] Add metrics for rows to track case and action in MergeRowsExec

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLite
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.{FullOuter, Inner, JoinType, LeftAnti, LeftOuter, RightOuter}
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, DeleteAction, Filter, HintInfo, InsertAction, Join, JoinHint, LogicalPlan, MergeAction, MergeIntoTable, MergeRows, NO_BROADCAST_AND_REPLICATION, Project, ReplaceData, UpdateAction, WriteDelta}
-import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Copy, Discard, Instruction, Keep, ROW_ID, Split}
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Copy, Delete, Discard, Insert, Instruction, Keep, ROW_ID, Split, Update}
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils.{OPERATION_COLUMN, WRITE_OPERATION, WRITE_WITH_METADATA_OPERATION}
 import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
 import org.apache.spark.sql.connector.write.{RowLevelOperationTable, SupportsDelta}
@@ -93,7 +93,7 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
 
           val notMatchedInstructions = notMatchedActions.map {
             case InsertAction(cond, assignments) =>
-              Keep(cond.getOrElse(TrueLiteral), assignments.map(_.value))
+              Keep(Insert, cond.getOrElse(TrueLiteral), assignments.map(_.value))
             case other =>
               throw new AnalysisException(
                 errorClass = "_LEGACY_ERROR_TEMP_3053",
@@ -199,7 +199,7 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
     // as the last MATCHED and NOT MATCHED BY SOURCE instruction
     // this logic is specific to data sources that replace groups of data
     val carryoverRowsOutput = Literal(WRITE_WITH_METADATA_OPERATION) +: targetTable.output
-    val keepCarryoverRowsInstruction = Copy(carryoverRowsOutput)
+    val keepCarryoverRowsInstruction = Keep(Copy, TrueLiteral, carryoverRowsOutput)
 
     val matchedInstructions = matchedActions.map { action =>
       toInstruction(action, metadataAttrs)
@@ -436,7 +436,7 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
         val rowValues = assignments.map(_.value)
         val metadataValues = nullifyMetadataOnUpdate(metadataAttrs)
         val output = Seq(Literal(WRITE_WITH_METADATA_OPERATION)) ++ rowValues ++ metadataValues
-        Keep(cond.getOrElse(TrueLiteral), output)
+        Keep(Update, cond.getOrElse(TrueLiteral), output)
 
       case DeleteAction(cond) =>
         Discard(cond.getOrElse(TrueLiteral))
@@ -445,7 +445,7 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
         val rowValues = assignments.map(_.value)
         val metadataValues = metadataAttrs.map(attr => Literal(null, attr.dataType))
         val output = Seq(Literal(WRITE_OPERATION)) ++ rowValues ++ metadataValues
-        Keep(cond.getOrElse(TrueLiteral), output)
+        Keep(Insert, cond.getOrElse(TrueLiteral), output)
 
       case other =>
         throw new AnalysisException(
@@ -471,15 +471,15 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
 
       case UpdateAction(cond, assignments) =>
         val output = deltaUpdateOutput(assignments, metadataAttrs, originalRowIdValues)
-        Keep(cond.getOrElse(TrueLiteral), output)
+        Keep(Update, cond.getOrElse(TrueLiteral), output)
 
       case DeleteAction(cond) =>
         val output = deltaDeleteOutput(rowAttrs, rowIdAttrs, metadataAttrs, originalRowIdValues)
-        Keep(cond.getOrElse(TrueLiteral), output)
+        Keep(Delete, cond.getOrElse(TrueLiteral), output)
 
       case InsertAction(cond, assignments) =>
         val output = deltaInsertOutput(assignments, metadataAttrs, originalRowIdValues)
-        Keep(cond.getOrElse(TrueLiteral), output)
+        Keep(Insert, cond.getOrElse(TrueLiteral), output)
 
       case other =>
         throw new AnalysisException(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeRows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeRows.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expression, Unevaluable}
-import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Instruction, ROW_ID}
 import org.apache.spark.sql.catalyst.trees.UnaryLike
 import org.apache.spark.sql.catalyst.util.truncatedString
@@ -88,19 +87,14 @@ object MergeRows {
     override def dataType: DataType = NullType
   }
 
-  // A special case of Keep where the row is kept as is.
-  case class Copy(output: Seq[Expression]) extends Instruction  {
-    override def condition: Expression = TrueLiteral
-    override def outputs: Seq[Seq[Expression]] = Seq(output)
-    override def children: Seq[Expression] = output
-
-    override protected def withNewChildrenInternal(
-        newChildren: IndexedSeq[Expression]): Expression = {
-      copy(output = newChildren)
-    }
-  }
+  sealed trait Context
+  case object Copy extends Context
+  case object Delete extends Context
+  case object Insert extends Context
+  case object Update extends Context
 
   case class Keep(
+      context: Context,
       condition: Expression,
       output: Seq[Expression])
     extends Instruction {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
@@ -26,11 +26,10 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.expressions.AttributeSet
 import org.apache.spark.sql.catalyst.expressions.BasePredicate
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.expressions.Projection
 import org.apache.spark.sql.catalyst.expressions.UnsafeProjection
 import org.apache.spark.sql.catalyst.expressions.codegen.GeneratePredicate
-import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Copy, Discard, Instruction, Keep, ROW_ID, Split}
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Context, Copy, Delete, Discard, Insert, Instruction, Keep, ROW_ID, Split, Update}
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.SparkPlan
@@ -49,7 +48,21 @@ case class MergeRowsExec(
 
   override lazy val metrics: Map[String, SQLMetric] = Map(
     "numTargetRowsCopied" -> SQLMetrics.createMetric(sparkContext,
-      "Number of target rows copied unmodified because they did not match any action."))
+      "Number of target rows copied unmodified because they did not match any action"),
+    "numTargetRowsInserted" -> SQLMetrics.createMetric(sparkContext,
+      "Number of target rows inserted"),
+    "numTargetRowsDeleted" -> SQLMetrics.createMetric(sparkContext,
+      "Number of target rows deleted"),
+    "numTargetRowsUpdated" -> SQLMetrics.createMetric(sparkContext,
+      "Number of target rows updated"),
+    "numTargetRowsMatchedUpdated" -> SQLMetrics.createMetric(sparkContext,
+      "Number of target rows updated by a matched clause"),
+    "numTargetRowsMatchedDeleted" -> SQLMetrics.createMetric(sparkContext,
+      "Number of target rows deleted by a matched clause"),
+    "numTargetRowsNotMatchedBySourceUpdated" -> SQLMetrics.createMetric(sparkContext,
+      "Number of target rows updated by a not matched by source clause"),
+    "numTargetRowsNotMatchedBySourceDeleted" -> SQLMetrics.createMetric(sparkContext,
+      "Number of target rows deleted by a not matched by source clause"))
 
   @transient override lazy val producedAttributes: AttributeSet = {
     AttributeSet(output.filterNot(attr => inputSet.contains(attr)))
@@ -113,11 +126,8 @@ case class MergeRowsExec(
 
   private def planInstructions(instructions: Seq[Instruction]): Seq[InstructionExec] = {
     instructions.map {
-      case Copy(output) =>
-        CopyExec(createProjection(output))
-
-      case Keep(cond, output) =>
-        KeepExec(createPredicate(cond), createProjection(output))
+      case Keep(context, cond, output) =>
+        KeepExec(context, createPredicate(cond), createProjection(output))
 
       case Discard(cond) =>
         DiscardExec(createPredicate(cond))
@@ -136,12 +146,8 @@ case class MergeRowsExec(
     def condition: BasePredicate
   }
 
-  case class CopyExec(projection: Projection) extends InstructionExec {
-    override lazy val condition: BasePredicate = createPredicate(TrueLiteral)
-    def apply(row: InternalRow): InternalRow = projection.apply(row)
-  }
-
   case class KeepExec(
+      context: Context,
       condition: BasePredicate,
       projection: Projection) extends InstructionExec {
     def apply(row: InternalRow): InternalRow = projection.apply(row)
@@ -219,9 +225,9 @@ case class MergeRowsExec(
 
       if (isTargetRowPresent && isSourceRowPresent) {
         cardinalityValidator.validate(row)
-        applyInstructions(row, matchedInstructions)
+        applyInstructions(row, matchedInstructions, sourcePresent = true)
       } else if (isSourceRowPresent) {
-        applyInstructions(row, notMatchedInstructions)
+        applyInstructions(row, notMatchedInstructions, sourcePresent = true)
       } else if (isTargetRowPresent) {
         applyInstructions(row, notMatchedBySourceInstructions)
       } else {
@@ -231,23 +237,32 @@ case class MergeRowsExec(
 
     private def applyInstructions(
         row: InternalRow,
-        instructions: Seq[InstructionExec]): InternalRow = {
+        instructions: Seq[InstructionExec],
+        sourcePresent: Boolean = false): InternalRow = {
 
       for (instruction <- instructions) {
         if (instruction.condition.eval(row)) {
           instruction match {
-            case copy: CopyExec =>
-              // group-based operations copy over target rows that didn't match any actions
-              longMetric("numTargetRowsCopied") += 1
-              return copy.apply(row)
-
             case keep: KeepExec =>
+              keep.context match {
+                case Copy => incrementCopyMetric()
+                case Update => incrementUpdateMetric(sourcePresent)
+                case Insert => incrementInsertMetric()
+                case Delete => incrementDeleteMetric(sourcePresent)
+                case _ => throw new IllegalArgumentException(
+                  s"Unexpected context for KeepExec: ${keep.context}")
+              }
+
               return keep.apply(row)
 
             case _: DiscardExec =>
+              incrementDeleteMetric(sourcePresent)
+
               return null
 
             case split: SplitExec =>
+              incrementUpdateMetric(sourcePresent)
+
               cachedExtraRow = split.projectExtraRow(row)
               return split.projectRow(row)
           }
@@ -255,6 +270,29 @@ case class MergeRowsExec(
       }
 
       null
+    }
+  }
+
+  // For group based merge, copy is inserted if row matches no other case
+  private def incrementCopyMetric(): Unit = longMetric("numTargetRowsCopied") += 1
+
+  private def incrementInsertMetric(): Unit = longMetric("numTargetRowsInserted") += 1
+
+  private def incrementDeleteMetric(sourcePresent: Boolean): Unit = {
+    longMetric("numTargetRowsDeleted") += 1
+    if (sourcePresent) {
+      longMetric("numTargetRowsMatchedDeleted") += 1
+    } else {
+      longMetric("numTargetRowsNotMatchedBySourceDeleted") += 1
+    }
+  }
+
+  private def incrementUpdateMetric(sourcePresent: Boolean): Unit = {
+    longMetric("numTargetRowsUpdated") += 1
+    if (sourcePresent) {
+      longMetric("numTargetRowsMatchedUpdated") += 1
+    } else {
+      longMetric("numTargetRowsNotMatchedBySourceUpdated") += 1
     }
   }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Add more metrics to MergeRowsExec: numTargetRowsInserted, numTargetRowsDeleted, numTargetRowsUpdated, numTargetRowsMatchedUpdated, numTargetRowsMatchedDeleted, numTargetRowsNotMatchedBySourceUpdated, numTargetRowsNotMatchedBySourceDeleted


### Why are the changes needed?
Help debug-ability of MERGE INTO operation by tracking how many rows fall into each case + action


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Add more unit test to MergeIntoTablesSuiteBase


### Was this patch authored or co-authored using generative AI tooling?
No
