### PR TITLE
[SPARK-52710][SQL] `DESCRIBE SCHEMA` should print collation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -189,8 +189,9 @@ case class DescribeDatabaseCommand(
       Row("Catalog Name", SESSION_CATALOG_NAME) ::
         Row("Database Name", dbMetadata.name) ::
         Row("Comment", dbMetadata.description) ::
-        Row("Location", CatalogUtils.URIToString(dbMetadata.locationUri))::
-        Row("Owner", allDbProperties.getOrElse(PROP_OWNER, "")) :: Nil
+        Row("Location", CatalogUtils.URIToString(dbMetadata.locationUri)) ::
+        Row("Owner", allDbProperties.getOrElse(PROP_OWNER, "")) ::
+        allDbProperties.get(PROP_COLLATION).map(Row("Collation", _)).toList
 
     if (extended) {
       val properties = allDbProperties -- CatalogV2Util.NAMESPACE_RESERVED_PROPERTIES

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/describe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/describe.sql.out
@@ -214,6 +214,41 @@ org.apache.spark.sql.catalyst.parser.ParseException
 
 
 -- !query
+DROP SCHEMA IF EXISTS test_schema
+-- !query analysis
+DropNamespace true, false
++- ResolvedNamespace V2SessionCatalog(spark_catalog), [test_schema]
+
+
+-- !query
+CREATE SCHEMA test_schema DEFAULT COLLATION UNICODE
+-- !query analysis
+CreateNamespace false, [collation=UNICODE]
++- ResolvedNamespace V2SessionCatalog(spark_catalog), [test_schema]
+
+
+-- !query
+DESCRIBE SCHEMA EXTENDED test_schema
+-- !query analysis
+DescribeNamespace true, [info_name#x, info_value#x]
++- ResolvedNamespace V2SessionCatalog(spark_catalog), [test_schema]
+
+
+-- !query
+ALTER SCHEMA test_schema DEFAULT COLLATION UTF8_LCASE
+-- !query analysis
+SetNamespaceCollationCommand UTF8_LCASE
++- ResolvedNamespace V2SessionCatalog(spark_catalog), [test_schema]
+
+
+-- !query
+DESCRIBE SCHEMA EXTENDED test_schema
+-- !query analysis
+DescribeNamespace true, [info_name#x, info_value#x]
++- ResolvedNamespace V2SessionCatalog(spark_catalog), [test_schema]
+
+
+-- !query
 DESC temp_v
 -- !query analysis
 DescribeTableCommand `temp_v`, false, [col_name#x, data_type#x, comment#x]

--- a/sql/core/src/test/resources/sql-tests/inputs/describe.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/describe.sql
@@ -64,6 +64,13 @@ DESC t PARTITION (c='Us');
 -- ParseException: PARTITION specification is incomplete
 DESC t PARTITION (c='Us', d);
 
+-- DESC SCHEMA
+DROP SCHEMA IF EXISTS test_schema;
+CREATE SCHEMA test_schema DEFAULT COLLATION UNICODE;
+DESCRIBE SCHEMA EXTENDED test_schema;
+ALTER SCHEMA test_schema DEFAULT COLLATION UTF8_LCASE;
+DESCRIBE SCHEMA EXTENDED test_schema;
+
 -- DESC Temp View
 
 DESC temp_v;

--- a/sql/core/src/test/resources/sql-tests/results/describe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/describe.sql.out
@@ -454,6 +454,58 @@ org.apache.spark.sql.catalyst.parser.ParseException
 
 
 -- !query
+DROP SCHEMA IF EXISTS test_schema
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+CREATE SCHEMA test_schema DEFAULT COLLATION UNICODE
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+DESCRIBE SCHEMA EXTENDED test_schema
+-- !query schema
+struct<info_name:string,info_value:string>
+-- !query output
+Catalog Name	spark_catalog
+Collation	UNICODE
+Comment	
+Location [not included in comparison]/{warehouse_dir}/test_schema.db
+Namespace Name	test_schema
+Owner	[not included in comparison]
+Properties
+
+
+-- !query
+ALTER SCHEMA test_schema DEFAULT COLLATION UTF8_LCASE
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+DESCRIBE SCHEMA EXTENDED test_schema
+-- !query schema
+struct<info_name:string,info_value:string>
+-- !query output
+Catalog Name	spark_catalog
+Collation	UTF8_LCASE
+Comment	
+Location [not included in comparison]/{warehouse_dir}/test_schema.db
+Namespace Name	test_schema
+Owner	[not included in comparison]
+Properties
+
+
+-- !query
 DESC temp_v
 -- !query schema
 struct<col_name:string,data_type:string,comment:string>

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -156,6 +156,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
     // SPARK-39564: don't print out serde to avoid introducing complicated and error-prone
     // regex magic.
     .set("spark.test.noSerdeInExplain", "true")
+    .set(SQLConf.SCHEMA_LEVEL_COLLATIONS_ENABLED, true)
 
   // SPARK-32106 Since we add SQL test 'transform.sql' will use `cat` command,
   // here we need to ignore it.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Extended `DescribeDatabaseCommand` to print collation.


### Why are the changes needed?
Part of new feature.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Updated `describe.sql`.


### Was this patch authored or co-authored using generative AI tooling?
No.
