### PR TITLE
[SPARK-52720][PS] Fix float32 type widening in `add`/`radd` under ANSI

### DIFF
--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -106,7 +106,7 @@ class NumericOps(DataTypeOps):
         spark_session = left._internal.spark_frame.sparkSession
         new_right = transform_boolean_operand_to_numeric(right, spark_type=left.spark.data_type)
 
-        def wrapped_add(lc, rc):
+        def wrapped_add(lc: PySparkColumn, rc: Any) -> PySparkColumn:
             expr = PySparkColumn.__add__(lc, rc)
             if is_ansi_mode_enabled(spark_session):
                 expr = _cast_back_float(expr, left.dtype, right)
@@ -164,7 +164,7 @@ class NumericOps(DataTypeOps):
         spark_session = left._internal.spark_frame.sparkSession
         new_right = transform_boolean_operand_to_numeric(right)
 
-        def wrapped_radd(lc, rc):
+        def wrapped_radd(lc: PySparkColumn, rc: Any) -> PySparkColumn:
             expr = PySparkColumn.__radd__(lc, rc)
             if is_ansi_mode_enabled(spark_session):
                 expr = _cast_back_float(expr, left.dtype, right)

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_arithmetic.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_arithmetic.py
@@ -41,7 +41,6 @@ class ArithmeticTestsMixin:
     def float_psser(self):
         return ps.from_pandas(self.float_pser)
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_add(self):
         pdf, psdf = self.pdf, self.psdf
         for col in self.numeric_df_cols:

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_reverse.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_reverse.py
@@ -42,7 +42,6 @@ class ReverseTestsMixin:
     def float_psser(self):
         return ps.from_pandas(self.float_pser)
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_radd(self):
         pdf, psdf = self.pdf, self.psdf
         for col in self.numeric_df_cols:

--- a/python/pyspark/pandas/tests/frame/test_constructor.py
+++ b/python/pyspark/pandas/tests/frame/test_constructor.py
@@ -549,7 +549,6 @@ class FrameConstructorMixin:
     @unittest.skipIf(
         not extension_float_dtypes_available, "pandas extension float dtypes are not available"
     )
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_extension_float_dtypes(self):
         pdf = pd.DataFrame(
             {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix float32 type widening in add/radd under ANSI

### Why are the changes needed?
Ensure pandas on Spark works well with ANSI mode on.
Part of https://issues.apache.org/jira/browse/SPARK-52700.

### Does this PR introduce _any_ user-facing change?
Yes, both add and radd work as expected under ANSI

```py
>>> ps.set_option("compute.fail_on_ansi_mode", False)
>>> ps.set_option("compute.ansi_mode_support", True)
>>> pser = pd.Series([1.1, 2.2, 3.3], dtype=np.float32)
>>> psser = ps.from_pandas(pser)
>>> psser + 1
0    2.1                                                                        
1    3.2
2    4.3
dtype: float32
>>> psser + True
0    2.1
1    3.2
2    4.3
dtype: float32
>>> 0.1 + psser
0    1.2
1    2.3
2    3.4
dtype: float32
```

### How was this patch tested?
Unit tests with both `SPARK_ANSI_SQL_MODE=false` and `SPARK_ANSI_SQL_MODE=true`

`"pyspark.pandas.tests.data_type_ops.test_num_arithmetic ArithmeticTests.test_add"`
`"pyspark.pandas.tests.data_type_ops.test_num_reverse ReverseTests.test_radd"`

### Was this patch authored or co-authored using generative AI tooling?
