### PR TITLE
[SPARK-52792][CORE] Remove `commons-lang3` dependency from `network-common`

### DIFF
--- a/common/network-common/pom.xml
+++ b/common/network-common/pom.xml
@@ -84,10 +84,6 @@
     <!-- Netty End -->
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
       <groupId>${leveldbjni.group}</groupId>
       <artifactId>leveldbjni-all</artifactId>
       <version>1.8</version>

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
@@ -104,7 +104,8 @@ public class TransportServer implements Closeable {
     EventLoopGroup workerGroup =  NettyUtils.createEventLoop(ioMode, conf.serverThreads(),
       conf.getModuleName() + "-server");
 
-    boolean isNotWindows = !System.getProperty("os.name").regionMatches(true, 0, "Windows", 0, 7);
+    String name = System.getProperty("os.name");
+    boolean isNotWindows = 7 > name.length() || !name.regionMatches(true, 0, "Windows", 0, 7);
     bootstrap = new ServerBootstrap()
       .group(bossGroup, workerGroup)
       .channel(NettyUtils.getServerChannelClass(ioMode))

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
@@ -33,7 +33,6 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
-import org.apache.commons.lang3.SystemUtils;
 
 import org.apache.spark.internal.SparkLogger;
 import org.apache.spark.internal.SparkLoggerFactory;
@@ -105,11 +104,12 @@ public class TransportServer implements Closeable {
     EventLoopGroup workerGroup =  NettyUtils.createEventLoop(ioMode, conf.serverThreads(),
       conf.getModuleName() + "-server");
 
+    boolean isNotWindows = !System.getProperty("os.name").regionMatches(true, 0, "Windows", 0, 7);
     bootstrap = new ServerBootstrap()
       .group(bossGroup, workerGroup)
       .channel(NettyUtils.getServerChannelClass(ioMode))
       .option(ChannelOption.ALLOCATOR, pooledAllocator)
-      .option(ChannelOption.SO_REUSEADDR, !SystemUtils.IS_OS_WINDOWS)
+      .option(ChannelOption.SO_REUSEADDR, isNotWindows)
       .childOption(ChannelOption.ALLOCATOR, pooledAllocator);
 
     this.metrics = new NettyMemoryMetrics(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `commons-lang3` dependency from `network-common` module.

### Why are the changes needed?

To make `network-common` module independent from the 3rd-party dependency and its vulnerability.

**BEFORE**
```
$ mvn dependency:tree -pl common/network-common | grep commons-lang3
[INFO] +- org.apache.commons:commons-lang3:jar:3.18.0:compile
```

**AFTER**
```
$ mvn dependency:tree -pl common/network-common | grep commons-lang3
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.