### PR TITLE
[SPARK-52751][PYTHON][CONNECT] Don't eagerly validate column name in `dataframe['col_name']`

### DIFF
--- a/python/docs/source/migration_guide/pyspark_upgrade.rst
+++ b/python/docs/source/migration_guide/pyspark_upgrade.rst
@@ -22,6 +22,8 @@ Upgrading PySpark
 Upgrading from PySpark 4.0 to 4.1
 ---------------------------------
 
+* In Spark 4.1, ``DataFrame['name']`` on Spark Connect Python Client no longer eagerly validate the column name. To restore the legacy behavior, set ``PYSPARK_VALIDATE_COLUMN_NAME_LEGACY`` environment variable to ``1``.
+
 * In Spark 4.1, Arrow-optimized Python UDF supports UDT input / output instead of falling back to the regular UDF. To restore the legacy behavior, set ``spark.sql.execution.pythonUDF.arrow.legacy.fallbackOnUDT`` to ``true``.
 
 * In Spark 4.1, unnecessary conversion to pandas instances is removed when ``spark.sql.execution.pythonUDF.arrow.enabled`` is enabled. As a result, the type coercion changes when the produced output has a schema different from the specified schema. To restore the previous behavior, enable ``spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled``.

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1732,22 +1732,6 @@ class DataFrame(ParentDataFrame):
                     )
                 )
             else:
-                # TODO: revisit classic Spark's Dataset.col
-                # if (sparkSession.sessionState.conf.supportQuotedRegexColumnName) {
-                #   colRegex(colName)
-                # } else {
-                #   ConnectColumn(addDataFrameIdToCol(resolve(colName)))
-                # }
-
-                # validate the column name
-                if not hasattr(self._session, "is_mock_session"):
-                    from pyspark.sql.connect.types import verify_col_name
-
-                    # Try best to verify the column name with cached schema
-                    # If fails, fall back to the server side validation
-                    if not verify_col_name(item, self._schema):
-                        self.select(item).isLocal()
-
                 return self._col(item)
         elif isinstance(item, Column):
             return self.filter(item)

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -133,8 +133,8 @@ class ColumnTestsMixin:
         self.assertTrue(isinstance(df["key"], Column))
         self.assertTrue(isinstance(df[0], Column))
         self.assertRaises(IndexError, lambda: df[2])
-        self.assertRaises(AnalysisException, lambda: df["bad_key"])
         self.assertRaises(TypeError, lambda: df[{}])
+        self.assertRaises(AnalysisException, lambda: df.select(df["bad_key"]).schema)
 
     def test_column_name_with_non_ascii(self):
         columnName = "数量"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Don't eagerly validate column name in `dataframe['col_name']`


### Why are the changes needed?
to save ANALYZE RPC, fail the query on connect server side

### Does this PR introduce _any_ user-facing change?
yes, `df['bad_column']` will fail on analysis or execution


### How was this patch tested?
updated tests


### Was this patch authored or co-authored using generative AI tooling?
no
