### PR TITLE
[SPARK-52804][BUILD] Add a check for the Java version used to build Spark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2629,7 +2629,8 @@
                     <version>${maven.version}</version>
                   </requireMavenVersion>
                   <requireJavaVersion>
-                    <version>${java.version}</version>
+                    <version>[17.0.11,)</version>
+                    <message>Java version must be 17.0.11 or higher</message>
                   </requireJavaVersion>
                   <bannedDependencies>
                     <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>17</java.version>
+    <java.minimum.version>17.0.11</java.minimum.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <maven.version>3.9.10</maven.version>
     <exec-maven-plugin.version>3.5.1</exec-maven-plugin.version>
@@ -2629,8 +2630,8 @@
                     <version>${maven.version}</version>
                   </requireMavenVersion>
                   <requireJavaVersion>
-                    <version>[17.0.11,)</version>
-                    <message>Java version must be 17.0.11 or higher</message>
+                    <version>[${java.minimum.version},)</version>
+                    <message>The Java version used to build the project is outdated. Please use ${java.minimum.version} or later.</message>
                   </requireJavaVersion>
                   <bannedDependencies>
                     <excludes>


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this pr, a new property named `java.minimum.version` has been introduced. Its purpose is to specify the minimum Java version required for building Spark projects. During the project build process, the Java version used by users will be validated based on this property:

- For the Maven build tool, the `version` property of `requireJavaVersion` of `maven-enforcer-plugin` in the current pr has been set to `[${java.minimum.version},)`.

- In the SBT build tool, this pr defines a task named `checkJavaVersion`. This task is designed to perform Java version checks with functionality similar to that of the `maven-enforcer-plugin`.

### Why are the changes needed?
To address similar questions raised by developers in https://github.com/apache/spark/pull/51144, it is necessary to verify the Java version used by users for building the Spark. Once it is detected that this version does not meet the version requirements for project building, clear information should be provided to users.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- It passed Github Actions.
- Currently, `java.minimum.version` is set to 17.0.11. Project build tests were carried out using Java versions 17.0.9/17.0.10/17.0.15/21.0.4. As expected, errors were reported for 17.0.9/17.0.10 along with messages, while 17.0.15/21.0.4 allowed for normal successful build:

**Maven**

```
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.642 s
[INFO] Finished at: 2025-07-17T00:19:22+08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.6.0:enforce (enforce-versions) on project spark-parent_2.13: 
[ERROR] Rule 1: org.apache.maven.enforcer.rules.version.RequireJavaVersion failed with message:
[ERROR] The Java version used to build the project is outdated. Please use 17.0.11 or later.
```

**SBT**

```
[warn] javac exited with exit code 2
[info] Compiling 1 protobuf files to /Users/yangjie01/SourceCode/git/spark-mine-sbt/core/target/scala-2.13/src_managed/main
[error] The Java version used to build the project is outdated. Please use Java 17.0.11 or later.
[error] (core / checkJavaVersion) The Java version used to build the project is outdated. Please use Java 17.0.11 or later.
```

### Was this patch authored or co-authored using generative AI tooling?
No