### PR TITLE
[SPARK-52790][CORE] Introduce new grid testing method in SparkFunSuite

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -747,7 +747,11 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
     assert(rows12(5).getString(0) === "special_character_underscorenot_present")
   }
 
-  val partitioningEnabledTestCase = Seq(true, false)
+  private val partitioningEnabledTestCase = Seq(
+    GridTestCase(true, testNameSuffix = "partitioning enabled"),
+    GridTestCase(false, testNameSuffix = "partitioning disabled")
+  )
+
   gridTest(
     "SPARK-37038: Test TABLESAMPLE"
   )(partitioningEnabledTestCase) { partitioningEnabled =>

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -236,10 +236,22 @@ abstract class SparkFunSuite
     }
   }
 
+  @deprecated("For better test naming, use the gridTest method that accepts a Seq[GridTestCase].")
   protected def gridTest[A](testNamePrefix: String, testTags: Tag*)(params: Seq[A])(
     testFun: A => Unit): Unit = {
     for (param <- params) {
       test(testNamePrefix + s" ($param)", testTags: _*)(testFun(param))
+    }
+  }
+
+  case class GridTestCase[T](params: T, testNameSuffix: String)
+
+  protected def gridTest[A](
+      testNamePrefix: String,
+      testTags: Tag*
+  )(params: Seq[GridTestCase[A]])(testFun: A => Unit): Unit = {
+    for (GridTestCase(params, testNameSuffix) <- params) {
+      test(s"$testNamePrefix - $testNameSuffix", testTags: _*)(testFun(params))
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -250,8 +250,9 @@ abstract class SparkFunSuite
       testNamePrefix: String,
       testTags: Tag*
   )(params: Seq[GridTestCase[A]])(testFun: A => Unit)(implicit dummy: DummyImplicit): Unit = {
-    for (GridTestCase(params, testNameSuffix) <- params) {
-      test(s"$testNamePrefix - $testNameSuffix", testTags: _*)(testFun(params))
+    params.foreach {
+      case GridTestCase(params, testNameSuffix) =>
+        test(s"$testNamePrefix - $testNameSuffix", testTags: _*)(testFun(params))
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -249,7 +249,7 @@ abstract class SparkFunSuite
   protected def gridTest[A](
       testNamePrefix: String,
       testTags: Tag*
-  )(params: Seq[GridTestCase[A]])(testFun: A => Unit): Unit = {
+  )(params: Seq[GridTestCase[A]])(testFun: A => Unit)(implicit dummy: DummyImplicit): Unit = {
     for (GridTestCase(params, testNameSuffix) <- params) {
       test(s"$testNamePrefix - $testNameSuffix", testTags: _*)(testFun(params))
     }


### PR DESCRIPTION
Currently, gridTest accepts test name prefix and sequence of parameters.

Final test name is made like this `testNamePrefix + s" ($param)"`. Which is not good since developers often don't know how final test name would look like and pass here sequence of map, or sequence of booleans, which results in unintuitive test case names.

E.g.
```
gridTest("Select with limit")(Seq(true, false)) { pushdownEnabled =>
 ...
}
```
Will result in registering of next test cases:
 * Select with limit (true)
 * Select with limit (false)


Instead of that, developers should provide descriptive name suffix:
```
gridTest("Select with limit")(Seq(
  GridTestCase(params = true, suffix = "pushdown enabled"),
  GridTestCase(params = false, suffix = "pushdown disabled"),
)) { pushdownEnabled =>  ... } 
```

Instead of relying on developers to look for base implementation and make some case class for parameters with overriden `toString` implementation, we should enforce engineers to provide suffix. (Even with proper `toString` implementation, intent of test case may be unknown).

### What changes were proposed in this pull request?
- Add new grid test which accepts `GridTestCase` case class, so developers need to provide test name suffix
- Deprecate old grid test (we can remove it as well, since it is not used in many places)
- Make JDBCV2Test use newer grid test method to be sure there are no conflicts in method invocation.

### Why are the changes needed?
Improving test naming and making `gridTests` more descriptive.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Build is enough


### Was this patch authored or co-authored using generative AI tooling?
No