### PR TITLE
[SPARK-52726][SQL] Normalize project list under Window

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/NormalizePlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/NormalizePlan.scala
@@ -154,6 +154,12 @@ object NormalizePlan extends PredicateHelper {
             .isDefined =>
         project.child
 
+      case window @ Window(_, _, _, innerProject: Project, _) =>
+        window.copy(child = normalizeProjectListOrder(innerProject))
+
+      case window @ Window(_, _, _, innerWindow: Window, _) =>
+        window.copy(child = normalizeWindowListOrder(innerWindow))
+
       case aggregate @ Aggregate(_, _, innerProject: Project, _) =>
         aggregate.copy(child = normalizeProjectListOrder(innerProject))
 
@@ -225,6 +231,10 @@ object NormalizePlan extends PredicateHelper {
 
   private def normalizeProjectListOrder(project: Project): Project = {
     project.copy(projectList = project.projectList.sortBy(_.name))
+  }
+
+  private def normalizeWindowListOrder(window: Window): Window = {
+    window.copy(windowExpressions = window.windowExpressions.sortBy(_.name))
   }
 
   private def normalizeAggregateListOrder(aggregate: Aggregate): Aggregate = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
@@ -83,21 +83,17 @@ class NormalizePlanSuite extends SparkFunSuite with SQLConfHelper {
       input.window(Seq(denseRankExpression, rankExpression), Seq(col1), Seq(col2.asc))
     assert(baselineInnerWindow != testInnerWindow)
 
-    val baselineRankAttr = baselineInnerWindow.output.find(_.name == "rank").get
-    val testRankAttr = testInnerWindow.output.find(_.name == "rank").get
+    val baselinePlan = baselineInnerWindow.window(
+      Seq(RowNumber().over(Seq(col3), Seq(rankExpression.toAttribute.asc), frame).as("row_num")),
+      Seq(col3),
+      Seq(rankExpression.toAttribute.asc)
+    )
 
-    val baselineOuterSpec = WindowSpecDefinition(Seq(col3), Seq(baselineRankAttr.asc), frame)
-    val baselineRowNumberExpression = WindowExpression(RowNumber(), baselineOuterSpec).as("row_num")
-
-    val testOuterSpec = WindowSpecDefinition(Seq(col3), Seq(testRankAttr.asc), frame)
-    val testRowNumberExpression = WindowExpression(RowNumber(), testOuterSpec).as("row_num")
-
-    val baselinePlan =
-      baselineInnerWindow.window(
-        Seq(baselineRowNumberExpression), Seq(col3), Seq(baselineRankAttr.asc)
-      )
-    val testPlan =
-      testInnerWindow.window(Seq(testRowNumberExpression), Seq(col3), Seq(testRankAttr.asc))
+    val testPlan = testInnerWindow.window(
+      Seq(RowNumber().over(Seq(col3), Seq(rankExpression.toAttribute.asc), frame).as("row_num")),
+      Seq(col3),
+      Seq(rankExpression.toAttribute.asc)
+    )
 
     assert(baselinePlan != testPlan)
     assert(NormalizePlan(baselinePlan) == NormalizePlan(testPlan))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
@@ -83,18 +83,26 @@ class NormalizePlanSuite extends SparkFunSuite with SQLConfHelper {
       input.window(Seq(denseRankExpression, rankExpression), Seq(col1), Seq(col2.asc))
     assert(baselineInnerWindow != testInnerWindow)
 
-    val baselineOuterSpec = WindowSpecDefinition(Seq(col3), Seq(rankExpression.toAttribute.asc), frame)
-    val baselineRowNumberExpression = WindowExpression(RowNumber(), baselineOuterSpec).as("row_num")
+    val baselineOuterSpec =
+      WindowSpecDefinition(Seq(col3), Seq(rankExpression.toAttribute.asc), frame)
+    val baselineRowNumberExpression =
+      WindowExpression(RowNumber(), baselineOuterSpec).as("row_num")
 
     val testOuterSpec = WindowSpecDefinition(Seq(col3), Seq(rankExpression.toAttribute.asc), frame)
     val testRowNumberExpression = WindowExpression(RowNumber(), testOuterSpec).as("row_num")
 
     val baselinePlan =
       baselineInnerWindow.window(
-        Seq(baselineRowNumberExpression), Seq(col3), Seq(rankExpression.toAttribute.asc)
+        Seq(baselineRowNumberExpression),
+        Seq(col3),
+        Seq(rankExpression.toAttribute.asc)
       )
     val testPlan =
-      testInnerWindow.window(Seq(testRowNumberExpression), Seq(col3), Seq(rankExpression.toAttribute.asc))
+      testInnerWindow.window(
+        Seq(testRowNumberExpression),
+        Seq(col3),
+        Seq(rankExpression.toAttribute.asc)
+      )
 
     assert(baselinePlan != testPlan)
     assert(NormalizePlan(baselinePlan) == NormalizePlan(testPlan))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
@@ -53,14 +53,15 @@ class NormalizePlanSuite extends SparkFunSuite with SQLConfHelper {
     val (col1, col2) = ($"col1".int, $"col2".int)
     val input = LocalRelation(col1, col2)
     val frame = SpecifiedWindowFrame(RangeFrame, UnboundedPreceding, CurrentRow)
-    val rankExpr = Rank(Seq.empty).over(Seq(col1), Seq(col2.asc), frame).as("rank")
+    val spec = WindowSpecDefinition(Seq(col1), Seq(col2.asc), frame)
+    val rankExpression = WindowExpression(Rank(Seq.empty), spec).as("rank")
 
     val baselinePlan = input
       .select(col1, col2)
-      .window(Seq(rankExpr), Seq(col1), Seq(col2.asc))
+      .window(Seq(rankExpression), Seq(col1), Seq(col2.asc))
     val testPlan = input
       .select(col2, col1)
-      .window(Seq(rankExpr), Seq(col1), Seq(col2.asc))
+      .window(Seq(rankExpression), Seq(col1), Seq(col2.asc))
 
     assert(baselinePlan != testPlan)
     assert(NormalizePlan(baselinePlan) == NormalizePlan(testPlan))
@@ -70,9 +71,10 @@ class NormalizePlanSuite extends SparkFunSuite with SQLConfHelper {
     val (col1, col2, col3) = ($"col1".int, $"col2".int, $"col3".int)
     val input = LocalRelation(col1, col2, col3)
     val frame = SpecifiedWindowFrame(RangeFrame, UnboundedPreceding, CurrentRow)
+    val spec = WindowSpecDefinition(Seq(col1), Seq(col2.asc), frame)
 
     val innerSpec = WindowSpecDefinition(Seq(col1), Seq(col2.asc), frame)
-    val rankExpression = WindowExpression(Rank(Seq.empty), innerSpec).as("rank")
+    val rankExpression = WindowExpression(Rank(Seq.empty), spec).as("rank")
     val denseRankExpression = WindowExpression(DenseRank(Seq.empty), innerSpec).as("dense_rank")
 
     val baselineInnerWindow =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
@@ -189,7 +189,7 @@ class NormalizePlanSuite extends SparkFunSuite with SQLConfHelper {
 
     // Before applying timezone, no timezone is set.
     testPlan.expressions.foreach {
-      case _@AssertTrue(firstCast: Cast, _, _@If(secondCast: Cast, _, _)) =>
+      case _ @ AssertTrue(firstCast: Cast, _, _ @ If(secondCast: Cast, _, _)) =>
         assert(firstCast.timeZoneId.isEmpty)
         assert(secondCast.timeZoneId.isEmpty)
       case _ =>
@@ -200,7 +200,7 @@ class NormalizePlanSuite extends SparkFunSuite with SQLConfHelper {
 
     // After applying timezone, only the second cast gets timezone.
     resolvedTestPlan.expressions.foreach {
-      case _@AssertTrue(firstCast: Cast, _, _@If(secondCast: Cast, _, _)) =>
+      case _ @ AssertTrue(firstCast: Cast, _, _ @ If(secondCast: Cast, _, _)) =>
         assert(firstCast.timeZoneId.isEmpty)
         assert(secondCast.timeZoneId.isDefined)
       case _ =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The logic to normalize the order of project list expressions within `Window` nodes by handling both the case when `Window.child` is another `Window` and when it is a `Project`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The change is necessary for single-pass analyzer, analogous to `Project` and `Aggregate` list normalization.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Using the existing unit tests, as well as by introducing two additional unit tests to `NormalizePlanSuite` which cover both newly introduced cases.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.