### PR TITLE
[SPARK-52760][PS] Fix float32 type widening in `sub`/`rsub` under ANSI

### DIFF
--- a/python/pyspark/pandas/tests/data_type_ops/test_num_arithmetic.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_arithmetic.py
@@ -59,7 +59,6 @@ class ArithmeticTestsMixin:
                 else:
                     self.assertRaises(TypeError, lambda: psser + psdf[n_col])
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_sub(self):
         pdf, psdf = self.pdf, self.psdf
         for col in self.numeric_df_cols:

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_reverse.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_reverse.py
@@ -55,7 +55,6 @@ class ReverseTestsMixin:
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) + psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) + psser)
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_rsub(self):
         pdf, psdf = self.pdf, self.psdf
         for col in self.numeric_df_cols:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix float32 type widening in `sub`/`rsub` under ANSI


### Why are the changes needed?
Ensure pandas on Spark works well with ANSI mode on.
Part of https://issues.apache.org/jira/browse/SPARK-52700.


### Does this PR introduce _any_ user-facing change?
Yes. `sub`/`rsub` under ANSI works as expected, as shown below.
```py
>>> ps.set_option("compute.fail_on_ansi_mode", False)
>>> ps.set_option("compute.ansi_mode_support", True)
>>> pser = pd.Series([1.1, 2.2, 3.3], dtype=np.float32)
>>> psser = ps.from_pandas(pser)
>>> psser - 1
0    0.1                                                                        
1    1.2
2    2.3
dtype: float32
>>> True - psser
0   -0.1
1   -1.2
2   -2.3
dtype: float32
>>> psser - 0.1
0    1.0
1    2.1
2    3.2
dtype: float32
```

### How was this patch tested?
Unit tests.

Commands below all passed
```
 1117  SPARK_ANSI_SQL_MODE=true  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_reverse ReverseTests.test_rsub"
 1118  SPARK_ANSI_SQL_MODE=false  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_reverse ReverseTests.test_rsub"
 1119  SPARK_ANSI_SQL_MODE=true  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_arithmetic ArithmeticTests.test_sub"
 1120  SPARK_ANSI_SQL_MODE=false  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_arithmetic ArithmeticTests.test_sub"
```


### Was this patch authored or co-authored using generative AI tooling?
No.
