### PR TITLE
[SPARK-52733][SQL][DOCS] Update the page about TIME literals

### DIFF
--- a/docs/sql-ref-literals.md
+++ b/docs/sql-ref-literals.md
@@ -373,7 +373,7 @@ SELECT -3.E-3D AS col;
 
 ### Datetime Literal
 
-A datetime literal is used to specify a date or timestamp value.
+A datetime literal is used to specify a date, time or timestamp value.
 
 #### Date Syntax
 
@@ -408,6 +408,44 @@ SELECT DATE '2011-11-11' AS col;
 +----------+
 |2011-11-11|
 +----------+
+```
+
+#### Time Syntax
+
+```sql
+TIME { '[h]h:[m]m[:]' |
+       '[h]h:[m]m:[s]s[.]' |
+       '[h]h:[m]m:[s]s.[ms][ms][ms][us][us][us]'}
+```
+**Note:** defaults to `00` if hour, minute or second is not specified.
+
+#### Time Examples
+
+```sql
+SELECT TIME'12:00' as col;
++--------+
+|col     |
++--------+
+|12:00:00|
++--------+
+SELECT TIME'2:0' as col;
++--------+
+|col     |
++--------+
+|02:00:00|
++--------+
+SELECT TIME'2:0:3' as col;
++--------+
+|col     |
++--------+
+|02:00:03|
++--------+
+SELECT TIME'23:59:59.999999' as col;
++---------------+
+|col            |
++---------------+
+|23:59:59.999999|
++---------------+
 ```
 
 #### Timestamp Syntax


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to update the doc page https://spark.apache.org/docs/latest/sql-ref-literals.html about literals, and provide information about the TIME literals. After the changes, the page looks like:
<img width="846" alt="Screenshot 2025-07-09 at 15 14 02" src="https://github.com/user-attachments/assets/973189f0-029c-46eb-9775-dbd3ee92cff4" />

### Why are the changes needed?
To improve user experience with Spark SQL, and provide actual information about the TIME data type.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By checking the result page.

### Was this patch authored or co-authored using generative AI tooling?
No.
