### PR TITLE
[SPARK-52638][SQL] Allow preserving Hive-style column order to be configurable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5989,6 +5989,16 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val HIVE_PRESERVE_LEGACY_COLUMN_ORDER =
+    buildConf("spark.sql.hive.preserveLegacyColumnOrder.enabled")
+      .internal()
+      .doc("When true, tables returned from HiveExternalCatalog preserve Hive-style column order " +
+        "where the partition columns are at the end.  Otherwise, the user-specified column order " +
+        "is returned.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(true)
+
   /**
    * Holds information about keys that have been deprecated.
    *

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5993,8 +5993,8 @@ object SQLConf {
     buildConf("spark.sql.legacy.preserveHiveColumnOrder")
       .internal()
       .doc("When true, tables created by HiveExternalCatalog will maintain Hive-style column " +
-        "order where the partition columns are at the end. " +
-        "Otherwise, use the user-specified column order.")
+        "order where the partition columns are at the end. Otherwise, use the user-specified " +
+        "column order. Does not affect tables with provider = `hive`")
       .version("4.1.0")
       .booleanConf
       .createWithDefault(true)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5989,12 +5989,12 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val HIVE_PRESERVE_LEGACY_COLUMN_ORDER =
-    buildConf("spark.sql.hive.preserveLegacyColumnOrder.enabled")
+  val LEGACY_PRESERVE_HIVE_COLUMN_ORDER =
+    buildConf("spark.sql.legacy.preserveHiveColumnOrder")
       .internal()
-      .doc("When true, tables returned from HiveExternalCatalog preserve Hive-style column order " +
-        "where the partition columns are at the end.  Otherwise, the user-specified column order " +
-        "is returned.")
+      .doc("When true, tables created by HiveExternalCatalog will maintain Hive-style column " +
+        "order where the partition columns are at the end. " +
+        "Otherwise, use the user-specified column order.")
       .version("4.1.0")
       .booleanConf
       .createWithDefault(true)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -820,8 +820,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
   // from the table properties.
   private def reorderSchema(schema: StructType, partColumnNames: Seq[String]): StructType = {
     if (conf.get(HIVE_PRESERVE_LEGACY_COLUMN_ORDER)) {
-      schema
-    } else {
       val partitionFields = partColumnNames.map { partCol =>
         schema.find(_.name == partCol).getOrElse {
           throw new AnalysisException(
@@ -832,6 +830,8 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
         }
       }
       StructType(schema.filterNot(partitionFields.contains) ++ partitionFields)
+    } else {
+      schema
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -36,9 +36,10 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
-import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogV2Util, Identifier, TableChange, TableInfo}
+import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogV2Util, Identifier, TableCatalog, TableChange, TableInfo}
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces.PROP_OWNER
+import org.apache.spark.sql.connector.expressions.Expressions
 import org.apache.spark.sql.execution.command.{DDLSuite, DDLUtils}
 import org.apache.spark.sql.execution.datasources.orc.OrcCompressionCodec
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetCompressionCodec, ParquetFooterReader}
@@ -3430,6 +3431,36 @@ class HiveDDLSuite
       verify(spyCatalog, times(1)).alterTable(any[CatalogTable])
       verify(spyCatalog, times(1)).alterTableDataSchema(
         any[String], any[String], any[StructType])
+    }
+  }
+
+  test("SPARK-52638: Allow preserving Hive-style column order to be configurable") {
+    val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
+    withSQLConf(
+      SQLConf.HIVE_PRESERVE_LEGACY_COLUMN_ORDER.key -> "false"
+    ) {
+      withTable("t1") {
+        val identifier = Identifier.of(Array("default"), "t1")
+        val outputSchema = new StructType()
+          .add("a", IntegerType, true, "comment1")
+          .add("b", IntegerType, true, "comment2")
+          .add("c", IntegerType, true, "comment3")
+          .add("d", IntegerType, true, "comment4")
+        catalog.createTable(
+          identifier,
+          new TableInfo.Builder()
+            .withProperties(Map.empty.asJava)
+            .withColumns(CatalogV2Util.structTypeToV2Columns(outputSchema))
+            .withPartitions(Array(Expressions.identity("a")))
+            .build()
+        )
+        val cols = catalog.loadTable(identifier).columns()
+        assert(cols.length == 4)
+        assert(cols(0).name() == "a")
+        assert(cols(1).name() == "b")
+        assert(cols(2).name() == "c")
+        assert(cols(3).name() == "d")
+      }
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -3437,7 +3437,7 @@ class HiveDDLSuite
   test("SPARK-52638: Allow preserving Hive-style column order to be configurable") {
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
     withSQLConf(
-      SQLConf.HIVE_PRESERVE_LEGACY_COLUMN_ORDER.key -> "false"
+      SQLConf.LEGACY_PRESERVE_HIVE_COLUMN_ORDER.key -> "false"
     ) {
       withTable("t1") {
         val identifier = Identifier.of(Array("default"), "t1")
@@ -3454,12 +3454,29 @@ class HiveDDLSuite
             .withPartitions(Array(Expressions.identity("a")))
             .build()
         )
-        val cols = catalog.loadTable(identifier).columns()
+        val table1 = catalog.loadTable(identifier)
+        val cols = table1.columns()
         assert(cols.length == 4)
         assert(cols(0).name() == "a")
         assert(cols(1).name() == "b")
         assert(cols(2).name() == "c")
         assert(cols(3).name() == "d")
+        assert(table1.properties().get("spark.sql.legacy.preserveHiveColumnOrder") == "false")
+
+        catalog.alterTable(
+          identifier,
+          TableChange.addColumn(Array("e"), IntegerType)
+        )
+
+        val table2 = catalog.loadTable(identifier)
+        val cols2 = table2.columns()
+        assert(cols2.length == 5)
+        assert(cols2(0).name() == "a")
+        assert(cols2(1).name() == "b")
+        assert(cols2(2).name() == "c")
+        assert(cols2(3).name() == "d")
+        assert(cols2(4).name() == "e")
+        assert(table2.properties().get("spark.sql.legacy.preserveHiveColumnOrder") == "false")
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a flag "spark.sql.hive.legacy.preserveHiveColumnOrder" to determine whether HiveExternalCatalog persists a table where schema preserves the Hive-style column order (schema at end), or the original user-specified column order when creating the table.


### Why are the changes needed?
Previously Spark relied heavily on Hive behavior.  Nowadays, there are more catalogs, especially with DSV2 API.  None of the other catalogs re-order the columns so that the partition columns are at the end.  Many systems now expect to work on any catalog, and this makes the expectation hard.

This was from the discussion here: https://github.com/apache/spark/pull/51280#discussion_r2175154462

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add test to HiveDDLSuite


### Was this patch authored or co-authored using generative AI tooling?
No
