### PR TITLE
[SPARK-52674][SQL] Clean up the usage of deprecated APIs related to `RandomStringUtils`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ConstantColumnVectorBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ConstantColumnVectorBenchmark.scala
@@ -268,7 +268,7 @@ object ConstantColumnVectorBenchmark extends BenchmarkBase {
 
     Seq(1, 5, 10, 15, 20, 30).foreach { length =>
       val builder = new UTF8StringBuilder()
-      builder.append(RandomStringUtils.random(length))
+      builder.append(RandomStringUtils.secure.next(length))
       val row = InternalRow(builder.build())
       testWrite(valuesPerIteration, batchSize, StringType, row)
     }
@@ -281,7 +281,7 @@ object ConstantColumnVectorBenchmark extends BenchmarkBase {
 
     Seq(1, 5, 10, 15, 20, 30).foreach { length =>
       val builder = new UTF8StringBuilder()
-      builder.append(RandomStringUtils.random(length))
+      builder.append(RandomStringUtils.secure.next(length))
       val row = InternalRow(builder.build())
       testRead(valuesPerIteration, batchSize, StringType, row)
     }
@@ -293,7 +293,7 @@ object ConstantColumnVectorBenchmark extends BenchmarkBase {
 
     Seq(1, 5, 10, 15, 20, 30).foreach { length =>
       val builder = new UTF8StringBuilder()
-      builder.append(RandomStringUtils.random(length))
+      builder.append(RandomStringUtils.secure.next(length))
       val row = InternalRow(builder.build())
       testWriteAndRead(valuesPerIteration, batchSize, StringType, row)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/CompressionSchemeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/CompressionSchemeBenchmark.scala
@@ -222,7 +222,7 @@ object CompressionSchemeBenchmark extends BenchmarkBase with AllCompressionSchem
     val testData = allocateLocal(count * (4 + strLen))
 
     val g = {
-      val dataTable = (0 until tableSize).map(_ => RandomStringUtils.randomAlphabetic(strLen))
+      val dataTable = (0 until tableSize).map(_ => RandomStringUtils.secure.nextAlphabetic(strLen))
       val rng = genHigherSkewData()
       () => dataTable(rng().toInt % tableSize)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaLengthByteArrayEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaLengthByteArrayEncodingSuite.scala
@@ -135,7 +135,7 @@ class ParquetDeltaLengthByteArrayEncodingSuite
       if (randomEmpty.nextInt() % 11 != 0) {
         maxLen = 0;
       }
-      samples(i) = RandomStringUtils.randomAlphanumeric(0, maxLen)
+      samples(i) = RandomStringUtils.secure.nextAlphanumeric(0, maxLen)
     }
     samples
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -104,12 +104,14 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
       var cpDir: String = null
 
       def startQuery(restart: Boolean): StreamingQuery = {
-        if (cpDir == null || !restart) cpDir = s"$dir/${RandomStringUtils.randomAlphabetic(10)}"
+        if (cpDir == null || !restart) {
+          cpDir = s"$dir/${RandomStringUtils.secure.nextAlphabetic(10)}"
+        }
         MemoryStream[Int].toDS().groupBy().count()
           .writeStream
           .format("memory")
           .outputMode("complete")
-          .queryName(s"name${RandomStringUtils.randomAlphabetic(10)}")
+          .queryName(s"name${RandomStringUtils.secure.nextAlphabetic(10)}")
           .option("checkpointLocation", cpDir)
           .start()
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr aims to clean up the usage of deprecated APIs related to `RandomStringUtils`, the relevant modifications were made with reference to:

- https://github.com/apache/commons-lang/blob/29ccc7665f3bc5d84155a3092ab2209a053324e6/src/main/java/org/apache/commons/lang3/RandomStringUtils.java#L113-L128

![image](https://github.com/user-attachments/assets/3005f7d6-1d70-4be9-9b0f-c66f00ce3cd7)


- https://github.com/apache/commons-lang/blob/29ccc7665f3bc5d84155a3092ab2209a053324e6/src/main/java/org/apache/commons/lang3/RandomStringUtils.java#L394-L409

![image](https://github.com/user-attachments/assets/7bb1d559-290b-4cc6-81d2-3ebd324294ff)


- https://github.com/apache/commons-lang/blob/29ccc7665f3bc5d84155a3092ab2209a053324e6/src/main/java/org/apache/commons/lang3/RandomStringUtils.java#L411-L427

![image](https://github.com/user-attachments/assets/70a97170-0bda-490d-9d81-9af326d52715)


### Why are the changes needed?
Clean up deprecated APIs usage.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
Noa
