### PR TITLE
[SPARK-52587][SHELL] spark-shell 2.13 support `-i` `-I` parameter

### DIFF
--- a/repl/src/main/scala/org/apache/spark/repl/Main.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/Main.scala
@@ -57,7 +57,9 @@ object Main extends Logging {
 
   def main(args: Array[String]): Unit = {
     isShellSession = true
-    doMain(args, new SparkILoop)
+    val settings = new GenericRunnerSettings(scalaOptionError)
+    settings.processArguments(args.toList, true)
+    doMain(args, new SparkILoop(settings))
   }
 
   // Visible for testing

--- a/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -31,9 +31,15 @@ import scala.util.Properties.{javaVersion, javaVmName, versionString}
 /**
  *  A Spark-specific interactive shell.
  */
-class SparkILoop(in0: BufferedReader, out: PrintWriter)
-  extends ILoop(ShellConfig(new GenericRunnerSettings(_ => ())), in0, out) {
-  def this() = this(null, new PrintWriter(Console.out, true))
+class SparkILoop(config: ShellConfig, in0: BufferedReader, out: PrintWriter)
+  extends ILoop(config, in0, out) {
+  def this(in0: BufferedReader, out: PrintWriter) = this(
+    ShellConfig(new GenericRunnerSettings(_ => ())), in0, out)
+
+  def this(settings: Settings) = this(ShellConfig(settings), null,
+    new PrintWriter(Console.out, true))
+
+  def this() = this(new GenericRunnerSettings(_ => ()))
 
   val initializationCommands: Seq[String] = Seq(
     """


### PR DESCRIPTION
### What changes were proposed in this pull request?


### Why are the changes needed?

In spark-shell 2.12 we supported the `-i` and `-I` parameters, but in version 2.13, we did not support it.

https://github.com/apache/spark/blob/185380c414d2e9822b90a9c0a9e83052a4aa83c1/repl/src/main/scala-2.12/org/apache/spark/repl/SparkILoop.scala#L170-L180


---

If we correctly construct ShellConfig, we can reuse scala's processing `-i` and `-I` logic.

scala.tools.nsc.interpreter.shell.ILoop#interpretPreamble
```scala
    for (f <- filesToLoad) {
      loadCommand(f)
      addReplay(s":load $f")
    }
    for (f <- filesToPaste) {
      pasteCommand(f)
      addReplay(s":paste $f")
    }
```


### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
local test

### Was this patch authored or co-authored using generative AI tooling?
No