### PR TITLE
[SPARK-52646][PS] Avoid CAST_INVALID_INPUT of `__eq__` in ANSI mode

### DIFF
--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -116,7 +116,7 @@ def _should_return_all_false(left: IndexOpsLike, right: Any) -> bool:
     based on incompatible dtypes: non-numeric vs. numeric (including bools).
     """
     from pyspark.pandas.base import IndexOpsMixin
-    from pandas.api.types import is_list_like
+    from pandas.api.types import is_list_like  # type: ignore[attr-defined]
 
     def are_both_numeric(left_dtype: Dtype, right_dtype: Dtype) -> bool:
         return is_numeric_dtype(left_dtype) and is_numeric_dtype(right_dtype)

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -115,10 +115,10 @@ def _should_return_all_false(left: IndexOpsLike, right: Any) -> bool:
     Determine if binary comparison should short-circuit to all False,
     based on incompatible dtypes: non-numeric vs. numeric (including bools).
     """
-    from pandas.api.types import is_numeric_dtype
+    from pandas.core.dtypes.common import is_numeric_dtype
     from pyspark.pandas.base import IndexOpsMixin
 
-    def are_both_numeric(left_dtype, right_dtype) -> bool:
+    def are_both_numeric(left_dtype: Dtype, right_dtype: Dtype) -> bool:
         return is_numeric_dtype(left_dtype) and is_numeric_dtype(right_dtype)
 
     left_dtype = left.dtype
@@ -419,7 +419,7 @@ class DataTypeOps(object, metaclass=ABCMeta):
     def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession):
             if _should_return_all_false(left, right):
-                return left._with_new_scol(F.lit(False)).rename(None)
+                return left._with_new_scol(F.lit(False)).rename(None)  # type: ignore[attr-defined]
 
         if isinstance(right, (list, tuple)):
             from pyspark.pandas.series import first_series, scol_for

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -417,16 +417,14 @@ class DataTypeOps(object, metaclass=ABCMeta):
         raise TypeError(">= can not be applied to %s." % self.pretty_name)
 
     def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.internal import InternalField
-
         if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession):
             if _should_return_all_false(left, right):
-                return left._with_new_scol(F.lit(False))
+                return left._with_new_scol(F.lit(False)).rename(None)
 
         if isinstance(right, (list, tuple)):
             from pyspark.pandas.series import first_series, scol_for
             from pyspark.pandas.frame import DataFrame
-            from pyspark.pandas.internal import NATURAL_ORDER_COLUMN_NAME
+            from pyspark.pandas.internal import NATURAL_ORDER_COLUMN_NAME, InternalField
 
             if len(left) != len(right):
                 raise ValueError("Lengths must be equal")

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -511,20 +511,6 @@ class DataTypeOps(object, metaclass=ABCMeta):
         else:
             from pyspark.pandas.base import column_op
 
