### PR TITLE
[SPARK-52671][SQL] RowEncoder shall not lookup a resolved UDT

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -8345,11 +8345,6 @@
       "Failed to get outer pointer for <innerCls>."
     ]
   },
-  "_LEGACY_ERROR_TEMP_2155" : {
-    "message" : [
-      "<userClass> is not annotated with SQLUserDefinedType nor registered with UDTRegistration.}"
-    ]
-  },
   "_LEGACY_ERROR_TEMP_2163" : {
     "message" : [
       "Initial type <dataType> must be a <target>."

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/ExecutionErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/ExecutionErrors.scala
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.spark.{QueryContext, SparkArithmeticException, SparkBuildInfo, SparkDateTimeException, SparkException, SparkRuntimeException, SparkUnsupportedOperationException, SparkUpgradeException}
 import org.apache.spark.sql.catalyst.WalkedTypePath
 import org.apache.spark.sql.internal.SqlApiConf
-import org.apache.spark.sql.types.{DataType, DoubleType, StringType, UserDefinedType}
+import org.apache.spark.sql.types.{DataType, DoubleType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
 
 private[sql] trait ExecutionErrors extends DataTypeErrorsBase {
@@ -158,13 +158,6 @@ private[sql] trait ExecutionErrors extends DataTypeErrorsBase {
     new SparkUnsupportedOperationException(
       errorClass = "UNSUPPORTED_DATATYPE",
       messageParameters = Map("typeName" -> toSQLType(typeName)))
-  }
-
-  def userDefinedTypeNotAnnotatedAndRegisteredError(udt: UserDefinedType[_]): Throwable = {
-    new SparkException(
-      errorClass = "_LEGACY_ERROR_TEMP_2155",
-      messageParameters = Map("userClass" -> udt.userClass.getName),
-      cause = null)
   }
 
   def cannotFindEncoderForTypeError(typeName: String): SparkUnsupportedOperationException = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.DataTypeTestUtils.{dayTimeIntervalTypes, yearMonthIntervalTypes}
 
-@SQLUserDefinedType(udt = classOf[ExamplePointUDT])
 class ExamplePoint(val x: Double, val y: Double) extends Serializable {
   override def hashCode: Int = 41 * (41 + x.toInt) + y.toInt
   override def equals(that: Any): Boolean = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.DataTypeTestUtils.{dayTimeIntervalTypes, yearMonthIntervalTypes}
 
+@SQLUserDefinedType(udt = classOf[ExamplePointUDT])
 class ExamplePoint(val x: Double, val y: Double) extends Serializable {
   override def hashCode: Int = 41 * (41 + x.toInt) + y.toInt
   override def equals(that: Any): Boolean = {
@@ -74,6 +75,26 @@ class ExamplePointUDT extends UserDefinedType[ExamplePoint] {
   private[spark] override def asNullable: ExamplePointUDT = this
 }
 
+class ExamplePointNotAnnotated(val x: Double, val y: Double) extends Serializable {
+  private val inner = new ExamplePoint(x, y)
+  override def hashCode: Int = inner.hashCode
+  override def equals(that: Any): Boolean = {
+    that match {
+      case e: ExamplePointNotAnnotated => inner.equals(e.inner)
+      case _ => false
+    }
+  }
+}
+class ExamplePointNotAnnotatedUDT extends UserDefinedType[ExamplePointNotAnnotated] {
+  override def sqlType: DataType = DoubleType
+  override def serialize(p: ExamplePointNotAnnotated): Double = p.x
+  override def deserialize(datum: Any): ExamplePointNotAnnotated = {
+    val x = datum.asInstanceOf[Double]
+    new ExamplePointNotAnnotated(x, 3.14 * datum.asInstanceOf[Double])
+  }
+  override def userClass: Class[ExamplePointNotAnnotated] = classOf[ExamplePointNotAnnotated]
+}
+
 class RowEncoderSuite extends CodegenInterpretedPlanTest {
 
   private val structOfString = new StructType().add("str", StringType)
@@ -110,7 +131,8 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
       .add("binary", BinaryType)
       .add("date", DateType)
       .add("timestamp", TimestampType)
-      .add("udt", new ExamplePointUDT))
+      .add("udt", new ExamplePointUDT)
+      .add("udtNotAnnotated", new ExamplePointNotAnnotatedUDT))
 
   encodeDecodeTest(
     new StructType()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a bug shown below
```sql
spark-sql (default)> select submissionTime from bbb;
xxx
spark-sql (default)> cache table a as select submissionTime from bbb;
org.apache.spark.SparkException: xxx is not annotated with SQLUserDefinedType nor registered with UDTRegistration.}
	at org.apache.spark.sql.errors.ExecutionErrors.userDefinedTypeNotAnnotatedAndRegisteredError(ExecutionErrors.scala:167)
	at org.apache.spark.sql.errors.ExecutionErrors.userDefinedTypeNotAnnotatedAndRegisteredError$(ExecutionErrors.scala:163)
	at org.apache.spark.sql.errors.ExecutionErrors$.userDefinedTypeNotAnnotatedAndRegisteredError(ExecutionErrors.scala:259)
	at org.apache.spark.sql.catalyst.encoders.RowEncoder$.$anonfun$encoderForDataType$1(RowEncoder.scala:108)
	at scala.Option.getOrElse(Option.scala:201)
	at org.apache.spark.sql.catalyst.encoders.RowEncoder$.encoderForDataType(RowEncoder.scala:108)
	at org.apache.spark.sql.catalyst.encoders.RowEncoder$.$anonfun$encoderForDataType$2(RowEncoder.scala:128)
	at scala.collection.ArrayOps$.map$extension(ArrayOps.scala:936)
	at org.apache.spark.sql.catalyst.encoders.RowEncoder$.encoderForDataType(RowEncoder.scala:125)
	at org.apache.spark.sql.catalyst.encoders.RowEncoder$.encoderFor(RowEncoder.scala:69)
	at org.apache.spark.sql.catalyst.encoders.RowEncoder$.encoderFor(RowEncoder.scala:65)
	at org.apache.spark.sql.classic.Dataset.toDF(Dataset.scala:519)
	at org.apache.spark.sql.classic.Dataset.groupBy(Dataset.scala:941)
	at org.apache.spark.sql.classic.Dataset.count(Dataset.scala:1501)
```

The RowEncoder tried to relookup a UDT which is already resolved




### Why are the changes needed?
bugfix


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?

modified tests in sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala


### Was this patch authored or co-authored using generative AI tooling?
no