### PR TITLE
[SPARK-52597][SS][TESTS] Fix the execution failure of `StateStoreBasicOperationsBenchmark`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/StateStoreBasicOperationsBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/StateStoreBasicOperationsBenchmark.scala
@@ -17,12 +17,15 @@
 
 package org.apache.spark.sql.execution.benchmark
 
+import java.util.UUID
+
 import scala.util.Random
 
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.execution.streaming.StreamExecution
 import org.apache.spark.sql.execution.streaming.state.{HDFSBackedStateStoreProvider, NoPrefixKeyStateEncoderSpec, RocksDBStateStoreProvider, StateStore, StateStoreConf, StateStoreId, StateStoreProvider}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType, TimestampType}
@@ -477,11 +480,16 @@ object StateStoreBasicOperationsBenchmark extends SqlBasedBenchmark {
     val sqlConf = new SQLConf()
     sqlConf.setConfString("spark.sql.streaming.stateStore.rocksdb.trackTotalNumberOfRows",
       trackTotalNumberOfRows.toString)
+    sqlConf.setConfString("spark.sql.streaming.stateStore.coordinatorReportSnapshotUploadLag",
+      false.toString)
     val storeConf = new StateStoreConf(sqlConf)
+
+    val configuration = new Configuration
+    configuration.set(StreamExecution.RUN_ID_KEY, UUID.randomUUID().toString)
 
     provider.init(
       storeId, keySchema, valueSchema, NoPrefixKeyStateEncoderSpec(keySchema),
-      useColumnFamilies = useColumnFamilies, storeConf, new Configuration,
+      useColumnFamilies = useColumnFamilies, storeConf, configuration,
       useMultipleValuesPerKey = useMultipleValuesPerKey)
     provider
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr has made the following changes to fix the `StateStoreBasicOperationsBenchmark`:

1. Following the suggestion from @zecookiez, set "spark.sql.streaming.stateStore.coordinatorReportSnapshotUploadLag" to false when initializing `StateStoreConf`.
2. When initializing the `RocksDBStateStoreProvider`, populate the `StreamExecution.RUN_ID_KEY` for the incoming Hadoop `Configuration`.


### Why are the changes needed?
Fix the execution failure of `StateStoreBasicOperationsBenchmark`:

```
build/sbt "sql/Test/runMain org.apache.spark.sql.execution.benchmark.StateStoreBasicOperationsBenchmark"
[error] Exception in thread "main" java.lang.AssertionError: assertion failed
[error] 	at scala.Predef$.assert(Predef.scala:264)
[error] 	at org.apache.spark.sql.execution.streaming.state.StateStoreProvider$.getRunId(StateStore.scala:673)
[error] 	at org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider.init(RocksDBStateStoreProvider.scala:394)
[error] 	at org.apache.spark.sql.execution.benchmark.StateStoreBasicOperationsBenchmark$.newRocksDBStateProvider(StateStoreBasicOperationsBenchmark.scala:484)
[error] 	at org.apache.spark.sql.execution.benchmark.StateStoreBasicOperationsBenchmark$.$anonfun$runPutBenchmark$3(StateStoreBasicOperationsBenchmark.scala:92)
[error] 	at scala.runtime.java8.JFunction1$mcVI$sp.apply(JFunction1$mcVI$sp.scala:18)
[error] 	at scala.collection.immutable.List.foreach(List.scala:334)
[error] 	at org.apache.spark.sql.execution.benchmark.StateStoreBasicOperationsBenchmark$.$anonfun$runPutBenchmark$2(StateStoreBasicOperationsBenchmark.scala:87)
[error] 	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
[error] 	at org.apache.spark.benchmark.BenchmarkBase.runBenchmark(BenchmarkBase.scala:42)
[error] 	at org.apache.spark.sql.execution.benchmark.StateStoreBasicOperationsBenchmark$.runPutBenchmark(StateStoreBasicOperationsBenchmark.scala:83)
[error] 	at org.apache.spark.sql.execution.benchmark.StateStoreBasicOperationsBenchmark$.runBenchmarkSuite(StateStoreBasicOperationsBenchmark.scala:55)
[error] 	at org.apache.spark.benchmark.BenchmarkBase.main(BenchmarkBase.scala:72)
[error] 	at org.apache.spark.sql.execution.benchmark.StateStoreBasicOperationsBenchmark.main(StateStoreBasicOperationsBenchmark.scala)
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- It has been locally confirmed that the `StateStoreBasicOperationsBenchmark` can be executed successfully.


### Was this patch authored or co-authored using generative AI tooling?
No
