### PR TITLE
[SPARK-52592][PS] Support creating a ps.Series from a ps.Series

### DIFF
--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -369,6 +369,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     pandas-on-Spark Series that corresponds to pandas Series logically. This holds Spark Column
     internally.
 
+    .. versionchanged:: 4.1.0
+        Support construction from a pandas-on-Spark Series input, which can be used with
+        additional parameters index, dtype, and name for overriding the original value.
+
     :ivar _internal: an internal immutable Frame to manage metadata.
     :type _internal: InternalFrame
     :ivar _psdf: Parent's pandas-on-Spark DataFrame
@@ -415,7 +419,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             assert not fastpath
 
             if name:
-                data.name = name
+                data = data.rename(name)
 
             if index:
                 data = data.reindex(index)

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -398,14 +398,19 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         self._anchor: DataFrame  # type: ignore[annotation-unchecked]
         self._col_label: Label  # type: ignore[annotation-unchecked]
-        if isinstance(data, DataFrame):
+        if isinstance(data, (DataFrame, Series)):
             assert dtype is None
             assert name is None
             assert not copy
             assert not fastpath
 
-            self._anchor = data
-            self._col_label = index
+            if isinstance(data, Series):
+                assert index is None
+                self._anchor = DataFrame(data)
+                self._col_label = self._anchor._internal.column_labels[0]
+            else:
+                self._anchor = data
+                self._col_label = index
         else:
             if isinstance(data, pd.Series):
                 assert index is None

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -376,9 +376,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     Parameters
     ----------
-    data : array-like, dict, or scalar value, pandas Series
+    data : array-like, dict, or scalar value, pandas Series, pandas-on-Spark Series
         Contains data stored in Series
-        Note that if `data` is a pandas Series, other arguments should not be used.
+        Note that if `data` is a Series, index, dtype, or name can also be
+        specified to override the original value.
     index : array-like or Index (1d)
         Values must be hashable and have the same length as `data`.
         Non-unique index values are allowed. Will default to
@@ -387,6 +388,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         dict.
     dtype : numpy.dtype or None
         If None, dtype will be inferred
