### PR TITLE
[SPARK-52765][K8S] Use `StandardCharsets.UTF_8` instead of `Charsets.UTF_8`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -17,9 +17,9 @@
 package org.apache.spark.deploy.k8s
 
 import java.io.File
+import java.nio.charset.StandardCharsets
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.google.common.base.Charsets
 import com.google.common.io.Files
 import io.fabric8.kubernetes.client.{ConfigBuilder, KubernetesClient, KubernetesClientBuilder}
 import io.fabric8.kubernetes.client.Config.KUBERNETES_REQUEST_RETRY_BACKOFFLIMIT_SYSTEM_PROPERTY
@@ -99,7 +99,7 @@ object SparkKubernetesClientFactory extends Logging {
         (token, configBuilder) => configBuilder.withOauthToken(token)
       }.withOption(oauthTokenFile) {
         (file, configBuilder) =>
-            configBuilder.withOauthToken(Files.asCharSource(file, Charsets.UTF_8).read())
+            configBuilder.withOauthToken(Files.asCharSource(file, StandardCharsets.UTF_8).read())
       }.withOption(caCertFile) {
         (file, configBuilder) => configBuilder.withCaCertFile(file)
       }.withOption(clientKeyFile) {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStepSuite.scala
@@ -30,7 +30,6 @@ import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.util.Utils
 
-
 class DriverKubernetesCredentialsFeatureStepSuite extends SparkFunSuite {
 
   private val credentialsTempDirectory = Utils.createTempDir()

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStepSuite.scala
@@ -17,10 +17,10 @@
 package org.apache.spark.deploy.k8s.features
 
 import java.io.File
+import java.nio.charset.StandardCharsets
 
 import scala.jdk.CollectionConverters._
 
-import com.google.common.base.Charsets
 import com.google.common.io.{BaseEncoding, Files}
 import io.fabric8.kubernetes.api.model.Secret
 
@@ -29,6 +29,7 @@ import org.apache.spark.deploy.k8s.{KubernetesTestConf, SparkPod}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.util.Utils
+
 
 class DriverKubernetesCredentialsFeatureStepSuite extends SparkFunSuite {
 
@@ -106,7 +107,7 @@ class DriverKubernetesCredentialsFeatureStepSuite extends SparkFunSuite {
     assert(credentialsSecret.getMetadata.getName ===
       s"${kubernetesConf.resourceNamePrefix}-kubernetes-credentials")
     val decodedSecretData = credentialsSecret.getData.asScala.map { data =>
-      (data._1, new String(BaseEncoding.base64().decode(data._2), Charsets.UTF_8))
+      (data._1, new String(BaseEncoding.base64().decode(data._2), StandardCharsets.UTF_8))
     }
     val expectedSecretData = Map(
       DRIVER_CREDENTIALS_CA_CERT_SECRET_NAME -> "ca-cert",
@@ -128,7 +129,7 @@ class DriverKubernetesCredentialsFeatureStepSuite extends SparkFunSuite {
 
   private def writeCredentials(credentialsFileName: String, credentialsContents: String): File = {
     val credentialsFile = new File(credentialsTempDirectory, credentialsFileName)
-    Files.asCharSink(credentialsFile, Charsets.UTF_8).write(credentialsContents)
+    Files.asCharSink(credentialsFile, StandardCharsets.UTF_8).write(credentialsContents)
     credentialsFile
   }
 }

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -17,12 +17,12 @@
 package org.apache.spark.deploy.k8s.integrationtest
 
 import java.io.File
+import java.nio.charset.StandardCharsets
 import java.nio.file.{Path, Paths}
 import java.util.UUID
 
 import scala.jdk.CollectionConverters._
 
-import com.google.common.base.Charsets
 import com.google.common.io.Files
 import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.client.{Watcher, WatcherException}
@@ -129,7 +129,7 @@ class KubernetesSuite extends SparkFunSuite
         val tagFile = new File(path)
         require(tagFile.isFile,
           s"No file found for image tag at ${tagFile.getAbsolutePath}.")
-        Files.asCharSource(tagFile, Charsets.UTF_8).read().trim
+        Files.asCharSource(tagFile, StandardCharsets.UTF_8).read().trim
       }
       .orElse(sys.props.get(CONFIG_KEY_IMAGE_TAG))
       .getOrElse {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR replaces `Charsets.UTF_8` with `StandardCharsets.UTF_8` because `Charsets.UTF_8` has been deprecated in Guava.

https://github.com/google/guava/blob/5c71d2a15435399fa62508d807d5cc83506f7496/guava/src/com/google/common/base/Charsets.java#L54-L59


<img width="536" height="106" alt="image" src="https://github.com/user-attachments/assets/b269ccce-361b-423c-b23e-215c155cfa52" />


### Why are the changes needed?
To clean up the use of deprecated APIs.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No