### PR TITLE
[SPARK-52718][PS] Fix float32 type widening in `rmod`/`mod` under ANSI

### DIFF
--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -79,8 +79,9 @@ def _cast_back_float(
 
     This function ensures pandas on Spark matches pandas behavior when performing
     arithmetic operations involving float32 and numeric values. In such cases, under ANSI mode,
-    Spark implicitly widen float32 to float64, when the other operand is a numeric type but not float32 (e.g., int,
-    bool), which deviates from pandas behavior where the result retains float32.
+    Spark implicitly widen float32 to float64, when the other operand is a numeric type
+    but not float32 (e.g., int, bool), which deviates from pandas behavior where the result
+    retains float32.
     """
     is_left_float = is_float_dtype(left_dtype)
     is_right_numeric = isinstance(right, (int, float, bool)) or (

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_mod.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_mod.py
@@ -42,6 +42,7 @@ class NumModTestsMixin:
             self.assert_eq(pser % pser, psser % psser, check_exact=False)
             self.assert_eq(pser % pser.astype(bool), psser % psser.astype(bool), check_exact=False)
             self.assert_eq(pser % True, psser % True, check_exact=False)
+            self.assert_eq(pser % 1, psser % 1, check_exact=False)
             if col in ["int", "int32"]:
                 self.assert_eq(
                     pd.Series([np.nan, np.nan, np.nan], dtype=float, name=col), psser % False

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_reverse.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_reverse.py
@@ -117,7 +117,6 @@ class ReverseTestsMixin:
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) ** psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) ** psser)
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_rmod(self):
         pdf, psdf = self.pdf, self.psdf
         for col in self.numeric_df_cols:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix float32 type widening in `rmod` under ANSI; utility `_cast_back_float` change also corrects float32 widening in mod with non-bool numeric operands.


### Why are the changes needed?
Ensure pandas on Spark works well with ANSI mode on.
Part of https://issues.apache.org/jira/browse/SPARK-52700.

In pandas, when performing mod or rmod operations involving a float32 and other numeric types (e.g., int, float64), the result retains the float32 dtype; but pandas on spark widen to float64

**Pandas**
```py
>>> s
0    1.1
1    2.2
2    3.3
dtype: float32
>>> s % 1
0    0.1
1    0.2
2    0.3
dtype: float32
>>> 1 % s
0    1.0
1    1.0
2    1.0
dtype: float32
>>> s % 0.1
0    7.450581e-09
1    1.490116e-08
2    9.999990e-02
dtype: float32
>>> 0.1 % s
0    0.1
1    0.1
2    0.1
dtype: float32
```

**Pandas on Spark**
```py
>>> psser
0    1.1
1    2.2
2    3.3
dtype: float32
>>> psser % 1
0    0.1
1    0.2
2    0.3
dtype: float64
>>> 1 % psser
0    1.0
1    1.0
2    1.0
dtype: float64
>>> psser % 0.1
0    2.384186e-08
1    4.768372e-08
2    9.999995e-02
dtype: float64
>>> 0.1 % psser
0    0.1
1    0.1
2    0.1
dtype: float64
```

### Does this PR introduce _any_ user-facing change?
Yes, both `rmod` and `mod` work as expected under ANSI


### How was this patch tested?
Unit tests


### Was this patch authored or co-authored using generative AI tooling?
No