### PR TITLE
[SPARK-52771][PS] Fix float32 type widening in `truediv`/`floordiv`

### DIFF
--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -427,21 +427,21 @@ class FractionalOps(NumericOps):
         new_right = transform_boolean_operand_to_numeric(right, spark_type=left.spark.data_type)
         left_dtype = left.dtype
 
-        def truediv(left: PySparkColumn, right: Any) -> PySparkColumn:
+        def truediv(lc: PySparkColumn, rc: Any) -> PySparkColumn:
             if is_ansi_mode_enabled(spark_session):
                 expr = F.when(
-                    F.lit(right == 0),
-                    F.when(left < 0, F.lit(float("-inf")))
-                    .when(left > 0, F.lit(float("inf")))
+                    F.lit(rc == 0),
+                    F.when(lc < 0, F.lit(float("-inf")))
+                    .when(lc > 0, F.lit(float("inf")))
                     .otherwise(F.lit(np.nan)),
-                ).otherwise(left / right)
+                ).otherwise(lc / rc)
             else:
                 expr = F.when(
-                    F.lit(right != 0) | F.lit(right).isNull(),
-                    left.__div__(right),
+                    F.lit(rc != 0) | F.lit(rc).isNull(),
+                    lc.__div__(rc),
                 ).otherwise(
-                    F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), left).otherwise(
-                        F.lit(np.inf).__div__(left)
+                    F.when(F.lit(lc == np.inf) | F.lit(lc == -np.inf), lc).otherwise(
+                        F.lit(np.inf).__div__(lc)
                     )
                 )
             return _cast_back_float(expr, left_dtype, right)
@@ -463,14 +463,14 @@ class FractionalOps(NumericOps):
             F.try_divide if use_try_divide else fallback_div
         )
 
-        def floordiv(left: PySparkColumn, right: Any) -> PySparkColumn:
-            expr = F.when(F.lit(right is np.nan), np.nan).otherwise(
+        def floordiv(lc: PySparkColumn, rc: Any) -> PySparkColumn:
+            expr = F.when(F.lit(rc is np.nan), np.nan).otherwise(
                 F.when(
-                    F.lit(right != 0) | F.lit(right).isNull(),
-                    F.floor(left.__div__(right)),
+                    F.lit(rc != 0) | F.lit(rc).isNull(),
+                    F.floor(lc.__div__(rc)),
                 ).otherwise(
-                    F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), left).otherwise(
-                        safe_div(F.lit(np.inf), left)
+                    F.when(F.lit(lc == np.inf) | F.lit(lc == -np.inf), lc).otherwise(
+                        safe_div(F.lit(np.inf), lc)
                     )
                 )
             )

--- a/python/pyspark/pandas/tests/computation/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/computation/test_binary_ops.py
@@ -122,8 +122,7 @@ class FrameBinaryOpsMixin:
             dtype=np.float32,
         )
         psdf = ps.from_pandas(pdf)
-        # TODO(SPARK-52332): Fix promotion from float32 to float64 during division
-        self.assert_eq(psdf["a"] / psdf["b"], (pdf["a"] / pdf["b"]).astype(np.float64))
+        self.assert_eq(psdf["a"] / psdf["b"], pdf["a"] / pdf["b"])
 
         # np.float64
         pdf = pd.DataFrame(

--- a/python/pyspark/pandas/tests/computation/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/computation/test_binary_ops.py
@@ -195,6 +195,10 @@ class FrameBinaryOpsMixin:
 
         self.assert_eq(psdf["a"] / psdf["b"], pdf["a"] / pdf["b"])
 
+        pser = pd.Series([1.1, 2.2, 3.3], dtype=np.float32)
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser / 1, pser / 1)
+
         # Negative
         psdf = ps.DataFrame({"a": ["x"], "b": [1]})
 
@@ -213,6 +217,10 @@ class FrameBinaryOpsMixin:
         self.assert_eq(pdf["b"] // 0, psdf["b"] // 0)
         self.assert_eq(pdf["c"] // 0, psdf["c"] // 0)
         self.assert_eq(pdf["d"] // 0, psdf["d"] // 0)
+
+        pser = pd.Series([1.1, 2.2, 3.3], dtype=np.float32)
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser // 1, pser // 1)
 
         ks_err_msg = "Floor division can not be applied to strings"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] // psdf["b"])


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix float32 type widening in `truediv`/`floordiv` when ANSI on/off.

### Why are the changes needed?
Ensure pandas on Spark works well with ANSI mode on/off.

Note that the issue exists whether ANSI mode is on or off, as shown below,

```py
>>> pser = pd.Series([1.1, 2.2, 3.3], dtype=np.float32)
>>> psser = ps.from_pandas(pser)
>>> spark.conf.set("spark.sql.ansi.enabled", False)
>>> psser / 1
0    1.1                                                                        
1    2.2
2    3.3
dtype: float64
>>> spark.conf.set("spark.sql.ansi.enabled", True)
>>> psser / 1
0    1.1
1    2.2
2    3.3
dtype: float64
```

### Does this PR introduce _any_ user-facing change?
Yes. truediv/floordiv under ANSI works as expected, with ANSI on/off, as shown below.

```py
>>> import pandas as pd
>>> import numpy as np
>>> 
>>> ps.set_option("compute.fail_on_ansi_mode", False)
>>> ps.set_option("compute.ansi_mode_support", True)
>>> 
>>> pser = pd.Series([1.1, 2.2, 3.3], dtype=np.float32)
>>> psser = ps.from_pandas(pser)
>>> psser / 1
0    1.1                                                                        
1    2.2
2    3.3
dtype: float32
>>> psser // 1
0    1.0
1    2.0
2    3.0
dtype: float32
```

### How was this patch tested?
Unit tests.

Commands below all passed
```
 1103  SPARK_ANSI_SQL_MODE=true  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.computation.test_binary_ops FrameBinaryOpsTests.test_binary_operator_truediv"
 1104  SPARK_ANSI_SQL_MODE=false  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.computation.test_binary_ops FrameBinaryOpsTests.test_binary_operator_truediv"
 1106  SPARK_ANSI_SQL_MODE=true  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.computation.test_binary_ops FrameBinaryOpsTests.test_binary_operator_floordiv"
 1108  SPARK_ANSI_SQL_MODE=false  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.computation.test_binary_ops FrameBinaryOpsTests.test_binary_operator_floordiv"
 1126  git status
 1127  SPARK_ANSI_SQL_MODE=true  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.computation.test_binary_ops FrameBinaryOpsTests.test_divide_by_zero_behavior"
 1128  SPARK_ANSI_SQL_MODE=false  ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.computation.test_binary_ops FrameBinaryOpsTests.test_divide_by_zero_behavior"
```

### Was this patch authored or co-authored using generative AI tooling?
No.
