### PR TITLE
[SPARK-52684][SQL] Make CACHE TABLE Commands atomic while encountering execution errors

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -26,7 +26,7 @@ import scala.concurrent.duration._
 
 import org.apache.commons.io.FileUtils
 
-import org.apache.spark.CleanerListener
+import org.apache.spark.{CleanerListener, SparkException}
 import org.apache.spark.executor.DataReadMethod._
 import org.apache.spark.executor.DataReadMethod.DataReadMethod
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerJobStart}
@@ -1728,5 +1728,14 @@ class CachedTableSuite extends QueryTest with SQLTestUtils
       assert(getNumInMemoryRelations(df) == 1)
     }
 
+  }
+
+  test("SPARK-52684: Atomicity of cache table on error") {
+    withTempView("SPARK_52684") {
+      intercept[SparkException] {
+        spark.sql("CACHE TABLE SPARK_52684 AS SELECT raise_error('SPARK-52684') AS c1")
+      }
+      assert(!spark.catalog.tableExists("SPARK_52684"))
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes CACHE TABLE commands atomic while encountering execution errors

### Why are the changes needed?

For now, when an AnalysisException occurs, no cache or view will be created, but an execution one occurs, a view or an erroneous 'cache' is created.

### Does this PR introduce _any_ user-facing change?

Yes, but it's a bugfix. It only affects rare corner case that a user leverages this bug to create an erroneous 'cache'/view for some particular purposes

### How was this patch tested?
new tests

### Was this patch authored or co-authored using generative AI tooling?
no