### PR TITLE
[SPARK-52796][PYTHON] Optimize LocalDataToArrowConversion.convert to improve its performance

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -317,8 +317,8 @@ class LocalDataToArrowConversion:
 
         def to_row(item: Any) -> tuple:
             if item is None:
-                return tuple([None for _ in range(len_column_names)])
-            elif isinstance(item, (Row, tuple)):  # inherited namedtuple
+                return tuple([None] * len_column_names)
+            elif isinstance(item, (Row, tuple)):
                 if len(item) != len_column_names:
                     raise PySparkValueError(
                         errorClass="AXIS_LENGTH_MISMATCH",
@@ -329,12 +329,12 @@ class LocalDataToArrowConversion:
                     )
                 return tuple(item)
             elif isinstance(item, dict):
-                return tuple([item.get(col) for i, col in enumerate(column_names)])
+                return tuple([item.get(col) for col in column_names])
             elif isinstance(item, VariantVal):
                 raise PySparkValueError("Rows cannot be of type VariantVal")
             elif hasattr(item, "__dict__"):
                 item = item.__dict__
-                return tuple([item.get(col) for i, col in enumerate(column_names)])
+                return tuple([item.get(col) for col in column_names])
             else:
                 if len(item) != len_column_names:
                     raise PySparkValueError(
@@ -353,7 +353,7 @@ class LocalDataToArrowConversion:
             for field in schema.fields
         ]
 
-        pylist: List[List] = [[conv(row[i]) for row in rows] for i, conv in enumerate(column_convs)]
+        pylist = [[conv(row[i]) for row in rows] for i, conv in enumerate(column_convs)]
 
         pa_schema = to_arrow_schema(
             StructType(

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -313,13 +313,14 @@ class LocalDataToArrowConversion:
         assert schema is not None and isinstance(schema, StructType)
 
         column_names = schema.fieldNames()
+        len_column_names = len(column_names)
 
         column_convs = [
             LocalDataToArrowConversion._create_converter(field.dataType, field.nullable)
             for field in schema.fields
         ]
 
-        pylist: List[List] = [[] for _ in range(len(column_names))]
+        pylist: List[List] = [[] for _ in range(len_column_names)]
 
         for item in data:
             if isinstance(item, VariantVal):
@@ -336,16 +337,16 @@ class LocalDataToArrowConversion:
                 for i, col in enumerate(column_names):
                     pylist[i].append(None)
             else:
-                if len(item) != len(column_names):
+                if len(item) != len_column_names:
                     raise PySparkValueError(
                         errorClass="AXIS_LENGTH_MISMATCH",
                         messageParameters={
-                            "expected_length": str(len(column_names)),
+                            "expected_length": str(len_column_names),
                             "actual_length": str(len(item)),
                         },
                     )
 
-                for i in range(len(column_names)):
+                for i in range(len_column_names):
                     pylist[i].append(column_convs[i](item[i]))
 
         pa_schema = to_arrow_schema(

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -325,8 +325,7 @@ class LocalDataToArrowConversion:
             if isinstance(item, VariantVal):
                 raise PySparkValueError("Rows cannot be of type VariantVal")
             if (
-                not isinstance(item, Row)
-                and not isinstance(item, tuple)  # inherited namedtuple
+                not isinstance(item, (Row, tuple))  # inherited namedtuple
                 and hasattr(item, "__dict__")
             ):
                 item = item.__dict__


### PR DESCRIPTION
### What changes were proposed in this pull request?

Optimizes `LocalDataToArrowConversion.convert` to improve its performace by:

- Reduce the number of `isinstance` calls
- Calculate `len(column_names)` in advance
- Separate creation of `rows` and conversion with for-comprehension to avoid expensive `list.append` calls
- Reorder `isinstance` check to likely to rarely
- Make creation of `rows` for-comprehension to avoid expensive `list.append` calls

### Why are the changes needed?

`LocalDataToArrowConversion.convert` has several performance overhead.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing tests, and manual benchmarks.

```py
def profile(f, _n=10, *args, **kwargs):
    import cProfile
    import pstats
    import gc
    st = None
    for _ in range(5):
        f(*args, **kwargs)
    for _ in range(_n):
        gc.collect()
        with cProfile.Profile() as pr:
            ret = f(*args, **kwargs)
        if st is None:
            st = pstats.Stats(pr)
        else:
            st.add(pstats.Stats(pr))
    st.sort_stats("time", "cumulative").print_stats()
    return ret

from pyspark.sql.conversion import LocalDataToArrowConversion
from pyspark.sql.types import *

data = [
    (i if i % 1000 else None, str(i), i)
    for i in range(1000000)
]
schema = (
    StructType()
    .add("i", IntegerType(), nullable=True)
    .add("s", StringType(), nullable=True)
    .add("ii", IntegerType(), nullable=False)
)

def test():
    LocalDataToArrowConversion.convert(data, schema, use_large_var_types=False)

profile(test)
```

- before

```
140001570 function calls in 15.355 seconds
```

- after

```
70001580 function calls in 4.845 seconds
```

### Was this patch authored or co-authored using generative AI tooling?

No.
