### PR TITLE
[SQL][SPARK-52801] Make name-precedence-in-order-by-and-having-with-conflicting-attributes suite deterministic

### DIFF
--- a/sql/core/src/test/resources/sql-tests/analyzer-results/name-precedence-in-order-by-and-having-with-conflicting-attributes.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/name-precedence-in-order-by-and-having-with-conflicting-attributes.sql.out
@@ -64,39 +64,54 @@ Filter (col1#x > 50)
 
 
 -- !query
-SELECT col1 AS c, 2 AS col1 FROM v1 ORDER BY col1
+SELECT * FROM (
+  SELECT col1 AS c, 2 AS col1 FROM v1 ORDER BY col1
+) ORDER BY 1
 -- !query analysis
-Sort [col1#x ASC NULLS FIRST], true
-+- Project [col1#x AS c#x, 2 AS col1#x]
-   +- SubqueryAlias v1
-      +- View (`v1`, [col1#x])
-         +- Project [cast(col1#x as int) AS col1#x]
-            +- Project [col1#x]
-               +- LocalRelation [col1#x]
+Sort [c#x ASC NULLS FIRST], true
++- Project [c#x, col1#x]
+   +- SubqueryAlias __auto_generated_subquery_name
+      +- Sort [col1#x ASC NULLS FIRST], true
+         +- Project [col1#x AS c#x, 2 AS col1#x]
+            +- SubqueryAlias v1
+               +- View (`v1`, [col1#x])
+                  +- Project [cast(col1#x as int) AS col1#x]
+                     +- Project [col1#x]
+                        +- LocalRelation [col1#x]
 
 
 -- !query
-SELECT col1 AS c, 2 AS col1 FROM v1 GROUP BY ALL ORDER BY col1
+SELECT * FROM (
+  SELECT col1 AS c, 2 AS col1 FROM v1 GROUP BY ALL ORDER BY col1
+) ORDER BY 1
 -- !query analysis
-Sort [col1#x ASC NULLS FIRST], true
-+- Aggregate [col1#x, 2], [col1#x AS c#x, 2 AS col1#x]
-   +- SubqueryAlias v1
-      +- View (`v1`, [col1#x])
-         +- Project [cast(col1#x as int) AS col1#x]
-            +- Project [col1#x]
-               +- LocalRelation [col1#x]
+Sort [c#x ASC NULLS FIRST], true
++- Project [c#x, col1#x]
+   +- SubqueryAlias __auto_generated_subquery_name
+      +- Sort [col1#x ASC NULLS FIRST], true
+         +- Aggregate [col1#x, 2], [col1#x AS c#x, 2 AS col1#x]
+            +- SubqueryAlias v1
+               +- View (`v1`, [col1#x])
+                  +- Project [cast(col1#x as int) AS col1#x]
+                     +- Project [col1#x]
+                        +- LocalRelation [col1#x]
 
 
 -- !query
-SELECT col1 AS c, 2 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50
+SELECT * FROM (
+  SELECT col1 AS c, 2 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50
+) ORDER BY 1
 -- !query analysis
-Filter (c#x > 50)
-+- Aggregate [col1#x, 2], [col1#x AS c#x, 2 AS col1#x]
-   +- SubqueryAlias v1
-      +- View (`v1`, [col1#x])
-         +- Project [cast(col1#x as int) AS col1#x]
-            +- Project [col1#x]
-               +- LocalRelation [col1#x]
+Sort [c#x ASC NULLS FIRST], true
++- Project [c#x, col1#x]
+   +- SubqueryAlias __auto_generated_subquery_name
+      +- Filter (c#x > 50)
+         +- Aggregate [col1#x, 2], [col1#x AS c#x, 2 AS col1#x]
+            +- SubqueryAlias v1
+               +- View (`v1`, [col1#x])
+                  +- Project [cast(col1#x as int) AS col1#x]
+                     +- Project [col1#x]
+                        +- LocalRelation [col1#x]
 
 
 -- !query
@@ -180,15 +195,20 @@ Sort [c#x ASC NULLS FIRST], true
 
 
 -- !query
-SELECT col1 AS c, 2 AS col1, 3 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50
+SELECT * FROM (
+  SELECT col1 AS c, 2 AS col1, 3 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50
+) ORDER BY 1
 -- !query analysis
-Filter (c#x > 50)
-+- Aggregate [col1#x, 2, 3], [col1#x AS c#x, 2 AS col1#x, 3 AS col1#x]
-   +- SubqueryAlias v1
-      +- View (`v1`, [col1#x])
-         +- Project [cast(col1#x as int) AS col1#x]
-            +- Project [col1#x]
-               +- LocalRelation [col1#x]
+Sort [c#x ASC NULLS FIRST], true
++- Project [c#x, col1#x, col1#x]
+   +- SubqueryAlias __auto_generated_subquery_name
+      +- Filter (c#x > 50)
+         +- Aggregate [col1#x, 2, 3], [col1#x AS c#x, 2 AS col1#x, 3 AS col1#x]
+            +- SubqueryAlias v1
+               +- View (`v1`, [col1#x])
+                  +- Project [cast(col1#x as int) AS col1#x]
+                     +- Project [col1#x]
+                        +- LocalRelation [col1#x]
 
 
 -- !query
@@ -216,15 +236,20 @@ Sort [col1#x ASC NULLS FIRST], true
 
 
 -- !query
-SELECT col1, 2 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50
+SELECT * FROM (
+  SELECT col1, 2 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50
+) ORDER BY 1
 -- !query analysis
-Filter (col1#x > 50)
-+- Aggregate [col1#x, 2], [col1#x, 2 AS col1#x]
-   +- SubqueryAlias v1
-      +- View (`v1`, [col1#x])
-         +- Project [cast(col1#x as int) AS col1#x]
-            +- Project [col1#x]
-               +- LocalRelation [col1#x]
+Sort [col1#x ASC NULLS FIRST], true
++- Project [col1#x, col1#x]
+   +- SubqueryAlias __auto_generated_subquery_name
+      +- Filter (col1#x > 50)
+         +- Aggregate [col1#x, 2], [col1#x, 2 AS col1#x]
+            +- SubqueryAlias v1
+               +- View (`v1`, [col1#x])
+                  +- Project [cast(col1#x as int) AS col1#x]
+                     +- Project [col1#x]
+                        +- LocalRelation [col1#x]
 
 
 -- !query
@@ -357,39 +382,54 @@ Filter (col1#x > banana)
 
 
 -- !query
-SELECT col1 AS c, 'col1' FROM v2 ORDER BY col1
+SELECT * FROM (
+  SELECT col1 AS c, 'col1' FROM v2 ORDER BY col1
+) ORDER BY 1
 -- !query analysis
-Sort [col1#x ASC NULLS FIRST], true
-+- Project [col1#x AS c#x, col1 AS col1#x]
-   +- SubqueryAlias v2
-      +- View (`v2`, [col1#x])
-         +- Project [cast(col1#x as string) AS col1#x]
-            +- Project [col1#x]
-               +- LocalRelation [col1#x]
+Sort [c#x ASC NULLS FIRST], true
++- Project [c#x, col1#x]
+   +- SubqueryAlias __auto_generated_subquery_name
+      +- Sort [col1#x ASC NULLS FIRST], true
+         +- Project [col1#x AS c#x, col1 AS col1#x]
+            +- SubqueryAlias v2
+               +- View (`v2`, [col1#x])
+                  +- Project [cast(col1#x as string) AS col1#x]
+                     +- Project [col1#x]
+                        +- LocalRelation [col1#x]
 
 
 -- !query
-SELECT col1 AS c, 'col1' FROM v2 GROUP BY ALL ORDER BY col1
+SELECT * FROM (
+  SELECT col1 AS c, 'col1' FROM v2 GROUP BY ALL ORDER BY col1
+) ORDER BY 1
 -- !query analysis
-Sort [col1#x ASC NULLS FIRST], true
-+- Aggregate [col1#x, col1], [col1#x AS c#x, col1 AS col1#x]
-   +- SubqueryAlias v2
-      +- View (`v2`, [col1#x])
-         +- Project [cast(col1#x as string) AS col1#x]
-            +- Project [col1#x]
-               +- LocalRelation [col1#x]
+Sort [c#x ASC NULLS FIRST], true
++- Project [c#x, col1#x]
+   +- SubqueryAlias __auto_generated_subquery_name
+      +- Sort [col1#x ASC NULLS FIRST], true
+         +- Aggregate [col1#x, col1], [col1#x AS c#x, col1 AS col1#x]
+            +- SubqueryAlias v2
+               +- View (`v2`, [col1#x])
+                  +- Project [cast(col1#x as string) AS col1#x]
+                     +- Project [col1#x]
+                        +- LocalRelation [col1#x]
 
 
 -- !query
-SELECT col1 AS c, 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana'
+SELECT * FROM (
+  SELECT col1 AS c, 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana'
+) ORDER BY 1
 -- !query analysis
-Filter (c#x > banana)
-+- Aggregate [col1#x, col1], [col1#x AS c#x, col1 AS col1#x]
-   +- SubqueryAlias v2
-      +- View (`v2`, [col1#x])
-         +- Project [cast(col1#x as string) AS col1#x]
-            +- Project [col1#x]
-               +- LocalRelation [col1#x]
+Sort [c#x ASC NULLS FIRST], true
++- Project [c#x, col1#x]
+   +- SubqueryAlias __auto_generated_subquery_name
+      +- Filter (c#x > banana)
+         +- Aggregate [col1#x, col1], [col1#x AS c#x, col1 AS col1#x]
+            +- SubqueryAlias v2
+               +- View (`v2`, [col1#x])
+                  +- Project [cast(col1#x as string) AS col1#x]
+                     +- Project [col1#x]
+                        +- LocalRelation [col1#x]
 
 
 -- !query
@@ -473,15 +513,20 @@ Sort [c#x ASC NULLS FIRST], true
 
 
 -- !query
-SELECT col1 AS c, 'col1', 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana'
+SELECT * FROM (
+  SELECT col1 AS c, 'col1', 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana'
+) ORDER BY 1
 -- !query analysis
-Filter (c#x > banana)
-+- Aggregate [col1#x, col1, col1], [col1#x AS c#x, col1 AS col1#x, col1 AS col1#x]
-   +- SubqueryAlias v2
-      +- View (`v2`, [col1#x])
-         +- Project [cast(col1#x as string) AS col1#x]
-            +- Project [col1#x]
-               +- LocalRelation [col1#x]
+Sort [c#x ASC NULLS FIRST], true
++- Project [c#x, col1#x, col1#x]
+   +- SubqueryAlias __auto_generated_subquery_name
+      +- Filter (c#x > banana)
+         +- Aggregate [col1#x, col1, col1], [col1#x AS c#x, col1 AS col1#x, col1 AS col1#x]
+            +- SubqueryAlias v2
+               +- View (`v2`, [col1#x])
+                  +- Project [cast(col1#x as string) AS col1#x]
+                     +- Project [col1#x]
+                        +- LocalRelation [col1#x]
 
 
 -- !query
@@ -509,15 +554,20 @@ Sort [col1#x ASC NULLS FIRST], true
 
 
 -- !query
-SELECT col1, 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana'
+SELECT * FROM (
+  SELECT col1, 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana'
+) ORDER BY 1
 -- !query analysis
-Filter (col1#x > banana)
-+- Aggregate [col1#x, col1], [col1#x, col1 AS col1#x]
-   +- SubqueryAlias v2
-      +- View (`v2`, [col1#x])
-         +- Project [cast(col1#x as string) AS col1#x]
-            +- Project [col1#x]
-               +- LocalRelation [col1#x]
+Sort [col1#x ASC NULLS FIRST], true
++- Project [col1#x, col1#x]
+   +- SubqueryAlias __auto_generated_subquery_name
+      +- Filter (col1#x > banana)
+         +- Aggregate [col1#x, col1], [col1#x, col1 AS col1#x]
+            +- SubqueryAlias v2
+               +- View (`v2`, [col1#x])
+                  +- Project [cast(col1#x as string) AS col1#x]
+                     +- Project [col1#x]
+                        +- LocalRelation [col1#x]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/inputs/name-precedence-in-order-by-and-having-with-conflicting-attributes.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/name-precedence-in-order-by-and-having-with-conflicting-attributes.sql
@@ -20,11 +20,17 @@ SELECT 2 AS col1 FROM v1 GROUP BY ALL ORDER BY col1;
 
 SELECT 2 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50;
 
-SELECT col1 AS c, 2 AS col1 FROM v1 ORDER BY col1;
+SELECT * FROM (
+  SELECT col1 AS c, 2 AS col1 FROM v1 ORDER BY col1
+) ORDER BY 1;
 
-SELECT col1 AS c, 2 AS col1 FROM v1 GROUP BY ALL ORDER BY col1;
+SELECT * FROM (
+  SELECT col1 AS c, 2 AS col1 FROM v1 GROUP BY ALL ORDER BY col1
+) ORDER BY 1;
 
-SELECT col1 AS c, 2 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50;
+SELECT * FROM (
+  SELECT col1 AS c, 2 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50
+) ORDER BY 1;
 
 -- Conflict in main output
 
@@ -38,13 +44,17 @@ SELECT col1 AS c, 2 AS col1, 3 AS col1 FROM v1 ORDER BY col1;
 
 SELECT col1 AS c, 2 AS col1, 3 AS col1 FROM v1 GROUP BY ALL ORDER BY col1;
 
-SELECT col1 AS c, 2 AS col1, 3 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50;
+SELECT * FROM (
+  SELECT col1 AS c, 2 AS col1, 3 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50
+) ORDER BY 1;
 
 SELECT col1, 2 AS col1 FROM v1 ORDER BY col1;
 
 SELECT col1, 2 AS col1 FROM v1 GROUP BY ALL ORDER BY col1;
 
-SELECT col1, 2 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50;
+SELECT * FROM (
+  SELECT col1, 2 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50
+) ORDER BY 1;
 
 -- Conflict in hidden output
 
@@ -70,11 +80,17 @@ SELECT 'col1' FROM v2 GROUP BY ALL ORDER BY col1;
 
 SELECT 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana';
 
-SELECT col1 AS c, 'col1' FROM v2 ORDER BY col1;
+SELECT * FROM (
+  SELECT col1 AS c, 'col1' FROM v2 ORDER BY col1
+) ORDER BY 1;
 
-SELECT col1 AS c, 'col1' FROM v2 GROUP BY ALL ORDER BY col1;
+SELECT * FROM (
+  SELECT col1 AS c, 'col1' FROM v2 GROUP BY ALL ORDER BY col1
+) ORDER BY 1;
 
-SELECT col1 AS c, 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana';
+SELECT * FROM (
+  SELECT col1 AS c, 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana'
+) ORDER BY 1;
 
 -- Conflict in main output
 
@@ -88,13 +104,17 @@ SELECT col1 AS c, 'col1', 'col1' FROM v2 ORDER BY col1;
 
 SELECT col1 AS c, 'col1', 'col1' FROM v2 GROUP BY ALL ORDER BY col1;
 
-SELECT col1 AS c, 'col1', 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana';
+SELECT * FROM (
+  SELECT col1 AS c, 'col1', 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana'
+) ORDER BY 1;
 
 SELECT col1, 'col1' FROM v2 ORDER BY col1;
 
 SELECT col1, 'col1' FROM v2 GROUP BY ALL ORDER BY col1;
 
-SELECT col1, 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana';
+SELECT * FROM (
+  SELECT col1, 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana';
+) ORDER BY 1;
 
 -- Conflict in hidden output
 

--- a/sql/core/src/test/resources/sql-tests/inputs/name-precedence-in-order-by-and-having-with-conflicting-attributes.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/name-precedence-in-order-by-and-having-with-conflicting-attributes.sql
@@ -113,7 +113,7 @@ SELECT col1, 'col1' FROM v2 ORDER BY col1;
 SELECT col1, 'col1' FROM v2 GROUP BY ALL ORDER BY col1;
 
 SELECT * FROM (
-  SELECT col1, 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana';
+  SELECT col1, 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana'
 ) ORDER BY 1;
 
 -- Conflict in hidden output

--- a/sql/core/src/test/resources/sql-tests/results/name-precedence-in-order-by-and-having-with-conflicting-attributes.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/name-precedence-in-order-by-and-having-with-conflicting-attributes.sql.out
@@ -60,46 +60,52 @@ struct<col1:int>
 
 
 -- !query
-SELECT col1 AS c, 2 AS col1 FROM v1 ORDER BY col1
+SELECT * FROM (
+  SELECT col1 AS c, 2 AS col1 FROM v1 ORDER BY col1
+) ORDER BY 1
 -- !query schema
 struct<c:int,col1:int>
 -- !query output
-42	2
-17	2
-99	2
-5	2
-42	2
-23	2
-8	2
-17	2
-76	2
-33	2
-99	2
-55	2
 3	2
-42	2
+5	2
 8	2
+8	2
+17	2
+17	2
+23	2
+33	2
+42	2
+42	2
+42	2
+55	2
+76	2
+99	2
+99	2
 
 
 -- !query
-SELECT col1 AS c, 2 AS col1 FROM v1 GROUP BY ALL ORDER BY col1
+SELECT * FROM (
+  SELECT col1 AS c, 2 AS col1 FROM v1 GROUP BY ALL ORDER BY col1
+) ORDER BY 1
 -- !query schema
 struct<c:int,col1:int>
 -- !query output
-42	2
-17	2
-99	2
-23	2
+3	2
 5	2
 8	2
-76	2
-55	2
+17	2
+23	2
 33	2
-3	2
+42	2
+55	2
+76	2
+99	2
 
 
 -- !query
-SELECT col1 AS c, 2 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50
+SELECT * FROM (
+  SELECT col1 AS c, 2 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50
+) ORDER BY 1
 -- !query schema
 struct<c:int,col1:int>
 -- !query output
@@ -216,7 +222,9 @@ struct<c:int,col1:int,col1:int>
 
 
 -- !query
-SELECT col1 AS c, 2 AS col1, 3 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50
+SELECT * FROM (
+  SELECT col1 AS c, 2 AS col1, 3 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50
+) ORDER BY 1
 -- !query schema
 struct<c:int,col1:int,col1:int>
 -- !query output
@@ -265,7 +273,9 @@ struct<col1:int,col1:int>
 
 
 -- !query
-SELECT col1, 2 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50
+SELECT * FROM (
+  SELECT col1, 2 AS col1 FROM v1 GROUP BY ALL HAVING col1 > 50
+) ORDER BY 1
 -- !query schema
 struct<col1:int,col1:int>
 -- !query output
@@ -406,7 +416,33 @@ col1
 
 
 -- !query
-SELECT col1 AS c, 'col1' FROM v2 ORDER BY col1
+SELECT * FROM (
+  SELECT col1 AS c, 'col1' FROM v2 ORDER BY col1
+) ORDER BY 1
+-- !query schema
+struct<c:string,col1:string>
+-- !query output
+apple	col1
+apple	col1
+apple	col1
+banana	col1
+banana	col1
+cherry	col1
+cherry	col1
+date	col1
+fig	col1
+grape	col1
+grape	col1
+kiwi	col1
+lemon	col1
+mango	col1
+orange	col1
+
+
+-- !query
+SELECT * FROM (
+  SELECT col1 AS c, 'col1' FROM v2 GROUP BY ALL ORDER BY col1
+) ORDER BY 1
 -- !query schema
 struct<c:string,col1:string>
 -- !query output
@@ -414,38 +450,18 @@ apple	col1
 banana	col1
 cherry	col1
 date	col1
-apple	col1
 fig	col1
 grape	col1
-banana	col1
 kiwi	col1
 lemon	col1
-cherry	col1
 mango	col1
-orange	col1
-apple	col1
-grape	col1
-
-
--- !query
-SELECT col1 AS c, 'col1' FROM v2 GROUP BY ALL ORDER BY col1
--- !query schema
-struct<c:string,col1:string>
--- !query output
-date	col1
-cherry	col1
-grape	col1
-apple	col1
-banana	col1
-fig	col1
-mango	col1
-kiwi	col1
-lemon	col1
 orange	col1
 
 
 -- !query
-SELECT col1 AS c, 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana'
+SELECT * FROM (
+  SELECT col1 AS c, 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana'
+) ORDER BY 1
 -- !query schema
 struct<c:string,col1:string>
 -- !query output
@@ -567,7 +583,9 @@ orange	col1	col1
 
 
 -- !query
-SELECT col1 AS c, 'col1', 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana'
+SELECT * FROM (
+  SELECT col1 AS c, 'col1', 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana'
+) ORDER BY 1
 -- !query schema
 struct<c:string,col1:string,col1:string>
 -- !query output
@@ -621,7 +639,9 @@ orange	col1
 
 
 -- !query
-SELECT col1, 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana'
+SELECT * FROM (
+  SELECT col1, 'col1' FROM v2 GROUP BY ALL HAVING col1 > 'banana'
+) ORDER BY 1
 -- !query schema
 struct<col1:string,col1:string>
 -- !query output


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add some `ORDER BY`s to avoid flaky results.

### Why are the changes needed?

To avoid flaky tests.

### Does this PR introduce _any_ user-facing change?

Test-only change.

### How was this patch tested?

Test-only change.

### Was this patch authored or co-authored using generative AI tooling?

No.