### PR TITLE
[SPARK-52745][SQL] Ensure one of the `schema` and `columns` in the Table interface is implemented and `columns` is preferable

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Table.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Table.java
@@ -20,6 +20,7 @@ package org.apache.spark.sql.connector.catalog;
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.catalog.constraints.Constraint;
 import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.errors.QueryCompilationErrors;
 import org.apache.spark.sql.types.StructType;
 
 import java.util.Collections;
@@ -56,7 +57,9 @@ public interface Table {
    * @deprecated This is deprecated. Please override {@link #columns} instead.
    */
   @Deprecated(since = "3.4.0")
-  StructType schema();
+  default StructType schema() {
+    throw QueryCompilationErrors.mustOverrideOneMethodError("columns");
+  }
 
   /**
    * Returns the columns of this table. If the table is not readable and doesn't have a schema, an

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -581,7 +581,6 @@ object ResolveDefaultColumns extends QueryErrorsBase
     }.toSeq
   }
 
-
   /**
    * These define existence default values for the struct fields for efficiency purposes.
    * The caller should avoid using such methods in a loop for efficiency.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.optimizer.{ConstantFolding, Optimizer}
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.trees.TreePattern.PLAN_EXPRESSION
-import org.apache.spark.sql.connector.catalog.{CatalogManager, DefaultValue, FunctionCatalog, Identifier, TableCatalog, TableCatalogCapability}
+import org.apache.spark.sql.connector.catalog.{CatalogManager, Column, DefaultValue, FunctionCatalog, Identifier, TableCatalog, TableCatalogCapability}
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryErrorsBase}
 import org.apache.spark.sql.internal.SQLConf
@@ -572,6 +572,15 @@ object ResolveDefaultColumns extends QueryErrorsBase
     }
     rows.toSeq
   }
+
+  /** If any fields in a schema have default values, appends them to the result. */
+  def getDescribeMetadata(cols: Array[Column]): Seq[(String, String, Any)] = {
+    cols.filter(_.defaultValue() != null).flatMap { col =>
+      ("", "", "") :: ("# Column Default Values", "", "") ::
+        (col.name, col.dataType.simpleString, col.defaultValue().getValue.value()) :: Nil
+    }.toSeq
+  }
+
 
   /**
    * These define existence default values for the struct fields for efficiency purposes.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -574,10 +574,10 @@ object ResolveDefaultColumns extends QueryErrorsBase
   }
 
   /** If any fields in a schema have default values, appends them to the result. */
-  def getDescribeMetadata(cols: Array[Column]): Seq[(String, String, Any)] = {
+  def getDescribeMetadata(cols: Array[Column]): Seq[(String, String, String)] = {
     cols.filter(_.defaultValue() != null).flatMap { col =>
       ("", "", "") :: ("# Column Default Values", "", "") ::
-        (col.name, col.dataType.simpleString, col.defaultValue().getValue.value()) :: Nil
+        (col.name, col.dataType.simpleString, col.defaultValue().getSql) :: Nil
     }.toSeq
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/write/RowLevelOperationTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/write/RowLevelOperationTable.scala
@@ -22,7 +22,6 @@ import java.util
 import org.apache.spark.sql.connector.catalog.{Column, SupportsRead, SupportsRowLevelOperations, SupportsWrite, Table, TableCapability}
 import org.apache.spark.sql.connector.catalog.constraints.Constraint
 import org.apache.spark.sql.connector.read.ScanBuilder
-import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/write/RowLevelOperationTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/write/RowLevelOperationTable.scala
@@ -38,7 +38,6 @@ private[sql] case class RowLevelOperationTable(
     operation: RowLevelOperation) extends Table with SupportsRead with SupportsWrite {
 
   override def name: String = table.name
-  override def schema: StructType = table.schema
   override def columns: Array[Column] = table.columns()
   override def capabilities: util.Set[TableCapability] = table.capabilities
   override def constraints(): Array[Constraint] = table.constraints()

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/Catalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/Catalog.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.catalog.{CatalogManager, SupportsNamespaces, TableCatalog}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.{CatalogHelper, MultipartIdentifierHelper, NamespaceHelper, TransformHelper}
+import org.apache.spark.sql.connector.catalog.CatalogV2Util.v2ColumnsToStructType
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.command.{ShowNamespacesCommand, ShowTablesCommand}
 import org.apache.spark.sql.execution.datasources.{DataSource, LogicalRelation}
@@ -408,7 +409,8 @@ class Catalog(sparkSession: SparkSession) extends catalog.Catalog {
         val clusteringColumnNames = clusterBySpecOpt.map { clusterBySpec =>
           clusterBySpec.columnNames.map(_.toString)
         }.getOrElse(Nil).toSet
-        schemaToColumns(table.schema(), partitionColumnNames.contains, bucketColumnNames.contains,
+        val schema = v2ColumnsToStructType(table.columns())
+        schemaToColumns(schema, partitionColumnNames.contains, bucketColumnNames.contains,
           clusteringColumnNames.contains)
 
       case ResolvedPersistentView(_, _, metadata) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
@@ -84,7 +84,7 @@ case class DescribeTableExec(
   private def addSchema(rows: ArrayBuffer[InternalRow]): Unit = {
     rows ++= table.columns().map{ column =>
       toCatalystRow(
-        column.name, column.dataType.simpleString, column.comment())
+        column.name, column.dataType.simpleString, column.comment)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
@@ -76,15 +76,15 @@ case class DescribeTableExec(
     rows += toCatalystRow("Table Properties", properties, "")
 
     // If any columns have default values, append them to the result.
-    ResolveDefaultColumns.getDescribeMetadata(table.schema).foreach { row =>
+    ResolveDefaultColumns.getDescribeMetadata(table.columns()).foreach { row =>
       rows += toCatalystRow(row._1, row._2, row._3)
     }
   }
 
   private def addSchema(rows: ArrayBuffer[InternalRow]): Unit = {
-    rows ++= table.schema.map{ column =>
+    rows ++= table.columns().map{ column =>
       toCatalystRow(
-        column.name, column.dataType.simpleString, column.getComment().orNull)
+        column.name, column.dataType.simpleString, column.comment())
     }
   }
 
@@ -107,11 +107,12 @@ case class DescribeTableExec(
     rows += toCatalystRow("# Clustering Information", "", "")
     rows += toCatalystRow(s"# ${output.head.name}", output(1).name, output(2).name)
     rows ++= clusterBySpec.columnNames.map { fieldNames =>
-      val nestedField = table.schema.findNestedField(fieldNames.fieldNames.toIndexedSeq)
+      val schema = CatalogV2Util.v2ColumnsToStructType(table.columns())
+      val nestedField = schema.findNestedField(fieldNames.fieldNames.toIndexedSeq)
       assert(nestedField.isDefined,
         "The clustering column " +
           s"${fieldNames.fieldNames.map(quoteIfNeeded).mkString(".")} " +
-          s"was not found in the table schema ${table.schema.catalogString}.")
+          s"was not found in the table schema ${schema.catalogString}.")
       nestedField.get
     }.map { case (path, field) =>
       toCatalystRow(
@@ -153,15 +154,15 @@ case class DescribeTableExec(
       if (partitionColumnsOnly) {
         rows += toCatalystRow("# Partition Information", "", "")
         rows += toCatalystRow(s"# ${output(0).name}", output(1).name, output(2).name)
+        val schema = CatalogV2Util.v2ColumnsToStructType(table.columns())
         rows ++= table.partitioning
           .map(_.asInstanceOf[IdentityTransform].ref.fieldNames())
           .map { fieldNames =>
-            val nestedField = table.schema.findNestedField(fieldNames.toImmutableArraySeq)
+            val nestedField = schema.findNestedField(fieldNames.toImmutableArraySeq)
             if (nestedField.isEmpty) {
               throw QueryExecutionErrors.partitionColumnNotFoundInTheTableSchemaError(
                 fieldNames.toSeq,
-                table.schema()
-              )
+                schema)
             }
             nestedField.get
           }.map { case (path, field) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablesExtendedExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablesExtendedExec.scala
@@ -114,8 +114,8 @@ case class ShowTablesExtendedExec(
         field => quoteIdentifier(field.name)).mkString("[", ", ", "]"))
     }
 
-    if (table.schema().nonEmpty) {
-      results.put("Schema", table.schema().treeString)
+    if (table.columns().nonEmpty) {
+      results.put("Schema", CatalogV2Util.v2ColumnsToStructType(table.columns()).treeString)
     }
 
     results.map { case (key, value) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTable.scala
@@ -32,7 +32,10 @@ import org.apache.spark.sql.jdbc.JdbcDialects
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-case class JDBCTable(ident: Identifier, schema: StructType, jdbcOptions: JDBCOptions)
+case class JDBCTable(
+    ident: Identifier,
+    override val schema: StructType,
+    jdbcOptions: JDBCOptions)
   extends Table
   with SupportsRead
   with SupportsWrite

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sinks/console.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sinks/console.scala
@@ -19,8 +19,8 @@ package org.apache.spark.sql.execution.streaming
 
 import java.util
 
-import org.apache.spark.sql._
-import org.apache.spark.sql.connector.catalog.{SupportsWrite, Table, TableCapability}
+import org.apache.spark.sql.{Column => _, _}
+import org.apache.spark.sql.connector.catalog.{Column, SupportsWrite, Table, TableCapability}
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, SupportsTruncate, Write, WriteBuilder}
 import org.apache.spark.sql.connector.write.streaming.StreamingWrite
 import org.apache.spark.sql.execution.streaming.sources.ConsoleWrite

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sinks/console.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sinks/console.scala
@@ -64,7 +64,7 @@ object ConsoleTable extends Table with SupportsWrite {
 
   override def name(): String = "console"
 
-  override def schema(): StructType = StructType(Nil)
+  override def columns(): Array[Column] = Array.empty
 
   override def capabilities(): util.Set[TableCapability] = {
     util.EnumSet.of(TableCapability.STREAMING_WRITE)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/util/BlockOnStopSource.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/util/BlockOnStopSource.scala
@@ -25,7 +25,7 @@ import org.apache.zookeeper.KeeperException.UnimplementedException
 import org.apache.spark.sql.{Row, SparkSession, SQLContext}
 import org.apache.spark.sql.classic.ClassicConversions.castToImpl
 import org.apache.spark.sql.classic.DataFrame
-import org.apache.spark.sql.connector.catalog.{SupportsRead, Table, TableCapability}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Column, SupportsRead, Table, TableCapability}
 import org.apache.spark.sql.connector.catalog.TableCapability.CONTINUOUS_READ
 import org.apache.spark.sql.connector.read.{streaming, InputPartition, Scan, ScanBuilder}
 import org.apache.spark.sql.connector.read.streaming.{ContinuousPartitionReaderFactory, ContinuousStream, PartitionOffset}
@@ -93,8 +93,9 @@ class BlockOnStopSource(spark: SparkSession, latch: CountDownLatch) extends Sour
 
 /** A V2 Table, which can create a blocking streaming source for ContinuousExecution. */
 class BlockOnStopSourceTable(latch: CountDownLatch) extends Table with SupportsRead {
-  override def schema(): StructType = BlockOnStopSourceProvider.schema
-
+  override def columns(): Array[Column] = {
+    CatalogV2Util.structTypeToV2Columns(BlockOnStopSourceProvider.schema)
+  }
   override def name(): String = "blockingSource"
 
   override def capabilities(): util.Set[TableCapability] = util.EnumSet.of(CONTINUOUS_READ)
@@ -102,7 +103,7 @@ class BlockOnStopSourceTable(latch: CountDownLatch) extends Table with SupportsR
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
     new ScanBuilder {
       override def build(): Scan = new Scan {
-        override def readSchema(): StructType = schema()
+        override def readSchema(): StructType = CatalogV2Util.v2ColumnsToStructType(columns())
 
         override def toContinuousStream(checkpointLocation: String): ContinuousStream = {
           new BlockOnStopContinuousStream(latch)

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DatasetManager.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DatasetManager.scala
@@ -24,7 +24,13 @@ import org.apache.spark.SparkException
 import org.apache.spark.internal.{Logging, LogKeys, MDC}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, TableCatalog, TableChange, TableInfo}
+import org.apache.spark.sql.connector.catalog.{
+  CatalogV2Util,
+  Identifier,
+  TableCatalog,
+  TableChange,
+  TableInfo
+}
 import org.apache.spark.sql.connector.catalog.CatalogV2Util.v2ColumnsToStructType
 import org.apache.spark.sql.connector.expressions.Expressions
 import org.apache.spark.sql.pipelines.graph.QueryOrigin.ExceptionHelpers

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DatasetManager.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DatasetManager.scala
@@ -24,13 +24,8 @@ import org.apache.spark.SparkException
 import org.apache.spark.internal.{Logging, LogKeys, MDC}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.connector.catalog.{
-  CatalogV2Util,
-  Identifier,
-  TableCatalog,
-  TableChange,
-  TableInfo
-}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, TableCatalog, TableChange, TableInfo}
+import org.apache.spark.sql.connector.catalog.CatalogV2Util.v2ColumnsToStructType
 import org.apache.spark.sql.connector.expressions.Expressions
 import org.apache.spark.sql.pipelines.graph.QueryOrigin.ExceptionHelpers
 import org.apache.spark.sql.pipelines.util.SchemaInferenceUtils.diffSchemas
@@ -185,7 +180,7 @@ object DatasetManager extends Logging {
 
     // Alter the table if we need to
     if (existingTableOpt.isDefined && !dropTable) {
-      val existingSchema = existingTableOpt.get.schema()
+      val existingSchema = v2ColumnsToStructType(existingTableOpt.get.columns())
 
       val targetSchema = if (table.isStreamingTable && !isFullRefresh) {
         SchemaMergingUtils.mergeSchemas(existingSchema, outputSchema)


### PR DESCRIPTION

### What changes were proposed in this pull request?

Make `Table.schema()` be able to be deprecated by
- Removing all callers except one in the Table.columns ()`
- Add default implementation


### Why are the changes needed?
`Table.schema()` has been marked as deprecated since 3.4.0. However, w/ all the callers and w/o a default implementation, users are unable to drop it in inherited ones.

For instance, I can not ignore this method in my spark-status-connector project

https://github.com/yaooqinn/spark-status-connector/blob/main/src/main/scala/org/apache/spark/yao/StatusTable.scala#L20 

### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?
existing tests


### Was this patch authored or co-authored using generative AI tooling?
no