### PR TITLE
[SPARK-52840][PYTHON][DOCS] Increase Pandas minimum version to 2.2.0

### DIFF
--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -225,7 +225,7 @@ Installable with ``pip install "pyspark[connect]"``.
 ========================== ================= ==========================
 Package                    Supported version Note
 ========================== ================= ==========================
-`pandas`                   >=2.0.0           Required for Spark Connect
+`pandas`                   >=2.2.0           Required for Spark Connect
 `pyarrow`                  >=11.0.0          Required for Spark Connect
 `grpcio`                   >=1.67.0          Required for Spark Connect
 `grpcio-status`            >=1.67.0          Required for Spark Connect
@@ -241,7 +241,7 @@ Installable with ``pip install "pyspark[sql]"``.
 ========= ================= ======================
 Package   Supported version Note
 ========= ================= ======================
-`pandas`  >=2.0.0           Required for Spark SQL
+`pandas`  >=2.2.0           Required for Spark SQL
 `pyarrow` >=11.0.0          Required for Spark SQL
 ========= ================= ======================
 
@@ -308,7 +308,7 @@ Installable with ``pip install "pyspark[pipelines]"``. Includes all dependencies
 ========================== ================= ===================================================
 Package                    Supported version Note
 ========================== ================= ===================================================
-`pandas`                   >=2.0.0           Required for Spark Connect and Spark SQL
+`pandas`                   >=2.2.0           Required for Spark Connect and Spark SQL
 `pyarrow`                  >=11.0.0          Required for Spark Connect and Spark SQL
 `grpcio`                   >=1.67.0          Required for Spark Connect
 `grpcio-status`            >=1.67.0          Required for Spark Connect

--- a/python/docs/source/tutorial/sql/arrow_pandas.rst
+++ b/python/docs/source/tutorial/sql/arrow_pandas.rst
@@ -434,7 +434,7 @@ working with timestamps in ``pandas_udf``\s to get the best performance, see
 Recommended Pandas and PyArrow Versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For usage with pyspark.sql, the minimum supported versions of Pandas is 2.0.0 and PyArrow is 11.0.0.
+For usage with pyspark.sql, the minimum supported versions of Pandas is 2.2.0 and PyArrow is 11.0.0.
 Higher versions may be used, however, compatibility and data correctness can not be guaranteed and should
 be verified by the user.
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Increase Pandas minimum version to 2.2.0

### Why are the changes needed?
Based on my tests for upgrading minimum python version to 3.10, Pandas < 2.2.0 fails a group of Pyspark tests


### Does this PR introduce _any_ user-facing change?
Yes, doc-only

### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
No