### PR TITLE
[SPARK-51557][SQL][TESTS] Add tests for TIME data type in Java API

### DIFF
--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -812,6 +812,26 @@ public class JavaDatasetSuite implements Serializable {
     Assertions.assertEquals(data, ds.collectAsList());
   }
 
+  @Test
+  public void testLocalTimeFilter() {
+    Encoder<LocalTime> encoder = Encoders.LOCALTIME();
+    List<LocalTime> data = Arrays.asList(
+      LocalTime.of(9, 30, 45),
+      LocalTime.of(14, 10, 10),
+      LocalTime.of(22, 10, 10)
+    );
+    Dataset<LocalTime> ds = spark.createDataset(data, encoder);
+
+    Dataset<LocalTime> filtered = ds.filter(
+      (FilterFunction<LocalTime>) time -> time.isAfter(LocalTime.of(12, 0, 0))
+    );
+    List<LocalTime> expectedFiltered = Arrays.asList(
+      LocalTime.of(14, 10, 10),
+      LocalTime.of(22, 10, 10)
+    );
+    Assertions.assertEquals(expectedFiltered, filtered.collectAsList());
+  }
+
   public static class KryoSerializable {
     String value;
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDFSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDFSuite.java
@@ -140,11 +140,11 @@ public class JavaUDFSuite implements Serializable {
 
   @Test
   public void udf8Test() {
-      spark.udf().register(
-          "plusTwoHours",
-          (java.time.LocalTime lt) -> lt.plusHours(2), new TimeType(6));
-      Row result = spark.sql("SELECT plusTwoHours(TIME '09:10:10')").head();
-      Assertions.assertEquals(LocalTime.of(11, 10, 10), result.get(0));
+    spark.udf().register(
+        "plusTwoHours",
+        (java.time.LocalTime lt) -> lt.plusHours(2), new TimeType(6));
+    Row result = spark.sql("SELECT plusTwoHours(TIME '09:10:10')").head();
+    Assertions.assertEquals(LocalTime.of(11, 10, 10), result.get(0));
   }
 
   @Test

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDFSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDFSuite.java
@@ -19,6 +19,7 @@ package test.org.apache.spark.sql;
 
 import java.io.Serializable;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 import org.apache.spark.sql.catalyst.FunctionIdentifier;
@@ -34,6 +35,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.classic.SparkSession;
 import org.apache.spark.sql.api.java.UDF2;
 import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.TimeType;
 
 // The test suite itself is Serializable so that anonymous Function implementations can be
 // serialized, as an alternative to converting these anonymous classes to static inner classes;
@@ -131,6 +133,21 @@ public class JavaUDFSuite implements Serializable {
           (java.time.LocalDate ld) -> ld.plusDays(1), DataTypes.DateType);
       Row result = spark.sql("SELECT plusDay(DATE '2019-02-26')").head();
       Assertions.assertEquals(LocalDate.parse("2019-02-27"), result.get(0));
+    } finally {
+      spark.conf().set(SQLConf.DATETIME_JAVA8API_ENABLED().key(), originConf);
+    }
+  }
+
+  @Test
+  public void udf8Test() {
+    String originConf = spark.conf().get(SQLConf.DATETIME_JAVA8API_ENABLED().key());
+    try {
+      spark.conf().set(SQLConf.DATETIME_JAVA8API_ENABLED().key(), "true");
+      spark.udf().register(
+          "plusTwoHours",
+          (java.time.LocalTime lt) -> lt.plusHours(2), new TimeType(6));
+      Row result = spark.sql("SELECT plusTwoHours(TIME '09:10:10')").head();
+      Assertions.assertEquals(LocalTime.of(11, 10, 10), result.get(0));
     } finally {
       spark.conf().set(SQLConf.DATETIME_JAVA8API_ENABLED().key(), originConf);
     }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDFSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDFSuite.java
@@ -140,17 +140,11 @@ public class JavaUDFSuite implements Serializable {
 
   @Test
   public void udf8Test() {
-    String originConf = spark.conf().get(SQLConf.DATETIME_JAVA8API_ENABLED().key());
-    try {
-      spark.conf().set(SQLConf.DATETIME_JAVA8API_ENABLED().key(), "true");
       spark.udf().register(
           "plusTwoHours",
           (java.time.LocalTime lt) -> lt.plusHours(2), new TimeType(6));
       Row result = spark.sql("SELECT plusTwoHours(TIME '09:10:10')").head();
       Assertions.assertEquals(LocalTime.of(11, 10, 10), result.get(0));
-    } finally {
-      spark.conf().set(SQLConf.DATETIME_JAVA8API_ENABLED().key(), originConf);
-    }
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds tests for the TIME data type in Spark's Java API, covering Dataset and UDF functionality with `java.time.LocalTime`:
  - Adding a dataset filter operations with `java.time.LocalTime` (there is not a similar one for `TimestampType`).
  - UDF registration and execution with TimeType in udf8Test - the same as the `udf7Test()` for `TimestampType`.
  - `testLocalTimeEncoder()` already existed for `TimestampType` parity.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As part of the TIME data type SPIP (SPARK-51162), we need test coverage in the Java API for Datasets and UDFs.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
  Added new test methods:
  - `JavaDatasetSuite.testLocalTimeFilter` - Tests Dataset filter with `LocalTime`
  - `JavaUDFSuite.udf8Test` - Tests UDF registration and execution with `LocalTime`

![Screenshot 2025-07-07 at 4 00 58 AM](https://github.com/user-attachments/assets/160f207e-e3e5-45a2-ac5d-35b55a76215e)
![Screenshot 2025-07-07 at 3 59 24 AM](https://github.com/user-attachments/assets/c18bf26d-a6ef-4445-95b0-a67566ac9fa0)


  I executed the tests themselves locally and also ran `./build/mvn test-compile -pl sql/core` to test compilation. 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No