### PR TITLE
[SPARK-52670][SQL] Make HiveResult work with UserDefinedType#stringifyValue

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
@@ -149,6 +149,6 @@ object HiveResult extends SQLConfHelper {
         startField,
         endField)
     case (v: VariantVal, VariantType) => v.toString
-    case (other, _: UserDefinedType[_]) => other.toString
+    case (other, u: UserDefinedType[_]) => u.stringifyValue(other)
   }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?

Make HiveResult work with UserDefinedType#stringifyValue


### Why are the changes needed?

If the `toString` of the underlying class of a UDT is not well-defined, the JDBC/thrift side might not be able to get a meaningful value.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
new tests

### Was this patch authored or co-authored using generative AI tooling?
no
