### PR TITLE
[SPARK-52665][BUILD] Fix make-distribution.sh [: missing `]'

### DIFF
--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -133,7 +133,7 @@ if [ $(command -v git) ]; then
     unset GITREV
 fi
 
-if [ "$SBT_ENABLED" == "true" && ! "$(command -v "$SBT")" ]; then
+if [ "$SBT_ENABLED" == "true" ] && [ ! "$(command -v "$SBT")" ]; then
   echo -e "Could not locate SBT command: '$SBT'."
   echo -e "Specify the SBT command with the --sbt flag"
   exit -1;


### PR DESCRIPTION
### What changes were proposed in this pull request?


### Why are the changes needed?

```bash
./dev/make-distribution.sh: line 136: [: missing `]'
```

https://github.com/koalaman/shellcheck/wiki/SC2107


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
local test


### Was this patch authored or co-authored using generative AI tooling?
No