-            if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession):
-                # Handle bool vs. non-bool numeric comparisons
-                left_is_bool = _is_boolean_type(left)
-                right_is_non_bool_numeric = is_numeric_dtype(right) and not _is_boolean_type(right)
-                if left_is_bool and right_is_non_bool_numeric:
-                    if isinstance(right, numbers.Number):
-                        left = transform_boolean_operand_to_numeric(
-                            left, spark_type=as_spark_type(type(right))
-                        )
-                    else:
-                        left = transform_boolean_operand_to_numeric(
-                            left, spark_type=right.spark.data_type
-                        )
-
             return column_op(PySparkColumn.__eq__)(left, right)
 
     def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -113,15 +113,7 @@ def transform_boolean_operand_to_numeric(
 def _should_return_all_false(left: IndexOpsLike, right: Any) -> bool:
     """
     Determine if binary comparison should short-circuit to all False,
-    based on incompatible dtypes.
-
-    This function is used to mimic pandas behavior when comparing operands
-    with non-matching dtypes that cannot be reasonably coerced, such as
-    comparing floats with strings.
-
-    It internally transforms boolean operands to numeric (long) and checks
-    whether both operands are numeric or not. If they are not, and their
-    dtypes differ, the comparison result is considered to be all False.
+    based on incompatible dtypes: non-numeric vs. numeric (including bools).
     """
     from pandas.api.types import is_numeric_dtype
     from pyspark.pandas.base import IndexOpsMixin

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -35,7 +35,6 @@ from pyspark.sql.types import (
     DecimalType,
     FractionalType,
     IntegralType,
-    LongType,
     MapType,
     NullType,
     NumericType,

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -52,6 +52,7 @@ from pyspark.pandas.typedef.typehints import (
     extension_float_dtypes_available,
     extension_object_dtypes_available,
     spark_type_to_pandas_dtype,
+    as_spark_type,
 )
 from pyspark.pandas.utils import is_ansi_mode_enabled
 
@@ -520,6 +521,12 @@ class DataTypeOps(object, metaclass=ABCMeta):
             return first_series(DataFrame(internal))
         else:
             from pyspark.pandas.base import column_op
+
+            if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession):
+                if _is_boolean_type(left):
+                    left = transform_boolean_operand_to_numeric(
+                        left, spark_type=as_spark_type(right.dtype)
+                    )
 
             return column_op(PySparkColumn.__eq__)(left, right)
 

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -117,17 +117,22 @@ def _should_return_all_false(left: IndexOpsLike, right: Any) -> bool:
     based on incompatible dtypes: non-numeric vs. numeric (including bools).
     """
     from pyspark.pandas.base import IndexOpsMixin
+    from pandas.api.types import is_list_like
 
     def are_both_numeric(left_dtype: Dtype, right_dtype: Dtype) -> bool:
         return is_numeric_dtype(left_dtype) and is_numeric_dtype(right_dtype)
 
     left_dtype = left.dtype
 
-    if isinstance(right, (IndexOpsMixin, np.ndarray, pd.Series)):
+    if isinstance(right, IndexOpsMixin):
         right_dtype = right.dtype
     elif isinstance(right, (list, tuple)):
         right_dtype = pd.Series(right).dtype
     else:
+        assert not is_list_like(right), (
+            "Only ps.Series, ps.Index, list, tuple, or scalar is supported as the "
+            "right-hand operand."
+        )
         right_dtype = pd.Series([right]).dtype
 
     return left_dtype != right_dtype and not are_both_numeric(left_dtype, right_dtype)

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -23,6 +23,7 @@ from itertools import chain
 import numpy as np
 import pandas as pd
 from pandas.api.types import CategoricalDtype
+from pandas.core.dtypes.common import is_numeric_dtype
 
 from pyspark.sql import functions as F, Column as PySparkColumn
 from pyspark.sql.types import (
@@ -100,8 +101,18 @@ def transform_boolean_operand_to_numeric(
         dtype = spark_type_to_pandas_dtype(
             spark_type, use_extension_dtypes=operand._internal.data_fields[0].is_extension_dtype
         )
+
+        if is_ansi_mode_enabled(operand._internal.spark_frame.sparkSession):
+            casted = (
+                F.when(operand.spark.column.isNull(), None)
+                .otherwise(F.when(operand.spark.column, F.lit(1)).otherwise(F.lit(0)))
+                .cast(spark_type)
+            )
+        else:
+            casted = operand.spark.column.cast(spark_type)
+
         return operand._with_new_scol(
-            operand.spark.column.cast(spark_type),
+            casted,
             field=operand._internal.data_fields[0].copy(dtype=dtype, spark_type=spark_type),
         )
     elif isinstance(operand, bool):
@@ -115,7 +126,6 @@ def _should_return_all_false(left: IndexOpsLike, right: Any) -> bool:
     Determine if binary comparison should short-circuit to all False,
     based on incompatible dtypes: non-numeric vs. numeric (including bools).
     """
-    from pandas.core.dtypes.common import is_numeric_dtype
     from pyspark.pandas.base import IndexOpsMixin
 
     def are_both_numeric(left_dtype: Dtype, right_dtype: Dtype) -> bool:
@@ -512,7 +522,10 @@ class DataTypeOps(object, metaclass=ABCMeta):
             from pyspark.pandas.base import column_op
 
             if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession):
-                if _is_boolean_type(left):
+                # Handle bool vs. non-bool numeric comparisons
+                left_is_bool = _is_boolean_type(left)
+                right_is_non_bool_numeric = is_numeric_dtype(right) and not _is_boolean_type(right)
+                if left_is_bool and right_is_non_bool_numeric:
                     left = transform_boolean_operand_to_numeric(
                         left, spark_type=as_spark_type(right.dtype)
                     )

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -52,7 +52,6 @@ from pyspark.pandas.typedef.typehints import (
     extension_float_dtypes_available,
     extension_object_dtypes_available,
     spark_type_to_pandas_dtype,
-    as_spark_type,
 )
 from pyspark.pandas.utils import is_ansi_mode_enabled
 

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -36,6 +36,7 @@ from pyspark.pandas.data_type_ops.base import (
     _is_boolean_type,
 )
 from pyspark.pandas.typedef.typehints import as_spark_type, extension_dtypes, pandas_on_spark_type
