### PR TITLE
[SPARK-52716][SDP][SQL] Remove comment from Flow trait and references

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
@@ -212,7 +212,6 @@ private[connect] object PipelinesHandler extends Logging {
         queryContext = QueryContext(
           Option(graphElementRegistry.defaultCatalog),
           Option(graphElementRegistry.defaultDatabase)),
-        comment = None,
         origin = QueryOrigin(
           objectType = Option(QueryOriginType.Flow.toString),
           objectName = Option(flowIdentifier.unquotedString),

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/Flow.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/Flow.scala
@@ -55,9 +55,6 @@ trait Flow extends GraphElement with Logging {
   /** The current query context (catalog and database) when the query is defined. */
   def queryContext: QueryContext
 
-  /** The comment associated with this flow */
-  def comment: Option[String]
-
   def sqlConf: Map[String, String]
 }
 
@@ -127,7 +124,6 @@ case class UnresolvedFlow(
     func: FlowFunction,
     queryContext: QueryContext,
     sqlConf: Map[String, String],
-    comment: Option[String] = None,
     override val once: Boolean,
     override val origin: QueryOrigin
 ) extends Flow
@@ -145,7 +141,6 @@ trait ResolutionCompletedFlow extends Flow {
   val destinationIdentifier: TableIdentifier = flow.destinationIdentifier
   def func: FlowFunction = flow.func
   def queryContext: QueryContext = flow.queryContext
-  def comment: Option[String] = flow.comment
   def sqlConf: Map[String, String] = funcResult.sqlConf
   def origin: QueryOrigin = flow.origin
 }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/SqlGraphRegistrationContext.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/SqlGraphRegistrationContext.scala
@@ -246,7 +246,6 @@ class SqlGraphRegistrationContext(
             currentCatalog = context.getCurrentCatalogOpt,
             currentDatabase = context.getCurrentDatabaseOpt
           ),
-          comment = cst.tableSpec.comment,
           origin = queryOrigin.copy(
             objectName = Option(stIdentifier.unquotedString),
             objectType = Option(QueryOriginType.Flow.toString)
@@ -297,7 +296,6 @@ class SqlGraphRegistrationContext(
             currentCatalog = context.getCurrentCatalogOpt,
             currentDatabase = context.getCurrentDatabaseOpt
           ),
-          comment = cmv.tableSpec.comment,
           origin = queryOrigin.copy(
             objectName = Option(mvIdentifier.unquotedString),
             objectType = Option(QueryOriginType.Flow.toString)
@@ -343,8 +341,7 @@ class SqlGraphRegistrationContext(
           origin = queryOrigin.copy(
             objectName = Option(viewIdentifier.unquotedString),
             objectType = Option(QueryOriginType.Flow.toString)
-          ),
-          comment = None
+          )
         )
       )
     }
@@ -387,8 +384,7 @@ class SqlGraphRegistrationContext(
           origin = queryOrigin.copy(
             objectName = Option(viewIdentifier.unquotedString),
             objectType = Option(QueryOriginType.Flow.toString)
-          ),
-          comment = None
+          )
         )
       )
     }
@@ -454,7 +450,6 @@ class SqlGraphRegistrationContext(
         UnresolvedFlow(
           identifier = flowIdentifier,
           destinationIdentifier = qualifiedDestinationIdentifier,
-          comment = cf.comment,
           func = FlowAnalysis.createFlowFunctionFromLogicalPlan(flowQueryLogicalPlan),
           sqlConf = context.getSqlConf,
           once = isOnce,

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
@@ -130,7 +130,6 @@ class SQLPipelineSuite extends PipelineTest with SQLTestUtils {
       resolvedDataflowGraph.resolvedFlows
         .filter(_.identifier == fullyQualifiedIdentifier("a"))
         .head
-    assert(flowA.comment.contains("this is a comment"))
     checkAnswer(flowA.df, Seq(Row(1), Row(2), Row(3)))
   }
 

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/TestGraphRegistrationContext.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/TestGraphRegistrationContext.scala
@@ -156,7 +156,6 @@ class TestGraphRegistrationContext(
           ),
           sqlConf = sqlConf,
           once = false,
-          comment = comment,
           origin = baseOrigin
         )
       )
@@ -207,7 +206,6 @@ class TestGraphRegistrationContext(
         ),
         sqlConf = sqlConf,
         once = false,
-        comment = comment,
         origin = origin
       )
     )
@@ -236,7 +234,6 @@ class TestGraphRegistrationContext(
         ),
         sqlConf = Map.empty,
         once = once,
-        comment = None,
         origin = QueryOrigin()
       )
     )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

* Removed the `comment` field from the `Flow` trait, child `UnresolvedFlow` and `ResolutionCompletedFlow 
* Removed all references of the comment field, including where it is being populated in [SqlGraphRegistrationContext.scala](https://github.com/apache/spark/pull/51406/files#diff-fd5952de374a6af7e4357eecdb8e48ebb862b4faa4b874303baff6448a1a7a4fL249)
* Update test [SqlPipelineSuite.scala](https://github.com/apache/spark/pull/51406/files#diff-f4551b9f9991c5a119c9f82ed894031cc8e91e8e011f3226572c591b26c8707cL133) to remove assertion for the field. This is the only place that's accessing/modifying the field value.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

In Spark Declarative Pipelines (SDP), the Flow trait has an unused `comment` field that is not being referenced anywhere.
Since there is no way for user to see flow comments as of now, this PR removes the field.



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Updated unit test that references the field and made sure all other test passes.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No