### PR TITLE
[SPARK-52833][SQL] Fix `VariantBuilder.appendFloat`

### DIFF
--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
@@ -229,7 +229,7 @@ public class VariantBuilder {
   public void appendFloat(float f) {
     checkCapacity(1 + 4);
     writeBuffer[writePos++] = primitiveHeader(FLOAT);
-    writeLong(writeBuffer, writePos, Float.floatToIntBits(f), 8);
+    writeLong(writeBuffer, writePos, Float.floatToIntBits(f), 4);
     writePos += 4;
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
@@ -908,6 +908,9 @@ class VariantExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     check(Array[Byte](1, 2, 3), "\"AQID\"")
     check(Literal(0, DateType), "\"1970-01-01\"")
 
+    val floatArray = Array.tabulate(25) { i => i.toFloat }
+    check(floatArray, floatArray.mkString("[", ",", "]"))
+
     withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
       check(Literal(0L, TimestampType), "\"1970-01-01 00:00:00+00:00\"")
       check(Literal(0L, TimestampNTZType), "\"1970-01-01 00:00:00\"")


### PR DESCRIPTION
### What changes were proposed in this pull request?

There is a small bug that `appendFloat` appends 8 bytes, which should be 4 instead. This doesn't cause a correctness issue, because `writeLong` writes the least significant `numBytes` bytes. When int is extended to long, the lower 4 bytes don't change. This may cause an exception when the buffer doesn't have enough capacity.

### Why are the changes needed?

Bug fix.

### Does this PR introduce _any_ user-facing change?

Yes, as stated above.

### How was this patch tested?

Unit test. It would fail (throw an exception) without the fix.

### Was this patch authored or co-authored using generative AI tooling?

No.