### PR TITLE
[SPARK-52759][SDP][SQL] Throw exception if pipeline has no tables or persisted views

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4495,6 +4495,13 @@
     ],
     "sqlState" : "42601"
   },
+  "NO_DATASET_IN_PIPELINE" : {
+    "message" : [
+      "Pipelines are expected to have at least one non-temporary dataset defined (tables, persisted views) but no non-temporary datasets were found in your pipeline.",
+      "Please verify that you have included the expected source files, and that your source code includes table definitions (e.g., CREATE MATERIALIZED VIEW in SQL code, @sdp.table in python code)."
+    ],
+    "sqlState" : "42617"
+  },
   "NO_DEFAULT_COLUMN_VALUE_AVAILABLE" : {
     "message" : [
       "Can't determine the default value for <colName> since it is not nullable and it has no default value."
@@ -4518,13 +4525,6 @@
       "Cannot find <catalystFieldPath> in Protobuf schema."
     ],
     "sqlState" : "42S22"
-  },
-  "NO_DATASET_IN_PIPELINE" : {
-    "message" : [
-      "Pipelines are expected to have at least one non-temporary dataset defined (tables, persisted views) but no non-temporary datasets were found in your pipeline.",
-      "Please verify that you have included the expected source files, and that your source code includes table definitions (e.g., CREATE MATERIALIZED VIEW in SQL code, @sdp.table in python code)."
-    ],
-    "sqlState" : "42617"
   },
   "NO_UDF_INTERFACE" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4495,7 +4495,7 @@
     ],
     "sqlState" : "42601"
   },
