### PR TITLE
[SPARK-52786][BUILD] Make pyspark-client package to upload with preview naming

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -137,12 +137,12 @@ if [[ "$1" == "finalize" ]]; then
     --repository-url https://upload.pypi.org/legacy/ \
     "pyspark_connect-$PYSPARK_VERSION.tar.gz" \
     "pyspark_connect-$PYSPARK_VERSION.tar.gz.asc"
-  svn update "pyspark_client-$RELEASE_VERSION.tar.gz"
-  svn update "pyspark_client-$RELEASE_VERSION.tar.gz.asc"
+  svn update "pyspark_client-$PYSPARK_VERSION.tar.gz"
+  svn update "pyspark_client-$PYSPARK_VERSION.tar.gz.asc"
   twine upload -u __token__ -p $PYPI_API_TOKEN \
     --repository-url https://upload.pypi.org/legacy/ \
-    "pyspark_client-$RELEASE_VERSION.tar.gz" \
-    "pyspark_client-$RELEASE_VERSION.tar.gz.asc"
+    "pyspark_client-$PYSPARK_VERSION.tar.gz" \
+    "pyspark_client-$PYSPARK_VERSION.tar.gz.asc"
   cd ..
   rm -rf svn-spark
   echo "PySpark uploaded"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to make pyspark-client package to upload with preview naming.

### Why are the changes needed?

Otherwise, it can't upload preview releases:

```
+ svn update pyspark_client-4.1.0-preview1.tar.gz
Updating 'pyspark_client-4.1.0-preview1.tar.gz':
At revision 78150.
+ svn update pyspark_client-4.1.0-preview1.tar.gz.asc
Updating 'pyspark_client-4.1.0-preview1.tar.gz.asc':
At revision 78150.
+ twine upload -u __token__ -p *** --repository-url https://upload.pypi.org/legacy/ pyspark_client-4.1.0-preview1.tar.gz pyspark_client-4.1.0-preview1.tar.gz.asc
InvalidDistribution: Cannot find file (or expand pattern): 'pyspark_client-4.1.0-preview1.tar.gz'
```

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.