### PR TITLE
[SPARK-52515][SQL][TESTS][FOLLOW-UP] Explicitly enable ANSI for overflow error case

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -2760,19 +2760,21 @@ class DataFrameAggregateSuite extends QueryTest
   }
 
   test("SPARK-52515: invalid k value > Int.MaxValue") {
-    val k: Long = Int.MaxValue + 1L
-    checkError(
-      exception = intercept[SparkArithmeticException] {
-        sql(s"SELECT approx_top_k(expr, $k) FROM VALUES (0), (1), (2) AS tab(expr);").collect()
-      },
-      condition = "CAST_OVERFLOW",
-      parameters = Map(
-        "value" -> (k.toString + "L"),
-        "sourceType" -> "\"BIGINT\"",
-        "targetType" -> "\"INT\"",
-        "ansiConfig" -> "\"spark.sql.ansi.enabled\""
+    withSQLConf("spark.sql.ansi.enabled" -> true.toString) {
+      val k: Long = Int.MaxValue + 1L
+      checkError(
+        exception = intercept[SparkArithmeticException] {
+          sql(s"SELECT approx_top_k(expr, $k) FROM VALUES (0), (1), (2) AS tab(expr);").collect()
+        },
+        condition = "CAST_OVERFLOW",
+        parameters = Map(
+          "value" -> (k.toString + "L"),
+          "sourceType" -> "\"BIGINT\"",
+          "targetType" -> "\"INT\"",
+          "ansiConfig" -> "\"spark.sql.ansi.enabled\""
+        )
       )
-    )
+    }
   }
 
   test("SPARK-52515: invalid k value null") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/51236 that explicily enables ANSI for overflow error test case


### Why are the changes needed?

The non-ANSI build is broken https://github.com/apache/spark/actions/runs/15987607479

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No