### PR TITLE
[MINOR][PYTHON][TESTS] De-flake unit tests of `collect_set` and `collect_list` in `test_connect_function`

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -551,8 +551,6 @@ class SparkConnectFunctionTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
             (CF.approx_count_distinct, SF.approx_count_distinct),
             (CF.approxCountDistinct, SF.approxCountDistinct),
             (CF.avg, SF.avg),
-            (CF.collect_list, SF.collect_list),
-            (CF.collect_set, SF.collect_set),
             (CF.listagg, SF.listagg),
             (CF.listagg_distinct, SF.listagg_distinct),
             (CF.string_agg, SF.string_agg),
@@ -586,6 +584,25 @@ class SparkConnectFunctionTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
             self.assert_eq(
                 cdf.groupBy("a").agg(cfunc("b"), cfunc(cdf.c)).toPandas(),
                 sdf.groupBy("a").agg(sfunc("b"), sfunc(sdf.c)).toPandas(),
+                check_exact=False,
+            )
+
+        for cfunc, sfunc in [
+            (CF.collect_list, SF.collect_list),
+            (CF.collect_set, SF.collect_set),
+        ]:
+            self.assert_eq(
+                cdf.select(CF.sort_array(cfunc("b")), CF.sort_array(cfunc(cdf.c))).toPandas(),
+                sdf.select(SF.sort_array(sfunc("b")), SF.sort_array(sfunc(sdf.c))).toPandas(),
+                check_exact=False,
+            )
+            self.assert_eq(
+                cdf.groupBy("a")
+                .agg(CF.sort_array(cfunc("b")), CF.sort_array(cfunc(cdf.c)))
+                .toPandas(),
+                sdf.groupBy("a")
+                .agg(SF.sort_array(sfunc("b")), SF.sort_array(sfunc(sdf.c)))
+                .toPandas(),
                 check_exact=False,
             )
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
De-flake unit tests of `collect_set` and `collect_list`, by sorting the output arrays


### Why are the changes needed?
the tests occasionally fail with 
```
AssertionError: DataFrame.iloc[:, 0] (column name="r1") are different
DataFrame.iloc[:, 0] (column name="r1") values are different (100.0 %)
[index]: [0]
[left]:  [[nan, 2.1, 0.5]]
[right]: [[2.1, nan, 0.5]]
At positional index 0, first diff: [nan 2.1 0.5] != [2.1 nan 0.5]
```


### Does this PR introduce _any_ user-facing change?
no, test-only

### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No