### PR TITLE
[SPARK-52636][K8S] Support `java_image_name` ARG in K8s `Dockerfile`

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+ARG java_image_name=azul/zulu-openjdk
 ARG java_image_tag=21
 
-FROM azul/zulu-openjdk:${java_image_tag}
+FROM ${java_image_name}:${java_image_tag}
 LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.ref.name="Apache Spark Scala/Java Image"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `java_image_name` ARG in K8s `Dockerfile`.

### Why are the changes needed?

Until now, we didn't parameterize K8s Docker image name because it's difficult to change the underlying OS distribution. However, if a user can provide a compatible (or forked) image, we had better allow it at the user's own risk. For instances,
- A user may want to upgrade to `Ubuntu 24.04` because `azul/zulu-openjdk` is still based on `Ubuntu 22.04`.
- A user may want to use `azul/zulu-openjdk-alpine` instead of `azul/zulu-openjdk`. Of course, the user should provide a compatible image (based on `azul/zulu-openjdk-alpine`).
- A user may want to use a different JDK like `eclipse-temurin` which is based on `Ubuntu 24.04`.
```
bin/docker-image-tool.sh -t testing -b java_image_name=eclipse-temurin -n build
```

### Does this PR introduce _any_ user-facing change?

No behavior change because we still use the default value is the same image name which we used so far.

### How was this patch tested?

Manually test.

### Was this patch authored or co-authored using generative AI tooling?

No.