### PR TITLE
[SPARK-52695][SQL] User Defined Type write support for xml file format

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlGenerator.scala
@@ -228,6 +228,8 @@ class StaxXmlGenerator(
         writeChild(field.name, field.dataType, value)
       }
 
+    case (u: UserDefinedType[_], v) => writeElement(u.sqlType, v, options)
+
     case (_, _) =>
       throw new SparkIllegalArgumentException(
         errorClass = "_LEGACY_ERROR_TEMP_3238",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds UDT write support for the XML file format

### Why are the changes needed?

IllegalArgumentException is being thrown while writing UDT values

### Does this PR introduce _any_ user-facing change?

Yes, if the udt's sqlType is compatible with XML file format, it becomes writable


### How was this patch tested?
new test


### Was this patch authored or co-authored using generative AI tooling?
no