### PR TITLE
[SPARK-52613][CORE][SQL] Restore printing full stacktrace when HBase/Hive DelegationTokenProvider hit exception

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/security/HBaseDelegationTokenProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/HBaseDelegationTokenProvider.scala
@@ -54,8 +54,8 @@ private[security] class HBaseDelegationTokenProvider
       creds.addToken(token.getService, token)
     } catch {
       case NonFatal(e) =>
-        logWarning(Utils.createFailedToGetTokenMessage(serviceName, e) + log" Retrying to fetch " +
-          log"HBase security token with ${MDC(SERVICE_NAME, serviceName)} connection parameter.")
+        logWarning(Utils.createFailedToGetTokenMessage(serviceName) + log" Retrying to fetch " +
+          log"HBase security token with ${MDC(SERVICE_NAME, serviceName)} connection parameter.", e)
         // Seems to be spark is trying to get the token from HBase 2.x.x  version or above where the
         // obtainToken(Configuration conf) API has been removed. Lets try obtaining the token from
         // another compatible API of HBase service.
@@ -98,7 +98,7 @@ private[security] class HBaseDelegationTokenProvider
       creds.addToken(token.getService, token)
     } catch {
       case NonFatal(e) =>
-        logWarning(Utils.createFailedToGetTokenMessage(serviceName, e))
+        logWarning(Utils.createFailedToGetTokenMessage(serviceName), e)
     } finally {
       if (null != hbaseConnection) {
         hbaseConnection.close()

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -3060,9 +3060,9 @@ private[spark] object Utils
   }
 
   /** Returns a string message about delegation token generation failure */
-  def createFailedToGetTokenMessage(serviceName: String, e: scala.Throwable): MessageWithContext = {
-    log"Failed to get token from service ${MDC(SERVICE_NAME, serviceName)} " +
-      log"due to ${MDC(ERROR, e)}. If ${MDC(SERVICE_NAME, serviceName)} is not used, " +
+  def createFailedToGetTokenMessage(serviceName: String): MessageWithContext = {
+    log"Failed to get token from service ${MDC(SERVICE_NAME, serviceName)}. " +
+      log"If ${MDC(SERVICE_NAME, serviceName)} is not used, " +
       log"set spark.security.credentials.${MDC(SERVICE_NAME, serviceName)}.enabled to false."
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/security/HiveDelegationTokenProvider.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/security/HiveDelegationTokenProvider.scala
@@ -114,7 +114,7 @@ private[spark] class HiveDelegationTokenProvider
       None
     } catch {
       case NonFatal(e) =>
-        logWarning(Utils.createFailedToGetTokenMessage(serviceName, e))
+        logWarning(Utils.createFailedToGetTokenMessage(serviceName), e)
         None
       case e: NoClassDefFoundError =>
         logWarning(classNotFoundErrorStr)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
After SPARK-35747(3.2.0), Spark stops printing full stacktrace when HBase/Hive/Kafka DelegationTokenProvider hit exceptions. 

SPARK-35747 actually makes two changes:
1. Remove full stacktrace from logs
2. Guide disabling unused DelegationTokenProvider - `If $serviceName is not used, set spark.security.credentials.$serviceName.enabled to false`

I think 2 is useful, but 1 is incorrect, this PR logically reverts 1 (changes in KafkaDelegationTokenProvider have been reverted in SPARK-47593(4.0.0))

We recently hit an issue related to HBaseDelegationTokenProvider, the printed error message is
```
[WARN] [main] HBaseDelegationTokenProvider#94 - Failed to get token from service hbase due to java.lang.reflect.InvocationTargetException. If hbase is not used, set spark.security.credentials.hbase.enabled to false. Retrying to fetch HBase security token with hbase connection parameter.
```
it makes us think it's related to a classpath issue, but eventually, after we changed the code to print the full stacktrace, we found the root cause is
```
org.apache.hadoop.hbase.security.AccessDeniedException: Insufficient permissions (user=***/***@***.COM, scope=hbase:meta, params=[table=hbase:meta,],action=EXEC)
```
Full stacktrace: https://gist.github.com/pan3793/46a3f6b956a7982646e1ee75603a1865

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Improve the diagnosis experience.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, the user would see rich error messages when HBase/Hive DelegationTokenProvider hit exceptions.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Manual test.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.