### PR TITLE
[SPARK-52797] Use `Utils.isWindows` instead of re-evaluating in `PythonWorkerFactory`

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -95,7 +95,7 @@ private[spark] class PythonWorkerFactory(
   // so we can also fall back to launching workers, pyspark/worker.py (by default) directly.
   private val useDaemon = {
     // This flag is ignored on Windows as it's unable to fork.
-    !System.getProperty("os.name").startsWith("Windows") && useDaemonEnabled
+    !Utils.isWindows && useDaemonEnabled
   }
 
   private val authHelper = new SocketAuthHelper(SparkEnv.get.conf)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `Utils.isWindows` variable instead of re-evaluating like `System.getProperty("os.name").startsWith("Windows")` in `PythonWorkerFactory`.

### Why are the changes needed?

To simplify the code.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.