### PR TITLE
[SPARK-52699][SQL] Support aggregating TIME type in interpreted mode

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
@@ -175,7 +175,7 @@ object InternalRow {
     case ShortType => (input, v) => input.setShort(ordinal, v.asInstanceOf[Short])
     case IntegerType | DateType | _: YearMonthIntervalType =>
       (input, v) => input.setInt(ordinal, v.asInstanceOf[Int])
-    case LongType | TimestampType | TimestampNTZType | _: DayTimeIntervalType =>
+    case LongType | TimestampType | TimestampNTZType | _: DayTimeIntervalType | _: TimeType =>
       (input, v) => input.setLong(ordinal, v.asInstanceOf[Long])
     case FloatType => (input, v) => input.setFloat(ordinal, v.asInstanceOf[Float])
     case DoubleType => (input, v) => input.setDouble(ordinal, v.asInstanceOf[Double])

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MutableProjectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MutableProjectionSuite.scala
@@ -32,7 +32,8 @@ class MutableProjectionSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   val fixedLengthTypes = Array[DataType](
     BooleanType, ByteType, ShortType, IntegerType, LongType, FloatType, DoubleType,
-    DateType, TimestampType) ++ dayTimeIntervalTypes ++ yearMonthIntervalTypes
+    DateType, TimestampType, TimestampNTZType, new TimeType(6)) ++
+    dayTimeIntervalTypes ++ yearMonthIntervalTypes
 
   val variableLengthTypes = Array(
     StringType, DecimalType.defaultConcreteType, CalendarIntervalType, BinaryType,
@@ -46,7 +47,7 @@ class MutableProjectionSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   testBothCodegenAndInterpreted("fixed-length types") {
     val inputRow = InternalRow.fromSeq(Seq(
-      true, 3.toByte, 15.toShort, -83, 129L, 1.0f, 5.0, 1, 2L) ++
+      true, 3.toByte, 15.toShort, -83, 129L, 1.0f, 5.0, 1, 2L, 3L, 4L) ++
       Seq.tabulate(dayTimeIntervalTypes.length)(_ => Long.MaxValue) ++
       Seq.tabulate(yearMonthIntervalTypes.length)(_ => Int.MaxValue))
     val proj = createMutableProjection(fixedLengthTypes)
@@ -55,7 +56,7 @@ class MutableProjectionSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   testBothCodegenAndInterpreted("unsafe buffer") {
     val inputRow = InternalRow.fromSeq(Seq(
-      false, 1.toByte, 9.toShort, -18, 53L, 3.2f, 7.8, 4, 9L) ++
+      false, 1.toByte, 9.toShort, -18, 53L, 3.2f, 7.8, 4, 9L, 10L, 11L) ++
       Seq.tabulate(dayTimeIntervalTypes.length)(_ => Long.MaxValue) ++
       Seq.tabulate(yearMonthIntervalTypes.length)(_ => Int.MaxValue))
     val numFields = fixedLengthTypes.length


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update `InternalRow#getWriter` to return the correct writer for the TIME type.

### Why are the changes needed?

Without this PR, aggregating the TIME type in interpreted mode fails. Consider the below query:
```
set spark.sql.codegen.factoryMode=NO_CODEGEN;

create or replace temp view v1(col1) as values
(time'22:33:01'),
(time'01:33:01'),
(null);

select max(col1), min(col1) from v1;
``` 
Without this change, the query fails with the following error:
```
Exception in task 0.0 in stage 0.0 (TID 0)
org.apache.spark.SparkUnsupportedOperationException: [UNSUPPORTED_CALL.WITHOUT_SUGGESTION] Cannot call the method "update" of the class "org.apache.spark.sql.catalyst.expressions.UnsafeRow".  SQLSTATE: 0A000
	at org.apache.spark.SparkUnsupportedOperationException$.apply(SparkException.scala:266) ~[spark-common-utils_2.13-4.1.0-SNAPSHOT.jar:4.1.0-SNAPSHOT]
```
### Does this PR introduce _any_ user-facing change?

No. The TIME type is not released yet.

### How was this patch tested?

Updated unit test.

### Was this patch authored or co-authored using generative AI tooling?

No.