### PR TITLE
[SPARK-52725][CORE] Delay resource profile manager initialization until plugin is loaded

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -483,7 +483,6 @@ class SparkContext(config: SparkConf) extends Logging {
     }
 
     _listenerBus = new LiveListenerBus(_conf)
-    _resourceProfileManager = new ResourceProfileManager(_conf, _listenerBus)
 
     // Initialize the app status store and listener before SparkEnv is created so that it gets
     // all events.
@@ -584,8 +583,9 @@ class SparkContext(config: SparkConf) extends Logging {
     _heartbeatReceiver = env.rpcEnv.setupEndpoint(
       HeartbeatReceiver.ENDPOINT_NAME, new HeartbeatReceiver(this))
 
-    // Initialize any plugins before the task scheduler is initialized.
+    // Initialize any plugins before initializing the task scheduler and resource profile manager.
     _plugins = PluginContainer(this, _resources.asJava)
+    _resourceProfileManager = new ResourceProfileManager(_conf, _listenerBus)
     _env.initializeShuffleManager()
     _env.initializeMemoryManager(SparkContext.numDriverCores(master, conf))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Follow #45052 

When we modify the memory configuration in the plugin, the new configuration cannot be updated to the defaultResourceProfile because it is initialized before the plugin is loaded.

For example, the initial spark.executor.memory is set to 8g, but after our plugin processes it, the value is adjusted to 2g. However, the executor's JVM launch parameter (-Xmx) still defaults to 8g according resource profile, which could lead to OOM kills due to onheap memory RSS usage exceeds expectations.

So, the ResourceProfileManager should be initilized after plugin loaded.


### Why are the changes needed?
Make memory configuration changes in plugins take effect at the resource profile.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
ut


### Was this patch authored or co-authored using generative AI tooling?
No
