### PR TITLE
[SPARK-52626][SQL] Allow grouping by the time type

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashMapGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashMapGenerator.scala
@@ -160,7 +160,8 @@ abstract class HashMapGenerator(
       case BooleanType => hashInt(s"$input ? 1 : 0")
       case ByteType | ShortType | IntegerType | DateType | _: YearMonthIntervalType =>
         hashInt(input)
-      case LongType | TimestampType | TimestampNTZType | _: DayTimeIntervalType => hashLong(input)
+      case LongType | TimestampType | TimestampNTZType | _: DayTimeIntervalType | _: TimeType =>
+        hashLong(input)
       case FloatType => hashInt(s"Float.floatToIntBits($input)")
       case DoubleType => hashLong(s"Double.doubleToLongBits($input)")
       case d: DecimalType =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -2903,7 +2903,7 @@ class DataFrameAggregateSuite extends QueryTest
     assert(badAgg2.checkInputDataTypes().isFailure)
   }
 
-  test("Support group by Time column") {
+  test("SPARK-52626: Support group by Time column") {
     val ts1 = "15:00:00"
     val ts2 = "22:00:00"
     val localTime = Seq(ts1, ts1, ts2).map(LocalTime.parse)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql
 
 import java.sql.{Date, Timestamp}
-import java.time.{Duration, LocalDateTime, Period}
+import java.time.{Duration, LocalDateTime, LocalTime, Period}
 
 import scala.util.Random
 
@@ -2901,6 +2901,17 @@ class DataFrameAggregateSuite extends QueryTest
       maxItemsTracked = Sum(BoundReference(1, LongType, nullable = true))
     )
     assert(badAgg2.checkInputDataTypes().isFailure)
+  }
+
+  test("Support group by Time column") {
+    val ts1 = "15:00:00"
+    val ts2 = "22:00:00"
+    val localTime = Seq(ts1, ts1, ts2).map(LocalTime.parse)
+    val df = localTime.toDF("t").groupBy("t").count().orderBy("t")
+    val expectedSchema =
+      new StructType().add(StructField("t", TimeType())).add("count", LongType, false)
+    assert (df.schema == expectedSchema)
+    checkAnswer(df, Seq(Row(LocalTime.parse(ts1), 2), Row(LocalTime.parse(ts2), 1)))
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support the time type in `HashMapGenerator#genComputeHash`.

### Why are the changes needed?

Allow grouping by the time type when wholestage codegen is on (it already works when wholestage codegen is off).

### Does this PR introduce _any_ user-facing change?

No. The time type is not released yet.

### How was this patch tested?

New test.

### Was this patch authored or co-authored using generative AI tooling?

No.