+    name : str, default None
+        The name to give to the Series.
     copy : boolean, default False
         Copy input data
     """

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -423,8 +423,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             if dtype:
                 data = data.astype(dtype)
 
-            self._anchor = DataFrame(data)
-            self._col_label = data._internal.column_labels[0]
+            anchor = DataFrame(data)
+            self._anchor = anchor
+            self._col_label = anchor._internal.column_labels[0]
+            object.__setattr__(anchor, "_psseries", {self._column_label: self})
         else:
             if isinstance(data, pd.Series):
                 assert index is None

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -398,19 +398,30 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         self._anchor: DataFrame  # type: ignore[annotation-unchecked]
         self._col_label: Label  # type: ignore[annotation-unchecked]
-        if isinstance(data, (DataFrame, Series)):
+        if isinstance(data, DataFrame):
             assert dtype is None
             assert name is None
             assert not copy
             assert not fastpath
 
-            if isinstance(data, Series):
-                assert index is None
-                self._anchor = DataFrame(data)
-                self._col_label = self._anchor._internal.column_labels[0]
-            else:
-                self._anchor = data
-                self._col_label = index
+            self._anchor = data
+            self._col_label = index
+
+        elif isinstance(data, Series):
+            assert not copy
+            assert not fastpath
+
+            if name:
+                data.name = name
+
+            if index:
+                data = data.reindex(index)
+
+            if dtype:
+                data = data.astype(dtype)
+
+            self._anchor = DataFrame(data)
+            self._col_label = data._internal.column_labels[0]
         else:
             if isinstance(data, pd.Series):
                 assert index is None

--- a/python/pyspark/pandas/tests/series/test_series.py
+++ b/python/pyspark/pandas/tests/series/test_series.py
@@ -106,7 +106,25 @@ class SeriesTestsMixin:
     def test_series_from_series(self):
         pser = ps.Series([1, 2, 3, 4, 5, 6, 7], name="x")
 
-        self.assert_eq(ps.Series(pser), pser)
+        pser_from_pser = ps.Series(pser)
+        self.assert_eq(pser_from_pser, pser)
+
+        pser = ps.Series([1, 2, 3])
+
+        # Specify new index
+        pser_from_pser = ps.Series(pser, index=[1])
+        self.assert_eq(pser_from_pser, ps.Series([2], index=[1]))
+
+        pser_from_pser = ps.Series(pser, index=[1, 2])
+        self.assert_eq(pser_from_pser, ps.Series([2, 3], index=[1, 2]))
+
+        # Specify new out-of-order index
+        pser_from_pser = ps.Series(pser, index=[1, 2, 0])
+        self.assert_eq(pser_from_pser, ps.Series([2, 3, 1], index=[1, 2, 0]))
+
+        # Specify new dtype and name
+        pser_from_pser = ps.Series(pser, name="y", dtype=float)
+        self.assert_eq(pser_from_pser, ps.Series([1, 2, 3], name="y", dtype=float))
 
     def test_all_null_series(self):
         pser_a = pd.Series([None, None, None], dtype="float64")

--- a/python/pyspark/pandas/tests/series/test_series.py
+++ b/python/pyspark/pandas/tests/series/test_series.py
@@ -103,6 +103,12 @@ class SeriesTestsMixin:
 
         self.assertTrue(pser_a.empty)
 
+    def test_series_from_series(self):
+        pser = ps.Series([1, 2, 3, 4, 5, 6, 7], name="x")
+
+        self.assert_eq(ps.Series(pser), pser)
+        self.assert_eq(ps.Series(pser, name="y"), pser.rename("y"))
+
     def test_all_null_series(self):
         pser_a = pd.Series([None, None, None], dtype="float64")
         pser_b = pd.Series([None, None, None], dtype="str")

--- a/python/pyspark/pandas/tests/series/test_series.py
+++ b/python/pyspark/pandas/tests/series/test_series.py
@@ -107,7 +107,6 @@ class SeriesTestsMixin:
         pser = ps.Series([1, 2, 3, 4, 5, 6, 7], name="x")
 
         self.assert_eq(ps.Series(pser), pser)
-        self.assert_eq(ps.Series(pser, name="y"), pser.rename("y"))
 
     def test_all_null_series(self):
         pser_a = pd.Series([None, None, None], dtype="float64")

--- a/python/pyspark/pandas/tests/series/test_series.py
+++ b/python/pyspark/pandas/tests/series/test_series.py
@@ -104,27 +104,27 @@ class SeriesTestsMixin:
         self.assertTrue(pser_a.empty)
 
     def test_series_from_series(self):
-        pser = ps.Series([1, 2, 3, 4, 5, 6, 7], name="x")
+        psser = ps.Series([1, 2, 3, 4, 5, 6, 7], name="x")
 
-        pser_from_pser = ps.Series(pser)
-        self.assert_eq(pser_from_pser, pser)
+        psser_from_psser = ps.Series(psser)
+        self.assert_eq(psser_from_psser, psser)
 
-        pser = ps.Series([1, 2, 3])
+        psser = ps.Series([1, 2, 3])
 
         # Specify new index
-        pser_from_pser = ps.Series(pser, index=[1])
-        self.assert_eq(pser_from_pser, ps.Series([2], index=[1]))
+        psser_from_psser = ps.Series(psser, index=[1])
+        self.assert_eq(psser_from_psser, ps.Series([2], index=[1]))
 
-        pser_from_pser = ps.Series(pser, index=[1, 2])
-        self.assert_eq(pser_from_pser, ps.Series([2, 3], index=[1, 2]))
+        psser_from_psser = ps.Series(psser, index=[1, 2])
+        self.assert_eq(psser_from_psser, ps.Series([2, 3], index=[1, 2]))
 
         # Specify new out-of-order index
-        pser_from_pser = ps.Series(pser, index=[1, 2, 0])
-        self.assert_eq(pser_from_pser, ps.Series([2, 3, 1], index=[1, 2, 0]))
+        psser_from_psser = ps.Series(psser, index=[1, 2, 0])
+        self.assert_eq(psser_from_psser, ps.Series([2, 3, 1], index=[1, 2, 0]))
 
         # Specify new dtype and name
-        pser_from_pser = ps.Series(pser, name="y", dtype=float)
-        self.assert_eq(pser_from_pser, ps.Series([1, 2, 3], name="y", dtype=float))
+        psser_from_psser = ps.Series(psser, name="y", dtype=float)
+        self.assert_eq(psser_from_psser, ps.Series([1, 2, 3], name="y", dtype=float))
 
     def test_all_null_series(self):
         pser_a = pd.Series([None, None, None], dtype="float64")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
I fixed the constructor to explicitly handle `Series` input similar to how it handles `DataFrame` input. It previously would fall to the else case that inputs it into a regular pandas Series constructor, leading to the error.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Previously, this code
```
obj = ps.Series([x for x in range(3)])
obj = ps.Series(obj)
```
would error:
```
...
pyspark.pandas.exceptions.PandasNotImplementedError: The method `pd.Series.__iter__()` is not implemented. If you want to collect your data as an NumPy array, use 'to_numpy()' instead.
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, previously, when you try to pass a `ps.Series` object into the `ps.Series.__init__()`, you can an error. Now, it will work successfully similar to how traditional pandas Series works.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Yes, I added a test.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