+from pyspark.pandas.utils import is_ansi_mode_enabled
 from pyspark.sql import functions as F, Column as PySparkColumn
 from pyspark.sql.types import BooleanType, StringType
 from pyspark.errors import PySparkValueError

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -20,6 +20,7 @@ from typing import Any, Union
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
+from pandas.core.dtypes.common import is_numeric_dtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
@@ -328,8 +329,6 @@ class BooleanOps(DataTypeOps):
         return operand
 
     def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pandas.core.dtypes.common import is_numeric_dtype
-
         if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession):
             # Handle bool vs. non-bool numeric comparisons
             left_is_bool = _is_boolean_type(left)

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -258,7 +258,7 @@ class NumericOps(DataTypeOps):
         else:
             if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession):
                 if _should_return_all_false(left, right):
-                    return left._with_new_scol(F.lit(False)).rename(None)
+                    return left._with_new_scol(F.lit(False)).rename(None)  # type: ignore[attr-defined]
                 if _is_boolean_type(right):
                     right = transform_boolean_operand_to_numeric(
                         right, spark_type=as_spark_type(left.dtype)

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -43,6 +43,7 @@ from pyspark.pandas.data_type_ops.base import (
     _sanitize_list_like,
     _is_valid_for_logical_operator,
     _is_boolean_type,
+    _should_return_all_false,
 )
 from pyspark.pandas.typedef.typehints import extension_dtypes, pandas_on_spark_type, as_spark_type
 from pyspark.pandas.utils import is_ansi_mode_enabled
@@ -251,9 +252,14 @@ class NumericOps(DataTypeOps):
 
     def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         # We can directly use `super().eq` when given object is list, tuple, dict or set.
+
         if not isinstance(right, IndexOpsMixin) and is_list_like(right):
             return super().eq(left, right)
-        return pyspark_column_op("__eq__", left, right, fillna=False)
+        else:
+            if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession):
+                if _should_return_all_false(left, right):
+                    return left._with_new_scol(F.lit(False))
+            return pyspark_column_op("__eq__", left, right, fillna=False)
 
     def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -258,7 +258,8 @@ class NumericOps(DataTypeOps):
         else:
             if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession):
                 if _should_return_all_false(left, right):
