### PR TITLE
[SPARK-52711][PS] Fix float32 type widening in `mul`/`rmul` under ANSI

### DIFF
--- a/python/pyspark/pandas/tests/data_type_ops/test_num_mul_div.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_mul_div.py
@@ -35,7 +35,6 @@ class NumMulDivTestsMixin:
     def float_psser(self):
         return ps.from_pandas(self.float_pser)
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_mul(self):
         pdf, psdf = self.pdf, self.psdf
         for col in self.numeric_df_cols:

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_reverse.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_reverse.py
@@ -67,7 +67,6 @@ class ReverseTestsMixin:
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) - psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) - psser)
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_rmul(self):
         pdf, psdf = self.pdf, self.psdf
         for col in self.numeric_df_cols:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix float32 type widening in `mul`/`rmul` under ANSI

### Why are the changes needed?
Ensure pandas on Spark works well with ANSI mode on.
Part of https://issues.apache.org/jira/browse/SPARK-52700.

### Does this PR introduce _any_ user-facing change?
Yes. `mul`/`rmul` under ANSI works as expected, as shown below.

```py
>>> ps.set_option("compute.fail_on_ansi_mode", False)
>>> ps.set_option("compute.ansi_mode_support", True)
>>> pser = pd.Series([1.1, 2.2, 3.3], dtype=np.float32)
>>> psser = ps.from_pandas(pser)
>>> psser * 1
0    1.1                                                                        
1    2.2
2    3.3
dtype: float32
>>> 0.1 * psser
0    0.11
1    0.22
2    0.33
dtype: float32
>>> False * psser
0    0.0
1    0.0
2    0.0
dtype: float32
```

### How was this patch tested?
Unit tests.

Commands below all passed
```
 1133  SPARK_ANSI_SQL_MODE=false  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_mul_div NumMulDivTests.test_mul"
 1134  SPARK_ANSI_SQL_MODE=true  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_mul_div NumMulDivTests.test_mul"
 1136  SPARK_ANSI_SQL_MODE=true  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_reverse ReverseTests.test_rmul"
 1137  SPARK_ANSI_SQL_MODE=false  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_reverse ReverseTests.test_rmul"
```


### Was this patch authored or co-authored using generative AI tooling?
No.
