### PR TITLE
[SPARK-51051][SQL]Add an optional parameter for `array_position` function to specify starting index for matching.

### DIFF
--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -1782,9 +1782,8 @@ def cardinality(col: "ColumnOrName") -> Column:
 cardinality.__doc__ = pysparkfuncs.cardinality.__doc__
 
 
-def array_position(col: "ColumnOrName", value: Any) -> Column:
-    return _invoke_function("array_position", _to_col(col), lit(value))
-
+def array_position(col: "ColumnOrName", value: Any, start: Union[Column, int] = 1) -> Column:
+    return _invoke_function("array_position", _to_col(col), lit(value), lit(start))
 
 array_position.__doc__ = pysparkfuncs.array_position.__doc__
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -18453,7 +18453,7 @@ def concat(*cols: "ColumnOrName") -> Column:
 
 
 @_try_remote_functions
-def array_position(col: "ColumnOrName", value: Any) -> Column:
+def array_position(col: "ColumnOrName", value: Any, start: Union[Column, int] = None) -> Column:
     """
     Array function: Locates the position of the first occurrence of the given value
     in the given array. Returns null if either of the arguments are null.
@@ -18462,6 +18462,9 @@ def array_position(col: "ColumnOrName", value: Any) -> Column:
 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
+
+    .. versionchanged:: 4.1.0
+        Supports start index.
 
     Notes
     -----
@@ -18477,6 +18480,8 @@ def array_position(col: "ColumnOrName", value: Any) -> Column:
 
         .. versionchanged:: 4.0.0
             `value` now also accepts a Column type.
+    start : :class:`~pyspark.sql.Column` or int, optional
+        the starting index to search from.
 
     Returns
     -------
@@ -18545,7 +18550,7 @@ def array_position(col: "ColumnOrName", value: Any) -> Column:
     Example 6: Finding the position of a column's value in an array of integers
 
     >>> from pyspark.sql import functions as sf
-    >>> df = spark.createDataFrame([([10, 20, 30], 20)], ['data', 'col'])
+    >>> df = spark.createDataFrame([([10, 20, 20], 20)], ['data', 'col'])
     >>> df.select(sf.array_position(df.data, df.col)).show()
     +-------------------------+
     |array_position(data, col)|
@@ -18553,8 +18558,22 @@ def array_position(col: "ColumnOrName", value: Any) -> Column:
     |                        2|
     +-------------------------+
 
+    Example 7: Finding the position of a column's value in an array of integers starting from the index 3
+
+    >>> from pyspark.sql import functions as sf
+    >>> df = spark.createDataFrame([([10, 20, 20], 20, 3)], ['data', 'col'])
+    >>> df.select(sf.array_position(df.data, df.col)).show()
+    +-------------------------+
+    |array_position(data, col)|
+    +-------------------------+
+    |                        3|
+    +-------------------------+
+
     """
