### PR TITLE
[SPARK-52547][INFRA][FOLLOW-UP] Set default GIT_BRANCH even for scheduled jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
           fi
 
           export ASF_PASSWORD GPG_PRIVATE_KEY GPG_PASSPHRASE ASF_USERNAME
-          export GIT_BRANCH
+          export GIT_BRANCH="${GIT_BRANCH:-master}"
           [ -n "$RELEASE_VERSION" ] && export RELEASE_VERSION
 
           if [ "$DRYRUN_MODE" = "1" ]; then


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/51245 that sets default GIT_BRANCH even for scheduled jobs.

### Why are the changes needed?

The main PR only fixes the case when the workflow is dispatched with inputs. For scheduled jobs, it does not use default values even so it has to be handled separately.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually via bash.

### Was this patch authored or co-authored using generative AI tooling?

No.