### PR TITLE
[DO NOT REVIEW] temp

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -1342,8 +1342,8 @@ collateClause
 
 nonTrivialPrimitiveType
     : STRING collateClause?
-    | (CHARACTER | CHAR) (LEFT_PAREN length=INTEGER_VALUE RIGHT_PAREN)?
-    | VARCHAR (LEFT_PAREN length=INTEGER_VALUE RIGHT_PAREN)?
+    | (CHARACTER | CHAR) (LEFT_PAREN length=INTEGER_VALUE RIGHT_PAREN)? collateClause?
+    | VARCHAR (LEFT_PAREN length=INTEGER_VALUE RIGHT_PAREN)? collateClause?
     | (DECIMAL | DEC | NUMERIC)
         (LEFT_PAREN precision=INTEGER_VALUE (COMMA scale=INTEGER_VALUE)? RIGHT_PAREN)?
     | INTERVAL

--- a/sql/api/src/main/java/org/apache/spark/sql/types/DataTypes.java
+++ b/sql/api/src/main/java/org/apache/spark/sql/types/DataTypes.java
@@ -261,20 +261,47 @@ public class DataTypes {
   }
 
   /**
-   * Creates a CharType with the given length.
+   * Creates a StringType with the given collation.
+   *
+   * @since 4.1.0
+   */
+  public static StringType createStringType(int collation) {
+    return new StringType(collation, NoConstraint$.MODULE$);
+  }
+
+  /**
+   * Creates a CharType with the given length and `UTF8_BINARY` collation.
    *
    * @since 4.0.0
    */
   public static CharType createCharType(int length) {
-    return new CharType(length);
+    return new DefaultCharType(length);
   }
 
   /**
-   * Creates a VarcharType with the given length.
+   * Creates a CharType with the given length and collation.
+   *
+   * @since 4.0.0
+   */
+  public static CharType createCharType(int length, int collationId) {
+    return new CharType(length, collationId);
+  }
+
+  /**
+   * Creates a VarcharType with the given length and `UTF8_BINARY` collation.
    *
    * @since 4.0.0
    */
   public static VarcharType createVarcharType(int length) {
-    return new VarcharType(length);
+    return new DefaultVarcharType(length);
+  }
+
+  /**
+   * Creates a VarcharType with the given length and collation.
+   *
+   * @since 4.0.0
+   */
+  public static VarcharType createVarcharType(int length, int collationId) {
+    return new VarcharType(length, collationId);
   }
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
@@ -81,9 +81,9 @@ object RowEncoder extends DataTypeErrorsBase {
       case DoubleType => BoxedDoubleEncoder
       case dt: DecimalType => JavaDecimalEncoder(dt, lenientSerialization = true)
       case BinaryType => BinaryEncoder
-      case CharType(length) if SqlApiConf.get.preserveCharVarcharTypeInfo =>
+      case CharType(length, _) if SqlApiConf.get.preserveCharVarcharTypeInfo =>
         CharEncoder(length)
-      case VarcharType(length) if SqlApiConf.get.preserveCharVarcharTypeInfo =>
+      case VarcharType(length, _) if SqlApiConf.get.preserveCharVarcharTypeInfo =>
         VarcharEncoder(length)
       case s: StringType if StringHelper.isPlainString(s) => StringEncoder
       case TimestampType if SqlApiConf.get.datetimeJava8ApiEnabled => InstantEncoder(lenient)

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
@@ -41,6 +41,7 @@ private[sql] trait SqlApiConf {
   def allowNegativeScaleOfDecimalEnabled: Boolean
   def charVarcharAsString: Boolean
   def preserveCharVarcharTypeInfo: Boolean
+  def charVarcharCollationsEnabled: Boolean
   def datetimeJava8ApiEnabled: Boolean
   def sessionLocalTimeZone: String
   def legacyTimeParserPolicy: LegacyBehaviorPolicy.Value
@@ -82,6 +83,7 @@ private[sql] object DefaultSqlApiConf extends SqlApiConf {
   override def allowNegativeScaleOfDecimalEnabled: Boolean = false
   override def charVarcharAsString: Boolean = false
   override def preserveCharVarcharTypeInfo: Boolean = false
+  override def charVarcharCollationsEnabled: Boolean = false
   override def datetimeJava8ApiEnabled: Boolean = false
   override def sessionLocalTimeZone: String = TimeZone.getDefault.getID
   override def legacyTimeParserPolicy: LegacyBehaviorPolicy.Value = LegacyBehaviorPolicy.CORRECTED

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -328,7 +328,11 @@ object DataType {
       fieldPath: String,
       fieldType: String,
       collationMap: Map[String, String]): Unit = {
-    if (collationMap.contains(fieldPath) && fieldType != "string") {
+    val isValidType = fieldType match {
+      case "string" | CHAR_TYPE(_) | VARCHAR_TYPE(_) => true
+      case _ => false
+    }
+    if (collationMap.contains(fieldPath) && !isValidType) {
       throw new SparkIllegalArgumentException(
         errorClass = "INVALID_JSON_DATA_TYPE_FOR_COLLATIONS",
         messageParameters = Map("jsonType" -> fieldType))

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StringType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StringType.scala
@@ -184,8 +184,8 @@ case object StringHelper extends PartialOrdering[StringConstraint] {
   }
 
   def removeCollation(s: StringType): StringType = s match {
-    case CharType(length) => CharType(length)
-    case VarcharType(length) => VarcharType(length)
+    case CharType(length, _) => DefaultCharType(length)
+    case VarcharType(length, _) => DefaultVarcharType(length)
     case _: StringType => StringType
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -66,8 +66,8 @@ object CatalystTypeConverters {
       case arrayType: ArrayType => ArrayConverter(arrayType.elementType)
       case mapType: MapType => MapConverter(mapType.keyType, mapType.valueType)
       case structType: StructType => StructConverter(structType)
-      case CharType(length) => new CharConverter(length)
-      case VarcharType(length) => new VarcharConverter(length)
+      case CharType(length, _) => new CharConverter(length)
+      case VarcharType(length, _) => new VarcharConverter(length)
       case _: StringType => StringConverter
       case DateType if SQLConf.get.datetimeJava8ApiEnabled => LocalDateConverter
       case DateType => DateConverter

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyCharTypePaddingHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyCharTypePaddingHelper.scala
@@ -103,7 +103,7 @@ object ApplyCharTypePaddingHelper {
         CharVarcharUtils
           .getRawType(attr.metadata)
           .flatMap {
-            case CharType(length) =>
+            case CharType(length, _) =>
               val (nulls, literalChars) =
                 list.map(_.eval().asInstanceOf[UTF8String]).partition(_ == null)
               val literalCharLengths = literalChars.map(_.numChars())
@@ -164,7 +164,7 @@ object ApplyCharTypePaddingHelper {
       lit: Expression): Option[Seq[Expression]] = {
     if (expr.dataType == StringType) {
       CharVarcharUtils.getRawType(metadata).flatMap {
-        case CharType(length) =>
+        case CharType(length, _) =>
           val str = lit.eval().asInstanceOf[UTF8String]
           if (str == null) {
             None

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -1090,9 +1090,9 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
 
               // We don't need to handle nested types here which shall fail before.
               def canAlterColumnType(from: DataType, to: DataType): Boolean = (from, to) match {
-                case (CharType(l1), CharType(l2)) => l1 == l2
-                case (CharType(l1), VarcharType(l2)) => l1 <= l2
-                case (VarcharType(l1), VarcharType(l2)) => l1 <= l2
+                case (CharType(l1, _), CharType(l2, _)) => l1 == l2
+                case (CharType(l1, _), VarcharType(l2, _)) => l1 <= l2
+                case (VarcharType(l1, _), VarcharType(l2, _)) => l1 <= l2
                 case _ => Cast.canUpCast(from, to)
               }
               if (!canAlterColumnType(field.dataType, newDataType)) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -170,7 +170,7 @@ object Literal {
       case _: DayTimeIntervalType if v.isInstanceOf[Duration] =>
         Literal(CatalystTypeConverters.createToCatalystConverter(dataType)(v), dataType)
       case _: ObjectType => Literal(v, dataType)
-      case CharType(_) | VarcharType(_) if SQLConf.get.preserveCharVarcharTypeInfo =>
+      case CharType(_, _) | VarcharType(_, _) if SQLConf.get.preserveCharVarcharTypeInfo =>
         Literal(CatalystTypeConverters.createToCatalystConverter(dataType)(v), dataType)
       case _ => Literal(CatalystTypeConverters.convertToCatalyst(v), dataType)
     }
@@ -203,10 +203,10 @@ object Literal {
     case t: TimeType => create(0L, t)
     case it: DayTimeIntervalType => create(0L, it)
     case it: YearMonthIntervalType => create(0, it)
-    case CharType(length) =>
+    case CharType(length, _) =>
       create(CharVarcharCodegenUtils.charTypeWriteSideCheck(UTF8String.fromString(""), length),
         dataType)
-    case VarcharType(length) =>
+    case VarcharType(length, _) =>
       create(CharVarcharCodegenUtils.varcharTypeWriteSideCheck(UTF8String.fromString(""), length),
         dataType)
     case st: StringType => Literal(UTF8String.fromString(""), st)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
@@ -349,7 +349,7 @@ case object VariantGet {
    */
   def checkDataType(dataType: DataType, allowStructsAndMaps: Boolean = true): Boolean =
     dataType match {
-    case CharType(_) | VarcharType(_) => false
+    case CharType(_, _) | VarcharType(_, _) => false
     case _: NumericType | BooleanType | _: StringType | BinaryType | _: DatetimeType |
         VariantType =>
       true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
@@ -40,8 +40,8 @@ object PhysicalDataType {
     case ShortType => PhysicalShortType
     case IntegerType => PhysicalIntegerType
     case LongType => PhysicalLongType
-    case VarcharType(_) => PhysicalStringType(StringType.collationId)
-    case CharType(_) => PhysicalStringType(StringType.collationId)
+    case VarcharType(_, collationId) => PhysicalStringType(collationId)
+    case CharType(_, collationId) => PhysicalStringType(collationId)
     case s: StringType => PhysicalStringType(s.collationId)
     case FloatType => PhysicalFloatType
     case DoubleType => PhysicalDoubleType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5312,6 +5312,12 @@ object SQLConf {
       .checkValue(_ >= 0, "The value must be non-negative.")
       .createWithDefault(8)
 
+  val CHAR_VARCHAR_COLLATIONS_ENABLED = buildConf("spark.sql.charVarcharCollationEnabled")
+    .doc("When true, Spark allows creation of collated char/varchar types.")
+    .version("4.1.0")
+    .booleanConf
+    .createWithDefault(true)
+
   val OPTIMIZE_NULL_AWARE_ANTI_JOIN =
     buildConf("spark.sql.optimizeNullAwareAntiJoin")
       .internal()
@@ -7027,6 +7033,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def charVarcharAsString: Boolean = getConf(SQLConf.LEGACY_CHAR_VARCHAR_AS_STRING)
 
   def preserveCharVarcharTypeInfo: Boolean = getConf(SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO)
+
+  def charVarcharCollationsEnabled: Boolean = getConf(SQLConf.CHAR_VARCHAR_COLLATIONS_ENABLED)
 
   def readSideCharPadding: Boolean = getConf(SQLConf.READ_SIDE_CHAR_PADDING)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/PartitioningUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/PartitioningUtils.scala
@@ -80,14 +80,14 @@ private[sql] object PartitioningUtils {
 
       val normalizedVal =
         if (SQLConf.get.charVarcharAsString) value else normalizedFiled.dataType match {
-          case CharType(len) if value != null && value != DEFAULT_PARTITION_NAME =>
+          case CharType(len, _) if value != null && value != DEFAULT_PARTITION_NAME =>
             val v = value match {
               case Some(str: String) => Some(charTypeWriteSideCheck(str, len))
               case str: String => charTypeWriteSideCheck(str, len)
               case other => other
             }
             v.asInstanceOf[T]
-          case VarcharType(len) if value != null && value != DEFAULT_PARTITION_NAME =>
+          case VarcharType(len, _) if value != null && value != DEFAULT_PARTITION_NAME =>
             val v = value match {
               case Some(str: String) => Some(varcharTypeWriteSideCheck(str, len))
               case str: String => varcharTypeWriteSideCheck(str, len)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DataTypeParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DataTypeParserSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.parser
 
 import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
+import org.apache.spark.sql.catalyst.util.CollationFactory
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.TimestampTypes
 import org.apache.spark.sql.types._
@@ -68,10 +69,14 @@ class DataTypeParserSuite extends SparkFunSuite with SQLHelper {
   checkDataType("timestamp_ntz", TimestampNTZType)
   checkDataType("timestamp_ltz", TimestampType)
   checkDataType("string", StringType)
-  checkDataType("ChaR(5)", CharType(5))
-  checkDataType("ChaRacter(5)", CharType(5))
+  checkDataType("ChaR(5)", DefaultCharType(5))
+  checkDataType("ChaRacter(5)", DefaultCharType(5))
+  checkDataType("cHaR(27)", DefaultCharType(27))
+  checkDataType("chAr(5) coLLate UTf8_binary",
+    CharType(5, CollationFactory.UTF8_BINARY_COLLATION_ID))
+  checkDataType("chAr(5) coLLate UTF8_lcaSE",
+    CharType(5, CollationFactory.UTF8_LCASE_COLLATION_ID))
   checkDataType("varchAr(20)", VarcharType(20))
-  checkDataType("cHaR(27)", CharType(27))
   checkDataType("BINARY", BinaryType)
   checkDataType("void", NullType)
   checkDataType("interval", CalendarIntervalType)

--- a/sql/connect/common/src/main/protobuf/spark/connect/types.proto
+++ b/sql/connect/common/src/main/protobuf/spark/connect/types.proto
@@ -147,11 +147,13 @@ message DataType {
   message Char {
     int32 length = 1;
     uint32 type_variation_reference = 2;
+    string collation = 3; // NOLINT
   }
 
   message VarChar {
     int32 length = 1;
     uint32 type_variation_reference = 2;
+    string collation = 3; // NOLINT
   }
 
   message Decimal {

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
@@ -175,16 +175,26 @@ object DataTypeProtoConverter {
             proto.DataType.Decimal.newBuilder().setPrecision(precision).setScale(scale).build())
           .build()
 
-      case CharType(length) =>
+      case CharType(length, collationId) =>
         proto.DataType
           .newBuilder()
-          .setChar(proto.DataType.Char.newBuilder().setLength(length).build())
+          .setChar(
+            proto.DataType.Char
+              .newBuilder()
+              .setLength(length)
+              .setCollation(CollationFactory.fetchCollation(collationId).collationName)
+              .build())
           .build()
 
-      case VarcharType(length) =>
+      case VarcharType(length, collationId) =>
         proto.DataType
           .newBuilder()
-          .setVarChar(proto.DataType.VarChar.newBuilder().setLength(length).build())
+          .setVarChar(
+            proto.DataType.VarChar
+              .newBuilder()
+              .setLength(length)
+              .setCollation(CollationFactory.fetchCollation(collationId).collationName)
+              .build())
           .build()
 
       // StringType must be matched after CharType and VarcharType

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzeColumnCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzeColumnCommand.scala
@@ -142,7 +142,7 @@ case class AnalyzeColumnCommand(
     case DoubleType | FloatType => true
     case BooleanType => true
     case _: DatetimeType => true
-    case CharType(_) | VarcharType(_) => false
+    case CharType(_, _) | VarcharType(_, _) => false
     case BinaryType | _: StringType => true
     case _ => false
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -153,10 +153,10 @@ object JdbcUtils extends Logging with SQLConfHelper {
       case ShortType => Option(JdbcType("INTEGER", java.sql.Types.SMALLINT))
       case ByteType => Option(JdbcType("BYTE", java.sql.Types.TINYINT))
       case BooleanType => Option(JdbcType("BIT(1)", java.sql.Types.BIT))
+      case CharType(n, _) => Option(JdbcType(s"CHAR($n)", java.sql.Types.CHAR))
+      case VarcharType(n, _) => Option(JdbcType(s"VARCHAR($n)", java.sql.Types.VARCHAR))
       case StringType => Option(JdbcType("TEXT", java.sql.Types.CLOB))
       case BinaryType => Option(JdbcType("BLOB", java.sql.Types.BLOB))
-      case CharType(n) => Option(JdbcType(s"CHAR($n)", java.sql.Types.CHAR))
-      case VarcharType(n) => Option(JdbcType(s"VARCHAR($n)", java.sql.Types.VARCHAR))
       case TimestampType => Option(JdbcType("TIMESTAMP", java.sql.Types.TIMESTAMP))
       // This is a common case of timestamp without time zone. Most of the databases either only
       // support TIMESTAMP type or use TIMESTAMP as an alias for TIMESTAMP WITHOUT TIME ZONE.

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -150,7 +150,7 @@ private case class OracleDialect() extends JdbcDialect with SQLConfHelper with N
     case ByteType => Some(JdbcType("NUMBER(3)", java.sql.Types.SMALLINT))
     case ShortType => Some(JdbcType("NUMBER(5)", java.sql.Types.SMALLINT))
     case StringType => Some(JdbcType("VARCHAR2(255)", java.sql.Types.VARCHAR))
-    case VarcharType(n) => Some(JdbcType(s"VARCHAR2($n)", java.sql.Types.VARCHAR))
+    case VarcharType(n, _) => Some(JdbcType(s"VARCHAR2($n)", java.sql.Types.VARCHAR))
     case TimestampType if !conf.legacyOracleTimestampMappingEnabled =>
       Some(JdbcType("TIMESTAMP WITH LOCAL TIME ZONE", TIMESTAMP_LTZ))
     case _ => None

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -190,9 +190,9 @@ trait CreatableRelationProvider {
       case MapType(k, v, _) => supportsDataType(k) && supportsDataType(v)
       case StructType(fields) => fields.forall(f => supportsDataType(f.dataType))
       case udt: UserDefinedType[_] => supportsDataType(udt.sqlType)
-      case BinaryType | BooleanType | ByteType | CharType(_) | DateType | _ : DecimalType |
-           DoubleType | FloatType | IntegerType | LongType | NullType | ObjectType(_) | ShortType |
-           _: StringType | TimestampNTZType | TimestampType | VarcharType(_) => true
+      case BinaryType | BooleanType | ByteType | CharType(_, _) | VarcharType(_, _) | DateType |
+           _ : DecimalType | DoubleType | FloatType | IntegerType | LongType | NullType |
+           ObjectType(_) | ShortType | _: StringType | TimestampNTZType | TimestampType => true
       case _ => false
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -46,13 +46,13 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
     val dataType = CatalystSqlParser.parseDataType(dt)
     checkColType(df.schema(1), dataType)
     dataType match {
-      case CharType(len) =>
+      case CharType(len, _) =>
         // char value will be padded if (<= len) or trimmed if (> len)
         val fixLenStr = if (insertVal != null) {
           insertVal.take(len).padTo(len, " ").mkString
         } else null
         checkAnswer(df, Row("1", fixLenStr))
-      case VarcharType(len) =>
+      case VarcharType(len, _) =>
         // varchar value will be remained if (<= len) or trimmed if (> len)
         val varLenStrWithUpperBound = if (insertVal != null) {
           insertVal.take(len)

--- a/sql/core/src/test/scala/org/apache/spark/sql/GenTPCDSData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GenTPCDSData.scala
@@ -163,7 +163,7 @@ class TPCDSTables(spark: SparkSession, dsdgenDir: String, scaleFactor: Int)
         val columns = schema.fields.map { f =>
           val c = f.dataType match {
             // Needs right-padding for char types
-            case CharType(n) => rpad(Column(f.name), n, " ")
+            case CharType(n, _) => rpad(Column(f.name), n, " ")
             // Don't need a cast for varchar types
             case _: VarcharType => col(f.name)
             case _ => col(f.name).cast(f.dataType)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkGetColumnsOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkGetColumnsOperation.scala
@@ -134,7 +134,7 @@ private[hive] class SparkGetColumnsOperation(
     case dt @ (BooleanType | _: NumericType | DateType | TimestampType | TimestampNTZType |
                CalendarIntervalType | NullType | _: AnsiIntervalType) =>
       Some(dt.defaultSize)
-    case CharType(n) => Some(n)
+    case CharType(n, _) => Some(n)
     case StructType(fields) =>
       val sizeArr = fields.map(f => getColumnSize(f.dataType))
       if (sizeArr.contains(None)) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Extended char/varchar to have `collationId` field. Extended parser to support collation syntax for char/varchar. Extended `replaceCharVarcharWithString` to be collation aware.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