-  "NO_DATASET_IN_PIPELINE" : {
+  "NO_DATASETS_IN_PIPELINE" : {
     "message" : [
       "Pipelines are expected to have at least one non-temporary dataset defined (tables, persisted views) but no non-temporary datasets were found in your pipeline.",
       "Please verify that you have included the expected source files, and that your source code includes table definitions (e.g., CREATE MATERIALIZED VIEW in SQL code, @sdp.table in python code)."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4519,6 +4519,15 @@
     ],
     "sqlState" : "42S22"
   },
+  "NO_TABLES_IN_PIPELINE" : {
+    "message": [
+      "Pipelines are expected to have at least one table defined but no tables were found in your pipeline.",
+      "Please verify that you have included the expected source files, and that your source code includes table definitions (e.g., CREATE MATERIALIZED VIEW in SQL code, @sdp.table in python code).",
+      "",
+      "Note that only tables and persistent views are counted towards this check. You may also encounter this error if you only include temp views or flows in your pipeline."
+    ],
+    "sqlState" : "42617"
+  },
   "NO_UDF_INTERFACE" : {
     "message" : [
       "UDF class <className> doesn't implement any UDF interface."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4519,12 +4519,10 @@
     ],
     "sqlState" : "42S22"
   },
-  "NO_TABLES_IN_PIPELINE" : {
+  "NO_DATASET_IN_PIPELINE" : {
     "message" : [
-      "Pipelines are expected to have at least one non-temporary dataset defined but no non-temporary datasets were found in your pipeline.",
-      "Please verify that you have included the expected source files, and that your source code includes table definitions (e.g., CREATE MATERIALIZED VIEW in SQL code, @sdp.table in python code).",
-      "",
-      "Note that only tables and persistent views are counted towards this check. You may also encounter this error if you only include temp views or flows in your pipeline."
+      "Pipelines are expected to have at least one non-temporary dataset defined (tables, persisted views) but no non-temporary datasets were found in your pipeline.",
+      "Please verify that you have included the expected source files, and that your source code includes table definitions (e.g., CREATE MATERIALIZED VIEW in SQL code, @sdp.table in python code)."
     ],
     "sqlState" : "42617"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4495,13 +4495,6 @@
     ],
     "sqlState" : "42601"
   },
-  "NO_DATASETS_IN_PIPELINE" : {
-    "message" : [
-      "Pipelines are expected to have at least one non-temporary dataset defined (tables, persisted views) but no non-temporary datasets were found in your pipeline.",
-      "Please verify that you have included the expected source files, and that your source code includes table definitions (e.g., CREATE MATERIALIZED VIEW in SQL code, @sdp.table in python code)."
-    ],
-    "sqlState" : "42617"
-  },
   "NO_DEFAULT_COLUMN_VALUE_AVAILABLE" : {
     "message" : [
       "Can't determine the default value for <colName> since it is not nullable and it has no default value."
@@ -4936,6 +4929,13 @@
       "Not found an id for the rule name \"<ruleName>\". Please modify RuleIdCollection.scala if you are adding a new rule."
     ],
     "sqlState" : "22023"
+  },
+  "RUN_EMPTY_PIPELINE" : {
+    "message" : [
+      "Pipelines are expected to have at least one non-temporary dataset defined (tables, persisted views) but no non-temporary datasets were found in your pipeline.",
+      "Please verify that you have included the expected source files, and that your source code includes table definitions (e.g., CREATE MATERIALIZED VIEW in SQL code, @sdp.table in python code)."
+    ],
+    "sqlState" : "42617"
   },
   "SCALAR_FUNCTION_NOT_COMPATIBLE" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4520,7 +4520,7 @@
     "sqlState" : "42S22"
   },
   "NO_TABLES_IN_PIPELINE" : {
-    "message": [
+    "message" : [
       "Pipelines are expected to have at least one table defined but no tables were found in your pipeline.",
       "Please verify that you have included the expected source files, and that your source code includes table definitions (e.g., CREATE MATERIALIZED VIEW in SQL code, @sdp.table in python code).",
       "",

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4521,7 +4521,7 @@
   },
   "NO_TABLES_IN_PIPELINE" : {
     "message" : [
-      "Pipelines are expected to have at least one table defined but no tables were found in your pipeline.",
+      "Pipelines are expected to have at least one non-temporary dataset defined but no non-temporary datasets were found in your pipeline.",
       "Please verify that you have included the expected source files, and that your source code includes table definitions (e.g., CREATE MATERIALIZED VIEW in SQL code, @sdp.table in python code).",
       "",
       "Note that only tables and persistent views are counted towards this check. You may also encounter this error if you only include temp views or flows in your pipeline."

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
@@ -420,18 +420,18 @@ class PythonPipelineSuite
         .map(_.identifier) == Seq(graphIdentifier("a"), graphIdentifier("something")))
   }
 
-  test("create pipeline without table will throw NO_DATASET_IN_PIPELINE exception") {
+  test("create pipeline without table will throw NO_DATASETS_IN_PIPELINE exception") {
     checkError(
       exception = intercept[AnalysisException] {
         buildGraph(s"""
             |spark.range(1)
             |""".stripMargin)
       },
-      condition = "NO_DATASET_IN_PIPELINE",
+      condition = "NO_DATASETS_IN_PIPELINE",
       parameters = Map.empty)
   }
 
-  test("create pipeline with only temp view will throw NO_DATASET_IN_PIPELINE exception") {
+  test("create pipeline with only temp view will throw NO_DATASETS_IN_PIPELINE exception") {
     checkError(
       exception = intercept[AnalysisException] {
         buildGraph(s"""
@@ -440,11 +440,11 @@ class PythonPipelineSuite
             |  return spark.range(5)
             |""".stripMargin)
       },
-      condition = "NO_DATASET_IN_PIPELINE",
+      condition = "NO_DATASETS_IN_PIPELINE",
       parameters = Map.empty)
   }
 
-  test("create pipeline with only flow will throw NO_DATASET_IN_PIPELINE exception") {
+  test("create pipeline with only flow will throw NO_DATASETS_IN_PIPELINE exception") {
     checkError(
       exception = intercept[AnalysisException] {
         buildGraph(s"""
@@ -453,7 +453,7 @@ class PythonPipelineSuite
             |  return spark.range(5)
             |""".stripMargin)
       },
-      condition = "NO_DATASET_IN_PIPELINE",
+      condition = "NO_DATASETS_IN_PIPELINE",
       parameters = Map.empty)
   }
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
@@ -420,23 +420,27 @@ class PythonPipelineSuite
   }
 
   test("create pipeline without table will fail") {
-    val ex = intercept[AnalysisException] {
-      buildGraph(s"""
+    checkError(
+      exception = intercept[AnalysisException] {
+        buildGraph(s"""
             |spark.range(1)
             |""".stripMargin)
-    }
-    assert(ex.getCondition == "NO_TABLES_IN_PIPELINE")
+      },
+      condition = "NO_DATASET_IN_PIPELINE",
+      parameters = Map.empty)
   }
 
   test("create pipeline with only temp view will fail") {
-    val ex = intercept[AnalysisException] {
-      buildGraph(s"""
-          |@sdp.temporary_view
-          |def view_1():
-          |  return spark.range(5)
-          |""".stripMargin)
-    }
-    assert(ex.getCondition == "NO_TABLES_IN_PIPELINE")
+    checkError(
+      exception = intercept[AnalysisException] {
+        buildGraph(s"""
+            |@sdp.temporary_view
+            |def view_1():
+            |  return spark.range(5)
+            |""".stripMargin)
+      },
+      condition = "NO_DATASET_IN_PIPELINE",
+      parameters = Map.empty)
   }
 
   /**

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
@@ -339,7 +339,8 @@ class PythonPipelineSuite
         TableIdentifier("st", Some("some_schema"), Some("some_catalog"))))
   }
 
-  test("view works") {
+  test("temporary views works") {
+    // A table is defined since pipeline with only temporary views is invalid.
     val graph = buildGraph(s"""
          |@sdp.table
          |def mv_1():

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
@@ -420,18 +420,18 @@ class PythonPipelineSuite
         .map(_.identifier) == Seq(graphIdentifier("a"), graphIdentifier("something")))
   }
 
-  test("create pipeline without table will throw NO_DATASETS_IN_PIPELINE exception") {
+  test("create pipeline without table will throw RUN_EMPTY_PIPELINE exception") {
     checkError(
       exception = intercept[AnalysisException] {
         buildGraph(s"""
             |spark.range(1)
             |""".stripMargin)
       },
-      condition = "NO_DATASETS_IN_PIPELINE",
+      condition = "RUN_EMPTY_PIPELINE",
       parameters = Map.empty)
   }
 
-  test("create pipeline with only temp view will throw NO_DATASETS_IN_PIPELINE exception") {
+  test("create pipeline with only temp view will throw RUN_EMPTY_PIPELINE exception") {
     checkError(
       exception = intercept[AnalysisException] {
         buildGraph(s"""
@@ -440,11 +440,11 @@ class PythonPipelineSuite
             |  return spark.range(5)
             |""".stripMargin)
       },
-      condition = "NO_DATASETS_IN_PIPELINE",
+      condition = "RUN_EMPTY_PIPELINE",
       parameters = Map.empty)
   }
 
-  test("create pipeline with only flow will throw NO_DATASETS_IN_PIPELINE exception") {
+  test("create pipeline with only flow will throw RUN_EMPTY_PIPELINE exception") {
     checkError(
       exception = intercept[AnalysisException] {
         buildGraph(s"""
@@ -453,7 +453,7 @@ class PythonPipelineSuite
             |  return spark.range(5)
             |""".stripMargin)
       },
-      condition = "NO_DATASETS_IN_PIPELINE",
+      condition = "RUN_EMPTY_PIPELINE",
       parameters = Map.empty)
   }
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
@@ -419,7 +419,7 @@ class PythonPipelineSuite
         .map(_.identifier) == Seq(graphIdentifier("a"), graphIdentifier("something")))
   }
 
-  test("create pipeline without table will fail") {
+  test("create pipeline without table will throw NO_DATASET_IN_PIPELINE exception") {
     checkError(
       exception = intercept[AnalysisException] {
         buildGraph(s"""
@@ -430,12 +430,25 @@ class PythonPipelineSuite
       parameters = Map.empty)
   }
 
-  test("create pipeline with only temp view will fail") {
+  test("create pipeline with only temp view will throw NO_DATASET_IN_PIPELINE exception") {
     checkError(
       exception = intercept[AnalysisException] {
         buildGraph(s"""
             |@sdp.temporary_view
             |def view_1():
+            |  return spark.range(5)
+            |""".stripMargin)
+      },
+      condition = "NO_DATASET_IN_PIPELINE",
+      parameters = Map.empty)
+  }
+
+  test("create pipeline with only flow will throw NO_DATASET_IN_PIPELINE exception") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        buildGraph(s"""
+            |@sdp.append_flow(target = "a")
+            |def flow():
             |  return spark.range(5)
             |""".stripMargin)
       },

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphRegistrationContext.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphRegistrationContext.scala
@@ -50,16 +50,21 @@ class GraphRegistrationContext(
   }
 
   def toDataflowGraph: DataflowGraph = {
+    // throw exception if pipeline does not have table or persisted view
+    if (tables.isEmpty && views.collect { case v: PersistedView =>
+        v
+      }.isEmpty) {
+      throw new AnalysisException(
+        errorClass = "NO_TABLES_IN_PIPELINE",
+        messageParameters = Map.empty)
+    }
     val qualifiedTables = tables.toSeq.map { t =>
-      t.copy(
-        identifier = GraphIdentifierManager
-          .parseAndQualifyTableIdentifier(
-            rawTableIdentifier = t.identifier,
-            currentCatalog = Some(defaultCatalog),
-            currentDatabase = Some(defaultDatabase)
-          )
-          .identifier
-      )
+      t.copy(identifier = GraphIdentifierManager
+        .parseAndQualifyTableIdentifier(
+          rawTableIdentifier = t.identifier,
+          currentCatalog = Some(defaultCatalog),
+          currentDatabase = Some(defaultDatabase))
+        .identifier)
     }
 
     val validatedViews = views.toSeq.collect {

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphRegistrationContext.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphRegistrationContext.scala
@@ -50,12 +50,11 @@ class GraphRegistrationContext(
   }
 
   def toDataflowGraph: DataflowGraph = {
-    // throw exception if pipeline does not have table or persisted view
     if (tables.isEmpty && views.collect { case v: PersistedView =>
         v
       }.isEmpty) {
       throw new AnalysisException(
-        errorClass = "NO_DATASET_IN_PIPELINE",
+        errorClass = "NO_DATASETS_IN_PIPELINE",
         messageParameters = Map.empty)
     }
     val qualifiedTables = tables.toSeq.map { t =>

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphRegistrationContext.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphRegistrationContext.scala
@@ -55,16 +55,19 @@ class GraphRegistrationContext(
         v
       }.isEmpty) {
       throw new AnalysisException(
-        errorClass = "NO_TABLES_IN_PIPELINE",
+        errorClass = "NO_DATASET_IN_PIPELINE",
         messageParameters = Map.empty)
     }
     val qualifiedTables = tables.toSeq.map { t =>
-      t.copy(identifier = GraphIdentifierManager
-        .parseAndQualifyTableIdentifier(
-          rawTableIdentifier = t.identifier,
-          currentCatalog = Some(defaultCatalog),
-          currentDatabase = Some(defaultDatabase))
-        .identifier)
+      t.copy(
+        identifier = GraphIdentifierManager
+          .parseAndQualifyTableIdentifier(
+            rawTableIdentifier = t.identifier,
+            currentCatalog = Some(defaultCatalog),
+            currentDatabase = Some(defaultDatabase)
+          )
+          .identifier
+      )
     }
 
     val validatedViews = views.toSeq.collect {

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphRegistrationContext.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphRegistrationContext.scala
@@ -54,7 +54,7 @@ class GraphRegistrationContext(
         v
       }.isEmpty) {
       throw new AnalysisException(
-        errorClass = "NO_DATASETS_IN_PIPELINE",
+        errorClass = "RUN_EMPTY_PIPELINE",
         messageParameters = Map.empty)
     }
     val qualifiedTables = tables.toSeq.map { t =>

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectInvalidPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectInvalidPipelineSuite.scala
@@ -42,7 +42,8 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
     assert(ex.getMessage.contains("Failed to resolve flows in the pipeline"))
     assertAnalysisException(
       ex.directFailures(fullyQualifiedIdentifier("b")),
-      "TABLE_OR_VIEW_NOT_FOUND")
+      "TABLE_OR_VIEW_NOT_FOUND"
+    )
   }
 
   test("Correctly differentiate between upstream and downstream errors") {
@@ -53,7 +54,8 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
       registerPersistedView("d", query = dfFlowFunc(spark.range(5).toDF()))
       registerPersistedView(
         "e",
-        query = sqlFlowFunc(spark, "SELECT nonExistentColumn FROM RANGE(5)"))
+        query = sqlFlowFunc(spark, "SELECT nonExistentColumn FROM RANGE(5)")
+      )
       registerPersistedView("f", query = readFlowFunc("e"))
     }
 
@@ -67,48 +69,67 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
       ex.getMessage.contains(
         s"Flows with errors: " +
           s"${fullyQualifiedIdentifier("b").unquotedString}," +
-          s" ${fullyQualifiedIdentifier("e").unquotedString}"))
+          s" ${fullyQualifiedIdentifier("e").unquotedString}"
+      )
+    )
     assert(
       ex.getMessage.contains(
         s"Flows that failed due to upstream errors: " +
           s"${fullyQualifiedIdentifier("c").unquotedString}, " +
-          s"${fullyQualifiedIdentifier("f").unquotedString}"))
+          s"${fullyQualifiedIdentifier("f").unquotedString}"
+      )
+    )
     assert(
       ex.directFailures.keySet == Set(
         fullyQualifiedIdentifier("b"),
-        fullyQualifiedIdentifier("e")))
+        fullyQualifiedIdentifier("e")
+      )
+    )
     assert(
       ex.downstreamFailures.keySet == Set(
         fullyQualifiedIdentifier("c"),
-        fullyQualifiedIdentifier("f")))
+        fullyQualifiedIdentifier("f")
+      )
+    )
     assertAnalysisException(
       ex.directFailures(fullyQualifiedIdentifier("b")),
-      "TABLE_OR_VIEW_NOT_FOUND")
+      "TABLE_OR_VIEW_NOT_FOUND"
+    )
     assert(
       ex.directFailures(fullyQualifiedIdentifier("e"))
-        .isInstanceOf[AnalysisException])
+        .isInstanceOf[AnalysisException]
+    )
     assert(
       ex.directFailures(fullyQualifiedIdentifier("e"))
         .getMessage
-        .contains("nonExistentColumn"))
+        .contains("nonExistentColumn")
+    )
     assert(
       ex.downstreamFailures(fullyQualifiedIdentifier("c"))
-        .isInstanceOf[UnresolvedDatasetException])
+        .isInstanceOf[UnresolvedDatasetException]
+    )
     assert(
       ex.downstreamFailures(fullyQualifiedIdentifier("c"))
         .getMessage
-        .contains(s"Failed to read dataset " +
-          s"'${fullyQualifiedIdentifier("b").unquotedString}'. " +
-          s"Dataset is defined in the pipeline but could not be resolved"))
+        .contains(
+          s"Failed to read dataset " +
+            s"'${fullyQualifiedIdentifier("b").unquotedString}'. " +
+            s"Dataset is defined in the pipeline but could not be resolved"
+        )
+    )
     assert(
       ex.downstreamFailures(fullyQualifiedIdentifier("f"))
-        .isInstanceOf[UnresolvedDatasetException])
+        .isInstanceOf[UnresolvedDatasetException]
+    )
     assert(
       ex.downstreamFailures(fullyQualifiedIdentifier("f"))
         .getMessage
-        .contains(s"Failed to read dataset " +
-          s"'${fullyQualifiedIdentifier("e").unquotedString}'. " +
-          s"Dataset is defined in the pipeline but could not be resolved"))
+        .contains(
+          s"Failed to read dataset " +
+            s"'${fullyQualifiedIdentifier("e").unquotedString}'. " +
+            s"Dataset is defined in the pipeline but could not be resolved"
+        )
+    )
   }
 
   test("correctly identify direct and downstream errors for multi-flow pipelines") {
@@ -118,9 +139,7 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
       registerFlow("a", "a_2", sqlFlowFunc(spark, "SELECT non_existent_col FROM RANGE(5)"))
       registerTable("b", query = Option(readFlowFunc("a")))
     }
-    val ex = intercept[UnresolvedPipelineException] {
-      new P().resolveToDataflowGraph().validate()
-    }
+    val ex = intercept[UnresolvedPipelineException] { new P().resolveToDataflowGraph().validate() }
     assert(ex.directFailures.keySet == Set(fullyQualifiedIdentifier("a_2")))
     assert(ex.downstreamFailures.keySet == Set(fullyQualifiedIdentifier("b")))
 
@@ -159,7 +178,8 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
     assert(
       ex.directFailures(fullyQualifiedIdentifier("c"))
         .getMessage
-        .contains("USING column `x` cannot be resolved on the right side"))
+        .contains("USING column `x` cannot be resolved on the right side")
+    )
   }
 
   test("Writing to one table by unioning flows with different schemas") {
@@ -171,7 +191,8 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
       registerPersistedView("b", query = dfFlowFunc(Seq(true, false).toDF("x")))
       registerPersistedView(
         "c",
-        query = sqlFlowFunc(spark, "SELECT x FROM a UNION SELECT x FROM b"))
+        query = sqlFlowFunc(spark, "SELECT x FROM a UNION SELECT x FROM b")
+      )
     }
 
     val dfg = new P().resolveToDataflowGraph()
@@ -185,7 +206,8 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
         .contains("compatible column types") ||
         ex.directFailures(fullyQualifiedIdentifier("c"))
           .getMessage
-          .contains("Failed to merge incompatible data types"))
+          .contains("Failed to merge incompatible data types")
+    )
   }
 
   test("Self reference") {
@@ -207,7 +229,10 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
     val e = intercept[CircularDependencyException] {
       new P().resolveToDataflowGraph().validate()
     }
-    val cycle = Set(fullyQualifiedIdentifier("a"), fullyQualifiedIdentifier("b"))
+    val cycle = Set(
+      fullyQualifiedIdentifier("a"),
+      fullyQualifiedIdentifier("b")
+    )
     assert(e.upstreamDataset != e.downstreamTable)
     assert(cycle.contains(e.upstreamDataset))
     assert(cycle.contains(e.downstreamTable))
@@ -221,7 +246,8 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
       registerPersistedView("a", query = dfFlowFunc(Seq(1, 2, 3).toDF("x")))
       registerPersistedView(
         "b",
-        query = sqlFlowFunc(spark, "SELECT * FROM a UNION SELECT * FROM d"))
+        query = sqlFlowFunc(spark, "SELECT * FROM a UNION SELECT * FROM d")
+      )
       registerPersistedView("c", query = readFlowFunc("b"))
       registerPersistedView("d", query = readFlowFunc("c"))
     }
@@ -229,7 +255,8 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
       Set(
         fullyQualifiedIdentifier("b"),
         fullyQualifiedIdentifier("c"),
-        fullyQualifiedIdentifier("d"))
+        fullyQualifiedIdentifier("d")
+      )
     val e = intercept[CircularDependencyException] {
       new P().resolveToDataflowGraph().validate()
     }
@@ -246,7 +273,8 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
       registerTable("a", query = Option(dfFlowFunc(Seq(1, 2, 3).toDF("x"))))
       registerTable(
         "b",
-        query = Option(sqlFlowFunc(spark, "SELECT * FROM a UNION SELECT * FROM d")))
+        query = Option(sqlFlowFunc(spark, "SELECT * FROM a UNION SELECT * FROM d"))
+      )
       registerTable("c", query = Option(readFlowFunc("b")))
       registerTable("d", query = Option(readFlowFunc("c")))
     }
@@ -254,7 +282,8 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
       Set(
         fullyQualifiedIdentifier("b"),
         fullyQualifiedIdentifier("c"),
-        fullyQualifiedIdentifier("d"))
+        fullyQualifiedIdentifier("d")
+      )
     val e = intercept[CircularDependencyException] {
       new P().resolveToDataflowGraph().validate()
     }
@@ -279,7 +308,8 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
       Set(
         fullyQualifiedIdentifier("b"),
         fullyQualifiedIdentifier("c"),
-        fullyQualifiedIdentifier("d"))
+        fullyQualifiedIdentifier("d")
+      )
     val e = intercept[CircularDependencyException] {
       new P().resolveToDataflowGraph().validate()
     }
@@ -305,7 +335,8 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
       Set(
         fullyQualifiedIdentifier("b"),
         fullyQualifiedIdentifier("c"),
-        fullyQualifiedIdentifier("d"))
+        fullyQualifiedIdentifier("d")
+      )
     val e = intercept[CircularDependencyException] {
       new P().resolveToDataflowGraph().validate()
     }
@@ -324,13 +355,18 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
     }
     val ex = intercept[AnalysisException] { p.resolveToDataflowGraph() }
     assert(
-      ex.getMessage.contains(s"Found duplicate sql conf for dataset " +
-        s"'${fullyQualifiedIdentifier("b").unquotedString}':"))
+      ex.getMessage.contains(
+        s"Found duplicate sql conf for dataset " +
+          s"'${fullyQualifiedIdentifier("b").unquotedString}':"
+      )
+    )
     assert(
       ex.getMessage.contains(
         s"'x' is defined by both " +
           s"'${fullyQualifiedIdentifier("a").unquotedString}' " +
-          s"and '${fullyQualifiedIdentifier("b").unquotedString}'"))
+          s"and '${fullyQualifiedIdentifier("b").unquotedString}'"
+      )
+    )
   }
 
   test("view-view conf conflict") {
@@ -343,17 +379,23 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
       registerTable(
         "c",
         query = Option(sqlFlowFunc(spark, "SELECT * FROM a UNION SELECT * FROM b")),
-        sqlConf = Map("y" -> "c-val"))
+        sqlConf = Map("y" -> "c-val")
+      )
     }
     val ex = intercept[AnalysisException] { p.resolveToDataflowGraph() }
     assert(
-      ex.getMessage.contains(s"Found duplicate sql conf for dataset " +
-        s"'${fullyQualifiedIdentifier("c").unquotedString}':"))
+      ex.getMessage.contains(
+        s"Found duplicate sql conf for dataset " +
+          s"'${fullyQualifiedIdentifier("c").unquotedString}':"
+      )
+    )
     assert(
       ex.getMessage.contains(
         s"'x' is defined by both " +
           s"'${fullyQualifiedIdentifier("a").unquotedString}' " +
-          s"and '${fullyQualifiedIdentifier("b").unquotedString}'"))
+          s"and '${fullyQualifiedIdentifier("b").unquotedString}'"
+      )
+    )
   }
 
   test("reading a complete view incrementally") {
@@ -368,8 +410,11 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
     assert(
       ex.directFailures(fullyQualifiedIdentifier("b"))
         .getMessage
-        .contains(s"View ${fullyQualifiedIdentifier("a").quotedString}" +
-          s" is a batch view and must be referenced using SparkSession#read."))
+        .contains(
+          s"View ${fullyQualifiedIdentifier("a").quotedString}" +
+            s" is a batch view and must be referenced using SparkSession#read."
+        )
+    )
   }
 
   test("reading an incremental view completely") {
@@ -386,8 +431,11 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
     assert(
       ex.directFailures(fullyQualifiedIdentifier("b"))
         .getMessage
-        .contains(s"View ${fullyQualifiedIdentifier("a").quotedString} " +
-          s"is a streaming view and must be referenced using SparkSession#readStream"))
+        .contains(
+          s"View ${fullyQualifiedIdentifier("a").quotedString} " +
+            s"is a streaming view and must be referenced using SparkSession#readStream"
+        )
+    )
   }
 
   test("Streaming table backed by batch relation fails validation") {
@@ -407,7 +455,9 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
       condition = "INVALID_FLOW_QUERY_TYPE.BATCH_RELATION_FOR_STREAMING_TABLE",
       parameters = Map(
         "flowIdentifier" -> fullyQualifiedIdentifier("a").quotedString,
-        "tableIdentifier" -> fullyQualifiedIdentifier("a").quotedString))
+        "tableIdentifier" -> fullyQualifiedIdentifier("a").quotedString
+      )
+    )
   }
 
   test("Materialized view backed by streaming relation fails validation") {
@@ -427,7 +477,9 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
       condition = "INVALID_FLOW_QUERY_TYPE.STREAMING_RELATION_FOR_MATERIALIZED_VIEW",
       parameters = Map(
         "flowIdentifier" -> fullyQualifiedIdentifier("a").quotedString,
-        "tableIdentifier" -> fullyQualifiedIdentifier("a").quotedString))
+        "tableIdentifier" -> fullyQualifiedIdentifier("a").quotedString
+      )
+    )
   }
 
   test("Once flow backed by streaming relation fails validation") {
@@ -440,7 +492,8 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
         destinationName = "a",
         name = "once_flow",
         query = dfFlowFunc(MemoryStream[Int].toDF()),
-        once = true)
+        once = true
+      )
     }.resolveToDataflowGraph()
 
     val ex = intercept[AnalysisException] {
@@ -450,7 +503,10 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
     checkError(
       exception = ex,
       condition = "INVALID_FLOW_QUERY_TYPE.STREAMING_RELATION_FOR_ONCE_FLOW",
-      parameters = Map("flowIdentifier" -> fullyQualifiedIdentifier("once_flow").quotedString))
+      parameters = Map(
+        "flowIdentifier" -> fullyQualifiedIdentifier("once_flow").quotedString
+      )
+    )
   }
 
   test("Inferred schema that isn't a subset of user-specified schema") {
@@ -461,12 +517,16 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
       registerTable(
         "a",
         query = Option(dfFlowFunc(Seq(1, 2).toDF("incorrect-col-name"))),
-        specifiedSchema = Option(new StructType().add("x", IntegerType)))
+        specifiedSchema = Option(new StructType().add("x", IntegerType))
+      )
     }.resolveToDataflowGraph()
     val ex1 = intercept[AnalysisException] { graph1.validate() }
     assert(
-      ex1.getMessage.contains(s"'${fullyQualifiedIdentifier("a").unquotedString}' " +
-        s"has a user-specified schema that is incompatible"))
+      ex1.getMessage.contains(
+        s"'${fullyQualifiedIdentifier("a").unquotedString}' " +
+          s"has a user-specified schema that is incompatible"
+      )
+    )
     assert(ex1.getMessage.contains("incorrect-col-name"))
 
     val graph2 = new TestGraphRegistrationContext(spark) {
@@ -475,8 +535,11 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
     }.resolveToDataflowGraph()
     val ex2 = intercept[AnalysisException] { graph2.validate() }
     assert(
-      ex2.getMessage.contains(s"'${fullyQualifiedIdentifier("a").unquotedString}' " +
-        s"has a user-specified schema that is incompatible"))
+      ex2.getMessage.contains(
+        s"'${fullyQualifiedIdentifier("a").unquotedString}' " +
+          s"has a user-specified schema that is incompatible"
+      )
+    )
     assert(ex2.getMessage.contains("boolean") && ex2.getMessage.contains("integer"))
 
     val streamingTableHint = "please full refresh"

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectInvalidPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectInvalidPipelineSuite.scala
@@ -68,15 +68,15 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
     assert(
       ex.getMessage.contains(
         s"Flows with errors: " +
-          s"${fullyQualifiedIdentifier("b").unquotedString}," +
-          s" ${fullyQualifiedIdentifier("e").unquotedString}"
+        s"${fullyQualifiedIdentifier("b").unquotedString}," +
+        s" ${fullyQualifiedIdentifier("e").unquotedString}"
       )
     )
     assert(
       ex.getMessage.contains(
         s"Flows that failed due to upstream errors: " +
-          s"${fullyQualifiedIdentifier("c").unquotedString}, " +
-          s"${fullyQualifiedIdentifier("f").unquotedString}"
+        s"${fullyQualifiedIdentifier("c").unquotedString}, " +
+        s"${fullyQualifiedIdentifier("f").unquotedString}"
       )
     )
     assert(
@@ -113,8 +113,8 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
         .getMessage
         .contains(
           s"Failed to read dataset " +
-            s"'${fullyQualifiedIdentifier("b").unquotedString}'. " +
-            s"Dataset is defined in the pipeline but could not be resolved"
+          s"'${fullyQualifiedIdentifier("b").unquotedString}'. " +
+          s"Dataset is defined in the pipeline but could not be resolved"
         )
     )
     assert(
@@ -126,8 +126,8 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
         .getMessage
         .contains(
           s"Failed to read dataset " +
-            s"'${fullyQualifiedIdentifier("e").unquotedString}'. " +
-            s"Dataset is defined in the pipeline but could not be resolved"
+          s"'${fullyQualifiedIdentifier("e").unquotedString}'. " +
+          s"Dataset is defined in the pipeline but could not be resolved"
         )
     )
   }
@@ -357,14 +357,14 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
     assert(
       ex.getMessage.contains(
         s"Found duplicate sql conf for dataset " +
-          s"'${fullyQualifiedIdentifier("b").unquotedString}':"
+        s"'${fullyQualifiedIdentifier("b").unquotedString}':"
       )
     )
     assert(
       ex.getMessage.contains(
         s"'x' is defined by both " +
-          s"'${fullyQualifiedIdentifier("a").unquotedString}' " +
-          s"and '${fullyQualifiedIdentifier("b").unquotedString}'"
+        s"'${fullyQualifiedIdentifier("a").unquotedString}' " +
+        s"and '${fullyQualifiedIdentifier("b").unquotedString}'"
       )
     )
   }
@@ -386,14 +386,14 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
     assert(
       ex.getMessage.contains(
         s"Found duplicate sql conf for dataset " +
-          s"'${fullyQualifiedIdentifier("c").unquotedString}':"
+        s"'${fullyQualifiedIdentifier("c").unquotedString}':"
       )
     )
     assert(
       ex.getMessage.contains(
         s"'x' is defined by both " +
-          s"'${fullyQualifiedIdentifier("a").unquotedString}' " +
-          s"and '${fullyQualifiedIdentifier("b").unquotedString}'"
+        s"'${fullyQualifiedIdentifier("a").unquotedString}' " +
+        s"and '${fullyQualifiedIdentifier("b").unquotedString}'"
       )
     )
   }
@@ -412,7 +412,7 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
         .getMessage
         .contains(
           s"View ${fullyQualifiedIdentifier("a").quotedString}" +
-            s" is a batch view and must be referenced using SparkSession#read."
+          s" is a batch view and must be referenced using SparkSession#read."
         )
     )
   }
@@ -433,7 +433,7 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
         .getMessage
         .contains(
           s"View ${fullyQualifiedIdentifier("a").quotedString} " +
-            s"is a streaming view and must be referenced using SparkSession#readStream"
+          s"is a streaming view and must be referenced using SparkSession#readStream"
         )
     )
   }
@@ -524,7 +524,7 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
     assert(
       ex1.getMessage.contains(
         s"'${fullyQualifiedIdentifier("a").unquotedString}' " +
-          s"has a user-specified schema that is incompatible"
+        s"has a user-specified schema that is incompatible"
       )
     )
     assert(ex1.getMessage.contains("incorrect-col-name"))
@@ -537,7 +537,7 @@ class ConnectInvalidPipelineSuite extends PipelineTest {
     assert(
       ex2.getMessage.contains(
         s"'${fullyQualifiedIdentifier("a").unquotedString}' " +
-          s"has a user-specified schema that is incompatible"
+        s"has a user-specified schema that is incompatible"
       )
     )
     assert(ex2.getMessage.contains("boolean") && ex2.getMessage.contains("integer"))

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectValidPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectValidPipelineSuite.scala
@@ -26,8 +26,9 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
- * Test suite for resolving the flows in a [[DataflowGraph]]. These examples are all semantically
- * correct and logically correct and connect should not result in any errors.
+ * Test suite for resolving the flows in a [[DataflowGraph]]. These
+ * examples are all semantically correct and logically correct and connect should not result in any
+ * errors.
  */
 class ConnectValidPipelineSuite extends PipelineTest {
   test("Extra simple") {
@@ -157,8 +158,13 @@ class ConnectValidPipelineSuite extends PipelineTest {
               UnresolvedRelation(
                 TableIdentifier("a"),
                 extraOptions = CaseInsensitiveStringMap.empty(),
-                isStreaming = true),
-              UnresolvedRelation(TableIdentifier("b"))))))
+                isStreaming = true
+              ),
+              UnresolvedRelation(TableIdentifier("b"))
+            )
+          )
+        )
+      )
     }
 
     val p = new P().resolveToDataflowGraph()
@@ -187,15 +193,22 @@ class ConnectValidPipelineSuite extends PipelineTest {
       registerPersistedView(
         "c",
         query = FlowAnalysis.createFlowFunctionFromLogicalPlan(
-          Union(Seq(
-            UnresolvedRelation(
-              TableIdentifier("a"),
-              extraOptions = CaseInsensitiveStringMap.empty(),
-              isStreaming = true),
-            UnresolvedRelation(
-              TableIdentifier("b"),
-              extraOptions = CaseInsensitiveStringMap.empty(),
-              isStreaming = true)))))
+          Union(
+            Seq(
+              UnresolvedRelation(
+                TableIdentifier("a"),
+                extraOptions = CaseInsensitiveStringMap.empty(),
+                isStreaming = true
+              ),
+              UnresolvedRelation(
+                TableIdentifier("b"),
+                extraOptions = CaseInsensitiveStringMap.empty(),
+                isStreaming = true
+              )
+            )
+          )
+        )
+      )
     }
 
     val p = new P().resolveToDataflowGraph()
@@ -245,7 +258,7 @@ class ConnectValidPipelineSuite extends PipelineTest {
     val graph = p.resolveToDataflowGraph()
     assert(
       graph
-        .flow(fullyQualifiedIdentifier("d", isView = false))
+        .flow(fullyQualifiedIdentifier("d", isTemporaryView = false))
         .sqlConf == Map("a" -> "a-val", "b" -> "b-val", "c" -> "c-val", "d" -> "d-val"))
   }
 

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectValidPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectValidPipelineSuite.scala
@@ -55,12 +55,16 @@ class ConnectValidPipelineSuite extends PipelineTest {
     verifyFlowSchema(
       p,
       fullyQualifiedIdentifier("a"),
-      new StructType().add("x", IntegerType, false))
+      new StructType().add("x", IntegerType, false)
+    )
     val outSchema = new StructType().add("y", IntegerType, false)
     verifyFlowSchema(p, fullyQualifiedIdentifier("b"), outSchema)
     assert(
-      p.resolvedFlow(fullyQualifiedIdentifier("b")).inputs == Set(fullyQualifiedIdentifier("a")),
-      "Flow did not have the expected inputs")
+      p.resolvedFlow(fullyQualifiedIdentifier("b")).inputs == Set(
+        fullyQualifiedIdentifier("a")
+      ),
+      "Flow did not have the expected inputs"
+    )
   }
 
   test("Dependencies") {
@@ -86,7 +90,8 @@ class ConnectValidPipelineSuite extends PipelineTest {
     class P extends TestGraphRegistrationContext(spark) {
       registerPersistedView(
         "b",
-        query = sqlFlowFunc(spark, """SELECT * FROM VALUES ((1)) OUTER JOIN d ON false"""))
+        query = sqlFlowFunc(spark, """SELECT * FROM VALUES ((1)) OUTER JOIN d ON false""")
+      )
       registerPersistedView("e", query = readFlowFunc("b"))
       registerPersistedView("d", query = dfFlowFunc(Seq(1).toDF("y")))
     }
@@ -111,8 +116,10 @@ class ConnectValidPipelineSuite extends PipelineTest {
     assert(
       p.resolvedFlow(fullyQualifiedIdentifier("c")).inputs == Set(
         fullyQualifiedIdentifier("a"),
-        fullyQualifiedIdentifier("b")),
-      "Flow did not have the expected inputs")
+        fullyQualifiedIdentifier("b")
+      ),
+      "Flow did not have the expected inputs"
+    )
   }
 
   test("Real join merges schema") {
@@ -122,10 +129,12 @@ class ConnectValidPipelineSuite extends PipelineTest {
     class P extends TestGraphRegistrationContext(spark) {
       registerPersistedView(
         "a",
-        query = dfFlowFunc(Seq((1, "a"), (2, "b"), (3, "c")).toDF("x", "y")))
+        query = dfFlowFunc(Seq((1, "a"), (2, "b"), (3, "c")).toDF("x", "y"))
+      )
       registerPersistedView(
         "b",
-        query = dfFlowFunc(Seq((2, "m"), (3, "n"), (4, "o")).toDF("x", "z")))
+        query = dfFlowFunc(Seq((2, "m"), (3, "n"), (4, "o")).toDF("x", "z"))
+      )
       registerPersistedView("c", query = sqlFlowFunc(spark, "SELECT * FROM a JOIN b USING (x)"))
     }
     val p = new P().resolveToDataflowGraph()
@@ -137,8 +146,10 @@ class ConnectValidPipelineSuite extends PipelineTest {
     assert(
       p.resolvedFlow(fullyQualifiedIdentifier("c")).inputs == Set(
         fullyQualifiedIdentifier("a"),
-        fullyQualifiedIdentifier("b")),
-      "Flow did not have the expected inputs")
+        fullyQualifiedIdentifier("b")
+      ),
+      "Flow did not have the expected inputs"
+    )
   }
 
   test("Union of streaming and batch Dataframes") {
@@ -171,12 +182,15 @@ class ConnectValidPipelineSuite extends PipelineTest {
     verifyFlowSchema(
       p,
       fullyQualifiedIdentifier("c"),
-      new StructType().add("value", IntegerType, false))
+      new StructType().add("value", IntegerType, false)
+    )
     assert(
       p.resolvedFlow(fullyQualifiedIdentifier("c")).inputs == Set(
         fullyQualifiedIdentifier("a"),
-        fullyQualifiedIdentifier("b")),
-      "Flow did not have the expected inputs")
+        fullyQualifiedIdentifier("b")
+      ),
+      "Flow did not have the expected inputs"
+    )
   }
 
   test("Union of two streaming Dataframes") {
@@ -215,12 +229,15 @@ class ConnectValidPipelineSuite extends PipelineTest {
     verifyFlowSchema(
       p,
       fullyQualifiedIdentifier("c"),
-      new StructType().add("value", IntegerType, false))
+      new StructType().add("value", IntegerType, false)
+    )
     assert(
       p.resolvedFlow(fullyQualifiedIdentifier("c")).inputs == Set(
         fullyQualifiedIdentifier("a"),
-        fullyQualifiedIdentifier("b")),
-      "Flow did not have the expected inputs")
+        fullyQualifiedIdentifier("b")
+      ),
+      "Flow did not have the expected inputs"
+    )
   }
 
   test("MultipleInputs") {
@@ -232,7 +249,8 @@ class ConnectValidPipelineSuite extends PipelineTest {
       registerPersistedView("b", query = dfFlowFunc(Seq(4, 5, 6).toDF("y")))
       registerPersistedView(
         "c",
-        query = sqlFlowFunc(spark, "SELECT x AS z FROM a UNION SELECT y AS z FROM b"))
+        query = sqlFlowFunc(spark, "SELECT x AS z FROM a UNION SELECT y AS z FROM b")
+      )
     }
     val p = new P().resolveToDataflowGraph()
     val schema = new StructType().add("z", IntegerType, false)
@@ -253,13 +271,15 @@ class ConnectValidPipelineSuite extends PipelineTest {
       registerTable(
         "d",
         query = Option(sqlFlowFunc(spark, "SELECT * FROM b UNION SELECT * FROM c")),
-        Map("d" -> "d-val"))
+        Map("d" -> "d-val")
+      )
     }
     val graph = p.resolveToDataflowGraph()
     assert(
       graph
-        .flow(fullyQualifiedIdentifier("d", isTemporaryView = false))
-        .sqlConf == Map("a" -> "a-val", "b" -> "b-val", "c" -> "c-val", "d" -> "d-val"))
+        .flow(fullyQualifiedIdentifier("d"))
+        .sqlConf == Map("a" -> "a-val", "b" -> "b-val", "c" -> "c-val", "d" -> "d-val")
+    )
   }
 
   test("Confs aren't fused past materialization points") {
@@ -272,23 +292,27 @@ class ConnectValidPipelineSuite extends PipelineTest {
       registerPersistedView(
         "c",
         query = dfFlowFunc(Seq(2).toDF("x")),
-        sqlConf = Map("c" -> "c-val"))
+        sqlConf = Map("c" -> "c-val")
+      )
       registerTable(
         "d",
         query = Option(sqlFlowFunc(spark, "SELECT * FROM b UNION SELECT * FROM c")),
-        Map("d" -> "d-val"))
+        Map("d" -> "d-val")
+      )
     }
     val graph = p.resolveToDataflowGraph()
     assert(graph.flow(fullyQualifiedIdentifier("a")).sqlConf == Map("a" -> "a-val"))
     assert(
       graph
         .flow(fullyQualifiedIdentifier("b"))
-        .sqlConf == Map("a" -> "a-val", "b" -> "b-val"))
+        .sqlConf == Map("a" -> "a-val", "b" -> "b-val")
+    )
     assert(graph.flow(fullyQualifiedIdentifier("c")).sqlConf == Map("c" -> "c-val"))
     assert(
       graph
         .flow(fullyQualifiedIdentifier("d"))
-        .sqlConf == Map("c" -> "c-val", "d" -> "d-val"))
+        .sqlConf == Map("c" -> "c-val", "d" -> "d-val")
+    )
   }
 
   test("Setting the same conf with the same value is totally cool") {
@@ -301,7 +325,8 @@ class ConnectValidPipelineSuite extends PipelineTest {
       registerTable(
         "c",
         query = Option(sqlFlowFunc(spark, "SELECT * FROM a UNION SELECT * FROM b")),
-        Map("key" -> "val"))
+        Map("key" -> "val")
+      )
     }
     val graph = p.resolveToDataflowGraph()
     assert(graph.flow(fullyQualifiedIdentifier("c")).sqlConf == Map("key" -> "val"))
@@ -322,8 +347,10 @@ class ConnectValidPipelineSuite extends PipelineTest {
     verifyFlowSchema(p, fullyQualifiedIdentifier("b-query"), schema)
     assert(
       p.resolvedFlow(fullyQualifiedIdentifier("b-query")).inputs == Set(
-        fullyQualifiedIdentifier("a")),
-      "Flow did not have the expected inputs")
+        fullyQualifiedIdentifier("a")
+      ),
+      "Flow did not have the expected inputs"
+    )
   }
 
   test("Default query and named query") {
@@ -342,15 +369,20 @@ class ConnectValidPipelineSuite extends PipelineTest {
     verifyFlowSchema(p, fullyQualifiedIdentifier("a"), schema)
     verifyFlowSchema(p, fullyQualifiedIdentifier("b2"), schema)
     assert(
-      p.resolvedFlow(fullyQualifiedIdentifier("b2")).inputs == Set(fullyQualifiedIdentifier("a")),
-      "Flow did not have the expected inputs")
+      p.resolvedFlow(fullyQualifiedIdentifier("b2")).inputs == Set(
+        fullyQualifiedIdentifier("a")
+      ),
+      "Flow did not have the expected inputs"
+    )
     verifyFlowSchema(
       p,
       fullyQualifiedIdentifier("b"),
-      new StructType().add("y", IntegerType, false))
+      new StructType().add("y", IntegerType, false)
+    )
     assert(
       p.resolvedFlow(fullyQualifiedIdentifier("b")).inputs == Set.empty,
-      "Flow did not have the expected inputs")
+      "Flow did not have the expected inputs"
+    )
   }
 
   test("Multi-query table with 2 complete queries") {
@@ -382,58 +414,78 @@ class ConnectValidPipelineSuite extends PipelineTest {
           UnresolvedRelation(
             TableIdentifier("incremental-view"),
             extraOptions = CaseInsensitiveStringMap.empty(),
-            isStreaming = true)))
+            isStreaming = true
+          )
+        )
+      )
       registerFlow(
         "`incremental-table`",
         "`append-once`",
         dfFlowFunc(Seq(1, 2).toDF("x")),
-        once = true)
+        once = true
+      )
     }.resolveToDataflowGraph()
 
     assert(
       graph
         .flow(fullyQualifiedIdentifier("complete-view"))
-        .isInstanceOf[CompleteFlow])
+        .isInstanceOf[CompleteFlow]
+    )
     assert(
       graph
         .flow(fullyQualifiedIdentifier("incremental-view"))
-        .isInstanceOf[StreamingFlow])
+        .isInstanceOf[StreamingFlow]
+    )
     assert(
       graph
         .flow(fullyQualifiedIdentifier("complete-table"))
-        .isInstanceOf[CompleteFlow])
+        .isInstanceOf[CompleteFlow]
+    )
     assert(
       graph
         .flow(fullyQualifiedIdentifier("incremental-table"))
-        .isInstanceOf[StreamingFlow])
+        .isInstanceOf[StreamingFlow]
+    )
     assert(
       graph
         .flow(fullyQualifiedIdentifier("append-once"))
-        .isInstanceOf[AppendOnceFlow])
+        .isInstanceOf[AppendOnceFlow]
+    )
   }
 
   test("Pipeline level default spark confs are applied with correct precedence") {
     val session = spark
     import session.implicits._
 
-    val P = new TestGraphRegistrationContext(spark, Map("default.conf" -> "value")) {
+    val P = new TestGraphRegistrationContext(
+      spark,
+      Map("default.conf" -> "value")
+    ) {
       registerTable(
         "a",
         query = Option(dfFlowFunc(Seq(1, 2, 3).toDF("x"))),
-        sqlConf = Map("other.conf" -> "value"))
+        sqlConf = Map("other.conf" -> "value")
+      )
       registerTable(
         "b",
         query = Option(sqlFlowFunc(spark, "SELECT x as y FROM a")),
-        sqlConf = Map("default.conf" -> "other-value"))
+        sqlConf = Map("default.conf" -> "other-value")
+      )
     }
     val p = P.resolveToDataflowGraph()
 
     assert(
       p.flow(fullyQualifiedIdentifier("a")).sqlConf == Map(
         "default.conf" -> "value",
-        "other.conf" -> "value"))
+        "other.conf" -> "value"
+      )
+    )
 
-    assert(p.flow(fullyQualifiedIdentifier("b")).sqlConf == Map("default.conf" -> "other-value"))
+    assert(
+      p.flow(fullyQualifiedIdentifier("b")).sqlConf == Map(
+        "default.conf" -> "other-value"
+      )
+    )
   }
 
   /** Verifies the [[DataflowGraph]] has the specified [[Flow]] with the specified schema. */
@@ -444,12 +496,15 @@ class ConnectValidPipelineSuite extends PipelineTest {
     assert(
       pipeline.flow.contains(identifier),
       s"Flow ${identifier.unquotedString} not found," +
-        s" all flow names: ${pipeline.flow.keys.map(_.unquotedString)}")
+        s" all flow names: ${pipeline.flow.keys.map(_.unquotedString)}"
+    )
     assert(
       pipeline.resolvedFlow.contains(identifier),
-      s"Flow ${identifier.unquotedString} has not been resolved")
+      s"Flow ${identifier.unquotedString} has not been resolved"
+    )
     assert(
       pipeline.resolvedFlow(identifier).schema == expected,
-      s"Flow ${identifier.unquotedString} has the wrong schema")
+      s"Flow ${identifier.unquotedString} has the wrong schema"
+    )
   }
 }

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
@@ -863,12 +863,13 @@ class SQLPipelineSuite extends PipelineTest with SQLTestUtils {
       exception = intercept[AnalysisException] {
         graphRegistrationContext.toDataflowGraph
       },
-      condition = "NO_TABLES_IN_PIPELINE",
+      condition = "NO_DATASET_IN_PIPELINE",
       sqlState = Option("42617"),
-      parameters = Map.empty)
+      parameters = Map.empty
+    )
   }
 
-  test("Only temp view pipeline fails") {
+  test("Pipeline with only temp views fails with NO_DATASET_IN_PIPELINE") {
     val graphRegistrationContext = new TestGraphRegistrationContext(spark)
     val sqlGraphRegistrationContext = new SqlGraphRegistrationContext(graphRegistrationContext)
 
@@ -877,14 +878,16 @@ class SQLPipelineSuite extends PipelineTest with SQLTestUtils {
                    |CREATE TEMPORARY VIEW a AS SELECT id FROM range(1,3);
                    |""".stripMargin,
       sqlFilePath = "a.sql",
-      spark = spark)
+      spark = spark
+    )
 
     checkError(
       exception = intercept[AnalysisException] {
         graphRegistrationContext.toDataflowGraph
       },
-      condition = "NO_TABLES_IN_PIPELINE",
+      condition = "NO_DATASET_IN_PIPELINE",
       sqlState = Option("42617"),
-      parameters = Map.empty)
+      parameters = Map.empty
+    )
   }
 }

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
@@ -853,7 +853,7 @@ class SQLPipelineSuite extends PipelineTest with SQLTestUtils {
     )
   }
 
-  test("No table defined pipeline fails with NO_DATASETS_IN_PIPELINE") {
+  test("No table defined pipeline fails with RUN_EMPTY_PIPELINE") {
     val graphRegistrationContext = new TestGraphRegistrationContext(spark)
     val sqlGraphRegistrationContext = new SqlGraphRegistrationContext(graphRegistrationContext)
 
@@ -863,13 +863,13 @@ class SQLPipelineSuite extends PipelineTest with SQLTestUtils {
       exception = intercept[AnalysisException] {
         graphRegistrationContext.toDataflowGraph
       },
-      condition = "NO_DATASETS_IN_PIPELINE",
+      condition = "RUN_EMPTY_PIPELINE",
       sqlState = Option("42617"),
       parameters = Map.empty
     )
   }
 
-  test("Pipeline with only temp views fails with NO_DATASETS_IN_PIPELINE") {
+  test("Pipeline with only temp views fails with RUN_EMPTY_PIPELINE") {
     val graphRegistrationContext = new TestGraphRegistrationContext(spark)
     val sqlGraphRegistrationContext = new SqlGraphRegistrationContext(graphRegistrationContext)
 
@@ -885,13 +885,13 @@ class SQLPipelineSuite extends PipelineTest with SQLTestUtils {
       exception = intercept[AnalysisException] {
         graphRegistrationContext.toDataflowGraph
       },
-      condition = "NO_DATASETS_IN_PIPELINE",
+      condition = "RUN_EMPTY_PIPELINE",
       sqlState = Option("42617"),
       parameters = Map.empty
     )
   }
 
-  test("Pipeline with only flow fails with NO_DATASETS_IN_PIPELINE") {
+  test("Pipeline with only flow fails with RUN_EMPTY_PIPELINE") {
     val graphRegistrationContext = new TestGraphRegistrationContext(spark)
     val sqlGraphRegistrationContext = new SqlGraphRegistrationContext(graphRegistrationContext)
 
@@ -908,7 +908,7 @@ class SQLPipelineSuite extends PipelineTest with SQLTestUtils {
       exception = intercept[AnalysisException] {
         graphRegistrationContext.toDataflowGraph
       },
-      condition = "NO_DATASETS_IN_PIPELINE",
+      condition = "RUN_EMPTY_PIPELINE",
       sqlState = Option("42617"),
       parameters = Map.empty
     )

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
@@ -853,7 +853,7 @@ class SQLPipelineSuite extends PipelineTest with SQLTestUtils {
     )
   }
 
-  test("No table defined pipeline fails with NO_DATASET_IN_PIPELINE") {
+  test("No table defined pipeline fails with NO_DATASETS_IN_PIPELINE") {
     val graphRegistrationContext = new TestGraphRegistrationContext(spark)
     val sqlGraphRegistrationContext = new SqlGraphRegistrationContext(graphRegistrationContext)
 
@@ -863,13 +863,13 @@ class SQLPipelineSuite extends PipelineTest with SQLTestUtils {
       exception = intercept[AnalysisException] {
         graphRegistrationContext.toDataflowGraph
       },
-      condition = "NO_DATASET_IN_PIPELINE",
+      condition = "NO_DATASETS_IN_PIPELINE",
       sqlState = Option("42617"),
       parameters = Map.empty
     )
   }
 
-  test("Pipeline with only temp views fails with NO_DATASET_IN_PIPELINE") {
+  test("Pipeline with only temp views fails with NO_DATASETS_IN_PIPELINE") {
     val graphRegistrationContext = new TestGraphRegistrationContext(spark)
     val sqlGraphRegistrationContext = new SqlGraphRegistrationContext(graphRegistrationContext)
 
@@ -885,13 +885,13 @@ class SQLPipelineSuite extends PipelineTest with SQLTestUtils {
       exception = intercept[AnalysisException] {
         graphRegistrationContext.toDataflowGraph
       },
-      condition = "NO_DATASET_IN_PIPELINE",
+      condition = "NO_DATASETS_IN_PIPELINE",
       sqlState = Option("42617"),
       parameters = Map.empty
     )
   }
 
-  test("Pipeline with only flow fails with NO_DATASET_IN_PIPELINE") {
+  test("Pipeline with only flow fails with NO_DATASETS_IN_PIPELINE") {
     val graphRegistrationContext = new TestGraphRegistrationContext(spark)
     val sqlGraphRegistrationContext = new SqlGraphRegistrationContext(graphRegistrationContext)
 
@@ -908,7 +908,7 @@ class SQLPipelineSuite extends PipelineTest with SQLTestUtils {
       exception = intercept[AnalysisException] {
         graphRegistrationContext.toDataflowGraph
       },
-      condition = "NO_DATASET_IN_PIPELINE",
+      condition = "NO_DATASETS_IN_PIPELINE",
       sqlState = Option("42617"),
       parameters = Map.empty
     )

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/TriggeredGraphExecutionSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/TriggeredGraphExecutionSuite.scala
@@ -119,13 +119,13 @@ class TriggeredGraphExecutionSuite extends ExecutionTest {
 
     val cFlow =
       resolvedGraph.resolvedFlows
-        .filter(_.identifier == fullyQualifiedIdentifier("c", isView = true))
+        .filter(_.identifier == fullyQualifiedIdentifier("c", isTemporaryView = true))
         .head
     assert(cFlow.inputs == Set(fullyQualifiedIdentifier("a")))
 
     val dFlow =
       resolvedGraph.resolvedFlows.filter(_.identifier == fullyQualifiedIdentifier("d")).head
-    assert(dFlow.inputs == Set(fullyQualifiedIdentifier("c", isView = true)))
+    assert(dFlow.inputs == Set(fullyQualifiedIdentifier("c", isTemporaryView = true)))
 
     val updateContext = TestPipelineUpdateContext(spark, unresolvedGraph)
     updateContext.pipelineExecution.runPipeline()
@@ -167,7 +167,7 @@ class TriggeredGraphExecutionSuite extends ExecutionTest {
     // no flow progress event for c, as it is a temporary view
     assertNoFlowProgressEvent(
       eventBuffer = updateContext.eventBuffer,
-      identifier = fullyQualifiedIdentifier("c", isView = true),
+      identifier = fullyQualifiedIdentifier("c", isTemporaryView = true),
       flowStatus = FlowStatus.STARTING
     )
     checkAnswer(

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/PipelineTest.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/PipelineTest.scala
@@ -83,9 +83,9 @@ abstract class PipelineTest
       name: String,
       catalog: Option[String] = catalogInPipelineSpec,
       database: Option[String] = databaseInPipelineSpec,
-      isView: Boolean = false
+      isTemporaryView: Boolean = false
   ): TableIdentifier = {
-    if (isView) {
+    if (isTemporaryView) {
       TableIdentifier(name)
     } else {
       TableIdentifier(

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/TestGraphRegistrationContext.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/TestGraphRegistrationContext.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.pipelines.utils
 
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.analysis.{LocalTempView, UnresolvedRelation, ViewType}
+import org.apache.spark.sql.catalyst.analysis.{LocalTempView, PersistedView => PersistedViewType, UnresolvedRelation, ViewType}
 import org.apache.spark.sql.classic.{DataFrame, SparkSession}
 import org.apache.spark.sql.pipelines.graph.{
   DataflowGraph,
@@ -161,6 +161,25 @@ class TestGraphRegistrationContext(
         )
       )
     }
+  }
+
+  def registerPersistedView(
+      name: String,
+      query: FlowFunction,
+      sqlConf: Map[String, String] = Map.empty,
+      comment: Option[String] = None,
+      origin: QueryOrigin = QueryOrigin.empty,
+      catalog: Option[String] = None,
+      database: Option[String] = None): Unit = {
+    registerView(
+      name = name,
+      query = query,
+      sqlConf = sqlConf,
+      comment = comment,
+      origin = origin,
+      viewType = PersistedViewType,
+      catalog = catalog,
+      database = database)
   }
 
   def registerView(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


When user runs a pipeline, throw a `RUN_EMPTY_PIPELINE` exception if the pipeline source directory does not contain any tables or persisted views. 

* Add checks in `GraphRegistrationContext. toDataflowGraph` to throw the exception if the pipeline does not have any tables or persisted views
* Modify test cases that currently register only temporary view to register persisted views instead since pipelines that only include temporary views are invalid now.
* Add additional test cases to ensure the exception is thrown correctly.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

In Spark Declarative Pipelines, using the CLI tool users run a pipeline that is defined from the configured pipeline root directory. This directory contains information such as the pipeline spec, and the source code files (Python, SQL) that define the pipeline tables/flows/views.

It’s possible the user tries to run a pipeline defined from a pipeline directory whose source files don’t actually define any tables or views. 

An exception should be thrown if the pipeline does not have any tables or views, to inform the user they should double check that they are running the pipeline in the correct directory. The previous behavior is that the pipeline just run to completion without emitting any info.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, this is an additive non-breaking behavior change. However, SDP has not been released, so no user should be impacted by this change.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Created additional test case to verify that the exception is indeed thrown.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
