### PR TITLE
[SPARK-52694][SQL] Add `o.a.s.sql.Encoders#udt`API

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/Encoders.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Encoders.scala
@@ -22,6 +22,7 @@ import java.lang.reflect.Modifier
 import scala.reflect.{classTag, ClassTag}
 import scala.reflect.runtime.universe.TypeTag
 
+import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.sql.catalyst.{JavaTypeInference, ScalaReflection}
 import org.apache.spark.sql.catalyst.encoders.{Codec, JavaSerializationCodec, KryoSerializationCodec, RowEncoder => SchemaInference}
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders._
@@ -368,4 +369,13 @@ object Encoders {
    */
   def scalaBoolean: Encoder[Boolean] = PrimitiveBooleanEncoder
 
+  /**
+   * An encoder for UserDefinedType.
+   * @since 4.1.0
+   */
+  @DeveloperApi
+  @Since("4.1.0")
+  def udt[T >: Null](tpe: UserDefinedType[T]): Encoder[T] = {
+    UDTEncoder(tpe)
+  }
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/Encoders.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Encoders.scala
@@ -22,7 +22,6 @@ import java.lang.reflect.Modifier
 import scala.reflect.{classTag, ClassTag}
 import scala.reflect.runtime.universe.TypeTag
 
-import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.sql.catalyst.{JavaTypeInference, ScalaReflection}
 import org.apache.spark.sql.catalyst.encoders.{Codec, JavaSerializationCodec, KryoSerializationCodec, RowEncoder => SchemaInference}
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders._

--- a/sql/api/src/main/scala/org/apache/spark/sql/Encoders.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Encoders.scala
@@ -370,11 +370,10 @@ object Encoders {
   def scalaBoolean: Encoder[Boolean] = PrimitiveBooleanEncoder
 
   /**
+   * :: DeveloperApi ::
    * An encoder for UserDefinedType.
    * @since 4.1.0
    */
-  @DeveloperApi
-  @Since("4.1.0")
   def udt[T >: Null](tpe: UserDefinedType[T]): Encoder[T] = {
     UDTEncoder(tpe)
   }

--- a/sql/api/src/main/scala/org/apache/spark/sql/Encoders.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Encoders.scala
@@ -370,7 +370,8 @@ object Encoders {
 
   /**
    * :: DeveloperApi ::
-   * An encoder for UserDefinedType.
+   *
+   * An encoder for [[UserDefinedType]].
    * @since 4.1.0
    */
   def udt[T >: Null](tpe: UserDefinedType[T]): Encoder[T] = {

--- a/sql/api/src/main/scala/org/apache/spark/sql/Encoders.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Encoders.scala
@@ -369,9 +369,7 @@ object Encoders {
   def scalaBoolean: Encoder[Boolean] = PrimitiveBooleanEncoder
 
   /**
-   * :: DeveloperApi ::
-   *
-   * An encoder for [[UserDefinedType]].
+   * An encoder for UserDefinedType.
    * @since 4.1.0
    */
   def udt[T >: Null](tpe: UserDefinedType[T]): Encoder[T] = {

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/encoders/AgnosticEncoder.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/encoders/AgnosticEncoder.scala
@@ -182,6 +182,12 @@ object AgnosticEncoders {
     override def clsTag: ClassTag[E] = ClassTag(udt.userClass)
   }
 
+  object UDTEncoder {
+    def apply[E >: Null](udt: UserDefinedType[E]): UDTEncoder[E] = {
+      new UDTEncoder(udt, udt.getClass.asInstanceOf[Class[_ <: UserDefinedType[_]]])
+    }
+  }
+
   // Enums are special leafs because we need to capture the class.
   protected abstract class EnumEncoder[E] extends AgnosticEncoder[E] {
     override def isPrimitive: Boolean = false

--- a/sql/core/src/test/scala/org/apache/spark/sql/UserDefinedTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UserDefinedTypeSuite.scala
@@ -319,4 +319,15 @@ class UserDefinedTypeSuite extends QueryTest with SharedSparkSession with Parque
     row.setInt(0, udt.serialize(Year.of(2018)))
     assert(row.getInt(0) == 2018)
   }
+
+  test("SPARK-52694: Add a DeveloperApi - Encoders#udt") {
+    val udt = new YearUDT()
+    implicit val yearEncoder: Encoder[Year] = Encoders.udt(udt)
+    val ds = spark.createDataset(Seq(Year.of(2018), Year.of(2019)))
+    assert(ds.schema.head.dataType == udt)
+    checkAnswer(ds.toDF("year"), Seq(Row(Year.of(2018)), Row(Year.of(2019))))
+    checkDataset(
+      spark.range(10).map(i => Year.of(i.toInt + 2018)),
+      (0 to 9).map(i => Year.of(i + 2018)): _*)
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/UserDefinedTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UserDefinedTypeSuite.scala
@@ -320,7 +320,7 @@ class UserDefinedTypeSuite extends QueryTest with SharedSparkSession with Parque
     assert(row.getInt(0) == 2018)
   }
 
-  test("SPARK-52694: Add a DeveloperApi - Encoders#udt") {
+  test("SPARK-52694: Add Encoders#udt") {
     val udt = new YearUDT()
     implicit val yearEncoder: Encoder[Year] = Encoders.udt(udt)
     val ds = spark.createDataset(Seq(Year.of(2018), Year.of(2019)))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds an encoder for UserDefinedType in org.apache.spark.sql.Encoders as a developer API.





### Why are the changes needed?

With Encoders.udt, developers can create Encoder[T] for UserDefinedType[T], which makes writing Spark DSL with udt and its associated class T much more easily.

### Does this PR introduce _any_ user-facing change?

Yes, a developer API will be added


### How was this patch tested?
new tests


### Was this patch authored or co-authored using generative AI tooling?
no