### PR TITLE
[SPARK-52593][PS] Avoid CAST_INVALID_INPUT of `MultiIndex.to_series`, `Series.dot` and `DataFrame.dot` in ANSI mode

### DIFF
--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -928,11 +928,11 @@ class Index(IndexOpsMixin):
                 field_names = result._internal.spark_type_for(
                     scol
                 ).fieldNames()  # type: ignore[attr-defined]
-                field_types = [result._internal.spark_type_for(scol[field]) for field in field_names]
+                field_types = [
+                    result._internal.spark_type_for(scol[field]) for field in field_names
+                ]
 
-                has_str = (
-                    any(isinstance(t, StringType) for t in field_types)
-                )
+                has_str = any(isinstance(t, StringType) for t in field_types)
                 if is_ansi_mode_enabled and has_str:
                     return F.array([scol[field].cast(StringType()) for field in field_names])
                 else:

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -933,7 +933,7 @@ class Index(IndexOpsMixin):
                 ]
 
                 has_str = any(isinstance(t, StringType) for t in field_types)
-                if is_ansi_mode_enabled(self._internal.spark_frame.sparkSession) and has_str:
+                if has_str and is_ansi_mode_enabled(self._internal.spark_frame.sparkSession):
                     return F.array([scol[field].cast(StringType()) for field in field_names])
                 else:
                     return F.array([scol[field] for field in field_names])

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -50,6 +50,7 @@ from pyspark.sql import functions as F
 from pyspark.sql.types import (
     DayTimeIntervalType,
     IntegralType,
+    StringType,
     TimestampType,
     TimestampNTZType,
 )
@@ -62,6 +63,7 @@ from pyspark.pandas.missing.indexes import MissingPandasLikeIndex
 from pyspark.pandas.series import Series, first_series
 from pyspark.pandas.spark.accessors import SparkIndexMethods
 from pyspark.pandas.utils import (
+    is_ansi_mode_enabled,
     is_name_like_tuple,
     is_name_like_value,
     name_like_string,
@@ -926,7 +928,15 @@ class Index(IndexOpsMixin):
                 field_names = result._internal.spark_type_for(
                     scol
                 ).fieldNames()  # type: ignore[attr-defined]
-                return F.array([scol[field] for field in field_names])
+                field_types = [result._internal.spark_type_for(scol[field]) for field in field_names]
+
+                has_str = (
+                    any(isinstance(t, StringType) for t in field_types)
+                )
+                if is_ansi_mode_enabled and has_str:
+                    return F.array([scol[field].cast(StringType()) for field in field_names])
+                else:
+                    return F.array([scol[field] for field in field_names])
 
             return result.spark.transform(struct_to_array)
 

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -933,7 +933,7 @@ class Index(IndexOpsMixin):
                 ]
 
                 has_str = any(isinstance(t, StringType) for t in field_types)
-                if is_ansi_mode_enabled and has_str:
+                if is_ansi_mode_enabled(self._internal.spark_frame.sparkSession) and has_str:
                     return F.array([scol[field].cast(StringType()) for field in field_names])
                 else:
                     return F.array([scol[field] for field in field_names])

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_dot_frame.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_dot_frame.py
@@ -21,7 +21,6 @@ from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
-from pyspark.testing.utils import is_ansi_mode_test, ansi_mode_not_supported_message
 
 
 class DiffFramesDotFrameMixin:
@@ -35,7 +34,6 @@ class DiffFramesDotFrameMixin:
         reset_option("compute.ops_on_diff_frames")
         super().tearDownClass()
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_frame_dot(self):
         pdf = pd.DataFrame([[0, 1, -2, -1], [1, 1, 1, 1]])
         psdf = ps.from_pandas(pdf)

--- a/python/pyspark/pandas/tests/indexes/test_conversion.py
+++ b/python/pyspark/pandas/tests/indexes/test_conversion.py
@@ -185,6 +185,12 @@ class ConversionMixin:
 
         self.assert_eq((psidx + 1).to_series(), (pidx + 1).to_series())
 
