### PR TITLE
[SPARK-52698][PYTHON] Improve type hints for datasource module

### DIFF
--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -19,15 +19,12 @@ from collections import UserDict
 from dataclasses import dataclass
 from typing import (
     Any,
-    Dict,
     Iterable,
     Iterator,
     List,
     Optional,
     Sequence,
-    Tuple,
     Type,
-    Union,
     TYPE_CHECKING,
 )
 
@@ -49,7 +46,6 @@ __all__ = [
     "DataSourceStreamWriter",
     "DataSourceRegistration",
     "InputPartition",
-    "SimpleDataSourceStreamReader",
     "WriterCommitMessage",
     "Filter",
     "EqualTo",
@@ -84,7 +80,7 @@ class DataSource(ABC):
     .. versionadded: 4.0.0
     """
 
-    def __init__(self, options: Dict[str, str]) -> None:
+    def __init__(self, options: dict[str, str]) -> None:
         """
         Initializes the data source with user-provided options.
 
@@ -114,7 +110,7 @@ class DataSource(ABC):
         """
         return cls.__name__
 
-    def schema(self) -> Union[StructType, str]:
+    def schema(self) -> StructType | str:
         """
         Returns the schema of the data source.
 
@@ -261,7 +257,7 @@ class DataSource(ABC):
         )
 
 
-ColumnPath = Tuple[str, ...]
+ColumnPath = tuple[str, ...]
 """
 A tuple of strings representing a column reference.
 
@@ -407,7 +403,7 @@ class In(Filter):
     """
 
     attribute: ColumnPath
-    value: Tuple[Any, ...]
+    value: tuple[Any, ...]
 
 
 @dataclass(frozen=True)
@@ -631,7 +627,7 @@ class DataSourceReader(ABC):
         )
 
     @abstractmethod
-    def read(self, partition: InputPartition) -> Union[Iterator[Tuple], Iterator["RecordBatch"]]:
+    def read(self, partition: InputPartition) -> Iterator[tuple] | Iterator["RecordBatch"]:
         """
         Generates data for a given partition and returns an iterator of tuples or rows.
 
@@ -760,7 +756,7 @@ class DataSourceStreamReader(ABC):
         )
 
     @abstractmethod
-    def read(self, partition: InputPartition) -> Union[Iterator[Tuple], Iterator["RecordBatch"]]:
+    def read(self, partition: InputPartition) -> Iterator[tuple] | Iterator["RecordBatch"]:
         """
         Generates data for a given partition and returns an iterator of tuples or rows.
 
@@ -852,7 +848,7 @@ class SimpleDataSourceStreamReader(ABC):
             messageParameters={"feature": "initialOffset"},
         )
 
-    def read(self, start: dict) -> Tuple[Iterator[Tuple], dict]:
+    def read(self, start: dict) -> tuple[Iterator[tuple], dict]:
         """
         Read all available data from start offset and return the offset that next read attempt
         starts from.
@@ -864,7 +860,7 @@ class SimpleDataSourceStreamReader(ABC):
 
         Returns
         -------
-        A :class:`Tuple` of an iterator of :class:`Tuple` and a dict\\s
+        A :class:`tuple` of an iterator of :class:`tuple` and a dict\\s
             The iterator contains all the available records after start offset.
             The dict is the end offset of this read attempt and the start of next read attempt.
         """
@@ -873,7 +869,7 @@ class SimpleDataSourceStreamReader(ABC):
             messageParameters={"feature": "read"},
         )
 
-    def readBetweenOffsets(self, start: dict, end: dict) -> Iterator[Tuple]:
+    def readBetweenOffsets(self, start: dict, end: dict) -> Iterator[tuple]:
         """
         Read all available data from specific start offset and end offset.
         This is invoked during failure recovery to re-read a batch deterministically.
@@ -888,7 +884,7 @@ class SimpleDataSourceStreamReader(ABC):
 
         Returns
         -------
-        iterator of :class:`Tuple`\\s
+        iterator of :class:`tuple`\\s
             All the records between start offset and end offset.
         """
         raise PySparkNotImplementedError(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR improves the type annotations in python/pyspark/sql/datasource.py to use Python 3.10 typing syntax and built-in types instead of their typing module equivalents.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Follows current Python typing recommendations and best practices.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No