### PR TITLE
[SPARK-52805][INFRA] Add `Java 17` build and install test pipeline

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -122,6 +122,7 @@ jobs:
               \"tpcds-1g\": \"$tpcds\",
               \"docker-integration-tests\": \"$docker\",
               \"lint\" : \"true\",
+              \"java17\" : \"true\",
               \"java25\" : \"true\",
               \"docs\" : \"$docs\",
               \"yarn\" : \"$yarn\",
@@ -919,6 +920,24 @@ jobs:
       run: ./R/install-dev.sh
     - name: R linter
       run: ./dev/lint-r
+
+  java17:
+    needs: [precondition]
+    if: fromJson(needs.precondition.outputs.required).java17 == 'true'
+    name: Java 17 build with Maven
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: zulu
+        java-version: 17
+    - name: Build with Maven
+      run: |
+        export MAVEN_OPTS="-Xss64m -Xmx4g -Xms4g -XX:ReservedCodeCacheSize=128m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
+        export MAVEN_CLI_OPTS="--no-transfer-progress"
+        ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pjvm-profiler -Pspark-ganglia-lgpl -Pkinesis-asl clean install
 
   java25:
     needs: [precondition]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add Java 17 clean build test.

### Why are the changes needed?

To clarify Java 17 clean build status always because Java 17 is the default Java version in the community.

### Does this PR introduce _any_ user-facing change?

No, this is an infra only change.

### How was this patch tested?

Pass the CIs with newly added test pipeline.

https://github.com/dongjoon-hyun/spark/actions/runs/16299727217/job/46031048273

<img width="211" height="70" alt="Screenshot 2025-07-15 at 10 54 26" src="https://github.com/user-attachments/assets/4763e4dd-2d2b-429a-ba28-4eab9aea52b5" />

### Was this patch authored or co-authored using generative AI tooling?

No.