### PR TITLE
[SPARK-52619][SQL][FOLLOWUP] Simplify casting of TIME to INT

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -856,14 +856,7 @@ case class Cast(
         }
       })
     case _: TimeType =>
-      buildCast[Long](_, t => {
-        val longValue = timeToLong(t)
-        if (longValue == longValue.toInt) {
-          longValue.toInt
-        } else {
-          errorOrNull(t, from, IntegerType)
-        }
-      })
+      buildCast[Long](_, t => timeToLong(t).toInt)
     case x: NumericType if ansiEnabled =>
       val exactNumeric = PhysicalNumericType.exactNumeric(x)
       b => exactNumeric.toInt(b)
@@ -2027,7 +2020,8 @@ case class Cast(
     case DateType =>
       (c, evPrim, evNull) => code"$evNull = true;"
     case TimestampType => castTimestampToIntegralTypeCode(ctx, "int", from, IntegerType)
-    case _: TimeType => castTimeToIntegralTypeCode(ctx, "int", from, IntegerType)
+    case _: TimeType =>
+      (c, evPrim, _) => code"$evPrim = (int) ${timeToLongCode(c)};"
     case DecimalType() => castDecimalToIntegralTypeCode("int")
     case LongType if ansiEnabled =>
       castIntegralTypeToIntegralTypeExactCode(ctx, "int", from, IntegerType)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to do not handle arithmetic overflow while casting a TIME values to INT values because an INT value can cover the full range in seconds from [00:00:00, 23:59:59] = [0, 86399].

### Why are the changes needed?
To avoid unnecessary arithmetic operations and to improve code maintenance.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the related tests:
```
$ build/sbt "test:testOnly *CastWithAnsiOffSuite"
$ build/sbt "test:testOnly *CastWithAnsiOnSuite"
$ build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z cast.sql"
```


### Was this patch authored or co-authored using generative AI tooling?
No.
