### PR TITLE
[SPARK-52753][SQL] Make parseDataType binary compatible with previous versions

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -234,11 +234,15 @@ object DataType {
     }
   }
 
+  private[sql] def parseDataType(json: JValue): DataType = {
+    parseDataType(json, fieldPath = "", collationsMap = Map.empty)
+  }
+
   // NOTE: Map fields must be sorted in alphabetical order to keep consistent with the Python side.
   private[sql] def parseDataType(
       json: JValue,
-      fieldPath: String = "",
-      collationsMap: Map[String, String] = Map.empty): DataType = json match {
+      fieldPath: String,
+      collationsMap: Map[String, String]): DataType = json match {
     case JString(name) =>
       collationsMap.get(fieldPath) match {
         case Some(collation) =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -1338,7 +1338,7 @@ class DataTypeSuite extends SparkFunSuite {
     assert(DataType.parseDataType(JsonMethods.parse(arrayJson)) === ArrayType(StringType))
 
     val parsedWithCollations = DataType.parseDataType(
-        JsonMethods.parse(arrayJson), collationsMap = collationsMap)
+        JsonMethods.parse(arrayJson), fieldPath = "", collationsMap = collationsMap)
     assert(parsedWithCollations === ArrayType(StringType(unicodeCollationId)))
   }
 
@@ -1360,7 +1360,7 @@ class DataTypeSuite extends SparkFunSuite {
     assert(DataType.parseDataType(JsonMethods.parse(mapJson)) === MapType(StringType, StringType))
 
     val parsedWithCollations = DataType.parseDataType(
-      JsonMethods.parse(mapJson), collationsMap = collationsMap)
+      JsonMethods.parse(mapJson), fieldPath = "", collationsMap = collationsMap)
     assert(parsedWithCollations ===
       MapType(StringType(unicodeCollationId), StringType(unicodeCollationId)))
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Refactoring the `parseDataType` method to have two overloads instead of using default values for optional parameters.


### Why are the changes needed?
In https://github.com/apache/spark/pull/46280 we changed the API of the internal `parseDataType` with two new parameters with default values. However, this change is not backward compatible because, in Scala, adding new parameters with default values alters the method signature at the bytecode level, making it incompatible with previously compiled code that relied on the original method definition ([source](https://contributors.scala-lang.org/t/can-we-make-adding-a-parameter-with-a-default-value-binary-compatible/6132)).

Even though this is an internal method it seems that some tools are still using it ([example](https://github.com/h2oai/sparkling-water/blob/master/utils/src/main/scala/org/apache/spark/sql/DataTypeExtensions.scala#L29)) so this change could break them.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests should be sufficient.


### Was this patch authored or co-authored using generative AI tooling?
No.
