### PR TITLE
[SPARK-52793][CORE] Support `isUnix` at `o.a.s.util.Utils`

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/SignalUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/SignalUtils.scala
@@ -21,7 +21,6 @@ import java.util.Collections
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.commons.lang3.SystemUtils
 import org.slf4j.Logger
 import sun.misc.{Signal, SignalHandler}
 
@@ -58,7 +57,7 @@ private[spark] object SignalUtils extends Logging {
    * All actions for a given signal are run in a separate thread.
    */
   def register(signal: String)(action: => Boolean): Unit = {
-    if (SystemUtils.IS_OS_UNIX) {
+    if (Utils.isUnix) {
       register(signal, log"Failed to register signal handler for ${MDC(SIGNAL, signal)}",
         logStackTrace = true)(action)
     }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1858,6 +1858,11 @@ private[spark] object Utils
   }
 
   /**
+   * Whether the underlying operating system is UNIX.
+   */
+  val isUnix = SystemUtils.IS_OS_UNIX
+
+  /**
    * Whether the underlying operating system is Windows.
    */
   val isWindows = SystemUtils.IS_OS_WINDOWS


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `isUnix` like `isWindows` and `isMac` at `org.apache.spark.util.Utils`.

### Why are the changes needed?

To centralize the OS logics in `Utils` class.

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a new API.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.