### PR TITLE
[SPARK-52766][INFRA] Allow manual dispatches of dry runs in the forked repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,10 +91,23 @@ jobs:
   release:
     name: Release Apache Spark
     runs-on: ubuntu-latest
-    # Do not allow dispatching this workflow manually in the main repo.
-    # and skip this workflow in forked repository when running as a
-    # scheduled job (dryrun).
-    if: ${{ (github.repository == 'apache/spark') != (inputs.branch != '' && inputs.release-version != '') }}
+    # Allow workflow to run only in the following cases:
+    # 1. In the apache/spark repository:
+    #    - Only allow dry runs (i.e., both 'branch' and 'release-version' inputs are empty).
+    # 2. In forked repositories:
+    #    - Allow real runs when both 'branch' and 'release-version' are provided.
+    #    - Allow dry runs only if manually dispatched (not on a schedule).
+    if: |
+      (
+        github.repository == 'apache/spark' &&
+        inputs.branch == '' &&
+        inputs.release-version == ''
+      ) || (
+        github.repository != 'apache/spark' &&
+        (
+          (inputs.branch != '' && inputs.release-version != '') || github.event_name == 'workflow_dispatch'
+        )
+      )
     steps:
       - name: Checkout Spark repository
         uses: actions/checkout@v4


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update the workflow condition to allow running only in the following cases:

- In apache/spark: only allow dry runs.

- In forks: allow real runs and allow dry runs only when manually dispatched.


### Why are the changes needed?

The current condition does not support all intended scenarios for running workflows in forks and the main repo.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.