### PR TITLE
[SPARK-52829][PYTHON] Fix LocalDataToArrowConversion.convert to handle empty rows properly

### DIFF
--- a/python/pyspark/sql/tests/test_creation.py
+++ b/python/pyspark/sql/tests/test_creation.py
@@ -35,6 +35,7 @@ from pyspark.errors import (
     PySparkTypeError,
     PySparkValueError,
 )
+from pyspark.testing import assertDataFrameEqual
 from pyspark.testing.sqlutils import (
     ReusedSQLTestCase,
     have_pandas,
@@ -227,6 +228,13 @@ class DataFrameCreationTestsMixin:
                 sdf.withColumn("test", F.col("dict_col")[F.col("str_col")]).collect(),
                 [Row(str_col="second", dict_col={"first": 0.7, "second": 0.3}, test=0.3)],
             )
+
+    def test_empty_schema(self):
+        schema = StructType()
+        for data in [[], [Row()]]:
+            with self.subTest(data=data):
+                sdf = self.spark.createDataFrame(data, schema)
+                assertDataFrameEqual(sdf, data)
 
 
 class DataFrameCreationTests(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `LocalDataToArrowConversion.convert` to handle empty rows properly.

### Why are the changes needed?

The following dataframe creation fails with Spark Connect:

```py
>>> from pyspark.sql.types import Row, StructType
>>> 
>>> data = [Row()] * 3
>>> schema = StructType()
>>> 
>>> spark.createDataFrame(data).show()
Traceback (most recent call last):
...
pyspark.errors.exceptions.connect.InvalidPlanInput: [INTERNAL_ERROR] Input data for LocalRelation does not produce a schema. SQLSTATE: XX000
```

whereas with Spark Classic:

```py
>>> spark.createDataFrame(data).show()
++
||
++
||
||
||
++
```

### Does this PR introduce _any_ user-facing change?

Yes, the empty rows will be handled properly.

### How was this patch tested?

Added the related test.

### Was this patch authored or co-authored using generative AI tooling?

No.