-                    return left._with_new_scol(F.lit(False)).rename(None)  # type: ignore[attr-defined]
+                    left_scol = left._with_new_scol(F.lit(False))
+                    return left_scol.rename(None)  # type: ignore[attr-defined]
                 if _is_boolean_type(right):
                     right = transform_boolean_operand_to_numeric(
                         right, spark_type=as_spark_type(left.dtype)

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -260,7 +260,7 @@ class NumericOps(DataTypeOps):
                 if _should_return_all_false(left, right):
                     left_scol = left._with_new_scol(F.lit(False))
                     return left_scol.rename(None)  # type: ignore[attr-defined]
-                if _is_boolean_type(right):
+                if _is_boolean_type(right):  # numeric vs. bool
                     right = transform_boolean_operand_to_numeric(
                         right, spark_type=as_spark_type(left.dtype)
                     )

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -45,7 +45,7 @@ from pyspark.pandas.data_type_ops.base import (
     _is_boolean_type,
     _should_return_all_false,
 )
-from pyspark.pandas.typedef.typehints import extension_dtypes, pandas_on_spark_type, as_spark_type
+from pyspark.pandas.typedef.typehints import extension_dtypes, pandas_on_spark_type
 from pyspark.pandas.utils import is_ansi_mode_enabled
 from pyspark.sql import functions as F, Column as PySparkColumn
 from pyspark.sql.types import (

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -258,7 +258,7 @@ class NumericOps(DataTypeOps):
         else:
             if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession):
                 if _should_return_all_false(left, right):
-                    return left._with_new_scol(F.lit(False))
+                    return left._with_new_scol(F.lit(False)).rename(None)
                 if _is_boolean_type(right):
                     right = transform_boolean_operand_to_numeric(
                         right, spark_type=as_spark_type(left.dtype)

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -45,7 +45,7 @@ from pyspark.pandas.data_type_ops.base import (
     _is_boolean_type,
     _should_return_all_false,
 )
-from pyspark.pandas.typedef.typehints import extension_dtypes, pandas_on_spark_type
+from pyspark.pandas.typedef.typehints import extension_dtypes, pandas_on_spark_type, as_spark_type
 from pyspark.pandas.utils import is_ansi_mode_enabled
 from pyspark.sql import functions as F, Column as PySparkColumn
 from pyspark.sql.types import (

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -262,7 +262,7 @@ class NumericOps(DataTypeOps):
                     return left_scol.rename(None)  # type: ignore[attr-defined]
                 if _is_boolean_type(right):  # numeric vs. bool
                     right = transform_boolean_operand_to_numeric(
-                        right, spark_type=as_spark_type(left.dtype)
+                        right, spark_type=left.spark.data_type
                     )
             return pyspark_column_op("__eq__", left, right, fillna=False)
 

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -259,6 +259,10 @@ class NumericOps(DataTypeOps):
             if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession):
                 if _should_return_all_false(left, right):
                     return left._with_new_scol(F.lit(False))
+                if _is_boolean_type(right):
+                    right = transform_boolean_operand_to_numeric(
+                        right, spark_type=as_spark_type(left.dtype)
+                    )
             return pyspark_column_op("__eq__", left, right, fillna=False)
 
     def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -252,7 +252,6 @@ class NumericOps(DataTypeOps):
 
     def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         # We can directly use `super().eq` when given object is list, tuple, dict or set.
-
         if not isinstance(right, IndexOpsMixin) and is_list_like(right):
             return super().eq(left, right)
         else:

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -23,6 +23,7 @@ import numpy as np
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
+from pyspark.testing.utils import is_ansi_mode_test
 from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
 from pyspark.pandas.typedef.typehints import (
     extension_dtypes_available,
@@ -127,6 +128,18 @@ class NumOpsTestsMixin:
                 self.assert_eq(~pser, ~psser)
             else:
                 self.assertRaises(TypeError, lambda: ~psser)
+
+    def test_comparison_dtype_compatibility(self):
+        pdf = pd.DataFrame(
+            {"int": [1, 2], "bool": [True, False], "float": [0.1, 0.2], "str": ["1", "2"]}
+        )
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(pdf["int"] == pdf["bool"], psdf["int"] == psdf["bool"])
+        self.assert_eq(pdf["bool"] == pdf["int"], psdf["bool"] == psdf["int"])
+        self.assert_eq(pdf["int"] == pdf["float"], psdf["int"] == psdf["float"])
+        if is_ansi_mode_test:  # TODO: match non-ansi behavior with pandas
+            self.assert_eq(pdf["int"] == pdf["str"], psdf["int"] == psdf["str"])
+        self.assert_eq(pdf["float"] == pdf["bool"], psdf["float"] == psdf["bool"])
 
     def test_eq(self):
         pdf, psdf = self.pdf, self.psdf


### PR DESCRIPTION
### What changes were proposed in this pull request?
Avoid CAST_INVALID_INPUT of `__eq__` in ANSI mode

To align with pandas under ANSI, following changes are prosed:
- 1 == "1" |  before: True after: False
- 1" == 1 | before: True after: False
- 1 == True | before: error after: True
- True == 1 | before: error after: True

### Why are the changes needed?
Ensure pandas on Spark works well with ANSI mode on.
Part of https://issues.apache.org/jira/browse/SPARK-52556.

### Does this PR introduce _any_ user-facing change?
```py
>>> import pandas as pd
>>> import numpy as np
>>> 
>>> ps.set_option("compute.fail_on_ansi_mode", False)
>>> ps.set_option("compute.ansi_mode_support", True)
>>> psidx1 = ps.Index([1, 2, 3])
>>> 
>>> psidx2 = ps.Index([1.0, 2.0, 3.0])
>>> psidx1 == psidx2
Index([True, True, True], dtype='bool')
>>> psidx2 == psidx1
Index([True, True, True], dtype='bool')
>>> 
>>> psidx3 = ps.Index(["1", "2", "3"])
>>> psidx1 == psidx3
Index([False, False, False], dtype='bool')
>>> psidx3 == psidx1
Index([False, False, False], dtype='bool')
>>> 
>>> psidx4 = ps.Index([True, False, True])
>>> psidx1 == psidx4
Index([True, False, False], dtype='bool')
>>> psidx4 == psidx1
Index([True, False, False], dtype='bool')
```

### How was this patch tested?
Commands below passed.
```py
SPARK_ANSI_SQL_MODE=false  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_ops NumOpsTests.test_comparison_dtype_compatibility"

SPARK_ANSI_SQL_MODE=true  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_ops NumOpsTests.test_comparison_dtype_compatibility"

SPARK_ANSI_SQL_MODE=false ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests.test_eq"

SPARK_ANSI_SQL_MODE=true ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests.test_eq"
```

### Was this patch authored or co-authored using generative AI tooling?
No.
