### PR TITLE
[SPARK-52586][SQL] Introduce AnyTimeType

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/DataTypeAstBuilder.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/DataTypeAstBuilder.scala
@@ -70,7 +70,7 @@ class DataTypeAstBuilder extends SqlBaseParserBaseVisitor[AnyRef] {
    */
   override def visitTimeDataType(ctx: TimeDataTypeContext): DataType = withOrigin(ctx) {
     val precision = if (ctx.precision == null) {
-      TimeType.MICROS_PRECISION
+      TimeType.DEFAULT_PRECISION
     } else {
       ctx.precision.getText.toInt
     }

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
@@ -175,3 +175,17 @@ private[spark] object AnsiIntervalType extends AbstractDataType {
 
   override private[sql] def defaultConcreteType: DataType = DayTimeIntervalType()
 }
+
+/**
+ * A TIME type of any valid precision.
+ */
+private[sql] abstract class AnyTimeType extends DatetimeType
+
+private[spark] object AnyTimeType extends AbstractDataType {
+  override private[sql] def simpleString: String = "time"
+
+  override private[sql] def acceptsType(other: DataType): Boolean =
+    other.isInstanceOf[AnyTimeType]
+
+  override private[sql] def defaultConcreteType: DataType = TimeType(TimeType.DEFAULT_PRECISION)
+}

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/TimeType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/TimeType.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.errors.DataTypeErrors
  * @since 4.1.0
  */
 @Unstable
-case class TimeType(precision: Int) extends DatetimeType {
+case class TimeType(precision: Int) extends AnyTimeType {
 
   if (precision < TimeType.MIN_PRECISION || precision > TimeType.MAX_PRECISION) {
     throw DataTypeErrors.unsupportedTimePrecisionError(precision)
@@ -51,6 +51,7 @@ object TimeType {
   val MIN_PRECISION: Int = 0
   val MICROS_PRECISION: Int = 6
   val MAX_PRECISION: Int = MICROS_PRECISION
+  val DEFAULT_PRECISION: Int = MICROS_PRECISION
 
-  def apply(): TimeType = new TimeType(MICROS_PRECISION)
+  def apply(): TimeType = new TimeType(DEFAULT_PRECISION)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -2568,10 +2568,7 @@ case class MakeTimestampNTZ(left: Expression, right: Expression)
     Seq(left.dataType, right.dataType)
   )
 
-  override def inputTypes: Seq[AbstractDataType] =
-    Seq(
-      DateType,
-      TypeCollection(TimeType.MIN_PRECISION to TimeType.MAX_PRECISION map TimeType.apply: _*))
+  override def inputTypes: Seq[AbstractDataType] = Seq(DateType, AnyTimeType)
 
   override def prettyName: String = "make_timestamp_ntz"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.catalyst.util.TimeFormatter
 import org.apache.spark.sql.catalyst.util.TypeUtils.ordinalNumber
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.types.StringTypeWithCollation
-import org.apache.spark.sql.types.{AbstractDataType, DataType, DecimalType, IntegerType, ObjectType, TimeType, TypeCollection}
+import org.apache.spark.sql.types.{AbstractDataType, AnyTimeType, DataType, DecimalType, IntegerType, ObjectType, TimeType}
 import org.apache.spark.unsafe.types.UTF8String
 
 /**
@@ -208,8 +208,7 @@ case class MinutesOfTime(child: Expression)
     Seq(child.dataType)
   )
 
-  override def inputTypes: Seq[AbstractDataType] =
-    Seq(TypeCollection(TimeType.MIN_PRECISION to TimeType.MAX_PRECISION map TimeType.apply: _*))
+  override def inputTypes: Seq[AbstractDataType] = Seq(AnyTimeType)
 
   override def children: Seq[Expression] = Seq(child)
 
@@ -268,8 +267,7 @@ case class HoursOfTime(child: Expression)
     Seq(child.dataType)
   )
 
-  override def inputTypes: Seq[AbstractDataType] =
-    Seq(TypeCollection(TimeType.MIN_PRECISION to TimeType.MAX_PRECISION map TimeType.apply: _*))
+  override def inputTypes: Seq[AbstractDataType] = Seq(AnyTimeType)
 
   override def children: Seq[Expression] = Seq(child)
 
@@ -330,8 +328,7 @@ case class SecondsOfTimeWithFraction(child: Expression)
       Seq(child.dataType, IntegerType))
   }
 
-  override def inputTypes: Seq[AbstractDataType] =
-    Seq(TypeCollection(TimeType.MIN_PRECISION to TimeType.MAX_PRECISION map TimeType.apply: _*))
+  override def inputTypes: Seq[AbstractDataType] = Seq(AnyTimeType)
 
   override def children: Seq[Expression] = Seq(child)
 
@@ -353,8 +350,7 @@ case class SecondsOfTime(child: Expression)
     Seq(child.dataType)
   )
 
-  override def inputTypes: Seq[AbstractDataType] =
-    Seq(TypeCollection(TimeType.MIN_PRECISION to TimeType.MAX_PRECISION map TimeType.apply: _*))
+  override def inputTypes: Seq[AbstractDataType] = Seq(AnyTimeType)
 
   override def children: Seq[Expression] = Seq(child)
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz.sql.out
@@ -118,7 +118,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "inputSql" : "\"0:0:0\"",
     "inputType" : "\"STRING\"",
     "paramIndex" : "second",
-    "requiredType" : "(\"TIME(0)\" or \"TIME(1)\" or \"TIME(2)\" or \"TIME(3)\" or \"TIME(4)\" or \"TIME(5)\" or \"TIME(6)\")",
+    "requiredType" : "\"TIME\"",
     "sqlExpr" : "\"make_timestamp_ntz(DATE '2025-06-20', 0:0:0)\""
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/results/timestamp-ntz.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp-ntz.sql.out
@@ -142,7 +142,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "inputSql" : "\"0:0:0\"",
     "inputType" : "\"STRING\"",
     "paramIndex" : "second",
-    "requiredType" : "(\"TIME(0)\" or \"TIME(1)\" or \"TIME(2)\" or \"TIME(3)\" or \"TIME(4)\" or \"TIME(5)\" or \"TIME(6)\")",
+    "requiredType" : "\"TIME\"",
     "sqlExpr" : "\"make_timestamp_ntz(DATE '2025-06-20', 0:0:0)\""
   },
   "queryContext" : [ {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to introduce the abstract class `AnyTimeType` and its companion object that represents the TIME type of any valid precision. Also added the default precision value which is set to 6 (microseconds) at the moment.

### Why are the changes needed?
1. This abstract class (and its companion) can be used in checks of input types like `inputTypes()` of `ExpectsInputTypes`. Apparently, instead of pointing out all valid TIME types: TIME(0), TIME(1), ..., TIME(6), and in the future TIME(7)..TIME(9), devs could refer to only `AnyTimeType`.
2. Improve user-facing errors like `DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE` which mentions all precisions of the TIME type.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the affected and modified test suites:
```
$ build/sbt "test:testOnly *TimeExpressionsSuite"
$ build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z time.sql"
$ build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z timestamp-ntz.sql"
```

### Was this patch authored or co-authored using generative AI tooling?
No.