### PR TITLE
[SPARK-52622][PS] Avoid CAST_INVALID_INPUT of `DataFrame.melt` in ANSI mode

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -10617,18 +10617,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         else:
             var_name = [var_name]  # type: ignore[list-item]
 
-        value_col_names = [
-            name_like_string(label) for label in column_labels if label in value_vars
-        ]
         value_col_types = [
-            self._internal.spark_frame.schema[col].dataType for col in value_col_names
+            self._internal.spark_column_for(label).expr.dataType for label in value_vars
         ]
         # If any value column is of StringType, cast all value columns to StringType to avoid
         # ANSI mode errors during explode - mixing strings and integers.
         string_cast_required_type = (
             StringType() if any(isinstance(t, StringType) for t in value_col_types) else None
         )
-        use_cast = is_ansi_mode_enabled(self._internal.spark_frame.sql_ctx.sparkSession)
+        use_cast = is_ansi_mode_enabled(self._internal.spark_frame.sparkSession)
 
         pairs = F.explode(
             F.array(

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -10617,12 +10617,33 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         else:
             var_name = [var_name]  # type: ignore[list-item]
 
+        value_col_names = [
+            name_like_string(label) for label in column_labels if label in value_vars
+        ]
+        value_col_types = [
+            self._internal.spark_frame.schema[col].dataType for col in value_col_names
+        ]
+        # If any value column is of StringType, cast all value columns to StringType to avoid
+        # ANSI mode errors during explode - mixing strings and integers.
+        string_cast_required_type = (
+            StringType() if any(isinstance(t, StringType) for t in value_col_types) else None
+        )
+        use_cast = is_ansi_mode_enabled(self._internal.spark_frame.sql_ctx.sparkSession)
+
         pairs = F.explode(
             F.array(
                 *[
                     F.struct(
                         *[F.lit(c).alias(name) for c, name in zip(label, var_name)],
-                        *[self._internal.spark_column_for(label).alias(value_name)],
+                        *[
+                            (
+                                self._internal.spark_column_for(label).cast(
+                                    string_cast_required_type
+                                )
+                                if use_cast and string_cast_required_type is not None
+                                else self._internal.spark_column_for(label)
+                            ).alias(value_name)
+                        ],
                     )
                     for label in column_labels
                     if label in value_vars


### PR DESCRIPTION
### What changes were proposed in this pull request?
Avoid CAST_INVALID_INPUT of `DataFrame.melt` in ANSI mode

### Why are the changes needed?
Ensure pandas on Spark works well with ANSI mode on.
Part of https://issues.apache.org/jira/browse/SPARK-52556.

### Does this PR introduce _any_ user-facing change?
Yes, `DataFrame.melt` work well with ANSI.

```py
>>> import pandas as pd
>>> import numpy as np
>>> 
>>> ps.set_option("compute.fail_on_ansi_mode", False)
>>> ps.set_option("compute.ansi_mode_support", True)
>>> df = ps.DataFrame({'A': {0: 'a', 1: 'b', 2: 'c'},
... 'B': {0: 1, 1: 3, 2: 5},
... 'C': {0: 2, 1: 4, 2: 6}},
... columns=['A', 'B', 'C'])
```

BEFORE
```py
>>> ps.melt(df)
...
pyspark.errors.exceptions.captured.NumberFormatException: [CAST_INVALID_INPUT] The value 'a' of the type "STRING" cannot be cast to "BIGINT" because it is malformed. Correct the value as per the syntax, or change its target type. Use `try_cast` to tolerate malformed input and return NULL instead. SQLSTATE: 22018
```

AFTER
```py
>>> ps.melt(df)
  variable value                                                                
0        A     a
1        B     1
2        C     2
3        A     b
4        B     3
5        C     4
6        A     c
7        B     5
8        C     6
```

### How was this patch tested?
Unit tests. Commands below pass

```
SPARK_ANSI_SQL_MODE=true ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.computation.test_melt FrameMeltTests.test_melt"

SPARK_ANSI_SQL_MODE=false ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.computation.test_melt FrameMeltTests.test_melt"
```

### Was this patch authored or co-authored using generative AI tooling?
No