### PR TITLE
[SPARK-52721][PYTHON] Fix message parameter for CANNOT_PARSE_DATATYPE

### DIFF
--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -207,7 +207,7 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         except Exception as e:
             raise PySparkValueError(
                 errorClass="CANNOT_PARSE_DATATYPE",
-                messageParameters={"error": str(e)},
+                messageParameters={"msg": str(e)},
             )
 
     def printSchema(self, level: Optional[int] = None) -> None:

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2012,7 +2012,7 @@ def _parse_datatype_json_value(
         else:
             raise PySparkValueError(
                 errorClass="CANNOT_PARSE_DATATYPE",
-                messageParameters={"error": str(json_value)},
+                messageParameters={"msg": str(json_value)},
             )
     else:
         tpe = json_value["type"]


### PR DESCRIPTION

### What changes were proposed in this pull request?

Fix message parameter for CANNOT_PARSE_DATATYPE


### Why are the changes needed?
bugfix

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- Before
AssertionError: Undefined error message parameter for error class: CANNOT_PARSE_DATATYPE. Parameters: {'error':

- After
pyspark.errors.exceptions.base.PySparkValueError: [CANNOT_PARSE_DATATYPE] Unable to parse datatype.

### Was this patch authored or co-authored using generative AI tooling?
no