### PR TITLE
[SPARK-52460][SQL][FOLLOWUP] Rename `timeToMicros` to `makeTime`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -555,7 +555,7 @@ case class MakeTime(
   override def replacement: Expression = StaticInvoke(
     classOf[DateTimeUtils.type],
     TimeType(TimeType.MICROS_PRECISION),
-    "timeToMicros",
+    "makeTime",
     children,
     inputTypes
   )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -788,14 +788,14 @@ object DateTimeUtils extends SparkDateTimeUtils {
   }
 
   /**
-   * Converts separate time fields in a long that represents microseconds since the start of
+   * Converts separate time fields in a long that represents nanoseconds since the start of
    * the day
    * @param hours the hour, from 0 to 23
    * @param minutes the minute, from 0 to 59
    * @param secsAndMicros the second, from 0 to 59.999999
-   * @return A time value represented as microseconds since the start of the day
+   * @return A time value represented as nanoseconds since the start of the day
    */
-  def timeToMicros(hours: Int, minutes: Int, secsAndMicros: Decimal): Long = {
+  def makeTime(hours: Int, minutes: Int, secsAndMicros: Decimal): Long = {
     try {
       val unscaledSecFrac = secsAndMicros.toUnscaledLong
       val fullSecs = Math.floorDiv(unscaledSecFrac, MICROS_PER_SECOND)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -1179,8 +1179,8 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     val secAndMicros = Decimal(sec + (micros / MICROS_PER_SECOND.toFloat), 16, 6)
 
     // Valid case
-    val microSecsTime = makeTime(hour, min, secAndMicros)
-    assert(microSecsTime === localTime(hour.toByte, min.toByte, sec.toByte, micros))
+    val nanoSecsTime = makeTime(hour, min, secAndMicros)
+    assert(nanoSecsTime === localTime(hour.toByte, min.toByte, sec.toByte, micros))
 
     // Invalid hour
     checkError(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -1179,13 +1179,13 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     val secAndMicros = Decimal(sec + (micros / MICROS_PER_SECOND.toFloat), 16, 6)
 
     // Valid case
-    val microSecsTime = timeToMicros(hour, min, secAndMicros)
+    val microSecsTime = makeTime(hour, min, secAndMicros)
     assert(microSecsTime === localTime(hour.toByte, min.toByte, sec.toByte, micros))
 
     // Invalid hour
     checkError(
       exception = intercept[SparkDateTimeException] {
-        timeToMicros(-1, min, secAndMicros)
+        makeTime(-1, min, secAndMicros)
       },
       condition = "DATETIME_FIELD_OUT_OF_BOUNDS.WITHOUT_SUGGESTION",
       parameters = Map("rangeMessage" -> "Invalid value for HourOfDay (valid values 0 - 23): -1"))
@@ -1193,7 +1193,7 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     // Invalid minute
     checkError(
       exception = intercept[SparkDateTimeException] {
-        timeToMicros(hour, -1, secAndMicros)
+        makeTime(hour, -1, secAndMicros)
       },
       condition = "DATETIME_FIELD_OUT_OF_BOUNDS.WITHOUT_SUGGESTION",
       parameters = Map("rangeMessage" ->
@@ -1209,7 +1209,7 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     ).foreach { invalidSecond =>
       checkError(
         exception = intercept[SparkDateTimeException] {
-          timeToMicros(hour, min, Decimal(invalidSecond, 16, 6))
+          makeTime(hour, min, Decimal(invalidSecond, 16, 6))
         },
         condition = "DATETIME_FIELD_OUT_OF_BOUNDS.WITHOUT_SUGGESTION",
         parameters = Map("rangeMessage" ->


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to rename the internal method `timeToMicros()` to `makeTime()` because:
1. It makes nanoseconds but not microseconds values
2. Actually it make a TIME values from time fields, but do not converts TIME values to micros.

### Why are the changes needed?
To improve code maintenance, and don't confuse other devs. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the related test suites:
```
$ build/sbt "test:testOnly *DateTimeUtilsSuite"
```


### Was this patch authored or co-authored using generative AI tooling?
No.