-    return _invoke_function_over_columns("array_position", col, lit(value))
+    if start is None:
+        return _invoke_function_over_columns("array_position", col, lit(value))
+    else:
+        return _invoke_function_over_columns("array_position", col, lit(value), lit(start))
 
 
 @_try_remote_functions

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -6344,6 +6344,20 @@ object functions {
     Column.fn("array_position", column, lit(value))
 
   /**
+   * Locates the position of the first occurrence of the value in the given array after the given 
+   * start position. Returns null if either of the arguments are null.
+   *
+   * @note
+   *   The position is not zero based, but 1 based index. Returns 0 if value could not be found in
+   *   array.
+   *
+   * @group array_funcs
+   * @since 2.4.0
+   */
+  def array_position(column: Column, value: Any, pos: Any): Column =
+    Column.fn("array_position", column, lit(value), lit(pos))
+
+  /**
    * Returns element of array at given index in value if column is array. Returns value for the
    * given key in value if column is map.
    *

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -6344,7 +6344,7 @@ object functions {
     Column.fn("array_position", column, lit(value))
 
   /**
-   * Locates the position of the first occurrence of the value in the given array after the given 
+   * Locates the position of the first occurrence of the value in the given array after the given
    * start position. Returns null if either of the arguments are null.
    *
    * @note

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2443,8 +2443,8 @@ case class ArrayMax(child: Expression)
  */
 @ExpressionDescription(
   usage = """
-    _FUNC_(array, element[, startExpr]) - Returns the (1-based) index of the first matching element of
-      the array after the start index as long, or 0 if no match is found.
+    _FUNC_(array, element[, startExpr]) - Returns the (1-based) index of the first matching element
+      of the array after the start index as long, or 0 if no match is found.
   """,
   examples = """
     Examples:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2433,18 +2433,18 @@ case class ArrayMax(child: Expression)
 
 
 /**
- * Returns the position of the first occurrence of element in the given array after 
- *       the given start index as long.
+ * Returns the position of the first occurrence of element in the given array after the
+ *       given start index as long.
  * Returns 0 if the given value could not be found in the array after the given start
  *       index. Returns null if either of the arguments are null
  *
- * NOTE: that this is not zero based, but 1-based index. The first element in the array has
- *       index 1.
+ * NOTE: that this is not zero based, but 1-based index. The first element in the array
+ *       has index 1.
  */
 @ExpressionDescription(
   usage = """
     _FUNC_(array, element[, startExpr]) - Returns the (1-based) index of the first matching element of
-      the array after the start index as long, or 0 if no match is found. 
+      the array after the start index as long, or 0 if no match is found.
   """,
   examples = """
     Examples:

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1862,29 +1862,36 @@ class CollectionExpressionsSuite
     val a1 = Literal.create(Seq[String](null, ""), ArrayType(StringType))
     val a2 = Literal.create(Seq(null), ArrayType(LongType))
     val a3 = Literal.create(null, ArrayType(StringType))
+    val a4 = Literal.create(Seq(1, null, 2, 3), ArrayType(IntegerType))
 
-    checkEvaluation(ArrayPosition(a0, Literal(3)), 4L)
-    checkEvaluation(ArrayPosition(a0, Literal(1)), 1L)
-    checkEvaluation(ArrayPosition(a0, Literal(0)), 0L)
-    checkEvaluation(ArrayPosition(a0, Literal.create(null, IntegerType)), null)
+    checkEvaluation(new ArrayPosition(a0, Literal(3)), 4L)
+    checkEvaluation(new ArrayPosition(a0, Literal(1)), 1L)
+    checkEvaluation(new ArrayPosition(a0, Literal(0)), 0L)
+    checkEvaluation(new ArrayPosition(a0, Literal.create(null, IntegerType)), null)
 
-    checkEvaluation(ArrayPosition(a1, Literal("")), 2L)
-    checkEvaluation(ArrayPosition(a1, Literal("a")), 0L)
-    checkEvaluation(ArrayPosition(a1, Literal.create(null, StringType)), null)
+    checkEvaluation(new ArrayPosition(a1, Literal("")), 2L)
+    checkEvaluation(new ArrayPosition(a1, Literal("a")), 0L)
+    checkEvaluation(new ArrayPosition(a1, Literal.create(null, StringType)), null)
 
-    checkEvaluation(ArrayPosition(a2, Literal(1L)), 0L)
-    checkEvaluation(ArrayPosition(a2, Literal.create(null, LongType)), null)
+    checkEvaluation(new ArrayPosition(a2, Literal(1L)), 0L)
+    checkEvaluation(new ArrayPosition(a2, Literal.create(null, LongType)), null)
 
-    checkEvaluation(ArrayPosition(a3, Literal("")), null)
-    checkEvaluation(ArrayPosition(a3, Literal.create(null, StringType)), null)
+    checkEvaluation(new ArrayPosition(a3, Literal("")), null)
+    checkEvaluation(new ArrayPosition(a3, Literal.create(null, StringType)), null)
+
+    checkEvaluation(new ArrayPosition(a4, Literal(""), Literal(1)), null)
+    checkEvaluation(new ArrayPosition(a4, Literal.create(null, StringType), Literal(1)), null)
+    checkEvaluation(new ArrayPosition(a4, Literal.create(1, IntegerType), Literal.create(null, IntegerType)), null)
 
     val aa0 = Literal.create(Seq[Seq[Int]](Seq[Int](1, 2), Seq[Int](3, 4)),
       ArrayType(ArrayType(IntegerType)))
     val aa1 = Literal.create(Seq[Seq[Int]](Seq[Int](5, 6), Seq[Int](2, 1)),
       ArrayType(ArrayType(IntegerType)))
     val aae = Literal.create(Seq[Int](1, 2), ArrayType(IntegerType))
-    checkEvaluation(ArrayPosition(aa0, aae), 1L)
-    checkEvaluation(ArrayPosition(aa1, aae), 0L)
+    checkEvaluation(new ArrayPosition(aa0, aae), 1L)
+    checkEvaluation(new ArrayPosition(aa1, aae), 0L)
+    checkEvaluation(new ArrayPosition(aa0, aae, Literal(1)), 1L)
+    checkEvaluation(new ArrayPosition(aa0, aae, Literal(2)), 0L)
   }
 
   test("elementAt") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1881,7 +1881,8 @@ class CollectionExpressionsSuite
 
     checkEvaluation(new ArrayPosition(a4, Literal(""), Literal(1)), null)
     checkEvaluation(new ArrayPosition(a4, Literal.create(null, StringType), Literal(1)), null)
-    checkEvaluation(new ArrayPosition(a4, Literal.create(1, IntegerType), Literal.create(null, IntegerType)), null)
+    checkEvaluation(new ArrayPosition(a4, Literal.create(1, IntegerType),
+      Literal.create(null, IntegerType)), null)
 
     val aa0 = Literal.create(Seq[Seq[Int]](Seq[Int](1, 2), Seq[Int](3, 4)),
       ArrayType(ArrayType(IntegerType)))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add an optional parameter for `array_position` function to specify starting index for matching.

### Why are the changes needed?
Provide the functionality like Postgresql supporting the third parameter (https://www.postgresql.org/docs/17/functions-array.html )

### Does this PR introduce _any_ user-facing change?
New capability to support the third parameter in the array_position function to specify starting index for matching.

### How was this patch tested?
Add test cases to existing UTs.

### Was this patch authored or co-authored using generative AI tooling?
No.