### PR TITLE
[SPARK-51516][SQL] Support TIME by the Thrift server

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -340,6 +340,7 @@ object SparkExecuteStatementOperation {
     case _: StringType => TTypeId.STRING_TYPE
     case _: DecimalType => TTypeId.DECIMAL_TYPE
     case DateType => TTypeId.DATE_TYPE
+    case _: TimeType => TTypeId.STRING_TYPE
     // TODO: Shall use TIMESTAMPLOCALTZ_TYPE, keep AS-IS now for
     // unnecessary behavior change
     case TimestampType => TTypeId.TIMESTAMP_TYPE

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerQueryTestSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerQueryTestSuite.scala
@@ -110,9 +110,7 @@ class ThriftServerQueryTestSuite extends SQLQueryTestSuite with SharedThriftServ
     "pipe-operators.sql",
     // VARIANT type
     "variant/named-function-arguments.sql",
-    "variant-field-extractions.sql",
-    // SPARK-51516: Support the TIME data type by Thrift Server
-    "time.sql"
+    "variant-field-extractions.sql"
   )
 
   override def runQueries(


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to convert `TIME` values to `TypeId.STRING_TYPE` because hive's Thrift server doesn't support any time type. And enable `time.sql` in the test suite `ThriftServerQueryTestSuite`.

### Why are the changes needed?
To extend test coverage, and check TIME in Thrift server tests.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running affected test suites:
```
$ build/sbt -Phive-thriftserver "hive-thriftserver/testOnly org.apache.spark.sql.hive.thriftserver.ThriftServerQueryTestSuite -- -z time.sql"
```


### Was this patch authored or co-authored using generative AI tooling?
No.
