### PR TITLE
[SPARK-52632][SQL] Pretty display V2 write plan nodes

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/noop/NoopDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/noop/NoopDataSource.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.internal.connector.{SimpleTableProvider, SupportsStr
 import org.apache.spark.sql.sources.DataSourceRegister
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.util.Utils
 
 /**
  * This is no-op datasource. It does not do anything besides consuming its input.
@@ -48,6 +49,7 @@ private[noop] object NoopTable extends Table with SupportsWrite {
       TableCapability.TRUNCATE,
       TableCapability.ACCEPT_ANY_SCHEMA)
   }
+  override def toString: String = Utils.getFormattedClassName(this)
 }
 
 private[noop] object NoopWriteBuilder extends WriteBuilder
@@ -59,7 +61,7 @@ private[noop] object NoopWriteBuilder extends WriteBuilder
 private[noop] object NoopWrite extends Write {
   override def toBatch: BatchWrite = NoopBatchWrite
   override def toStreaming: StreamingWrite = NoopStreamingWrite
-  override def toString: String = "NoopWrite"
+  override def toString: String = Utils.getFormattedClassName(this)
 }
 
 private[noop] object NoopBatchWrite extends BatchWrite {
@@ -68,7 +70,7 @@ private[noop] object NoopBatchWrite extends BatchWrite {
   override def useCommitCoordinator(): Boolean = false
   override def commit(messages: Array[WriterCommitMessage]): Unit = {}
   override def abort(messages: Array[WriterCommitMessage]): Unit = {}
-  override def toString: String = "NoopBatchWrite"
+  override def toString: String = Utils.getFormattedClassName(this)
 }
 
 private[noop] object NoopWriterFactory extends DataWriterFactory {
@@ -88,7 +90,7 @@ private[noop] object NoopStreamingWrite extends StreamingWrite {
   override def useCommitCoordinator(): Boolean = false
   override def commit(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}
   override def abort(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}
-  override def toString: String = "NoopStreamingWrite"
+  override def toString: String = Utils.getFormattedClassName(this)
 }
 
 private[noop] object NoopStreamingDataWriterFactory extends StreamingDataWriterFactory {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/noop/NoopDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/noop/NoopDataSource.scala
@@ -59,6 +59,7 @@ private[noop] object NoopWriteBuilder extends WriteBuilder
 private[noop] object NoopWrite extends Write {
   override def toBatch: BatchWrite = NoopBatchWrite
   override def toStreaming: StreamingWrite = NoopStreamingWrite
+  override def toString: String = "NoopWrite"
 }
 
 private[noop] object NoopBatchWrite extends BatchWrite {
@@ -67,6 +68,7 @@ private[noop] object NoopBatchWrite extends BatchWrite {
   override def useCommitCoordinator(): Boolean = false
   override def commit(messages: Array[WriterCommitMessage]): Unit = {}
   override def abort(messages: Array[WriterCommitMessage]): Unit = {}
+  override def toString: String = "NoopBatchWrite"
 }
 
 private[noop] object NoopWriterFactory extends DataWriterFactory {
@@ -86,6 +88,7 @@ private[noop] object NoopStreamingWrite extends StreamingWrite {
   override def useCommitCoordinator(): Boolean = false
   override def commit(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}
   override def abort(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}
+  override def toString: String = "NoopStreamingWrite"
 }
 
 private[noop] object NoopStreamingDataWriterFactory extends StreamingDataWriterFactory {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
@@ -303,8 +303,6 @@ case class ReplaceDataExec(
     projections: ReplaceDataProjections,
     write: Write) extends V2ExistingTableWriteExec {
 
-  override val stringArgs: Iterator[Any] = Iterator(query, write)
-
   override def writingTask: WritingSparkTask[_] = {
     projections match {
       case ReplaceDataProjections(dataProj, Some(metadataProj)) =>
@@ -328,8 +326,6 @@ case class WriteDeltaExec(
     projections: WriteDeltaProjections,
     write: DeltaWrite) extends V2ExistingTableWriteExec {
 
-  override lazy val stringArgs: Iterator[Any] = Iterator(query, write)
-
   override lazy val writingTask: WritingSparkTask[_] = {
     if (projections.metadataProjection.isDefined) {
       DeltaWithMetadataWritingSparkTask(projections)
@@ -349,6 +345,8 @@ case class WriteToDataSourceV2Exec(
     query: SparkPlan,
     writeMetrics: Seq[CustomMetric]) extends V2TableWriteExec {
 
+  override val stringArgs: Iterator[Any] = Iterator(batchWrite, query)
+
   override val customMetrics: Map[String, SQLMetric] = writeMetrics.map { customMetric =>
     customMetric.name() -> SQLMetrics.createV2CustomMetric(sparkContext, customMetric)
   }.toMap
@@ -366,6 +364,8 @@ case class WriteToDataSourceV2Exec(
 trait V2ExistingTableWriteExec extends V2TableWriteExec {
   def refreshCache: () => Unit
   def write: Write
+
+  override val stringArgs: Iterator[Any] = Iterator(query, write)
 
   override val customMetrics: Map[String, SQLMetric] =
     write.supportedCustomMetrics().map { customMetric =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Pretty display V2 write plan nodes by overriding `def stringArgs`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Better UX for UI display and `EXPLAIN` output

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, change affects UI display and `EXPLAIN` output for V2 write cases.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Use AppendData as an example.

Before
<img width="1721" alt="Xnip2025-07-01_16-39-59" src="https://github.com/user-attachments/assets/9dcab5e2-c768-45a3-8c0b-f7059c8c1389" />
After
<img width="1712" alt="Xnip2025-07-01_16-30-00" src="https://github.com/user-attachments/assets/fd3fdd7c-da5e-49be-b801-f3debde02808" />

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.