### PR TITLE
[SPARK-52860][SQL][Test] Support V2 write schema evolution in InMemoryTable

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -23,6 +23,7 @@ import java.util
 import java.util.OptionalLong
 
 import scala.collection.mutable
+import scala.jdk.CollectionConverters._
 
 import com.google.common.base.Objects
 
@@ -50,7 +51,7 @@ import org.apache.spark.util.ArrayImplicits._
  */
 abstract class InMemoryBaseTable(
     val name: String,
-    override val columns: Array[Column],
+    val initialColumns: Array[Column],
     override val partitioning: Array[Transform],
     override val properties: util.Map[String, String],
     override val constraints: Array[Constraint] = Array.empty,
@@ -67,6 +68,10 @@ abstract class InMemoryBaseTable(
 
   // Stores the table version validated during the last `ALTER TABLE ... ADD CONSTRAINT` operation.
   private var validatedTableVersion: String = null
+
+  private var tableColumns: Array[Column] = initialColumns
+
+  override def columns(): Array[Column] = tableColumns
 
   override def currentVersion(): String = currentTableVersion.toString
 
@@ -114,7 +119,7 @@ abstract class InMemoryBaseTable(
     }
   }
 
-  override val schema: StructType = CatalogV2Util.v2ColumnsToStructType(columns)
+  override def schema(): StructType = CatalogV2Util.v2ColumnsToStructType(columns())
 
   // purposely exposes a metadata column that conflicts with a data column in some tests
   override val metadataColumns: Array[MetadataColumn] = Array(IndexColumn, PartitionKeyColumn)
@@ -126,6 +131,8 @@ abstract class InMemoryBaseTable(
 
   private val allowUnsupportedTransforms =
     properties.getOrDefault("allow-unsupported-transforms", "false").toBoolean
+
+  private val acceptAnySchema = properties.getOrDefault("accept-any-schema", "false").toBoolean
 
   partitioning.foreach {
     case _: IdentityTransform =>
@@ -257,9 +264,9 @@ abstract class InMemoryBaseTable(
       val newRows = new BufferedRows(to)
       rows.rows.foreach { r =>
         val newRow = new GenericInternalRow(r.numFields)
-        for (i <- 0 until r.numFields) newRow.update(i, r.get(i, schema(i).dataType))
+        for (i <- 0 until r.numFields) newRow.update(i, r.get(i, schema()(i).dataType))
         for (i <- 0 until partitionSchema.length) {
-          val j = schema.fieldIndex(partitionSchema(i).name)
+          val j = schema().fieldIndex(partitionSchema(i).name)
           newRow.update(j, to(i))
         }
         newRows.withRow(newRow)
@@ -331,7 +338,7 @@ abstract class InMemoryBaseTable(
     this
   }
 
-  override def capabilities: util.Set[TableCapability] = util.EnumSet.of(
+  def baseCapabiilities: Set[TableCapability] = Set(
     TableCapability.BATCH_READ,
     TableCapability.BATCH_WRITE,
     TableCapability.STREAMING_WRITE,
@@ -339,6 +346,14 @@ abstract class InMemoryBaseTable(
     TableCapability.OVERWRITE_DYNAMIC,
     TableCapability.TRUNCATE,
     TableCapability.ACCEPT_ANY_SCHEMA)
+
+  override def capabilities(): util.Set[TableCapability] = {
+    if (acceptAnySchema) {
+      (baseCapabiilities ++ Set(TableCapability.ACCEPT_ANY_SCHEMA)).asJava
+    } else {
+      baseCapabiilities.asJava
+    }
+  }
 
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
     new InMemoryScanBuilder(schema, options)
@@ -558,7 +573,12 @@ abstract class InMemoryBaseTable(
         advisoryPartitionSize.getOrElse(0)
       }
 
-      override def toBatch: BatchWrite = writer
+      override def toBatch: BatchWrite = {
+        val newSchema = info.schema()
+        tableColumns = CatalogV2Util.structTypeToV2Columns(
+          mergeSchema(CatalogV2Util.v2ColumnsToStructType(columns()), newSchema))
+        writer
+      }
 
       override def toStreaming: StreamingWrite = streamingWriter match {
         case exc: StreamingNotSupportedOperation => exc.throwsException()
@@ -571,6 +591,17 @@ abstract class InMemoryBaseTable(
 
       override def reportDriverMetrics(): Array[CustomTaskMetric] = {
         Array(new InMemoryCustomDriverTaskMetric(rows.size))
+      }
+
+      def mergeSchema(oldType: StructType, newType: StructType): StructType = {
+        val (oldFields, newFields) = (oldType.fields, newType.fields)
+
+        // this does not override the old field with the new field with same name for now
+        val nameToFieldMap = oldFields.map (f => f.name -> f).toMap
+        val remainingNewFields = newFields.filterNot (f => nameToFieldMap.contains (f.name) )
+
+        // Create the merged struct with the new fields are appended at the end of the struct.
+        StructType (oldFields ++ remainingNewFields)
       }
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -337,7 +337,8 @@ abstract class InMemoryBaseTable(
     TableCapability.STREAMING_WRITE,
     TableCapability.OVERWRITE_BY_FILTER,
     TableCapability.OVERWRITE_DYNAMIC,
-    TableCapability.TRUNCATE)
+    TableCapability.TRUNCATE,
+    TableCapability.ACCEPT_ANY_SCHEMA)
 
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
     new InMemoryScanBuilder(schema, options)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -344,8 +344,7 @@ abstract class InMemoryBaseTable(
     TableCapability.STREAMING_WRITE,
     TableCapability.OVERWRITE_BY_FILTER,
     TableCapability.OVERWRITE_DYNAMIC,
-    TableCapability.TRUNCATE,
-    TableCapability.ACCEPT_ANY_SCHEMA)
+    TableCapability.TRUNCATE)
 
   override def capabilities(): util.Set[TableCapability] = {
     if (acceptAnySchema) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
@@ -846,6 +846,20 @@ class DataSourceV2DataFrameSuite
     }
   }
 
+  test("insert with schema evolution") {
+    val tableName = "testcat.ns1.ns2.tbl"
+    withTable(tableName) {
+      val columns = Array(
+        Column.create("c1", IntegerType)
+      )
+      val tableInfo = new TableInfo.Builder().withColumns(columns).build()
+      catalog("testcat").createTable(Identifier.of(Array("ns1", "ns2"), "tbl"), tableInfo)
+      Seq((1, "a"), (2, "b"), (3, "c")).toDF("c1", "c2")
+        .writeTo(tableName)
+        .append()
+    }
+  }
+
   private def executeAndKeepPhysicalPlan[T <: SparkPlan](func: => Unit): T = {
     val qe = withQueryExecutionsCaptured(spark) {
       func

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.connector
 
 import java.util.Collections
 
+import scala.jdk.CollectionConverters._
+
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SaveMode}
 import org.apache.spark.sql.QueryTest.withQueryExecutionsCaptured
@@ -848,15 +850,25 @@ class DataSourceV2DataFrameSuite
 
   test("insert with schema evolution") {
     val tableName = "testcat.ns1.ns2.tbl"
+    val ident = Identifier.of(Array("ns1", "ns2"), "tbl")
     withTable(tableName) {
-      val columns = Array(
-        Column.create("c1", IntegerType)
-      )
-      val tableInfo = new TableInfo.Builder().withColumns(columns).build()
-      catalog("testcat").createTable(Identifier.of(Array("ns1", "ns2"), "tbl"), tableInfo)
-      Seq((1, "a"), (2, "b"), (3, "c")).toDF("c1", "c2")
-        .writeTo(tableName)
-        .append()
+      val tableInfo = new TableInfo.Builder().
+        withColumns(
+          Array(Column.create("c1", IntegerType)))
+        .withProperties(
+          Map("accept-any-schema" -> "true").asJava)
+        .build()
+      catalog("testcat").createTable(ident, tableInfo)
+
+      val data = Seq((1, "a"), (2, "b"), (3, "c")).toDF("c1", "c2")
+      data.writeTo(tableName).append()
+
+      checkAnswer(spark.table(tableName), data)
+      val cols = catalog("testcat").loadTable(ident).columns()
+      val expectedCols = Array(
+        Column.create("c1", IntegerType),
+        Column.create("c2", StringType))
+      assert(cols === expectedCols)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add test for DSV2 Write schema evolution for InMemoryTable, by making it support TableCapability.ACCEPT_ANY_SCHEMA.

### Why are the changes needed?
There is a test on the analysis phase in V2WriteAnalysisSuite to make sure it skips the output resolution if this flag is enabled.  But it is not end-to-end test for this feature (schema evolution on V2Write).  For authors of DSV2 connector, its better to have an end to end test using the demo InMemoryTable to show to how to use this feature.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Ran the new test


### Was this patch authored or co-authored using generative AI tooling?
No
