### PR TITLE
  [SPARK-52619][SQL] Cast TimeType to IntegralType

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -2027,7 +2027,7 @@ case class Cast(
     case DateType =>
       (c, evPrim, evNull) => code"$evNull = true;"
     case TimestampType => castTimestampToIntegralTypeCode(ctx, "int", from, IntegerType)
-    case TimeType(_) => castTimeToIntegralTypeCode(ctx, "int", from, IntegerType)
+    case _: TimeType => castTimeToIntegralTypeCode(ctx, "int", from, IntegerType)
     case DecimalType() => castDecimalToIntegralTypeCode("int")
     case LongType if ansiEnabled =>
       castIntegralTypeToIntegralTypeExactCode(ctx, "int", from, IntegerType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -135,6 +135,7 @@ object Cast extends QueryErrorsBase {
     case (_, VariantType) => variant.VariantGet.checkDataType(from, allowStructsAndMaps = false)
 
     case (_: TimeType, _: TimeType) => true
+    case (_: TimeType, _: IntegralType) => true
 
     // non-null variants can generate nulls even in ANSI mode
     case (ArrayType(fromType, fn), ArrayType(toType, tn)) =>
@@ -254,6 +255,7 @@ object Cast extends QueryErrorsBase {
     case (_, VariantType) => variant.VariantGet.checkDataType(from, allowStructsAndMaps = false)
 
     case (_: TimeType, _: TimeType) => true
+    case (_: TimeType, _: IntegralType) => true
 
     case (ArrayType(fromType, fn), ArrayType(toType, tn)) =>
       canCast(fromType, toType) &&
@@ -370,6 +372,7 @@ object Cast extends QueryErrorsBase {
     case (_, _: StringType) => false
 
     case (TimestampType, ByteType | ShortType | IntegerType) => true
+    case (_: TimeType, ByteType | ShortType) => true
     case (FloatType | DoubleType, TimestampType) => true
     case (TimestampType, DateType) => false
     case (_, DateType) => true
@@ -720,6 +723,9 @@ case class Cast(
   private[this] def timestampToDouble(ts: Long): Double = {
     ts / MICROS_PER_SECOND.toDouble
   }
+  private[this] def timeToLong(timeNanos: Long): Long = {
+    Math.floorDiv(timeNanos, NANOS_PER_SECOND)
+  }
 
   // DateConverter
   private[this] def castToDate(from: DataType): Any => Any = from match {
@@ -807,6 +813,8 @@ case class Cast(
       buildCast[Int](_, d => null)
     case TimestampType =>
       buildCast[Long](_, t => timestampToLong(t))
+    case _: TimeType =>
+      buildCast[Long](_, t => timeToLong(t))
     case x: NumericType if ansiEnabled =>
       val exactNumeric = PhysicalNumericType.exactNumeric(x)
       b => exactNumeric.toLong(b)
@@ -847,6 +855,15 @@ case class Cast(
           errorOrNull(t, from, IntegerType)
         }
       })
+    case _: TimeType =>
+      buildCast[Long](_, t => {
+        val longValue = timeToLong(t)
+        if (longValue == longValue.toInt) {
+          longValue.toInt
+        } else {
+          errorOrNull(t, from, IntegerType)
+        }
+      })
     case x: NumericType if ansiEnabled =>
       val exactNumeric = PhysicalNumericType.exactNumeric(x)
       b => exactNumeric.toInt(b)
@@ -877,6 +894,15 @@ case class Cast(
     case TimestampType =>
       buildCast[Long](_, t => {
         val longValue = timestampToLong(t)
+        if (longValue == longValue.toShort) {
+          longValue.toShort
+        } else {
+          errorOrNull(t, from, ShortType)
+        }
+      })
+    case _: TimeType =>
+      buildCast[Long](_, t => {
+        val longValue = timeToLong(t)
         if (longValue == longValue.toShort) {
           longValue.toShort
         } else {
@@ -924,6 +950,15 @@ case class Cast(
     case TimestampType =>
       buildCast[Long](_, t => {
         val longValue = timestampToLong(t)
+        if (longValue == longValue.toByte) {
+          longValue.toByte
+        } else {
+          errorOrNull(t, from, ByteType)
+        }
+      })
+    case _: TimeType =>
+      buildCast[Long](_, t => {
+        val longValue = timeToLong(t)
         if (longValue == longValue.toByte) {
           longValue.toByte
         } else {
@@ -1723,6 +1758,9 @@ case class Cast(
   private[this] def timestampToDoubleCode(ts: ExprValue): Block =
     code"$ts / (double)$MICROS_PER_SECOND"
 
+  private[this] def timeToLongCode(timeValue: ExprValue): Block =
+    code"Math.floorDiv($timeValue, ${NANOS_PER_SECOND}L)"
+
   private[this] def castToBooleanCode(
       from: DataType,
       ctx: CodegenContext): CastFunction = from match {
@@ -1780,6 +1818,33 @@ case class Cast(
             $overflow
           }
         """
+  }
+
+  private[this] def castTimeToIntegralTypeCode(
+      ctx: CodegenContext,
+      integralType: String,
+      from: DataType,
+      to: DataType): CastFunction = {
+
+    val longValue = ctx.freshName("longValue")
+    val fromDt = ctx.addReferenceObj("from", from, from.getClass.getName)
+    val toDt = ctx.addReferenceObj("to", to, to.getClass.getName)
+
+    (c, evPrim, evNull) =>
+      val overflow = if (ansiEnabled) {
+        code"""throw QueryExecutionErrors.castingCauseOverflowError($c, $fromDt, $toDt);"""
+      } else {
+        code"$evNull = true;"
+      }
+
+      code"""
+      long $longValue = ${timeToLongCode(c)};
+      if ($longValue == ($integralType) $longValue) {
+        $evPrim = ($integralType) $longValue;
+      } else {
+        $overflow
+      }
+    """
   }
 
   private[this] def castDayTimeIntervalToIntegralTypeCode(
@@ -1888,6 +1953,7 @@ case class Cast(
     case DateType =>
       (c, evPrim, evNull) => code"$evNull = true;"
     case TimestampType => castTimestampToIntegralTypeCode(ctx, "byte", from, ByteType)
+    case _: TimeType => castTimeToIntegralTypeCode(ctx, "byte", from, ByteType)
     case DecimalType() => castDecimalToIntegralTypeCode("byte")
     case ShortType | IntegerType | LongType if ansiEnabled =>
       castIntegralTypeToIntegralTypeExactCode(ctx, "byte", from, ByteType)
@@ -1925,6 +1991,7 @@ case class Cast(
     case DateType =>
       (c, evPrim, evNull) => code"$evNull = true;"
     case TimestampType => castTimestampToIntegralTypeCode(ctx, "short", from, ShortType)
+    case _: TimeType => castTimeToIntegralTypeCode(ctx, "short", from, ShortType)
     case DecimalType() => castDecimalToIntegralTypeCode("short")
     case IntegerType | LongType if ansiEnabled =>
       castIntegralTypeToIntegralTypeExactCode(ctx, "short", from, ShortType)
@@ -1960,6 +2027,7 @@ case class Cast(
     case DateType =>
       (c, evPrim, evNull) => code"$evNull = true;"
     case TimestampType => castTimestampToIntegralTypeCode(ctx, "int", from, IntegerType)
+    case TimeType(_) => castTimeToIntegralTypeCode(ctx, "int", from, IntegerType)
     case DecimalType() => castDecimalToIntegralTypeCode("int")
     case LongType if ansiEnabled =>
       castIntegralTypeToIntegralTypeExactCode(ctx, "int", from, IntegerType)
@@ -1996,6 +2064,8 @@ case class Cast(
       (c, evPrim, evNull) => code"$evNull = true;"
     case TimestampType =>
       (c, evPrim, evNull) => code"$evPrim = (long) ${timestampToLongCode(c)};"
+    case _: TimeType =>
+      (c, evPrim, evNull) => code"$evPrim = (long) ${timeToLongCode(c)};"
     case DecimalType() => castDecimalToIntegralTypeCode("long")
     case FloatType | DoubleType if ansiEnabled =>
       castFractionToIntegralTypeCode(ctx, "long", from, LongType)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -1507,8 +1507,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       }
     }
   }
-  test("cast time to integral types") {
-
+  test("SPARK-52619: cast time to integral types") {
     // Test normal cases that should work with a small number like 112 seconds after midnight
     val smallTime = Literal.create(LocalTime.of(0, 1, 52), TimeType(6))
     checkEvaluation(cast(smallTime, ByteType), 112.toByte)
@@ -1516,43 +1515,38 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(cast(smallTime, IntegerType), 112)
     checkEvaluation(cast(smallTime, LongType), 112L)
 
-    // Test edge cases
-    val midnight = Literal.create(LocalTime.MIDNIGHT, TimeType(6)) // 0 seconds
+    // Test midnight to all integral types
+    val midnight = Literal.create(LocalTime.MIDNIGHT, TimeType(6))
     checkEvaluation(cast(midnight, ByteType), 0.toByte)
     checkEvaluation(cast(midnight, ShortType), 0.toShort)
     checkEvaluation(cast(midnight, IntegerType), 0)
     checkEvaluation(cast(midnight, LongType), 0L)
 
-    // Test fractional seconds rounding
-    val fractionalTime = Literal.create(LocalTime.of(0, 0, 17, 500000000), TimeType(6))
-    checkEvaluation(cast(fractionalTime, IntegerType), 17)
-    checkEvaluation(cast(fractionalTime, LongType), 17L)
-
-    val noon6 = Literal.create(LocalTime.NOON, TimeType(6)) // 12:00:00 = 43200 seconds
-    val oneTwoThreeTime5 = Literal.create(LocalTime.of(1, 2, 3), TimeType(5))
-    val maxTime4 = Literal.create(
-      LocalTime.of(23, 59, 59, 999999999),
-      TimeType(4)
-    )
-
-    checkEvaluation(cast(noon6, IntegerType), 43200)
-    checkEvaluation(cast(noon6, LongType), 43200L)
-
+    // Precision rounding/truncation tests with fractional seconds
+    val time0 = Literal.create(LocalTime.NOON, TimeType(0))
+    val time2 = Literal.create(LocalTime.of(12, 0, 0, 120000000), TimeType(2))
+    val time4 = Literal.create(LocalTime.of(12, 0, 0, 345600000), TimeType(4))
+    val oneTwoThreeTime5 = Literal.create(LocalTime.of(1, 2, 3, 555550000), TimeType(5))
+    val maxTime4 = Literal.create(LocalTime.of(23, 59, 59, 999900000), TimeType(4))
+    val fractional5 = Literal.create(LocalTime.of(0, 0, 17, 500000000), TimeType(1))
+    val fractional000001 = Literal.create(LocalTime.of(0, 0, 17, 1000), TimeType(6))
+    val fractional999999 = Literal.create(LocalTime.of(0, 0, 17, 999999000), TimeType(6))
+    val fractional6 = Literal.create(LocalTime.of(0, 0, 17, 600000000), TimeType(1))
+    val fractional4 = Literal.create(LocalTime.of(0, 0, 17, 400000000), TimeType(1))
+    val fractional555 = Literal.create(LocalTime.of(0, 0, 17, 555000000), TimeType(3))
+    checkEvaluation(cast(fractional5, IntegerType), 17)
+    checkEvaluation(cast(fractional5, LongType), 17L)
+    checkEvaluation(cast(fractional000001, IntegerType), 17)
+    checkEvaluation(cast(fractional999999, IntegerType), 17)
+    checkEvaluation(cast(fractional6, IntegerType), 17)
+    checkEvaluation(cast(fractional4, IntegerType), 17)
+    checkEvaluation(cast(fractional555, IntegerType), 17)
+    checkEvaluation(cast(time0, IntegerType), 43200)
+    checkEvaluation(cast(time2, IntegerType), 43200)
+    checkEvaluation(cast(time4, IntegerType), 43200)
     checkEvaluation(cast(oneTwoThreeTime5, IntegerType), 3723)
     checkEvaluation(cast(oneTwoThreeTime5, LongType), 3723L)
-
-    checkEvaluation(cast(maxTime4, IntegerType), 86399) // Truncated to 86399 seconds
+    checkEvaluation(cast(maxTime4, IntegerType), 86399)
     checkEvaluation(cast(maxTime4, LongType), 86399L)
-
-
-    // Test different precisions with Noon
-    val noon0 = Literal.create(LocalTime.NOON, TimeType(0))
-    val noon2 = Literal.create(LocalTime.NOON, TimeType(2))
-    val noon4 = Literal.create(LocalTime.NOON, TimeType(4))
-
-    checkEvaluation(cast(noon0, IntegerType), 43200)
-    checkEvaluation(cast(noon2, IntegerType), 43200)
-    checkEvaluation(cast(noon4, IntegerType), 43200)
-
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -1517,7 +1517,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(cast(smallTime, LongType), 112L)
 
     // Test edge cases
-    val midnight = Literal.create(LocalTime.of(0, 0, 0), TimeType(6)) // 0 seconds
+    val midnight = Literal.create(LocalTime.MIDNIGHT, TimeType(6)) // 0 seconds
     checkEvaluation(cast(midnight, ByteType), 0.toByte)
     checkEvaluation(cast(midnight, ShortType), 0.toShort)
     checkEvaluation(cast(midnight, IntegerType), 0)
@@ -1527,6 +1527,32 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
     val fractionalTime = Literal.create(LocalTime.of(0, 0, 17, 500000000), TimeType(6))
     checkEvaluation(cast(fractionalTime, IntegerType), 17)
     checkEvaluation(cast(fractionalTime, LongType), 17L)
+
+    val noon6 = Literal.create(LocalTime.NOON, TimeType(6)) // 12:00:00 = 43200 seconds
+    val oneTwoThreeTime5 = Literal.create(LocalTime.of(1, 2, 3), TimeType(5))
+    val maxTime4 = Literal.create(
+      LocalTime.of(23, 59, 59, 999999999),
+      TimeType(4)
+    )
+
+    checkEvaluation(cast(noon6, IntegerType), 43200)
+    checkEvaluation(cast(noon6, LongType), 43200L)
+
+    checkEvaluation(cast(oneTwoThreeTime5, IntegerType), 3723)
+    checkEvaluation(cast(oneTwoThreeTime5, LongType), 3723L)
+
+    checkEvaluation(cast(maxTime4, IntegerType), 86399) // Truncated to 86399 seconds
+    checkEvaluation(cast(maxTime4, LongType), 86399L)
+
+
+    // Test different precisions with Noon
+    val noon0 = Literal.create(LocalTime.NOON, TimeType(0))
+    val noon2 = Literal.create(LocalTime.NOON, TimeType(2))
+    val noon4 = Literal.create(LocalTime.NOON, TimeType(4))
+
+    checkEvaluation(cast(noon0, IntegerType), 43200)
+    checkEvaluation(cast(noon2, IntegerType), 43200)
+    checkEvaluation(cast(noon4, IntegerType), 43200)
 
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -1507,4 +1507,26 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       }
     }
   }
+  test("cast time to integral types") {
+
+    // Test normal cases that should work with a small number like 112 seconds after midnight
+    val smallTime = Literal.create(LocalTime.of(0, 1, 52), TimeType(6))
+    checkEvaluation(cast(smallTime, ByteType), 112.toByte)
+    checkEvaluation(cast(smallTime, ShortType), 112.toShort)
+    checkEvaluation(cast(smallTime, IntegerType), 112)
+    checkEvaluation(cast(smallTime, LongType), 112L)
+
+    // Test edge cases
+    val midnight = Literal.create(LocalTime.of(0, 0, 0), TimeType(6)) // 0 seconds
+    checkEvaluation(cast(midnight, ByteType), 0.toByte)
+    checkEvaluation(cast(midnight, ShortType), 0.toShort)
+    checkEvaluation(cast(midnight, IntegerType), 0)
+    checkEvaluation(cast(midnight, LongType), 0L)
+
+    // Test fractional seconds rounding
+    val fractionalTime = Literal.create(LocalTime.of(0, 0, 17, 500000000), TimeType(6))
+    checkEvaluation(cast(fractionalTime, IntegerType), 17)
+    checkEvaluation(cast(fractionalTime, LongType), 17L)
+
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
@@ -908,17 +908,22 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
     }
   }
 
-  test("cast time to integral types with overflow") {
+  test("cast time to integral types with overflow with ansi off") {
     // Create a time that will overflow Byte and Short: 23:59:59 = 86399 seconds
-    val largeTime = Literal.create(LocalTime.of(23, 59, 59), TimeType(6))
+    val largeTime6 = Literal.create(LocalTime.of(23, 59, 59), TimeType(6))
+    val largeTime1 = Literal.create(LocalTime.of(23, 59, 59), TimeType(1))
 
     // Long and Int should work (86399 fits in both)
-    checkEvaluation(cast(largeTime, LongType), 86399L)
-    checkEvaluation(cast(largeTime, IntegerType), 86399)
+    checkEvaluation(cast(largeTime6, LongType), 86399L)
+    checkEvaluation(cast(largeTime6, IntegerType), 86399)
 
     // Short and Byte should overflow and return null (non-ANSI mode)
     // 86399 > Short.MaxValue (32767) and > Byte.MaxValue (127)
-    checkEvaluation(cast(largeTime, ShortType), null)
-    checkEvaluation(cast(largeTime, ByteType), null)
+    checkEvaluation(cast(largeTime6, ShortType), null)
+    checkEvaluation(cast(largeTime6, ByteType), null)
+
+    checkEvaluation(cast(largeTime1, ShortType), null)
+    checkEvaluation(cast(largeTime1, ByteType), null)
+
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
@@ -908,22 +908,19 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
     }
   }
 
-  test("cast time to integral types with overflow with ansi off") {
+  test("SPARK-52619: cast time to integral types with overflow with ansi off") {
     // Create a time that will overflow Byte and Short: 23:59:59 = 86399 seconds
-    val largeTime6 = Literal.create(LocalTime.of(23, 59, 59), TimeType(6))
-    val largeTime1 = Literal.create(LocalTime.of(23, 59, 59), TimeType(1))
+    val largeTime6 = Literal.create(LocalTime.of(23, 59, 59, 123456000), TimeType(6))
+    val largeTime1 = Literal.create(LocalTime.of(23, 59, 59, 100000000), TimeType(1))
 
     // Long and Int should work (86399 fits in both)
-    checkEvaluation(cast(largeTime6, LongType), 86399L)
-    checkEvaluation(cast(largeTime6, IntegerType), 86399)
-
     // Short and Byte should overflow and return null (non-ANSI mode)
     // 86399 > Short.MaxValue (32767) and > Byte.MaxValue (127)
+    checkEvaluation(cast(largeTime6, LongType), 86399L)
+    checkEvaluation(cast(largeTime6, IntegerType), 86399)
     checkEvaluation(cast(largeTime6, ShortType), null)
     checkEvaluation(cast(largeTime6, ByteType), null)
-
     checkEvaluation(cast(largeTime1, ShortType), null)
     checkEvaluation(cast(largeTime1, ByteType), null)
-
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
@@ -798,17 +798,24 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
     }
   }
 
-  test("cast TimeType to integral types with overflow") {
+  test("cast TimeType to integral types with overflow with ansi on") {
     // Test overflow cases: 23:59:59 = 86399 seconds
-    val largeTime = Literal.create(LocalTime.of(23, 59, 59), TimeType(6))
+    val largeTime6 = Literal.create(LocalTime.of(23, 59, 59), TimeType(6))
+    val largeTime4 = Literal.create(LocalTime.of(23, 59, 59), TimeType(4))
 
     // Short and Byte should overflow and throw ArithmeticException (ANSI mode)
     // 86399 > Short.MaxValue (32767) and > Byte.MaxValue (127)
     checkExceptionInExpression[SparkArithmeticException](
-      cast(largeTime, ShortType),
-      castOverflowErrMsg(largeTime.value, TimeType(6), ShortType))
+      cast(largeTime6, ShortType),
+      castOverflowErrMsg(largeTime6.value, TimeType(6), ShortType))
     checkExceptionInExpression[SparkArithmeticException](
-      cast(largeTime, ByteType),
-      castOverflowErrMsg(largeTime.value, TimeType(6), ByteType))
+      cast(largeTime6, ByteType),
+      castOverflowErrMsg(largeTime6.value, TimeType(6), ByteType))
+    checkExceptionInExpression[SparkArithmeticException](
+      cast(largeTime4, ShortType),
+      castOverflowErrMsg(largeTime4.value, TimeType(4), ShortType))
+    checkExceptionInExpression[SparkArithmeticException](
+      cast(largeTime4, ByteType),
+      castOverflowErrMsg(largeTime4.value, TimeType(4), ByteType))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
@@ -798,24 +798,29 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
     }
   }
 
-  test("cast TimeType to integral types with overflow with ansi on") {
+  test("SPARK-52619: cast time to integral types with overflow with ansi on") {
     // Test overflow cases: 23:59:59 = 86399 seconds
-    val largeTime6 = Literal.create(LocalTime.of(23, 59, 59), TimeType(6))
-    val largeTime4 = Literal.create(LocalTime.of(23, 59, 59), TimeType(4))
+    val largeTime6 = Literal.create(LocalTime.of(23, 59, 59, 123456000), TimeType(6))
+    val largeTime4 = Literal.create(LocalTime.of(23, 59, 59, 678900000), TimeType(4))
 
     // Short and Byte should overflow and throw ArithmeticException (ANSI mode)
     // 86399 > Short.MaxValue (32767) and > Byte.MaxValue (127)
-    checkExceptionInExpression[SparkArithmeticException](
-      cast(largeTime6, ShortType),
-      castOverflowErrMsg(largeTime6.value, TimeType(6), ShortType))
-    checkExceptionInExpression[SparkArithmeticException](
-      cast(largeTime6, ByteType),
-      castOverflowErrMsg(largeTime6.value, TimeType(6), ByteType))
-    checkExceptionInExpression[SparkArithmeticException](
-      cast(largeTime4, ShortType),
-      castOverflowErrMsg(largeTime4.value, TimeType(4), ShortType))
-    checkExceptionInExpression[SparkArithmeticException](
-      cast(largeTime4, ByteType),
-      castOverflowErrMsg(largeTime4.value, TimeType(4), ByteType))
+    Seq(
+      (largeTime6, ShortType),
+      (largeTime6, ByteType),
+      (largeTime4, ShortType),
+      (largeTime4, ByteType)
+    ).foreach { case (timeValue, targetType) =>
+      checkErrorInExpression[SparkArithmeticException](
+        cast(timeValue, targetType),
+        "CAST_OVERFLOW",
+        Map(
+          "value" -> s"TIME '${timeValue.toString}'",
+          "sourceType" -> s"\"${timeValue.dataType.sql}\"",
+          "targetType" -> s"\"${targetType.sql}\"",
+          "ansiConfig" -> "\"spark.sql.ansi.enabled\""
+        )
+      )
+    }
   }
 }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cast.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cast.sql.out
@@ -882,6 +882,97 @@ Project [cast(10.654321 as interval month) AS CAST(10.654321 AS INTERVAL MONTH)#
 
 
 -- !query
+SELECT CAST(TIME '00:01:52' AS tinyint)
+-- !query analysis
+Project [cast(00:01:52 as tinyint) AS CAST(TIME '00:01:52' AS TINYINT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '00:01:52' AS smallint)
+-- !query analysis
+Project [cast(00:01:52 as smallint) AS CAST(TIME '00:01:52' AS SMALLINT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '00:01:52' AS int)
+-- !query analysis
+Project [cast(00:01:52 as int) AS CAST(TIME '00:01:52' AS INT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '00:01:52' AS bigint)
+-- !query analysis
+Project [cast(00:01:52 as bigint) AS CAST(TIME '00:01:52' AS BIGINT)#xL]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '23:59:59' AS tinyint)
+-- !query analysis
+Project [cast(23:59:59 as tinyint) AS CAST(TIME '23:59:59' AS TINYINT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '23:59:59' AS smallint)
+-- !query analysis
+Project [cast(23:59:59 as smallint) AS CAST(TIME '23:59:59' AS SMALLINT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '23:59:59' AS int)
+-- !query analysis
+Project [cast(23:59:59 as int) AS CAST(TIME '23:59:59' AS INT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '23:59:59' AS bigint)
+-- !query analysis
+Project [cast(23:59:59 as bigint) AS CAST(TIME '23:59:59' AS BIGINT)#xL]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '00:00:17.5' AS tinyint)
+-- !query analysis
+Project [cast(00:00:17.5 as tinyint) AS CAST(TIME '00:00:17.5' AS TINYINT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '00:00:17.5' AS int)
+-- !query analysis
+Project [cast(00:00:17.5 as int) AS CAST(TIME '00:00:17.5' AS INT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '00:00:17.9' AS int)
+-- !query analysis
+Project [cast(00:00:17.9 as int) AS CAST(TIME '00:00:17.9' AS INT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '00:00:00' AS tinyint)
+-- !query analysis
+Project [cast(00:00:00 as tinyint) AS CAST(TIME '00:00:00' AS TINYINT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '00:00:00' AS int)
+-- !query analysis
+Project [cast(00:00:00 as int) AS CAST(TIME '00:00:00' AS INT)#x]
++- OneRowRelation
+
+
+-- !query
 SELECT '1.23' :: int
 -- !query analysis
 Project [cast(1.23 as int) AS CAST(1.23 AS INT)#x]
@@ -1030,6 +1121,34 @@ Project [cast(INTERVAL '08:11:10.001' HOUR TO SECOND as decimal(10,4)) AS CAST(I
 select 10.123456BD :: interval day to second
 -- !query analysis
 Project [cast(10.123456 as interval day to second) AS CAST(10.123456 AS INTERVAL DAY TO SECOND)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT TIME '00:01:52' :: tinyint
+-- !query analysis
+Project [cast(00:01:52 as tinyint) AS CAST(TIME '00:01:52' AS TINYINT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT TIME '00:01:52' :: int
+-- !query analysis
+Project [cast(00:01:52 as int) AS CAST(TIME '00:01:52' AS INT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT TIME '23:59:59' :: tinyint
+-- !query analysis
+Project [cast(23:59:59 as tinyint) AS CAST(TIME '23:59:59' AS TINYINT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT TIME '23:59:59' :: int
+-- !query analysis
+Project [cast(23:59:59 as int) AS CAST(TIME '23:59:59' AS INT)#x]
 +- OneRowRelation
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/nonansi/cast.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/nonansi/cast.sql.out
@@ -746,6 +746,97 @@ Project [cast(10.654321 as interval month) AS CAST(10.654321 AS INTERVAL MONTH)#
 
 
 -- !query
+SELECT CAST(TIME '00:01:52' AS tinyint)
+-- !query analysis
+Project [cast(00:01:52 as tinyint) AS CAST(TIME '00:01:52' AS TINYINT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '00:01:52' AS smallint)
+-- !query analysis
+Project [cast(00:01:52 as smallint) AS CAST(TIME '00:01:52' AS SMALLINT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '00:01:52' AS int)
+-- !query analysis
+Project [cast(00:01:52 as int) AS CAST(TIME '00:01:52' AS INT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '00:01:52' AS bigint)
+-- !query analysis
+Project [cast(00:01:52 as bigint) AS CAST(TIME '00:01:52' AS BIGINT)#xL]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '23:59:59' AS tinyint)
+-- !query analysis
+Project [cast(23:59:59 as tinyint) AS CAST(TIME '23:59:59' AS TINYINT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '23:59:59' AS smallint)
+-- !query analysis
+Project [cast(23:59:59 as smallint) AS CAST(TIME '23:59:59' AS SMALLINT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '23:59:59' AS int)
+-- !query analysis
+Project [cast(23:59:59 as int) AS CAST(TIME '23:59:59' AS INT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '23:59:59' AS bigint)
+-- !query analysis
+Project [cast(23:59:59 as bigint) AS CAST(TIME '23:59:59' AS BIGINT)#xL]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '00:00:17.5' AS tinyint)
+-- !query analysis
+Project [cast(00:00:17.5 as tinyint) AS CAST(TIME '00:00:17.5' AS TINYINT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '00:00:17.5' AS int)
+-- !query analysis
+Project [cast(00:00:17.5 as int) AS CAST(TIME '00:00:17.5' AS INT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '00:00:17.9' AS int)
+-- !query analysis
+Project [cast(00:00:17.9 as int) AS CAST(TIME '00:00:17.9' AS INT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '00:00:00' AS tinyint)
+-- !query analysis
+Project [cast(00:00:00 as tinyint) AS CAST(TIME '00:00:00' AS TINYINT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(TIME '00:00:00' AS int)
+-- !query analysis
+Project [cast(00:00:00 as int) AS CAST(TIME '00:00:00' AS INT)#x]
++- OneRowRelation
+
+
+-- !query
 SELECT '1.23' :: int
 -- !query analysis
 Project [cast(1.23 as int) AS CAST(1.23 AS INT)#x]
@@ -877,6 +968,34 @@ Project [cast(INTERVAL '08:11:10.001' HOUR TO SECOND as decimal(10,4)) AS CAST(I
 select 10.123456BD :: interval day to second
 -- !query analysis
 Project [cast(10.123456 as interval day to second) AS CAST(10.123456 AS INTERVAL DAY TO SECOND)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT TIME '00:01:52' :: tinyint
+-- !query analysis
+Project [cast(00:01:52 as tinyint) AS CAST(TIME '00:01:52' AS TINYINT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT TIME '00:01:52' :: int
+-- !query analysis
+Project [cast(00:01:52 as int) AS CAST(TIME '00:01:52' AS INT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT TIME '23:59:59' :: tinyint
+-- !query analysis
+Project [cast(23:59:59 as tinyint) AS CAST(TIME '23:59:59' AS TINYINT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT TIME '23:59:59' :: int
+-- !query analysis
+Project [cast(23:59:59 as int) AS CAST(TIME '23:59:59' AS INT)#x]
 +- OneRowRelation
 
 

--- a/sql/core/src/test/resources/sql-tests/inputs/cast.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cast.sql
@@ -147,6 +147,27 @@ select cast(80.654321BD as interval hour to minute);
 select cast(-10.123456BD as interval year to month);
 select cast(10.654321BD as interval month);
 
+-- cast TIME to integral types
+SELECT CAST(TIME '00:01:52' AS tinyint);
+SELECT CAST(TIME '00:01:52' AS smallint);
+SELECT CAST(TIME '00:01:52' AS int);
+SELECT CAST(TIME '00:01:52' AS bigint);
+
+-- cast TIME to integral types with potential overflow
+SELECT CAST(TIME '23:59:59' AS tinyint);
+SELECT CAST(TIME '23:59:59' AS smallint);
+SELECT CAST(TIME '23:59:59' AS int);
+SELECT CAST(TIME '23:59:59' AS bigint);
+
+-- cast TIME with fractional seconds (should floor)
+SELECT CAST(TIME '00:00:17.5' AS tinyint);
+SELECT CAST(TIME '00:00:17.5' AS int);
+SELECT CAST(TIME '00:00:17.9' AS int);
+
+-- cast TIME edge cases
+SELECT CAST(TIME '00:00:00' AS tinyint);
+SELECT CAST(TIME '00:00:00' AS int);
+
 -- cast double colon syntax tests
 SELECT '1.23' :: int;
 SELECT 'abc' :: int;
@@ -167,6 +188,12 @@ select interval '-10-2' year to month :: smallint;
 select -10L :: interval second;
 select interval '08:11:10.001' hour to second :: decimal(10, 4);
 select 10.123456BD :: interval day to second;
+
+-- cast TIME using double colon syntax
+SELECT TIME '00:01:52' :: tinyint;
+SELECT TIME '00:01:52' :: int;
+SELECT TIME '23:59:59' :: tinyint;
+SELECT TIME '23:59:59' :: int;
 
 SELECT '1.23' :: int :: long;
 SELECT '2147483648' :: long :: int;

--- a/sql/core/src/test/resources/sql-tests/results/cast.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cast.sql.out
@@ -1662,6 +1662,130 @@ struct<CAST(10.654321 AS INTERVAL MONTH):interval month>
 
 
 -- !query
+SELECT CAST(TIME '00:01:52' AS tinyint)
+-- !query schema
+struct<CAST(TIME '00:01:52' AS TINYINT):tinyint>
+-- !query output
+112
+
+
+-- !query
+SELECT CAST(TIME '00:01:52' AS smallint)
+-- !query schema
+struct<CAST(TIME '00:01:52' AS SMALLINT):smallint>
+-- !query output
+112
+
+
+-- !query
+SELECT CAST(TIME '00:01:52' AS int)
+-- !query schema
+struct<CAST(TIME '00:01:52' AS INT):int>
+-- !query output
+112
+
+
+-- !query
+SELECT CAST(TIME '00:01:52' AS bigint)
+-- !query schema
+struct<CAST(TIME '00:01:52' AS BIGINT):bigint>
+-- !query output
+112
+
+
+-- !query
+SELECT CAST(TIME '23:59:59' AS tinyint)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkArithmeticException
+{
+  "errorClass" : "CAST_OVERFLOW",
+  "sqlState" : "22003",
+  "messageParameters" : {
+    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
+    "sourceType" : "\"TIME(6)\"",
+    "targetType" : "\"TINYINT\"",
+    "value" : "TIME '23:59:59'"
+  }
+}
+
+
+-- !query
+SELECT CAST(TIME '23:59:59' AS smallint)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkArithmeticException
+{
+  "errorClass" : "CAST_OVERFLOW",
+  "sqlState" : "22003",
+  "messageParameters" : {
+    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
+    "sourceType" : "\"TIME(6)\"",
+    "targetType" : "\"SMALLINT\"",
+    "value" : "TIME '23:59:59'"
+  }
+}
+
+
+-- !query
+SELECT CAST(TIME '23:59:59' AS int)
+-- !query schema
+struct<CAST(TIME '23:59:59' AS INT):int>
+-- !query output
+86399
+
+
+-- !query
+SELECT CAST(TIME '23:59:59' AS bigint)
+-- !query schema
+struct<CAST(TIME '23:59:59' AS BIGINT):bigint>
+-- !query output
+86399
+
+
+-- !query
+SELECT CAST(TIME '00:00:17.5' AS tinyint)
+-- !query schema
+struct<CAST(TIME '00:00:17.5' AS TINYINT):tinyint>
+-- !query output
+17
+
+
+-- !query
+SELECT CAST(TIME '00:00:17.5' AS int)
+-- !query schema
+struct<CAST(TIME '00:00:17.5' AS INT):int>
+-- !query output
+17
+
+
+-- !query
+SELECT CAST(TIME '00:00:17.9' AS int)
+-- !query schema
+struct<CAST(TIME '00:00:17.9' AS INT):int>
+-- !query output
+17
+
+
+-- !query
+SELECT CAST(TIME '00:00:00' AS tinyint)
+-- !query schema
+struct<CAST(TIME '00:00:00' AS TINYINT):tinyint>
+-- !query output
+0
+
+
+-- !query
+SELECT CAST(TIME '00:00:00' AS int)
+-- !query schema
+struct<CAST(TIME '00:00:00' AS INT):int>
+-- !query output
+0
+
+
+-- !query
 SELECT '1.23' :: int
 -- !query schema
 struct<>
@@ -1915,6 +2039,48 @@ select 10.123456BD :: interval day to second
 struct<CAST(10.123456 AS INTERVAL DAY TO SECOND):interval day to second>
 -- !query output
 0 00:00:10.123456000
+
+
+-- !query
+SELECT TIME '00:01:52' :: tinyint
+-- !query schema
+struct<CAST(TIME '00:01:52' AS TINYINT):tinyint>
+-- !query output
+112
+
+
+-- !query
+SELECT TIME '00:01:52' :: int
+-- !query schema
+struct<CAST(TIME '00:01:52' AS INT):int>
+-- !query output
+112
+
+
+-- !query
+SELECT TIME '23:59:59' :: tinyint
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkArithmeticException
+{
+  "errorClass" : "CAST_OVERFLOW",
+  "sqlState" : "22003",
+  "messageParameters" : {
+    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
+    "sourceType" : "\"TIME(6)\"",
+    "targetType" : "\"TINYINT\"",
+    "value" : "TIME '23:59:59'"
+  }
+}
+
+
+-- !query
+SELECT TIME '23:59:59' :: int
+-- !query schema
+struct<CAST(TIME '23:59:59' AS INT):int>
+-- !query output
+86399
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/nonansi/cast.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/nonansi/cast.sql.out
@@ -917,6 +917,110 @@ struct<CAST(10.654321 AS INTERVAL MONTH):interval month>
 
 
 -- !query
+SELECT CAST(TIME '00:01:52' AS tinyint)
+-- !query schema
+struct<CAST(TIME '00:01:52' AS TINYINT):tinyint>
+-- !query output
+112
+
+
+-- !query
+SELECT CAST(TIME '00:01:52' AS smallint)
+-- !query schema
+struct<CAST(TIME '00:01:52' AS SMALLINT):smallint>
+-- !query output
+112
+
+
+-- !query
+SELECT CAST(TIME '00:01:52' AS int)
+-- !query schema
+struct<CAST(TIME '00:01:52' AS INT):int>
+-- !query output
+112
+
+
+-- !query
+SELECT CAST(TIME '00:01:52' AS bigint)
+-- !query schema
+struct<CAST(TIME '00:01:52' AS BIGINT):bigint>
+-- !query output
+112
+
+
+-- !query
+SELECT CAST(TIME '23:59:59' AS tinyint)
+-- !query schema
+struct<CAST(TIME '23:59:59' AS TINYINT):tinyint>
+-- !query output
+NULL
+
+
+-- !query
+SELECT CAST(TIME '23:59:59' AS smallint)
+-- !query schema
+struct<CAST(TIME '23:59:59' AS SMALLINT):smallint>
+-- !query output
+NULL
+
+
+-- !query
+SELECT CAST(TIME '23:59:59' AS int)
+-- !query schema
+struct<CAST(TIME '23:59:59' AS INT):int>
+-- !query output
+86399
+
+
+-- !query
+SELECT CAST(TIME '23:59:59' AS bigint)
+-- !query schema
+struct<CAST(TIME '23:59:59' AS BIGINT):bigint>
+-- !query output
+86399
+
+
+-- !query
+SELECT CAST(TIME '00:00:17.5' AS tinyint)
+-- !query schema
+struct<CAST(TIME '00:00:17.5' AS TINYINT):tinyint>
+-- !query output
+17
+
+
+-- !query
+SELECT CAST(TIME '00:00:17.5' AS int)
+-- !query schema
+struct<CAST(TIME '00:00:17.5' AS INT):int>
+-- !query output
+17
+
+
+-- !query
+SELECT CAST(TIME '00:00:17.9' AS int)
+-- !query schema
+struct<CAST(TIME '00:00:17.9' AS INT):int>
+-- !query output
+17
+
+
+-- !query
+SELECT CAST(TIME '00:00:00' AS tinyint)
+-- !query schema
+struct<CAST(TIME '00:00:00' AS TINYINT):tinyint>
+-- !query output
+0
+
+
+-- !query
+SELECT CAST(TIME '00:00:00' AS int)
+-- !query schema
+struct<CAST(TIME '00:00:00' AS INT):int>
+-- !query output
+0
+
+
+-- !query
 SELECT '1.23' :: int
 -- !query schema
 struct<CAST(1.23 AS INT):int>
@@ -1067,6 +1171,38 @@ select 10.123456BD :: interval day to second
 struct<CAST(10.123456 AS INTERVAL DAY TO SECOND):interval day to second>
 -- !query output
 0 00:00:10.123456000
+
+
+-- !query
+SELECT TIME '00:01:52' :: tinyint
+-- !query schema
+struct<CAST(TIME '00:01:52' AS TINYINT):tinyint>
+-- !query output
+112
+
+
+-- !query
+SELECT TIME '00:01:52' :: int
+-- !query schema
+struct<CAST(TIME '00:01:52' AS INT):int>
+-- !query output
+112
+
+
+-- !query
+SELECT TIME '23:59:59' :: tinyint
+-- !query schema
+struct<CAST(TIME '23:59:59' AS TINYINT):tinyint>
+-- !query output
+NULL
+
+
+-- !query
+SELECT TIME '23:59:59' :: int
+-- !query schema
+struct<CAST(TIME '23:59:59' AS INT):int>
+-- !query output
+86399
 
 
 -- !query


### PR DESCRIPTION
 <!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

 
  Implementation of [SPARK-5261](https://issues.apache.org/jira/browse/SPARK-52619) which is for casting from `TimeType ` i.e. `TIME` data type to `IntegralType`  (`ByteType`, `ShortType`, `IntegerType`, `LongType`) i.e. (`BYTE`, `SHORT`, `INT`, `LONG`) following the SQL standard by flooring `TIME` values to seconds since midnight.

  #### Changes:
  - Add `TIME` to integral casting logic in `Cast.scala` with proper overflow handling
  - Can potentially overflow on both `Short` and `Byte`
  - Add unit test coverage for `TIME` casting scenarios for both ansi and non-ansi
  - Update SQL integration tests with TIME casting examples for valid and error cases
  - Handle fractional seconds with "proper rounding" behavior - which is to truncate
  
  
     
     **Note:** `TimeType` to `IntegralType` largely follows `TimestampType` to integral casting for a few reasons:
  1. Both types are stored as `Long` internally (`TIME`: nanoseconds since midnight, `TIMESTAMP`: microseconds since epoch)
  2. Since they are both already stored as Long, there is a conversion to `Long` seconds as an intermediate step before casting to smaller integral types
  3. Uses similar overflow checking (i.e. `longValue == longValue.toByte`) to validate conversion safety
 
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
  Currently, Spark SQL's`TIME` data type cannot be cast to integral types. The reasons for this functionality are:
  - Better overall SQL standard compliance
  - Interoperability/Code Migrations with other database systems that support `TIME` to integral casting
  - Also to enable simple arithmetic operations by using `TIME` values as integers

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. This PR adds new casting functionality from `TimeType` -> (`Byte`, `Short`, `Int`, `Long`) that previously did not exist.  

 **Before this change:**
```scala
  spark.sql("SELECT CAST(TIME '10:10:10' AS INT)").show()
 /*
 org.apache.spark.sql.catalyst.ExtendedAnalysisException: [DATATYPE_MISMATCH.CAST_WITHOUT_SUGGESTION] Cannot resolve "CAST(TIME '10:10:10' AS INT)" due to data type mismatch: cannot cast "TIME(6)" to "INT". SQLSTATE: 42K09; line 1 pos 7;
'Project [unresolvedalias(cast(10:10:10 as int))]
*/
```
  After this change:
```sql
  SELECT CAST(TIME '10:10:10' AS INT)
  /**** Returns: 36610 (seconds since midnight) ****/

  SELECT CAST(TIME '00:00:04' AS TINYINT)
  /**** Returns: 4 ****/

  SELECT CAST(TIME '23:59:59' AS TINYINT)
  /**** Error: CAST_OVERFLOW - SQLSTATE: 22003 - when ansi flag is enabled - (86399 > 127) ****/
  /**** Returns: NULL when ansi flag is set to False - (86399 > 127) ****/

  Fractional seconds are truncated:
  SELECT CAST(TIME '00:00:01.7' AS INT)
  /**** Returns: 1 (floored not rounded up so 1 and not 2) ****/
  ```
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
  1. Unit tests: Added comprehensive test coverage in CastSuiteBase, CastWithAnsiOnSuite, and CastWithAnsiOffSuite covering:
    - Basic `TimeType` to `IntegralType` casting
    - Overflow scenarios for smaller types (`ByteType`, `ShortType`)
    - Fractional second truncation
    - `ANSI` mode vs `non-ANSI` mode behavior
  
<img width="1111" height="572" alt="Screenshot 2025-07-11 at 11 15 37 PM" src="https://github.com/user-attachments/assets/ff258b22-8b33-4b4a-9a87-4be1855d5a50" />
<img width="1111" height="572" alt="Screenshot 2025-07-11 at 11 14 28 PM" src="https://github.com/user-attachments/assets/39ab5724-c868-4a67-889e-b064b242c52b" />

  2. SQL integration tests: Updated cast.sql with `TIME` casting examples and expected outputs - updated Golden Files and then ran test successfully
  
  ```bash
   SPARK_GENERATE_GOLDEN_FILES=1 ./build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z cast.sql"
 ./build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z cast.sql"
 ```
  3. Manual testing in Spark shell:
  ```scala
  val timeData = Seq(
    LocalTime.of(0, 0, 0),      // midnight = 0 seconds
    LocalTime.of(0, 0, 8),      // 8 seconds
    LocalTime.of(4, 41, 17),    // 16,877 seconds
    LocalTime.of(23, 59, 59)    // 86,399 seconds
  ).toDF("time_col")

  timeData.select(
    $"time_col",
    $"time_col".cast(IntegerType).alias("time_to_int"),
    $"time_col".cast(ByteType).alias("time_to_byte")
  ).show()

  // Results:
  // +--------+-----------+------------+
  // |time_col|time_to_int|time_to_byte|
  // +--------+-----------+------------+
  // |00:00:00|          0|           0|
  // |00:00:08|          8|           8|
  // |04:41:17|      16877|        NULL| // Overflow for BYTE
  // |23:59:59|      86399|        NULL| // Overflow for BYTE
  // +--------+-----------+------------+
```
  4. Fractional second testing manually in spark-shell:
  ```scala
  val edgeCases = Seq(
    LocalTime.of(0, 0, 0, 900000000),  // 0.9 seconds -> 0
    LocalTime.of(0, 0, 1, 700000000)   // 1.7 seconds -> 1
  ).toDF("time_col")

  edgeCases.select($"time_col", $"time_col".cast(IntegerType).alias("as_int")).show()
  /*
  +----------+------+
   |  time_col|as_int|
  +----------+------+
   |00:00:00.9|     0|
   |00:00:00.3|     0|
   |00:00:01.7|     1|
  +----------+------+
  */

```
  5. Overflow error message when there is overflow - manual test in spark-shell
  ```scala
  timeData.select(                                                                                                                                                                     $"time_col",                                                                                                                                                                                                                                                                                           
$"time_col".cast(ByteType).alias("time_to_byte")                                                                                                                            
).show()

timeData.select(                                                                                                                                                                     $"time_col",
        $"time_col".cast(ByteType).alias("time_to_byte")
      ).show()
     
     /*
org.apache.spark.SparkArithmeticException: [CAST_OVERFLOW] The value TIME '04:41:17' of the type "TIME(6)" cannot be cast to "TINYINT" due to an overflow. Use `try_cast` to tolerate overflow and return NULL instead. SQLSTATE: 22003
  at org.apache.spark.sql.errors.QueryExecutionErrors$.castingCauseOverflowError(QueryExecutionErrors.scala:87)
*/
``` 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No