### PR TITLE
[SPARK-52824][SS] CheckpointFileManager error classification

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -273,6 +273,24 @@
     ],
     "sqlState" : "0A000"
   },
+  "CANNOT_LOAD_CHECKPOINT_FILE_MANAGER" : {
+    "message" : [
+      "Error loading streaming checkpoint file manager for path=<path>."
+    ],
+    "subClass" : {
+      "ERROR_LOADING_CLASS" : {
+        "message" : [
+          "Error instantiating streaming checkpoint file manager for path=<path> with className=<className>. msg=<msg>."
+        ]
+      },
+      "UNCATEGORIZED" : {
+        "message" : [
+          ""
+        ]
+      }
+    },
+    "sqlState" : "58030"
+  },
   "CANNOT_LOAD_FUNCTION_CLASS" : {
     "message" : [
       "Cannot load class <className> when registering the function <functionName>, please make sure it is on the classpath."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -3086,4 +3086,22 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       )
     )
   }
+
+  def cannotLoadCheckpointFileManagerClass(path: String, className: String, err: Throwable):
+  Throwable = {
+    new SparkException(
+      errorClass = "CANNOT_LOAD_CHECKPOINT_FILE_MANAGER.ERROR_LOADING_CLASS",
+      messageParameters = Map("path" -> path, "className" -> className, "msg" -> err.toString),
+      cause = err
+    )
+  }
+
+  def cannotLoadCheckpointFileManager(path: String, err: Throwable):
+  Throwable = {
+    new SparkException(
+      errorClass = "CANNOT_LOAD_CHECKPOINT_FILE_MANAGER.UNCATEGORIZED",
+      messageParameters = Map("path" -> path),
+      cause = err
+    )
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -3086,22 +3086,4 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       )
     )
   }
-
-  def cannotLoadCheckpointFileManagerClass(path: String, className: String, err: Throwable):
-  Throwable = {
-    new SparkException(
-      errorClass = "CANNOT_LOAD_CHECKPOINT_FILE_MANAGER.ERROR_LOADING_CLASS",
-      messageParameters = Map("path" -> path, "className" -> className, "msg" -> err.toString),
-      cause = err
-    )
-  }
-
-  def cannotLoadCheckpointFileManager(path: String, err: Throwable):
-  Throwable = {
-    new SparkException(
-      errorClass = "CANNOT_LOAD_CHECKPOINT_FILE_MANAGER.UNCATEGORIZED",
-      messageParameters = Map("path" -> path),
-      cause = err
-    )
-  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CheckpointFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CheckpointFileManager.scala
@@ -208,10 +208,10 @@ object CheckpointFileManager extends Logging {
           .asInstanceOf[CheckpointFileManager]
       } catch {
         case e: InvocationTargetException if e.getCause != null =>
-          throw QueryExecutionErrors.cannotLoadCheckpointFileManagerClass(path.toString,
+          throw StreamingErrors.cannotLoadCheckpointFileManagerClass(path.toString,
             fileManagerClass, e.getCause)
         case NonFatal(e) =>
-          throw QueryExecutionErrors.cannotLoadCheckpointFileManagerClass(path.toString,
+          throw StreamingErrors.cannotLoadCheckpointFileManagerClass(path.toString,
               fileManagerClass, e)
       }
     }
@@ -229,7 +229,7 @@ object CheckpointFileManager extends Logging {
             log"and fault-tolerance of your Structured Streaming is not guaranteed.")
         new FileSystemBasedCheckpointFileManager(path, hadoopConf)
       case NonFatal(e) =>
-        throw QueryExecutionErrors.cannotLoadCheckpointFileManager(path.toString, e)
+        throw StreamingErrors.cannotLoadCheckpointFileManager(path.toString, e)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingErrors.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.streaming
+
+import org.apache.spark.SparkException
+
+object StreamingErrors {
+  def cannotLoadCheckpointFileManagerClass(path: String, className: String, err: Throwable):
+  Throwable = {
+    new SparkException(
+      errorClass = "CANNOT_LOAD_CHECKPOINT_FILE_MANAGER.ERROR_LOADING_CLASS",
+      messageParameters = Map("path" -> path, "className" -> className, "msg" -> err.toString),
+      cause = err
+    )
+  }
+
+  def cannotLoadCheckpointFileManager(path: String, err: Throwable):
+  Throwable = {
+    new SparkException(
+      errorClass = "CANNOT_LOAD_CHECKPOINT_FILE_MANAGER.UNCATEGORIZED",
+      messageParameters = Map("path" -> path),
+      cause = err
+    )
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingErrors.scala
@@ -18,6 +18,9 @@ package org.apache.spark.sql.execution.streaming
 
 import org.apache.spark.SparkException
 
+/**
+ * Object for grouping error messages from streaming query exceptions
+ */
 object StreamingErrors {
   def cannotLoadCheckpointFileManagerClass(path: String, className: String, err: Throwable):
   Throwable = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add new Spark error class for errors thrown from CheckpointFileManager.create. Additionally, unwrap InvocationTargetException error so that the underlying error is top-level.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Error classification, and users are confused by InvocationTargetException thrown from this class.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, new error classification

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No