+        # Multiindex
+        arrays = [[1, 2], ["red", "blue"]]
+        psidx = ps.MultiIndex.from_arrays(arrays, names=("number", "color"))
+        res_psser = psidx.to_series()
+        self.assert_eq(list(res_psser.values), [["1", "red"], ["2", "blue"]])
+
         pidx = self.pdf.set_index("b", append=True).index
         psidx = self.psdf.set_index("b", append=True).index
 

--- a/python/pyspark/pandas/tests/indexes/test_conversion.py
+++ b/python/pyspark/pandas/tests/indexes/test_conversion.py
@@ -189,6 +189,7 @@ class ConversionMixin:
         arrays = [[1, 2], ["red", "blue"]]
         psidx = ps.MultiIndex.from_arrays(arrays, names=("number", "color"))
         res_psser = psidx.to_series()
+        # TODO(SPARK-53050): MultiIndex.to_series() should return tuples for each entry
         self.assert_eq(list(res_psser.values), [["1", "red"], ["2", "blue"]])
 
         pidx = self.pdf.set_index("b", append=True).index

--- a/python/pyspark/pandas/tests/series/test_series.py
+++ b/python/pyspark/pandas/tests/series/test_series.py
@@ -30,7 +30,6 @@ from pyspark.testing.pandasutils import (
     SPARK_CONF_ARROW_ENABLED,
 )
 from pyspark.testing.sqlutils import SQLTestUtils
-from pyspark.testing.utils import is_ansi_mode_test, ansi_mode_not_supported_message
 from pyspark.pandas.exceptions import PandasNotImplementedError
 from pyspark.pandas.missing.series import MissingPandasLikeSeries
 from pyspark.pandas.typedef.typehints import extension_object_dtypes_available
@@ -685,7 +684,6 @@ class SeriesTestsMixin:
             self.assert_eq(p_name, k_name)
             self.assert_eq(p_items, k_items)
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_dot(self):
         pdf = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
         psdf = ps.from_pandas(pdf)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Under ANSI, `MultiIndex.to_series` fails with CAST_INVALID_INPUT, which further fails `Series.dot` and `DataFrame.dot`.

The PR aims to avoid CAST_INVALID_INPUT in the above three API.

### Why are the changes needed?
Ensure pandas on Spark works well with ANSI mode on.
Part of https://issues.apache.org/jira/browse/SPARK-52556.

### Does this PR introduce _any_ user-facing change?
Yes. The root cause `MultiIndex.to_series` works as show below:

```py
>>> arrays = [[1,  2], ["red", "blue"]]
>>> pidx = pd.MultiIndex.from_arrays(arrays, names=("number", "color"))
>>> psidx = ps.from_pandas(pidx)
```

FROM
```py
>>> psidx.to_series()
...
org.apache.spark.SparkNumberFormatException: [CAST_INVALID_INPUT] The value 'blue' of the type "STRING" cannot be cast to "BIGINT" because it is malformed. Correct the value as per the syntax, or change its target type. Use `try_cast` to tolerate malformed input and return NULL instead. SQLSTATE: 22018
...
```

TO
```py
>>> psidx.to_series()
number  color
1       red       [1, red]
2       blue     [2, blue]
dtype: object
```

So `Series.dot` and `DataFrame.dot` work under ANSI.

### How was this patch tested?
Unit tests.
Commands below pass.

```
 1019  SPARK_ANSI_SQL_MODE=true ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.indexes.test_conversion ConversionTests.test_to_series"
 1020  SPARK_ANSI_SQL_MODE=false ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.indexes.test_conversion ConversionTests.test_to_series"
```

```
 1060  SPARK_ANSI_SQL_MODE=true  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.series.test_series SeriesTests.test_dot"
 1061  SPARK_ANSI_SQL_MODE=false  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.series.test_series SeriesTests.test_dot"
```



### Was this patch authored or co-authored using generative AI tooling?
No