### PR TITLE
[SPARK-52778][BUILD] Upgrade `commons-lang3` to 3.18.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -46,7 +46,7 @@ commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-io/2.19.0//commons-io-2.19.0.jar
 commons-lang/2.6//commons-lang-2.6.jar
-commons-lang3/3.17.0//commons-lang3-3.17.0.jar
+commons-lang3/3.18.0//commons-lang3-3.18.0.jar
 commons-math3/3.6.1//commons-math3-3.6.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
 commons-text/1.13.1//commons-text-1.13.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
     <!-- To support Hive UDF jars built by Hive 2.0.0 ~ 2.3.9 and 3.0.0 ~ 3.1.3. -->
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->
-    <commons-lang3.version>3.17.0</commons-lang3.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <!-- org.apache.commons/commons-pool2/-->
     <commons-pool2.version>2.12.1</commons-pool2.version>
     <datanucleus-core.version>4.1.17</datanucleus-core.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `commons-lang3` to 3.18.0.

Although SPARK-52469 removes ` org.apache.commons.lang3.JavaVersion` usages, we still use many methods of `commons-lang3`.
- #51174

### Why are the changes needed?

To bring the latest bug fixes.
- https://commons.apache.org/proper/commons-lang/changes.html#a3.18.0
  - apache/commons-lang/pull/1327
  - apache/commons-lang/pull/1297
  - apache/commons-lang/pull/1273

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.