### PR TITLE
[SPARK-52841][SQL][TESTS] Fix PlanStabilitySuite id normalization

### DIFF
--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/explain.txt
@@ -61,127 +61,127 @@ Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
-Condition : (((isnotnull(c_customer_sk#1) AND isnotnull(c_current_addr_sk#3)) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(Subquery scalar-subquery#4, [id=#5], xxhash64(c_current_addr_sk#3, 42)))
+Condition : (((isnotnull(c_customer_sk#1) AND isnotnull(c_current_addr_sk#3)) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(Subquery scalar-subquery#4, [id=#1], xxhash64(c_current_addr_sk#3, 42)))
 
 (4) Exchange
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
-Arguments: hashpartitioning(c_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
+Arguments: hashpartitioning(c_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (5) Sort [codegen id : 2]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 Arguments: [c_customer_sk#1 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.web_sales
-Output [2]: [ws_bill_customer_sk#6, ws_sold_date_sk#7]
+Output [2]: [ws_bill_customer_sk#5, ws_sold_date_sk#6]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#7), dynamicpruningexpression(ws_sold_date_sk#7 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#6), dynamicpruningexpression(ws_sold_date_sk#6 IN dynamicpruning#7)]
 PushedFilters: [IsNotNull(ws_bill_customer_sk)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
 (7) ColumnarToRow [codegen id : 4]
-Input [2]: [ws_bill_customer_sk#6, ws_sold_date_sk#7]
+Input [2]: [ws_bill_customer_sk#5, ws_sold_date_sk#6]
 
 (8) Filter [codegen id : 4]
-Input [2]: [ws_bill_customer_sk#6, ws_sold_date_sk#7]
-Condition : isnotnull(ws_bill_customer_sk#6)
+Input [2]: [ws_bill_customer_sk#5, ws_sold_date_sk#6]
+Condition : isnotnull(ws_bill_customer_sk#5)
 
 (9) ReusedExchange [Reuses operator id: 60]
-Output [1]: [d_date_sk#9]
+Output [1]: [d_date_sk#8]
 
 (10) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ws_sold_date_sk#7]
-Right keys [1]: [d_date_sk#9]
+Left keys [1]: [ws_sold_date_sk#6]
+Right keys [1]: [d_date_sk#8]
 Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 4]
-Output [1]: [ws_bill_customer_sk#6 AS customer_sk#10]
-Input [3]: [ws_bill_customer_sk#6, ws_sold_date_sk#7, d_date_sk#9]
+Output [1]: [ws_bill_customer_sk#5 AS customer_sk#9]
+Input [3]: [ws_bill_customer_sk#5, ws_sold_date_sk#6, d_date_sk#8]
 
 (12) Scan parquet spark_catalog.default.catalog_sales
-Output [2]: [cs_ship_customer_sk#11, cs_sold_date_sk#12]
+Output [2]: [cs_ship_customer_sk#10, cs_sold_date_sk#11]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#12), dynamicpruningexpression(cs_sold_date_sk#12 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#11), dynamicpruningexpression(cs_sold_date_sk#11 IN dynamicpruning#7)]
 PushedFilters: [IsNotNull(cs_ship_customer_sk)]
 ReadSchema: struct<cs_ship_customer_sk:int>
 
 (13) ColumnarToRow [codegen id : 6]
-Input [2]: [cs_ship_customer_sk#11, cs_sold_date_sk#12]
+Input [2]: [cs_ship_customer_sk#10, cs_sold_date_sk#11]
 
 (14) Filter [codegen id : 6]
-Input [2]: [cs_ship_customer_sk#11, cs_sold_date_sk#12]
-Condition : isnotnull(cs_ship_customer_sk#11)
+Input [2]: [cs_ship_customer_sk#10, cs_sold_date_sk#11]
+Condition : isnotnull(cs_ship_customer_sk#10)
 
 (15) ReusedExchange [Reuses operator id: 60]
-Output [1]: [d_date_sk#13]
+Output [1]: [d_date_sk#12]
 
 (16) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [cs_sold_date_sk#12]
-Right keys [1]: [d_date_sk#13]
+Left keys [1]: [cs_sold_date_sk#11]
+Right keys [1]: [d_date_sk#12]
 Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 6]
-Output [1]: [cs_ship_customer_sk#11 AS customer_sk#14]
-Input [3]: [cs_ship_customer_sk#11, cs_sold_date_sk#12, d_date_sk#13]
+Output [1]: [cs_ship_customer_sk#10 AS customer_sk#13]
+Input [3]: [cs_ship_customer_sk#10, cs_sold_date_sk#11, d_date_sk#12]
 
 (18) Union
 
 (19) Exchange
-Input [1]: [customer_sk#10]
-Arguments: hashpartitioning(customer_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [1]: [customer_sk#9]
+Arguments: hashpartitioning(customer_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (20) Sort [codegen id : 7]
-Input [1]: [customer_sk#10]
-Arguments: [customer_sk#10 ASC NULLS FIRST], false, 0
+Input [1]: [customer_sk#9]
+Arguments: [customer_sk#9 ASC NULLS FIRST], false, 0
 
 (21) SortMergeJoin [codegen id : 8]
 Left keys [1]: [c_customer_sk#1]
-Right keys [1]: [customer_sk#10]
+Right keys [1]: [customer_sk#9]
 Join type: LeftSemi
 Join condition: None
 
 (22) Scan parquet spark_catalog.default.store_sales
-Output [2]: [ss_customer_sk#15, ss_sold_date_sk#16]
+Output [2]: [ss_customer_sk#14, ss_sold_date_sk#15]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#16), dynamicpruningexpression(ss_sold_date_sk#16 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#15), dynamicpruningexpression(ss_sold_date_sk#15 IN dynamicpruning#7)]
 PushedFilters: [IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int>
 
 (23) ColumnarToRow [codegen id : 10]
-Input [2]: [ss_customer_sk#15, ss_sold_date_sk#16]
+Input [2]: [ss_customer_sk#14, ss_sold_date_sk#15]
 
 (24) Filter [codegen id : 10]
-Input [2]: [ss_customer_sk#15, ss_sold_date_sk#16]
-Condition : isnotnull(ss_customer_sk#15)
+Input [2]: [ss_customer_sk#14, ss_sold_date_sk#15]
+Condition : isnotnull(ss_customer_sk#14)
 
 (25) ReusedExchange [Reuses operator id: 60]
-Output [1]: [d_date_sk#17]
+Output [1]: [d_date_sk#16]
 
 (26) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [ss_sold_date_sk#16]
-Right keys [1]: [d_date_sk#17]
+Left keys [1]: [ss_sold_date_sk#15]
+Right keys [1]: [d_date_sk#16]
 Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 10]
-Output [1]: [ss_customer_sk#15 AS customer_sk#18]
-Input [3]: [ss_customer_sk#15, ss_sold_date_sk#16, d_date_sk#17]
+Output [1]: [ss_customer_sk#14 AS customer_sk#17]
+Input [3]: [ss_customer_sk#14, ss_sold_date_sk#15, d_date_sk#16]
 
 (28) Exchange
-Input [1]: [customer_sk#18]
-Arguments: hashpartitioning(customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [1]: [customer_sk#17]
+Arguments: hashpartitioning(customer_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (29) Sort [codegen id : 11]
-Input [1]: [customer_sk#18]
-Arguments: [customer_sk#18 ASC NULLS FIRST], false, 0
+Input [1]: [customer_sk#17]
+Arguments: [customer_sk#17 ASC NULLS FIRST], false, 0
 
 (30) SortMergeJoin [codegen id : 13]
 Left keys [1]: [c_customer_sk#1]
-Right keys [1]: [customer_sk#18]
+Right keys [1]: [customer_sk#17]
 Join type: LeftSemi
 Join condition: None
 
@@ -190,90 +190,90 @@ Output [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
 (32) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#19, ca_county#20]
+Output [2]: [ca_address_sk#18, ca_county#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Douglas County,Gaines County,Richland County,Walker County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
 (33) ColumnarToRow [codegen id : 12]
-Input [2]: [ca_address_sk#19, ca_county#20]
+Input [2]: [ca_address_sk#18, ca_county#19]
 
 (34) Filter [codegen id : 12]
-Input [2]: [ca_address_sk#19, ca_county#20]
-Condition : (ca_county#20 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#19))
+Input [2]: [ca_address_sk#18, ca_county#19]
+Condition : (ca_county#19 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#18))
 
 (35) Project [codegen id : 12]
-Output [1]: [ca_address_sk#19]
-Input [2]: [ca_address_sk#19, ca_county#20]
+Output [1]: [ca_address_sk#18]
+Input [2]: [ca_address_sk#18, ca_county#19]
 
 (36) BroadcastExchange
-Input [1]: [ca_address_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+Input [1]: [ca_address_sk#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 (37) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [c_current_addr_sk#3]
-Right keys [1]: [ca_address_sk#19]
+Right keys [1]: [ca_address_sk#18]
 Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 13]
 Output [1]: [c_current_cdemo_sk#2]
-Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#19]
+Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#18]
 
 (39) BroadcastExchange
 Input [1]: [c_current_cdemo_sk#2]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
 (40) Scan parquet spark_catalog.default.customer_demographics
-Output [9]: [cd_demo_sk#21, cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
+Output [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string,cd_purchase_estimate:int,cd_credit_rating:string,cd_dep_count:int,cd_dep_employed_count:int,cd_dep_college_count:int>
 
 (41) ColumnarToRow
-Input [9]: [cd_demo_sk#21, cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
+Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 
 (42) Filter
-Input [9]: [cd_demo_sk#21, cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
-Condition : isnotnull(cd_demo_sk#21)
+Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Condition : isnotnull(cd_demo_sk#20)
 
 (43) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_current_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#21]
+Right keys [1]: [cd_demo_sk#20]
 Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 14]
-Output [8]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
-Input [10]: [c_current_cdemo_sk#2, cd_demo_sk#21, cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
+Output [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Input [10]: [c_current_cdemo_sk#2, cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 
 (45) HashAggregate [codegen id : 14]
-Input [8]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
-Keys [8]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
+Input [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#30]
-Results [9]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29, count#31]
+Aggregate Attributes [1]: [count#29]
+Results [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
 
 (46) Exchange
-Input [9]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29, count#31]
-Arguments: hashpartitioning(cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
+Arguments: hashpartitioning(cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
 (47) HashAggregate [codegen id : 15]
-Input [9]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29, count#31]
-Keys [8]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
+Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
+Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#32]
-Results [14]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, count(1)#32 AS cnt1#33, cd_purchase_estimate#25, count(1)#32 AS cnt2#34, cd_credit_rating#26, count(1)#32 AS cnt3#35, cd_dep_count#27, count(1)#32 AS cnt4#36, cd_dep_employed_count#28, count(1)#32 AS cnt5#37, cd_dep_college_count#29, count(1)#32 AS cnt6#38]
+Aggregate Attributes [1]: [count(1)#31]
+Results [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, count(1)#31 AS cnt1#32, cd_purchase_estimate#24, count(1)#31 AS cnt2#33, cd_credit_rating#25, count(1)#31 AS cnt3#34, cd_dep_count#26, count(1)#31 AS cnt4#35, cd_dep_employed_count#27, count(1)#31 AS cnt5#36, cd_dep_college_count#28, count(1)#31 AS cnt6#37]
 
 (48) TakeOrderedAndProject
-Input [14]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cnt1#33, cd_purchase_estimate#25, cnt2#34, cd_credit_rating#26, cnt3#35, cd_dep_count#27, cnt4#36, cd_dep_employed_count#28, cnt5#37, cd_dep_college_count#29, cnt6#38]
-Arguments: 100, [cd_gender#22 ASC NULLS FIRST, cd_marital_status#23 ASC NULLS FIRST, cd_education_status#24 ASC NULLS FIRST, cd_purchase_estimate#25 ASC NULLS FIRST, cd_credit_rating#26 ASC NULLS FIRST, cd_dep_count#27 ASC NULLS FIRST, cd_dep_employed_count#28 ASC NULLS FIRST, cd_dep_college_count#29 ASC NULLS FIRST], [cd_gender#22, cd_marital_status#23, cd_education_status#24, cnt1#33, cd_purchase_estimate#25, cnt2#34, cd_credit_rating#26, cnt3#35, cd_dep_count#27, cnt4#36, cd_dep_employed_count#28, cnt5#37, cd_dep_college_count#29, cnt6#38]
+Input [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
+Arguments: 100, [cd_gender#21 ASC NULLS FIRST, cd_marital_status#22 ASC NULLS FIRST, cd_education_status#23 ASC NULLS FIRST, cd_purchase_estimate#24 ASC NULLS FIRST, cd_credit_rating#25 ASC NULLS FIRST, cd_dep_count#26 ASC NULLS FIRST, cd_dep_employed_count#27 ASC NULLS FIRST, cd_dep_college_count#28 ASC NULLS FIRST], [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#4, [id=#5]
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#4, [id=#1]
 ObjectHashAggregate (55)
 +- Exchange (54)
    +- ObjectHashAggregate (53)
@@ -284,42 +284,42 @@ ObjectHashAggregate (55)
 
 
 (49) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#19, ca_county#20]
+Output [2]: [ca_address_sk#18, ca_county#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Douglas County,Gaines County,Richland County,Walker County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
 (50) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#19, ca_county#20]
+Input [2]: [ca_address_sk#18, ca_county#19]
 
 (51) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#19, ca_county#20]
-Condition : (ca_county#20 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#19))
+Input [2]: [ca_address_sk#18, ca_county#19]
+Condition : (ca_county#19 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#18))
 
 (52) Project [codegen id : 1]
-Output [1]: [ca_address_sk#19]
-Input [2]: [ca_address_sk#19, ca_county#20]
+Output [1]: [ca_address_sk#18]
+Input [2]: [ca_address_sk#18, ca_county#19]
 
 (53) ObjectHashAggregate
-Input [1]: [ca_address_sk#19]
+Input [1]: [ca_address_sk#18]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#19, 42), 2555, 57765, 0, 0)]
-Aggregate Attributes [1]: [buf#39]
-Results [1]: [buf#40]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)]
+Aggregate Attributes [1]: [buf#38]
+Results [1]: [buf#39]
 
 (54) Exchange
-Input [1]: [buf#40]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
+Input [1]: [buf#39]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
 (55) ObjectHashAggregate
-Input [1]: [buf#40]
+Input [1]: [buf#39]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#19, 42), 2555, 57765, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#19, 42), 2555, 57765, 0, 0)#41]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#19, 42), 2555, 57765, 0, 0)#41 AS bloomFilter#42]
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)#40]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)#40 AS bloomFilter#41]
 
-Subquery:2 Hosting operator id = 6 Hosting Expression = ws_sold_date_sk#7 IN dynamicpruning#8
+Subquery:2 Hosting operator id = 6 Hosting Expression = ws_sold_date_sk#6 IN dynamicpruning#7
 BroadcastExchange (60)
 +- * Project (59)
    +- * Filter (58)
@@ -328,29 +328,29 @@ BroadcastExchange (60)
 
 
 (56) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#9, d_year#43, d_moy#44]
+Output [3]: [d_date_sk#8, d_year#42, d_moy#43]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2002), GreaterThanOrEqual(d_moy,4), LessThanOrEqual(d_moy,7), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (57) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#43, d_moy#44]
+Input [3]: [d_date_sk#8, d_year#42, d_moy#43]
 
 (58) Filter [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#43, d_moy#44]
-Condition : (((((isnotnull(d_year#43) AND isnotnull(d_moy#44)) AND (d_year#43 = 2002)) AND (d_moy#44 >= 4)) AND (d_moy#44 <= 7)) AND isnotnull(d_date_sk#9))
+Input [3]: [d_date_sk#8, d_year#42, d_moy#43]
+Condition : (((((isnotnull(d_year#42) AND isnotnull(d_moy#43)) AND (d_year#42 = 2002)) AND (d_moy#43 >= 4)) AND (d_moy#43 <= 7)) AND isnotnull(d_date_sk#8))
 
 (59) Project [codegen id : 1]
-Output [1]: [d_date_sk#9]
-Input [3]: [d_date_sk#9, d_year#43, d_moy#44]
+Output [1]: [d_date_sk#8]
+Input [3]: [d_date_sk#8, d_year#42, d_moy#43]
 
 (60) BroadcastExchange
-Input [1]: [d_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+Input [1]: [d_date_sk#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
-Subquery:3 Hosting operator id = 12 Hosting Expression = cs_sold_date_sk#12 IN dynamicpruning#8
+Subquery:3 Hosting operator id = 12 Hosting Expression = cs_sold_date_sk#11 IN dynamicpruning#7
 
-Subquery:4 Hosting operator id = 22 Hosting Expression = ss_sold_date_sk#16 IN dynamicpruning#8
+Subquery:4 Hosting operator id = 22 Hosting Expression = ss_sold_date_sk#15 IN dynamicpruning#7
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59.sf100/explain.txt
@@ -82,11 +82,11 @@ Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
 
 (6) Filter [codegen id : 1]
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
-Condition : ((isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(d_week_seq#5, 42)))
+Condition : ((isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5)) AND might_contain(Subquery scalar-subquery#7, [id=#1], xxhash64(d_week_seq#5, 42)))
 
 (7) BroadcastExchange
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
@@ -102,222 +102,222 @@ Input [6]: [ss_store_sk#1, ss_sales_price#2, ss_sold_date_sk#3, d_date_sk#4, d_w
 Input [4]: [ss_store_sk#1, ss_sales_price#2, d_week_seq#5, d_day_name#6]
 Keys [2]: [d_week_seq#5, ss_store_sk#1]
 Functions [7]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#6 = Sunday   ) THEN ss_sales_price#2 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#6 = Monday   ) THEN ss_sales_price#2 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#6 = Tuesday  ) THEN ss_sales_price#2 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#6 = Wednesday) THEN ss_sales_price#2 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#6 = Thursday ) THEN ss_sales_price#2 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#6 = Friday   ) THEN ss_sales_price#2 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#6 = Saturday ) THEN ss_sales_price#2 END))]
-Aggregate Attributes [7]: [sum#9, sum#10, sum#11, sum#12, sum#13, sum#14, sum#15]
-Results [9]: [d_week_seq#5, ss_store_sk#1, sum#16, sum#17, sum#18, sum#19, sum#20, sum#21, sum#22]
+Aggregate Attributes [7]: [sum#8, sum#9, sum#10, sum#11, sum#12, sum#13, sum#14]
+Results [9]: [d_week_seq#5, ss_store_sk#1, sum#15, sum#16, sum#17, sum#18, sum#19, sum#20, sum#21]
 
 (11) Exchange
-Input [9]: [d_week_seq#5, ss_store_sk#1, sum#16, sum#17, sum#18, sum#19, sum#20, sum#21, sum#22]
-Arguments: hashpartitioning(d_week_seq#5, ss_store_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [9]: [d_week_seq#5, ss_store_sk#1, sum#15, sum#16, sum#17, sum#18, sum#19, sum#20, sum#21]
+Arguments: hashpartitioning(d_week_seq#5, ss_store_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (12) HashAggregate [codegen id : 10]
-Input [9]: [d_week_seq#5, ss_store_sk#1, sum#16, sum#17, sum#18, sum#19, sum#20, sum#21, sum#22]
+Input [9]: [d_week_seq#5, ss_store_sk#1, sum#15, sum#16, sum#17, sum#18, sum#19, sum#20, sum#21]
 Keys [2]: [d_week_seq#5, ss_store_sk#1]
 Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#6 = Sunday   ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Monday   ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Tuesday  ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Wednesday) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Thursday ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Friday   ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Saturday ) THEN ss_sales_price#2 END))]
-Aggregate Attributes [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#6 = Sunday   ) THEN ss_sales_price#2 END))#23, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Monday   ) THEN ss_sales_price#2 END))#24, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Tuesday  ) THEN ss_sales_price#2 END))#25, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Wednesday) THEN ss_sales_price#2 END))#26, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Thursday ) THEN ss_sales_price#2 END))#27, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Friday   ) THEN ss_sales_price#2 END))#28, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Saturday ) THEN ss_sales_price#2 END))#29]
-Results [9]: [d_week_seq#5, ss_store_sk#1, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Sunday   ) THEN ss_sales_price#2 END))#23,17,2) AS sun_sales#30, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Monday   ) THEN ss_sales_price#2 END))#24,17,2) AS mon_sales#31, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Tuesday  ) THEN ss_sales_price#2 END))#25,17,2) AS tue_sales#32, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Wednesday) THEN ss_sales_price#2 END))#26,17,2) AS wed_sales#33, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Thursday ) THEN ss_sales_price#2 END))#27,17,2) AS thu_sales#34, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Friday   ) THEN ss_sales_price#2 END))#28,17,2) AS fri_sales#35, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Saturday ) THEN ss_sales_price#2 END))#29,17,2) AS sat_sales#36]
+Aggregate Attributes [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#6 = Sunday   ) THEN ss_sales_price#2 END))#22, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Monday   ) THEN ss_sales_price#2 END))#23, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Tuesday  ) THEN ss_sales_price#2 END))#24, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Wednesday) THEN ss_sales_price#2 END))#25, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Thursday ) THEN ss_sales_price#2 END))#26, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Friday   ) THEN ss_sales_price#2 END))#27, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Saturday ) THEN ss_sales_price#2 END))#28]
+Results [9]: [d_week_seq#5, ss_store_sk#1, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Sunday   ) THEN ss_sales_price#2 END))#22,17,2) AS sun_sales#29, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Monday   ) THEN ss_sales_price#2 END))#23,17,2) AS mon_sales#30, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Tuesday  ) THEN ss_sales_price#2 END))#24,17,2) AS tue_sales#31, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Wednesday) THEN ss_sales_price#2 END))#25,17,2) AS wed_sales#32, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Thursday ) THEN ss_sales_price#2 END))#26,17,2) AS thu_sales#33, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Friday   ) THEN ss_sales_price#2 END))#27,17,2) AS fri_sales#34, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Saturday ) THEN ss_sales_price#2 END))#28,17,2) AS sat_sales#35]
 
 (13) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#37, s_store_id#38, s_store_name#39]
+Output [3]: [s_store_sk#36, s_store_id#37, s_store_name#38]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_id)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string,s_store_name:string>
 
 (14) ColumnarToRow [codegen id : 3]
-Input [3]: [s_store_sk#37, s_store_id#38, s_store_name#39]
+Input [3]: [s_store_sk#36, s_store_id#37, s_store_name#38]
 
 (15) Filter [codegen id : 3]
-Input [3]: [s_store_sk#37, s_store_id#38, s_store_name#39]
-Condition : (isnotnull(s_store_sk#37) AND isnotnull(s_store_id#38))
+Input [3]: [s_store_sk#36, s_store_id#37, s_store_name#38]
+Condition : (isnotnull(s_store_sk#36) AND isnotnull(s_store_id#37))
 
 (16) BroadcastExchange
-Input [3]: [s_store_sk#37, s_store_id#38, s_store_name#39]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
+Input [3]: [s_store_sk#36, s_store_id#37, s_store_name#38]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
 
 (17) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#1]
-Right keys [1]: [s_store_sk#37]
+Right keys [1]: [s_store_sk#36]
 Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 10]
-Output [10]: [d_week_seq#5, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_id#38, s_store_name#39]
-Input [12]: [d_week_seq#5, ss_store_sk#1, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_sk#37, s_store_id#38, s_store_name#39]
+Output [10]: [d_week_seq#5, sun_sales#29, mon_sales#30, tue_sales#31, wed_sales#32, thu_sales#33, fri_sales#34, sat_sales#35, s_store_id#37, s_store_name#38]
+Input [12]: [d_week_seq#5, ss_store_sk#1, sun_sales#29, mon_sales#30, tue_sales#31, wed_sales#32, thu_sales#33, fri_sales#34, sat_sales#35, s_store_sk#36, s_store_id#37, s_store_name#38]
 
 (19) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_month_seq#40, d_week_seq#41]
+Output [2]: [d_month_seq#39, d_week_seq#40]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1185), LessThanOrEqual(d_month_seq,1196), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
 (20) ColumnarToRow [codegen id : 4]
-Input [2]: [d_month_seq#40, d_week_seq#41]
+Input [2]: [d_month_seq#39, d_week_seq#40]
 
 (21) Filter [codegen id : 4]
-Input [2]: [d_month_seq#40, d_week_seq#41]
-Condition : (((isnotnull(d_month_seq#40) AND (d_month_seq#40 >= 1185)) AND (d_month_seq#40 <= 1196)) AND isnotnull(d_week_seq#41))
+Input [2]: [d_month_seq#39, d_week_seq#40]
+Condition : (((isnotnull(d_month_seq#39) AND (d_month_seq#39 >= 1185)) AND (d_month_seq#39 <= 1196)) AND isnotnull(d_week_seq#40))
 
 (22) Project [codegen id : 4]
-Output [1]: [d_week_seq#41]
-Input [2]: [d_month_seq#40, d_week_seq#41]
+Output [1]: [d_week_seq#40]
+Input [2]: [d_month_seq#39, d_week_seq#40]
 
 (23) BroadcastExchange
-Input [1]: [d_week_seq#41]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+Input [1]: [d_week_seq#40]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 (24) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [d_week_seq#5]
-Right keys [1]: [d_week_seq#41]
+Right keys [1]: [d_week_seq#40]
 Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 10]
-Output [10]: [s_store_name#39 AS s_store_name1#42, d_week_seq#5 AS d_week_seq1#43, s_store_id#38 AS s_store_id1#44, sun_sales#30 AS sun_sales1#45, mon_sales#31 AS mon_sales1#46, tue_sales#32 AS tue_sales1#47, wed_sales#33 AS wed_sales1#48, thu_sales#34 AS thu_sales1#49, fri_sales#35 AS fri_sales1#50, sat_sales#36 AS sat_sales1#51]
-Input [11]: [d_week_seq#5, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_id#38, s_store_name#39, d_week_seq#41]
+Output [10]: [s_store_name#38 AS s_store_name1#41, d_week_seq#5 AS d_week_seq1#42, s_store_id#37 AS s_store_id1#43, sun_sales#29 AS sun_sales1#44, mon_sales#30 AS mon_sales1#45, tue_sales#31 AS tue_sales1#46, wed_sales#32 AS wed_sales1#47, thu_sales#33 AS thu_sales1#48, fri_sales#34 AS fri_sales1#49, sat_sales#35 AS sat_sales1#50]
+Input [11]: [d_week_seq#5, sun_sales#29, mon_sales#30, tue_sales#31, wed_sales#32, thu_sales#33, fri_sales#34, sat_sales#35, s_store_id#37, s_store_name#38, d_week_seq#40]
 
 (26) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
+Output [3]: [ss_store_sk#51, ss_sales_price#52, ss_sold_date_sk#53]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#54)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#53)]
 PushedFilters: [IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_store_sk:int,ss_sales_price:decimal(7,2)>
 
 (27) ColumnarToRow [codegen id : 6]
-Input [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
+Input [3]: [ss_store_sk#51, ss_sales_price#52, ss_sold_date_sk#53]
 
 (28) Filter [codegen id : 6]
-Input [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
-Condition : isnotnull(ss_store_sk#52)
+Input [3]: [ss_store_sk#51, ss_sales_price#52, ss_sold_date_sk#53]
+Condition : isnotnull(ss_store_sk#51)
 
 (29) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
+Output [3]: [d_date_sk#54, d_week_seq#55, d_day_name#56]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int,d_day_name:string>
 
 (30) ColumnarToRow [codegen id : 5]
-Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
+Input [3]: [d_date_sk#54, d_week_seq#55, d_day_name#56]
 
 (31) Filter [codegen id : 5]
-Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
-Condition : ((isnotnull(d_date_sk#55) AND isnotnull(d_week_seq#56)) AND might_contain(Subquery scalar-subquery#58, [id=#59], xxhash64(d_week_seq#56, 42)))
+Input [3]: [d_date_sk#54, d_week_seq#55, d_day_name#56]
+Condition : ((isnotnull(d_date_sk#54) AND isnotnull(d_week_seq#55)) AND might_contain(Subquery scalar-subquery#57, [id=#6], xxhash64(d_week_seq#55, 42)))
 
 (32) BroadcastExchange
-Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
+Input [3]: [d_date_sk#54, d_week_seq#55, d_day_name#56]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
 (33) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ss_sold_date_sk#54]
-Right keys [1]: [d_date_sk#55]
+Left keys [1]: [ss_sold_date_sk#53]
+Right keys [1]: [d_date_sk#54]
 Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 6]
-Output [4]: [ss_store_sk#52, ss_sales_price#53, d_week_seq#56, d_day_name#57]
-Input [6]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54, d_date_sk#55, d_week_seq#56, d_day_name#57]
+Output [4]: [ss_store_sk#51, ss_sales_price#52, d_week_seq#55, d_day_name#56]
+Input [6]: [ss_store_sk#51, ss_sales_price#52, ss_sold_date_sk#53, d_date_sk#54, d_week_seq#55, d_day_name#56]
 
 (35) HashAggregate [codegen id : 6]
-Input [4]: [ss_store_sk#52, ss_sales_price#53, d_week_seq#56, d_day_name#57]
-Keys [2]: [d_week_seq#56, ss_store_sk#52]
-Functions [6]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))]
-Aggregate Attributes [6]: [sum#60, sum#61, sum#62, sum#63, sum#64, sum#65]
-Results [8]: [d_week_seq#56, ss_store_sk#52, sum#66, sum#67, sum#68, sum#69, sum#70, sum#71]
+Input [4]: [ss_store_sk#51, ss_sales_price#52, d_week_seq#55, d_day_name#56]
+Keys [2]: [d_week_seq#55, ss_store_sk#51]
+Functions [6]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Sunday   ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Monday   ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Wednesday) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Thursday ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Friday   ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Saturday ) THEN ss_sales_price#52 END))]
+Aggregate Attributes [6]: [sum#58, sum#59, sum#60, sum#61, sum#62, sum#63]
+Results [8]: [d_week_seq#55, ss_store_sk#51, sum#64, sum#65, sum#66, sum#67, sum#68, sum#69]
 
 (36) Exchange
-Input [8]: [d_week_seq#56, ss_store_sk#52, sum#66, sum#67, sum#68, sum#69, sum#70, sum#71]
-Arguments: hashpartitioning(d_week_seq#56, ss_store_sk#52, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [8]: [d_week_seq#55, ss_store_sk#51, sum#64, sum#65, sum#66, sum#67, sum#68, sum#69]
+Arguments: hashpartitioning(d_week_seq#55, ss_store_sk#51, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (37) HashAggregate [codegen id : 9]
-Input [8]: [d_week_seq#56, ss_store_sk#52, sum#66, sum#67, sum#68, sum#69, sum#70, sum#71]
-Keys [2]: [d_week_seq#56, ss_store_sk#52]
-Functions [6]: [sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))]
-Aggregate Attributes [6]: [sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END))#23, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END))#24, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END))#26, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END))#27, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END))#28, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))#29]
-Results [8]: [d_week_seq#56, ss_store_sk#52, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END))#23,17,2) AS sun_sales#72, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END))#24,17,2) AS mon_sales#73, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END))#26,17,2) AS wed_sales#74, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END))#27,17,2) AS thu_sales#75, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END))#28,17,2) AS fri_sales#76, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))#29,17,2) AS sat_sales#77]
+Input [8]: [d_week_seq#55, ss_store_sk#51, sum#64, sum#65, sum#66, sum#67, sum#68, sum#69]
+Keys [2]: [d_week_seq#55, ss_store_sk#51]
+Functions [6]: [sum(UnscaledValue(CASE WHEN (d_day_name#56 = Sunday   ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Monday   ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Wednesday) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Thursday ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Friday   ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Saturday ) THEN ss_sales_price#52 END))]
+Aggregate Attributes [6]: [sum(UnscaledValue(CASE WHEN (d_day_name#56 = Sunday   ) THEN ss_sales_price#52 END))#22, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Monday   ) THEN ss_sales_price#52 END))#23, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Wednesday) THEN ss_sales_price#52 END))#25, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Thursday ) THEN ss_sales_price#52 END))#26, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Friday   ) THEN ss_sales_price#52 END))#27, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Saturday ) THEN ss_sales_price#52 END))#28]
+Results [8]: [d_week_seq#55, ss_store_sk#51, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Sunday   ) THEN ss_sales_price#52 END))#22,17,2) AS sun_sales#70, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Monday   ) THEN ss_sales_price#52 END))#23,17,2) AS mon_sales#71, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Wednesday) THEN ss_sales_price#52 END))#25,17,2) AS wed_sales#72, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Thursday ) THEN ss_sales_price#52 END))#26,17,2) AS thu_sales#73, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Friday   ) THEN ss_sales_price#52 END))#27,17,2) AS fri_sales#74, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Saturday ) THEN ss_sales_price#52 END))#28,17,2) AS sat_sales#75]
 
 (38) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#78, s_store_id#79]
+Output [2]: [s_store_sk#76, s_store_id#77]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_id)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
 (39) ColumnarToRow [codegen id : 7]
-Input [2]: [s_store_sk#78, s_store_id#79]
+Input [2]: [s_store_sk#76, s_store_id#77]
 
 (40) Filter [codegen id : 7]
-Input [2]: [s_store_sk#78, s_store_id#79]
-Condition : (isnotnull(s_store_sk#78) AND isnotnull(s_store_id#79))
+Input [2]: [s_store_sk#76, s_store_id#77]
+Condition : (isnotnull(s_store_sk#76) AND isnotnull(s_store_id#77))
 
 (41) BroadcastExchange
-Input [2]: [s_store_sk#78, s_store_id#79]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
+Input [2]: [s_store_sk#76, s_store_id#77]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
 
 (42) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ss_store_sk#52]
-Right keys [1]: [s_store_sk#78]
+Left keys [1]: [ss_store_sk#51]
+Right keys [1]: [s_store_sk#76]
 Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 9]
-Output [8]: [d_week_seq#56, sun_sales#72, mon_sales#73, wed_sales#74, thu_sales#75, fri_sales#76, sat_sales#77, s_store_id#79]
-Input [10]: [d_week_seq#56, ss_store_sk#52, sun_sales#72, mon_sales#73, wed_sales#74, thu_sales#75, fri_sales#76, sat_sales#77, s_store_sk#78, s_store_id#79]
+Output [8]: [d_week_seq#55, sun_sales#70, mon_sales#71, wed_sales#72, thu_sales#73, fri_sales#74, sat_sales#75, s_store_id#77]
+Input [10]: [d_week_seq#55, ss_store_sk#51, sun_sales#70, mon_sales#71, wed_sales#72, thu_sales#73, fri_sales#74, sat_sales#75, s_store_sk#76, s_store_id#77]
 
 (44) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_month_seq#80, d_week_seq#81]
+Output [2]: [d_month_seq#78, d_week_seq#79]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1197), LessThanOrEqual(d_month_seq,1208), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
 (45) ColumnarToRow [codegen id : 8]
-Input [2]: [d_month_seq#80, d_week_seq#81]
+Input [2]: [d_month_seq#78, d_week_seq#79]
 
 (46) Filter [codegen id : 8]
-Input [2]: [d_month_seq#80, d_week_seq#81]
-Condition : (((isnotnull(d_month_seq#80) AND (d_month_seq#80 >= 1197)) AND (d_month_seq#80 <= 1208)) AND isnotnull(d_week_seq#81))
+Input [2]: [d_month_seq#78, d_week_seq#79]
+Condition : (((isnotnull(d_month_seq#78) AND (d_month_seq#78 >= 1197)) AND (d_month_seq#78 <= 1208)) AND isnotnull(d_week_seq#79))
 
 (47) Project [codegen id : 8]
-Output [1]: [d_week_seq#81]
-Input [2]: [d_month_seq#80, d_week_seq#81]
+Output [1]: [d_week_seq#79]
+Input [2]: [d_month_seq#78, d_week_seq#79]
 
 (48) BroadcastExchange
-Input [1]: [d_week_seq#81]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+Input [1]: [d_week_seq#79]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
 (49) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [d_week_seq#56]
-Right keys [1]: [d_week_seq#81]
+Left keys [1]: [d_week_seq#55]
+Right keys [1]: [d_week_seq#79]
 Join type: Inner
 Join condition: None
 
 (50) Project [codegen id : 9]
-Output [8]: [d_week_seq#56 AS d_week_seq2#82, s_store_id#79 AS s_store_id2#83, sun_sales#72 AS sun_sales2#84, mon_sales#73 AS mon_sales2#85, wed_sales#74 AS wed_sales2#86, thu_sales#75 AS thu_sales2#87, fri_sales#76 AS fri_sales2#88, sat_sales#77 AS sat_sales2#89]
-Input [9]: [d_week_seq#56, sun_sales#72, mon_sales#73, wed_sales#74, thu_sales#75, fri_sales#76, sat_sales#77, s_store_id#79, d_week_seq#81]
+Output [8]: [d_week_seq#55 AS d_week_seq2#80, s_store_id#77 AS s_store_id2#81, sun_sales#70 AS sun_sales2#82, mon_sales#71 AS mon_sales2#83, wed_sales#72 AS wed_sales2#84, thu_sales#73 AS thu_sales2#85, fri_sales#74 AS fri_sales2#86, sat_sales#75 AS sat_sales2#87]
+Input [9]: [d_week_seq#55, sun_sales#70, mon_sales#71, wed_sales#72, thu_sales#73, fri_sales#74, sat_sales#75, s_store_id#77, d_week_seq#79]
 
 (51) BroadcastExchange
-Input [8]: [d_week_seq2#82, s_store_id2#83, sun_sales2#84, mon_sales2#85, wed_sales2#86, thu_sales2#87, fri_sales2#88, sat_sales2#89]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false), [plan_id=9]
+Input [8]: [d_week_seq2#80, s_store_id2#81, sun_sales2#82, mon_sales2#83, wed_sales2#84, thu_sales2#85, fri_sales2#86, sat_sales2#87]
+Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false), [plan_id=11]
 
 (52) BroadcastHashJoin [codegen id : 10]
-Left keys [2]: [s_store_id1#44, d_week_seq1#43]
-Right keys [2]: [s_store_id2#83, (d_week_seq2#82 - 52)]
+Left keys [2]: [s_store_id1#43, d_week_seq1#42]
+Right keys [2]: [s_store_id2#81, (d_week_seq2#80 - 52)]
 Join type: Inner
 Join condition: None
 
 (53) Project [codegen id : 10]
-Output [10]: [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1#45 / sun_sales2#84) AS (sun_sales1 / sun_sales2)#90, (mon_sales1#46 / mon_sales2#85) AS (mon_sales1 / mon_sales2)#91, (tue_sales1#47 / tue_sales1#47) AS (tue_sales1 / tue_sales1)#92, (wed_sales1#48 / wed_sales2#86) AS (wed_sales1 / wed_sales2)#93, (thu_sales1#49 / thu_sales2#87) AS (thu_sales1 / thu_sales2)#94, (fri_sales1#50 / fri_sales2#88) AS (fri_sales1 / fri_sales2)#95, (sat_sales1#51 / sat_sales2#89) AS (sat_sales1 / sat_sales2)#96]
-Input [18]: [s_store_name1#42, d_week_seq1#43, s_store_id1#44, sun_sales1#45, mon_sales1#46, tue_sales1#47, wed_sales1#48, thu_sales1#49, fri_sales1#50, sat_sales1#51, d_week_seq2#82, s_store_id2#83, sun_sales2#84, mon_sales2#85, wed_sales2#86, thu_sales2#87, fri_sales2#88, sat_sales2#89]
+Output [10]: [s_store_name1#41, s_store_id1#43, d_week_seq1#42, (sun_sales1#44 / sun_sales2#82) AS (sun_sales1 / sun_sales2)#88, (mon_sales1#45 / mon_sales2#83) AS (mon_sales1 / mon_sales2)#89, (tue_sales1#46 / tue_sales1#46) AS (tue_sales1 / tue_sales1)#90, (wed_sales1#47 / wed_sales2#84) AS (wed_sales1 / wed_sales2)#91, (thu_sales1#48 / thu_sales2#85) AS (thu_sales1 / thu_sales2)#92, (fri_sales1#49 / fri_sales2#86) AS (fri_sales1 / fri_sales2)#93, (sat_sales1#50 / sat_sales2#87) AS (sat_sales1 / sat_sales2)#94]
+Input [18]: [s_store_name1#41, d_week_seq1#42, s_store_id1#43, sun_sales1#44, mon_sales1#45, tue_sales1#46, wed_sales1#47, thu_sales1#48, fri_sales1#49, sat_sales1#50, d_week_seq2#80, s_store_id2#81, sun_sales2#82, mon_sales2#83, wed_sales2#84, thu_sales2#85, fri_sales2#86, sat_sales2#87]
 
 (54) TakeOrderedAndProject
-Input [10]: [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1 / sun_sales2)#90, (mon_sales1 / mon_sales2)#91, (tue_sales1 / tue_sales1)#92, (wed_sales1 / wed_sales2)#93, (thu_sales1 / thu_sales2)#94, (fri_sales1 / fri_sales2)#95, (sat_sales1 / sat_sales2)#96]
-Arguments: 100, [s_store_name1#42 ASC NULLS FIRST, s_store_id1#44 ASC NULLS FIRST, d_week_seq1#43 ASC NULLS FIRST], [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1 / sun_sales2)#90, (mon_sales1 / mon_sales2)#91, (tue_sales1 / tue_sales1)#92, (wed_sales1 / wed_sales2)#93, (thu_sales1 / thu_sales2)#94, (fri_sales1 / fri_sales2)#95, (sat_sales1 / sat_sales2)#96]
+Input [10]: [s_store_name1#41, s_store_id1#43, d_week_seq1#42, (sun_sales1 / sun_sales2)#88, (mon_sales1 / mon_sales2)#89, (tue_sales1 / tue_sales1)#90, (wed_sales1 / wed_sales2)#91, (thu_sales1 / thu_sales2)#92, (fri_sales1 / fri_sales2)#93, (sat_sales1 / sat_sales2)#94]
+Arguments: 100, [s_store_name1#41 ASC NULLS FIRST, s_store_id1#43 ASC NULLS FIRST, d_week_seq1#42 ASC NULLS FIRST], [s_store_name1#41, s_store_id1#43, d_week_seq1#42, (sun_sales1 / sun_sales2)#88, (mon_sales1 / mon_sales2)#89, (tue_sales1 / tue_sales1)#90, (wed_sales1 / wed_sales2)#91, (thu_sales1 / thu_sales2)#92, (fri_sales1 / fri_sales2)#93, (sat_sales1 / sat_sales2)#94]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 6 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+Subquery:1 Hosting operator id = 6 Hosting Expression = Subquery scalar-subquery#7, [id=#1]
 ObjectHashAggregate (61)
 +- Exchange (60)
    +- ObjectHashAggregate (59)
@@ -328,42 +328,42 @@ ObjectHashAggregate (61)
 
 
 (55) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_month_seq#40, d_week_seq#41]
+Output [2]: [d_month_seq#39, d_week_seq#40]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1185), LessThanOrEqual(d_month_seq,1196), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
 (56) ColumnarToRow [codegen id : 1]
-Input [2]: [d_month_seq#40, d_week_seq#41]
+Input [2]: [d_month_seq#39, d_week_seq#40]
 
 (57) Filter [codegen id : 1]
-Input [2]: [d_month_seq#40, d_week_seq#41]
-Condition : (((isnotnull(d_month_seq#40) AND (d_month_seq#40 >= 1185)) AND (d_month_seq#40 <= 1196)) AND isnotnull(d_week_seq#41))
+Input [2]: [d_month_seq#39, d_week_seq#40]
+Condition : (((isnotnull(d_month_seq#39) AND (d_month_seq#39 >= 1185)) AND (d_month_seq#39 <= 1196)) AND isnotnull(d_week_seq#40))
 
 (58) Project [codegen id : 1]
-Output [1]: [d_week_seq#41]
-Input [2]: [d_month_seq#40, d_week_seq#41]
+Output [1]: [d_week_seq#40]
+Input [2]: [d_month_seq#39, d_week_seq#40]
 
 (59) ObjectHashAggregate
-Input [1]: [d_week_seq#41]
+Input [1]: [d_week_seq#40]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)]
-Aggregate Attributes [1]: [buf#97]
-Results [1]: [buf#98]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#40, 42), 335, 8990, 0, 0)]
+Aggregate Attributes [1]: [buf#95]
+Results [1]: [buf#96]
 
 (60) Exchange
-Input [1]: [buf#98]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
+Input [1]: [buf#96]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
 
 (61) ObjectHashAggregate
-Input [1]: [buf#98]
+Input [1]: [buf#96]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)#99]
-Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)#99 AS bloomFilter#100]
+Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#40, 42), 335, 8990, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#40, 42), 335, 8990, 0, 0)#97]
+Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#40, 42), 335, 8990, 0, 0)#97 AS bloomFilter#98]
 
-Subquery:2 Hosting operator id = 31 Hosting Expression = Subquery scalar-subquery#58, [id=#59]
+Subquery:2 Hosting operator id = 31 Hosting Expression = Subquery scalar-subquery#57, [id=#6]
 ObjectHashAggregate (68)
 +- Exchange (67)
    +- ObjectHashAggregate (66)
@@ -374,39 +374,39 @@ ObjectHashAggregate (68)
 
 
 (62) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_month_seq#80, d_week_seq#81]
+Output [2]: [d_month_seq#78, d_week_seq#79]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1197), LessThanOrEqual(d_month_seq,1208), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
 (63) ColumnarToRow [codegen id : 1]
-Input [2]: [d_month_seq#80, d_week_seq#81]
+Input [2]: [d_month_seq#78, d_week_seq#79]
 
 (64) Filter [codegen id : 1]
-Input [2]: [d_month_seq#80, d_week_seq#81]
-Condition : (((isnotnull(d_month_seq#80) AND (d_month_seq#80 >= 1197)) AND (d_month_seq#80 <= 1208)) AND isnotnull(d_week_seq#81))
+Input [2]: [d_month_seq#78, d_week_seq#79]
+Condition : (((isnotnull(d_month_seq#78) AND (d_month_seq#78 >= 1197)) AND (d_month_seq#78 <= 1208)) AND isnotnull(d_week_seq#79))
 
 (65) Project [codegen id : 1]
-Output [1]: [d_week_seq#81]
-Input [2]: [d_month_seq#80, d_week_seq#81]
+Output [1]: [d_week_seq#79]
+Input [2]: [d_month_seq#78, d_week_seq#79]
 
 (66) ObjectHashAggregate
-Input [1]: [d_week_seq#81]
+Input [1]: [d_week_seq#79]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#81, 42), 335, 8990, 0, 0)]
-Aggregate Attributes [1]: [buf#101]
-Results [1]: [buf#102]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#79, 42), 335, 8990, 0, 0)]
+Aggregate Attributes [1]: [buf#99]
+Results [1]: [buf#100]
 
 (67) Exchange
-Input [1]: [buf#102]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
+Input [1]: [buf#100]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
 
 (68) ObjectHashAggregate
-Input [1]: [buf#102]
+Input [1]: [buf#100]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#81, 42), 335, 8990, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#81, 42), 335, 8990, 0, 0)#103]
-Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#81, 42), 335, 8990, 0, 0)#103 AS bloomFilter#104]
+Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#79, 42), 335, 8990, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#79, 42), 335, 8990, 0, 0)#101]
+Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#79, 42), 335, 8990, 0, 0)#101 AS bloomFilter#102]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.sf100/explain.txt
@@ -64,124 +64,124 @@ Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
 
 (3) Filter [codegen id : 1]
 Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
-Condition : ((isnotnull(c_current_addr_sk#5) AND isnotnull(c_current_cdemo_sk#4)) AND might_contain(Subquery scalar-subquery#6, [id=#7], xxhash64(c_current_addr_sk#5, 42)))
+Condition : ((isnotnull(c_current_addr_sk#5) AND isnotnull(c_current_cdemo_sk#4)) AND might_contain(Subquery scalar-subquery#6, [id=#1], xxhash64(c_current_addr_sk#5, 42)))
 
 (4) Exchange
 Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
-Arguments: hashpartitioning(c_customer_sk#3, 5), ENSURE_REQUIREMENTS, [plan_id=1]
+Arguments: hashpartitioning(c_customer_sk#3, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (5) Sort [codegen id : 2]
 Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
 Arguments: [c_customer_sk#3 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.store_sales
-Output [2]: [ss_customer_sk#8, ss_sold_date_sk#9]
+Output [2]: [ss_customer_sk#7, ss_sold_date_sk#8]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#9), dynamicpruningexpression(ss_sold_date_sk#9 IN dynamicpruning#10)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#8), dynamicpruningexpression(ss_sold_date_sk#8 IN dynamicpruning#9)]
 ReadSchema: struct<ss_customer_sk:int>
 
 (7) ColumnarToRow [codegen id : 4]
-Input [2]: [ss_customer_sk#8, ss_sold_date_sk#9]
+Input [2]: [ss_customer_sk#7, ss_sold_date_sk#8]
 
 (8) ReusedExchange [Reuses operator id: 63]
-Output [1]: [d_date_sk#11]
+Output [1]: [d_date_sk#10]
 
 (9) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#9]
-Right keys [1]: [d_date_sk#11]
+Left keys [1]: [ss_sold_date_sk#8]
+Right keys [1]: [d_date_sk#10]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
-Output [1]: [ss_customer_sk#8]
-Input [3]: [ss_customer_sk#8, ss_sold_date_sk#9, d_date_sk#11]
+Output [1]: [ss_customer_sk#7]
+Input [3]: [ss_customer_sk#7, ss_sold_date_sk#8, d_date_sk#10]
 
 (11) Exchange
-Input [1]: [ss_customer_sk#8]
-Arguments: hashpartitioning(ss_customer_sk#8, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [1]: [ss_customer_sk#7]
+Arguments: hashpartitioning(ss_customer_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (12) Sort [codegen id : 5]
-Input [1]: [ss_customer_sk#8]
-Arguments: [ss_customer_sk#8 ASC NULLS FIRST], false, 0
+Input [1]: [ss_customer_sk#7]
+Arguments: [ss_customer_sk#7 ASC NULLS FIRST], false, 0
 
 (13) SortMergeJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#3]
-Right keys [1]: [ss_customer_sk#8]
+Right keys [1]: [ss_customer_sk#7]
 Join type: LeftSemi
 Join condition: None
 
 (14) Scan parquet spark_catalog.default.web_sales
-Output [2]: [ws_bill_customer_sk#12, ws_sold_date_sk#13]
+Output [2]: [ws_bill_customer_sk#11, ws_sold_date_sk#12]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#13), dynamicpruningexpression(ws_sold_date_sk#13 IN dynamicpruning#10)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#12), dynamicpruningexpression(ws_sold_date_sk#12 IN dynamicpruning#9)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
 (15) ColumnarToRow [codegen id : 8]
-Input [2]: [ws_bill_customer_sk#12, ws_sold_date_sk#13]
+Input [2]: [ws_bill_customer_sk#11, ws_sold_date_sk#12]
 
 (16) ReusedExchange [Reuses operator id: 63]
-Output [1]: [d_date_sk#14]
+Output [1]: [d_date_sk#13]
 
 (17) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ws_sold_date_sk#13]
-Right keys [1]: [d_date_sk#14]
+Left keys [1]: [ws_sold_date_sk#12]
+Right keys [1]: [d_date_sk#13]
 Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 8]
-Output [1]: [ws_bill_customer_sk#12]
-Input [3]: [ws_bill_customer_sk#12, ws_sold_date_sk#13, d_date_sk#14]
+Output [1]: [ws_bill_customer_sk#11]
+Input [3]: [ws_bill_customer_sk#11, ws_sold_date_sk#12, d_date_sk#13]
 
 (19) Exchange
-Input [1]: [ws_bill_customer_sk#12]
-Arguments: hashpartitioning(ws_bill_customer_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [1]: [ws_bill_customer_sk#11]
+Arguments: hashpartitioning(ws_bill_customer_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (20) Sort [codegen id : 9]
-Input [1]: [ws_bill_customer_sk#12]
-Arguments: [ws_bill_customer_sk#12 ASC NULLS FIRST], false, 0
+Input [1]: [ws_bill_customer_sk#11]
+Arguments: [ws_bill_customer_sk#11 ASC NULLS FIRST], false, 0
 
 (21) SortMergeJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#3]
-Right keys [1]: [ws_bill_customer_sk#12]
+Right keys [1]: [ws_bill_customer_sk#11]
 Join type: ExistenceJoin(exists#2)
 Join condition: None
 
 (22) Scan parquet spark_catalog.default.catalog_sales
-Output [2]: [cs_ship_customer_sk#15, cs_sold_date_sk#16]
+Output [2]: [cs_ship_customer_sk#14, cs_sold_date_sk#15]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#16), dynamicpruningexpression(cs_sold_date_sk#16 IN dynamicpruning#10)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#15), dynamicpruningexpression(cs_sold_date_sk#15 IN dynamicpruning#9)]
 ReadSchema: struct<cs_ship_customer_sk:int>
 
 (23) ColumnarToRow [codegen id : 12]
-Input [2]: [cs_ship_customer_sk#15, cs_sold_date_sk#16]
+Input [2]: [cs_ship_customer_sk#14, cs_sold_date_sk#15]
 
 (24) ReusedExchange [Reuses operator id: 63]
-Output [1]: [d_date_sk#17]
+Output [1]: [d_date_sk#16]
 
 (25) BroadcastHashJoin [codegen id : 12]
-Left keys [1]: [cs_sold_date_sk#16]
-Right keys [1]: [d_date_sk#17]
+Left keys [1]: [cs_sold_date_sk#15]
+Right keys [1]: [d_date_sk#16]
 Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 12]
-Output [1]: [cs_ship_customer_sk#15]
-Input [3]: [cs_ship_customer_sk#15, cs_sold_date_sk#16, d_date_sk#17]
+Output [1]: [cs_ship_customer_sk#14]
+Input [3]: [cs_ship_customer_sk#14, cs_sold_date_sk#15, d_date_sk#16]
 
 (27) Exchange
-Input [1]: [cs_ship_customer_sk#15]
-Arguments: hashpartitioning(cs_ship_customer_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [1]: [cs_ship_customer_sk#14]
+Arguments: hashpartitioning(cs_ship_customer_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (28) Sort [codegen id : 13]
-Input [1]: [cs_ship_customer_sk#15]
-Arguments: [cs_ship_customer_sk#15 ASC NULLS FIRST], false, 0
+Input [1]: [cs_ship_customer_sk#14]
+Arguments: [cs_ship_customer_sk#14 ASC NULLS FIRST], false, 0
 
 (29) SortMergeJoin [codegen id : 15]
 Left keys [1]: [c_customer_sk#3]
-Right keys [1]: [cs_ship_customer_sk#15]
+Right keys [1]: [cs_ship_customer_sk#14]
 Join type: ExistenceJoin(exists#1)
 Join condition: None
 
@@ -194,102 +194,102 @@ Output [2]: [c_current_cdemo_sk#4, c_current_addr_sk#5]
 Input [5]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5, exists#2, exists#1]
 
 (32) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#18, ca_county#19]
+Output [2]: [ca_address_sk#17, ca_county#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Jefferson County,La Porte County,Rush County,Toole County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
 (33) ColumnarToRow [codegen id : 14]
-Input [2]: [ca_address_sk#18, ca_county#19]
+Input [2]: [ca_address_sk#17, ca_county#18]
 
 (34) Filter [codegen id : 14]
-Input [2]: [ca_address_sk#18, ca_county#19]
-Condition : (ca_county#19 IN (Rush County,Toole County,Jefferson County,Dona Ana County,La Porte County) AND isnotnull(ca_address_sk#18))
+Input [2]: [ca_address_sk#17, ca_county#18]
+Condition : (ca_county#18 IN (Rush County,Toole County,Jefferson County,Dona Ana County,La Porte County) AND isnotnull(ca_address_sk#17))
 
 (35) Project [codegen id : 14]
-Output [1]: [ca_address_sk#18]
-Input [2]: [ca_address_sk#18, ca_county#19]
+Output [1]: [ca_address_sk#17]
+Input [2]: [ca_address_sk#17, ca_county#18]
 
 (36) BroadcastExchange
-Input [1]: [ca_address_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+Input [1]: [ca_address_sk#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
 (37) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [c_current_addr_sk#5]
-Right keys [1]: [ca_address_sk#18]
+Right keys [1]: [ca_address_sk#17]
 Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 15]
 Output [1]: [c_current_cdemo_sk#4]
-Input [3]: [c_current_cdemo_sk#4, c_current_addr_sk#5, ca_address_sk#18]
+Input [3]: [c_current_cdemo_sk#4, c_current_addr_sk#5, ca_address_sk#17]
 
 (39) Exchange
 Input [1]: [c_current_cdemo_sk#4]
-Arguments: hashpartitioning(c_current_cdemo_sk#4, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Arguments: hashpartitioning(c_current_cdemo_sk#4, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
 (40) Sort [codegen id : 16]
 Input [1]: [c_current_cdemo_sk#4]
 Arguments: [c_current_cdemo_sk#4 ASC NULLS FIRST], false, 0
 
 (41) Scan parquet spark_catalog.default.customer_demographics
-Output [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Output [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string,cd_purchase_estimate:int,cd_credit_rating:string,cd_dep_count:int,cd_dep_employed_count:int,cd_dep_college_count:int>
 
 (42) ColumnarToRow [codegen id : 17]
-Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Input [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 
 (43) Filter [codegen id : 17]
-Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Condition : isnotnull(cd_demo_sk#20)
+Input [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Condition : isnotnull(cd_demo_sk#19)
 
 (44) Exchange
-Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Arguments: hashpartitioning(cd_demo_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Input [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Arguments: hashpartitioning(cd_demo_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (45) Sort [codegen id : 18]
-Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Arguments: [cd_demo_sk#20 ASC NULLS FIRST], false, 0
+Input [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Arguments: [cd_demo_sk#19 ASC NULLS FIRST], false, 0
 
 (46) SortMergeJoin [codegen id : 19]
 Left keys [1]: [c_current_cdemo_sk#4]
-Right keys [1]: [cd_demo_sk#20]
+Right keys [1]: [cd_demo_sk#19]
 Join type: Inner
 Join condition: None
 
 (47) Project [codegen id : 19]
-Output [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Input [10]: [c_current_cdemo_sk#4, cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Output [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Input [10]: [c_current_cdemo_sk#4, cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 
 (48) HashAggregate [codegen id : 19]
-Input [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Input [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Keys [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#29]
-Results [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
+Aggregate Attributes [1]: [count#28]
+Results [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#29]
 
 (49) Exchange
-Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
-Arguments: hashpartitioning(cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#29]
+Arguments: hashpartitioning(cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (50) HashAggregate [codegen id : 20]
-Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
-Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Input [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#29]
+Keys [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#31]
-Results [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, count(1)#31 AS cnt1#32, cd_purchase_estimate#24, count(1)#31 AS cnt2#33, cd_credit_rating#25, count(1)#31 AS cnt3#34, cd_dep_count#26, count(1)#31 AS cnt4#35, cd_dep_employed_count#27, count(1)#31 AS cnt5#36, cd_dep_college_count#28, count(1)#31 AS cnt6#37]
+Aggregate Attributes [1]: [count(1)#30]
+Results [14]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, count(1)#30 AS cnt1#31, cd_purchase_estimate#23, count(1)#30 AS cnt2#32, cd_credit_rating#24, count(1)#30 AS cnt3#33, cd_dep_count#25, count(1)#30 AS cnt4#34, cd_dep_employed_count#26, count(1)#30 AS cnt5#35, cd_dep_college_count#27, count(1)#30 AS cnt6#36]
 
 (51) TakeOrderedAndProject
-Input [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
-Arguments: 100, [cd_gender#21 ASC NULLS FIRST, cd_marital_status#22 ASC NULLS FIRST, cd_education_status#23 ASC NULLS FIRST, cd_purchase_estimate#24 ASC NULLS FIRST, cd_credit_rating#25 ASC NULLS FIRST, cd_dep_count#26 ASC NULLS FIRST, cd_dep_employed_count#27 ASC NULLS FIRST, cd_dep_college_count#28 ASC NULLS FIRST], [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
+Input [14]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cnt1#31, cd_purchase_estimate#23, cnt2#32, cd_credit_rating#24, cnt3#33, cd_dep_count#25, cnt4#34, cd_dep_employed_count#26, cnt5#35, cd_dep_college_count#27, cnt6#36]
+Arguments: 100, [cd_gender#20 ASC NULLS FIRST, cd_marital_status#21 ASC NULLS FIRST, cd_education_status#22 ASC NULLS FIRST, cd_purchase_estimate#23 ASC NULLS FIRST, cd_credit_rating#24 ASC NULLS FIRST, cd_dep_count#25 ASC NULLS FIRST, cd_dep_employed_count#26 ASC NULLS FIRST, cd_dep_college_count#27 ASC NULLS FIRST], [cd_gender#20, cd_marital_status#21, cd_education_status#22, cnt1#31, cd_purchase_estimate#23, cnt2#32, cd_credit_rating#24, cnt3#33, cd_dep_count#25, cnt4#34, cd_dep_employed_count#26, cnt5#35, cd_dep_college_count#27, cnt6#36]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#6, [id=#7]
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#6, [id=#1]
 ObjectHashAggregate (58)
 +- Exchange (57)
    +- ObjectHashAggregate (56)
@@ -300,42 +300,42 @@ ObjectHashAggregate (58)
 
 
 (52) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#18, ca_county#19]
+Output [2]: [ca_address_sk#17, ca_county#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Jefferson County,La Porte County,Rush County,Toole County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
 (53) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#18, ca_county#19]
+Input [2]: [ca_address_sk#17, ca_county#18]
 
 (54) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#18, ca_county#19]
-Condition : (ca_county#19 IN (Rush County,Toole County,Jefferson County,Dona Ana County,La Porte County) AND isnotnull(ca_address_sk#18))
+Input [2]: [ca_address_sk#17, ca_county#18]
+Condition : (ca_county#18 IN (Rush County,Toole County,Jefferson County,Dona Ana County,La Porte County) AND isnotnull(ca_address_sk#17))
 
 (55) Project [codegen id : 1]
-Output [1]: [ca_address_sk#18]
-Input [2]: [ca_address_sk#18, ca_county#19]
+Output [1]: [ca_address_sk#17]
+Input [2]: [ca_address_sk#17, ca_county#18]
 
 (56) ObjectHashAggregate
-Input [1]: [ca_address_sk#18]
+Input [1]: [ca_address_sk#17]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)]
-Aggregate Attributes [1]: [buf#38]
-Results [1]: [buf#39]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#17, 42), 2555, 57765, 0, 0)]
+Aggregate Attributes [1]: [buf#37]
+Results [1]: [buf#38]
 
 (57) Exchange
-Input [1]: [buf#39]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+Input [1]: [buf#38]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
 
 (58) ObjectHashAggregate
-Input [1]: [buf#39]
+Input [1]: [buf#38]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)#40]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)#40 AS bloomFilter#41]
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#17, 42), 2555, 57765, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#17, 42), 2555, 57765, 0, 0)#39]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#17, 42), 2555, 57765, 0, 0)#39 AS bloomFilter#40]
 
-Subquery:2 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#9 IN dynamicpruning#10
+Subquery:2 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
 BroadcastExchange (63)
 +- * Project (62)
    +- * Filter (61)
@@ -344,29 +344,29 @@ BroadcastExchange (63)
 
 
 (59) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#11, d_year#42, d_moy#43]
+Output [3]: [d_date_sk#10, d_year#41, d_moy#42]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2002), GreaterThanOrEqual(d_moy,1), LessThanOrEqual(d_moy,4), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (60) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#11, d_year#42, d_moy#43]
+Input [3]: [d_date_sk#10, d_year#41, d_moy#42]
 
 (61) Filter [codegen id : 1]
-Input [3]: [d_date_sk#11, d_year#42, d_moy#43]
-Condition : (((((isnotnull(d_year#42) AND isnotnull(d_moy#43)) AND (d_year#42 = 2002)) AND (d_moy#43 >= 1)) AND (d_moy#43 <= 4)) AND isnotnull(d_date_sk#11))
+Input [3]: [d_date_sk#10, d_year#41, d_moy#42]
+Condition : (((((isnotnull(d_year#41) AND isnotnull(d_moy#42)) AND (d_year#41 = 2002)) AND (d_moy#42 >= 1)) AND (d_moy#42 <= 4)) AND isnotnull(d_date_sk#10))
 
 (62) Project [codegen id : 1]
-Output [1]: [d_date_sk#11]
-Input [3]: [d_date_sk#11, d_year#42, d_moy#43]
+Output [1]: [d_date_sk#10]
+Input [3]: [d_date_sk#10, d_year#41, d_moy#42]
 
 (63) BroadcastExchange
-Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+Input [1]: [d_date_sk#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-Subquery:3 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#13 IN dynamicpruning#10
+Subquery:3 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#12 IN dynamicpruning#9
 
-Subquery:4 Hosting operator id = 22 Hosting Expression = cs_sold_date_sk#16 IN dynamicpruning#10
+Subquery:4 Hosting operator id = 22 Hosting Expression = cs_sold_date_sk#15 IN dynamicpruning#9
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/explain.txt
@@ -450,195 +450,195 @@ Results [5]: [i_brand_id#38, i_class_id#39, i_category_id#40, sum((cast(ss_quant
 
 (72) Filter [codegen id : 38]
 Input [5]: [i_brand_id#38, i_class_id#39, i_category_id#40, sales#49, number_sales#50]
-Condition : (isnotnull(sales#49) AND (cast(sales#49 as decimal(32,6)) > cast(Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
+Condition : (isnotnull(sales#49) AND (cast(sales#49 as decimal(32,6)) > cast(Subquery scalar-subquery#51, [id=#12] as decimal(32,6))))
 
 (73) Project [codegen id : 38]
-Output [6]: [sales#49, number_sales#50, store AS channel#53, i_brand_id#38 AS i_brand_id#54, i_class_id#39 AS i_class_id#55, i_category_id#40 AS i_category_id#56]
+Output [6]: [sales#49, number_sales#50, store AS channel#52, i_brand_id#38 AS i_brand_id#53, i_class_id#39 AS i_class_id#54, i_category_id#40 AS i_category_id#55]
 Input [5]: [i_brand_id#38, i_class_id#39, i_category_id#40, sales#49, number_sales#50]
 
 (74) Scan parquet spark_catalog.default.catalog_sales
-Output [4]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60]
+Output [4]: [cs_item_sk#56, cs_quantity#57, cs_list_price#58, cs_sold_date_sk#59]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#60), dynamicpruningexpression(cs_sold_date_sk#60 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#59), dynamicpruningexpression(cs_sold_date_sk#59 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (75) ColumnarToRow [codegen id : 75]
-Input [4]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60]
+Input [4]: [cs_item_sk#56, cs_quantity#57, cs_list_price#58, cs_sold_date_sk#59]
 
 (76) Filter [codegen id : 75]
-Input [4]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60]
-Condition : isnotnull(cs_item_sk#57)
+Input [4]: [cs_item_sk#56, cs_quantity#57, cs_list_price#58, cs_sold_date_sk#59]
+Condition : isnotnull(cs_item_sk#56)
 
 (77) ReusedExchange [Reuses operator id: 56]
-Output [1]: [ss_item_sk#61]
+Output [1]: [ss_item_sk#60]
 
 (78) BroadcastHashJoin [codegen id : 75]
-Left keys [1]: [cs_item_sk#57]
-Right keys [1]: [ss_item_sk#61]
+Left keys [1]: [cs_item_sk#56]
+Right keys [1]: [ss_item_sk#60]
 Join type: LeftSemi
 Join condition: None
 
 (79) ReusedExchange [Reuses operator id: 135]
-Output [1]: [d_date_sk#62]
+Output [1]: [d_date_sk#61]
 
 (80) BroadcastHashJoin [codegen id : 75]
-Left keys [1]: [cs_sold_date_sk#60]
-Right keys [1]: [d_date_sk#62]
+Left keys [1]: [cs_sold_date_sk#59]
+Right keys [1]: [d_date_sk#61]
 Join type: Inner
 Join condition: None
 
 (81) Project [codegen id : 75]
-Output [3]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59]
-Input [5]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60, d_date_sk#62]
+Output [3]: [cs_item_sk#56, cs_quantity#57, cs_list_price#58]
+Input [5]: [cs_item_sk#56, cs_quantity#57, cs_list_price#58, cs_sold_date_sk#59, d_date_sk#61]
 
 (82) ReusedExchange [Reuses operator id: 66]
-Output [4]: [i_item_sk#63, i_brand_id#64, i_class_id#65, i_category_id#66]
+Output [4]: [i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65]
 
 (83) BroadcastHashJoin [codegen id : 75]
-Left keys [1]: [cs_item_sk#57]
-Right keys [1]: [i_item_sk#63]
+Left keys [1]: [cs_item_sk#56]
+Right keys [1]: [i_item_sk#62]
 Join type: Inner
 Join condition: None
 
 (84) Project [codegen id : 75]
-Output [5]: [cs_quantity#58, cs_list_price#59, i_brand_id#64, i_class_id#65, i_category_id#66]
-Input [7]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, i_item_sk#63, i_brand_id#64, i_class_id#65, i_category_id#66]
+Output [5]: [cs_quantity#57, cs_list_price#58, i_brand_id#63, i_class_id#64, i_category_id#65]
+Input [7]: [cs_item_sk#56, cs_quantity#57, cs_list_price#58, i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65]
 
 (85) HashAggregate [codegen id : 75]
-Input [5]: [cs_quantity#58, cs_list_price#59, i_brand_id#64, i_class_id#65, i_category_id#66]
-Keys [3]: [i_brand_id#64, i_class_id#65, i_category_id#66]
-Functions [2]: [partial_sum((cast(cs_quantity#58 as decimal(10,0)) * cs_list_price#59)), partial_count(1)]
-Aggregate Attributes [3]: [sum#67, isEmpty#68, count#69]
-Results [6]: [i_brand_id#64, i_class_id#65, i_category_id#66, sum#70, isEmpty#71, count#72]
+Input [5]: [cs_quantity#57, cs_list_price#58, i_brand_id#63, i_class_id#64, i_category_id#65]
+Keys [3]: [i_brand_id#63, i_class_id#64, i_category_id#65]
+Functions [2]: [partial_sum((cast(cs_quantity#57 as decimal(10,0)) * cs_list_price#58)), partial_count(1)]
+Aggregate Attributes [3]: [sum#66, isEmpty#67, count#68]
+Results [6]: [i_brand_id#63, i_class_id#64, i_category_id#65, sum#69, isEmpty#70, count#71]
 
 (86) Exchange
-Input [6]: [i_brand_id#64, i_class_id#65, i_category_id#66, sum#70, isEmpty#71, count#72]
-Arguments: hashpartitioning(i_brand_id#64, i_class_id#65, i_category_id#66, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [6]: [i_brand_id#63, i_class_id#64, i_category_id#65, sum#69, isEmpty#70, count#71]
+Arguments: hashpartitioning(i_brand_id#63, i_class_id#64, i_category_id#65, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (87) HashAggregate [codegen id : 76]
-Input [6]: [i_brand_id#64, i_class_id#65, i_category_id#66, sum#70, isEmpty#71, count#72]
-Keys [3]: [i_brand_id#64, i_class_id#65, i_category_id#66]
-Functions [2]: [sum((cast(cs_quantity#58 as decimal(10,0)) * cs_list_price#59)), count(1)]
-Aggregate Attributes [2]: [sum((cast(cs_quantity#58 as decimal(10,0)) * cs_list_price#59))#73, count(1)#74]
-Results [5]: [i_brand_id#64, i_class_id#65, i_category_id#66, sum((cast(cs_quantity#58 as decimal(10,0)) * cs_list_price#59))#73 AS sales#75, count(1)#74 AS number_sales#76]
+Input [6]: [i_brand_id#63, i_class_id#64, i_category_id#65, sum#69, isEmpty#70, count#71]
+Keys [3]: [i_brand_id#63, i_class_id#64, i_category_id#65]
+Functions [2]: [sum((cast(cs_quantity#57 as decimal(10,0)) * cs_list_price#58)), count(1)]
+Aggregate Attributes [2]: [sum((cast(cs_quantity#57 as decimal(10,0)) * cs_list_price#58))#72, count(1)#73]
+Results [5]: [i_brand_id#63, i_class_id#64, i_category_id#65, sum((cast(cs_quantity#57 as decimal(10,0)) * cs_list_price#58))#72 AS sales#74, count(1)#73 AS number_sales#75]
 
 (88) Filter [codegen id : 76]
-Input [5]: [i_brand_id#64, i_class_id#65, i_category_id#66, sales#75, number_sales#76]
-Condition : (isnotnull(sales#75) AND (cast(sales#75 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
+Input [5]: [i_brand_id#63, i_class_id#64, i_category_id#65, sales#74, number_sales#75]
+Condition : (isnotnull(sales#74) AND (cast(sales#74 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#12] as decimal(32,6))))
 
 (89) Project [codegen id : 76]
-Output [6]: [sales#75, number_sales#76, catalog AS channel#77, i_brand_id#64, i_class_id#65, i_category_id#66]
-Input [5]: [i_brand_id#64, i_class_id#65, i_category_id#66, sales#75, number_sales#76]
+Output [6]: [sales#74, number_sales#75, catalog AS channel#76, i_brand_id#63, i_class_id#64, i_category_id#65]
+Input [5]: [i_brand_id#63, i_class_id#64, i_category_id#65, sales#74, number_sales#75]
 
 (90) Scan parquet spark_catalog.default.web_sales
-Output [4]: [ws_item_sk#78, ws_quantity#79, ws_list_price#80, ws_sold_date_sk#81]
+Output [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#81), dynamicpruningexpression(ws_sold_date_sk#81 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#80), dynamicpruningexpression(ws_sold_date_sk#80 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (91) ColumnarToRow [codegen id : 113]
-Input [4]: [ws_item_sk#78, ws_quantity#79, ws_list_price#80, ws_sold_date_sk#81]
+Input [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
 
 (92) Filter [codegen id : 113]
-Input [4]: [ws_item_sk#78, ws_quantity#79, ws_list_price#80, ws_sold_date_sk#81]
-Condition : isnotnull(ws_item_sk#78)
+Input [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
+Condition : isnotnull(ws_item_sk#77)
 
 (93) ReusedExchange [Reuses operator id: 56]
-Output [1]: [ss_item_sk#82]
+Output [1]: [ss_item_sk#81]
 
 (94) BroadcastHashJoin [codegen id : 113]
-Left keys [1]: [ws_item_sk#78]
-Right keys [1]: [ss_item_sk#82]
+Left keys [1]: [ws_item_sk#77]
+Right keys [1]: [ss_item_sk#81]
 Join type: LeftSemi
 Join condition: None
 
 (95) ReusedExchange [Reuses operator id: 135]
-Output [1]: [d_date_sk#83]
+Output [1]: [d_date_sk#82]
 
 (96) BroadcastHashJoin [codegen id : 113]
-Left keys [1]: [ws_sold_date_sk#81]
-Right keys [1]: [d_date_sk#83]
+Left keys [1]: [ws_sold_date_sk#80]
+Right keys [1]: [d_date_sk#82]
 Join type: Inner
 Join condition: None
 
 (97) Project [codegen id : 113]
-Output [3]: [ws_item_sk#78, ws_quantity#79, ws_list_price#80]
-Input [5]: [ws_item_sk#78, ws_quantity#79, ws_list_price#80, ws_sold_date_sk#81, d_date_sk#83]
+Output [3]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79]
+Input [5]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80, d_date_sk#82]
 
 (98) ReusedExchange [Reuses operator id: 66]
-Output [4]: [i_item_sk#84, i_brand_id#85, i_class_id#86, i_category_id#87]
+Output [4]: [i_item_sk#83, i_brand_id#84, i_class_id#85, i_category_id#86]
 
 (99) BroadcastHashJoin [codegen id : 113]
-Left keys [1]: [ws_item_sk#78]
-Right keys [1]: [i_item_sk#84]
+Left keys [1]: [ws_item_sk#77]
+Right keys [1]: [i_item_sk#83]
 Join type: Inner
 Join condition: None
 
 (100) Project [codegen id : 113]
-Output [5]: [ws_quantity#79, ws_list_price#80, i_brand_id#85, i_class_id#86, i_category_id#87]
-Input [7]: [ws_item_sk#78, ws_quantity#79, ws_list_price#80, i_item_sk#84, i_brand_id#85, i_class_id#86, i_category_id#87]
+Output [5]: [ws_quantity#78, ws_list_price#79, i_brand_id#84, i_class_id#85, i_category_id#86]
+Input [7]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, i_item_sk#83, i_brand_id#84, i_class_id#85, i_category_id#86]
 
 (101) HashAggregate [codegen id : 113]
-Input [5]: [ws_quantity#79, ws_list_price#80, i_brand_id#85, i_class_id#86, i_category_id#87]
-Keys [3]: [i_brand_id#85, i_class_id#86, i_category_id#87]
-Functions [2]: [partial_sum((cast(ws_quantity#79 as decimal(10,0)) * ws_list_price#80)), partial_count(1)]
-Aggregate Attributes [3]: [sum#88, isEmpty#89, count#90]
-Results [6]: [i_brand_id#85, i_class_id#86, i_category_id#87, sum#91, isEmpty#92, count#93]
+Input [5]: [ws_quantity#78, ws_list_price#79, i_brand_id#84, i_class_id#85, i_category_id#86]
+Keys [3]: [i_brand_id#84, i_class_id#85, i_category_id#86]
+Functions [2]: [partial_sum((cast(ws_quantity#78 as decimal(10,0)) * ws_list_price#79)), partial_count(1)]
+Aggregate Attributes [3]: [sum#87, isEmpty#88, count#89]
+Results [6]: [i_brand_id#84, i_class_id#85, i_category_id#86, sum#90, isEmpty#91, count#92]
 
 (102) Exchange
-Input [6]: [i_brand_id#85, i_class_id#86, i_category_id#87, sum#91, isEmpty#92, count#93]
-Arguments: hashpartitioning(i_brand_id#85, i_class_id#86, i_category_id#87, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+Input [6]: [i_brand_id#84, i_class_id#85, i_category_id#86, sum#90, isEmpty#91, count#92]
+Arguments: hashpartitioning(i_brand_id#84, i_class_id#85, i_category_id#86, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (103) HashAggregate [codegen id : 114]
-Input [6]: [i_brand_id#85, i_class_id#86, i_category_id#87, sum#91, isEmpty#92, count#93]
-Keys [3]: [i_brand_id#85, i_class_id#86, i_category_id#87]
-Functions [2]: [sum((cast(ws_quantity#79 as decimal(10,0)) * ws_list_price#80)), count(1)]
-Aggregate Attributes [2]: [sum((cast(ws_quantity#79 as decimal(10,0)) * ws_list_price#80))#94, count(1)#95]
-Results [5]: [i_brand_id#85, i_class_id#86, i_category_id#87, sum((cast(ws_quantity#79 as decimal(10,0)) * ws_list_price#80))#94 AS sales#96, count(1)#95 AS number_sales#97]
+Input [6]: [i_brand_id#84, i_class_id#85, i_category_id#86, sum#90, isEmpty#91, count#92]
+Keys [3]: [i_brand_id#84, i_class_id#85, i_category_id#86]
+Functions [2]: [sum((cast(ws_quantity#78 as decimal(10,0)) * ws_list_price#79)), count(1)]
+Aggregate Attributes [2]: [sum((cast(ws_quantity#78 as decimal(10,0)) * ws_list_price#79))#93, count(1)#94]
+Results [5]: [i_brand_id#84, i_class_id#85, i_category_id#86, sum((cast(ws_quantity#78 as decimal(10,0)) * ws_list_price#79))#93 AS sales#95, count(1)#94 AS number_sales#96]
 
 (104) Filter [codegen id : 114]
-Input [5]: [i_brand_id#85, i_class_id#86, i_category_id#87, sales#96, number_sales#97]
-Condition : (isnotnull(sales#96) AND (cast(sales#96 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
+Input [5]: [i_brand_id#84, i_class_id#85, i_category_id#86, sales#95, number_sales#96]
+Condition : (isnotnull(sales#95) AND (cast(sales#95 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#12] as decimal(32,6))))
 
 (105) Project [codegen id : 114]
-Output [6]: [sales#96, number_sales#97, web AS channel#98, i_brand_id#85, i_class_id#86, i_category_id#87]
-Input [5]: [i_brand_id#85, i_class_id#86, i_category_id#87, sales#96, number_sales#97]
+Output [6]: [sales#95, number_sales#96, web AS channel#97, i_brand_id#84, i_class_id#85, i_category_id#86]
+Input [5]: [i_brand_id#84, i_class_id#85, i_category_id#86, sales#95, number_sales#96]
 
 (106) Union
 
 (107) Expand [codegen id : 115]
-Input [6]: [sales#49, number_sales#50, channel#53, i_brand_id#54, i_class_id#55, i_category_id#56]
-Arguments: [[sales#49, number_sales#50, channel#53, i_brand_id#54, i_class_id#55, i_category_id#56, 0], [sales#49, number_sales#50, channel#53, i_brand_id#54, i_class_id#55, null, 1], [sales#49, number_sales#50, channel#53, i_brand_id#54, null, null, 3], [sales#49, number_sales#50, channel#53, null, null, null, 7], [sales#49, number_sales#50, null, null, null, null, 15]], [sales#49, number_sales#50, channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, spark_grouping_id#103]
+Input [6]: [sales#49, number_sales#50, channel#52, i_brand_id#53, i_class_id#54, i_category_id#55]
+Arguments: [[sales#49, number_sales#50, channel#52, i_brand_id#53, i_class_id#54, i_category_id#55, 0], [sales#49, number_sales#50, channel#52, i_brand_id#53, i_class_id#54, null, 1], [sales#49, number_sales#50, channel#52, i_brand_id#53, null, null, 3], [sales#49, number_sales#50, channel#52, null, null, null, 7], [sales#49, number_sales#50, null, null, null, null, 15]], [sales#49, number_sales#50, channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, spark_grouping_id#102]
 
 (108) HashAggregate [codegen id : 115]
-Input [7]: [sales#49, number_sales#50, channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, spark_grouping_id#103]
-Keys [5]: [channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, spark_grouping_id#103]
+Input [7]: [sales#49, number_sales#50, channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, spark_grouping_id#102]
+Keys [5]: [channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, spark_grouping_id#102]
 Functions [2]: [partial_sum(sales#49), partial_sum(number_sales#50)]
-Aggregate Attributes [3]: [sum#104, isEmpty#105, sum#106]
-Results [8]: [channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, spark_grouping_id#103, sum#107, isEmpty#108, sum#109]
+Aggregate Attributes [3]: [sum#103, isEmpty#104, sum#105]
+Results [8]: [channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, spark_grouping_id#102, sum#106, isEmpty#107, sum#108]
 
 (109) Exchange
-Input [8]: [channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, spark_grouping_id#103, sum#107, isEmpty#108, sum#109]
-Arguments: hashpartitioning(channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, spark_grouping_id#103, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [8]: [channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, spark_grouping_id#102, sum#106, isEmpty#107, sum#108]
+Arguments: hashpartitioning(channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, spark_grouping_id#102, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
 (110) HashAggregate [codegen id : 116]
-Input [8]: [channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, spark_grouping_id#103, sum#107, isEmpty#108, sum#109]
-Keys [5]: [channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, spark_grouping_id#103]
+Input [8]: [channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, spark_grouping_id#102, sum#106, isEmpty#107, sum#108]
+Keys [5]: [channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, spark_grouping_id#102]
 Functions [2]: [sum(sales#49), sum(number_sales#50)]
-Aggregate Attributes [2]: [sum(sales#49)#110, sum(number_sales#50)#111]
-Results [6]: [channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, sum(sales#49)#110 AS sum(sales)#112, sum(number_sales#50)#111 AS sum(number_sales)#113]
+Aggregate Attributes [2]: [sum(sales#49)#109, sum(number_sales#50)#110]
+Results [6]: [channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, sum(sales#49)#109 AS sum(sales)#111, sum(number_sales#50)#110 AS sum(number_sales)#112]
 
 (111) TakeOrderedAndProject
-Input [6]: [channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, sum(sales)#112, sum(number_sales)#113]
-Arguments: 100, [channel#99 ASC NULLS FIRST, i_brand_id#100 ASC NULLS FIRST, i_class_id#101 ASC NULLS FIRST, i_category_id#102 ASC NULLS FIRST], [channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, sum(sales)#112, sum(number_sales)#113]
+Input [6]: [channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, sum(sales)#111, sum(number_sales)#112]
+Arguments: 100, [channel#98 ASC NULLS FIRST, i_brand_id#99 ASC NULLS FIRST, i_class_id#100 ASC NULLS FIRST, i_category_id#101 ASC NULLS FIRST], [channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, sum(sales)#111, sum(number_sales)#112]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 72 Hosting Expression = Subquery scalar-subquery#51, [id=#52]
+Subquery:1 Hosting operator id = 72 Hosting Expression = Subquery scalar-subquery#51, [id=#12]
 * HashAggregate (130)
 +- Exchange (129)
    +- * HashAggregate (128)
@@ -661,99 +661,99 @@ Subquery:1 Hosting operator id = 72 Hosting Expression = Subquery scalar-subquer
 
 
 (112) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_quantity#114, ss_list_price#115, ss_sold_date_sk#116]
+Output [3]: [ss_quantity#113, ss_list_price#114, ss_sold_date_sk#115]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#116), dynamicpruningexpression(ss_sold_date_sk#116 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#115), dynamicpruningexpression(ss_sold_date_sk#115 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (113) ColumnarToRow [codegen id : 2]
-Input [3]: [ss_quantity#114, ss_list_price#115, ss_sold_date_sk#116]
+Input [3]: [ss_quantity#113, ss_list_price#114, ss_sold_date_sk#115]
 
 (114) ReusedExchange [Reuses operator id: 140]
-Output [1]: [d_date_sk#117]
+Output [1]: [d_date_sk#116]
 
 (115) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#116]
-Right keys [1]: [d_date_sk#117]
+Left keys [1]: [ss_sold_date_sk#115]
+Right keys [1]: [d_date_sk#116]
 Join type: Inner
 Join condition: None
 
 (116) Project [codegen id : 2]
-Output [2]: [ss_quantity#114 AS quantity#118, ss_list_price#115 AS list_price#119]
-Input [4]: [ss_quantity#114, ss_list_price#115, ss_sold_date_sk#116, d_date_sk#117]
+Output [2]: [ss_quantity#113 AS quantity#117, ss_list_price#114 AS list_price#118]
+Input [4]: [ss_quantity#113, ss_list_price#114, ss_sold_date_sk#115, d_date_sk#116]
 
 (117) Scan parquet spark_catalog.default.catalog_sales
-Output [3]: [cs_quantity#120, cs_list_price#121, cs_sold_date_sk#122]
+Output [3]: [cs_quantity#119, cs_list_price#120, cs_sold_date_sk#121]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#122), dynamicpruningexpression(cs_sold_date_sk#122 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#121), dynamicpruningexpression(cs_sold_date_sk#121 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (118) ColumnarToRow [codegen id : 4]
-Input [3]: [cs_quantity#120, cs_list_price#121, cs_sold_date_sk#122]
+Input [3]: [cs_quantity#119, cs_list_price#120, cs_sold_date_sk#121]
 
 (119) ReusedExchange [Reuses operator id: 140]
-Output [1]: [d_date_sk#123]
+Output [1]: [d_date_sk#122]
 
 (120) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_sold_date_sk#122]
-Right keys [1]: [d_date_sk#123]
+Left keys [1]: [cs_sold_date_sk#121]
+Right keys [1]: [d_date_sk#122]
 Join type: Inner
 Join condition: None
 
 (121) Project [codegen id : 4]
-Output [2]: [cs_quantity#120 AS quantity#124, cs_list_price#121 AS list_price#125]
-Input [4]: [cs_quantity#120, cs_list_price#121, cs_sold_date_sk#122, d_date_sk#123]
+Output [2]: [cs_quantity#119 AS quantity#123, cs_list_price#120 AS list_price#124]
+Input [4]: [cs_quantity#119, cs_list_price#120, cs_sold_date_sk#121, d_date_sk#122]
 
 (122) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_quantity#126, ws_list_price#127, ws_sold_date_sk#128]
+Output [3]: [ws_quantity#125, ws_list_price#126, ws_sold_date_sk#127]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#128), dynamicpruningexpression(ws_sold_date_sk#128 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#127), dynamicpruningexpression(ws_sold_date_sk#127 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (123) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_quantity#126, ws_list_price#127, ws_sold_date_sk#128]
+Input [3]: [ws_quantity#125, ws_list_price#126, ws_sold_date_sk#127]
 
 (124) ReusedExchange [Reuses operator id: 140]
-Output [1]: [d_date_sk#129]
+Output [1]: [d_date_sk#128]
 
 (125) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#128]
-Right keys [1]: [d_date_sk#129]
+Left keys [1]: [ws_sold_date_sk#127]
+Right keys [1]: [d_date_sk#128]
 Join type: Inner
 Join condition: None
 
 (126) Project [codegen id : 6]
-Output [2]: [ws_quantity#126 AS quantity#130, ws_list_price#127 AS list_price#131]
-Input [4]: [ws_quantity#126, ws_list_price#127, ws_sold_date_sk#128, d_date_sk#129]
+Output [2]: [ws_quantity#125 AS quantity#129, ws_list_price#126 AS list_price#130]
+Input [4]: [ws_quantity#125, ws_list_price#126, ws_sold_date_sk#127, d_date_sk#128]
 
 (127) Union
 
 (128) HashAggregate [codegen id : 7]
-Input [2]: [quantity#118, list_price#119]
+Input [2]: [quantity#117, list_price#118]
 Keys: []
-Functions [1]: [partial_avg((cast(quantity#118 as decimal(10,0)) * list_price#119))]
-Aggregate Attributes [2]: [sum#132, count#133]
-Results [2]: [sum#134, count#135]
+Functions [1]: [partial_avg((cast(quantity#117 as decimal(10,0)) * list_price#118))]
+Aggregate Attributes [2]: [sum#131, count#132]
+Results [2]: [sum#133, count#134]
 
 (129) Exchange
-Input [2]: [sum#134, count#135]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
+Input [2]: [sum#133, count#134]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=16]
 
 (130) HashAggregate [codegen id : 8]
-Input [2]: [sum#134, count#135]
+Input [2]: [sum#133, count#134]
 Keys: []
-Functions [1]: [avg((cast(quantity#118 as decimal(10,0)) * list_price#119))]
-Aggregate Attributes [1]: [avg((cast(quantity#118 as decimal(10,0)) * list_price#119))#136]
-Results [1]: [avg((cast(quantity#118 as decimal(10,0)) * list_price#119))#136 AS average_sales#137]
+Functions [1]: [avg((cast(quantity#117 as decimal(10,0)) * list_price#118))]
+Aggregate Attributes [1]: [avg((cast(quantity#117 as decimal(10,0)) * list_price#118))#135]
+Results [1]: [avg((cast(quantity#117 as decimal(10,0)) * list_price#118))#135 AS average_sales#136]
 
-Subquery:2 Hosting operator id = 112 Hosting Expression = ss_sold_date_sk#116 IN dynamicpruning#12
+Subquery:2 Hosting operator id = 112 Hosting Expression = ss_sold_date_sk#115 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 117 Hosting Expression = cs_sold_date_sk#122 IN dynamicpruning#12
+Subquery:3 Hosting operator id = 117 Hosting Expression = cs_sold_date_sk#121 IN dynamicpruning#12
 
-Subquery:4 Hosting operator id = 122 Hosting Expression = ws_sold_date_sk#128 IN dynamicpruning#12
+Subquery:4 Hosting operator id = 122 Hosting Expression = ws_sold_date_sk#127 IN dynamicpruning#12
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (135)
@@ -764,26 +764,26 @@ BroadcastExchange (135)
 
 
 (131) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#36, d_year#138, d_moy#139]
+Output [3]: [d_date_sk#36, d_year#137, d_moy#138]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2001), EqualTo(d_moy,11), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (132) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#36, d_year#138, d_moy#139]
+Input [3]: [d_date_sk#36, d_year#137, d_moy#138]
 
 (133) Filter [codegen id : 1]
-Input [3]: [d_date_sk#36, d_year#138, d_moy#139]
-Condition : ((((isnotnull(d_year#138) AND isnotnull(d_moy#139)) AND (d_year#138 = 2001)) AND (d_moy#139 = 11)) AND isnotnull(d_date_sk#36))
+Input [3]: [d_date_sk#36, d_year#137, d_moy#138]
+Condition : ((((isnotnull(d_year#137) AND isnotnull(d_moy#138)) AND (d_year#137 = 2001)) AND (d_moy#138 = 11)) AND isnotnull(d_date_sk#36))
 
 (134) Project [codegen id : 1]
 Output [1]: [d_date_sk#36]
-Input [3]: [d_date_sk#36, d_year#138, d_moy#139]
+Input [3]: [d_date_sk#36, d_year#137, d_moy#138]
 
 (135) BroadcastExchange
 Input [1]: [d_date_sk#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=17]
 
 Subquery:6 Hosting operator id = 7 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
 BroadcastExchange (140)
@@ -794,37 +794,37 @@ BroadcastExchange (140)
 
 
 (136) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#13, d_year#140]
+Output [2]: [d_date_sk#13, d_year#139]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (137) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#140]
+Input [2]: [d_date_sk#13, d_year#139]
 
 (138) Filter [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#140]
-Condition : (((isnotnull(d_year#140) AND (d_year#140 >= 1999)) AND (d_year#140 <= 2001)) AND isnotnull(d_date_sk#13))
+Input [2]: [d_date_sk#13, d_year#139]
+Condition : (((isnotnull(d_year#139) AND (d_year#139 >= 1999)) AND (d_year#139 <= 2001)) AND isnotnull(d_date_sk#13))
 
 (139) Project [codegen id : 1]
 Output [1]: [d_date_sk#13]
-Input [2]: [d_date_sk#13, d_year#140]
+Input [2]: [d_date_sk#13, d_year#139]
 
 (140) BroadcastExchange
 Input [1]: [d_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=18]
 
 Subquery:7 Hosting operator id = 18 Hosting Expression = cs_sold_date_sk#19 IN dynamicpruning#12
 
 Subquery:8 Hosting operator id = 41 Hosting Expression = ws_sold_date_sk#29 IN dynamicpruning#12
 
-Subquery:9 Hosting operator id = 88 Hosting Expression = ReusedSubquery Subquery scalar-subquery#51, [id=#52]
+Subquery:9 Hosting operator id = 88 Hosting Expression = ReusedSubquery Subquery scalar-subquery#51, [id=#12]
 
-Subquery:10 Hosting operator id = 74 Hosting Expression = cs_sold_date_sk#60 IN dynamicpruning#5
+Subquery:10 Hosting operator id = 74 Hosting Expression = cs_sold_date_sk#59 IN dynamicpruning#5
 
-Subquery:11 Hosting operator id = 104 Hosting Expression = ReusedSubquery Subquery scalar-subquery#51, [id=#52]
+Subquery:11 Hosting operator id = 104 Hosting Expression = ReusedSubquery Subquery scalar-subquery#51, [id=#12]
 
-Subquery:12 Hosting operator id = 90 Hosting Expression = ws_sold_date_sk#81 IN dynamicpruning#5
+Subquery:12 Hosting operator id = 90 Hosting Expression = ws_sold_date_sk#80 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/explain.txt
@@ -420,195 +420,195 @@ Results [5]: [i_brand_id#37, i_class_id#38, i_category_id#39, sum((cast(ss_quant
 
 (66) Filter [codegen id : 26]
 Input [5]: [i_brand_id#37, i_class_id#38, i_category_id#39, sales#49, number_sales#50]
-Condition : (isnotnull(sales#49) AND (cast(sales#49 as decimal(32,6)) > cast(Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
+Condition : (isnotnull(sales#49) AND (cast(sales#49 as decimal(32,6)) > cast(Subquery scalar-subquery#51, [id=#10] as decimal(32,6))))
 
 (67) Project [codegen id : 26]
-Output [6]: [sales#49, number_sales#50, store AS channel#53, i_brand_id#37 AS i_brand_id#54, i_class_id#38 AS i_class_id#55, i_category_id#39 AS i_category_id#56]
+Output [6]: [sales#49, number_sales#50, store AS channel#52, i_brand_id#37 AS i_brand_id#53, i_class_id#38 AS i_class_id#54, i_category_id#39 AS i_category_id#55]
 Input [5]: [i_brand_id#37, i_class_id#38, i_category_id#39, sales#49, number_sales#50]
 
 (68) Scan parquet spark_catalog.default.catalog_sales
-Output [4]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60]
+Output [4]: [cs_item_sk#56, cs_quantity#57, cs_list_price#58, cs_sold_date_sk#59]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#60), dynamicpruningexpression(cs_sold_date_sk#60 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#59), dynamicpruningexpression(cs_sold_date_sk#59 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (69) ColumnarToRow [codegen id : 51]
-Input [4]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60]
+Input [4]: [cs_item_sk#56, cs_quantity#57, cs_list_price#58, cs_sold_date_sk#59]
 
 (70) Filter [codegen id : 51]
-Input [4]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60]
-Condition : isnotnull(cs_item_sk#57)
+Input [4]: [cs_item_sk#56, cs_quantity#57, cs_list_price#58, cs_sold_date_sk#59]
+Condition : isnotnull(cs_item_sk#56)
 
 (71) ReusedExchange [Reuses operator id: 50]
-Output [1]: [ss_item_sk#61]
+Output [1]: [ss_item_sk#60]
 
 (72) BroadcastHashJoin [codegen id : 51]
-Left keys [1]: [cs_item_sk#57]
-Right keys [1]: [ss_item_sk#61]
+Left keys [1]: [cs_item_sk#56]
+Right keys [1]: [ss_item_sk#60]
 Join type: LeftSemi
 Join condition: None
 
 (73) ReusedExchange [Reuses operator id: 57]
-Output [4]: [i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65]
+Output [4]: [i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64]
 
 (74) BroadcastHashJoin [codegen id : 51]
-Left keys [1]: [cs_item_sk#57]
-Right keys [1]: [i_item_sk#62]
+Left keys [1]: [cs_item_sk#56]
+Right keys [1]: [i_item_sk#61]
 Join type: Inner
 Join condition: None
 
 (75) Project [codegen id : 51]
-Output [6]: [cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60, i_brand_id#63, i_class_id#64, i_category_id#65]
-Input [8]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60, i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65]
+Output [6]: [cs_quantity#57, cs_list_price#58, cs_sold_date_sk#59, i_brand_id#62, i_class_id#63, i_category_id#64]
+Input [8]: [cs_item_sk#56, cs_quantity#57, cs_list_price#58, cs_sold_date_sk#59, i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64]
 
 (76) ReusedExchange [Reuses operator id: 129]
-Output [1]: [d_date_sk#66]
+Output [1]: [d_date_sk#65]
 
 (77) BroadcastHashJoin [codegen id : 51]
-Left keys [1]: [cs_sold_date_sk#60]
-Right keys [1]: [d_date_sk#66]
+Left keys [1]: [cs_sold_date_sk#59]
+Right keys [1]: [d_date_sk#65]
 Join type: Inner
 Join condition: None
 
 (78) Project [codegen id : 51]
-Output [5]: [cs_quantity#58, cs_list_price#59, i_brand_id#63, i_class_id#64, i_category_id#65]
-Input [7]: [cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60, i_brand_id#63, i_class_id#64, i_category_id#65, d_date_sk#66]
+Output [5]: [cs_quantity#57, cs_list_price#58, i_brand_id#62, i_class_id#63, i_category_id#64]
+Input [7]: [cs_quantity#57, cs_list_price#58, cs_sold_date_sk#59, i_brand_id#62, i_class_id#63, i_category_id#64, d_date_sk#65]
 
 (79) HashAggregate [codegen id : 51]
-Input [5]: [cs_quantity#58, cs_list_price#59, i_brand_id#63, i_class_id#64, i_category_id#65]
-Keys [3]: [i_brand_id#63, i_class_id#64, i_category_id#65]
-Functions [2]: [partial_sum((cast(cs_quantity#58 as decimal(10,0)) * cs_list_price#59)), partial_count(1)]
-Aggregate Attributes [3]: [sum#67, isEmpty#68, count#69]
-Results [6]: [i_brand_id#63, i_class_id#64, i_category_id#65, sum#70, isEmpty#71, count#72]
+Input [5]: [cs_quantity#57, cs_list_price#58, i_brand_id#62, i_class_id#63, i_category_id#64]
+Keys [3]: [i_brand_id#62, i_class_id#63, i_category_id#64]
+Functions [2]: [partial_sum((cast(cs_quantity#57 as decimal(10,0)) * cs_list_price#58)), partial_count(1)]
+Aggregate Attributes [3]: [sum#66, isEmpty#67, count#68]
+Results [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#69, isEmpty#70, count#71]
 
 (80) Exchange
-Input [6]: [i_brand_id#63, i_class_id#64, i_category_id#65, sum#70, isEmpty#71, count#72]
-Arguments: hashpartitioning(i_brand_id#63, i_class_id#64, i_category_id#65, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#69, isEmpty#70, count#71]
+Arguments: hashpartitioning(i_brand_id#62, i_class_id#63, i_category_id#64, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (81) HashAggregate [codegen id : 52]
-Input [6]: [i_brand_id#63, i_class_id#64, i_category_id#65, sum#70, isEmpty#71, count#72]
-Keys [3]: [i_brand_id#63, i_class_id#64, i_category_id#65]
-Functions [2]: [sum((cast(cs_quantity#58 as decimal(10,0)) * cs_list_price#59)), count(1)]
-Aggregate Attributes [2]: [sum((cast(cs_quantity#58 as decimal(10,0)) * cs_list_price#59))#73, count(1)#74]
-Results [5]: [i_brand_id#63, i_class_id#64, i_category_id#65, sum((cast(cs_quantity#58 as decimal(10,0)) * cs_list_price#59))#73 AS sales#75, count(1)#74 AS number_sales#76]
+Input [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#69, isEmpty#70, count#71]
+Keys [3]: [i_brand_id#62, i_class_id#63, i_category_id#64]
+Functions [2]: [sum((cast(cs_quantity#57 as decimal(10,0)) * cs_list_price#58)), count(1)]
+Aggregate Attributes [2]: [sum((cast(cs_quantity#57 as decimal(10,0)) * cs_list_price#58))#72, count(1)#73]
+Results [5]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum((cast(cs_quantity#57 as decimal(10,0)) * cs_list_price#58))#72 AS sales#74, count(1)#73 AS number_sales#75]
 
 (82) Filter [codegen id : 52]
-Input [5]: [i_brand_id#63, i_class_id#64, i_category_id#65, sales#75, number_sales#76]
-Condition : (isnotnull(sales#75) AND (cast(sales#75 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
+Input [5]: [i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
+Condition : (isnotnull(sales#74) AND (cast(sales#74 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#10] as decimal(32,6))))
 
 (83) Project [codegen id : 52]
-Output [6]: [sales#75, number_sales#76, catalog AS channel#77, i_brand_id#63, i_class_id#64, i_category_id#65]
-Input [5]: [i_brand_id#63, i_class_id#64, i_category_id#65, sales#75, number_sales#76]
+Output [6]: [sales#74, number_sales#75, catalog AS channel#76, i_brand_id#62, i_class_id#63, i_category_id#64]
+Input [5]: [i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
 
 (84) Scan parquet spark_catalog.default.web_sales
-Output [4]: [ws_item_sk#78, ws_quantity#79, ws_list_price#80, ws_sold_date_sk#81]
+Output [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#81), dynamicpruningexpression(ws_sold_date_sk#81 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#80), dynamicpruningexpression(ws_sold_date_sk#80 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (85) ColumnarToRow [codegen id : 77]
-Input [4]: [ws_item_sk#78, ws_quantity#79, ws_list_price#80, ws_sold_date_sk#81]
+Input [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
 
 (86) Filter [codegen id : 77]
-Input [4]: [ws_item_sk#78, ws_quantity#79, ws_list_price#80, ws_sold_date_sk#81]
-Condition : isnotnull(ws_item_sk#78)
+Input [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
+Condition : isnotnull(ws_item_sk#77)
 
 (87) ReusedExchange [Reuses operator id: 50]
-Output [1]: [ss_item_sk#82]
+Output [1]: [ss_item_sk#81]
 
 (88) BroadcastHashJoin [codegen id : 77]
-Left keys [1]: [ws_item_sk#78]
-Right keys [1]: [ss_item_sk#82]
+Left keys [1]: [ws_item_sk#77]
+Right keys [1]: [ss_item_sk#81]
 Join type: LeftSemi
 Join condition: None
 
 (89) ReusedExchange [Reuses operator id: 57]
-Output [4]: [i_item_sk#83, i_brand_id#84, i_class_id#85, i_category_id#86]
+Output [4]: [i_item_sk#82, i_brand_id#83, i_class_id#84, i_category_id#85]
 
 (90) BroadcastHashJoin [codegen id : 77]
-Left keys [1]: [ws_item_sk#78]
-Right keys [1]: [i_item_sk#83]
+Left keys [1]: [ws_item_sk#77]
+Right keys [1]: [i_item_sk#82]
 Join type: Inner
 Join condition: None
 
 (91) Project [codegen id : 77]
-Output [6]: [ws_quantity#79, ws_list_price#80, ws_sold_date_sk#81, i_brand_id#84, i_class_id#85, i_category_id#86]
-Input [8]: [ws_item_sk#78, ws_quantity#79, ws_list_price#80, ws_sold_date_sk#81, i_item_sk#83, i_brand_id#84, i_class_id#85, i_category_id#86]
+Output [6]: [ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80, i_brand_id#83, i_class_id#84, i_category_id#85]
+Input [8]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80, i_item_sk#82, i_brand_id#83, i_class_id#84, i_category_id#85]
 
 (92) ReusedExchange [Reuses operator id: 129]
-Output [1]: [d_date_sk#87]
+Output [1]: [d_date_sk#86]
 
 (93) BroadcastHashJoin [codegen id : 77]
-Left keys [1]: [ws_sold_date_sk#81]
-Right keys [1]: [d_date_sk#87]
+Left keys [1]: [ws_sold_date_sk#80]
+Right keys [1]: [d_date_sk#86]
 Join type: Inner
 Join condition: None
 
 (94) Project [codegen id : 77]
-Output [5]: [ws_quantity#79, ws_list_price#80, i_brand_id#84, i_class_id#85, i_category_id#86]
-Input [7]: [ws_quantity#79, ws_list_price#80, ws_sold_date_sk#81, i_brand_id#84, i_class_id#85, i_category_id#86, d_date_sk#87]
+Output [5]: [ws_quantity#78, ws_list_price#79, i_brand_id#83, i_class_id#84, i_category_id#85]
+Input [7]: [ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80, i_brand_id#83, i_class_id#84, i_category_id#85, d_date_sk#86]
 
 (95) HashAggregate [codegen id : 77]
-Input [5]: [ws_quantity#79, ws_list_price#80, i_brand_id#84, i_class_id#85, i_category_id#86]
-Keys [3]: [i_brand_id#84, i_class_id#85, i_category_id#86]
-Functions [2]: [partial_sum((cast(ws_quantity#79 as decimal(10,0)) * ws_list_price#80)), partial_count(1)]
-Aggregate Attributes [3]: [sum#88, isEmpty#89, count#90]
-Results [6]: [i_brand_id#84, i_class_id#85, i_category_id#86, sum#91, isEmpty#92, count#93]
+Input [5]: [ws_quantity#78, ws_list_price#79, i_brand_id#83, i_class_id#84, i_category_id#85]
+Keys [3]: [i_brand_id#83, i_class_id#84, i_category_id#85]
+Functions [2]: [partial_sum((cast(ws_quantity#78 as decimal(10,0)) * ws_list_price#79)), partial_count(1)]
+Aggregate Attributes [3]: [sum#87, isEmpty#88, count#89]
+Results [6]: [i_brand_id#83, i_class_id#84, i_category_id#85, sum#90, isEmpty#91, count#92]
 
 (96) Exchange
-Input [6]: [i_brand_id#84, i_class_id#85, i_category_id#86, sum#91, isEmpty#92, count#93]
-Arguments: hashpartitioning(i_brand_id#84, i_class_id#85, i_category_id#86, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [6]: [i_brand_id#83, i_class_id#84, i_category_id#85, sum#90, isEmpty#91, count#92]
+Arguments: hashpartitioning(i_brand_id#83, i_class_id#84, i_category_id#85, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (97) HashAggregate [codegen id : 78]
-Input [6]: [i_brand_id#84, i_class_id#85, i_category_id#86, sum#91, isEmpty#92, count#93]
-Keys [3]: [i_brand_id#84, i_class_id#85, i_category_id#86]
-Functions [2]: [sum((cast(ws_quantity#79 as decimal(10,0)) * ws_list_price#80)), count(1)]
-Aggregate Attributes [2]: [sum((cast(ws_quantity#79 as decimal(10,0)) * ws_list_price#80))#94, count(1)#95]
-Results [5]: [i_brand_id#84, i_class_id#85, i_category_id#86, sum((cast(ws_quantity#79 as decimal(10,0)) * ws_list_price#80))#94 AS sales#96, count(1)#95 AS number_sales#97]
+Input [6]: [i_brand_id#83, i_class_id#84, i_category_id#85, sum#90, isEmpty#91, count#92]
+Keys [3]: [i_brand_id#83, i_class_id#84, i_category_id#85]
+Functions [2]: [sum((cast(ws_quantity#78 as decimal(10,0)) * ws_list_price#79)), count(1)]
+Aggregate Attributes [2]: [sum((cast(ws_quantity#78 as decimal(10,0)) * ws_list_price#79))#93, count(1)#94]
+Results [5]: [i_brand_id#83, i_class_id#84, i_category_id#85, sum((cast(ws_quantity#78 as decimal(10,0)) * ws_list_price#79))#93 AS sales#95, count(1)#94 AS number_sales#96]
 
 (98) Filter [codegen id : 78]
-Input [5]: [i_brand_id#84, i_class_id#85, i_category_id#86, sales#96, number_sales#97]
-Condition : (isnotnull(sales#96) AND (cast(sales#96 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
+Input [5]: [i_brand_id#83, i_class_id#84, i_category_id#85, sales#95, number_sales#96]
+Condition : (isnotnull(sales#95) AND (cast(sales#95 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#10] as decimal(32,6))))
 
 (99) Project [codegen id : 78]
-Output [6]: [sales#96, number_sales#97, web AS channel#98, i_brand_id#84, i_class_id#85, i_category_id#86]
-Input [5]: [i_brand_id#84, i_class_id#85, i_category_id#86, sales#96, number_sales#97]
+Output [6]: [sales#95, number_sales#96, web AS channel#97, i_brand_id#83, i_class_id#84, i_category_id#85]
+Input [5]: [i_brand_id#83, i_class_id#84, i_category_id#85, sales#95, number_sales#96]
 
 (100) Union
 
 (101) Expand [codegen id : 79]
-Input [6]: [sales#49, number_sales#50, channel#53, i_brand_id#54, i_class_id#55, i_category_id#56]
-Arguments: [[sales#49, number_sales#50, channel#53, i_brand_id#54, i_class_id#55, i_category_id#56, 0], [sales#49, number_sales#50, channel#53, i_brand_id#54, i_class_id#55, null, 1], [sales#49, number_sales#50, channel#53, i_brand_id#54, null, null, 3], [sales#49, number_sales#50, channel#53, null, null, null, 7], [sales#49, number_sales#50, null, null, null, null, 15]], [sales#49, number_sales#50, channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, spark_grouping_id#103]
+Input [6]: [sales#49, number_sales#50, channel#52, i_brand_id#53, i_class_id#54, i_category_id#55]
+Arguments: [[sales#49, number_sales#50, channel#52, i_brand_id#53, i_class_id#54, i_category_id#55, 0], [sales#49, number_sales#50, channel#52, i_brand_id#53, i_class_id#54, null, 1], [sales#49, number_sales#50, channel#52, i_brand_id#53, null, null, 3], [sales#49, number_sales#50, channel#52, null, null, null, 7], [sales#49, number_sales#50, null, null, null, null, 15]], [sales#49, number_sales#50, channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, spark_grouping_id#102]
 
 (102) HashAggregate [codegen id : 79]
-Input [7]: [sales#49, number_sales#50, channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, spark_grouping_id#103]
-Keys [5]: [channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, spark_grouping_id#103]
+Input [7]: [sales#49, number_sales#50, channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, spark_grouping_id#102]
+Keys [5]: [channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, spark_grouping_id#102]
 Functions [2]: [partial_sum(sales#49), partial_sum(number_sales#50)]
-Aggregate Attributes [3]: [sum#104, isEmpty#105, sum#106]
-Results [8]: [channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, spark_grouping_id#103, sum#107, isEmpty#108, sum#109]
+Aggregate Attributes [3]: [sum#103, isEmpty#104, sum#105]
+Results [8]: [channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, spark_grouping_id#102, sum#106, isEmpty#107, sum#108]
 
 (103) Exchange
-Input [8]: [channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, spark_grouping_id#103, sum#107, isEmpty#108, sum#109]
-Arguments: hashpartitioning(channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, spark_grouping_id#103, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [8]: [channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, spark_grouping_id#102, sum#106, isEmpty#107, sum#108]
+Arguments: hashpartitioning(channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, spark_grouping_id#102, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (104) HashAggregate [codegen id : 80]
-Input [8]: [channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, spark_grouping_id#103, sum#107, isEmpty#108, sum#109]
-Keys [5]: [channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, spark_grouping_id#103]
+Input [8]: [channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, spark_grouping_id#102, sum#106, isEmpty#107, sum#108]
+Keys [5]: [channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, spark_grouping_id#102]
 Functions [2]: [sum(sales#49), sum(number_sales#50)]
-Aggregate Attributes [2]: [sum(sales#49)#110, sum(number_sales#50)#111]
-Results [6]: [channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, sum(sales#49)#110 AS sum(sales)#112, sum(number_sales#50)#111 AS sum(number_sales)#113]
+Aggregate Attributes [2]: [sum(sales#49)#109, sum(number_sales#50)#110]
+Results [6]: [channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, sum(sales#49)#109 AS sum(sales)#111, sum(number_sales#50)#110 AS sum(number_sales)#112]
 
 (105) TakeOrderedAndProject
-Input [6]: [channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, sum(sales)#112, sum(number_sales)#113]
-Arguments: 100, [channel#99 ASC NULLS FIRST, i_brand_id#100 ASC NULLS FIRST, i_class_id#101 ASC NULLS FIRST, i_category_id#102 ASC NULLS FIRST], [channel#99, i_brand_id#100, i_class_id#101, i_category_id#102, sum(sales)#112, sum(number_sales)#113]
+Input [6]: [channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, sum(sales)#111, sum(number_sales)#112]
+Arguments: 100, [channel#98 ASC NULLS FIRST, i_brand_id#99 ASC NULLS FIRST, i_class_id#100 ASC NULLS FIRST, i_category_id#101 ASC NULLS FIRST], [channel#98, i_brand_id#99, i_class_id#100, i_category_id#101, sum(sales)#111, sum(number_sales)#112]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 66 Hosting Expression = Subquery scalar-subquery#51, [id=#52]
+Subquery:1 Hosting operator id = 66 Hosting Expression = Subquery scalar-subquery#51, [id=#10]
 * HashAggregate (124)
 +- Exchange (123)
    +- * HashAggregate (122)
@@ -631,99 +631,99 @@ Subquery:1 Hosting operator id = 66 Hosting Expression = Subquery scalar-subquer
 
 
 (106) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_quantity#114, ss_list_price#115, ss_sold_date_sk#116]
+Output [3]: [ss_quantity#113, ss_list_price#114, ss_sold_date_sk#115]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#116), dynamicpruningexpression(ss_sold_date_sk#116 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#115), dynamicpruningexpression(ss_sold_date_sk#115 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (107) ColumnarToRow [codegen id : 2]
-Input [3]: [ss_quantity#114, ss_list_price#115, ss_sold_date_sk#116]
+Input [3]: [ss_quantity#113, ss_list_price#114, ss_sold_date_sk#115]
 
 (108) ReusedExchange [Reuses operator id: 134]
-Output [1]: [d_date_sk#117]
+Output [1]: [d_date_sk#116]
 
 (109) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#116]
-Right keys [1]: [d_date_sk#117]
+Left keys [1]: [ss_sold_date_sk#115]
+Right keys [1]: [d_date_sk#116]
 Join type: Inner
 Join condition: None
 
 (110) Project [codegen id : 2]
-Output [2]: [ss_quantity#114 AS quantity#118, ss_list_price#115 AS list_price#119]
-Input [4]: [ss_quantity#114, ss_list_price#115, ss_sold_date_sk#116, d_date_sk#117]
+Output [2]: [ss_quantity#113 AS quantity#117, ss_list_price#114 AS list_price#118]
+Input [4]: [ss_quantity#113, ss_list_price#114, ss_sold_date_sk#115, d_date_sk#116]
 
 (111) Scan parquet spark_catalog.default.catalog_sales
-Output [3]: [cs_quantity#120, cs_list_price#121, cs_sold_date_sk#122]
+Output [3]: [cs_quantity#119, cs_list_price#120, cs_sold_date_sk#121]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#122), dynamicpruningexpression(cs_sold_date_sk#122 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#121), dynamicpruningexpression(cs_sold_date_sk#121 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (112) ColumnarToRow [codegen id : 4]
-Input [3]: [cs_quantity#120, cs_list_price#121, cs_sold_date_sk#122]
+Input [3]: [cs_quantity#119, cs_list_price#120, cs_sold_date_sk#121]
 
 (113) ReusedExchange [Reuses operator id: 134]
-Output [1]: [d_date_sk#123]
+Output [1]: [d_date_sk#122]
 
 (114) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_sold_date_sk#122]
-Right keys [1]: [d_date_sk#123]
+Left keys [1]: [cs_sold_date_sk#121]
+Right keys [1]: [d_date_sk#122]
 Join type: Inner
 Join condition: None
 
 (115) Project [codegen id : 4]
-Output [2]: [cs_quantity#120 AS quantity#124, cs_list_price#121 AS list_price#125]
-Input [4]: [cs_quantity#120, cs_list_price#121, cs_sold_date_sk#122, d_date_sk#123]
+Output [2]: [cs_quantity#119 AS quantity#123, cs_list_price#120 AS list_price#124]
+Input [4]: [cs_quantity#119, cs_list_price#120, cs_sold_date_sk#121, d_date_sk#122]
 
 (116) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_quantity#126, ws_list_price#127, ws_sold_date_sk#128]
+Output [3]: [ws_quantity#125, ws_list_price#126, ws_sold_date_sk#127]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#128), dynamicpruningexpression(ws_sold_date_sk#128 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#127), dynamicpruningexpression(ws_sold_date_sk#127 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (117) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_quantity#126, ws_list_price#127, ws_sold_date_sk#128]
+Input [3]: [ws_quantity#125, ws_list_price#126, ws_sold_date_sk#127]
 
 (118) ReusedExchange [Reuses operator id: 134]
-Output [1]: [d_date_sk#129]
+Output [1]: [d_date_sk#128]
 
 (119) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#128]
-Right keys [1]: [d_date_sk#129]
+Left keys [1]: [ws_sold_date_sk#127]
+Right keys [1]: [d_date_sk#128]
 Join type: Inner
 Join condition: None
 
 (120) Project [codegen id : 6]
-Output [2]: [ws_quantity#126 AS quantity#130, ws_list_price#127 AS list_price#131]
-Input [4]: [ws_quantity#126, ws_list_price#127, ws_sold_date_sk#128, d_date_sk#129]
+Output [2]: [ws_quantity#125 AS quantity#129, ws_list_price#126 AS list_price#130]
+Input [4]: [ws_quantity#125, ws_list_price#126, ws_sold_date_sk#127, d_date_sk#128]
 
 (121) Union
 
 (122) HashAggregate [codegen id : 7]
-Input [2]: [quantity#118, list_price#119]
+Input [2]: [quantity#117, list_price#118]
 Keys: []
-Functions [1]: [partial_avg((cast(quantity#118 as decimal(10,0)) * list_price#119))]
-Aggregate Attributes [2]: [sum#132, count#133]
-Results [2]: [sum#134, count#135]
+Functions [1]: [partial_avg((cast(quantity#117 as decimal(10,0)) * list_price#118))]
+Aggregate Attributes [2]: [sum#131, count#132]
+Results [2]: [sum#133, count#134]
 
 (123) Exchange
-Input [2]: [sum#134, count#135]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
+Input [2]: [sum#133, count#134]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
 
 (124) HashAggregate [codegen id : 8]
-Input [2]: [sum#134, count#135]
+Input [2]: [sum#133, count#134]
 Keys: []
-Functions [1]: [avg((cast(quantity#118 as decimal(10,0)) * list_price#119))]
-Aggregate Attributes [1]: [avg((cast(quantity#118 as decimal(10,0)) * list_price#119))#136]
-Results [1]: [avg((cast(quantity#118 as decimal(10,0)) * list_price#119))#136 AS average_sales#137]
+Functions [1]: [avg((cast(quantity#117 as decimal(10,0)) * list_price#118))]
+Aggregate Attributes [1]: [avg((cast(quantity#117 as decimal(10,0)) * list_price#118))#135]
+Results [1]: [avg((cast(quantity#117 as decimal(10,0)) * list_price#118))#135 AS average_sales#136]
 
-Subquery:2 Hosting operator id = 106 Hosting Expression = ss_sold_date_sk#116 IN dynamicpruning#12
+Subquery:2 Hosting operator id = 106 Hosting Expression = ss_sold_date_sk#115 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 111 Hosting Expression = cs_sold_date_sk#122 IN dynamicpruning#12
+Subquery:3 Hosting operator id = 111 Hosting Expression = cs_sold_date_sk#121 IN dynamicpruning#12
 
-Subquery:4 Hosting operator id = 116 Hosting Expression = ws_sold_date_sk#128 IN dynamicpruning#12
+Subquery:4 Hosting operator id = 116 Hosting Expression = ws_sold_date_sk#127 IN dynamicpruning#12
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (129)
@@ -734,26 +734,26 @@ BroadcastExchange (129)
 
 
 (125) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#40, d_year#138, d_moy#139]
+Output [3]: [d_date_sk#40, d_year#137, d_moy#138]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2001), EqualTo(d_moy,11), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (126) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#40, d_year#138, d_moy#139]
+Input [3]: [d_date_sk#40, d_year#137, d_moy#138]
 
 (127) Filter [codegen id : 1]
-Input [3]: [d_date_sk#40, d_year#138, d_moy#139]
-Condition : ((((isnotnull(d_year#138) AND isnotnull(d_moy#139)) AND (d_year#138 = 2001)) AND (d_moy#139 = 11)) AND isnotnull(d_date_sk#40))
+Input [3]: [d_date_sk#40, d_year#137, d_moy#138]
+Condition : ((((isnotnull(d_year#137) AND isnotnull(d_moy#138)) AND (d_year#137 = 2001)) AND (d_moy#138 = 11)) AND isnotnull(d_date_sk#40))
 
 (128) Project [codegen id : 1]
 Output [1]: [d_date_sk#40]
-Input [3]: [d_date_sk#40, d_year#138, d_moy#139]
+Input [3]: [d_date_sk#40, d_year#137, d_moy#138]
 
 (129) BroadcastExchange
 Input [1]: [d_date_sk#40]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
 
 Subquery:6 Hosting operator id = 7 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
 BroadcastExchange (134)
@@ -764,37 +764,37 @@ BroadcastExchange (134)
 
 
 (130) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#24, d_year#140]
+Output [2]: [d_date_sk#24, d_year#139]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (131) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#24, d_year#140]
+Input [2]: [d_date_sk#24, d_year#139]
 
 (132) Filter [codegen id : 1]
-Input [2]: [d_date_sk#24, d_year#140]
-Condition : (((isnotnull(d_year#140) AND (d_year#140 >= 1999)) AND (d_year#140 <= 2001)) AND isnotnull(d_date_sk#24))
+Input [2]: [d_date_sk#24, d_year#139]
+Condition : (((isnotnull(d_year#139) AND (d_year#139 >= 1999)) AND (d_year#139 <= 2001)) AND isnotnull(d_date_sk#24))
 
 (133) Project [codegen id : 1]
 Output [1]: [d_date_sk#24]
-Input [2]: [d_date_sk#24, d_year#140]
+Input [2]: [d_date_sk#24, d_year#139]
 
 (134) BroadcastExchange
 Input [1]: [d_date_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=16]
 
 Subquery:7 Hosting operator id = 13 Hosting Expression = cs_sold_date_sk#18 IN dynamicpruning#12
 
 Subquery:8 Hosting operator id = 36 Hosting Expression = ws_sold_date_sk#29 IN dynamicpruning#12
 
-Subquery:9 Hosting operator id = 82 Hosting Expression = ReusedSubquery Subquery scalar-subquery#51, [id=#52]
+Subquery:9 Hosting operator id = 82 Hosting Expression = ReusedSubquery Subquery scalar-subquery#51, [id=#10]
 
-Subquery:10 Hosting operator id = 68 Hosting Expression = cs_sold_date_sk#60 IN dynamicpruning#5
+Subquery:10 Hosting operator id = 68 Hosting Expression = cs_sold_date_sk#59 IN dynamicpruning#5
 
-Subquery:11 Hosting operator id = 98 Hosting Expression = ReusedSubquery Subquery scalar-subquery#51, [id=#52]
+Subquery:11 Hosting operator id = 98 Hosting Expression = ReusedSubquery Subquery scalar-subquery#51, [id=#10]
 
-Subquery:12 Hosting operator id = 84 Hosting Expression = ws_sold_date_sk#81 IN dynamicpruning#5
+Subquery:12 Hosting operator id = 84 Hosting Expression = ws_sold_date_sk#80 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/explain.txt
@@ -429,97 +429,97 @@ Results [6]: [store AS channel#49, i_brand_id#38, i_class_id#39, i_category_id#4
 
 (72) Filter [codegen id : 76]
 Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51]
-Condition : (isnotnull(sales#50) AND (cast(sales#50 as decimal(32,6)) > cast(Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
+Condition : (isnotnull(sales#50) AND (cast(sales#50 as decimal(32,6)) > cast(Subquery scalar-subquery#52, [id=#12] as decimal(32,6))))
 
 (73) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57]
+Output [4]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#57), dynamicpruningexpression(ss_sold_date_sk#57 IN dynamicpruning#58)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#56), dynamicpruningexpression(ss_sold_date_sk#56 IN dynamicpruning#57)]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (74) ColumnarToRow [codegen id : 74]
-Input [4]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57]
+Input [4]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56]
 
 (75) Filter [codegen id : 74]
-Input [4]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57]
-Condition : isnotnull(ss_item_sk#54)
+Input [4]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56]
+Condition : isnotnull(ss_item_sk#53)
 
 (76) ReusedExchange [Reuses operator id: 56]
-Output [1]: [ss_item_sk#59]
+Output [1]: [ss_item_sk#58]
 
 (77) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_item_sk#54]
-Right keys [1]: [ss_item_sk#59]
+Left keys [1]: [ss_item_sk#53]
+Right keys [1]: [ss_item_sk#58]
 Join type: LeftSemi
 Join condition: None
 
 (78) ReusedExchange [Reuses operator id: 128]
-Output [1]: [d_date_sk#60]
+Output [1]: [d_date_sk#59]
 
 (79) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_sold_date_sk#57]
-Right keys [1]: [d_date_sk#60]
+Left keys [1]: [ss_sold_date_sk#56]
+Right keys [1]: [d_date_sk#59]
 Join type: Inner
 Join condition: None
 
 (80) Project [codegen id : 74]
-Output [3]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56]
-Input [5]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57, d_date_sk#60]
+Output [3]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55]
+Input [5]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56, d_date_sk#59]
 
 (81) ReusedExchange [Reuses operator id: 66]
-Output [4]: [i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64]
+Output [4]: [i_item_sk#60, i_brand_id#61, i_class_id#62, i_category_id#63]
 
 (82) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_item_sk#54]
-Right keys [1]: [i_item_sk#61]
+Left keys [1]: [ss_item_sk#53]
+Right keys [1]: [i_item_sk#60]
 Join type: Inner
 Join condition: None
 
 (83) Project [codegen id : 74]
-Output [5]: [ss_quantity#55, ss_list_price#56, i_brand_id#62, i_class_id#63, i_category_id#64]
-Input [7]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64]
+Output [5]: [ss_quantity#54, ss_list_price#55, i_brand_id#61, i_class_id#62, i_category_id#63]
+Input [7]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, i_item_sk#60, i_brand_id#61, i_class_id#62, i_category_id#63]
 
 (84) HashAggregate [codegen id : 74]
-Input [5]: [ss_quantity#55, ss_list_price#56, i_brand_id#62, i_class_id#63, i_category_id#64]
-Keys [3]: [i_brand_id#62, i_class_id#63, i_category_id#64]
-Functions [2]: [partial_sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56)), partial_count(1)]
-Aggregate Attributes [3]: [sum#65, isEmpty#66, count#67]
-Results [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#68, isEmpty#69, count#70]
+Input [5]: [ss_quantity#54, ss_list_price#55, i_brand_id#61, i_class_id#62, i_category_id#63]
+Keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
+Functions [2]: [partial_sum((cast(ss_quantity#54 as decimal(10,0)) * ss_list_price#55)), partial_count(1)]
+Aggregate Attributes [3]: [sum#64, isEmpty#65, count#66]
+Results [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#67, isEmpty#68, count#69]
 
 (85) Exchange
-Input [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#68, isEmpty#69, count#70]
-Arguments: hashpartitioning(i_brand_id#62, i_class_id#63, i_category_id#64, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#67, isEmpty#68, count#69]
+Arguments: hashpartitioning(i_brand_id#61, i_class_id#62, i_category_id#63, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (86) HashAggregate [codegen id : 75]
-Input [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#68, isEmpty#69, count#70]
-Keys [3]: [i_brand_id#62, i_class_id#63, i_category_id#64]
-Functions [2]: [sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56)), count(1)]
-Aggregate Attributes [2]: [sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56))#71, count(1)#72]
-Results [6]: [store AS channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56))#71 AS sales#74, count(1)#72 AS number_sales#75]
+Input [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#67, isEmpty#68, count#69]
+Keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
+Functions [2]: [sum((cast(ss_quantity#54 as decimal(10,0)) * ss_list_price#55)), count(1)]
+Aggregate Attributes [2]: [sum((cast(ss_quantity#54 as decimal(10,0)) * ss_list_price#55))#70, count(1)#71]
+Results [6]: [store AS channel#72, i_brand_id#61, i_class_id#62, i_category_id#63, sum((cast(ss_quantity#54 as decimal(10,0)) * ss_list_price#55))#70 AS sales#73, count(1)#71 AS number_sales#74]
 
 (87) Filter [codegen id : 75]
-Input [6]: [channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
-Condition : (isnotnull(sales#74) AND (cast(sales#74 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
+Input [6]: [channel#72, i_brand_id#61, i_class_id#62, i_category_id#63, sales#73, number_sales#74]
+Condition : (isnotnull(sales#73) AND (cast(sales#73 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#12] as decimal(32,6))))
 
 (88) BroadcastExchange
-Input [6]: [channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
-Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [plan_id=13]
+Input [6]: [channel#72, i_brand_id#61, i_class_id#62, i_category_id#63, sales#73, number_sales#74]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [plan_id=14]
 
 (89) BroadcastHashJoin [codegen id : 76]
 Left keys [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
-Right keys [3]: [i_brand_id#62, i_class_id#63, i_category_id#64]
+Right keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
 Join type: Inner
 Join condition: None
 
 (90) TakeOrderedAndProject
-Input [12]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51, channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
-Arguments: 100, [i_brand_id#38 ASC NULLS FIRST, i_class_id#39 ASC NULLS FIRST, i_category_id#40 ASC NULLS FIRST], [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51, channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
+Input [12]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51, channel#72, i_brand_id#61, i_class_id#62, i_category_id#63, sales#73, number_sales#74]
+Arguments: 100, [i_brand_id#38 ASC NULLS FIRST, i_class_id#39 ASC NULLS FIRST, i_category_id#40 ASC NULLS FIRST], [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51, channel#72, i_brand_id#61, i_class_id#62, i_category_id#63, sales#73, number_sales#74]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 72 Hosting Expression = Subquery scalar-subquery#52, [id=#53]
+Subquery:1 Hosting operator id = 72 Hosting Expression = Subquery scalar-subquery#52, [id=#12]
 * HashAggregate (109)
 +- Exchange (108)
    +- * HashAggregate (107)
@@ -542,99 +542,99 @@ Subquery:1 Hosting operator id = 72 Hosting Expression = Subquery scalar-subquer
 
 
 (91) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_quantity#76, ss_list_price#77, ss_sold_date_sk#78]
+Output [3]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#78), dynamicpruningexpression(ss_sold_date_sk#78 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#77), dynamicpruningexpression(ss_sold_date_sk#77 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (92) ColumnarToRow [codegen id : 2]
-Input [3]: [ss_quantity#76, ss_list_price#77, ss_sold_date_sk#78]
+Input [3]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77]
 
 (93) ReusedExchange [Reuses operator id: 123]
-Output [1]: [d_date_sk#79]
+Output [1]: [d_date_sk#78]
 
 (94) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#78]
-Right keys [1]: [d_date_sk#79]
+Left keys [1]: [ss_sold_date_sk#77]
+Right keys [1]: [d_date_sk#78]
 Join type: Inner
 Join condition: None
 
 (95) Project [codegen id : 2]
-Output [2]: [ss_quantity#76 AS quantity#80, ss_list_price#77 AS list_price#81]
-Input [4]: [ss_quantity#76, ss_list_price#77, ss_sold_date_sk#78, d_date_sk#79]
+Output [2]: [ss_quantity#75 AS quantity#79, ss_list_price#76 AS list_price#80]
+Input [4]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77, d_date_sk#78]
 
 (96) Scan parquet spark_catalog.default.catalog_sales
-Output [3]: [cs_quantity#82, cs_list_price#83, cs_sold_date_sk#84]
+Output [3]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#84), dynamicpruningexpression(cs_sold_date_sk#84 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#83), dynamicpruningexpression(cs_sold_date_sk#83 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (97) ColumnarToRow [codegen id : 4]
-Input [3]: [cs_quantity#82, cs_list_price#83, cs_sold_date_sk#84]
+Input [3]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83]
 
 (98) ReusedExchange [Reuses operator id: 123]
-Output [1]: [d_date_sk#85]
+Output [1]: [d_date_sk#84]
 
 (99) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_sold_date_sk#84]
-Right keys [1]: [d_date_sk#85]
+Left keys [1]: [cs_sold_date_sk#83]
+Right keys [1]: [d_date_sk#84]
 Join type: Inner
 Join condition: None
 
 (100) Project [codegen id : 4]
-Output [2]: [cs_quantity#82 AS quantity#86, cs_list_price#83 AS list_price#87]
-Input [4]: [cs_quantity#82, cs_list_price#83, cs_sold_date_sk#84, d_date_sk#85]
+Output [2]: [cs_quantity#81 AS quantity#85, cs_list_price#82 AS list_price#86]
+Input [4]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83, d_date_sk#84]
 
 (101) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90]
+Output [3]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#90), dynamicpruningexpression(ws_sold_date_sk#90 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#89), dynamicpruningexpression(ws_sold_date_sk#89 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (102) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90]
+Input [3]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89]
 
 (103) ReusedExchange [Reuses operator id: 123]
-Output [1]: [d_date_sk#91]
+Output [1]: [d_date_sk#90]
 
 (104) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#90]
-Right keys [1]: [d_date_sk#91]
+Left keys [1]: [ws_sold_date_sk#89]
+Right keys [1]: [d_date_sk#90]
 Join type: Inner
 Join condition: None
 
 (105) Project [codegen id : 6]
-Output [2]: [ws_quantity#88 AS quantity#92, ws_list_price#89 AS list_price#93]
-Input [4]: [ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90, d_date_sk#91]
+Output [2]: [ws_quantity#87 AS quantity#91, ws_list_price#88 AS list_price#92]
+Input [4]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89, d_date_sk#90]
 
 (106) Union
 
 (107) HashAggregate [codegen id : 7]
-Input [2]: [quantity#80, list_price#81]
+Input [2]: [quantity#79, list_price#80]
 Keys: []
-Functions [1]: [partial_avg((cast(quantity#80 as decimal(10,0)) * list_price#81))]
-Aggregate Attributes [2]: [sum#94, count#95]
-Results [2]: [sum#96, count#97]
+Functions [1]: [partial_avg((cast(quantity#79 as decimal(10,0)) * list_price#80))]
+Aggregate Attributes [2]: [sum#93, count#94]
+Results [2]: [sum#95, count#96]
 
 (108) Exchange
-Input [2]: [sum#96, count#97]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
+Input [2]: [sum#95, count#96]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
 
 (109) HashAggregate [codegen id : 8]
-Input [2]: [sum#96, count#97]
+Input [2]: [sum#95, count#96]
 Keys: []
-Functions [1]: [avg((cast(quantity#80 as decimal(10,0)) * list_price#81))]
-Aggregate Attributes [1]: [avg((cast(quantity#80 as decimal(10,0)) * list_price#81))#98]
-Results [1]: [avg((cast(quantity#80 as decimal(10,0)) * list_price#81))#98 AS average_sales#99]
+Functions [1]: [avg((cast(quantity#79 as decimal(10,0)) * list_price#80))]
+Aggregate Attributes [1]: [avg((cast(quantity#79 as decimal(10,0)) * list_price#80))#97]
+Results [1]: [avg((cast(quantity#79 as decimal(10,0)) * list_price#80))#97 AS average_sales#98]
 
-Subquery:2 Hosting operator id = 91 Hosting Expression = ss_sold_date_sk#78 IN dynamicpruning#12
+Subquery:2 Hosting operator id = 91 Hosting Expression = ss_sold_date_sk#77 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 96 Hosting Expression = cs_sold_date_sk#84 IN dynamicpruning#12
+Subquery:3 Hosting operator id = 96 Hosting Expression = cs_sold_date_sk#83 IN dynamicpruning#12
 
-Subquery:4 Hosting operator id = 101 Hosting Expression = ws_sold_date_sk#90 IN dynamicpruning#12
+Subquery:4 Hosting operator id = 101 Hosting Expression = ws_sold_date_sk#89 IN dynamicpruning#12
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (114)
@@ -645,30 +645,30 @@ BroadcastExchange (114)
 
 
 (110) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#36, d_week_seq#100]
+Output [2]: [d_date_sk#36, d_week_seq#99]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#101), IsNotNull(d_date_sk)]
+PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#100), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
 (111) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#36, d_week_seq#100]
+Input [2]: [d_date_sk#36, d_week_seq#99]
 
 (112) Filter [codegen id : 1]
-Input [2]: [d_date_sk#36, d_week_seq#100]
-Condition : ((isnotnull(d_week_seq#100) AND (d_week_seq#100 = ReusedSubquery Subquery scalar-subquery#101, [id=#102])) AND isnotnull(d_date_sk#36))
+Input [2]: [d_date_sk#36, d_week_seq#99]
+Condition : ((isnotnull(d_week_seq#99) AND (d_week_seq#99 = ReusedSubquery Subquery scalar-subquery#100, [id=#16])) AND isnotnull(d_date_sk#36))
 
 (113) Project [codegen id : 1]
 Output [1]: [d_date_sk#36]
-Input [2]: [d_date_sk#36, d_week_seq#100]
+Input [2]: [d_date_sk#36, d_week_seq#99]
 
 (114) BroadcastExchange
 Input [1]: [d_date_sk#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=17]
 
-Subquery:6 Hosting operator id = 112 Hosting Expression = ReusedSubquery Subquery scalar-subquery#101, [id=#102]
+Subquery:6 Hosting operator id = 112 Hosting Expression = ReusedSubquery Subquery scalar-subquery#100, [id=#16]
 
-Subquery:7 Hosting operator id = 110 Hosting Expression = Subquery scalar-subquery#101, [id=#102]
+Subquery:7 Hosting operator id = 110 Hosting Expression = Subquery scalar-subquery#100, [id=#16]
 * Project (118)
 +- * Filter (117)
    +- * ColumnarToRow (116)
@@ -676,22 +676,22 @@ Subquery:7 Hosting operator id = 110 Hosting Expression = Subquery scalar-subque
 
 
 (115) Scan parquet spark_catalog.default.date_dim
-Output [4]: [d_week_seq#103, d_year#104, d_moy#105, d_dom#106]
+Output [4]: [d_week_seq#101, d_year#102, d_moy#103, d_dom#104]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,2000), EqualTo(d_moy,12), EqualTo(d_dom,11)]
 ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
 
 (116) ColumnarToRow [codegen id : 1]
-Input [4]: [d_week_seq#103, d_year#104, d_moy#105, d_dom#106]
+Input [4]: [d_week_seq#101, d_year#102, d_moy#103, d_dom#104]
 
 (117) Filter [codegen id : 1]
-Input [4]: [d_week_seq#103, d_year#104, d_moy#105, d_dom#106]
-Condition : (((((isnotnull(d_year#104) AND isnotnull(d_moy#105)) AND isnotnull(d_dom#106)) AND (d_year#104 = 2000)) AND (d_moy#105 = 12)) AND (d_dom#106 = 11))
+Input [4]: [d_week_seq#101, d_year#102, d_moy#103, d_dom#104]
+Condition : (((((isnotnull(d_year#102) AND isnotnull(d_moy#103)) AND isnotnull(d_dom#104)) AND (d_year#102 = 2000)) AND (d_moy#103 = 12)) AND (d_dom#104 = 11))
 
 (118) Project [codegen id : 1]
-Output [1]: [d_week_seq#103]
-Input [4]: [d_week_seq#103, d_year#104, d_moy#105, d_dom#106]
+Output [1]: [d_week_seq#101]
+Input [4]: [d_week_seq#101, d_year#102, d_moy#103, d_dom#104]
 
 Subquery:8 Hosting operator id = 7 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
 BroadcastExchange (123)
@@ -702,34 +702,34 @@ BroadcastExchange (123)
 
 
 (119) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#13, d_year#107]
+Output [2]: [d_date_sk#13, d_year#105]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (120) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#107]
+Input [2]: [d_date_sk#13, d_year#105]
 
 (121) Filter [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#107]
-Condition : (((isnotnull(d_year#107) AND (d_year#107 >= 1999)) AND (d_year#107 <= 2001)) AND isnotnull(d_date_sk#13))
+Input [2]: [d_date_sk#13, d_year#105]
+Condition : (((isnotnull(d_year#105) AND (d_year#105 >= 1999)) AND (d_year#105 <= 2001)) AND isnotnull(d_date_sk#13))
 
 (122) Project [codegen id : 1]
 Output [1]: [d_date_sk#13]
-Input [2]: [d_date_sk#13, d_year#107]
+Input [2]: [d_date_sk#13, d_year#105]
 
 (123) BroadcastExchange
 Input [1]: [d_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=18]
 
 Subquery:9 Hosting operator id = 18 Hosting Expression = cs_sold_date_sk#19 IN dynamicpruning#12
 
 Subquery:10 Hosting operator id = 41 Hosting Expression = ws_sold_date_sk#29 IN dynamicpruning#12
 
-Subquery:11 Hosting operator id = 87 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#53]
+Subquery:11 Hosting operator id = 87 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#12]
 
-Subquery:12 Hosting operator id = 73 Hosting Expression = ss_sold_date_sk#57 IN dynamicpruning#58
+Subquery:12 Hosting operator id = 73 Hosting Expression = ss_sold_date_sk#56 IN dynamicpruning#57
 BroadcastExchange (128)
 +- * Project (127)
    +- * Filter (126)
@@ -738,30 +738,30 @@ BroadcastExchange (128)
 
 
 (124) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#60, d_week_seq#108]
+Output [2]: [d_date_sk#59, d_week_seq#106]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#109), IsNotNull(d_date_sk)]
+PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#107), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
 (125) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#60, d_week_seq#108]
+Input [2]: [d_date_sk#59, d_week_seq#106]
 
 (126) Filter [codegen id : 1]
-Input [2]: [d_date_sk#60, d_week_seq#108]
-Condition : ((isnotnull(d_week_seq#108) AND (d_week_seq#108 = ReusedSubquery Subquery scalar-subquery#109, [id=#110])) AND isnotnull(d_date_sk#60))
+Input [2]: [d_date_sk#59, d_week_seq#106]
+Condition : ((isnotnull(d_week_seq#106) AND (d_week_seq#106 = ReusedSubquery Subquery scalar-subquery#107, [id=#19])) AND isnotnull(d_date_sk#59))
 
 (127) Project [codegen id : 1]
-Output [1]: [d_date_sk#60]
-Input [2]: [d_date_sk#60, d_week_seq#108]
+Output [1]: [d_date_sk#59]
+Input [2]: [d_date_sk#59, d_week_seq#106]
 
 (128) BroadcastExchange
-Input [1]: [d_date_sk#60]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=17]
+Input [1]: [d_date_sk#59]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=20]
 
-Subquery:13 Hosting operator id = 126 Hosting Expression = ReusedSubquery Subquery scalar-subquery#109, [id=#110]
+Subquery:13 Hosting operator id = 126 Hosting Expression = ReusedSubquery Subquery scalar-subquery#107, [id=#19]
 
-Subquery:14 Hosting operator id = 124 Hosting Expression = Subquery scalar-subquery#109, [id=#110]
+Subquery:14 Hosting operator id = 124 Hosting Expression = Subquery scalar-subquery#107, [id=#19]
 * Project (132)
 +- * Filter (131)
    +- * ColumnarToRow (130)
@@ -769,21 +769,21 @@ Subquery:14 Hosting operator id = 124 Hosting Expression = Subquery scalar-subqu
 
 
 (129) Scan parquet spark_catalog.default.date_dim
-Output [4]: [d_week_seq#111, d_year#112, d_moy#113, d_dom#114]
+Output [4]: [d_week_seq#108, d_year#109, d_moy#110, d_dom#111]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,1999), EqualTo(d_moy,12), EqualTo(d_dom,11)]
 ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
 
 (130) ColumnarToRow [codegen id : 1]
-Input [4]: [d_week_seq#111, d_year#112, d_moy#113, d_dom#114]
+Input [4]: [d_week_seq#108, d_year#109, d_moy#110, d_dom#111]
 
 (131) Filter [codegen id : 1]
-Input [4]: [d_week_seq#111, d_year#112, d_moy#113, d_dom#114]
-Condition : (((((isnotnull(d_year#112) AND isnotnull(d_moy#113)) AND isnotnull(d_dom#114)) AND (d_year#112 = 1999)) AND (d_moy#113 = 12)) AND (d_dom#114 = 11))
+Input [4]: [d_week_seq#108, d_year#109, d_moy#110, d_dom#111]
+Condition : (((((isnotnull(d_year#109) AND isnotnull(d_moy#110)) AND isnotnull(d_dom#111)) AND (d_year#109 = 1999)) AND (d_moy#110 = 12)) AND (d_dom#111 = 11))
 
 (132) Project [codegen id : 1]
-Output [1]: [d_week_seq#111]
-Input [4]: [d_week_seq#111, d_year#112, d_moy#113, d_dom#114]
+Output [1]: [d_week_seq#108]
+Input [4]: [d_week_seq#108, d_year#109, d_moy#110, d_dom#111]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b/explain.txt
@@ -399,97 +399,97 @@ Results [6]: [store AS channel#49, i_brand_id#37, i_class_id#38, i_category_id#3
 
 (66) Filter [codegen id : 52]
 Input [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51]
-Condition : (isnotnull(sales#50) AND (cast(sales#50 as decimal(32,6)) > cast(Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
+Condition : (isnotnull(sales#50) AND (cast(sales#50 as decimal(32,6)) > cast(Subquery scalar-subquery#52, [id=#10] as decimal(32,6))))
 
 (67) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57]
+Output [4]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#57), dynamicpruningexpression(ss_sold_date_sk#57 IN dynamicpruning#58)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#56), dynamicpruningexpression(ss_sold_date_sk#56 IN dynamicpruning#57)]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (68) ColumnarToRow [codegen id : 50]
-Input [4]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57]
+Input [4]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56]
 
 (69) Filter [codegen id : 50]
-Input [4]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57]
-Condition : isnotnull(ss_item_sk#54)
+Input [4]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56]
+Condition : isnotnull(ss_item_sk#53)
 
 (70) ReusedExchange [Reuses operator id: 50]
-Output [1]: [ss_item_sk#59]
+Output [1]: [ss_item_sk#58]
 
 (71) BroadcastHashJoin [codegen id : 50]
-Left keys [1]: [ss_item_sk#54]
-Right keys [1]: [ss_item_sk#59]
+Left keys [1]: [ss_item_sk#53]
+Right keys [1]: [ss_item_sk#58]
 Join type: LeftSemi
 Join condition: None
 
 (72) ReusedExchange [Reuses operator id: 57]
-Output [4]: [i_item_sk#60, i_brand_id#61, i_class_id#62, i_category_id#63]
+Output [4]: [i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
 
 (73) BroadcastHashJoin [codegen id : 50]
-Left keys [1]: [ss_item_sk#54]
-Right keys [1]: [i_item_sk#60]
+Left keys [1]: [ss_item_sk#53]
+Right keys [1]: [i_item_sk#59]
 Join type: Inner
 Join condition: None
 
 (74) Project [codegen id : 50]
-Output [6]: [ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57, i_brand_id#61, i_class_id#62, i_category_id#63]
-Input [8]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57, i_item_sk#60, i_brand_id#61, i_class_id#62, i_category_id#63]
+Output [6]: [ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56, i_brand_id#60, i_class_id#61, i_category_id#62]
+Input [8]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56, i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
 
 (75) ReusedExchange [Reuses operator id: 122]
-Output [1]: [d_date_sk#64]
+Output [1]: [d_date_sk#63]
 
 (76) BroadcastHashJoin [codegen id : 50]
-Left keys [1]: [ss_sold_date_sk#57]
-Right keys [1]: [d_date_sk#64]
+Left keys [1]: [ss_sold_date_sk#56]
+Right keys [1]: [d_date_sk#63]
 Join type: Inner
 Join condition: None
 
 (77) Project [codegen id : 50]
-Output [5]: [ss_quantity#55, ss_list_price#56, i_brand_id#61, i_class_id#62, i_category_id#63]
-Input [7]: [ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57, i_brand_id#61, i_class_id#62, i_category_id#63, d_date_sk#64]
+Output [5]: [ss_quantity#54, ss_list_price#55, i_brand_id#60, i_class_id#61, i_category_id#62]
+Input [7]: [ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56, i_brand_id#60, i_class_id#61, i_category_id#62, d_date_sk#63]
 
 (78) HashAggregate [codegen id : 50]
-Input [5]: [ss_quantity#55, ss_list_price#56, i_brand_id#61, i_class_id#62, i_category_id#63]
-Keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
-Functions [2]: [partial_sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56)), partial_count(1)]
-Aggregate Attributes [3]: [sum#65, isEmpty#66, count#67]
-Results [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#68, isEmpty#69, count#70]
+Input [5]: [ss_quantity#54, ss_list_price#55, i_brand_id#60, i_class_id#61, i_category_id#62]
+Keys [3]: [i_brand_id#60, i_class_id#61, i_category_id#62]
+Functions [2]: [partial_sum((cast(ss_quantity#54 as decimal(10,0)) * ss_list_price#55)), partial_count(1)]
+Aggregate Attributes [3]: [sum#64, isEmpty#65, count#66]
+Results [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#67, isEmpty#68, count#69]
 
 (79) Exchange
-Input [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#68, isEmpty#69, count#70]
-Arguments: hashpartitioning(i_brand_id#61, i_class_id#62, i_category_id#63, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#67, isEmpty#68, count#69]
+Arguments: hashpartitioning(i_brand_id#60, i_class_id#61, i_category_id#62, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (80) HashAggregate [codegen id : 51]
-Input [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#68, isEmpty#69, count#70]
-Keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
-Functions [2]: [sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56)), count(1)]
-Aggregate Attributes [2]: [sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56))#71, count(1)#72]
-Results [6]: [store AS channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56))#71 AS sales#74, count(1)#72 AS number_sales#75]
+Input [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#67, isEmpty#68, count#69]
+Keys [3]: [i_brand_id#60, i_class_id#61, i_category_id#62]
+Functions [2]: [sum((cast(ss_quantity#54 as decimal(10,0)) * ss_list_price#55)), count(1)]
+Aggregate Attributes [2]: [sum((cast(ss_quantity#54 as decimal(10,0)) * ss_list_price#55))#70, count(1)#71]
+Results [6]: [store AS channel#72, i_brand_id#60, i_class_id#61, i_category_id#62, sum((cast(ss_quantity#54 as decimal(10,0)) * ss_list_price#55))#70 AS sales#73, count(1)#71 AS number_sales#74]
 
 (81) Filter [codegen id : 51]
-Input [6]: [channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sales#74, number_sales#75]
-Condition : (isnotnull(sales#74) AND (cast(sales#74 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
+Input [6]: [channel#72, i_brand_id#60, i_class_id#61, i_category_id#62, sales#73, number_sales#74]
+Condition : (isnotnull(sales#73) AND (cast(sales#73 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#10] as decimal(32,6))))
 
 (82) BroadcastExchange
-Input [6]: [channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sales#74, number_sales#75]
-Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [plan_id=11]
+Input [6]: [channel#72, i_brand_id#60, i_class_id#61, i_category_id#62, sales#73, number_sales#74]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [plan_id=12]
 
 (83) BroadcastHashJoin [codegen id : 52]
 Left keys [3]: [i_brand_id#37, i_class_id#38, i_category_id#39]
-Right keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
+Right keys [3]: [i_brand_id#60, i_class_id#61, i_category_id#62]
 Join type: Inner
 Join condition: None
 
 (84) TakeOrderedAndProject
-Input [12]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51, channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sales#74, number_sales#75]
-Arguments: 100, [i_brand_id#37 ASC NULLS FIRST, i_class_id#38 ASC NULLS FIRST, i_category_id#39 ASC NULLS FIRST], [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51, channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sales#74, number_sales#75]
+Input [12]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51, channel#72, i_brand_id#60, i_class_id#61, i_category_id#62, sales#73, number_sales#74]
+Arguments: 100, [i_brand_id#37 ASC NULLS FIRST, i_class_id#38 ASC NULLS FIRST, i_category_id#39 ASC NULLS FIRST], [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51, channel#72, i_brand_id#60, i_class_id#61, i_category_id#62, sales#73, number_sales#74]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 66 Hosting Expression = Subquery scalar-subquery#52, [id=#53]
+Subquery:1 Hosting operator id = 66 Hosting Expression = Subquery scalar-subquery#52, [id=#10]
 * HashAggregate (103)
 +- Exchange (102)
    +- * HashAggregate (101)
@@ -512,99 +512,99 @@ Subquery:1 Hosting operator id = 66 Hosting Expression = Subquery scalar-subquer
 
 
 (85) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_quantity#76, ss_list_price#77, ss_sold_date_sk#78]
+Output [3]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#78), dynamicpruningexpression(ss_sold_date_sk#78 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#77), dynamicpruningexpression(ss_sold_date_sk#77 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (86) ColumnarToRow [codegen id : 2]
-Input [3]: [ss_quantity#76, ss_list_price#77, ss_sold_date_sk#78]
+Input [3]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77]
 
 (87) ReusedExchange [Reuses operator id: 117]
-Output [1]: [d_date_sk#79]
+Output [1]: [d_date_sk#78]
 
 (88) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#78]
-Right keys [1]: [d_date_sk#79]
+Left keys [1]: [ss_sold_date_sk#77]
+Right keys [1]: [d_date_sk#78]
 Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 2]
-Output [2]: [ss_quantity#76 AS quantity#80, ss_list_price#77 AS list_price#81]
-Input [4]: [ss_quantity#76, ss_list_price#77, ss_sold_date_sk#78, d_date_sk#79]
+Output [2]: [ss_quantity#75 AS quantity#79, ss_list_price#76 AS list_price#80]
+Input [4]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77, d_date_sk#78]
 
 (90) Scan parquet spark_catalog.default.catalog_sales
-Output [3]: [cs_quantity#82, cs_list_price#83, cs_sold_date_sk#84]
+Output [3]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#84), dynamicpruningexpression(cs_sold_date_sk#84 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#83), dynamicpruningexpression(cs_sold_date_sk#83 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (91) ColumnarToRow [codegen id : 4]
-Input [3]: [cs_quantity#82, cs_list_price#83, cs_sold_date_sk#84]
+Input [3]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83]
 
 (92) ReusedExchange [Reuses operator id: 117]
-Output [1]: [d_date_sk#85]
+Output [1]: [d_date_sk#84]
 
 (93) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_sold_date_sk#84]
-Right keys [1]: [d_date_sk#85]
+Left keys [1]: [cs_sold_date_sk#83]
+Right keys [1]: [d_date_sk#84]
 Join type: Inner
 Join condition: None
 
 (94) Project [codegen id : 4]
-Output [2]: [cs_quantity#82 AS quantity#86, cs_list_price#83 AS list_price#87]
-Input [4]: [cs_quantity#82, cs_list_price#83, cs_sold_date_sk#84, d_date_sk#85]
+Output [2]: [cs_quantity#81 AS quantity#85, cs_list_price#82 AS list_price#86]
+Input [4]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83, d_date_sk#84]
 
 (95) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90]
+Output [3]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#90), dynamicpruningexpression(ws_sold_date_sk#90 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#89), dynamicpruningexpression(ws_sold_date_sk#89 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (96) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90]
+Input [3]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89]
 
 (97) ReusedExchange [Reuses operator id: 117]
-Output [1]: [d_date_sk#91]
+Output [1]: [d_date_sk#90]
 
 (98) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#90]
-Right keys [1]: [d_date_sk#91]
+Left keys [1]: [ws_sold_date_sk#89]
+Right keys [1]: [d_date_sk#90]
 Join type: Inner
 Join condition: None
 
 (99) Project [codegen id : 6]
-Output [2]: [ws_quantity#88 AS quantity#92, ws_list_price#89 AS list_price#93]
-Input [4]: [ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90, d_date_sk#91]
+Output [2]: [ws_quantity#87 AS quantity#91, ws_list_price#88 AS list_price#92]
+Input [4]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89, d_date_sk#90]
 
 (100) Union
 
 (101) HashAggregate [codegen id : 7]
-Input [2]: [quantity#80, list_price#81]
+Input [2]: [quantity#79, list_price#80]
 Keys: []
-Functions [1]: [partial_avg((cast(quantity#80 as decimal(10,0)) * list_price#81))]
-Aggregate Attributes [2]: [sum#94, count#95]
-Results [2]: [sum#96, count#97]
+Functions [1]: [partial_avg((cast(quantity#79 as decimal(10,0)) * list_price#80))]
+Aggregate Attributes [2]: [sum#93, count#94]
+Results [2]: [sum#95, count#96]
 
 (102) Exchange
-Input [2]: [sum#96, count#97]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
+Input [2]: [sum#95, count#96]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
 
 (103) HashAggregate [codegen id : 8]
-Input [2]: [sum#96, count#97]
+Input [2]: [sum#95, count#96]
 Keys: []
-Functions [1]: [avg((cast(quantity#80 as decimal(10,0)) * list_price#81))]
-Aggregate Attributes [1]: [avg((cast(quantity#80 as decimal(10,0)) * list_price#81))#98]
-Results [1]: [avg((cast(quantity#80 as decimal(10,0)) * list_price#81))#98 AS average_sales#99]
+Functions [1]: [avg((cast(quantity#79 as decimal(10,0)) * list_price#80))]
+Aggregate Attributes [1]: [avg((cast(quantity#79 as decimal(10,0)) * list_price#80))#97]
+Results [1]: [avg((cast(quantity#79 as decimal(10,0)) * list_price#80))#97 AS average_sales#98]
 
-Subquery:2 Hosting operator id = 85 Hosting Expression = ss_sold_date_sk#78 IN dynamicpruning#12
+Subquery:2 Hosting operator id = 85 Hosting Expression = ss_sold_date_sk#77 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 90 Hosting Expression = cs_sold_date_sk#84 IN dynamicpruning#12
+Subquery:3 Hosting operator id = 90 Hosting Expression = cs_sold_date_sk#83 IN dynamicpruning#12
 
-Subquery:4 Hosting operator id = 95 Hosting Expression = ws_sold_date_sk#90 IN dynamicpruning#12
+Subquery:4 Hosting operator id = 95 Hosting Expression = ws_sold_date_sk#89 IN dynamicpruning#12
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (108)
@@ -615,30 +615,30 @@ BroadcastExchange (108)
 
 
 (104) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#40, d_week_seq#100]
+Output [2]: [d_date_sk#40, d_week_seq#99]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#101), IsNotNull(d_date_sk)]
+PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#100), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
 (105) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#40, d_week_seq#100]
+Input [2]: [d_date_sk#40, d_week_seq#99]
 
 (106) Filter [codegen id : 1]
-Input [2]: [d_date_sk#40, d_week_seq#100]
-Condition : ((isnotnull(d_week_seq#100) AND (d_week_seq#100 = ReusedSubquery Subquery scalar-subquery#101, [id=#102])) AND isnotnull(d_date_sk#40))
+Input [2]: [d_date_sk#40, d_week_seq#99]
+Condition : ((isnotnull(d_week_seq#99) AND (d_week_seq#99 = ReusedSubquery Subquery scalar-subquery#100, [id=#14])) AND isnotnull(d_date_sk#40))
 
 (107) Project [codegen id : 1]
 Output [1]: [d_date_sk#40]
-Input [2]: [d_date_sk#40, d_week_seq#100]
+Input [2]: [d_date_sk#40, d_week_seq#99]
 
 (108) BroadcastExchange
 Input [1]: [d_date_sk#40]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
 
-Subquery:6 Hosting operator id = 106 Hosting Expression = ReusedSubquery Subquery scalar-subquery#101, [id=#102]
+Subquery:6 Hosting operator id = 106 Hosting Expression = ReusedSubquery Subquery scalar-subquery#100, [id=#14]
 
-Subquery:7 Hosting operator id = 104 Hosting Expression = Subquery scalar-subquery#101, [id=#102]
+Subquery:7 Hosting operator id = 104 Hosting Expression = Subquery scalar-subquery#100, [id=#14]
 * Project (112)
 +- * Filter (111)
    +- * ColumnarToRow (110)
@@ -646,22 +646,22 @@ Subquery:7 Hosting operator id = 104 Hosting Expression = Subquery scalar-subque
 
 
 (109) Scan parquet spark_catalog.default.date_dim
-Output [4]: [d_week_seq#103, d_year#104, d_moy#105, d_dom#106]
+Output [4]: [d_week_seq#101, d_year#102, d_moy#103, d_dom#104]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,2000), EqualTo(d_moy,12), EqualTo(d_dom,11)]
 ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
 
 (110) ColumnarToRow [codegen id : 1]
-Input [4]: [d_week_seq#103, d_year#104, d_moy#105, d_dom#106]
+Input [4]: [d_week_seq#101, d_year#102, d_moy#103, d_dom#104]
 
 (111) Filter [codegen id : 1]
-Input [4]: [d_week_seq#103, d_year#104, d_moy#105, d_dom#106]
-Condition : (((((isnotnull(d_year#104) AND isnotnull(d_moy#105)) AND isnotnull(d_dom#106)) AND (d_year#104 = 2000)) AND (d_moy#105 = 12)) AND (d_dom#106 = 11))
+Input [4]: [d_week_seq#101, d_year#102, d_moy#103, d_dom#104]
+Condition : (((((isnotnull(d_year#102) AND isnotnull(d_moy#103)) AND isnotnull(d_dom#104)) AND (d_year#102 = 2000)) AND (d_moy#103 = 12)) AND (d_dom#104 = 11))
 
 (112) Project [codegen id : 1]
-Output [1]: [d_week_seq#103]
-Input [4]: [d_week_seq#103, d_year#104, d_moy#105, d_dom#106]
+Output [1]: [d_week_seq#101]
+Input [4]: [d_week_seq#101, d_year#102, d_moy#103, d_dom#104]
 
 Subquery:8 Hosting operator id = 7 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
 BroadcastExchange (117)
@@ -672,34 +672,34 @@ BroadcastExchange (117)
 
 
 (113) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#24, d_year#107]
+Output [2]: [d_date_sk#24, d_year#105]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (114) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#24, d_year#107]
+Input [2]: [d_date_sk#24, d_year#105]
 
 (115) Filter [codegen id : 1]
-Input [2]: [d_date_sk#24, d_year#107]
-Condition : (((isnotnull(d_year#107) AND (d_year#107 >= 1999)) AND (d_year#107 <= 2001)) AND isnotnull(d_date_sk#24))
+Input [2]: [d_date_sk#24, d_year#105]
+Condition : (((isnotnull(d_year#105) AND (d_year#105 >= 1999)) AND (d_year#105 <= 2001)) AND isnotnull(d_date_sk#24))
 
 (116) Project [codegen id : 1]
 Output [1]: [d_date_sk#24]
-Input [2]: [d_date_sk#24, d_year#107]
+Input [2]: [d_date_sk#24, d_year#105]
 
 (117) BroadcastExchange
 Input [1]: [d_date_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=16]
 
 Subquery:9 Hosting operator id = 13 Hosting Expression = cs_sold_date_sk#18 IN dynamicpruning#12
 
 Subquery:10 Hosting operator id = 36 Hosting Expression = ws_sold_date_sk#29 IN dynamicpruning#12
 
-Subquery:11 Hosting operator id = 81 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#53]
+Subquery:11 Hosting operator id = 81 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#10]
 
-Subquery:12 Hosting operator id = 67 Hosting Expression = ss_sold_date_sk#57 IN dynamicpruning#58
+Subquery:12 Hosting operator id = 67 Hosting Expression = ss_sold_date_sk#56 IN dynamicpruning#57
 BroadcastExchange (122)
 +- * Project (121)
    +- * Filter (120)
@@ -708,30 +708,30 @@ BroadcastExchange (122)
 
 
 (118) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#64, d_week_seq#108]
+Output [2]: [d_date_sk#63, d_week_seq#106]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#109), IsNotNull(d_date_sk)]
+PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#107), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
 (119) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#64, d_week_seq#108]
+Input [2]: [d_date_sk#63, d_week_seq#106]
 
 (120) Filter [codegen id : 1]
-Input [2]: [d_date_sk#64, d_week_seq#108]
-Condition : ((isnotnull(d_week_seq#108) AND (d_week_seq#108 = ReusedSubquery Subquery scalar-subquery#109, [id=#110])) AND isnotnull(d_date_sk#64))
+Input [2]: [d_date_sk#63, d_week_seq#106]
+Condition : ((isnotnull(d_week_seq#106) AND (d_week_seq#106 = ReusedSubquery Subquery scalar-subquery#107, [id=#17])) AND isnotnull(d_date_sk#63))
 
 (121) Project [codegen id : 1]
-Output [1]: [d_date_sk#64]
-Input [2]: [d_date_sk#64, d_week_seq#108]
+Output [1]: [d_date_sk#63]
+Input [2]: [d_date_sk#63, d_week_seq#106]
 
 (122) BroadcastExchange
-Input [1]: [d_date_sk#64]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
+Input [1]: [d_date_sk#63]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=18]
 
-Subquery:13 Hosting operator id = 120 Hosting Expression = ReusedSubquery Subquery scalar-subquery#109, [id=#110]
+Subquery:13 Hosting operator id = 120 Hosting Expression = ReusedSubquery Subquery scalar-subquery#107, [id=#17]
 
-Subquery:14 Hosting operator id = 118 Hosting Expression = Subquery scalar-subquery#109, [id=#110]
+Subquery:14 Hosting operator id = 118 Hosting Expression = Subquery scalar-subquery#107, [id=#17]
 * Project (126)
 +- * Filter (125)
    +- * ColumnarToRow (124)
@@ -739,21 +739,21 @@ Subquery:14 Hosting operator id = 118 Hosting Expression = Subquery scalar-subqu
 
 
 (123) Scan parquet spark_catalog.default.date_dim
-Output [4]: [d_week_seq#111, d_year#112, d_moy#113, d_dom#114]
+Output [4]: [d_week_seq#108, d_year#109, d_moy#110, d_dom#111]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,1999), EqualTo(d_moy,12), EqualTo(d_dom,11)]
 ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
 
 (124) ColumnarToRow [codegen id : 1]
-Input [4]: [d_week_seq#111, d_year#112, d_moy#113, d_dom#114]
+Input [4]: [d_week_seq#108, d_year#109, d_moy#110, d_dom#111]
 
 (125) Filter [codegen id : 1]
-Input [4]: [d_week_seq#111, d_year#112, d_moy#113, d_dom#114]
-Condition : (((((isnotnull(d_year#112) AND isnotnull(d_moy#113)) AND isnotnull(d_dom#114)) AND (d_year#112 = 1999)) AND (d_moy#113 = 12)) AND (d_dom#114 = 11))
+Input [4]: [d_week_seq#108, d_year#109, d_moy#110, d_dom#111]
+Condition : (((((isnotnull(d_year#109) AND isnotnull(d_moy#110)) AND isnotnull(d_dom#111)) AND (d_year#109 = 1999)) AND (d_moy#110 = 12)) AND (d_dom#111 = 11))
 
 (126) Project [codegen id : 1]
-Output [1]: [d_week_seq#111]
-Input [4]: [d_week_seq#111, d_year#112, d_moy#113, d_dom#114]
+Output [1]: [d_week_seq#108]
+Input [4]: [d_week_seq#108, d_year#109, d_moy#110, d_dom#111]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/explain.txt
@@ -58,7 +58,7 @@ Input [8]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_wareho
 
 (3) Filter [codegen id : 1]
 Input [8]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_warehouse_sk#4, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, cs_sold_date_sk#8]
-Condition : (((((isnotnull(cs_ship_date_sk#1) AND isnotnull(cs_ship_addr_sk#2)) AND isnotnull(cs_call_center_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(cs_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(cs_call_center_sk#3, 42))) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(cs_ship_date_sk#1, 42)))
+Condition : (((((isnotnull(cs_ship_date_sk#1) AND isnotnull(cs_ship_addr_sk#2)) AND isnotnull(cs_call_center_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#1], xxhash64(cs_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#10, [id=#2], xxhash64(cs_call_center_sk#3, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#3], xxhash64(cs_ship_date_sk#1, 42)))
 
 (4) Project [codegen id : 1]
 Output [7]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_warehouse_sk#4, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
@@ -66,201 +66,201 @@ Input [8]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_wareho
 
 (5) Exchange
 Input [7]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_warehouse_sk#4, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
-Arguments: hashpartitioning(cs_order_number#5, 5), ENSURE_REQUIREMENTS, [plan_id=1]
+Arguments: hashpartitioning(cs_order_number#5, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (6) Sort [codegen id : 2]
 Input [7]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_warehouse_sk#4, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
 Arguments: [cs_order_number#5 ASC NULLS FIRST], false, 0
 
 (7) Scan parquet spark_catalog.default.catalog_sales
-Output [3]: [cs_warehouse_sk#15, cs_order_number#16, cs_sold_date_sk#17]
+Output [3]: [cs_warehouse_sk#12, cs_order_number#13, cs_sold_date_sk#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 ReadSchema: struct<cs_warehouse_sk:int,cs_order_number:int>
 
 (8) ColumnarToRow [codegen id : 3]
-Input [3]: [cs_warehouse_sk#15, cs_order_number#16, cs_sold_date_sk#17]
+Input [3]: [cs_warehouse_sk#12, cs_order_number#13, cs_sold_date_sk#14]
 
 (9) Project [codegen id : 3]
-Output [2]: [cs_warehouse_sk#15, cs_order_number#16]
-Input [3]: [cs_warehouse_sk#15, cs_order_number#16, cs_sold_date_sk#17]
+Output [2]: [cs_warehouse_sk#12, cs_order_number#13]
+Input [3]: [cs_warehouse_sk#12, cs_order_number#13, cs_sold_date_sk#14]
 
 (10) Exchange
-Input [2]: [cs_warehouse_sk#15, cs_order_number#16]
-Arguments: hashpartitioning(cs_order_number#16, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [2]: [cs_warehouse_sk#12, cs_order_number#13]
+Arguments: hashpartitioning(cs_order_number#13, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (11) Sort [codegen id : 4]
-Input [2]: [cs_warehouse_sk#15, cs_order_number#16]
-Arguments: [cs_order_number#16 ASC NULLS FIRST], false, 0
+Input [2]: [cs_warehouse_sk#12, cs_order_number#13]
+Arguments: [cs_order_number#13 ASC NULLS FIRST], false, 0
 
 (12) SortMergeJoin [codegen id : 5]
 Left keys [1]: [cs_order_number#5]
-Right keys [1]: [cs_order_number#16]
+Right keys [1]: [cs_order_number#13]
 Join type: LeftSemi
-Join condition: NOT (cs_warehouse_sk#4 = cs_warehouse_sk#15)
+Join condition: NOT (cs_warehouse_sk#4 = cs_warehouse_sk#12)
 
 (13) Project [codegen id : 5]
 Output [6]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
 Input [7]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_warehouse_sk#4, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
 
 (14) Scan parquet spark_catalog.default.catalog_returns
-Output [2]: [cr_order_number#18, cr_returned_date_sk#19]
+Output [2]: [cr_order_number#15, cr_returned_date_sk#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
 ReadSchema: struct<cr_order_number:int>
 
 (15) ColumnarToRow [codegen id : 6]
-Input [2]: [cr_order_number#18, cr_returned_date_sk#19]
+Input [2]: [cr_order_number#15, cr_returned_date_sk#16]
 
 (16) Project [codegen id : 6]
-Output [1]: [cr_order_number#18]
-Input [2]: [cr_order_number#18, cr_returned_date_sk#19]
+Output [1]: [cr_order_number#15]
+Input [2]: [cr_order_number#15, cr_returned_date_sk#16]
 
 (17) Exchange
-Input [1]: [cr_order_number#18]
-Arguments: hashpartitioning(cr_order_number#18, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [1]: [cr_order_number#15]
+Arguments: hashpartitioning(cr_order_number#15, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (18) Sort [codegen id : 7]
-Input [1]: [cr_order_number#18]
-Arguments: [cr_order_number#18 ASC NULLS FIRST], false, 0
+Input [1]: [cr_order_number#15]
+Arguments: [cr_order_number#15 ASC NULLS FIRST], false, 0
 
 (19) SortMergeJoin [codegen id : 11]
 Left keys [1]: [cs_order_number#5]
-Right keys [1]: [cr_order_number#18]
+Right keys [1]: [cr_order_number#15]
 Join type: LeftAnti
 Join condition: None
 
 (20) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#20, ca_state#21]
+Output [2]: [ca_address_sk#17, ca_state#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,GA), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
 (21) ColumnarToRow [codegen id : 8]
-Input [2]: [ca_address_sk#20, ca_state#21]
+Input [2]: [ca_address_sk#17, ca_state#18]
 
 (22) Filter [codegen id : 8]
-Input [2]: [ca_address_sk#20, ca_state#21]
-Condition : ((isnotnull(ca_state#21) AND (ca_state#21 = GA)) AND isnotnull(ca_address_sk#20))
+Input [2]: [ca_address_sk#17, ca_state#18]
+Condition : ((isnotnull(ca_state#18) AND (ca_state#18 = GA)) AND isnotnull(ca_address_sk#17))
 
 (23) Project [codegen id : 8]
-Output [1]: [ca_address_sk#20]
-Input [2]: [ca_address_sk#20, ca_state#21]
+Output [1]: [ca_address_sk#17]
+Input [2]: [ca_address_sk#17, ca_state#18]
 
 (24) BroadcastExchange
-Input [1]: [ca_address_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+Input [1]: [ca_address_sk#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 (25) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_ship_addr_sk#2]
-Right keys [1]: [ca_address_sk#20]
+Right keys [1]: [ca_address_sk#17]
 Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 11]
 Output [5]: [cs_ship_date_sk#1, cs_call_center_sk#3, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
-Input [7]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, ca_address_sk#20]
+Input [7]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, ca_address_sk#17]
 
 (27) Scan parquet spark_catalog.default.call_center
-Output [2]: [cc_call_center_sk#22, cc_county#23]
+Output [2]: [cc_call_center_sk#19, cc_county#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/call_center]
 PushedFilters: [IsNotNull(cc_county), EqualTo(cc_county,Williamson County), IsNotNull(cc_call_center_sk)]
 ReadSchema: struct<cc_call_center_sk:int,cc_county:string>
 
 (28) ColumnarToRow [codegen id : 9]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
+Input [2]: [cc_call_center_sk#19, cc_county#20]
 
 (29) Filter [codegen id : 9]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
-Condition : ((isnotnull(cc_county#23) AND (cc_county#23 = Williamson County)) AND isnotnull(cc_call_center_sk#22))
+Input [2]: [cc_call_center_sk#19, cc_county#20]
+Condition : ((isnotnull(cc_county#20) AND (cc_county#20 = Williamson County)) AND isnotnull(cc_call_center_sk#19))
 
 (30) Project [codegen id : 9]
-Output [1]: [cc_call_center_sk#22]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
+Output [1]: [cc_call_center_sk#19]
+Input [2]: [cc_call_center_sk#19, cc_county#20]
 
 (31) BroadcastExchange
-Input [1]: [cc_call_center_sk#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+Input [1]: [cc_call_center_sk#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
 (32) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_call_center_sk#3]
-Right keys [1]: [cc_call_center_sk#22]
+Right keys [1]: [cc_call_center_sk#19]
 Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 11]
 Output [4]: [cs_ship_date_sk#1, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
-Input [6]: [cs_ship_date_sk#1, cs_call_center_sk#3, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, cc_call_center_sk#22]
+Input [6]: [cs_ship_date_sk#1, cs_call_center_sk#3, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, cc_call_center_sk#19]
 
 (34) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#24, d_date#25]
+Output [2]: [d_date_sk#21, d_date#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2002-02-01), LessThanOrEqual(d_date,2002-04-02), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (35) ColumnarToRow [codegen id : 10]
-Input [2]: [d_date_sk#24, d_date#25]
+Input [2]: [d_date_sk#21, d_date#22]
 
 (36) Filter [codegen id : 10]
-Input [2]: [d_date_sk#24, d_date#25]
-Condition : (((isnotnull(d_date#25) AND (d_date#25 >= 2002-02-01)) AND (d_date#25 <= 2002-04-02)) AND isnotnull(d_date_sk#24))
+Input [2]: [d_date_sk#21, d_date#22]
+Condition : (((isnotnull(d_date#22) AND (d_date#22 >= 2002-02-01)) AND (d_date#22 <= 2002-04-02)) AND isnotnull(d_date_sk#21))
 
 (37) Project [codegen id : 10]
-Output [1]: [d_date_sk#24]
-Input [2]: [d_date_sk#24, d_date#25]
+Output [1]: [d_date_sk#21]
+Input [2]: [d_date_sk#21, d_date#22]
 
 (38) BroadcastExchange
-Input [1]: [d_date_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+Input [1]: [d_date_sk#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_ship_date_sk#1]
-Right keys [1]: [d_date_sk#24]
+Right keys [1]: [d_date_sk#21]
 Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 11]
 Output [3]: [cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
-Input [5]: [cs_ship_date_sk#1, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, d_date_sk#24]
+Input [5]: [cs_ship_date_sk#1, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, d_date_sk#21]
 
 (41) HashAggregate [codegen id : 11]
 Input [3]: [cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
 Keys [1]: [cs_order_number#5]
 Functions [2]: [partial_sum(UnscaledValue(cs_ext_ship_cost#6)), partial_sum(UnscaledValue(cs_net_profit#7))]
-Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_ship_cost#6))#26, sum(UnscaledValue(cs_net_profit#7))#27]
-Results [3]: [cs_order_number#5, sum#28, sum#29]
+Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_ship_cost#6))#23, sum(UnscaledValue(cs_net_profit#7))#24]
+Results [3]: [cs_order_number#5, sum#25, sum#26]
 
 (42) HashAggregate [codegen id : 11]
-Input [3]: [cs_order_number#5, sum#28, sum#29]
+Input [3]: [cs_order_number#5, sum#25, sum#26]
 Keys [1]: [cs_order_number#5]
 Functions [2]: [merge_sum(UnscaledValue(cs_ext_ship_cost#6)), merge_sum(UnscaledValue(cs_net_profit#7))]
-Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_ship_cost#6))#26, sum(UnscaledValue(cs_net_profit#7))#27]
-Results [3]: [cs_order_number#5, sum#28, sum#29]
+Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_ship_cost#6))#23, sum(UnscaledValue(cs_net_profit#7))#24]
+Results [3]: [cs_order_number#5, sum#25, sum#26]
 
 (43) HashAggregate [codegen id : 11]
-Input [3]: [cs_order_number#5, sum#28, sum#29]
+Input [3]: [cs_order_number#5, sum#25, sum#26]
 Keys: []
 Functions [3]: [merge_sum(UnscaledValue(cs_ext_ship_cost#6)), merge_sum(UnscaledValue(cs_net_profit#7)), partial_count(distinct cs_order_number#5)]
-Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_ship_cost#6))#26, sum(UnscaledValue(cs_net_profit#7))#27, count(cs_order_number#5)#30]
-Results [3]: [sum#28, sum#29, count#31]
+Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_ship_cost#6))#23, sum(UnscaledValue(cs_net_profit#7))#24, count(cs_order_number#5)#27]
+Results [3]: [sum#25, sum#26, count#28]
 
 (44) Exchange
-Input [3]: [sum#28, sum#29, count#31]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
+Input [3]: [sum#25, sum#26, count#28]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
 
 (45) HashAggregate [codegen id : 12]
-Input [3]: [sum#28, sum#29, count#31]
+Input [3]: [sum#25, sum#26, count#28]
 Keys: []
 Functions [3]: [sum(UnscaledValue(cs_ext_ship_cost#6)), sum(UnscaledValue(cs_net_profit#7)), count(distinct cs_order_number#5)]
-Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_ship_cost#6))#26, sum(UnscaledValue(cs_net_profit#7))#27, count(cs_order_number#5)#30]
-Results [3]: [count(cs_order_number#5)#30 AS order count #32, MakeDecimal(sum(UnscaledValue(cs_ext_ship_cost#6))#26,17,2) AS total shipping cost #33, MakeDecimal(sum(UnscaledValue(cs_net_profit#7))#27,17,2) AS total net profit #34]
+Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_ship_cost#6))#23, sum(UnscaledValue(cs_net_profit#7))#24, count(cs_order_number#5)#27]
+Results [3]: [count(cs_order_number#5)#27 AS order count #29, MakeDecimal(sum(UnscaledValue(cs_ext_ship_cost#6))#23,17,2) AS total shipping cost #30, MakeDecimal(sum(UnscaledValue(cs_net_profit#7))#24,17,2) AS total net profit #31]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#9, [id=#10]
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#9, [id=#1]
 ObjectHashAggregate (52)
 +- Exchange (51)
    +- ObjectHashAggregate (50)
@@ -271,42 +271,42 @@ ObjectHashAggregate (52)
 
 
 (46) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#20, ca_state#21]
+Output [2]: [ca_address_sk#17, ca_state#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,GA), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
 (47) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#20, ca_state#21]
+Input [2]: [ca_address_sk#17, ca_state#18]
 
 (48) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#20, ca_state#21]
-Condition : ((isnotnull(ca_state#21) AND (ca_state#21 = GA)) AND isnotnull(ca_address_sk#20))
+Input [2]: [ca_address_sk#17, ca_state#18]
+Condition : ((isnotnull(ca_state#18) AND (ca_state#18 = GA)) AND isnotnull(ca_address_sk#17))
 
 (49) Project [codegen id : 1]
-Output [1]: [ca_address_sk#20]
-Input [2]: [ca_address_sk#20, ca_state#21]
+Output [1]: [ca_address_sk#17]
+Input [2]: [ca_address_sk#17, ca_state#18]
 
 (50) ObjectHashAggregate
-Input [1]: [ca_address_sk#20]
+Input [1]: [ca_address_sk#17]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)]
-Aggregate Attributes [1]: [buf#35]
-Results [1]: [buf#36]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#17, 42), 17961, 333176, 0, 0)]
+Aggregate Attributes [1]: [buf#32]
+Results [1]: [buf#33]
 
 (51) Exchange
-Input [1]: [buf#36]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
+Input [1]: [buf#33]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
 
 (52) ObjectHashAggregate
-Input [1]: [buf#36]
+Input [1]: [buf#33]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)#37]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)#37 AS bloomFilter#38]
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#17, 42), 17961, 333176, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#17, 42), 17961, 333176, 0, 0)#34]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#17, 42), 17961, 333176, 0, 0)#34 AS bloomFilter#35]
 
-Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#11, [id=#12]
+Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#10, [id=#2]
 ObjectHashAggregate (59)
 +- Exchange (58)
    +- ObjectHashAggregate (57)
@@ -317,42 +317,42 @@ ObjectHashAggregate (59)
 
 
 (53) Scan parquet spark_catalog.default.call_center
-Output [2]: [cc_call_center_sk#22, cc_county#23]
+Output [2]: [cc_call_center_sk#19, cc_county#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/call_center]
 PushedFilters: [IsNotNull(cc_county), EqualTo(cc_county,Williamson County), IsNotNull(cc_call_center_sk)]
 ReadSchema: struct<cc_call_center_sk:int,cc_county:string>
 
 (54) ColumnarToRow [codegen id : 1]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
+Input [2]: [cc_call_center_sk#19, cc_county#20]
 
 (55) Filter [codegen id : 1]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
-Condition : ((isnotnull(cc_county#23) AND (cc_county#23 = Williamson County)) AND isnotnull(cc_call_center_sk#22))
+Input [2]: [cc_call_center_sk#19, cc_county#20]
+Condition : ((isnotnull(cc_county#20) AND (cc_county#20 = Williamson County)) AND isnotnull(cc_call_center_sk#19))
 
 (56) Project [codegen id : 1]
-Output [1]: [cc_call_center_sk#22]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
+Output [1]: [cc_call_center_sk#19]
+Input [2]: [cc_call_center_sk#19, cc_county#20]
 
 (57) ObjectHashAggregate
-Input [1]: [cc_call_center_sk#22]
+Input [1]: [cc_call_center_sk#19]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(cc_call_center_sk#22, 42), 4, 144, 0, 0)]
-Aggregate Attributes [1]: [buf#39]
-Results [1]: [buf#40]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cc_call_center_sk#19, 42), 4, 144, 0, 0)]
+Aggregate Attributes [1]: [buf#36]
+Results [1]: [buf#37]
 
 (58) Exchange
-Input [1]: [buf#40]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+Input [1]: [buf#37]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
 
 (59) ObjectHashAggregate
-Input [1]: [buf#40]
+Input [1]: [buf#37]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#22, 42), 4, 144, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#22, 42), 4, 144, 0, 0)#41]
-Results [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#22, 42), 4, 144, 0, 0)#41 AS bloomFilter#42]
+Functions [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#19, 42), 4, 144, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#19, 42), 4, 144, 0, 0)#38]
+Results [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#19, 42), 4, 144, 0, 0)#38 AS bloomFilter#39]
 
-Subquery:3 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
+Subquery:3 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#11, [id=#3]
 ObjectHashAggregate (66)
 +- Exchange (65)
    +- ObjectHashAggregate (64)
@@ -363,39 +363,39 @@ ObjectHashAggregate (66)
 
 
 (60) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#24, d_date#25]
+Output [2]: [d_date_sk#21, d_date#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2002-02-01), LessThanOrEqual(d_date,2002-04-02), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (61) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#24, d_date#25]
+Input [2]: [d_date_sk#21, d_date#22]
 
 (62) Filter [codegen id : 1]
-Input [2]: [d_date_sk#24, d_date#25]
-Condition : (((isnotnull(d_date#25) AND (d_date#25 >= 2002-02-01)) AND (d_date#25 <= 2002-04-02)) AND isnotnull(d_date_sk#24))
+Input [2]: [d_date_sk#21, d_date#22]
+Condition : (((isnotnull(d_date#22) AND (d_date#22 >= 2002-02-01)) AND (d_date#22 <= 2002-04-02)) AND isnotnull(d_date_sk#21))
 
 (63) Project [codegen id : 1]
-Output [1]: [d_date_sk#24]
-Input [2]: [d_date_sk#24, d_date#25]
+Output [1]: [d_date_sk#21]
+Input [2]: [d_date_sk#21, d_date#22]
 
 (64) ObjectHashAggregate
-Input [1]: [d_date_sk#24]
+Input [1]: [d_date_sk#21]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(d_date_sk#24, 42), 73049, 1141755, 0, 0)]
-Aggregate Attributes [1]: [buf#43]
-Results [1]: [buf#44]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(d_date_sk#21, 42), 73049, 1141755, 0, 0)]
+Aggregate Attributes [1]: [buf#40]
+Results [1]: [buf#41]
 
 (65) Exchange
-Input [1]: [buf#44]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
+Input [1]: [buf#41]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
 
 (66) ObjectHashAggregate
-Input [1]: [buf#44]
+Input [1]: [buf#41]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(d_date_sk#24, 42), 73049, 1141755, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_date_sk#24, 42), 73049, 1141755, 0, 0)#45]
-Results [1]: [bloom_filter_agg(xxhash64(d_date_sk#24, 42), 73049, 1141755, 0, 0)#45 AS bloomFilter#46]
+Functions [1]: [bloom_filter_agg(xxhash64(d_date_sk#21, 42), 73049, 1141755, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_date_sk#21, 42), 73049, 1141755, 0, 0)#42]
+Results [1]: [bloom_filter_agg(xxhash64(d_date_sk#21, 42), 73049, 1141755, 0, 0)#42 AS bloomFilter#43]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2.sf100/explain.txt
@@ -94,11 +94,11 @@ Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
 
 (10) Filter [codegen id : 3]
 Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
-Condition : ((isnotnull(d_date_sk#9) AND isnotnull(d_week_seq#10)) AND might_contain(Subquery scalar-subquery#12, [id=#13], xxhash64(d_week_seq#10, 42)))
+Condition : ((isnotnull(d_date_sk#9) AND isnotnull(d_week_seq#10)) AND might_contain(Subquery scalar-subquery#12, [id=#1], xxhash64(d_week_seq#10, 42)))
 
 (11) BroadcastExchange
 Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [sold_date_sk#3]
@@ -114,185 +114,185 @@ Input [5]: [sold_date_sk#3, sales_price#4, d_date_sk#9, d_week_seq#10, d_day_nam
 Input [3]: [sales_price#4, d_week_seq#10, d_day_name#11]
 Keys [1]: [d_week_seq#10]
 Functions [7]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Sunday   ) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Monday   ) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Tuesday  ) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Wednesday) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Thursday ) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Friday   ) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Saturday ) THEN sales_price#4 END))]
-Aggregate Attributes [7]: [sum#14, sum#15, sum#16, sum#17, sum#18, sum#19, sum#20]
-Results [8]: [d_week_seq#10, sum#21, sum#22, sum#23, sum#24, sum#25, sum#26, sum#27]
+Aggregate Attributes [7]: [sum#13, sum#14, sum#15, sum#16, sum#17, sum#18, sum#19]
+Results [8]: [d_week_seq#10, sum#20, sum#21, sum#22, sum#23, sum#24, sum#25, sum#26]
 
 (15) Exchange
-Input [8]: [d_week_seq#10, sum#21, sum#22, sum#23, sum#24, sum#25, sum#26, sum#27]
-Arguments: hashpartitioning(d_week_seq#10, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [8]: [d_week_seq#10, sum#20, sum#21, sum#22, sum#23, sum#24, sum#25, sum#26]
+Arguments: hashpartitioning(d_week_seq#10, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (16) HashAggregate [codegen id : 12]
-Input [8]: [d_week_seq#10, sum#21, sum#22, sum#23, sum#24, sum#25, sum#26, sum#27]
+Input [8]: [d_week_seq#10, sum#20, sum#21, sum#22, sum#23, sum#24, sum#25, sum#26]
 Keys [1]: [d_week_seq#10]
 Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#11 = Sunday   ) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Monday   ) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Tuesday  ) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Wednesday) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Thursday ) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Friday   ) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Saturday ) THEN sales_price#4 END))]
-Aggregate Attributes [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#11 = Sunday   ) THEN sales_price#4 END))#28, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Monday   ) THEN sales_price#4 END))#29, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Tuesday  ) THEN sales_price#4 END))#30, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Wednesday) THEN sales_price#4 END))#31, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Thursday ) THEN sales_price#4 END))#32, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Friday   ) THEN sales_price#4 END))#33, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Saturday ) THEN sales_price#4 END))#34]
-Results [8]: [d_week_seq#10, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Sunday   ) THEN sales_price#4 END))#28,17,2) AS sun_sales#35, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Monday   ) THEN sales_price#4 END))#29,17,2) AS mon_sales#36, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Tuesday  ) THEN sales_price#4 END))#30,17,2) AS tue_sales#37, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Wednesday) THEN sales_price#4 END))#31,17,2) AS wed_sales#38, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Thursday ) THEN sales_price#4 END))#32,17,2) AS thu_sales#39, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Friday   ) THEN sales_price#4 END))#33,17,2) AS fri_sales#40, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Saturday ) THEN sales_price#4 END))#34,17,2) AS sat_sales#41]
+Aggregate Attributes [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#11 = Sunday   ) THEN sales_price#4 END))#27, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Monday   ) THEN sales_price#4 END))#28, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Tuesday  ) THEN sales_price#4 END))#29, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Wednesday) THEN sales_price#4 END))#30, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Thursday ) THEN sales_price#4 END))#31, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Friday   ) THEN sales_price#4 END))#32, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Saturday ) THEN sales_price#4 END))#33]
+Results [8]: [d_week_seq#10, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Sunday   ) THEN sales_price#4 END))#27,17,2) AS sun_sales#34, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Monday   ) THEN sales_price#4 END))#28,17,2) AS mon_sales#35, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Tuesday  ) THEN sales_price#4 END))#29,17,2) AS tue_sales#36, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Wednesday) THEN sales_price#4 END))#30,17,2) AS wed_sales#37, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Thursday ) THEN sales_price#4 END))#31,17,2) AS thu_sales#38, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Friday   ) THEN sales_price#4 END))#32,17,2) AS fri_sales#39, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Saturday ) THEN sales_price#4 END))#33,17,2) AS sat_sales#40]
 
 (17) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_week_seq#42, d_year#43]
+Output [2]: [d_week_seq#41, d_year#42]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_week_seq:int,d_year:int>
 
 (18) ColumnarToRow [codegen id : 5]
-Input [2]: [d_week_seq#42, d_year#43]
+Input [2]: [d_week_seq#41, d_year#42]
 
 (19) Filter [codegen id : 5]
-Input [2]: [d_week_seq#42, d_year#43]
-Condition : ((isnotnull(d_year#43) AND (d_year#43 = 2001)) AND isnotnull(d_week_seq#42))
+Input [2]: [d_week_seq#41, d_year#42]
+Condition : ((isnotnull(d_year#42) AND (d_year#42 = 2001)) AND isnotnull(d_week_seq#41))
 
 (20) Project [codegen id : 5]
-Output [1]: [d_week_seq#42]
-Input [2]: [d_week_seq#42, d_year#43]
+Output [1]: [d_week_seq#41]
+Input [2]: [d_week_seq#41, d_year#42]
 
 (21) BroadcastExchange
-Input [1]: [d_week_seq#42]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
+Input [1]: [d_week_seq#41]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
 (22) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [d_week_seq#10]
-Right keys [1]: [d_week_seq#42]
+Right keys [1]: [d_week_seq#41]
 Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 12]
-Output [8]: [d_week_seq#10 AS d_week_seq1#44, sun_sales#35 AS sun_sales1#45, mon_sales#36 AS mon_sales1#46, tue_sales#37 AS tue_sales1#47, wed_sales#38 AS wed_sales1#48, thu_sales#39 AS thu_sales1#49, fri_sales#40 AS fri_sales1#50, sat_sales#41 AS sat_sales1#51]
-Input [9]: [d_week_seq#10, sun_sales#35, mon_sales#36, tue_sales#37, wed_sales#38, thu_sales#39, fri_sales#40, sat_sales#41, d_week_seq#42]
+Output [8]: [d_week_seq#10 AS d_week_seq1#43, sun_sales#34 AS sun_sales1#44, mon_sales#35 AS mon_sales1#45, tue_sales#36 AS tue_sales1#46, wed_sales#37 AS wed_sales1#47, thu_sales#38 AS thu_sales1#48, fri_sales#39 AS fri_sales1#49, sat_sales#40 AS sat_sales1#50]
+Input [9]: [d_week_seq#10, sun_sales#34, mon_sales#35, tue_sales#36, wed_sales#37, thu_sales#38, fri_sales#39, sat_sales#40, d_week_seq#41]
 
 (24) Scan parquet spark_catalog.default.web_sales
-Output [2]: [ws_ext_sales_price#52, ws_sold_date_sk#53]
+Output [2]: [ws_ext_sales_price#51, ws_sold_date_sk#52]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#53)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#52)]
 ReadSchema: struct<ws_ext_sales_price:decimal(7,2)>
 
 (25) ColumnarToRow [codegen id : 6]
-Input [2]: [ws_ext_sales_price#52, ws_sold_date_sk#53]
+Input [2]: [ws_ext_sales_price#51, ws_sold_date_sk#52]
 
 (26) Project [codegen id : 6]
-Output [2]: [ws_sold_date_sk#53 AS sold_date_sk#54, ws_ext_sales_price#52 AS sales_price#55]
-Input [2]: [ws_ext_sales_price#52, ws_sold_date_sk#53]
+Output [2]: [ws_sold_date_sk#52 AS sold_date_sk#53, ws_ext_sales_price#51 AS sales_price#54]
+Input [2]: [ws_ext_sales_price#51, ws_sold_date_sk#52]
 
 (27) Scan parquet spark_catalog.default.catalog_sales
-Output [2]: [cs_ext_sales_price#56, cs_sold_date_sk#57]
+Output [2]: [cs_ext_sales_price#55, cs_sold_date_sk#56]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#57)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#56)]
 ReadSchema: struct<cs_ext_sales_price:decimal(7,2)>
 
 (28) ColumnarToRow [codegen id : 7]
-Input [2]: [cs_ext_sales_price#56, cs_sold_date_sk#57]
+Input [2]: [cs_ext_sales_price#55, cs_sold_date_sk#56]
 
 (29) Project [codegen id : 7]
-Output [2]: [cs_sold_date_sk#57 AS sold_date_sk#58, cs_ext_sales_price#56 AS sales_price#59]
-Input [2]: [cs_ext_sales_price#56, cs_sold_date_sk#57]
+Output [2]: [cs_sold_date_sk#56 AS sold_date_sk#57, cs_ext_sales_price#55 AS sales_price#58]
+Input [2]: [cs_ext_sales_price#55, cs_sold_date_sk#56]
 
 (30) Union
 
 (31) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#60, d_week_seq#61, d_day_name#62]
+Output [3]: [d_date_sk#59, d_week_seq#60, d_day_name#61]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int,d_day_name:string>
 
 (32) ColumnarToRow [codegen id : 8]
-Input [3]: [d_date_sk#60, d_week_seq#61, d_day_name#62]
+Input [3]: [d_date_sk#59, d_week_seq#60, d_day_name#61]
 
 (33) Filter [codegen id : 8]
-Input [3]: [d_date_sk#60, d_week_seq#61, d_day_name#62]
-Condition : ((isnotnull(d_date_sk#60) AND isnotnull(d_week_seq#61)) AND might_contain(Subquery scalar-subquery#63, [id=#64], xxhash64(d_week_seq#61, 42)))
+Input [3]: [d_date_sk#59, d_week_seq#60, d_day_name#61]
+Condition : ((isnotnull(d_date_sk#59) AND isnotnull(d_week_seq#60)) AND might_contain(Subquery scalar-subquery#62, [id=#5], xxhash64(d_week_seq#60, 42)))
 
 (34) BroadcastExchange
-Input [3]: [d_date_sk#60, d_week_seq#61, d_day_name#62]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
+Input [3]: [d_date_sk#59, d_week_seq#60, d_day_name#61]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=6]
 
 (35) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [sold_date_sk#54]
-Right keys [1]: [d_date_sk#60]
+Left keys [1]: [sold_date_sk#53]
+Right keys [1]: [d_date_sk#59]
 Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 9]
-Output [3]: [sales_price#55, d_week_seq#61, d_day_name#62]
-Input [5]: [sold_date_sk#54, sales_price#55, d_date_sk#60, d_week_seq#61, d_day_name#62]
+Output [3]: [sales_price#54, d_week_seq#60, d_day_name#61]
+Input [5]: [sold_date_sk#53, sales_price#54, d_date_sk#59, d_week_seq#60, d_day_name#61]
 
 (37) HashAggregate [codegen id : 9]
-Input [3]: [sales_price#55, d_week_seq#61, d_day_name#62]
-Keys [1]: [d_week_seq#61]
-Functions [7]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#62 = Sunday   ) THEN sales_price#55 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#62 = Monday   ) THEN sales_price#55 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#62 = Tuesday  ) THEN sales_price#55 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#62 = Wednesday) THEN sales_price#55 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#62 = Thursday ) THEN sales_price#55 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#62 = Friday   ) THEN sales_price#55 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#62 = Saturday ) THEN sales_price#55 END))]
-Aggregate Attributes [7]: [sum#65, sum#66, sum#67, sum#68, sum#69, sum#70, sum#71]
-Results [8]: [d_week_seq#61, sum#72, sum#73, sum#74, sum#75, sum#76, sum#77, sum#78]
+Input [3]: [sales_price#54, d_week_seq#60, d_day_name#61]
+Keys [1]: [d_week_seq#60]
+Functions [7]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Sunday   ) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Monday   ) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Tuesday  ) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Wednesday) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Thursday ) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Friday   ) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Saturday ) THEN sales_price#54 END))]
+Aggregate Attributes [7]: [sum#63, sum#64, sum#65, sum#66, sum#67, sum#68, sum#69]
+Results [8]: [d_week_seq#60, sum#70, sum#71, sum#72, sum#73, sum#74, sum#75, sum#76]
 
 (38) Exchange
-Input [8]: [d_week_seq#61, sum#72, sum#73, sum#74, sum#75, sum#76, sum#77, sum#78]
-Arguments: hashpartitioning(d_week_seq#61, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [8]: [d_week_seq#60, sum#70, sum#71, sum#72, sum#73, sum#74, sum#75, sum#76]
+Arguments: hashpartitioning(d_week_seq#60, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
 (39) HashAggregate [codegen id : 11]
-Input [8]: [d_week_seq#61, sum#72, sum#73, sum#74, sum#75, sum#76, sum#77, sum#78]
-Keys [1]: [d_week_seq#61]
-Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#62 = Sunday   ) THEN sales_price#55 END)), sum(UnscaledValue(CASE WHEN (d_day_name#62 = Monday   ) THEN sales_price#55 END)), sum(UnscaledValue(CASE WHEN (d_day_name#62 = Tuesday  ) THEN sales_price#55 END)), sum(UnscaledValue(CASE WHEN (d_day_name#62 = Wednesday) THEN sales_price#55 END)), sum(UnscaledValue(CASE WHEN (d_day_name#62 = Thursday ) THEN sales_price#55 END)), sum(UnscaledValue(CASE WHEN (d_day_name#62 = Friday   ) THEN sales_price#55 END)), sum(UnscaledValue(CASE WHEN (d_day_name#62 = Saturday ) THEN sales_price#55 END))]
-Aggregate Attributes [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#62 = Sunday   ) THEN sales_price#55 END))#28, sum(UnscaledValue(CASE WHEN (d_day_name#62 = Monday   ) THEN sales_price#55 END))#29, sum(UnscaledValue(CASE WHEN (d_day_name#62 = Tuesday  ) THEN sales_price#55 END))#30, sum(UnscaledValue(CASE WHEN (d_day_name#62 = Wednesday) THEN sales_price#55 END))#31, sum(UnscaledValue(CASE WHEN (d_day_name#62 = Thursday ) THEN sales_price#55 END))#32, sum(UnscaledValue(CASE WHEN (d_day_name#62 = Friday   ) THEN sales_price#55 END))#33, sum(UnscaledValue(CASE WHEN (d_day_name#62 = Saturday ) THEN sales_price#55 END))#34]
-Results [8]: [d_week_seq#61, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#62 = Sunday   ) THEN sales_price#55 END))#28,17,2) AS sun_sales#79, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#62 = Monday   ) THEN sales_price#55 END))#29,17,2) AS mon_sales#80, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#62 = Tuesday  ) THEN sales_price#55 END))#30,17,2) AS tue_sales#81, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#62 = Wednesday) THEN sales_price#55 END))#31,17,2) AS wed_sales#82, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#62 = Thursday ) THEN sales_price#55 END))#32,17,2) AS thu_sales#83, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#62 = Friday   ) THEN sales_price#55 END))#33,17,2) AS fri_sales#84, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#62 = Saturday ) THEN sales_price#55 END))#34,17,2) AS sat_sales#85]
+Input [8]: [d_week_seq#60, sum#70, sum#71, sum#72, sum#73, sum#74, sum#75, sum#76]
+Keys [1]: [d_week_seq#60]
+Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#61 = Sunday   ) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Monday   ) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Tuesday  ) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Wednesday) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Thursday ) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Friday   ) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Saturday ) THEN sales_price#54 END))]
+Aggregate Attributes [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#61 = Sunday   ) THEN sales_price#54 END))#27, sum(UnscaledValue(CASE WHEN (d_day_name#61 = Monday   ) THEN sales_price#54 END))#28, sum(UnscaledValue(CASE WHEN (d_day_name#61 = Tuesday  ) THEN sales_price#54 END))#29, sum(UnscaledValue(CASE WHEN (d_day_name#61 = Wednesday) THEN sales_price#54 END))#30, sum(UnscaledValue(CASE WHEN (d_day_name#61 = Thursday ) THEN sales_price#54 END))#31, sum(UnscaledValue(CASE WHEN (d_day_name#61 = Friday   ) THEN sales_price#54 END))#32, sum(UnscaledValue(CASE WHEN (d_day_name#61 = Saturday ) THEN sales_price#54 END))#33]
+Results [8]: [d_week_seq#60, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#61 = Sunday   ) THEN sales_price#54 END))#27,17,2) AS sun_sales#77, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#61 = Monday   ) THEN sales_price#54 END))#28,17,2) AS mon_sales#78, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#61 = Tuesday  ) THEN sales_price#54 END))#29,17,2) AS tue_sales#79, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#61 = Wednesday) THEN sales_price#54 END))#30,17,2) AS wed_sales#80, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#61 = Thursday ) THEN sales_price#54 END))#31,17,2) AS thu_sales#81, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#61 = Friday   ) THEN sales_price#54 END))#32,17,2) AS fri_sales#82, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#61 = Saturday ) THEN sales_price#54 END))#33,17,2) AS sat_sales#83]
 
 (40) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_week_seq#86, d_year#87]
+Output [2]: [d_week_seq#84, d_year#85]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_week_seq:int,d_year:int>
 
 (41) ColumnarToRow [codegen id : 10]
-Input [2]: [d_week_seq#86, d_year#87]
+Input [2]: [d_week_seq#84, d_year#85]
 
 (42) Filter [codegen id : 10]
-Input [2]: [d_week_seq#86, d_year#87]
-Condition : ((isnotnull(d_year#87) AND (d_year#87 = 2002)) AND isnotnull(d_week_seq#86))
+Input [2]: [d_week_seq#84, d_year#85]
+Condition : ((isnotnull(d_year#85) AND (d_year#85 = 2002)) AND isnotnull(d_week_seq#84))
 
 (43) Project [codegen id : 10]
-Output [1]: [d_week_seq#86]
-Input [2]: [d_week_seq#86, d_year#87]
+Output [1]: [d_week_seq#84]
+Input [2]: [d_week_seq#84, d_year#85]
 
 (44) BroadcastExchange
-Input [1]: [d_week_seq#86]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+Input [1]: [d_week_seq#84]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
 (45) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [d_week_seq#61]
-Right keys [1]: [d_week_seq#86]
+Left keys [1]: [d_week_seq#60]
+Right keys [1]: [d_week_seq#84]
 Join type: Inner
 Join condition: None
 
 (46) Project [codegen id : 11]
-Output [8]: [d_week_seq#61 AS d_week_seq2#88, sun_sales#79 AS sun_sales2#89, mon_sales#80 AS mon_sales2#90, tue_sales#81 AS tue_sales2#91, wed_sales#82 AS wed_sales2#92, thu_sales#83 AS thu_sales2#93, fri_sales#84 AS fri_sales2#94, sat_sales#85 AS sat_sales2#95]
-Input [9]: [d_week_seq#61, sun_sales#79, mon_sales#80, tue_sales#81, wed_sales#82, thu_sales#83, fri_sales#84, sat_sales#85, d_week_seq#86]
+Output [8]: [d_week_seq#60 AS d_week_seq2#86, sun_sales#77 AS sun_sales2#87, mon_sales#78 AS mon_sales2#88, tue_sales#79 AS tue_sales2#89, wed_sales#80 AS wed_sales2#90, thu_sales#81 AS thu_sales2#91, fri_sales#82 AS fri_sales2#92, sat_sales#83 AS sat_sales2#93]
+Input [9]: [d_week_seq#60, sun_sales#77, mon_sales#78, tue_sales#79, wed_sales#80, thu_sales#81, fri_sales#82, sat_sales#83, d_week_seq#84]
 
 (47) BroadcastExchange
-Input [8]: [d_week_seq2#88, sun_sales2#89, mon_sales2#90, tue_sales2#91, wed_sales2#92, thu_sales2#93, fri_sales2#94, sat_sales2#95]
-Arguments: HashedRelationBroadcastMode(List(cast((input[0, int, true] - 53) as bigint)),false), [plan_id=7]
+Input [8]: [d_week_seq2#86, sun_sales2#87, mon_sales2#88, tue_sales2#89, wed_sales2#90, thu_sales2#91, fri_sales2#92, sat_sales2#93]
+Arguments: HashedRelationBroadcastMode(List(cast((input[0, int, true] - 53) as bigint)),false), [plan_id=9]
 
 (48) BroadcastHashJoin [codegen id : 12]
-Left keys [1]: [d_week_seq1#44]
-Right keys [1]: [(d_week_seq2#88 - 53)]
+Left keys [1]: [d_week_seq1#43]
+Right keys [1]: [(d_week_seq2#86 - 53)]
 Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 12]
-Output [8]: [d_week_seq1#44, round((sun_sales1#45 / sun_sales2#89), 2) AS round((sun_sales1 / sun_sales2), 2)#96, round((mon_sales1#46 / mon_sales2#90), 2) AS round((mon_sales1 / mon_sales2), 2)#97, round((tue_sales1#47 / tue_sales2#91), 2) AS round((tue_sales1 / tue_sales2), 2)#98, round((wed_sales1#48 / wed_sales2#92), 2) AS round((wed_sales1 / wed_sales2), 2)#99, round((thu_sales1#49 / thu_sales2#93), 2) AS round((thu_sales1 / thu_sales2), 2)#100, round((fri_sales1#50 / fri_sales2#94), 2) AS round((fri_sales1 / fri_sales2), 2)#101, round((sat_sales1#51 / sat_sales2#95), 2) AS round((sat_sales1 / sat_sales2), 2)#102]
-Input [16]: [d_week_seq1#44, sun_sales1#45, mon_sales1#46, tue_sales1#47, wed_sales1#48, thu_sales1#49, fri_sales1#50, sat_sales1#51, d_week_seq2#88, sun_sales2#89, mon_sales2#90, tue_sales2#91, wed_sales2#92, thu_sales2#93, fri_sales2#94, sat_sales2#95]
+Output [8]: [d_week_seq1#43, round((sun_sales1#44 / sun_sales2#87), 2) AS round((sun_sales1 / sun_sales2), 2)#94, round((mon_sales1#45 / mon_sales2#88), 2) AS round((mon_sales1 / mon_sales2), 2)#95, round((tue_sales1#46 / tue_sales2#89), 2) AS round((tue_sales1 / tue_sales2), 2)#96, round((wed_sales1#47 / wed_sales2#90), 2) AS round((wed_sales1 / wed_sales2), 2)#97, round((thu_sales1#48 / thu_sales2#91), 2) AS round((thu_sales1 / thu_sales2), 2)#98, round((fri_sales1#49 / fri_sales2#92), 2) AS round((fri_sales1 / fri_sales2), 2)#99, round((sat_sales1#50 / sat_sales2#93), 2) AS round((sat_sales1 / sat_sales2), 2)#100]
+Input [16]: [d_week_seq1#43, sun_sales1#44, mon_sales1#45, tue_sales1#46, wed_sales1#47, thu_sales1#48, fri_sales1#49, sat_sales1#50, d_week_seq2#86, sun_sales2#87, mon_sales2#88, tue_sales2#89, wed_sales2#90, thu_sales2#91, fri_sales2#92, sat_sales2#93]
 
 (50) Exchange
-Input [8]: [d_week_seq1#44, round((sun_sales1 / sun_sales2), 2)#96, round((mon_sales1 / mon_sales2), 2)#97, round((tue_sales1 / tue_sales2), 2)#98, round((wed_sales1 / wed_sales2), 2)#99, round((thu_sales1 / thu_sales2), 2)#100, round((fri_sales1 / fri_sales2), 2)#101, round((sat_sales1 / sat_sales2), 2)#102]
-Arguments: rangepartitioning(d_week_seq1#44 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [8]: [d_week_seq1#43, round((sun_sales1 / sun_sales2), 2)#94, round((mon_sales1 / mon_sales2), 2)#95, round((tue_sales1 / tue_sales2), 2)#96, round((wed_sales1 / wed_sales2), 2)#97, round((thu_sales1 / thu_sales2), 2)#98, round((fri_sales1 / fri_sales2), 2)#99, round((sat_sales1 / sat_sales2), 2)#100]
+Arguments: rangepartitioning(d_week_seq1#43 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (51) Sort [codegen id : 13]
-Input [8]: [d_week_seq1#44, round((sun_sales1 / sun_sales2), 2)#96, round((mon_sales1 / mon_sales2), 2)#97, round((tue_sales1 / tue_sales2), 2)#98, round((wed_sales1 / wed_sales2), 2)#99, round((thu_sales1 / thu_sales2), 2)#100, round((fri_sales1 / fri_sales2), 2)#101, round((sat_sales1 / sat_sales2), 2)#102]
-Arguments: [d_week_seq1#44 ASC NULLS FIRST], true, 0
+Input [8]: [d_week_seq1#43, round((sun_sales1 / sun_sales2), 2)#94, round((mon_sales1 / mon_sales2), 2)#95, round((tue_sales1 / tue_sales2), 2)#96, round((wed_sales1 / wed_sales2), 2)#97, round((thu_sales1 / thu_sales2), 2)#98, round((fri_sales1 / fri_sales2), 2)#99, round((sat_sales1 / sat_sales2), 2)#100]
+Arguments: [d_week_seq1#43 ASC NULLS FIRST], true, 0
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 10 Hosting Expression = Subquery scalar-subquery#12, [id=#13]
+Subquery:1 Hosting operator id = 10 Hosting Expression = Subquery scalar-subquery#12, [id=#1]
 ObjectHashAggregate (58)
 +- Exchange (57)
    +- ObjectHashAggregate (56)
@@ -303,42 +303,42 @@ ObjectHashAggregate (58)
 
 
 (52) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_week_seq#42, d_year#43]
+Output [2]: [d_week_seq#41, d_year#42]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_week_seq:int,d_year:int>
 
 (53) ColumnarToRow [codegen id : 1]
-Input [2]: [d_week_seq#42, d_year#43]
+Input [2]: [d_week_seq#41, d_year#42]
 
 (54) Filter [codegen id : 1]
-Input [2]: [d_week_seq#42, d_year#43]
-Condition : ((isnotnull(d_year#43) AND (d_year#43 = 2001)) AND isnotnull(d_week_seq#42))
+Input [2]: [d_week_seq#41, d_year#42]
+Condition : ((isnotnull(d_year#42) AND (d_year#42 = 2001)) AND isnotnull(d_week_seq#41))
 
 (55) Project [codegen id : 1]
-Output [1]: [d_week_seq#42]
-Input [2]: [d_week_seq#42, d_year#43]
+Output [1]: [d_week_seq#41]
+Input [2]: [d_week_seq#41, d_year#42]
 
 (56) ObjectHashAggregate
-Input [1]: [d_week_seq#42]
+Input [1]: [d_week_seq#41]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#42, 42), 362, 9656, 0, 0)]
-Aggregate Attributes [1]: [buf#103]
-Results [1]: [buf#104]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#41, 42), 362, 9656, 0, 0)]
+Aggregate Attributes [1]: [buf#101]
+Results [1]: [buf#102]
 
 (57) Exchange
-Input [1]: [buf#104]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+Input [1]: [buf#102]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
 
 (58) ObjectHashAggregate
-Input [1]: [buf#104]
+Input [1]: [buf#102]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#42, 42), 362, 9656, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#42, 42), 362, 9656, 0, 0)#105]
-Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#42, 42), 362, 9656, 0, 0)#105 AS bloomFilter#106]
+Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 362, 9656, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 362, 9656, 0, 0)#103]
+Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 362, 9656, 0, 0)#103 AS bloomFilter#104]
 
-Subquery:2 Hosting operator id = 33 Hosting Expression = Subquery scalar-subquery#63, [id=#64]
+Subquery:2 Hosting operator id = 33 Hosting Expression = Subquery scalar-subquery#62, [id=#5]
 ObjectHashAggregate (65)
 +- Exchange (64)
    +- ObjectHashAggregate (63)
@@ -349,39 +349,39 @@ ObjectHashAggregate (65)
 
 
 (59) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_week_seq#86, d_year#87]
+Output [2]: [d_week_seq#84, d_year#85]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_week_seq:int,d_year:int>
 
 (60) ColumnarToRow [codegen id : 1]
-Input [2]: [d_week_seq#86, d_year#87]
+Input [2]: [d_week_seq#84, d_year#85]
 
 (61) Filter [codegen id : 1]
-Input [2]: [d_week_seq#86, d_year#87]
-Condition : ((isnotnull(d_year#87) AND (d_year#87 = 2002)) AND isnotnull(d_week_seq#86))
+Input [2]: [d_week_seq#84, d_year#85]
+Condition : ((isnotnull(d_year#85) AND (d_year#85 = 2002)) AND isnotnull(d_week_seq#84))
 
 (62) Project [codegen id : 1]
-Output [1]: [d_week_seq#86]
-Input [2]: [d_week_seq#86, d_year#87]
+Output [1]: [d_week_seq#84]
+Input [2]: [d_week_seq#84, d_year#85]
 
 (63) ObjectHashAggregate
-Input [1]: [d_week_seq#86]
+Input [1]: [d_week_seq#84]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#86, 42), 362, 9656, 0, 0)]
-Aggregate Attributes [1]: [buf#107]
-Results [1]: [buf#108]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#84, 42), 362, 9656, 0, 0)]
+Aggregate Attributes [1]: [buf#105]
+Results [1]: [buf#106]
 
 (64) Exchange
-Input [1]: [buf#108]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
+Input [1]: [buf#106]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
 
 (65) ObjectHashAggregate
-Input [1]: [buf#108]
+Input [1]: [buf#106]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#86, 42), 362, 9656, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#86, 42), 362, 9656, 0, 0)#109]
-Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#86, 42), 362, 9656, 0, 0)#109 AS bloomFilter#110]
+Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#84, 42), 362, 9656, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#84, 42), 362, 9656, 0, 0)#107]
+Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#84, 42), 362, 9656, 0, 0)#107 AS bloomFilter#108]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a.sf100/explain.txt
@@ -295,7 +295,7 @@ Results [2]: [c_customer_sk#24, sum((cast(ss_quantity#21 as decimal(10,0)) * ss_
 
 (44) Filter [codegen id : 15]
 Input [2]: [c_customer_sk#24, ssales#30]
-Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * Subquery scalar-subquery#31, [id=#32])))
+Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * Subquery scalar-subquery#31, [id=#7])))
 
 (45) Project [codegen id : 15]
 Output [1]: [c_customer_sk#24]
@@ -316,196 +316,196 @@ Output [3]: [cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
 Input [4]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
 
 (49) ReusedExchange [Reuses operator id: 95]
-Output [1]: [d_date_sk#33]
+Output [1]: [d_date_sk#32]
 
 (50) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [cs_sold_date_sk#5]
-Right keys [1]: [d_date_sk#33]
+Right keys [1]: [d_date_sk#32]
 Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 17]
-Output [1]: [(cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4) AS sales#34]
-Input [4]: [cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5, d_date_sk#33]
+Output [1]: [(cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4) AS sales#33]
+Input [4]: [cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5, d_date_sk#32]
 
 (52) Scan parquet spark_catalog.default.web_sales
-Output [5]: [ws_item_sk#35, ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
+Output [5]: [ws_item_sk#34, ws_bill_customer_sk#35, ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#39), dynamicpruningexpression(ws_sold_date_sk#39 IN dynamicpruning#6)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#38), dynamicpruningexpression(ws_sold_date_sk#38 IN dynamicpruning#6)]
 ReadSchema: struct<ws_item_sk:int,ws_bill_customer_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (53) ColumnarToRow [codegen id : 18]
-Input [5]: [ws_item_sk#35, ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
+Input [5]: [ws_item_sk#34, ws_bill_customer_sk#35, ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
 
 (54) Exchange
-Input [5]: [ws_item_sk#35, ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
-Arguments: hashpartitioning(ws_item_sk#35, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Input [5]: [ws_item_sk#34, ws_bill_customer_sk#35, ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
+Arguments: hashpartitioning(ws_item_sk#34, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (55) Sort [codegen id : 19]
-Input [5]: [ws_item_sk#35, ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
-Arguments: [ws_item_sk#35 ASC NULLS FIRST], false, 0
+Input [5]: [ws_item_sk#34, ws_bill_customer_sk#35, ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
+Arguments: [ws_item_sk#34 ASC NULLS FIRST], false, 0
 
 (56) ReusedExchange [Reuses operator id: 11]
-Output [2]: [ss_item_sk#40, d_date#41]
+Output [2]: [ss_item_sk#39, d_date#40]
 
 (57) Sort [codegen id : 22]
-Input [2]: [ss_item_sk#40, d_date#41]
-Arguments: [ss_item_sk#40 ASC NULLS FIRST], false, 0
+Input [2]: [ss_item_sk#39, d_date#40]
+Arguments: [ss_item_sk#39 ASC NULLS FIRST], false, 0
 
 (58) ReusedExchange [Reuses operator id: 16]
-Output [2]: [i_item_sk#42, i_item_desc#43]
+Output [2]: [i_item_sk#41, i_item_desc#42]
 
 (59) Sort [codegen id : 24]
-Input [2]: [i_item_sk#42, i_item_desc#43]
-Arguments: [i_item_sk#42 ASC NULLS FIRST], false, 0
+Input [2]: [i_item_sk#41, i_item_desc#42]
+Arguments: [i_item_sk#41 ASC NULLS FIRST], false, 0
 
 (60) SortMergeJoin [codegen id : 25]
-Left keys [1]: [ss_item_sk#40]
-Right keys [1]: [i_item_sk#42]
+Left keys [1]: [ss_item_sk#39]
+Right keys [1]: [i_item_sk#41]
 Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 25]
-Output [3]: [d_date#41, i_item_sk#42, substr(i_item_desc#43, 1, 30) AS _groupingexpression#44]
-Input [4]: [ss_item_sk#40, d_date#41, i_item_sk#42, i_item_desc#43]
+Output [3]: [d_date#40, i_item_sk#41, substr(i_item_desc#42, 1, 30) AS _groupingexpression#43]
+Input [4]: [ss_item_sk#39, d_date#40, i_item_sk#41, i_item_desc#42]
 
 (62) HashAggregate [codegen id : 25]
-Input [3]: [d_date#41, i_item_sk#42, _groupingexpression#44]
-Keys [3]: [_groupingexpression#44, i_item_sk#42, d_date#41]
+Input [3]: [d_date#40, i_item_sk#41, _groupingexpression#43]
+Keys [3]: [_groupingexpression#43, i_item_sk#41, d_date#40]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#15]
-Results [4]: [_groupingexpression#44, i_item_sk#42, d_date#41, count#16]
+Results [4]: [_groupingexpression#43, i_item_sk#41, d_date#40, count#16]
 
 (63) HashAggregate [codegen id : 25]
-Input [4]: [_groupingexpression#44, i_item_sk#42, d_date#41, count#16]
-Keys [3]: [_groupingexpression#44, i_item_sk#42, d_date#41]
+Input [4]: [_groupingexpression#43, i_item_sk#41, d_date#40, count#16]
+Keys [3]: [_groupingexpression#43, i_item_sk#41, d_date#40]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#17]
-Results [2]: [i_item_sk#42 AS item_sk#45, count(1)#17 AS cnt#46]
+Results [2]: [i_item_sk#41 AS item_sk#44, count(1)#17 AS cnt#45]
 
 (64) Filter [codegen id : 25]
-Input [2]: [item_sk#45, cnt#46]
-Condition : (cnt#46 > 4)
+Input [2]: [item_sk#44, cnt#45]
+Condition : (cnt#45 > 4)
 
 (65) Project [codegen id : 25]
-Output [1]: [item_sk#45]
-Input [2]: [item_sk#45, cnt#46]
+Output [1]: [item_sk#44]
+Input [2]: [item_sk#44, cnt#45]
 
 (66) Sort [codegen id : 25]
-Input [1]: [item_sk#45]
-Arguments: [item_sk#45 ASC NULLS FIRST], false, 0
+Input [1]: [item_sk#44]
+Arguments: [item_sk#44 ASC NULLS FIRST], false, 0
 
 (67) SortMergeJoin [codegen id : 26]
-Left keys [1]: [ws_item_sk#35]
-Right keys [1]: [item_sk#45]
+Left keys [1]: [ws_item_sk#34]
+Right keys [1]: [item_sk#44]
 Join type: LeftSemi
 Join condition: None
 
 (68) Project [codegen id : 26]
-Output [4]: [ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
-Input [5]: [ws_item_sk#35, ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
+Output [4]: [ws_bill_customer_sk#35, ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
+Input [5]: [ws_item_sk#34, ws_bill_customer_sk#35, ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
 
 (69) Exchange
-Input [4]: [ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
-Arguments: hashpartitioning(ws_bill_customer_sk#36, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [4]: [ws_bill_customer_sk#35, ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
+Arguments: hashpartitioning(ws_bill_customer_sk#35, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (70) Sort [codegen id : 27]
-Input [4]: [ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
-Arguments: [ws_bill_customer_sk#36 ASC NULLS FIRST], false, 0
+Input [4]: [ws_bill_customer_sk#35, ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
+Arguments: [ws_bill_customer_sk#35 ASC NULLS FIRST], false, 0
 
 (71) ReusedExchange [Reuses operator id: 33]
-Output [3]: [ss_customer_sk#47, ss_quantity#48, ss_sales_price#49]
+Output [3]: [ss_customer_sk#46, ss_quantity#47, ss_sales_price#48]
 
 (72) Sort [codegen id : 29]
-Input [3]: [ss_customer_sk#47, ss_quantity#48, ss_sales_price#49]
-Arguments: [ss_customer_sk#47 ASC NULLS FIRST], false, 0
+Input [3]: [ss_customer_sk#46, ss_quantity#47, ss_sales_price#48]
+Arguments: [ss_customer_sk#46 ASC NULLS FIRST], false, 0
 
 (73) ReusedExchange [Reuses operator id: 38]
-Output [1]: [c_customer_sk#50]
+Output [1]: [c_customer_sk#49]
 
 (74) Sort [codegen id : 31]
-Input [1]: [c_customer_sk#50]
-Arguments: [c_customer_sk#50 ASC NULLS FIRST], false, 0
+Input [1]: [c_customer_sk#49]
+Arguments: [c_customer_sk#49 ASC NULLS FIRST], false, 0
 
 (75) SortMergeJoin [codegen id : 32]
-Left keys [1]: [ss_customer_sk#47]
-Right keys [1]: [c_customer_sk#50]
+Left keys [1]: [ss_customer_sk#46]
+Right keys [1]: [c_customer_sk#49]
 Join type: Inner
 Join condition: None
 
 (76) Project [codegen id : 32]
-Output [3]: [ss_quantity#48, ss_sales_price#49, c_customer_sk#50]
-Input [4]: [ss_customer_sk#47, ss_quantity#48, ss_sales_price#49, c_customer_sk#50]
+Output [3]: [ss_quantity#47, ss_sales_price#48, c_customer_sk#49]
+Input [4]: [ss_customer_sk#46, ss_quantity#47, ss_sales_price#48, c_customer_sk#49]
 
 (77) HashAggregate [codegen id : 32]
-Input [3]: [ss_quantity#48, ss_sales_price#49, c_customer_sk#50]
-Keys [1]: [c_customer_sk#50]
-Functions [1]: [partial_sum((cast(ss_quantity#48 as decimal(10,0)) * ss_sales_price#49))]
-Aggregate Attributes [2]: [sum#51, isEmpty#52]
-Results [3]: [c_customer_sk#50, sum#53, isEmpty#54]
+Input [3]: [ss_quantity#47, ss_sales_price#48, c_customer_sk#49]
+Keys [1]: [c_customer_sk#49]
+Functions [1]: [partial_sum((cast(ss_quantity#47 as decimal(10,0)) * ss_sales_price#48))]
+Aggregate Attributes [2]: [sum#50, isEmpty#51]
+Results [3]: [c_customer_sk#49, sum#52, isEmpty#53]
 
 (78) HashAggregate [codegen id : 32]
-Input [3]: [c_customer_sk#50, sum#53, isEmpty#54]
-Keys [1]: [c_customer_sk#50]
-Functions [1]: [sum((cast(ss_quantity#48 as decimal(10,0)) * ss_sales_price#49))]
-Aggregate Attributes [1]: [sum((cast(ss_quantity#48 as decimal(10,0)) * ss_sales_price#49))#29]
-Results [2]: [c_customer_sk#50, sum((cast(ss_quantity#48 as decimal(10,0)) * ss_sales_price#49))#29 AS ssales#55]
+Input [3]: [c_customer_sk#49, sum#52, isEmpty#53]
+Keys [1]: [c_customer_sk#49]
+Functions [1]: [sum((cast(ss_quantity#47 as decimal(10,0)) * ss_sales_price#48))]
+Aggregate Attributes [1]: [sum((cast(ss_quantity#47 as decimal(10,0)) * ss_sales_price#48))#29]
+Results [2]: [c_customer_sk#49, sum((cast(ss_quantity#47 as decimal(10,0)) * ss_sales_price#48))#29 AS ssales#54]
 
 (79) Filter [codegen id : 32]
-Input [2]: [c_customer_sk#50, ssales#55]
-Condition : (isnotnull(ssales#55) AND (cast(ssales#55 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#32])))
+Input [2]: [c_customer_sk#49, ssales#54]
+Condition : (isnotnull(ssales#54) AND (cast(ssales#54 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#7])))
 
 (80) Project [codegen id : 32]
-Output [1]: [c_customer_sk#50]
-Input [2]: [c_customer_sk#50, ssales#55]
+Output [1]: [c_customer_sk#49]
+Input [2]: [c_customer_sk#49, ssales#54]
 
 (81) Sort [codegen id : 32]
-Input [1]: [c_customer_sk#50]
-Arguments: [c_customer_sk#50 ASC NULLS FIRST], false, 0
+Input [1]: [c_customer_sk#49]
+Arguments: [c_customer_sk#49 ASC NULLS FIRST], false, 0
 
 (82) SortMergeJoin [codegen id : 34]
-Left keys [1]: [ws_bill_customer_sk#36]
-Right keys [1]: [c_customer_sk#50]
+Left keys [1]: [ws_bill_customer_sk#35]
+Right keys [1]: [c_customer_sk#49]
 Join type: LeftSemi
 Join condition: None
 
 (83) Project [codegen id : 34]
-Output [3]: [ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
-Input [4]: [ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
+Output [3]: [ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
+Input [4]: [ws_bill_customer_sk#35, ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
 
 (84) ReusedExchange [Reuses operator id: 95]
-Output [1]: [d_date_sk#56]
+Output [1]: [d_date_sk#55]
 
 (85) BroadcastHashJoin [codegen id : 34]
-Left keys [1]: [ws_sold_date_sk#39]
-Right keys [1]: [d_date_sk#56]
+Left keys [1]: [ws_sold_date_sk#38]
+Right keys [1]: [d_date_sk#55]
 Join type: Inner
 Join condition: None
 
 (86) Project [codegen id : 34]
-Output [1]: [(cast(ws_quantity#37 as decimal(10,0)) * ws_list_price#38) AS sales#57]
-Input [4]: [ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39, d_date_sk#56]
+Output [1]: [(cast(ws_quantity#36 as decimal(10,0)) * ws_list_price#37) AS sales#56]
+Input [4]: [ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38, d_date_sk#55]
 
 (87) Union
 
 (88) HashAggregate [codegen id : 35]
-Input [1]: [sales#34]
+Input [1]: [sales#33]
 Keys: []
-Functions [1]: [partial_sum(sales#34)]
-Aggregate Attributes [2]: [sum#58, isEmpty#59]
-Results [2]: [sum#60, isEmpty#61]
+Functions [1]: [partial_sum(sales#33)]
+Aggregate Attributes [2]: [sum#57, isEmpty#58]
+Results [2]: [sum#59, isEmpty#60]
 
 (89) Exchange
-Input [2]: [sum#60, isEmpty#61]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+Input [2]: [sum#59, isEmpty#60]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
 
 (90) HashAggregate [codegen id : 36]
-Input [2]: [sum#60, isEmpty#61]
+Input [2]: [sum#59, isEmpty#60]
 Keys: []
-Functions [1]: [sum(sales#34)]
-Aggregate Attributes [1]: [sum(sales#34)#62]
-Results [1]: [sum(sales#34)#62 AS sum(sales)#63]
+Functions [1]: [sum(sales#33)]
+Aggregate Attributes [1]: [sum(sales#33)#61]
+Results [1]: [sum(sales#33)#61 AS sum(sales)#62]
 
 ===== Subqueries =====
 
@@ -518,26 +518,26 @@ BroadcastExchange (95)
 
 
 (91) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#33, d_year#64, d_moy#65]
+Output [3]: [d_date_sk#32, d_year#63, d_moy#64]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,2), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (92) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#33, d_year#64, d_moy#65]
+Input [3]: [d_date_sk#32, d_year#63, d_moy#64]
 
 (93) Filter [codegen id : 1]
-Input [3]: [d_date_sk#33, d_year#64, d_moy#65]
-Condition : ((((isnotnull(d_year#64) AND isnotnull(d_moy#65)) AND (d_year#64 = 2000)) AND (d_moy#65 = 2)) AND isnotnull(d_date_sk#33))
+Input [3]: [d_date_sk#32, d_year#63, d_moy#64]
+Condition : ((((isnotnull(d_year#63) AND isnotnull(d_moy#64)) AND (d_year#63 = 2000)) AND (d_moy#64 = 2)) AND isnotnull(d_date_sk#32))
 
 (94) Project [codegen id : 1]
-Output [1]: [d_date_sk#33]
-Input [3]: [d_date_sk#33, d_year#64, d_moy#65]
+Output [1]: [d_date_sk#32]
+Input [3]: [d_date_sk#32, d_year#63, d_moy#64]
 
 (95) BroadcastExchange
-Input [1]: [d_date_sk#33]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+Input [1]: [d_date_sk#32]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
 Subquery:2 Hosting operator id = 5 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
 BroadcastExchange (100)
@@ -548,28 +548,28 @@ BroadcastExchange (100)
 
 
 (96) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#10, d_date#11, d_year#66]
+Output [3]: [d_date_sk#10, d_date#11, d_year#65]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_year, [2000,2001,2002,2003]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_year:int>
 
 (97) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#10, d_date#11, d_year#66]
+Input [3]: [d_date_sk#10, d_date#11, d_year#65]
 
 (98) Filter [codegen id : 1]
-Input [3]: [d_date_sk#10, d_date#11, d_year#66]
-Condition : (d_year#66 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#10))
+Input [3]: [d_date_sk#10, d_date#11, d_year#65]
+Condition : (d_year#65 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#10))
 
 (99) Project [codegen id : 1]
 Output [2]: [d_date_sk#10, d_date#11]
-Input [3]: [d_date_sk#10, d_date#11, d_year#66]
+Input [3]: [d_date_sk#10, d_date#11, d_year#65]
 
 (100) BroadcastExchange
 Input [2]: [d_date_sk#10, d_date#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=12]
 
-Subquery:3 Hosting operator id = 44 Hosting Expression = Subquery scalar-subquery#31, [id=#32]
+Subquery:3 Hosting operator id = 44 Hosting Expression = Subquery scalar-subquery#31, [id=#7]
 * HashAggregate (117)
 +- Exchange (116)
    +- * HashAggregate (115)
@@ -590,91 +590,91 @@ Subquery:3 Hosting operator id = 44 Hosting Expression = Subquery scalar-subquer
 
 
 (101) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_customer_sk#67, ss_quantity#68, ss_sales_price#69, ss_sold_date_sk#70]
+Output [4]: [ss_customer_sk#66, ss_quantity#67, ss_sales_price#68, ss_sold_date_sk#69]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#70), dynamicpruningexpression(ss_sold_date_sk#70 IN dynamicpruning#71)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#69), dynamicpruningexpression(ss_sold_date_sk#69 IN dynamicpruning#70)]
 PushedFilters: [IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int,ss_quantity:int,ss_sales_price:decimal(7,2)>
 
 (102) ColumnarToRow [codegen id : 2]
-Input [4]: [ss_customer_sk#67, ss_quantity#68, ss_sales_price#69, ss_sold_date_sk#70]
+Input [4]: [ss_customer_sk#66, ss_quantity#67, ss_sales_price#68, ss_sold_date_sk#69]
 
 (103) Filter [codegen id : 2]
-Input [4]: [ss_customer_sk#67, ss_quantity#68, ss_sales_price#69, ss_sold_date_sk#70]
-Condition : isnotnull(ss_customer_sk#67)
+Input [4]: [ss_customer_sk#66, ss_quantity#67, ss_sales_price#68, ss_sold_date_sk#69]
+Condition : isnotnull(ss_customer_sk#66)
 
 (104) ReusedExchange [Reuses operator id: 122]
-Output [1]: [d_date_sk#72]
+Output [1]: [d_date_sk#71]
 
 (105) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#70]
-Right keys [1]: [d_date_sk#72]
+Left keys [1]: [ss_sold_date_sk#69]
+Right keys [1]: [d_date_sk#71]
 Join type: Inner
 Join condition: None
 
 (106) Project [codegen id : 2]
-Output [3]: [ss_customer_sk#67, ss_quantity#68, ss_sales_price#69]
-Input [5]: [ss_customer_sk#67, ss_quantity#68, ss_sales_price#69, ss_sold_date_sk#70, d_date_sk#72]
+Output [3]: [ss_customer_sk#66, ss_quantity#67, ss_sales_price#68]
+Input [5]: [ss_customer_sk#66, ss_quantity#67, ss_sales_price#68, ss_sold_date_sk#69, d_date_sk#71]
 
 (107) Exchange
-Input [3]: [ss_customer_sk#67, ss_quantity#68, ss_sales_price#69]
-Arguments: hashpartitioning(ss_customer_sk#67, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [3]: [ss_customer_sk#66, ss_quantity#67, ss_sales_price#68]
+Arguments: hashpartitioning(ss_customer_sk#66, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (108) Sort [codegen id : 3]
-Input [3]: [ss_customer_sk#67, ss_quantity#68, ss_sales_price#69]
-Arguments: [ss_customer_sk#67 ASC NULLS FIRST], false, 0
+Input [3]: [ss_customer_sk#66, ss_quantity#67, ss_sales_price#68]
+Arguments: [ss_customer_sk#66 ASC NULLS FIRST], false, 0
 
 (109) ReusedExchange [Reuses operator id: 38]
-Output [1]: [c_customer_sk#73]
+Output [1]: [c_customer_sk#72]
 
 (110) Sort [codegen id : 5]
-Input [1]: [c_customer_sk#73]
-Arguments: [c_customer_sk#73 ASC NULLS FIRST], false, 0
+Input [1]: [c_customer_sk#72]
+Arguments: [c_customer_sk#72 ASC NULLS FIRST], false, 0
 
 (111) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_customer_sk#67]
-Right keys [1]: [c_customer_sk#73]
+Left keys [1]: [ss_customer_sk#66]
+Right keys [1]: [c_customer_sk#72]
 Join type: Inner
 Join condition: None
 
 (112) Project [codegen id : 6]
-Output [3]: [ss_quantity#68, ss_sales_price#69, c_customer_sk#73]
-Input [4]: [ss_customer_sk#67, ss_quantity#68, ss_sales_price#69, c_customer_sk#73]
+Output [3]: [ss_quantity#67, ss_sales_price#68, c_customer_sk#72]
+Input [4]: [ss_customer_sk#66, ss_quantity#67, ss_sales_price#68, c_customer_sk#72]
 
 (113) HashAggregate [codegen id : 6]
-Input [3]: [ss_quantity#68, ss_sales_price#69, c_customer_sk#73]
-Keys [1]: [c_customer_sk#73]
-Functions [1]: [partial_sum((cast(ss_quantity#68 as decimal(10,0)) * ss_sales_price#69))]
-Aggregate Attributes [2]: [sum#74, isEmpty#75]
-Results [3]: [c_customer_sk#73, sum#76, isEmpty#77]
+Input [3]: [ss_quantity#67, ss_sales_price#68, c_customer_sk#72]
+Keys [1]: [c_customer_sk#72]
+Functions [1]: [partial_sum((cast(ss_quantity#67 as decimal(10,0)) * ss_sales_price#68))]
+Aggregate Attributes [2]: [sum#73, isEmpty#74]
+Results [3]: [c_customer_sk#72, sum#75, isEmpty#76]
 
 (114) HashAggregate [codegen id : 6]
-Input [3]: [c_customer_sk#73, sum#76, isEmpty#77]
-Keys [1]: [c_customer_sk#73]
-Functions [1]: [sum((cast(ss_quantity#68 as decimal(10,0)) * ss_sales_price#69))]
-Aggregate Attributes [1]: [sum((cast(ss_quantity#68 as decimal(10,0)) * ss_sales_price#69))#78]
-Results [1]: [sum((cast(ss_quantity#68 as decimal(10,0)) * ss_sales_price#69))#78 AS csales#79]
+Input [3]: [c_customer_sk#72, sum#75, isEmpty#76]
+Keys [1]: [c_customer_sk#72]
+Functions [1]: [sum((cast(ss_quantity#67 as decimal(10,0)) * ss_sales_price#68))]
+Aggregate Attributes [1]: [sum((cast(ss_quantity#67 as decimal(10,0)) * ss_sales_price#68))#77]
+Results [1]: [sum((cast(ss_quantity#67 as decimal(10,0)) * ss_sales_price#68))#77 AS csales#78]
 
 (115) HashAggregate [codegen id : 6]
-Input [1]: [csales#79]
+Input [1]: [csales#78]
 Keys: []
-Functions [1]: [partial_max(csales#79)]
-Aggregate Attributes [1]: [max#80]
-Results [1]: [max#81]
+Functions [1]: [partial_max(csales#78)]
+Aggregate Attributes [1]: [max#79]
+Results [1]: [max#80]
 
 (116) Exchange
-Input [1]: [max#81]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
+Input [1]: [max#80]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
 
 (117) HashAggregate [codegen id : 7]
-Input [1]: [max#81]
+Input [1]: [max#80]
 Keys: []
-Functions [1]: [max(csales#79)]
-Aggregate Attributes [1]: [max(csales#79)#82]
-Results [1]: [max(csales#79)#82 AS tpcds_cmax#83]
+Functions [1]: [max(csales#78)]
+Aggregate Attributes [1]: [max(csales#78)#81]
+Results [1]: [max(csales#78)#81 AS tpcds_cmax#82]
 
-Subquery:4 Hosting operator id = 101 Hosting Expression = ss_sold_date_sk#70 IN dynamicpruning#71
+Subquery:4 Hosting operator id = 101 Hosting Expression = ss_sold_date_sk#69 IN dynamicpruning#70
 BroadcastExchange (122)
 +- * Project (121)
    +- * Filter (120)
@@ -683,29 +683,29 @@ BroadcastExchange (122)
 
 
 (118) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#72, d_year#84]
+Output [2]: [d_date_sk#71, d_year#83]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_year, [2000,2001,2002,2003]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (119) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#72, d_year#84]
+Input [2]: [d_date_sk#71, d_year#83]
 
 (120) Filter [codegen id : 1]
-Input [2]: [d_date_sk#72, d_year#84]
-Condition : (d_year#84 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#72))
+Input [2]: [d_date_sk#71, d_year#83]
+Condition : (d_year#83 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#71))
 
 (121) Project [codegen id : 1]
-Output [1]: [d_date_sk#72]
-Input [2]: [d_date_sk#72, d_year#84]
+Output [1]: [d_date_sk#71]
+Input [2]: [d_date_sk#71, d_year#83]
 
 (122) BroadcastExchange
-Input [1]: [d_date_sk#72]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
+Input [1]: [d_date_sk#71]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
 
-Subquery:5 Hosting operator id = 52 Hosting Expression = ws_sold_date_sk#39 IN dynamicpruning#6
+Subquery:5 Hosting operator id = 52 Hosting Expression = ws_sold_date_sk#38 IN dynamicpruning#6
 
-Subquery:6 Hosting operator id = 79 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#32]
+Subquery:6 Hosting operator id = 79 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#7]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a/explain.txt
@@ -247,7 +247,7 @@ Results [2]: [c_customer_sk#24, sum((cast(ss_quantity#21 as decimal(10,0)) * ss_
 
 (38) Filter [codegen id : 9]
 Input [2]: [c_customer_sk#24, ssales#30]
-Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * Subquery scalar-subquery#31, [id=#32])))
+Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * Subquery scalar-subquery#31, [id=#7])))
 
 (39) Project [codegen id : 9]
 Output [1]: [c_customer_sk#24]
@@ -268,113 +268,113 @@ Output [3]: [cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
 Input [4]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
 
 (43) ReusedExchange [Reuses operator id: 71]
-Output [1]: [d_date_sk#33]
+Output [1]: [d_date_sk#32]
 
 (44) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_sold_date_sk#5]
-Right keys [1]: [d_date_sk#33]
+Right keys [1]: [d_date_sk#32]
 Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 11]
-Output [1]: [(cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4) AS sales#34]
-Input [4]: [cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5, d_date_sk#33]
+Output [1]: [(cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4) AS sales#33]
+Input [4]: [cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5, d_date_sk#32]
 
 (46) Scan parquet spark_catalog.default.web_sales
-Output [5]: [ws_item_sk#35, ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
+Output [5]: [ws_item_sk#34, ws_bill_customer_sk#35, ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#39), dynamicpruningexpression(ws_sold_date_sk#39 IN dynamicpruning#6)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#38), dynamicpruningexpression(ws_sold_date_sk#38 IN dynamicpruning#6)]
 ReadSchema: struct<ws_item_sk:int,ws_bill_customer_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (47) ColumnarToRow [codegen id : 16]
-Input [5]: [ws_item_sk#35, ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
+Input [5]: [ws_item_sk#34, ws_bill_customer_sk#35, ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
 
 (48) ReusedExchange [Reuses operator id: 20]
-Output [1]: [item_sk#40]
+Output [1]: [item_sk#39]
 
 (49) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_item_sk#35]
-Right keys [1]: [item_sk#40]
+Left keys [1]: [ws_item_sk#34]
+Right keys [1]: [item_sk#39]
 Join type: LeftSemi
 Join condition: None
 
 (50) Project [codegen id : 16]
-Output [4]: [ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
-Input [5]: [ws_item_sk#35, ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
+Output [4]: [ws_bill_customer_sk#35, ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
+Input [5]: [ws_item_sk#34, ws_bill_customer_sk#35, ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
 
 (51) Exchange
-Input [4]: [ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
-Arguments: hashpartitioning(ws_bill_customer_sk#36, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Input [4]: [ws_bill_customer_sk#35, ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
+Arguments: hashpartitioning(ws_bill_customer_sk#35, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (52) Sort [codegen id : 17]
-Input [4]: [ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
-Arguments: [ws_bill_customer_sk#36 ASC NULLS FIRST], false, 0
+Input [4]: [ws_bill_customer_sk#35, ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
+Arguments: [ws_bill_customer_sk#35 ASC NULLS FIRST], false, 0
 
 (53) ReusedExchange [Reuses operator id: 36]
-Output [3]: [c_customer_sk#41, sum#42, isEmpty#43]
+Output [3]: [c_customer_sk#40, sum#41, isEmpty#42]
 
 (54) HashAggregate [codegen id : 20]
-Input [3]: [c_customer_sk#41, sum#42, isEmpty#43]
-Keys [1]: [c_customer_sk#41]
-Functions [1]: [sum((cast(ss_quantity#44 as decimal(10,0)) * ss_sales_price#45))]
-Aggregate Attributes [1]: [sum((cast(ss_quantity#44 as decimal(10,0)) * ss_sales_price#45))#29]
-Results [2]: [c_customer_sk#41, sum((cast(ss_quantity#44 as decimal(10,0)) * ss_sales_price#45))#29 AS ssales#46]
+Input [3]: [c_customer_sk#40, sum#41, isEmpty#42]
+Keys [1]: [c_customer_sk#40]
+Functions [1]: [sum((cast(ss_quantity#43 as decimal(10,0)) * ss_sales_price#44))]
+Aggregate Attributes [1]: [sum((cast(ss_quantity#43 as decimal(10,0)) * ss_sales_price#44))#29]
+Results [2]: [c_customer_sk#40, sum((cast(ss_quantity#43 as decimal(10,0)) * ss_sales_price#44))#29 AS ssales#45]
 
 (55) Filter [codegen id : 20]
-Input [2]: [c_customer_sk#41, ssales#46]
-Condition : (isnotnull(ssales#46) AND (cast(ssales#46 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#32])))
+Input [2]: [c_customer_sk#40, ssales#45]
+Condition : (isnotnull(ssales#45) AND (cast(ssales#45 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#7])))
 
 (56) Project [codegen id : 20]
-Output [1]: [c_customer_sk#41]
-Input [2]: [c_customer_sk#41, ssales#46]
+Output [1]: [c_customer_sk#40]
+Input [2]: [c_customer_sk#40, ssales#45]
 
 (57) Sort [codegen id : 20]
-Input [1]: [c_customer_sk#41]
-Arguments: [c_customer_sk#41 ASC NULLS FIRST], false, 0
+Input [1]: [c_customer_sk#40]
+Arguments: [c_customer_sk#40 ASC NULLS FIRST], false, 0
 
 (58) SortMergeJoin [codegen id : 22]
-Left keys [1]: [ws_bill_customer_sk#36]
-Right keys [1]: [c_customer_sk#41]
+Left keys [1]: [ws_bill_customer_sk#35]
+Right keys [1]: [c_customer_sk#40]
 Join type: LeftSemi
 Join condition: None
 
 (59) Project [codegen id : 22]
-Output [3]: [ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
-Input [4]: [ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
+Output [3]: [ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
+Input [4]: [ws_bill_customer_sk#35, ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38]
 
 (60) ReusedExchange [Reuses operator id: 71]
-Output [1]: [d_date_sk#47]
+Output [1]: [d_date_sk#46]
 
 (61) BroadcastHashJoin [codegen id : 22]
-Left keys [1]: [ws_sold_date_sk#39]
-Right keys [1]: [d_date_sk#47]
+Left keys [1]: [ws_sold_date_sk#38]
+Right keys [1]: [d_date_sk#46]
 Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 22]
-Output [1]: [(cast(ws_quantity#37 as decimal(10,0)) * ws_list_price#38) AS sales#48]
-Input [4]: [ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39, d_date_sk#47]
+Output [1]: [(cast(ws_quantity#36 as decimal(10,0)) * ws_list_price#37) AS sales#47]
+Input [4]: [ws_quantity#36, ws_list_price#37, ws_sold_date_sk#38, d_date_sk#46]
 
 (63) Union
 
 (64) HashAggregate [codegen id : 23]
-Input [1]: [sales#34]
+Input [1]: [sales#33]
 Keys: []
-Functions [1]: [partial_sum(sales#34)]
-Aggregate Attributes [2]: [sum#49, isEmpty#50]
-Results [2]: [sum#51, isEmpty#52]
+Functions [1]: [partial_sum(sales#33)]
+Aggregate Attributes [2]: [sum#48, isEmpty#49]
+Results [2]: [sum#50, isEmpty#51]
 
 (65) Exchange
-Input [2]: [sum#51, isEmpty#52]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
+Input [2]: [sum#50, isEmpty#51]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
 
 (66) HashAggregate [codegen id : 24]
-Input [2]: [sum#51, isEmpty#52]
+Input [2]: [sum#50, isEmpty#51]
 Keys: []
-Functions [1]: [sum(sales#34)]
-Aggregate Attributes [1]: [sum(sales#34)#53]
-Results [1]: [sum(sales#34)#53 AS sum(sales)#54]
+Functions [1]: [sum(sales#33)]
+Aggregate Attributes [1]: [sum(sales#33)#52]
+Results [1]: [sum(sales#33)#52 AS sum(sales)#53]
 
 ===== Subqueries =====
 
@@ -387,26 +387,26 @@ BroadcastExchange (71)
 
 
 (67) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#33, d_year#55, d_moy#56]
+Output [3]: [d_date_sk#32, d_year#54, d_moy#55]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,2), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (68) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#33, d_year#55, d_moy#56]
+Input [3]: [d_date_sk#32, d_year#54, d_moy#55]
 
 (69) Filter [codegen id : 1]
-Input [3]: [d_date_sk#33, d_year#55, d_moy#56]
-Condition : ((((isnotnull(d_year#55) AND isnotnull(d_moy#56)) AND (d_year#55 = 2000)) AND (d_moy#56 = 2)) AND isnotnull(d_date_sk#33))
+Input [3]: [d_date_sk#32, d_year#54, d_moy#55]
+Condition : ((((isnotnull(d_year#54) AND isnotnull(d_moy#55)) AND (d_year#54 = 2000)) AND (d_moy#55 = 2)) AND isnotnull(d_date_sk#32))
 
 (70) Project [codegen id : 1]
-Output [1]: [d_date_sk#33]
-Input [3]: [d_date_sk#33, d_year#55, d_moy#56]
+Output [1]: [d_date_sk#32]
+Input [3]: [d_date_sk#32, d_year#54, d_moy#55]
 
 (71) BroadcastExchange
-Input [1]: [d_date_sk#33]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+Input [1]: [d_date_sk#32]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
 Subquery:2 Hosting operator id = 3 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
 BroadcastExchange (76)
@@ -417,28 +417,28 @@ BroadcastExchange (76)
 
 
 (72) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#10, d_date#11, d_year#57]
+Output [3]: [d_date_sk#10, d_date#11, d_year#56]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_year, [2000,2001,2002,2003]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_year:int>
 
 (73) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#10, d_date#11, d_year#57]
+Input [3]: [d_date_sk#10, d_date#11, d_year#56]
 
 (74) Filter [codegen id : 1]
-Input [3]: [d_date_sk#10, d_date#11, d_year#57]
-Condition : (d_year#57 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#10))
+Input [3]: [d_date_sk#10, d_date#11, d_year#56]
+Condition : (d_year#56 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#10))
 
 (75) Project [codegen id : 1]
 Output [2]: [d_date_sk#10, d_date#11]
-Input [3]: [d_date_sk#10, d_date#11, d_year#57]
+Input [3]: [d_date_sk#10, d_date#11, d_year#56]
 
 (76) BroadcastExchange
 Input [2]: [d_date_sk#10, d_date#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-Subquery:3 Hosting operator id = 38 Hosting Expression = Subquery scalar-subquery#31, [id=#32]
+Subquery:3 Hosting operator id = 38 Hosting Expression = Subquery scalar-subquery#31, [id=#7]
 * HashAggregate (91)
 +- Exchange (90)
    +- * HashAggregate (89)
@@ -457,83 +457,83 @@ Subquery:3 Hosting operator id = 38 Hosting Expression = Subquery scalar-subquer
 
 
 (77) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_customer_sk#58, ss_quantity#59, ss_sales_price#60, ss_sold_date_sk#61]
+Output [4]: [ss_customer_sk#57, ss_quantity#58, ss_sales_price#59, ss_sold_date_sk#60]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#61), dynamicpruningexpression(ss_sold_date_sk#61 IN dynamicpruning#62)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#60), dynamicpruningexpression(ss_sold_date_sk#60 IN dynamicpruning#61)]
 PushedFilters: [IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int,ss_quantity:int,ss_sales_price:decimal(7,2)>
 
 (78) ColumnarToRow [codegen id : 3]
-Input [4]: [ss_customer_sk#58, ss_quantity#59, ss_sales_price#60, ss_sold_date_sk#61]
+Input [4]: [ss_customer_sk#57, ss_quantity#58, ss_sales_price#59, ss_sold_date_sk#60]
 
 (79) Filter [codegen id : 3]
-Input [4]: [ss_customer_sk#58, ss_quantity#59, ss_sales_price#60, ss_sold_date_sk#61]
-Condition : isnotnull(ss_customer_sk#58)
+Input [4]: [ss_customer_sk#57, ss_quantity#58, ss_sales_price#59, ss_sold_date_sk#60]
+Condition : isnotnull(ss_customer_sk#57)
 
 (80) ReusedExchange [Reuses operator id: 32]
-Output [1]: [c_customer_sk#63]
+Output [1]: [c_customer_sk#62]
 
 (81) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_customer_sk#58]
-Right keys [1]: [c_customer_sk#63]
+Left keys [1]: [ss_customer_sk#57]
+Right keys [1]: [c_customer_sk#62]
 Join type: Inner
 Join condition: None
 
 (82) Project [codegen id : 3]
-Output [4]: [ss_quantity#59, ss_sales_price#60, ss_sold_date_sk#61, c_customer_sk#63]
-Input [5]: [ss_customer_sk#58, ss_quantity#59, ss_sales_price#60, ss_sold_date_sk#61, c_customer_sk#63]
+Output [4]: [ss_quantity#58, ss_sales_price#59, ss_sold_date_sk#60, c_customer_sk#62]
+Input [5]: [ss_customer_sk#57, ss_quantity#58, ss_sales_price#59, ss_sold_date_sk#60, c_customer_sk#62]
 
 (83) ReusedExchange [Reuses operator id: 96]
-Output [1]: [d_date_sk#64]
+Output [1]: [d_date_sk#63]
 
 (84) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_sold_date_sk#61]
-Right keys [1]: [d_date_sk#64]
+Left keys [1]: [ss_sold_date_sk#60]
+Right keys [1]: [d_date_sk#63]
 Join type: Inner
 Join condition: None
 
 (85) Project [codegen id : 3]
-Output [3]: [ss_quantity#59, ss_sales_price#60, c_customer_sk#63]
-Input [5]: [ss_quantity#59, ss_sales_price#60, ss_sold_date_sk#61, c_customer_sk#63, d_date_sk#64]
+Output [3]: [ss_quantity#58, ss_sales_price#59, c_customer_sk#62]
+Input [5]: [ss_quantity#58, ss_sales_price#59, ss_sold_date_sk#60, c_customer_sk#62, d_date_sk#63]
 
 (86) HashAggregate [codegen id : 3]
-Input [3]: [ss_quantity#59, ss_sales_price#60, c_customer_sk#63]
-Keys [1]: [c_customer_sk#63]
-Functions [1]: [partial_sum((cast(ss_quantity#59 as decimal(10,0)) * ss_sales_price#60))]
-Aggregate Attributes [2]: [sum#65, isEmpty#66]
-Results [3]: [c_customer_sk#63, sum#67, isEmpty#68]
+Input [3]: [ss_quantity#58, ss_sales_price#59, c_customer_sk#62]
+Keys [1]: [c_customer_sk#62]
+Functions [1]: [partial_sum((cast(ss_quantity#58 as decimal(10,0)) * ss_sales_price#59))]
+Aggregate Attributes [2]: [sum#64, isEmpty#65]
+Results [3]: [c_customer_sk#62, sum#66, isEmpty#67]
 
 (87) Exchange
-Input [3]: [c_customer_sk#63, sum#67, isEmpty#68]
-Arguments: hashpartitioning(c_customer_sk#63, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [3]: [c_customer_sk#62, sum#66, isEmpty#67]
+Arguments: hashpartitioning(c_customer_sk#62, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (88) HashAggregate [codegen id : 4]
-Input [3]: [c_customer_sk#63, sum#67, isEmpty#68]
-Keys [1]: [c_customer_sk#63]
-Functions [1]: [sum((cast(ss_quantity#59 as decimal(10,0)) * ss_sales_price#60))]
-Aggregate Attributes [1]: [sum((cast(ss_quantity#59 as decimal(10,0)) * ss_sales_price#60))#69]
-Results [1]: [sum((cast(ss_quantity#59 as decimal(10,0)) * ss_sales_price#60))#69 AS csales#70]
+Input [3]: [c_customer_sk#62, sum#66, isEmpty#67]
+Keys [1]: [c_customer_sk#62]
+Functions [1]: [sum((cast(ss_quantity#58 as decimal(10,0)) * ss_sales_price#59))]
+Aggregate Attributes [1]: [sum((cast(ss_quantity#58 as decimal(10,0)) * ss_sales_price#59))#68]
+Results [1]: [sum((cast(ss_quantity#58 as decimal(10,0)) * ss_sales_price#59))#68 AS csales#69]
 
 (89) HashAggregate [codegen id : 4]
-Input [1]: [csales#70]
+Input [1]: [csales#69]
 Keys: []
-Functions [1]: [partial_max(csales#70)]
-Aggregate Attributes [1]: [max#71]
-Results [1]: [max#72]
+Functions [1]: [partial_max(csales#69)]
+Aggregate Attributes [1]: [max#70]
+Results [1]: [max#71]
 
 (90) Exchange
-Input [1]: [max#72]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
+Input [1]: [max#71]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
 
 (91) HashAggregate [codegen id : 5]
-Input [1]: [max#72]
+Input [1]: [max#71]
 Keys: []
-Functions [1]: [max(csales#70)]
-Aggregate Attributes [1]: [max(csales#70)#73]
-Results [1]: [max(csales#70)#73 AS tpcds_cmax#74]
+Functions [1]: [max(csales#69)]
+Aggregate Attributes [1]: [max(csales#69)#72]
+Results [1]: [max(csales#69)#72 AS tpcds_cmax#73]
 
-Subquery:4 Hosting operator id = 77 Hosting Expression = ss_sold_date_sk#61 IN dynamicpruning#62
+Subquery:4 Hosting operator id = 77 Hosting Expression = ss_sold_date_sk#60 IN dynamicpruning#61
 BroadcastExchange (96)
 +- * Project (95)
    +- * Filter (94)
@@ -542,29 +542,29 @@ BroadcastExchange (96)
 
 
 (92) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#64, d_year#75]
+Output [2]: [d_date_sk#63, d_year#74]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_year, [2000,2001,2002,2003]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (93) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#64, d_year#75]
+Input [2]: [d_date_sk#63, d_year#74]
 
 (94) Filter [codegen id : 1]
-Input [2]: [d_date_sk#64, d_year#75]
-Condition : (d_year#75 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#64))
+Input [2]: [d_date_sk#63, d_year#74]
+Condition : (d_year#74 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#63))
 
 (95) Project [codegen id : 1]
-Output [1]: [d_date_sk#64]
-Input [2]: [d_date_sk#64, d_year#75]
+Output [1]: [d_date_sk#63]
+Input [2]: [d_date_sk#63, d_year#74]
 
 (96) BroadcastExchange
-Input [1]: [d_date_sk#64]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=13]
+Input [1]: [d_date_sk#63]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
 
-Subquery:5 Hosting operator id = 46 Hosting Expression = ws_sold_date_sk#39 IN dynamicpruning#6
+Subquery:5 Hosting operator id = 46 Hosting Expression = ws_sold_date_sk#38 IN dynamicpruning#6
 
-Subquery:6 Hosting operator id = 55 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#32]
+Subquery:6 Hosting operator id = 55 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#7]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b.sf100/explain.txt
@@ -339,7 +339,7 @@ Results [2]: [c_customer_sk#24, sum((cast(ss_quantity#21 as decimal(10,0)) * ss_
 
 (45) Filter [codegen id : 15]
 Input [2]: [c_customer_sk#24, ssales#30]
-Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * Subquery scalar-subquery#31, [id=#32])))
+Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * Subquery scalar-subquery#31, [id=#7])))
 
 (46) Project [codegen id : 15]
 Output [1]: [c_customer_sk#24]
@@ -356,39 +356,39 @@ Join type: LeftSemi
 Join condition: None
 
 (49) ReusedExchange [Reuses operator id: 134]
-Output [1]: [d_date_sk#33]
+Output [1]: [d_date_sk#32]
 
 (50) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [cs_sold_date_sk#5]
-Right keys [1]: [d_date_sk#33]
+Right keys [1]: [d_date_sk#32]
 Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 17]
 Output [3]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4]
-Input [5]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5, d_date_sk#33]
+Input [5]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5, d_date_sk#32]
 
 (52) Scan parquet spark_catalog.default.customer
-Output [3]: [c_customer_sk#34, c_first_name#35, c_last_name#36]
+Output [3]: [c_customer_sk#33, c_first_name#34, c_last_name#35]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string>
 
 (53) ColumnarToRow [codegen id : 18]
-Input [3]: [c_customer_sk#34, c_first_name#35, c_last_name#36]
+Input [3]: [c_customer_sk#33, c_first_name#34, c_last_name#35]
 
 (54) Filter [codegen id : 18]
-Input [3]: [c_customer_sk#34, c_first_name#35, c_last_name#36]
-Condition : isnotnull(c_customer_sk#34)
+Input [3]: [c_customer_sk#33, c_first_name#34, c_last_name#35]
+Condition : isnotnull(c_customer_sk#33)
 
 (55) Exchange
-Input [3]: [c_customer_sk#34, c_first_name#35, c_last_name#36]
-Arguments: hashpartitioning(c_customer_sk#34, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Input [3]: [c_customer_sk#33, c_first_name#34, c_last_name#35]
+Arguments: hashpartitioning(c_customer_sk#33, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (56) Sort [codegen id : 19]
-Input [3]: [c_customer_sk#34, c_first_name#35, c_last_name#36]
-Arguments: [c_customer_sk#34 ASC NULLS FIRST], false, 0
+Input [3]: [c_customer_sk#33, c_first_name#34, c_last_name#35]
+Arguments: [c_customer_sk#33 ASC NULLS FIRST], false, 0
 
 (57) ReusedExchange [Reuses operator id: 34]
 Output [3]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22]
@@ -430,7 +430,7 @@ Results [2]: [c_customer_sk#24, sum((cast(ss_quantity#21 as decimal(10,0)) * ss_
 
 (65) Filter [codegen id : 24]
 Input [2]: [c_customer_sk#24, ssales#30]
-Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#32])))
+Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#7])))
 
 (66) Project [codegen id : 24]
 Output [1]: [c_customer_sk#24]
@@ -441,295 +441,295 @@ Input [1]: [c_customer_sk#24]
 Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 
 (68) SortMergeJoin [codegen id : 25]
-Left keys [1]: [c_customer_sk#34]
+Left keys [1]: [c_customer_sk#33]
 Right keys [1]: [c_customer_sk#24]
 Join type: LeftSemi
 Join condition: None
 
 (69) SortMergeJoin [codegen id : 26]
 Left keys [1]: [cs_bill_customer_sk#1]
-Right keys [1]: [c_customer_sk#34]
+Right keys [1]: [c_customer_sk#33]
 Join type: Inner
 Join condition: None
 
 (70) Project [codegen id : 26]
-Output [4]: [cs_quantity#3, cs_list_price#4, c_first_name#35, c_last_name#36]
-Input [6]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, c_customer_sk#34, c_first_name#35, c_last_name#36]
+Output [4]: [cs_quantity#3, cs_list_price#4, c_first_name#34, c_last_name#35]
+Input [6]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, c_customer_sk#33, c_first_name#34, c_last_name#35]
 
 (71) HashAggregate [codegen id : 26]
-Input [4]: [cs_quantity#3, cs_list_price#4, c_first_name#35, c_last_name#36]
-Keys [2]: [c_last_name#36, c_first_name#35]
+Input [4]: [cs_quantity#3, cs_list_price#4, c_first_name#34, c_last_name#35]
+Keys [2]: [c_last_name#35, c_first_name#34]
 Functions [1]: [partial_sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))]
-Aggregate Attributes [2]: [sum#37, isEmpty#38]
-Results [4]: [c_last_name#36, c_first_name#35, sum#39, isEmpty#40]
+Aggregate Attributes [2]: [sum#36, isEmpty#37]
+Results [4]: [c_last_name#35, c_first_name#34, sum#38, isEmpty#39]
 
 (72) Exchange
-Input [4]: [c_last_name#36, c_first_name#35, sum#39, isEmpty#40]
-Arguments: hashpartitioning(c_last_name#36, c_first_name#35, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [4]: [c_last_name#35, c_first_name#34, sum#38, isEmpty#39]
+Arguments: hashpartitioning(c_last_name#35, c_first_name#34, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (73) HashAggregate [codegen id : 27]
-Input [4]: [c_last_name#36, c_first_name#35, sum#39, isEmpty#40]
-Keys [2]: [c_last_name#36, c_first_name#35]
+Input [4]: [c_last_name#35, c_first_name#34, sum#38, isEmpty#39]
+Keys [2]: [c_last_name#35, c_first_name#34]
 Functions [1]: [sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))]
-Aggregate Attributes [1]: [sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))#41]
-Results [3]: [c_last_name#36, c_first_name#35, sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))#41 AS sales#42]
+Aggregate Attributes [1]: [sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))#40]
+Results [3]: [c_last_name#35, c_first_name#34, sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))#40 AS sales#41]
 
 (74) Scan parquet spark_catalog.default.web_sales
-Output [5]: [ws_item_sk#43, ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
+Output [5]: [ws_item_sk#42, ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#47), dynamicpruningexpression(ws_sold_date_sk#47 IN dynamicpruning#6)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#46), dynamicpruningexpression(ws_sold_date_sk#46 IN dynamicpruning#6)]
 PushedFilters: [IsNotNull(ws_bill_customer_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_bill_customer_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (75) ColumnarToRow [codegen id : 28]
-Input [5]: [ws_item_sk#43, ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
+Input [5]: [ws_item_sk#42, ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46]
 
 (76) Filter [codegen id : 28]
-Input [5]: [ws_item_sk#43, ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
-Condition : isnotnull(ws_bill_customer_sk#44)
+Input [5]: [ws_item_sk#42, ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46]
+Condition : isnotnull(ws_bill_customer_sk#43)
 
 (77) Exchange
-Input [5]: [ws_item_sk#43, ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
-Arguments: hashpartitioning(ws_item_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [5]: [ws_item_sk#42, ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46]
+Arguments: hashpartitioning(ws_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (78) Sort [codegen id : 29]
-Input [5]: [ws_item_sk#43, ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
-Arguments: [ws_item_sk#43 ASC NULLS FIRST], false, 0
+Input [5]: [ws_item_sk#42, ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46]
+Arguments: [ws_item_sk#42 ASC NULLS FIRST], false, 0
 
 (79) ReusedExchange [Reuses operator id: 12]
-Output [2]: [ss_item_sk#48, d_date#49]
+Output [2]: [ss_item_sk#47, d_date#48]
 
 (80) Sort [codegen id : 32]
-Input [2]: [ss_item_sk#48, d_date#49]
-Arguments: [ss_item_sk#48 ASC NULLS FIRST], false, 0
+Input [2]: [ss_item_sk#47, d_date#48]
+Arguments: [ss_item_sk#47 ASC NULLS FIRST], false, 0
 
 (81) ReusedExchange [Reuses operator id: 17]
-Output [2]: [i_item_sk#50, i_item_desc#51]
+Output [2]: [i_item_sk#49, i_item_desc#50]
 
 (82) Sort [codegen id : 34]
-Input [2]: [i_item_sk#50, i_item_desc#51]
-Arguments: [i_item_sk#50 ASC NULLS FIRST], false, 0
+Input [2]: [i_item_sk#49, i_item_desc#50]
+Arguments: [i_item_sk#49 ASC NULLS FIRST], false, 0
 
 (83) SortMergeJoin [codegen id : 35]
-Left keys [1]: [ss_item_sk#48]
-Right keys [1]: [i_item_sk#50]
+Left keys [1]: [ss_item_sk#47]
+Right keys [1]: [i_item_sk#49]
 Join type: Inner
 Join condition: None
 
 (84) Project [codegen id : 35]
-Output [3]: [d_date#49, i_item_sk#50, substr(i_item_desc#51, 1, 30) AS _groupingexpression#52]
-Input [4]: [ss_item_sk#48, d_date#49, i_item_sk#50, i_item_desc#51]
+Output [3]: [d_date#48, i_item_sk#49, substr(i_item_desc#50, 1, 30) AS _groupingexpression#51]
+Input [4]: [ss_item_sk#47, d_date#48, i_item_sk#49, i_item_desc#50]
 
 (85) HashAggregate [codegen id : 35]
-Input [3]: [d_date#49, i_item_sk#50, _groupingexpression#52]
-Keys [3]: [_groupingexpression#52, i_item_sk#50, d_date#49]
+Input [3]: [d_date#48, i_item_sk#49, _groupingexpression#51]
+Keys [3]: [_groupingexpression#51, i_item_sk#49, d_date#48]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#15]
-Results [4]: [_groupingexpression#52, i_item_sk#50, d_date#49, count#16]
+Results [4]: [_groupingexpression#51, i_item_sk#49, d_date#48, count#16]
 
 (86) HashAggregate [codegen id : 35]
-Input [4]: [_groupingexpression#52, i_item_sk#50, d_date#49, count#16]
-Keys [3]: [_groupingexpression#52, i_item_sk#50, d_date#49]
+Input [4]: [_groupingexpression#51, i_item_sk#49, d_date#48, count#16]
+Keys [3]: [_groupingexpression#51, i_item_sk#49, d_date#48]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#17]
-Results [2]: [i_item_sk#50 AS item_sk#53, count(1)#17 AS cnt#54]
+Results [2]: [i_item_sk#49 AS item_sk#52, count(1)#17 AS cnt#53]
 
 (87) Filter [codegen id : 35]
-Input [2]: [item_sk#53, cnt#54]
-Condition : (cnt#54 > 4)
+Input [2]: [item_sk#52, cnt#53]
+Condition : (cnt#53 > 4)
 
 (88) Project [codegen id : 35]
-Output [1]: [item_sk#53]
-Input [2]: [item_sk#53, cnt#54]
+Output [1]: [item_sk#52]
+Input [2]: [item_sk#52, cnt#53]
 
 (89) Sort [codegen id : 35]
-Input [1]: [item_sk#53]
-Arguments: [item_sk#53 ASC NULLS FIRST], false, 0
+Input [1]: [item_sk#52]
+Arguments: [item_sk#52 ASC NULLS FIRST], false, 0
 
 (90) SortMergeJoin [codegen id : 36]
-Left keys [1]: [ws_item_sk#43]
-Right keys [1]: [item_sk#53]
+Left keys [1]: [ws_item_sk#42]
+Right keys [1]: [item_sk#52]
 Join type: LeftSemi
 Join condition: None
 
 (91) Project [codegen id : 36]
-Output [4]: [ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
-Input [5]: [ws_item_sk#43, ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
+Output [4]: [ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46]
+Input [5]: [ws_item_sk#42, ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46]
 
 (92) Exchange
-Input [4]: [ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
-Arguments: hashpartitioning(ws_bill_customer_sk#44, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [4]: [ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46]
+Arguments: hashpartitioning(ws_bill_customer_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (93) Sort [codegen id : 37]
-Input [4]: [ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
-Arguments: [ws_bill_customer_sk#44 ASC NULLS FIRST], false, 0
+Input [4]: [ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46]
+Arguments: [ws_bill_customer_sk#43 ASC NULLS FIRST], false, 0
 
 (94) ReusedExchange [Reuses operator id: 34]
-Output [3]: [ss_customer_sk#55, ss_quantity#56, ss_sales_price#57]
+Output [3]: [ss_customer_sk#54, ss_quantity#55, ss_sales_price#56]
 
 (95) Sort [codegen id : 39]
-Input [3]: [ss_customer_sk#55, ss_quantity#56, ss_sales_price#57]
-Arguments: [ss_customer_sk#55 ASC NULLS FIRST], false, 0
+Input [3]: [ss_customer_sk#54, ss_quantity#55, ss_sales_price#56]
+Arguments: [ss_customer_sk#54 ASC NULLS FIRST], false, 0
 
 (96) ReusedExchange [Reuses operator id: 39]
-Output [1]: [c_customer_sk#58]
+Output [1]: [c_customer_sk#57]
 
 (97) Sort [codegen id : 41]
-Input [1]: [c_customer_sk#58]
-Arguments: [c_customer_sk#58 ASC NULLS FIRST], false, 0
+Input [1]: [c_customer_sk#57]
+Arguments: [c_customer_sk#57 ASC NULLS FIRST], false, 0
 
 (98) SortMergeJoin [codegen id : 42]
-Left keys [1]: [ss_customer_sk#55]
-Right keys [1]: [c_customer_sk#58]
+Left keys [1]: [ss_customer_sk#54]
+Right keys [1]: [c_customer_sk#57]
 Join type: Inner
 Join condition: None
 
 (99) Project [codegen id : 42]
-Output [3]: [ss_quantity#56, ss_sales_price#57, c_customer_sk#58]
-Input [4]: [ss_customer_sk#55, ss_quantity#56, ss_sales_price#57, c_customer_sk#58]
+Output [3]: [ss_quantity#55, ss_sales_price#56, c_customer_sk#57]
+Input [4]: [ss_customer_sk#54, ss_quantity#55, ss_sales_price#56, c_customer_sk#57]
 
 (100) HashAggregate [codegen id : 42]
-Input [3]: [ss_quantity#56, ss_sales_price#57, c_customer_sk#58]
-Keys [1]: [c_customer_sk#58]
-Functions [1]: [partial_sum((cast(ss_quantity#56 as decimal(10,0)) * ss_sales_price#57))]
-Aggregate Attributes [2]: [sum#59, isEmpty#60]
-Results [3]: [c_customer_sk#58, sum#61, isEmpty#62]
+Input [3]: [ss_quantity#55, ss_sales_price#56, c_customer_sk#57]
+Keys [1]: [c_customer_sk#57]
+Functions [1]: [partial_sum((cast(ss_quantity#55 as decimal(10,0)) * ss_sales_price#56))]
+Aggregate Attributes [2]: [sum#58, isEmpty#59]
+Results [3]: [c_customer_sk#57, sum#60, isEmpty#61]
 
 (101) HashAggregate [codegen id : 42]
-Input [3]: [c_customer_sk#58, sum#61, isEmpty#62]
-Keys [1]: [c_customer_sk#58]
-Functions [1]: [sum((cast(ss_quantity#56 as decimal(10,0)) * ss_sales_price#57))]
-Aggregate Attributes [1]: [sum((cast(ss_quantity#56 as decimal(10,0)) * ss_sales_price#57))#29]
-Results [2]: [c_customer_sk#58, sum((cast(ss_quantity#56 as decimal(10,0)) * ss_sales_price#57))#29 AS ssales#63]
+Input [3]: [c_customer_sk#57, sum#60, isEmpty#61]
+Keys [1]: [c_customer_sk#57]
+Functions [1]: [sum((cast(ss_quantity#55 as decimal(10,0)) * ss_sales_price#56))]
+Aggregate Attributes [1]: [sum((cast(ss_quantity#55 as decimal(10,0)) * ss_sales_price#56))#29]
+Results [2]: [c_customer_sk#57, sum((cast(ss_quantity#55 as decimal(10,0)) * ss_sales_price#56))#29 AS ssales#62]
 
 (102) Filter [codegen id : 42]
-Input [2]: [c_customer_sk#58, ssales#63]
-Condition : (isnotnull(ssales#63) AND (cast(ssales#63 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#32])))
+Input [2]: [c_customer_sk#57, ssales#62]
+Condition : (isnotnull(ssales#62) AND (cast(ssales#62 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#7])))
 
 (103) Project [codegen id : 42]
-Output [1]: [c_customer_sk#58]
-Input [2]: [c_customer_sk#58, ssales#63]
+Output [1]: [c_customer_sk#57]
+Input [2]: [c_customer_sk#57, ssales#62]
 
 (104) Sort [codegen id : 42]
-Input [1]: [c_customer_sk#58]
-Arguments: [c_customer_sk#58 ASC NULLS FIRST], false, 0
+Input [1]: [c_customer_sk#57]
+Arguments: [c_customer_sk#57 ASC NULLS FIRST], false, 0
 
 (105) SortMergeJoin [codegen id : 44]
-Left keys [1]: [ws_bill_customer_sk#44]
-Right keys [1]: [c_customer_sk#58]
+Left keys [1]: [ws_bill_customer_sk#43]
+Right keys [1]: [c_customer_sk#57]
 Join type: LeftSemi
 Join condition: None
 
 (106) ReusedExchange [Reuses operator id: 134]
-Output [1]: [d_date_sk#64]
+Output [1]: [d_date_sk#63]
 
 (107) BroadcastHashJoin [codegen id : 44]
-Left keys [1]: [ws_sold_date_sk#47]
-Right keys [1]: [d_date_sk#64]
+Left keys [1]: [ws_sold_date_sk#46]
+Right keys [1]: [d_date_sk#63]
 Join type: Inner
 Join condition: None
 
 (108) Project [codegen id : 44]
-Output [3]: [ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46]
-Input [5]: [ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47, d_date_sk#64]
+Output [3]: [ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45]
+Input [5]: [ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46, d_date_sk#63]
 
 (109) ReusedExchange [Reuses operator id: 55]
-Output [3]: [c_customer_sk#65, c_first_name#66, c_last_name#67]
+Output [3]: [c_customer_sk#64, c_first_name#65, c_last_name#66]
 
 (110) Sort [codegen id : 46]
-Input [3]: [c_customer_sk#65, c_first_name#66, c_last_name#67]
-Arguments: [c_customer_sk#65 ASC NULLS FIRST], false, 0
+Input [3]: [c_customer_sk#64, c_first_name#65, c_last_name#66]
+Arguments: [c_customer_sk#64 ASC NULLS FIRST], false, 0
 
 (111) ReusedExchange [Reuses operator id: 34]
-Output [3]: [ss_customer_sk#55, ss_quantity#56, ss_sales_price#57]
+Output [3]: [ss_customer_sk#54, ss_quantity#55, ss_sales_price#56]
 
 (112) Sort [codegen id : 48]
-Input [3]: [ss_customer_sk#55, ss_quantity#56, ss_sales_price#57]
-Arguments: [ss_customer_sk#55 ASC NULLS FIRST], false, 0
+Input [3]: [ss_customer_sk#54, ss_quantity#55, ss_sales_price#56]
+Arguments: [ss_customer_sk#54 ASC NULLS FIRST], false, 0
 
 (113) ReusedExchange [Reuses operator id: 39]
-Output [1]: [c_customer_sk#58]
+Output [1]: [c_customer_sk#57]
 
 (114) Sort [codegen id : 50]
-Input [1]: [c_customer_sk#58]
-Arguments: [c_customer_sk#58 ASC NULLS FIRST], false, 0
+Input [1]: [c_customer_sk#57]
+Arguments: [c_customer_sk#57 ASC NULLS FIRST], false, 0
 
 (115) SortMergeJoin [codegen id : 51]
-Left keys [1]: [ss_customer_sk#55]
-Right keys [1]: [c_customer_sk#58]
+Left keys [1]: [ss_customer_sk#54]
+Right keys [1]: [c_customer_sk#57]
 Join type: Inner
 Join condition: None
 
 (116) Project [codegen id : 51]
-Output [3]: [ss_quantity#56, ss_sales_price#57, c_customer_sk#58]
-Input [4]: [ss_customer_sk#55, ss_quantity#56, ss_sales_price#57, c_customer_sk#58]
+Output [3]: [ss_quantity#55, ss_sales_price#56, c_customer_sk#57]
+Input [4]: [ss_customer_sk#54, ss_quantity#55, ss_sales_price#56, c_customer_sk#57]
 
 (117) HashAggregate [codegen id : 51]
-Input [3]: [ss_quantity#56, ss_sales_price#57, c_customer_sk#58]
-Keys [1]: [c_customer_sk#58]
-Functions [1]: [partial_sum((cast(ss_quantity#56 as decimal(10,0)) * ss_sales_price#57))]
-Aggregate Attributes [2]: [sum#59, isEmpty#60]
-Results [3]: [c_customer_sk#58, sum#61, isEmpty#62]
+Input [3]: [ss_quantity#55, ss_sales_price#56, c_customer_sk#57]
+Keys [1]: [c_customer_sk#57]
+Functions [1]: [partial_sum((cast(ss_quantity#55 as decimal(10,0)) * ss_sales_price#56))]
+Aggregate Attributes [2]: [sum#58, isEmpty#59]
+Results [3]: [c_customer_sk#57, sum#60, isEmpty#61]
 
 (118) HashAggregate [codegen id : 51]
-Input [3]: [c_customer_sk#58, sum#61, isEmpty#62]
-Keys [1]: [c_customer_sk#58]
-Functions [1]: [sum((cast(ss_quantity#56 as decimal(10,0)) * ss_sales_price#57))]
-Aggregate Attributes [1]: [sum((cast(ss_quantity#56 as decimal(10,0)) * ss_sales_price#57))#29]
-Results [2]: [c_customer_sk#58, sum((cast(ss_quantity#56 as decimal(10,0)) * ss_sales_price#57))#29 AS ssales#63]
+Input [3]: [c_customer_sk#57, sum#60, isEmpty#61]
+Keys [1]: [c_customer_sk#57]
+Functions [1]: [sum((cast(ss_quantity#55 as decimal(10,0)) * ss_sales_price#56))]
+Aggregate Attributes [1]: [sum((cast(ss_quantity#55 as decimal(10,0)) * ss_sales_price#56))#29]
+Results [2]: [c_customer_sk#57, sum((cast(ss_quantity#55 as decimal(10,0)) * ss_sales_price#56))#29 AS ssales#62]
 
 (119) Filter [codegen id : 51]
-Input [2]: [c_customer_sk#58, ssales#63]
-Condition : (isnotnull(ssales#63) AND (cast(ssales#63 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#32])))
+Input [2]: [c_customer_sk#57, ssales#62]
+Condition : (isnotnull(ssales#62) AND (cast(ssales#62 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#7])))
 
 (120) Project [codegen id : 51]
-Output [1]: [c_customer_sk#58]
-Input [2]: [c_customer_sk#58, ssales#63]
+Output [1]: [c_customer_sk#57]
+Input [2]: [c_customer_sk#57, ssales#62]
 
 (121) Sort [codegen id : 51]
-Input [1]: [c_customer_sk#58]
-Arguments: [c_customer_sk#58 ASC NULLS FIRST], false, 0
+Input [1]: [c_customer_sk#57]
+Arguments: [c_customer_sk#57 ASC NULLS FIRST], false, 0
 
 (122) SortMergeJoin [codegen id : 52]
-Left keys [1]: [c_customer_sk#65]
-Right keys [1]: [c_customer_sk#58]
+Left keys [1]: [c_customer_sk#64]
+Right keys [1]: [c_customer_sk#57]
 Join type: LeftSemi
 Join condition: None
 
 (123) SortMergeJoin [codegen id : 53]
-Left keys [1]: [ws_bill_customer_sk#44]
-Right keys [1]: [c_customer_sk#65]
+Left keys [1]: [ws_bill_customer_sk#43]
+Right keys [1]: [c_customer_sk#64]
 Join type: Inner
 Join condition: None
 
 (124) Project [codegen id : 53]
-Output [4]: [ws_quantity#45, ws_list_price#46, c_first_name#66, c_last_name#67]
-Input [6]: [ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, c_customer_sk#65, c_first_name#66, c_last_name#67]
+Output [4]: [ws_quantity#44, ws_list_price#45, c_first_name#65, c_last_name#66]
+Input [6]: [ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, c_customer_sk#64, c_first_name#65, c_last_name#66]
 
 (125) HashAggregate [codegen id : 53]
-Input [4]: [ws_quantity#45, ws_list_price#46, c_first_name#66, c_last_name#67]
-Keys [2]: [c_last_name#67, c_first_name#66]
-Functions [1]: [partial_sum((cast(ws_quantity#45 as decimal(10,0)) * ws_list_price#46))]
-Aggregate Attributes [2]: [sum#68, isEmpty#69]
-Results [4]: [c_last_name#67, c_first_name#66, sum#70, isEmpty#71]
+Input [4]: [ws_quantity#44, ws_list_price#45, c_first_name#65, c_last_name#66]
+Keys [2]: [c_last_name#66, c_first_name#65]
+Functions [1]: [partial_sum((cast(ws_quantity#44 as decimal(10,0)) * ws_list_price#45))]
+Aggregate Attributes [2]: [sum#67, isEmpty#68]
+Results [4]: [c_last_name#66, c_first_name#65, sum#69, isEmpty#70]
 
 (126) Exchange
-Input [4]: [c_last_name#67, c_first_name#66, sum#70, isEmpty#71]
-Arguments: hashpartitioning(c_last_name#67, c_first_name#66, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [4]: [c_last_name#66, c_first_name#65, sum#69, isEmpty#70]
+Arguments: hashpartitioning(c_last_name#66, c_first_name#65, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (127) HashAggregate [codegen id : 54]
-Input [4]: [c_last_name#67, c_first_name#66, sum#70, isEmpty#71]
-Keys [2]: [c_last_name#67, c_first_name#66]
-Functions [1]: [sum((cast(ws_quantity#45 as decimal(10,0)) * ws_list_price#46))]
-Aggregate Attributes [1]: [sum((cast(ws_quantity#45 as decimal(10,0)) * ws_list_price#46))#72]
-Results [3]: [c_last_name#67, c_first_name#66, sum((cast(ws_quantity#45 as decimal(10,0)) * ws_list_price#46))#72 AS sales#73]
+Input [4]: [c_last_name#66, c_first_name#65, sum#69, isEmpty#70]
+Keys [2]: [c_last_name#66, c_first_name#65]
+Functions [1]: [sum((cast(ws_quantity#44 as decimal(10,0)) * ws_list_price#45))]
+Aggregate Attributes [1]: [sum((cast(ws_quantity#44 as decimal(10,0)) * ws_list_price#45))#71]
+Results [3]: [c_last_name#66, c_first_name#65, sum((cast(ws_quantity#44 as decimal(10,0)) * ws_list_price#45))#71 AS sales#72]
 
 (128) Union
 
 (129) TakeOrderedAndProject
-Input [3]: [c_last_name#36, c_first_name#35, sales#42]
-Arguments: 100, [c_last_name#36 ASC NULLS FIRST, c_first_name#35 ASC NULLS FIRST, sales#42 ASC NULLS FIRST], [c_last_name#36, c_first_name#35, sales#42]
+Input [3]: [c_last_name#35, c_first_name#34, sales#41]
+Arguments: 100, [c_last_name#35 ASC NULLS FIRST, c_first_name#34 ASC NULLS FIRST, sales#41 ASC NULLS FIRST], [c_last_name#35, c_first_name#34, sales#41]
 
 ===== Subqueries =====
 
@@ -742,26 +742,26 @@ BroadcastExchange (134)
 
 
 (130) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#33, d_year#74, d_moy#75]
+Output [3]: [d_date_sk#32, d_year#73, d_moy#74]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,2), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (131) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#33, d_year#74, d_moy#75]
+Input [3]: [d_date_sk#32, d_year#73, d_moy#74]
 
 (132) Filter [codegen id : 1]
-Input [3]: [d_date_sk#33, d_year#74, d_moy#75]
-Condition : ((((isnotnull(d_year#74) AND isnotnull(d_moy#75)) AND (d_year#74 = 2000)) AND (d_moy#75 = 2)) AND isnotnull(d_date_sk#33))
+Input [3]: [d_date_sk#32, d_year#73, d_moy#74]
+Condition : ((((isnotnull(d_year#73) AND isnotnull(d_moy#74)) AND (d_year#73 = 2000)) AND (d_moy#74 = 2)) AND isnotnull(d_date_sk#32))
 
 (133) Project [codegen id : 1]
-Output [1]: [d_date_sk#33]
-Input [3]: [d_date_sk#33, d_year#74, d_moy#75]
+Output [1]: [d_date_sk#32]
+Input [3]: [d_date_sk#32, d_year#73, d_moy#74]
 
 (134) BroadcastExchange
-Input [1]: [d_date_sk#33]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=12]
+Input [1]: [d_date_sk#32]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=13]
 
 Subquery:2 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
 BroadcastExchange (139)
@@ -772,28 +772,28 @@ BroadcastExchange (139)
 
 
 (135) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#10, d_date#11, d_year#76]
+Output [3]: [d_date_sk#10, d_date#11, d_year#75]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_year, [2000,2001,2002,2003]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_year:int>
 
 (136) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#10, d_date#11, d_year#76]
+Input [3]: [d_date_sk#10, d_date#11, d_year#75]
 
 (137) Filter [codegen id : 1]
-Input [3]: [d_date_sk#10, d_date#11, d_year#76]
-Condition : (d_year#76 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#10))
+Input [3]: [d_date_sk#10, d_date#11, d_year#75]
+Condition : (d_year#75 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#10))
 
 (138) Project [codegen id : 1]
 Output [2]: [d_date_sk#10, d_date#11]
-Input [3]: [d_date_sk#10, d_date#11, d_year#76]
+Input [3]: [d_date_sk#10, d_date#11, d_year#75]
 
 (139) BroadcastExchange
 Input [2]: [d_date_sk#10, d_date#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
 
-Subquery:3 Hosting operator id = 45 Hosting Expression = Subquery scalar-subquery#31, [id=#32]
+Subquery:3 Hosting operator id = 45 Hosting Expression = Subquery scalar-subquery#31, [id=#7]
 * HashAggregate (156)
 +- Exchange (155)
    +- * HashAggregate (154)
@@ -814,91 +814,91 @@ Subquery:3 Hosting operator id = 45 Hosting Expression = Subquery scalar-subquer
 
 
 (140) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_customer_sk#77, ss_quantity#78, ss_sales_price#79, ss_sold_date_sk#80]
+Output [4]: [ss_customer_sk#76, ss_quantity#77, ss_sales_price#78, ss_sold_date_sk#79]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#80), dynamicpruningexpression(ss_sold_date_sk#80 IN dynamicpruning#81)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#79), dynamicpruningexpression(ss_sold_date_sk#79 IN dynamicpruning#80)]
 PushedFilters: [IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int,ss_quantity:int,ss_sales_price:decimal(7,2)>
 
 (141) ColumnarToRow [codegen id : 2]
-Input [4]: [ss_customer_sk#77, ss_quantity#78, ss_sales_price#79, ss_sold_date_sk#80]
+Input [4]: [ss_customer_sk#76, ss_quantity#77, ss_sales_price#78, ss_sold_date_sk#79]
 
 (142) Filter [codegen id : 2]
-Input [4]: [ss_customer_sk#77, ss_quantity#78, ss_sales_price#79, ss_sold_date_sk#80]
-Condition : isnotnull(ss_customer_sk#77)
+Input [4]: [ss_customer_sk#76, ss_quantity#77, ss_sales_price#78, ss_sold_date_sk#79]
+Condition : isnotnull(ss_customer_sk#76)
 
 (143) ReusedExchange [Reuses operator id: 161]
-Output [1]: [d_date_sk#82]
+Output [1]: [d_date_sk#81]
 
 (144) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#80]
-Right keys [1]: [d_date_sk#82]
+Left keys [1]: [ss_sold_date_sk#79]
+Right keys [1]: [d_date_sk#81]
 Join type: Inner
 Join condition: None
 
 (145) Project [codegen id : 2]
-Output [3]: [ss_customer_sk#77, ss_quantity#78, ss_sales_price#79]
-Input [5]: [ss_customer_sk#77, ss_quantity#78, ss_sales_price#79, ss_sold_date_sk#80, d_date_sk#82]
+Output [3]: [ss_customer_sk#76, ss_quantity#77, ss_sales_price#78]
+Input [5]: [ss_customer_sk#76, ss_quantity#77, ss_sales_price#78, ss_sold_date_sk#79, d_date_sk#81]
 
 (146) Exchange
-Input [3]: [ss_customer_sk#77, ss_quantity#78, ss_sales_price#79]
-Arguments: hashpartitioning(ss_customer_sk#77, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [3]: [ss_customer_sk#76, ss_quantity#77, ss_sales_price#78]
+Arguments: hashpartitioning(ss_customer_sk#76, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
 (147) Sort [codegen id : 3]
-Input [3]: [ss_customer_sk#77, ss_quantity#78, ss_sales_price#79]
-Arguments: [ss_customer_sk#77 ASC NULLS FIRST], false, 0
+Input [3]: [ss_customer_sk#76, ss_quantity#77, ss_sales_price#78]
+Arguments: [ss_customer_sk#76 ASC NULLS FIRST], false, 0
 
 (148) ReusedExchange [Reuses operator id: 39]
-Output [1]: [c_customer_sk#83]
+Output [1]: [c_customer_sk#82]
 
 (149) Sort [codegen id : 5]
-Input [1]: [c_customer_sk#83]
-Arguments: [c_customer_sk#83 ASC NULLS FIRST], false, 0
+Input [1]: [c_customer_sk#82]
+Arguments: [c_customer_sk#82 ASC NULLS FIRST], false, 0
 
 (150) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_customer_sk#77]
-Right keys [1]: [c_customer_sk#83]
+Left keys [1]: [ss_customer_sk#76]
+Right keys [1]: [c_customer_sk#82]
 Join type: Inner
 Join condition: None
 
 (151) Project [codegen id : 6]
-Output [3]: [ss_quantity#78, ss_sales_price#79, c_customer_sk#83]
-Input [4]: [ss_customer_sk#77, ss_quantity#78, ss_sales_price#79, c_customer_sk#83]
+Output [3]: [ss_quantity#77, ss_sales_price#78, c_customer_sk#82]
+Input [4]: [ss_customer_sk#76, ss_quantity#77, ss_sales_price#78, c_customer_sk#82]
 
 (152) HashAggregate [codegen id : 6]
-Input [3]: [ss_quantity#78, ss_sales_price#79, c_customer_sk#83]
-Keys [1]: [c_customer_sk#83]
-Functions [1]: [partial_sum((cast(ss_quantity#78 as decimal(10,0)) * ss_sales_price#79))]
-Aggregate Attributes [2]: [sum#84, isEmpty#85]
-Results [3]: [c_customer_sk#83, sum#86, isEmpty#87]
+Input [3]: [ss_quantity#77, ss_sales_price#78, c_customer_sk#82]
+Keys [1]: [c_customer_sk#82]
+Functions [1]: [partial_sum((cast(ss_quantity#77 as decimal(10,0)) * ss_sales_price#78))]
+Aggregate Attributes [2]: [sum#83, isEmpty#84]
+Results [3]: [c_customer_sk#82, sum#85, isEmpty#86]
 
 (153) HashAggregate [codegen id : 6]
-Input [3]: [c_customer_sk#83, sum#86, isEmpty#87]
-Keys [1]: [c_customer_sk#83]
-Functions [1]: [sum((cast(ss_quantity#78 as decimal(10,0)) * ss_sales_price#79))]
-Aggregate Attributes [1]: [sum((cast(ss_quantity#78 as decimal(10,0)) * ss_sales_price#79))#88]
-Results [1]: [sum((cast(ss_quantity#78 as decimal(10,0)) * ss_sales_price#79))#88 AS csales#89]
+Input [3]: [c_customer_sk#82, sum#85, isEmpty#86]
+Keys [1]: [c_customer_sk#82]
+Functions [1]: [sum((cast(ss_quantity#77 as decimal(10,0)) * ss_sales_price#78))]
+Aggregate Attributes [1]: [sum((cast(ss_quantity#77 as decimal(10,0)) * ss_sales_price#78))#87]
+Results [1]: [sum((cast(ss_quantity#77 as decimal(10,0)) * ss_sales_price#78))#87 AS csales#88]
 
 (154) HashAggregate [codegen id : 6]
-Input [1]: [csales#89]
+Input [1]: [csales#88]
 Keys: []
-Functions [1]: [partial_max(csales#89)]
-Aggregate Attributes [1]: [max#90]
-Results [1]: [max#91]
+Functions [1]: [partial_max(csales#88)]
+Aggregate Attributes [1]: [max#89]
+Results [1]: [max#90]
 
 (155) Exchange
-Input [1]: [max#91]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
+Input [1]: [max#90]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=16]
 
 (156) HashAggregate [codegen id : 7]
-Input [1]: [max#91]
+Input [1]: [max#90]
 Keys: []
-Functions [1]: [max(csales#89)]
-Aggregate Attributes [1]: [max(csales#89)#92]
-Results [1]: [max(csales#89)#92 AS tpcds_cmax#93]
+Functions [1]: [max(csales#88)]
+Aggregate Attributes [1]: [max(csales#88)#91]
+Results [1]: [max(csales#88)#91 AS tpcds_cmax#92]
 
-Subquery:4 Hosting operator id = 140 Hosting Expression = ss_sold_date_sk#80 IN dynamicpruning#81
+Subquery:4 Hosting operator id = 140 Hosting Expression = ss_sold_date_sk#79 IN dynamicpruning#80
 BroadcastExchange (161)
 +- * Project (160)
    +- * Filter (159)
@@ -907,33 +907,33 @@ BroadcastExchange (161)
 
 
 (157) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#82, d_year#94]
+Output [2]: [d_date_sk#81, d_year#93]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_year, [2000,2001,2002,2003]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (158) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#82, d_year#94]
+Input [2]: [d_date_sk#81, d_year#93]
 
 (159) Filter [codegen id : 1]
-Input [2]: [d_date_sk#82, d_year#94]
-Condition : (d_year#94 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#82))
+Input [2]: [d_date_sk#81, d_year#93]
+Condition : (d_year#93 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#81))
 
 (160) Project [codegen id : 1]
-Output [1]: [d_date_sk#82]
-Input [2]: [d_date_sk#82, d_year#94]
+Output [1]: [d_date_sk#81]
+Input [2]: [d_date_sk#81, d_year#93]
 
 (161) BroadcastExchange
-Input [1]: [d_date_sk#82]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=16]
+Input [1]: [d_date_sk#81]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=17]
 
-Subquery:5 Hosting operator id = 65 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#32]
+Subquery:5 Hosting operator id = 65 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#7]
 
-Subquery:6 Hosting operator id = 74 Hosting Expression = ws_sold_date_sk#47 IN dynamicpruning#6
+Subquery:6 Hosting operator id = 74 Hosting Expression = ws_sold_date_sk#46 IN dynamicpruning#6
 
-Subquery:7 Hosting operator id = 102 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#32]
+Subquery:7 Hosting operator id = 102 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#7]
 
-Subquery:8 Hosting operator id = 119 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#32]
+Subquery:8 Hosting operator id = 119 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#7]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b/explain.txt
@@ -273,7 +273,7 @@ Results [2]: [c_customer_sk#24, sum((cast(ss_quantity#21 as decimal(10,0)) * ss_
 
 (39) Filter [codegen id : 9]
 Input [2]: [c_customer_sk#24, ssales#30]
-Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * Subquery scalar-subquery#31, [id=#32])))
+Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * Subquery scalar-subquery#31, [id=#7])))
 
 (40) Project [codegen id : 9]
 Output [1]: [c_customer_sk#24]
@@ -290,26 +290,26 @@ Join type: LeftSemi
 Join condition: None
 
 (43) Scan parquet spark_catalog.default.customer
-Output [3]: [c_customer_sk#33, c_first_name#34, c_last_name#35]
+Output [3]: [c_customer_sk#32, c_first_name#33, c_last_name#34]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string>
 
 (44) ColumnarToRow [codegen id : 10]
-Input [3]: [c_customer_sk#33, c_first_name#34, c_last_name#35]
+Input [3]: [c_customer_sk#32, c_first_name#33, c_last_name#34]
 
 (45) Filter [codegen id : 10]
-Input [3]: [c_customer_sk#33, c_first_name#34, c_last_name#35]
-Condition : isnotnull(c_customer_sk#33)
+Input [3]: [c_customer_sk#32, c_first_name#33, c_last_name#34]
+Condition : isnotnull(c_customer_sk#32)
 
 (46) Exchange
-Input [3]: [c_customer_sk#33, c_first_name#34, c_last_name#35]
-Arguments: hashpartitioning(c_customer_sk#33, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Input [3]: [c_customer_sk#32, c_first_name#33, c_last_name#34]
+Arguments: hashpartitioning(c_customer_sk#32, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (47) Sort [codegen id : 11]
-Input [3]: [c_customer_sk#33, c_first_name#34, c_last_name#35]
-Arguments: [c_customer_sk#33 ASC NULLS FIRST], false, 0
+Input [3]: [c_customer_sk#32, c_first_name#33, c_last_name#34]
+Arguments: [c_customer_sk#32 ASC NULLS FIRST], false, 0
 
 (48) ReusedExchange [Reuses operator id: 37]
 Output [3]: [c_customer_sk#24, sum#27, isEmpty#28]
@@ -323,7 +323,7 @@ Results [2]: [c_customer_sk#24, sum((cast(ss_quantity#21 as decimal(10,0)) * ss_
 
 (50) Filter [codegen id : 14]
 Input [2]: [c_customer_sk#24, ssales#30]
-Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#32])))
+Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#7])))
 
 (51) Project [codegen id : 14]
 Output [1]: [c_customer_sk#24]
@@ -334,169 +334,169 @@ Input [1]: [c_customer_sk#24]
 Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 
 (53) SortMergeJoin [codegen id : 15]
-Left keys [1]: [c_customer_sk#33]
+Left keys [1]: [c_customer_sk#32]
 Right keys [1]: [c_customer_sk#24]
 Join type: LeftSemi
 Join condition: None
 
 (54) BroadcastExchange
-Input [3]: [c_customer_sk#33, c_first_name#34, c_last_name#35]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
+Input [3]: [c_customer_sk#32, c_first_name#33, c_last_name#34]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
 
 (55) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [cs_bill_customer_sk#1]
-Right keys [1]: [c_customer_sk#33]
+Right keys [1]: [c_customer_sk#32]
 Join type: Inner
 Join condition: None
 
 (56) Project [codegen id : 17]
-Output [5]: [cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5, c_first_name#34, c_last_name#35]
-Input [7]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5, c_customer_sk#33, c_first_name#34, c_last_name#35]
+Output [5]: [cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5, c_first_name#33, c_last_name#34]
+Input [7]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5, c_customer_sk#32, c_first_name#33, c_last_name#34]
 
 (57) ReusedExchange [Reuses operator id: 92]
-Output [1]: [d_date_sk#36]
+Output [1]: [d_date_sk#35]
 
 (58) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [cs_sold_date_sk#5]
-Right keys [1]: [d_date_sk#36]
+Right keys [1]: [d_date_sk#35]
 Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 17]
-Output [4]: [cs_quantity#3, cs_list_price#4, c_first_name#34, c_last_name#35]
-Input [6]: [cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5, c_first_name#34, c_last_name#35, d_date_sk#36]
+Output [4]: [cs_quantity#3, cs_list_price#4, c_first_name#33, c_last_name#34]
+Input [6]: [cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5, c_first_name#33, c_last_name#34, d_date_sk#35]
 
 (60) HashAggregate [codegen id : 17]
-Input [4]: [cs_quantity#3, cs_list_price#4, c_first_name#34, c_last_name#35]
-Keys [2]: [c_last_name#35, c_first_name#34]
+Input [4]: [cs_quantity#3, cs_list_price#4, c_first_name#33, c_last_name#34]
+Keys [2]: [c_last_name#34, c_first_name#33]
 Functions [1]: [partial_sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))]
-Aggregate Attributes [2]: [sum#37, isEmpty#38]
-Results [4]: [c_last_name#35, c_first_name#34, sum#39, isEmpty#40]
+Aggregate Attributes [2]: [sum#36, isEmpty#37]
+Results [4]: [c_last_name#34, c_first_name#33, sum#38, isEmpty#39]
 
 (61) Exchange
-Input [4]: [c_last_name#35, c_first_name#34, sum#39, isEmpty#40]
-Arguments: hashpartitioning(c_last_name#35, c_first_name#34, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [4]: [c_last_name#34, c_first_name#33, sum#38, isEmpty#39]
+Arguments: hashpartitioning(c_last_name#34, c_first_name#33, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (62) HashAggregate [codegen id : 18]
-Input [4]: [c_last_name#35, c_first_name#34, sum#39, isEmpty#40]
-Keys [2]: [c_last_name#35, c_first_name#34]
+Input [4]: [c_last_name#34, c_first_name#33, sum#38, isEmpty#39]
+Keys [2]: [c_last_name#34, c_first_name#33]
 Functions [1]: [sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))]
-Aggregate Attributes [1]: [sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))#41]
-Results [3]: [c_last_name#35, c_first_name#34, sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))#41 AS sales#42]
+Aggregate Attributes [1]: [sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))#40]
+Results [3]: [c_last_name#34, c_first_name#33, sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))#40 AS sales#41]
 
 (63) Scan parquet spark_catalog.default.web_sales
-Output [5]: [ws_item_sk#43, ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
+Output [5]: [ws_item_sk#42, ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#47), dynamicpruningexpression(ws_sold_date_sk#47 IN dynamicpruning#6)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#46), dynamicpruningexpression(ws_sold_date_sk#46 IN dynamicpruning#6)]
 PushedFilters: [IsNotNull(ws_bill_customer_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_bill_customer_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (64) ColumnarToRow [codegen id : 23]
-Input [5]: [ws_item_sk#43, ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
+Input [5]: [ws_item_sk#42, ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46]
 
 (65) Filter [codegen id : 23]
-Input [5]: [ws_item_sk#43, ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
-Condition : isnotnull(ws_bill_customer_sk#44)
+Input [5]: [ws_item_sk#42, ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46]
+Condition : isnotnull(ws_bill_customer_sk#43)
 
 (66) ReusedExchange [Reuses operator id: 21]
-Output [1]: [item_sk#48]
+Output [1]: [item_sk#47]
 
 (67) BroadcastHashJoin [codegen id : 23]
-Left keys [1]: [ws_item_sk#43]
-Right keys [1]: [item_sk#48]
+Left keys [1]: [ws_item_sk#42]
+Right keys [1]: [item_sk#47]
 Join type: LeftSemi
 Join condition: None
 
 (68) Project [codegen id : 23]
-Output [4]: [ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
-Input [5]: [ws_item_sk#43, ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
+Output [4]: [ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46]
+Input [5]: [ws_item_sk#42, ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46]
 
 (69) Exchange
-Input [4]: [ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
-Arguments: hashpartitioning(ws_bill_customer_sk#44, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [4]: [ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46]
+Arguments: hashpartitioning(ws_bill_customer_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (70) Sort [codegen id : 24]
-Input [4]: [ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
-Arguments: [ws_bill_customer_sk#44 ASC NULLS FIRST], false, 0
+Input [4]: [ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46]
+Arguments: [ws_bill_customer_sk#43 ASC NULLS FIRST], false, 0
 
 (71) ReusedExchange [Reuses operator id: 37]
-Output [3]: [c_customer_sk#49, sum#50, isEmpty#51]
+Output [3]: [c_customer_sk#48, sum#49, isEmpty#50]
 
 (72) HashAggregate [codegen id : 27]
-Input [3]: [c_customer_sk#49, sum#50, isEmpty#51]
-Keys [1]: [c_customer_sk#49]
-Functions [1]: [sum((cast(ss_quantity#52 as decimal(10,0)) * ss_sales_price#53))]
-Aggregate Attributes [1]: [sum((cast(ss_quantity#52 as decimal(10,0)) * ss_sales_price#53))#29]
-Results [2]: [c_customer_sk#49, sum((cast(ss_quantity#52 as decimal(10,0)) * ss_sales_price#53))#29 AS ssales#54]
+Input [3]: [c_customer_sk#48, sum#49, isEmpty#50]
+Keys [1]: [c_customer_sk#48]
+Functions [1]: [sum((cast(ss_quantity#51 as decimal(10,0)) * ss_sales_price#52))]
+Aggregate Attributes [1]: [sum((cast(ss_quantity#51 as decimal(10,0)) * ss_sales_price#52))#29]
+Results [2]: [c_customer_sk#48, sum((cast(ss_quantity#51 as decimal(10,0)) * ss_sales_price#52))#29 AS ssales#53]
 
 (73) Filter [codegen id : 27]
-Input [2]: [c_customer_sk#49, ssales#54]
-Condition : (isnotnull(ssales#54) AND (cast(ssales#54 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#32])))
+Input [2]: [c_customer_sk#48, ssales#53]
+Condition : (isnotnull(ssales#53) AND (cast(ssales#53 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#7])))
 
 (74) Project [codegen id : 27]
-Output [1]: [c_customer_sk#49]
-Input [2]: [c_customer_sk#49, ssales#54]
+Output [1]: [c_customer_sk#48]
+Input [2]: [c_customer_sk#48, ssales#53]
 
 (75) Sort [codegen id : 27]
-Input [1]: [c_customer_sk#49]
-Arguments: [c_customer_sk#49 ASC NULLS FIRST], false, 0
+Input [1]: [c_customer_sk#48]
+Arguments: [c_customer_sk#48 ASC NULLS FIRST], false, 0
 
 (76) SortMergeJoin [codegen id : 35]
-Left keys [1]: [ws_bill_customer_sk#44]
-Right keys [1]: [c_customer_sk#49]
+Left keys [1]: [ws_bill_customer_sk#43]
+Right keys [1]: [c_customer_sk#48]
 Join type: LeftSemi
 Join condition: None
 
 (77) ReusedExchange [Reuses operator id: 54]
-Output [3]: [c_customer_sk#55, c_first_name#56, c_last_name#57]
+Output [3]: [c_customer_sk#54, c_first_name#55, c_last_name#56]
 
 (78) BroadcastHashJoin [codegen id : 35]
-Left keys [1]: [ws_bill_customer_sk#44]
-Right keys [1]: [c_customer_sk#55]
+Left keys [1]: [ws_bill_customer_sk#43]
+Right keys [1]: [c_customer_sk#54]
 Join type: Inner
 Join condition: None
 
 (79) Project [codegen id : 35]
-Output [5]: [ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47, c_first_name#56, c_last_name#57]
-Input [7]: [ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47, c_customer_sk#55, c_first_name#56, c_last_name#57]
+Output [5]: [ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46, c_first_name#55, c_last_name#56]
+Input [7]: [ws_bill_customer_sk#43, ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46, c_customer_sk#54, c_first_name#55, c_last_name#56]
 
 (80) ReusedExchange [Reuses operator id: 92]
-Output [1]: [d_date_sk#58]
+Output [1]: [d_date_sk#57]
 
 (81) BroadcastHashJoin [codegen id : 35]
-Left keys [1]: [ws_sold_date_sk#47]
-Right keys [1]: [d_date_sk#58]
+Left keys [1]: [ws_sold_date_sk#46]
+Right keys [1]: [d_date_sk#57]
 Join type: Inner
 Join condition: None
 
 (82) Project [codegen id : 35]
-Output [4]: [ws_quantity#45, ws_list_price#46, c_first_name#56, c_last_name#57]
-Input [6]: [ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47, c_first_name#56, c_last_name#57, d_date_sk#58]
+Output [4]: [ws_quantity#44, ws_list_price#45, c_first_name#55, c_last_name#56]
+Input [6]: [ws_quantity#44, ws_list_price#45, ws_sold_date_sk#46, c_first_name#55, c_last_name#56, d_date_sk#57]
 
 (83) HashAggregate [codegen id : 35]
-Input [4]: [ws_quantity#45, ws_list_price#46, c_first_name#56, c_last_name#57]
-Keys [2]: [c_last_name#57, c_first_name#56]
-Functions [1]: [partial_sum((cast(ws_quantity#45 as decimal(10,0)) * ws_list_price#46))]
-Aggregate Attributes [2]: [sum#59, isEmpty#60]
-Results [4]: [c_last_name#57, c_first_name#56, sum#61, isEmpty#62]
+Input [4]: [ws_quantity#44, ws_list_price#45, c_first_name#55, c_last_name#56]
+Keys [2]: [c_last_name#56, c_first_name#55]
+Functions [1]: [partial_sum((cast(ws_quantity#44 as decimal(10,0)) * ws_list_price#45))]
+Aggregate Attributes [2]: [sum#58, isEmpty#59]
+Results [4]: [c_last_name#56, c_first_name#55, sum#60, isEmpty#61]
 
 (84) Exchange
-Input [4]: [c_last_name#57, c_first_name#56, sum#61, isEmpty#62]
-Arguments: hashpartitioning(c_last_name#57, c_first_name#56, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [4]: [c_last_name#56, c_first_name#55, sum#60, isEmpty#61]
+Arguments: hashpartitioning(c_last_name#56, c_first_name#55, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (85) HashAggregate [codegen id : 36]
-Input [4]: [c_last_name#57, c_first_name#56, sum#61, isEmpty#62]
-Keys [2]: [c_last_name#57, c_first_name#56]
-Functions [1]: [sum((cast(ws_quantity#45 as decimal(10,0)) * ws_list_price#46))]
-Aggregate Attributes [1]: [sum((cast(ws_quantity#45 as decimal(10,0)) * ws_list_price#46))#63]
-Results [3]: [c_last_name#57, c_first_name#56, sum((cast(ws_quantity#45 as decimal(10,0)) * ws_list_price#46))#63 AS sales#64]
+Input [4]: [c_last_name#56, c_first_name#55, sum#60, isEmpty#61]
+Keys [2]: [c_last_name#56, c_first_name#55]
+Functions [1]: [sum((cast(ws_quantity#44 as decimal(10,0)) * ws_list_price#45))]
+Aggregate Attributes [1]: [sum((cast(ws_quantity#44 as decimal(10,0)) * ws_list_price#45))#62]
+Results [3]: [c_last_name#56, c_first_name#55, sum((cast(ws_quantity#44 as decimal(10,0)) * ws_list_price#45))#62 AS sales#63]
 
 (86) Union
 
 (87) TakeOrderedAndProject
-Input [3]: [c_last_name#35, c_first_name#34, sales#42]
-Arguments: 100, [c_last_name#35 ASC NULLS FIRST, c_first_name#34 ASC NULLS FIRST, sales#42 ASC NULLS FIRST], [c_last_name#35, c_first_name#34, sales#42]
+Input [3]: [c_last_name#34, c_first_name#33, sales#41]
+Arguments: 100, [c_last_name#34 ASC NULLS FIRST, c_first_name#33 ASC NULLS FIRST, sales#41 ASC NULLS FIRST], [c_last_name#34, c_first_name#33, sales#41]
 
 ===== Subqueries =====
 
@@ -509,26 +509,26 @@ BroadcastExchange (92)
 
 
 (88) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#36, d_year#65, d_moy#66]
+Output [3]: [d_date_sk#35, d_year#64, d_moy#65]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,2), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (89) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#36, d_year#65, d_moy#66]
+Input [3]: [d_date_sk#35, d_year#64, d_moy#65]
 
 (90) Filter [codegen id : 1]
-Input [3]: [d_date_sk#36, d_year#65, d_moy#66]
-Condition : ((((isnotnull(d_year#65) AND isnotnull(d_moy#66)) AND (d_year#65 = 2000)) AND (d_moy#66 = 2)) AND isnotnull(d_date_sk#36))
+Input [3]: [d_date_sk#35, d_year#64, d_moy#65]
+Condition : ((((isnotnull(d_year#64) AND isnotnull(d_moy#65)) AND (d_year#64 = 2000)) AND (d_moy#65 = 2)) AND isnotnull(d_date_sk#35))
 
 (91) Project [codegen id : 1]
-Output [1]: [d_date_sk#36]
-Input [3]: [d_date_sk#36, d_year#65, d_moy#66]
+Output [1]: [d_date_sk#35]
+Input [3]: [d_date_sk#35, d_year#64, d_moy#65]
 
 (92) BroadcastExchange
-Input [1]: [d_date_sk#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=12]
+Input [1]: [d_date_sk#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=13]
 
 Subquery:2 Hosting operator id = 4 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
 BroadcastExchange (97)
@@ -539,28 +539,28 @@ BroadcastExchange (97)
 
 
 (93) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#10, d_date#11, d_year#67]
+Output [3]: [d_date_sk#10, d_date#11, d_year#66]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_year, [2000,2001,2002,2003]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_year:int>
 
 (94) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#10, d_date#11, d_year#67]
+Input [3]: [d_date_sk#10, d_date#11, d_year#66]
 
 (95) Filter [codegen id : 1]
-Input [3]: [d_date_sk#10, d_date#11, d_year#67]
-Condition : (d_year#67 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#10))
+Input [3]: [d_date_sk#10, d_date#11, d_year#66]
+Condition : (d_year#66 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#10))
 
 (96) Project [codegen id : 1]
 Output [2]: [d_date_sk#10, d_date#11]
-Input [3]: [d_date_sk#10, d_date#11, d_year#67]
+Input [3]: [d_date_sk#10, d_date#11, d_year#66]
 
 (97) BroadcastExchange
 Input [2]: [d_date_sk#10, d_date#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
 
-Subquery:3 Hosting operator id = 39 Hosting Expression = Subquery scalar-subquery#31, [id=#32]
+Subquery:3 Hosting operator id = 39 Hosting Expression = Subquery scalar-subquery#31, [id=#7]
 * HashAggregate (112)
 +- Exchange (111)
    +- * HashAggregate (110)
@@ -579,83 +579,83 @@ Subquery:3 Hosting operator id = 39 Hosting Expression = Subquery scalar-subquer
 
 
 (98) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_customer_sk#68, ss_quantity#69, ss_sales_price#70, ss_sold_date_sk#71]
+Output [4]: [ss_customer_sk#67, ss_quantity#68, ss_sales_price#69, ss_sold_date_sk#70]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#71), dynamicpruningexpression(ss_sold_date_sk#71 IN dynamicpruning#72)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#70), dynamicpruningexpression(ss_sold_date_sk#70 IN dynamicpruning#71)]
 PushedFilters: [IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int,ss_quantity:int,ss_sales_price:decimal(7,2)>
 
 (99) ColumnarToRow [codegen id : 3]
-Input [4]: [ss_customer_sk#68, ss_quantity#69, ss_sales_price#70, ss_sold_date_sk#71]
+Input [4]: [ss_customer_sk#67, ss_quantity#68, ss_sales_price#69, ss_sold_date_sk#70]
 
 (100) Filter [codegen id : 3]
-Input [4]: [ss_customer_sk#68, ss_quantity#69, ss_sales_price#70, ss_sold_date_sk#71]
-Condition : isnotnull(ss_customer_sk#68)
+Input [4]: [ss_customer_sk#67, ss_quantity#68, ss_sales_price#69, ss_sold_date_sk#70]
+Condition : isnotnull(ss_customer_sk#67)
 
 (101) ReusedExchange [Reuses operator id: 33]
-Output [1]: [c_customer_sk#73]
+Output [1]: [c_customer_sk#72]
 
 (102) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_customer_sk#68]
-Right keys [1]: [c_customer_sk#73]
+Left keys [1]: [ss_customer_sk#67]
+Right keys [1]: [c_customer_sk#72]
 Join type: Inner
 Join condition: None
 
 (103) Project [codegen id : 3]
-Output [4]: [ss_quantity#69, ss_sales_price#70, ss_sold_date_sk#71, c_customer_sk#73]
-Input [5]: [ss_customer_sk#68, ss_quantity#69, ss_sales_price#70, ss_sold_date_sk#71, c_customer_sk#73]
+Output [4]: [ss_quantity#68, ss_sales_price#69, ss_sold_date_sk#70, c_customer_sk#72]
+Input [5]: [ss_customer_sk#67, ss_quantity#68, ss_sales_price#69, ss_sold_date_sk#70, c_customer_sk#72]
 
 (104) ReusedExchange [Reuses operator id: 117]
-Output [1]: [d_date_sk#74]
+Output [1]: [d_date_sk#73]
 
 (105) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_sold_date_sk#71]
-Right keys [1]: [d_date_sk#74]
+Left keys [1]: [ss_sold_date_sk#70]
+Right keys [1]: [d_date_sk#73]
 Join type: Inner
 Join condition: None
 
 (106) Project [codegen id : 3]
-Output [3]: [ss_quantity#69, ss_sales_price#70, c_customer_sk#73]
-Input [5]: [ss_quantity#69, ss_sales_price#70, ss_sold_date_sk#71, c_customer_sk#73, d_date_sk#74]
+Output [3]: [ss_quantity#68, ss_sales_price#69, c_customer_sk#72]
+Input [5]: [ss_quantity#68, ss_sales_price#69, ss_sold_date_sk#70, c_customer_sk#72, d_date_sk#73]
 
 (107) HashAggregate [codegen id : 3]
-Input [3]: [ss_quantity#69, ss_sales_price#70, c_customer_sk#73]
-Keys [1]: [c_customer_sk#73]
-Functions [1]: [partial_sum((cast(ss_quantity#69 as decimal(10,0)) * ss_sales_price#70))]
-Aggregate Attributes [2]: [sum#75, isEmpty#76]
-Results [3]: [c_customer_sk#73, sum#77, isEmpty#78]
+Input [3]: [ss_quantity#68, ss_sales_price#69, c_customer_sk#72]
+Keys [1]: [c_customer_sk#72]
+Functions [1]: [partial_sum((cast(ss_quantity#68 as decimal(10,0)) * ss_sales_price#69))]
+Aggregate Attributes [2]: [sum#74, isEmpty#75]
+Results [3]: [c_customer_sk#72, sum#76, isEmpty#77]
 
 (108) Exchange
-Input [3]: [c_customer_sk#73, sum#77, isEmpty#78]
-Arguments: hashpartitioning(c_customer_sk#73, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [3]: [c_customer_sk#72, sum#76, isEmpty#77]
+Arguments: hashpartitioning(c_customer_sk#72, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
 (109) HashAggregate [codegen id : 4]
-Input [3]: [c_customer_sk#73, sum#77, isEmpty#78]
-Keys [1]: [c_customer_sk#73]
-Functions [1]: [sum((cast(ss_quantity#69 as decimal(10,0)) * ss_sales_price#70))]
-Aggregate Attributes [1]: [sum((cast(ss_quantity#69 as decimal(10,0)) * ss_sales_price#70))#79]
-Results [1]: [sum((cast(ss_quantity#69 as decimal(10,0)) * ss_sales_price#70))#79 AS csales#80]
+Input [3]: [c_customer_sk#72, sum#76, isEmpty#77]
+Keys [1]: [c_customer_sk#72]
+Functions [1]: [sum((cast(ss_quantity#68 as decimal(10,0)) * ss_sales_price#69))]
+Aggregate Attributes [1]: [sum((cast(ss_quantity#68 as decimal(10,0)) * ss_sales_price#69))#78]
+Results [1]: [sum((cast(ss_quantity#68 as decimal(10,0)) * ss_sales_price#69))#78 AS csales#79]
 
 (110) HashAggregate [codegen id : 4]
-Input [1]: [csales#80]
+Input [1]: [csales#79]
 Keys: []
-Functions [1]: [partial_max(csales#80)]
-Aggregate Attributes [1]: [max#81]
-Results [1]: [max#82]
+Functions [1]: [partial_max(csales#79)]
+Aggregate Attributes [1]: [max#80]
+Results [1]: [max#81]
 
 (111) Exchange
-Input [1]: [max#82]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
+Input [1]: [max#81]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=16]
 
 (112) HashAggregate [codegen id : 5]
-Input [1]: [max#82]
+Input [1]: [max#81]
 Keys: []
-Functions [1]: [max(csales#80)]
-Aggregate Attributes [1]: [max(csales#80)#83]
-Results [1]: [max(csales#80)#83 AS tpcds_cmax#84]
+Functions [1]: [max(csales#79)]
+Aggregate Attributes [1]: [max(csales#79)#82]
+Results [1]: [max(csales#79)#82 AS tpcds_cmax#83]
 
-Subquery:4 Hosting operator id = 98 Hosting Expression = ss_sold_date_sk#71 IN dynamicpruning#72
+Subquery:4 Hosting operator id = 98 Hosting Expression = ss_sold_date_sk#70 IN dynamicpruning#71
 BroadcastExchange (117)
 +- * Project (116)
    +- * Filter (115)
@@ -664,31 +664,31 @@ BroadcastExchange (117)
 
 
 (113) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#74, d_year#85]
+Output [2]: [d_date_sk#73, d_year#84]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_year, [2000,2001,2002,2003]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (114) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#74, d_year#85]
+Input [2]: [d_date_sk#73, d_year#84]
 
 (115) Filter [codegen id : 1]
-Input [2]: [d_date_sk#74, d_year#85]
-Condition : (d_year#85 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#74))
+Input [2]: [d_date_sk#73, d_year#84]
+Condition : (d_year#84 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#73))
 
 (116) Project [codegen id : 1]
-Output [1]: [d_date_sk#74]
-Input [2]: [d_date_sk#74, d_year#85]
+Output [1]: [d_date_sk#73]
+Input [2]: [d_date_sk#73, d_year#84]
 
 (117) BroadcastExchange
-Input [1]: [d_date_sk#74]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=16]
+Input [1]: [d_date_sk#73]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=17]
 
-Subquery:5 Hosting operator id = 50 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#32]
+Subquery:5 Hosting operator id = 50 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#7]
 
-Subquery:6 Hosting operator id = 63 Hosting Expression = ws_sold_date_sk#47 IN dynamicpruning#6
+Subquery:6 Hosting operator id = 63 Hosting Expression = ws_sold_date_sk#46 IN dynamicpruning#6
 
-Subquery:7 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#32]
+Subquery:7 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#7]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
@@ -62,227 +62,227 @@ Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, s
 
 (3) Filter [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-Condition : ((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_store_sk#3, 42)))
+Condition : ((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#1], xxhash64(ss_store_sk#3, 42)))
 
 (4) Project [codegen id : 2]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
 
 (5) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Output [6]: [i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_color), EqualTo(i_color,pale                ), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (6) ColumnarToRow [codegen id : 1]
-Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [6]: [i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
 
 (7) Filter [codegen id : 1]
-Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
-Condition : ((isnotnull(i_color#12) AND (i_color#12 = pale                )) AND isnotnull(i_item_sk#9))
+Input [6]: [i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
+Condition : ((isnotnull(i_color#11) AND (i_color#11 = pale                )) AND isnotnull(i_item_sk#8))
 
 (8) BroadcastExchange
-Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
+Input [6]: [i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#9]
+Right keys [1]: [i_item_sk#8]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 2]
-Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
-Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
+Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
 
 (11) Exchange
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
-Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
+Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (12) Sort [codegen id : 3]
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
 Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
 
 (13) Scan parquet spark_catalog.default.customer
-Output [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Output [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
 ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
 
 (14) ColumnarToRow [codegen id : 4]
-Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
 
 (15) Filter [codegen id : 4]
-Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
-Condition : (isnotnull(c_customer_sk#15) AND isnotnull(c_birth_country#18))
+Input [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
+Condition : (isnotnull(c_customer_sk#14) AND isnotnull(c_birth_country#17))
 
 (16) Exchange
-Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
-Arguments: hashpartitioning(c_customer_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
+Arguments: hashpartitioning(c_customer_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (17) Sort [codegen id : 5]
-Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
-Arguments: [c_customer_sk#15 ASC NULLS FIRST], false, 0
+Input [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
+Arguments: [c_customer_sk#14 ASC NULLS FIRST], false, 0
 
 (18) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#2]
-Right keys [1]: [c_customer_sk#15]
+Right keys [1]: [c_customer_sk#14]
 Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 6]
-Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17]
+Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
 
 (20) Exchange
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
-Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17]
+Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (21) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17]
 Arguments: [ss_ticket_number#4 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST], false, 0
 
 (22) Scan parquet spark_catalog.default.store_returns
-Output [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
+Output [3]: [sr_item_sk#18, sr_ticket_number#19, sr_returned_date_sk#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
 
 (23) ColumnarToRow [codegen id : 8]
-Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
+Input [3]: [sr_item_sk#18, sr_ticket_number#19, sr_returned_date_sk#20]
 
 (24) Filter [codegen id : 8]
-Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
-Condition : (isnotnull(sr_ticket_number#20) AND isnotnull(sr_item_sk#19))
+Input [3]: [sr_item_sk#18, sr_ticket_number#19, sr_returned_date_sk#20]
+Condition : (isnotnull(sr_ticket_number#19) AND isnotnull(sr_item_sk#18))
 
 (25) Project [codegen id : 8]
-Output [2]: [sr_item_sk#19, sr_ticket_number#20]
-Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
+Output [2]: [sr_item_sk#18, sr_ticket_number#19]
+Input [3]: [sr_item_sk#18, sr_ticket_number#19, sr_returned_date_sk#20]
 
 (26) Exchange
-Input [2]: [sr_item_sk#19, sr_ticket_number#20]
-Arguments: hashpartitioning(sr_ticket_number#20, sr_item_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [2]: [sr_item_sk#18, sr_ticket_number#19]
+Arguments: hashpartitioning(sr_ticket_number#19, sr_item_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (27) Sort [codegen id : 9]
-Input [2]: [sr_item_sk#19, sr_ticket_number#20]
-Arguments: [sr_ticket_number#20 ASC NULLS FIRST, sr_item_sk#19 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#18, sr_ticket_number#19]
+Arguments: [sr_ticket_number#19 ASC NULLS FIRST, sr_item_sk#18 ASC NULLS FIRST], false, 0
 
 (28) SortMergeJoin [codegen id : 12]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
-Right keys [2]: [sr_ticket_number#20, sr_item_sk#19]
+Right keys [2]: [sr_ticket_number#19, sr_item_sk#18]
 Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 12]
-Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
-Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, sr_item_sk#19, sr_ticket_number#20]
+Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17]
+Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17, sr_item_sk#18, sr_ticket_number#19]
 
 (30) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Output [5]: [s_store_sk#21, s_store_name#22, s_market_id#23, s_state#24, s_zip#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
 (31) ColumnarToRow [codegen id : 10]
-Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Input [5]: [s_store_sk#21, s_store_name#22, s_market_id#23, s_state#24, s_zip#25]
 
 (32) Filter [codegen id : 10]
-Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
-Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
+Input [5]: [s_store_sk#21, s_store_name#22, s_market_id#23, s_state#24, s_zip#25]
+Condition : (((isnotnull(s_market_id#23) AND (s_market_id#23 = 8)) AND isnotnull(s_store_sk#21)) AND isnotnull(s_zip#25))
 
 (33) Project [codegen id : 10]
-Output [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
-Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Output [4]: [s_store_sk#21, s_store_name#22, s_state#24, s_zip#25]
+Input [5]: [s_store_sk#21, s_store_name#22, s_market_id#23, s_state#24, s_zip#25]
 
 (34) BroadcastExchange
-Input [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
-Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=6]
+Input [4]: [s_store_sk#21, s_store_name#22, s_state#24, s_zip#25]
+Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=7]
 
 (35) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Output [3]: [ca_state#26, ca_zip#27, ca_country#28]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
 (36) ColumnarToRow
-Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Input [3]: [ca_state#26, ca_zip#27, ca_country#28]
 
 (37) Filter
-Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
-Condition : (isnotnull(ca_country#29) AND isnotnull(ca_zip#28))
+Input [3]: [ca_state#26, ca_zip#27, ca_country#28]
+Condition : (isnotnull(ca_country#28) AND isnotnull(ca_zip#27))
 
 (38) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [s_zip#26]
-Right keys [1]: [ca_zip#28]
+Left keys [1]: [s_zip#25]
+Right keys [1]: [ca_zip#27]
 Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 11]
-Output [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
-Input [7]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26, ca_state#27, ca_zip#28, ca_country#29]
+Output [5]: [s_store_sk#21, s_store_name#22, s_state#24, ca_state#26, ca_country#28]
+Input [7]: [s_store_sk#21, s_store_name#22, s_state#24, s_zip#25, ca_state#26, ca_zip#27, ca_country#28]
 
 (40) BroadcastExchange
-Input [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [plan_id=7]
+Input [5]: [s_store_sk#21, s_store_name#22, s_state#24, ca_state#26, ca_country#28]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [plan_id=8]
 
 (41) BroadcastHashJoin [codegen id : 12]
-Left keys [2]: [ss_store_sk#3, c_birth_country#18]
-Right keys [2]: [s_store_sk#22, upper(ca_country#29)]
+Left keys [2]: [ss_store_sk#3, c_birth_country#17]
+Right keys [2]: [s_store_sk#21, upper(ca_country#28)]
 Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 12]
-Output [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
-Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
+Output [11]: [ss_net_paid#5, s_store_name#22, s_state#24, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, ca_state#26]
+Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17, s_store_sk#21, s_store_name#22, s_state#24, ca_state#26, ca_country#28]
 
 (43) HashAggregate [codegen id : 12]
-Input [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
-Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
+Input [11]: [ss_net_paid#5, s_store_name#22, s_state#24, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, ca_state#26]
+Keys [10]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum#30]
-Results [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
+Aggregate Attributes [1]: [sum#29]
+Results [11]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10, sum#30]
 
 (44) Exchange
-Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
-Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [11]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10, sum#30]
+Arguments: hashpartitioning(c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (45) HashAggregate [codegen id : 13]
-Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
-Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
+Input [11]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10, sum#30]
+Keys [10]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10]
 Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#32]
-Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#32,17,2) AS netpaid#33]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#31]
+Results [4]: [c_last_name#16, c_first_name#15, s_store_name#22, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#31,17,2) AS netpaid#32]
 
 (46) HashAggregate [codegen id : 13]
-Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, netpaid#33]
-Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
-Functions [1]: [partial_sum(netpaid#33)]
-Aggregate Attributes [2]: [sum#34, isEmpty#35]
-Results [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
+Input [4]: [c_last_name#16, c_first_name#15, s_store_name#22, netpaid#32]
+Keys [3]: [c_last_name#16, c_first_name#15, s_store_name#22]
+Functions [1]: [partial_sum(netpaid#32)]
+Aggregate Attributes [2]: [sum#33, isEmpty#34]
+Results [5]: [c_last_name#16, c_first_name#15, s_store_name#22, sum#35, isEmpty#36]
 
 (47) Exchange
-Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
-Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [5]: [c_last_name#16, c_first_name#15, s_store_name#22, sum#35, isEmpty#36]
+Arguments: hashpartitioning(c_last_name#16, c_first_name#15, s_store_name#22, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (48) HashAggregate [codegen id : 14]
-Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
-Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
-Functions [1]: [sum(netpaid#33)]
-Aggregate Attributes [1]: [sum(netpaid#33)#38]
-Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, sum(netpaid#33)#38 AS paid#39]
+Input [5]: [c_last_name#16, c_first_name#15, s_store_name#22, sum#35, isEmpty#36]
+Keys [3]: [c_last_name#16, c_first_name#15, s_store_name#22]
+Functions [1]: [sum(netpaid#32)]
+Aggregate Attributes [1]: [sum(netpaid#32)#37]
+Results [4]: [c_last_name#16, c_first_name#15, s_store_name#22, sum(netpaid#32)#37 AS paid#38]
 
 (49) Filter [codegen id : 14]
-Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, paid#39]
-Condition : (isnotnull(paid#39) AND (cast(paid#39 as decimal(33,8)) > cast(Subquery scalar-subquery#40, [id=#41] as decimal(33,8))))
+Input [4]: [c_last_name#16, c_first_name#15, s_store_name#22, paid#38]
+Condition : (isnotnull(paid#38) AND (cast(paid#38 as decimal(33,8)) > cast(Subquery scalar-subquery#39, [id=#11] as decimal(33,8))))
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#40, [id=#41]
+Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#39, [id=#11]
 * HashAggregate (96)
 +- Exchange (95)
    +- * HashAggregate (94)
@@ -333,222 +333,222 @@ Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquer
 
 
 (50) Scan parquet spark_catalog.default.store_sales
-Output [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
+Output [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_paid:decimal(7,2)>
 
 (51) ColumnarToRow [codegen id : 2]
-Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
+Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
 
 (52) Filter [codegen id : 2]
-Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
-Condition : (((isnotnull(ss_ticket_number#45) AND isnotnull(ss_item_sk#42)) AND isnotnull(ss_store_sk#44)) AND isnotnull(ss_customer_sk#43))
+Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
+Condition : (((isnotnull(ss_ticket_number#43) AND isnotnull(ss_item_sk#40)) AND isnotnull(ss_store_sk#42)) AND isnotnull(ss_customer_sk#41))
 
 (53) Project [codegen id : 2]
-Output [5]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46]
-Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
+Output [5]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44]
+Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
 
 (54) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+Output [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
 (55) ColumnarToRow [codegen id : 1]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
 
 (56) Filter [codegen id : 1]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
-Condition : (((isnotnull(s_market_id#50) AND (s_market_id#50 = 8)) AND isnotnull(s_store_sk#48)) AND isnotnull(s_zip#52))
+Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
+Condition : (((isnotnull(s_market_id#48) AND (s_market_id#48 = 8)) AND isnotnull(s_store_sk#46)) AND isnotnull(s_zip#50))
 
 (57) Project [codegen id : 1]
-Output [4]: [s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+Output [4]: [s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
+Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
 
 (58) BroadcastExchange
-Input [4]: [s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+Input [4]: [s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=12]
 
 (59) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_store_sk#44]
-Right keys [1]: [s_store_sk#48]
+Left keys [1]: [ss_store_sk#42]
+Right keys [1]: [s_store_sk#46]
 Join type: Inner
 Join condition: None
 
 (60) Project [codegen id : 2]
-Output [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
-Input [9]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
+Output [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
+Input [9]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
 
 (61) Exchange
-Input [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
-Arguments: hashpartitioning(ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
+Arguments: hashpartitioning(ss_item_sk#40, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (62) Sort [codegen id : 3]
-Input [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
-Arguments: [ss_item_sk#42 ASC NULLS FIRST], false, 0
+Input [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
+Arguments: [ss_item_sk#40 ASC NULLS FIRST], false, 0
 
 (63) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Output [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (64) ColumnarToRow [codegen id : 4]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
 
 (65) Filter [codegen id : 4]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Condition : isnotnull(i_item_sk#53)
+Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Condition : isnotnull(i_item_sk#51)
 
 (66) Exchange
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: hashpartitioning(i_item_sk#53, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Arguments: hashpartitioning(i_item_sk#51, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (67) Sort [codegen id : 5]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: [i_item_sk#53 ASC NULLS FIRST], false, 0
+Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Arguments: [i_item_sk#51 ASC NULLS FIRST], false, 0
 
 (68) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_item_sk#42]
-Right keys [1]: [i_item_sk#53]
+Left keys [1]: [ss_item_sk#40]
+Right keys [1]: [i_item_sk#51]
 Join type: Inner
 Join condition: None
 
 (69) Project [codegen id : 6]
-Output [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Input [13]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Output [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Input [13]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
 
 (70) Exchange
-Input [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: hashpartitioning(ss_customer_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Arguments: hashpartitioning(ss_customer_sk#41, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
 (71) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: [ss_customer_sk#43 ASC NULLS FIRST], false, 0
+Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Arguments: [ss_customer_sk#41 ASC NULLS FIRST], false, 0
 
 (72) ReusedExchange [Reuses operator id: 16]
-Output [4]: [c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
+Output [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
 
 (73) Sort [codegen id : 9]
-Input [4]: [c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: [c_customer_sk#59 ASC NULLS FIRST], false, 0
+Input [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: [c_customer_sk#57 ASC NULLS FIRST], false, 0
 
 (74) SortMergeJoin [codegen id : 10]
-Left keys [1]: [ss_customer_sk#43]
-Right keys [1]: [c_customer_sk#59]
+Left keys [1]: [ss_customer_sk#41]
+Right keys [1]: [c_customer_sk#57]
 Join type: Inner
 Join condition: None
 
 (75) Project [codegen id : 10]
-Output [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Input [16]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
+Output [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Input [16]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
 
 (76) Exchange
-Input [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: hashpartitioning(ss_ticket_number#45, ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: hashpartitioning(ss_ticket_number#43, ss_item_sk#40, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
 (77) Sort [codegen id : 11]
-Input [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: [ss_ticket_number#45 ASC NULLS FIRST, ss_item_sk#42 ASC NULLS FIRST], false, 0
+Input [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: [ss_ticket_number#43 ASC NULLS FIRST, ss_item_sk#40 ASC NULLS FIRST], false, 0
 
 (78) ReusedExchange [Reuses operator id: 26]
-Output [2]: [sr_item_sk#63, sr_ticket_number#64]
+Output [2]: [sr_item_sk#61, sr_ticket_number#62]
 
 (79) Sort [codegen id : 13]
-Input [2]: [sr_item_sk#63, sr_ticket_number#64]
-Arguments: [sr_ticket_number#64 ASC NULLS FIRST, sr_item_sk#63 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#61, sr_ticket_number#62]
+Arguments: [sr_ticket_number#62 ASC NULLS FIRST, sr_item_sk#61 ASC NULLS FIRST], false, 0
 
 (80) SortMergeJoin [codegen id : 14]
-Left keys [2]: [ss_ticket_number#45, ss_item_sk#42]
-Right keys [2]: [sr_ticket_number#64, sr_item_sk#63]
+Left keys [2]: [ss_ticket_number#43, ss_item_sk#40]
+Right keys [2]: [sr_ticket_number#62, sr_item_sk#61]
 Join type: Inner
 Join condition: None
 
 (81) Project [codegen id : 14]
-Output [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Input [16]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62, sr_item_sk#63, sr_ticket_number#64]
+Output [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Input [16]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, sr_item_sk#61, sr_ticket_number#62]
 
 (82) Exchange
-Input [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: hashpartitioning(c_birth_country#62, s_zip#52, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Input [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: hashpartitioning(c_birth_country#60, s_zip#50, 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
 (83) Sort [codegen id : 15]
-Input [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: [c_birth_country#62 ASC NULLS FIRST, s_zip#52 ASC NULLS FIRST], false, 0
+Input [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: [c_birth_country#60 ASC NULLS FIRST, s_zip#50 ASC NULLS FIRST], false, 0
 
 (84) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#65, ca_zip#66, ca_country#67]
+Output [3]: [ca_state#63, ca_zip#64, ca_country#65]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
 (85) ColumnarToRow [codegen id : 16]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
+Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
 
 (86) Filter [codegen id : 16]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Condition : (isnotnull(ca_country#67) AND isnotnull(ca_zip#66))
+Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
+Condition : (isnotnull(ca_country#65) AND isnotnull(ca_zip#64))
 
 (87) Exchange
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Arguments: hashpartitioning(upper(ca_country#67), ca_zip#66, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
+Arguments: hashpartitioning(upper(ca_country#65), ca_zip#64, 5), ENSURE_REQUIREMENTS, [plan_id=18]
 
 (88) Sort [codegen id : 17]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Arguments: [upper(ca_country#67) ASC NULLS FIRST, ca_zip#66 ASC NULLS FIRST], false, 0
+Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
+Arguments: [upper(ca_country#65) ASC NULLS FIRST, ca_zip#64 ASC NULLS FIRST], false, 0
 
 (89) SortMergeJoin [codegen id : 18]
-Left keys [2]: [c_birth_country#62, s_zip#52]
-Right keys [2]: [upper(ca_country#67), ca_zip#66]
+Left keys [2]: [c_birth_country#60, s_zip#50]
+Right keys [2]: [upper(ca_country#65), ca_zip#64]
 Join type: Inner
 Join condition: None
 
 (90) Project [codegen id : 18]
-Output [11]: [ss_net_paid#46, s_store_name#49, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, ca_state#65]
-Input [15]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62, ca_state#65, ca_zip#66, ca_country#67]
+Output [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#63]
+Input [15]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, ca_state#63, ca_zip#64, ca_country#65]
 
 (91) HashAggregate [codegen id : 18]
-Input [11]: [ss_net_paid#46, s_store_name#49, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, ca_state#65]
-Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#46))]
-Aggregate Attributes [1]: [sum#68]
-Results [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
+Input [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#63]
+Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#44))]
+Aggregate Attributes [1]: [sum#66]
+Results [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
 
 (92) Exchange
-Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
-Arguments: hashpartitioning(c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
+Arguments: hashpartitioning(c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, 5), ENSURE_REQUIREMENTS, [plan_id=19]
 
 (93) HashAggregate [codegen id : 19]
-Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
-Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#46))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#46))#32]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#46))#32,17,2) AS netpaid#70]
+Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
+Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#44))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#44))#31]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#44))#31,17,2) AS netpaid#68]
 
 (94) HashAggregate [codegen id : 19]
-Input [1]: [netpaid#70]
+Input [1]: [netpaid#68]
 Keys: []
-Functions [1]: [partial_avg(netpaid#70)]
-Aggregate Attributes [2]: [sum#71, count#72]
-Results [2]: [sum#73, count#74]
+Functions [1]: [partial_avg(netpaid#68)]
+Aggregate Attributes [2]: [sum#69, count#70]
+Results [2]: [sum#71, count#72]
 
 (95) Exchange
-Input [2]: [sum#73, count#74]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
+Input [2]: [sum#71, count#72]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=20]
 
 (96) HashAggregate [codegen id : 20]
-Input [2]: [sum#73, count#74]
+Input [2]: [sum#71, count#72]
 Keys: []
-Functions [1]: [avg(netpaid#70)]
-Aggregate Attributes [1]: [avg(netpaid#70)#75]
-Results [1]: [(0.05 * avg(netpaid#70)#75) AS (0.05 * avg(netpaid))#76]
+Functions [1]: [avg(netpaid#68)]
+Aggregate Attributes [1]: [avg(netpaid#68)#73]
+Results [1]: [(0.05 * avg(netpaid#68)#73) AS (0.05 * avg(netpaid))#74]
 
-Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#1]
 ObjectHashAggregate (103)
 +- Exchange (102)
    +- ObjectHashAggregate (101)
@@ -559,39 +559,39 @@ ObjectHashAggregate (103)
 
 
 (97) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
+Output [3]: [s_store_sk#21, s_market_id#23, s_zip#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_market_id:int,s_zip:string>
 
 (98) ColumnarToRow [codegen id : 1]
-Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
+Input [3]: [s_store_sk#21, s_market_id#23, s_zip#25]
 
 (99) Filter [codegen id : 1]
-Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
-Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
+Input [3]: [s_store_sk#21, s_market_id#23, s_zip#25]
+Condition : (((isnotnull(s_market_id#23) AND (s_market_id#23 = 8)) AND isnotnull(s_store_sk#21)) AND isnotnull(s_zip#25))
 
 (100) Project [codegen id : 1]
-Output [1]: [s_store_sk#22]
-Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
+Output [1]: [s_store_sk#21]
+Input [3]: [s_store_sk#21, s_market_id#23, s_zip#25]
 
 (101) ObjectHashAggregate
-Input [1]: [s_store_sk#22]
+Input [1]: [s_store_sk#21]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)]
-Aggregate Attributes [1]: [buf#77]
-Results [1]: [buf#78]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(s_store_sk#21, 42), 40, 1250, 0, 0)]
+Aggregate Attributes [1]: [buf#75]
+Results [1]: [buf#76]
 
 (102) Exchange
-Input [1]: [buf#78]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
+Input [1]: [buf#76]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=21]
 
 (103) ObjectHashAggregate
-Input [1]: [buf#78]
+Input [1]: [buf#76]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#79]
-Results [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#79 AS bloomFilter#80]
+Functions [1]: [bloom_filter_agg(xxhash64(s_store_sk#21, 42), 40, 1250, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(s_store_sk#21, 42), 40, 1250, 0, 0)#77]
+Results [1]: [bloom_filter_agg(xxhash64(s_store_sk#21, 42), 40, 1250, 0, 0)#77 AS bloomFilter#78]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a/explain.txt
@@ -263,11 +263,11 @@ Results [4]: [c_last_name#23, c_first_name#22, s_store_name#11, sum(netpaid#31)#
 
 (46) Filter [codegen id : 11]
 Input [4]: [c_last_name#23, c_first_name#22, s_store_name#11, paid#37]
-Condition : (isnotnull(paid#37) AND (cast(paid#37 as decimal(33,8)) > cast(Subquery scalar-subquery#38, [id=#39] as decimal(33,8))))
+Condition : (isnotnull(paid#37) AND (cast(paid#37 as decimal(33,8)) > cast(Subquery scalar-subquery#38, [id=#9] as decimal(33,8))))
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquery#38, [id=#39]
+Subquery:1 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquery#38, [id=#9]
 * HashAggregate (73)
 +- Exchange (72)
    +- * HashAggregate (71)
@@ -298,130 +298,130 @@ Subquery:1 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquer
 
 
 (47) ReusedExchange [Reuses operator id: 5]
-Output [5]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44]
+Output [5]: [ss_item_sk#39, ss_customer_sk#40, ss_store_sk#41, ss_ticket_number#42, ss_net_paid#43]
 
 (48) Sort [codegen id : 2]
-Input [5]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44]
-Arguments: [ss_ticket_number#43 ASC NULLS FIRST, ss_item_sk#40 ASC NULLS FIRST], false, 0
+Input [5]: [ss_item_sk#39, ss_customer_sk#40, ss_store_sk#41, ss_ticket_number#42, ss_net_paid#43]
+Arguments: [ss_ticket_number#42 ASC NULLS FIRST, ss_item_sk#39 ASC NULLS FIRST], false, 0
 
 (49) ReusedExchange [Reuses operator id: 11]
-Output [2]: [sr_item_sk#45, sr_ticket_number#46]
+Output [2]: [sr_item_sk#44, sr_ticket_number#45]
 
 (50) Sort [codegen id : 4]
-Input [2]: [sr_item_sk#45, sr_ticket_number#46]
-Arguments: [sr_ticket_number#46 ASC NULLS FIRST, sr_item_sk#45 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#44, sr_ticket_number#45]
+Arguments: [sr_ticket_number#45 ASC NULLS FIRST, sr_item_sk#44 ASC NULLS FIRST], false, 0
 
 (51) SortMergeJoin [codegen id : 9]
-Left keys [2]: [ss_ticket_number#43, ss_item_sk#40]
-Right keys [2]: [sr_ticket_number#46, sr_item_sk#45]
+Left keys [2]: [ss_ticket_number#42, ss_item_sk#39]
+Right keys [2]: [sr_ticket_number#45, sr_item_sk#44]
 Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 9]
-Output [4]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_net_paid#44]
-Input [7]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, sr_item_sk#45, sr_ticket_number#46]
+Output [4]: [ss_item_sk#39, ss_customer_sk#40, ss_store_sk#41, ss_net_paid#43]
+Input [7]: [ss_item_sk#39, ss_customer_sk#40, ss_store_sk#41, ss_ticket_number#42, ss_net_paid#43, sr_item_sk#44, sr_ticket_number#45]
 
 (53) ReusedExchange [Reuses operator id: 19]
-Output [4]: [s_store_sk#47, s_store_name#48, s_state#49, s_zip#50]
+Output [4]: [s_store_sk#46, s_store_name#47, s_state#48, s_zip#49]
 
 (54) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ss_store_sk#42]
-Right keys [1]: [s_store_sk#47]
+Left keys [1]: [ss_store_sk#41]
+Right keys [1]: [s_store_sk#46]
 Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 9]
-Output [6]: [ss_item_sk#40, ss_customer_sk#41, ss_net_paid#44, s_store_name#48, s_state#49, s_zip#50]
-Input [8]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_net_paid#44, s_store_sk#47, s_store_name#48, s_state#49, s_zip#50]
+Output [6]: [ss_item_sk#39, ss_customer_sk#40, ss_net_paid#43, s_store_name#47, s_state#48, s_zip#49]
+Input [8]: [ss_item_sk#39, ss_customer_sk#40, ss_store_sk#41, ss_net_paid#43, s_store_sk#46, s_store_name#47, s_state#48, s_zip#49]
 
 (56) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Output [6]: [i_item_sk#50, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (57) ColumnarToRow [codegen id : 6]
-Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Input [6]: [i_item_sk#50, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
 
 (58) Filter [codegen id : 6]
-Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Condition : isnotnull(i_item_sk#51)
+Input [6]: [i_item_sk#50, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
+Condition : isnotnull(i_item_sk#50)
 
 (59) BroadcastExchange
-Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
+Input [6]: [i_item_sk#50, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=10]
 
 (60) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ss_item_sk#40]
-Right keys [1]: [i_item_sk#51]
+Left keys [1]: [ss_item_sk#39]
+Right keys [1]: [i_item_sk#50]
 Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 9]
-Output [10]: [ss_customer_sk#41, ss_net_paid#44, s_store_name#48, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_net_paid#44, s_store_name#48, s_state#49, s_zip#50, i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Output [10]: [ss_customer_sk#40, ss_net_paid#43, s_store_name#47, s_state#48, s_zip#49, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
+Input [12]: [ss_item_sk#39, ss_customer_sk#40, ss_net_paid#43, s_store_name#47, s_state#48, s_zip#49, i_item_sk#50, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
 
 (62) ReusedExchange [Reuses operator id: 31]
-Output [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Output [4]: [c_customer_sk#56, c_first_name#57, c_last_name#58, c_birth_country#59]
 
 (63) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ss_customer_sk#41]
-Right keys [1]: [c_customer_sk#57]
+Left keys [1]: [ss_customer_sk#40]
+Right keys [1]: [c_customer_sk#56]
 Join type: Inner
 Join condition: None
 
 (64) Project [codegen id : 9]
-Output [12]: [ss_net_paid#44, s_store_name#48, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Input [14]: [ss_customer_sk#41, ss_net_paid#44, s_store_name#48, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Output [12]: [ss_net_paid#43, s_store_name#47, s_state#48, s_zip#49, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55, c_first_name#57, c_last_name#58, c_birth_country#59]
+Input [14]: [ss_customer_sk#40, ss_net_paid#43, s_store_name#47, s_state#48, s_zip#49, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55, c_customer_sk#56, c_first_name#57, c_last_name#58, c_birth_country#59]
 
 (65) ReusedExchange [Reuses operator id: 37]
-Output [3]: [ca_state#61, ca_zip#62, ca_country#63]
+Output [3]: [ca_state#60, ca_zip#61, ca_country#62]
 
 (66) BroadcastHashJoin [codegen id : 9]
-Left keys [2]: [c_birth_country#60, s_zip#50]
-Right keys [2]: [upper(ca_country#63), ca_zip#62]
+Left keys [2]: [c_birth_country#59, s_zip#49]
+Right keys [2]: [upper(ca_country#62), ca_zip#61]
 Join type: Inner
 Join condition: None
 
 (67) Project [codegen id : 9]
-Output [11]: [ss_net_paid#44, s_store_name#48, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#61]
-Input [15]: [ss_net_paid#44, s_store_name#48, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, ca_state#61, ca_zip#62, ca_country#63]
+Output [11]: [ss_net_paid#43, s_store_name#47, s_state#48, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55, c_first_name#57, c_last_name#58, ca_state#60]
+Input [15]: [ss_net_paid#43, s_store_name#47, s_state#48, s_zip#49, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55, c_first_name#57, c_last_name#58, c_birth_country#59, ca_state#60, ca_zip#61, ca_country#62]
 
 (68) HashAggregate [codegen id : 9]
-Input [11]: [ss_net_paid#44, s_store_name#48, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#61]
-Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#48, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#44))]
-Aggregate Attributes [1]: [sum#64]
-Results [11]: [c_last_name#59, c_first_name#58, s_store_name#48, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#65]
+Input [11]: [ss_net_paid#43, s_store_name#47, s_state#48, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55, c_first_name#57, c_last_name#58, ca_state#60]
+Keys [10]: [c_last_name#58, c_first_name#57, s_store_name#47, ca_state#60, s_state#48, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#43))]
+Aggregate Attributes [1]: [sum#63]
+Results [11]: [c_last_name#58, c_first_name#57, s_store_name#47, ca_state#60, s_state#48, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52, sum#64]
 
 (69) Exchange
-Input [11]: [c_last_name#59, c_first_name#58, s_store_name#48, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#65]
-Arguments: hashpartitioning(c_last_name#59, c_first_name#58, s_store_name#48, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [11]: [c_last_name#58, c_first_name#57, s_store_name#47, ca_state#60, s_state#48, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52, sum#64]
+Arguments: hashpartitioning(c_last_name#58, c_first_name#57, s_store_name#47, ca_state#60, s_state#48, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (70) HashAggregate [codegen id : 10]
-Input [11]: [c_last_name#59, c_first_name#58, s_store_name#48, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#65]
-Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#48, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#44))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#44))#30]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#44))#30,17,2) AS netpaid#66]
+Input [11]: [c_last_name#58, c_first_name#57, s_store_name#47, ca_state#60, s_state#48, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52, sum#64]
+Keys [10]: [c_last_name#58, c_first_name#57, s_store_name#47, ca_state#60, s_state#48, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#43))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#43))#30]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#43))#30,17,2) AS netpaid#65]
 
 (71) HashAggregate [codegen id : 10]
-Input [1]: [netpaid#66]
+Input [1]: [netpaid#65]
 Keys: []
-Functions [1]: [partial_avg(netpaid#66)]
-Aggregate Attributes [2]: [sum#67, count#68]
-Results [2]: [sum#69, count#70]
+Functions [1]: [partial_avg(netpaid#65)]
+Aggregate Attributes [2]: [sum#66, count#67]
+Results [2]: [sum#68, count#69]
 
 (72) Exchange
-Input [2]: [sum#69, count#70]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
+Input [2]: [sum#68, count#69]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
 
 (73) HashAggregate [codegen id : 11]
-Input [2]: [sum#69, count#70]
+Input [2]: [sum#68, count#69]
 Keys: []
-Functions [1]: [avg(netpaid#66)]
-Aggregate Attributes [1]: [avg(netpaid#66)#71]
-Results [1]: [(0.05 * avg(netpaid#66)#71) AS (0.05 * avg(netpaid))#72]
+Functions [1]: [avg(netpaid#65)]
+Aggregate Attributes [1]: [avg(netpaid#65)#70]
+Results [1]: [(0.05 * avg(netpaid#65)#70) AS (0.05 * avg(netpaid))#71]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
@@ -62,227 +62,227 @@ Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, s
 
 (3) Filter [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-Condition : ((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_store_sk#3, 42)))
+Condition : ((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#1], xxhash64(ss_store_sk#3, 42)))
 
 (4) Project [codegen id : 2]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
 
 (5) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Output [6]: [i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_color), EqualTo(i_color,chiffon             ), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (6) ColumnarToRow [codegen id : 1]
-Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [6]: [i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
 
 (7) Filter [codegen id : 1]
-Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
-Condition : ((isnotnull(i_color#12) AND (i_color#12 = chiffon             )) AND isnotnull(i_item_sk#9))
+Input [6]: [i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
+Condition : ((isnotnull(i_color#11) AND (i_color#11 = chiffon             )) AND isnotnull(i_item_sk#8))
 
 (8) BroadcastExchange
-Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
+Input [6]: [i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#9]
+Right keys [1]: [i_item_sk#8]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 2]
-Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
-Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
+Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
 
 (11) Exchange
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
-Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
+Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (12) Sort [codegen id : 3]
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
 Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
 
 (13) Scan parquet spark_catalog.default.customer
-Output [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Output [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
 ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
 
 (14) ColumnarToRow [codegen id : 4]
-Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
 
 (15) Filter [codegen id : 4]
-Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
-Condition : (isnotnull(c_customer_sk#15) AND isnotnull(c_birth_country#18))
+Input [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
+Condition : (isnotnull(c_customer_sk#14) AND isnotnull(c_birth_country#17))
 
 (16) Exchange
-Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
-Arguments: hashpartitioning(c_customer_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
+Arguments: hashpartitioning(c_customer_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (17) Sort [codegen id : 5]
-Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
-Arguments: [c_customer_sk#15 ASC NULLS FIRST], false, 0
+Input [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
+Arguments: [c_customer_sk#14 ASC NULLS FIRST], false, 0
 
 (18) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#2]
-Right keys [1]: [c_customer_sk#15]
+Right keys [1]: [c_customer_sk#14]
 Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 6]
-Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17]
+Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
 
 (20) Exchange
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
-Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17]
+Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (21) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17]
 Arguments: [ss_ticket_number#4 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST], false, 0
 
 (22) Scan parquet spark_catalog.default.store_returns
-Output [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
+Output [3]: [sr_item_sk#18, sr_ticket_number#19, sr_returned_date_sk#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
 
 (23) ColumnarToRow [codegen id : 8]
-Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
+Input [3]: [sr_item_sk#18, sr_ticket_number#19, sr_returned_date_sk#20]
 
 (24) Filter [codegen id : 8]
-Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
-Condition : (isnotnull(sr_ticket_number#20) AND isnotnull(sr_item_sk#19))
+Input [3]: [sr_item_sk#18, sr_ticket_number#19, sr_returned_date_sk#20]
+Condition : (isnotnull(sr_ticket_number#19) AND isnotnull(sr_item_sk#18))
 
 (25) Project [codegen id : 8]
-Output [2]: [sr_item_sk#19, sr_ticket_number#20]
-Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
+Output [2]: [sr_item_sk#18, sr_ticket_number#19]
+Input [3]: [sr_item_sk#18, sr_ticket_number#19, sr_returned_date_sk#20]
 
 (26) Exchange
-Input [2]: [sr_item_sk#19, sr_ticket_number#20]
-Arguments: hashpartitioning(sr_ticket_number#20, sr_item_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [2]: [sr_item_sk#18, sr_ticket_number#19]
+Arguments: hashpartitioning(sr_ticket_number#19, sr_item_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (27) Sort [codegen id : 9]
-Input [2]: [sr_item_sk#19, sr_ticket_number#20]
-Arguments: [sr_ticket_number#20 ASC NULLS FIRST, sr_item_sk#19 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#18, sr_ticket_number#19]
+Arguments: [sr_ticket_number#19 ASC NULLS FIRST, sr_item_sk#18 ASC NULLS FIRST], false, 0
 
 (28) SortMergeJoin [codegen id : 12]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
-Right keys [2]: [sr_ticket_number#20, sr_item_sk#19]
+Right keys [2]: [sr_ticket_number#19, sr_item_sk#18]
 Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 12]
-Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
-Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, sr_item_sk#19, sr_ticket_number#20]
+Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17]
+Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17, sr_item_sk#18, sr_ticket_number#19]
 
 (30) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Output [5]: [s_store_sk#21, s_store_name#22, s_market_id#23, s_state#24, s_zip#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
 (31) ColumnarToRow [codegen id : 10]
-Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Input [5]: [s_store_sk#21, s_store_name#22, s_market_id#23, s_state#24, s_zip#25]
 
 (32) Filter [codegen id : 10]
-Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
-Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
+Input [5]: [s_store_sk#21, s_store_name#22, s_market_id#23, s_state#24, s_zip#25]
+Condition : (((isnotnull(s_market_id#23) AND (s_market_id#23 = 8)) AND isnotnull(s_store_sk#21)) AND isnotnull(s_zip#25))
 
 (33) Project [codegen id : 10]
-Output [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
-Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Output [4]: [s_store_sk#21, s_store_name#22, s_state#24, s_zip#25]
+Input [5]: [s_store_sk#21, s_store_name#22, s_market_id#23, s_state#24, s_zip#25]
 
 (34) BroadcastExchange
-Input [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
-Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=6]
+Input [4]: [s_store_sk#21, s_store_name#22, s_state#24, s_zip#25]
+Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=7]
 
 (35) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Output [3]: [ca_state#26, ca_zip#27, ca_country#28]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
 (36) ColumnarToRow
-Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Input [3]: [ca_state#26, ca_zip#27, ca_country#28]
 
 (37) Filter
-Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
-Condition : (isnotnull(ca_country#29) AND isnotnull(ca_zip#28))
+Input [3]: [ca_state#26, ca_zip#27, ca_country#28]
+Condition : (isnotnull(ca_country#28) AND isnotnull(ca_zip#27))
 
 (38) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [s_zip#26]
-Right keys [1]: [ca_zip#28]
+Left keys [1]: [s_zip#25]
+Right keys [1]: [ca_zip#27]
 Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 11]
-Output [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
-Input [7]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26, ca_state#27, ca_zip#28, ca_country#29]
+Output [5]: [s_store_sk#21, s_store_name#22, s_state#24, ca_state#26, ca_country#28]
+Input [7]: [s_store_sk#21, s_store_name#22, s_state#24, s_zip#25, ca_state#26, ca_zip#27, ca_country#28]
 
 (40) BroadcastExchange
-Input [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [plan_id=7]
+Input [5]: [s_store_sk#21, s_store_name#22, s_state#24, ca_state#26, ca_country#28]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [plan_id=8]
 
 (41) BroadcastHashJoin [codegen id : 12]
-Left keys [2]: [ss_store_sk#3, c_birth_country#18]
-Right keys [2]: [s_store_sk#22, upper(ca_country#29)]
+Left keys [2]: [ss_store_sk#3, c_birth_country#17]
+Right keys [2]: [s_store_sk#21, upper(ca_country#28)]
 Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 12]
-Output [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
-Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
+Output [11]: [ss_net_paid#5, s_store_name#22, s_state#24, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, ca_state#26]
+Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17, s_store_sk#21, s_store_name#22, s_state#24, ca_state#26, ca_country#28]
 
 (43) HashAggregate [codegen id : 12]
-Input [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
-Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
+Input [11]: [ss_net_paid#5, s_store_name#22, s_state#24, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, ca_state#26]
+Keys [10]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum#30]
-Results [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
+Aggregate Attributes [1]: [sum#29]
+Results [11]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10, sum#30]
 
 (44) Exchange
-Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
-Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [11]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10, sum#30]
+Arguments: hashpartitioning(c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (45) HashAggregate [codegen id : 13]
-Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
-Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
+Input [11]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10, sum#30]
+Keys [10]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10]
 Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#32]
-Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#32,17,2) AS netpaid#33]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#31]
+Results [4]: [c_last_name#16, c_first_name#15, s_store_name#22, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#31,17,2) AS netpaid#32]
 
 (46) HashAggregate [codegen id : 13]
-Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, netpaid#33]
-Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
-Functions [1]: [partial_sum(netpaid#33)]
-Aggregate Attributes [2]: [sum#34, isEmpty#35]
-Results [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
+Input [4]: [c_last_name#16, c_first_name#15, s_store_name#22, netpaid#32]
+Keys [3]: [c_last_name#16, c_first_name#15, s_store_name#22]
+Functions [1]: [partial_sum(netpaid#32)]
+Aggregate Attributes [2]: [sum#33, isEmpty#34]
+Results [5]: [c_last_name#16, c_first_name#15, s_store_name#22, sum#35, isEmpty#36]
 
 (47) Exchange
-Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
-Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [5]: [c_last_name#16, c_first_name#15, s_store_name#22, sum#35, isEmpty#36]
+Arguments: hashpartitioning(c_last_name#16, c_first_name#15, s_store_name#22, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (48) HashAggregate [codegen id : 14]
-Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
-Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
-Functions [1]: [sum(netpaid#33)]
-Aggregate Attributes [1]: [sum(netpaid#33)#38]
-Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, sum(netpaid#33)#38 AS paid#39]
+Input [5]: [c_last_name#16, c_first_name#15, s_store_name#22, sum#35, isEmpty#36]
+Keys [3]: [c_last_name#16, c_first_name#15, s_store_name#22]
+Functions [1]: [sum(netpaid#32)]
+Aggregate Attributes [1]: [sum(netpaid#32)#37]
+Results [4]: [c_last_name#16, c_first_name#15, s_store_name#22, sum(netpaid#32)#37 AS paid#38]
 
 (49) Filter [codegen id : 14]
-Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, paid#39]
-Condition : (isnotnull(paid#39) AND (cast(paid#39 as decimal(33,8)) > cast(Subquery scalar-subquery#40, [id=#41] as decimal(33,8))))
+Input [4]: [c_last_name#16, c_first_name#15, s_store_name#22, paid#38]
+Condition : (isnotnull(paid#38) AND (cast(paid#38 as decimal(33,8)) > cast(Subquery scalar-subquery#39, [id=#11] as decimal(33,8))))
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#40, [id=#41]
+Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#39, [id=#11]
 * HashAggregate (96)
 +- Exchange (95)
    +- * HashAggregate (94)
@@ -333,222 +333,222 @@ Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquer
 
 
 (50) Scan parquet spark_catalog.default.store_sales
-Output [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
+Output [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_paid:decimal(7,2)>
 
 (51) ColumnarToRow [codegen id : 2]
-Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
+Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
 
 (52) Filter [codegen id : 2]
-Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
-Condition : (((isnotnull(ss_ticket_number#45) AND isnotnull(ss_item_sk#42)) AND isnotnull(ss_store_sk#44)) AND isnotnull(ss_customer_sk#43))
+Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
+Condition : (((isnotnull(ss_ticket_number#43) AND isnotnull(ss_item_sk#40)) AND isnotnull(ss_store_sk#42)) AND isnotnull(ss_customer_sk#41))
 
 (53) Project [codegen id : 2]
-Output [5]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46]
-Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
+Output [5]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44]
+Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
 
 (54) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+Output [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
 (55) ColumnarToRow [codegen id : 1]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
 
 (56) Filter [codegen id : 1]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
-Condition : (((isnotnull(s_market_id#50) AND (s_market_id#50 = 8)) AND isnotnull(s_store_sk#48)) AND isnotnull(s_zip#52))
+Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
+Condition : (((isnotnull(s_market_id#48) AND (s_market_id#48 = 8)) AND isnotnull(s_store_sk#46)) AND isnotnull(s_zip#50))
 
 (57) Project [codegen id : 1]
-Output [4]: [s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+Output [4]: [s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
+Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
 
 (58) BroadcastExchange
-Input [4]: [s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+Input [4]: [s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=12]
 
 (59) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_store_sk#44]
-Right keys [1]: [s_store_sk#48]
+Left keys [1]: [ss_store_sk#42]
+Right keys [1]: [s_store_sk#46]
 Join type: Inner
 Join condition: None
 
 (60) Project [codegen id : 2]
-Output [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
-Input [9]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
+Output [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
+Input [9]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
 
 (61) Exchange
-Input [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
-Arguments: hashpartitioning(ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
+Arguments: hashpartitioning(ss_item_sk#40, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (62) Sort [codegen id : 3]
-Input [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
-Arguments: [ss_item_sk#42 ASC NULLS FIRST], false, 0
+Input [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
+Arguments: [ss_item_sk#40 ASC NULLS FIRST], false, 0
 
 (63) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Output [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (64) ColumnarToRow [codegen id : 4]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
 
 (65) Filter [codegen id : 4]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Condition : isnotnull(i_item_sk#53)
+Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Condition : isnotnull(i_item_sk#51)
 
 (66) Exchange
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: hashpartitioning(i_item_sk#53, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Arguments: hashpartitioning(i_item_sk#51, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (67) Sort [codegen id : 5]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: [i_item_sk#53 ASC NULLS FIRST], false, 0
+Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Arguments: [i_item_sk#51 ASC NULLS FIRST], false, 0
 
 (68) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_item_sk#42]
-Right keys [1]: [i_item_sk#53]
+Left keys [1]: [ss_item_sk#40]
+Right keys [1]: [i_item_sk#51]
 Join type: Inner
 Join condition: None
 
 (69) Project [codegen id : 6]
-Output [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Input [13]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Output [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Input [13]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
 
 (70) Exchange
-Input [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: hashpartitioning(ss_customer_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Arguments: hashpartitioning(ss_customer_sk#41, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
 (71) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: [ss_customer_sk#43 ASC NULLS FIRST], false, 0
+Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Arguments: [ss_customer_sk#41 ASC NULLS FIRST], false, 0
 
 (72) ReusedExchange [Reuses operator id: 16]
-Output [4]: [c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
+Output [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
 
 (73) Sort [codegen id : 9]
-Input [4]: [c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: [c_customer_sk#59 ASC NULLS FIRST], false, 0
+Input [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: [c_customer_sk#57 ASC NULLS FIRST], false, 0
 
 (74) SortMergeJoin [codegen id : 10]
-Left keys [1]: [ss_customer_sk#43]
-Right keys [1]: [c_customer_sk#59]
+Left keys [1]: [ss_customer_sk#41]
+Right keys [1]: [c_customer_sk#57]
 Join type: Inner
 Join condition: None
 
 (75) Project [codegen id : 10]
-Output [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Input [16]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
+Output [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Input [16]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
 
 (76) Exchange
-Input [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: hashpartitioning(ss_ticket_number#45, ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: hashpartitioning(ss_ticket_number#43, ss_item_sk#40, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
 (77) Sort [codegen id : 11]
-Input [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: [ss_ticket_number#45 ASC NULLS FIRST, ss_item_sk#42 ASC NULLS FIRST], false, 0
+Input [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: [ss_ticket_number#43 ASC NULLS FIRST, ss_item_sk#40 ASC NULLS FIRST], false, 0
 
 (78) ReusedExchange [Reuses operator id: 26]
-Output [2]: [sr_item_sk#63, sr_ticket_number#64]
+Output [2]: [sr_item_sk#61, sr_ticket_number#62]
 
 (79) Sort [codegen id : 13]
-Input [2]: [sr_item_sk#63, sr_ticket_number#64]
-Arguments: [sr_ticket_number#64 ASC NULLS FIRST, sr_item_sk#63 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#61, sr_ticket_number#62]
+Arguments: [sr_ticket_number#62 ASC NULLS FIRST, sr_item_sk#61 ASC NULLS FIRST], false, 0
 
 (80) SortMergeJoin [codegen id : 14]
-Left keys [2]: [ss_ticket_number#45, ss_item_sk#42]
-Right keys [2]: [sr_ticket_number#64, sr_item_sk#63]
+Left keys [2]: [ss_ticket_number#43, ss_item_sk#40]
+Right keys [2]: [sr_ticket_number#62, sr_item_sk#61]
 Join type: Inner
 Join condition: None
 
 (81) Project [codegen id : 14]
-Output [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Input [16]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62, sr_item_sk#63, sr_ticket_number#64]
+Output [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Input [16]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, sr_item_sk#61, sr_ticket_number#62]
 
 (82) Exchange
-Input [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: hashpartitioning(c_birth_country#62, s_zip#52, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Input [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: hashpartitioning(c_birth_country#60, s_zip#50, 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
 (83) Sort [codegen id : 15]
-Input [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: [c_birth_country#62 ASC NULLS FIRST, s_zip#52 ASC NULLS FIRST], false, 0
+Input [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: [c_birth_country#60 ASC NULLS FIRST, s_zip#50 ASC NULLS FIRST], false, 0
 
 (84) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#65, ca_zip#66, ca_country#67]
+Output [3]: [ca_state#63, ca_zip#64, ca_country#65]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
 (85) ColumnarToRow [codegen id : 16]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
+Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
 
 (86) Filter [codegen id : 16]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Condition : (isnotnull(ca_country#67) AND isnotnull(ca_zip#66))
+Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
+Condition : (isnotnull(ca_country#65) AND isnotnull(ca_zip#64))
 
 (87) Exchange
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Arguments: hashpartitioning(upper(ca_country#67), ca_zip#66, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
+Arguments: hashpartitioning(upper(ca_country#65), ca_zip#64, 5), ENSURE_REQUIREMENTS, [plan_id=18]
 
 (88) Sort [codegen id : 17]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Arguments: [upper(ca_country#67) ASC NULLS FIRST, ca_zip#66 ASC NULLS FIRST], false, 0
+Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
+Arguments: [upper(ca_country#65) ASC NULLS FIRST, ca_zip#64 ASC NULLS FIRST], false, 0
 
 (89) SortMergeJoin [codegen id : 18]
-Left keys [2]: [c_birth_country#62, s_zip#52]
-Right keys [2]: [upper(ca_country#67), ca_zip#66]
+Left keys [2]: [c_birth_country#60, s_zip#50]
+Right keys [2]: [upper(ca_country#65), ca_zip#64]
 Join type: Inner
 Join condition: None
 
 (90) Project [codegen id : 18]
-Output [11]: [ss_net_paid#46, s_store_name#49, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, ca_state#65]
-Input [15]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62, ca_state#65, ca_zip#66, ca_country#67]
+Output [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#63]
+Input [15]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, ca_state#63, ca_zip#64, ca_country#65]
 
 (91) HashAggregate [codegen id : 18]
-Input [11]: [ss_net_paid#46, s_store_name#49, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, ca_state#65]
-Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#46))]
-Aggregate Attributes [1]: [sum#68]
-Results [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
+Input [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#63]
+Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#44))]
+Aggregate Attributes [1]: [sum#66]
+Results [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
 
 (92) Exchange
-Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
-Arguments: hashpartitioning(c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
+Arguments: hashpartitioning(c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, 5), ENSURE_REQUIREMENTS, [plan_id=19]
 
 (93) HashAggregate [codegen id : 19]
-Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
-Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#46))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#46))#32]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#46))#32,17,2) AS netpaid#70]
+Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
+Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#44))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#44))#31]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#44))#31,17,2) AS netpaid#68]
 
 (94) HashAggregate [codegen id : 19]
-Input [1]: [netpaid#70]
+Input [1]: [netpaid#68]
 Keys: []
-Functions [1]: [partial_avg(netpaid#70)]
-Aggregate Attributes [2]: [sum#71, count#72]
-Results [2]: [sum#73, count#74]
+Functions [1]: [partial_avg(netpaid#68)]
+Aggregate Attributes [2]: [sum#69, count#70]
+Results [2]: [sum#71, count#72]
 
 (95) Exchange
-Input [2]: [sum#73, count#74]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
+Input [2]: [sum#71, count#72]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=20]
 
 (96) HashAggregate [codegen id : 20]
-Input [2]: [sum#73, count#74]
+Input [2]: [sum#71, count#72]
 Keys: []
-Functions [1]: [avg(netpaid#70)]
-Aggregate Attributes [1]: [avg(netpaid#70)#75]
-Results [1]: [(0.05 * avg(netpaid#70)#75) AS (0.05 * avg(netpaid))#76]
+Functions [1]: [avg(netpaid#68)]
+Aggregate Attributes [1]: [avg(netpaid#68)#73]
+Results [1]: [(0.05 * avg(netpaid#68)#73) AS (0.05 * avg(netpaid))#74]
 
-Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#1]
 ObjectHashAggregate (103)
 +- Exchange (102)
    +- ObjectHashAggregate (101)
@@ -559,39 +559,39 @@ ObjectHashAggregate (103)
 
 
 (97) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
+Output [3]: [s_store_sk#21, s_market_id#23, s_zip#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_market_id:int,s_zip:string>
 
 (98) ColumnarToRow [codegen id : 1]
-Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
+Input [3]: [s_store_sk#21, s_market_id#23, s_zip#25]
 
 (99) Filter [codegen id : 1]
-Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
-Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
+Input [3]: [s_store_sk#21, s_market_id#23, s_zip#25]
+Condition : (((isnotnull(s_market_id#23) AND (s_market_id#23 = 8)) AND isnotnull(s_store_sk#21)) AND isnotnull(s_zip#25))
 
 (100) Project [codegen id : 1]
-Output [1]: [s_store_sk#22]
-Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
+Output [1]: [s_store_sk#21]
+Input [3]: [s_store_sk#21, s_market_id#23, s_zip#25]
 
 (101) ObjectHashAggregate
-Input [1]: [s_store_sk#22]
+Input [1]: [s_store_sk#21]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)]
-Aggregate Attributes [1]: [buf#77]
-Results [1]: [buf#78]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(s_store_sk#21, 42), 40, 1250, 0, 0)]
+Aggregate Attributes [1]: [buf#75]
+Results [1]: [buf#76]
 
 (102) Exchange
-Input [1]: [buf#78]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
+Input [1]: [buf#76]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=21]
 
 (103) ObjectHashAggregate
-Input [1]: [buf#78]
+Input [1]: [buf#76]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#79]
-Results [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#79 AS bloomFilter#80]
+Functions [1]: [bloom_filter_agg(xxhash64(s_store_sk#21, 42), 40, 1250, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(s_store_sk#21, 42), 40, 1250, 0, 0)#77]
+Results [1]: [bloom_filter_agg(xxhash64(s_store_sk#21, 42), 40, 1250, 0, 0)#77 AS bloomFilter#78]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b/explain.txt
@@ -263,11 +263,11 @@ Results [4]: [c_last_name#23, c_first_name#22, s_store_name#11, sum(netpaid#31)#
 
 (46) Filter [codegen id : 11]
 Input [4]: [c_last_name#23, c_first_name#22, s_store_name#11, paid#37]
-Condition : (isnotnull(paid#37) AND (cast(paid#37 as decimal(33,8)) > cast(Subquery scalar-subquery#38, [id=#39] as decimal(33,8))))
+Condition : (isnotnull(paid#37) AND (cast(paid#37 as decimal(33,8)) > cast(Subquery scalar-subquery#38, [id=#9] as decimal(33,8))))
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquery#38, [id=#39]
+Subquery:1 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquery#38, [id=#9]
 * HashAggregate (73)
 +- Exchange (72)
    +- * HashAggregate (71)
@@ -298,130 +298,130 @@ Subquery:1 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquer
 
 
 (47) ReusedExchange [Reuses operator id: 5]
-Output [5]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44]
+Output [5]: [ss_item_sk#39, ss_customer_sk#40, ss_store_sk#41, ss_ticket_number#42, ss_net_paid#43]
 
 (48) Sort [codegen id : 2]
-Input [5]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44]
-Arguments: [ss_ticket_number#43 ASC NULLS FIRST, ss_item_sk#40 ASC NULLS FIRST], false, 0
+Input [5]: [ss_item_sk#39, ss_customer_sk#40, ss_store_sk#41, ss_ticket_number#42, ss_net_paid#43]
+Arguments: [ss_ticket_number#42 ASC NULLS FIRST, ss_item_sk#39 ASC NULLS FIRST], false, 0
 
 (49) ReusedExchange [Reuses operator id: 11]
-Output [2]: [sr_item_sk#45, sr_ticket_number#46]
+Output [2]: [sr_item_sk#44, sr_ticket_number#45]
 
 (50) Sort [codegen id : 4]
-Input [2]: [sr_item_sk#45, sr_ticket_number#46]
-Arguments: [sr_ticket_number#46 ASC NULLS FIRST, sr_item_sk#45 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#44, sr_ticket_number#45]
+Arguments: [sr_ticket_number#45 ASC NULLS FIRST, sr_item_sk#44 ASC NULLS FIRST], false, 0
 
 (51) SortMergeJoin [codegen id : 9]
-Left keys [2]: [ss_ticket_number#43, ss_item_sk#40]
-Right keys [2]: [sr_ticket_number#46, sr_item_sk#45]
+Left keys [2]: [ss_ticket_number#42, ss_item_sk#39]
+Right keys [2]: [sr_ticket_number#45, sr_item_sk#44]
 Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 9]
-Output [4]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_net_paid#44]
-Input [7]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, sr_item_sk#45, sr_ticket_number#46]
+Output [4]: [ss_item_sk#39, ss_customer_sk#40, ss_store_sk#41, ss_net_paid#43]
+Input [7]: [ss_item_sk#39, ss_customer_sk#40, ss_store_sk#41, ss_ticket_number#42, ss_net_paid#43, sr_item_sk#44, sr_ticket_number#45]
 
 (53) ReusedExchange [Reuses operator id: 19]
-Output [4]: [s_store_sk#47, s_store_name#48, s_state#49, s_zip#50]
+Output [4]: [s_store_sk#46, s_store_name#47, s_state#48, s_zip#49]
 
 (54) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ss_store_sk#42]
-Right keys [1]: [s_store_sk#47]
+Left keys [1]: [ss_store_sk#41]
+Right keys [1]: [s_store_sk#46]
 Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 9]
-Output [6]: [ss_item_sk#40, ss_customer_sk#41, ss_net_paid#44, s_store_name#48, s_state#49, s_zip#50]
-Input [8]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_net_paid#44, s_store_sk#47, s_store_name#48, s_state#49, s_zip#50]
+Output [6]: [ss_item_sk#39, ss_customer_sk#40, ss_net_paid#43, s_store_name#47, s_state#48, s_zip#49]
+Input [8]: [ss_item_sk#39, ss_customer_sk#40, ss_store_sk#41, ss_net_paid#43, s_store_sk#46, s_store_name#47, s_state#48, s_zip#49]
 
 (56) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Output [6]: [i_item_sk#50, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (57) ColumnarToRow [codegen id : 6]
-Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Input [6]: [i_item_sk#50, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
 
 (58) Filter [codegen id : 6]
-Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Condition : isnotnull(i_item_sk#51)
+Input [6]: [i_item_sk#50, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
+Condition : isnotnull(i_item_sk#50)
 
 (59) BroadcastExchange
-Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
+Input [6]: [i_item_sk#50, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=10]
 
 (60) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ss_item_sk#40]
-Right keys [1]: [i_item_sk#51]
+Left keys [1]: [ss_item_sk#39]
+Right keys [1]: [i_item_sk#50]
 Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 9]
-Output [10]: [ss_customer_sk#41, ss_net_paid#44, s_store_name#48, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_net_paid#44, s_store_name#48, s_state#49, s_zip#50, i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Output [10]: [ss_customer_sk#40, ss_net_paid#43, s_store_name#47, s_state#48, s_zip#49, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
+Input [12]: [ss_item_sk#39, ss_customer_sk#40, ss_net_paid#43, s_store_name#47, s_state#48, s_zip#49, i_item_sk#50, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
 
 (62) ReusedExchange [Reuses operator id: 31]
-Output [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Output [4]: [c_customer_sk#56, c_first_name#57, c_last_name#58, c_birth_country#59]
 
 (63) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ss_customer_sk#41]
-Right keys [1]: [c_customer_sk#57]
+Left keys [1]: [ss_customer_sk#40]
+Right keys [1]: [c_customer_sk#56]
 Join type: Inner
 Join condition: None
 
 (64) Project [codegen id : 9]
-Output [12]: [ss_net_paid#44, s_store_name#48, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Input [14]: [ss_customer_sk#41, ss_net_paid#44, s_store_name#48, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Output [12]: [ss_net_paid#43, s_store_name#47, s_state#48, s_zip#49, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55, c_first_name#57, c_last_name#58, c_birth_country#59]
+Input [14]: [ss_customer_sk#40, ss_net_paid#43, s_store_name#47, s_state#48, s_zip#49, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55, c_customer_sk#56, c_first_name#57, c_last_name#58, c_birth_country#59]
 
 (65) ReusedExchange [Reuses operator id: 37]
-Output [3]: [ca_state#61, ca_zip#62, ca_country#63]
+Output [3]: [ca_state#60, ca_zip#61, ca_country#62]
 
 (66) BroadcastHashJoin [codegen id : 9]
-Left keys [2]: [c_birth_country#60, s_zip#50]
-Right keys [2]: [upper(ca_country#63), ca_zip#62]
+Left keys [2]: [c_birth_country#59, s_zip#49]
+Right keys [2]: [upper(ca_country#62), ca_zip#61]
 Join type: Inner
 Join condition: None
 
 (67) Project [codegen id : 9]
-Output [11]: [ss_net_paid#44, s_store_name#48, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#61]
-Input [15]: [ss_net_paid#44, s_store_name#48, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, ca_state#61, ca_zip#62, ca_country#63]
+Output [11]: [ss_net_paid#43, s_store_name#47, s_state#48, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55, c_first_name#57, c_last_name#58, ca_state#60]
+Input [15]: [ss_net_paid#43, s_store_name#47, s_state#48, s_zip#49, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55, c_first_name#57, c_last_name#58, c_birth_country#59, ca_state#60, ca_zip#61, ca_country#62]
 
 (68) HashAggregate [codegen id : 9]
-Input [11]: [ss_net_paid#44, s_store_name#48, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#61]
-Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#48, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#44))]
-Aggregate Attributes [1]: [sum#64]
-Results [11]: [c_last_name#59, c_first_name#58, s_store_name#48, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#65]
+Input [11]: [ss_net_paid#43, s_store_name#47, s_state#48, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55, c_first_name#57, c_last_name#58, ca_state#60]
+Keys [10]: [c_last_name#58, c_first_name#57, s_store_name#47, ca_state#60, s_state#48, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#43))]
+Aggregate Attributes [1]: [sum#63]
+Results [11]: [c_last_name#58, c_first_name#57, s_store_name#47, ca_state#60, s_state#48, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52, sum#64]
 
 (69) Exchange
-Input [11]: [c_last_name#59, c_first_name#58, s_store_name#48, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#65]
-Arguments: hashpartitioning(c_last_name#59, c_first_name#58, s_store_name#48, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [11]: [c_last_name#58, c_first_name#57, s_store_name#47, ca_state#60, s_state#48, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52, sum#64]
+Arguments: hashpartitioning(c_last_name#58, c_first_name#57, s_store_name#47, ca_state#60, s_state#48, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (70) HashAggregate [codegen id : 10]
-Input [11]: [c_last_name#59, c_first_name#58, s_store_name#48, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#65]
-Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#48, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#44))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#44))#30]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#44))#30,17,2) AS netpaid#66]
+Input [11]: [c_last_name#58, c_first_name#57, s_store_name#47, ca_state#60, s_state#48, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52, sum#64]
+Keys [10]: [c_last_name#58, c_first_name#57, s_store_name#47, ca_state#60, s_state#48, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#43))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#43))#30]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#43))#30,17,2) AS netpaid#65]
 
 (71) HashAggregate [codegen id : 10]
-Input [1]: [netpaid#66]
+Input [1]: [netpaid#65]
 Keys: []
-Functions [1]: [partial_avg(netpaid#66)]
-Aggregate Attributes [2]: [sum#67, count#68]
-Results [2]: [sum#69, count#70]
+Functions [1]: [partial_avg(netpaid#65)]
+Aggregate Attributes [2]: [sum#66, count#67]
+Results [2]: [sum#68, count#69]
 
 (72) Exchange
-Input [2]: [sum#69, count#70]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
+Input [2]: [sum#68, count#69]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
 
 (73) HashAggregate [codegen id : 11]
-Input [2]: [sum#69, count#70]
+Input [2]: [sum#68, count#69]
 Keys: []
-Functions [1]: [avg(netpaid#66)]
-Aggregate Attributes [1]: [avg(netpaid#66)#71]
-Results [1]: [(0.05 * avg(netpaid#66)#71) AS (0.05 * avg(netpaid))#72]
+Functions [1]: [avg(netpaid#65)]
+Aggregate Attributes [1]: [avg(netpaid#65)#70]
+Results [1]: [(0.05 * avg(netpaid#65)#70) AS (0.05 * avg(netpaid))#71]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32.sf100/explain.txt
@@ -65,42 +65,42 @@ Input [3]: [cs_item_sk#3, cs_ext_discount_amt#4, cs_sold_date_sk#5]
 
 (8) Filter [codegen id : 3]
 Input [3]: [cs_item_sk#3, cs_ext_discount_amt#4, cs_sold_date_sk#5]
-Condition : (isnotnull(cs_item_sk#3) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(cs_item_sk#3, 42)))
+Condition : (isnotnull(cs_item_sk#3) AND might_contain(Subquery scalar-subquery#7, [id=#2], xxhash64(cs_item_sk#3, 42)))
 
 (9) ReusedExchange [Reuses operator id: 41]
-Output [1]: [d_date_sk#9]
+Output [1]: [d_date_sk#8]
 
 (10) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_sold_date_sk#5]
-Right keys [1]: [d_date_sk#9]
+Right keys [1]: [d_date_sk#8]
 Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 3]
 Output [2]: [cs_item_sk#3, cs_ext_discount_amt#4]
-Input [4]: [cs_item_sk#3, cs_ext_discount_amt#4, cs_sold_date_sk#5, d_date_sk#9]
+Input [4]: [cs_item_sk#3, cs_ext_discount_amt#4, cs_sold_date_sk#5, d_date_sk#8]
 
 (12) HashAggregate [codegen id : 3]
 Input [2]: [cs_item_sk#3, cs_ext_discount_amt#4]
 Keys [1]: [cs_item_sk#3]
 Functions [1]: [partial_avg(UnscaledValue(cs_ext_discount_amt#4))]
-Aggregate Attributes [2]: [sum#10, count#11]
-Results [3]: [cs_item_sk#3, sum#12, count#13]
+Aggregate Attributes [2]: [sum#9, count#10]
+Results [3]: [cs_item_sk#3, sum#11, count#12]
 
 (13) Exchange
-Input [3]: [cs_item_sk#3, sum#12, count#13]
-Arguments: hashpartitioning(cs_item_sk#3, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [3]: [cs_item_sk#3, sum#11, count#12]
+Arguments: hashpartitioning(cs_item_sk#3, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (14) HashAggregate
-Input [3]: [cs_item_sk#3, sum#12, count#13]
+Input [3]: [cs_item_sk#3, sum#11, count#12]
 Keys [1]: [cs_item_sk#3]
 Functions [1]: [avg(UnscaledValue(cs_ext_discount_amt#4))]
-Aggregate Attributes [1]: [avg(UnscaledValue(cs_ext_discount_amt#4))#14]
-Results [2]: [(1.3 * cast((avg(UnscaledValue(cs_ext_discount_amt#4))#14 / 100.0) as decimal(11,6))) AS (1.3 * avg(cs_ext_discount_amt))#15, cs_item_sk#3]
+Aggregate Attributes [1]: [avg(UnscaledValue(cs_ext_discount_amt#4))#13]
+Results [2]: [(1.3 * cast((avg(UnscaledValue(cs_ext_discount_amt#4))#13 / 100.0) as decimal(11,6))) AS (1.3 * avg(cs_ext_discount_amt))#14, cs_item_sk#3]
 
 (15) Filter
-Input [2]: [(1.3 * avg(cs_ext_discount_amt))#15, cs_item_sk#3]
-Condition : isnotnull((1.3 * avg(cs_ext_discount_amt))#15)
+Input [2]: [(1.3 * avg(cs_ext_discount_amt))#14, cs_item_sk#3]
+Condition : isnotnull((1.3 * avg(cs_ext_discount_amt))#14)
 
 (16) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
@@ -109,72 +109,72 @@ Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 4]
-Output [2]: [i_item_sk#1, (1.3 * avg(cs_ext_discount_amt))#15]
-Input [3]: [i_item_sk#1, (1.3 * avg(cs_ext_discount_amt))#15, cs_item_sk#3]
+Output [2]: [i_item_sk#1, (1.3 * avg(cs_ext_discount_amt))#14]
+Input [3]: [i_item_sk#1, (1.3 * avg(cs_ext_discount_amt))#14, cs_item_sk#3]
 
 (18) BroadcastExchange
-Input [2]: [i_item_sk#1, (1.3 * avg(cs_ext_discount_amt))#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
+Input [2]: [i_item_sk#1, (1.3 * avg(cs_ext_discount_amt))#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
 (19) Scan parquet spark_catalog.default.catalog_sales
-Output [3]: [cs_item_sk#16, cs_ext_discount_amt#17, cs_sold_date_sk#18]
+Output [3]: [cs_item_sk#15, cs_ext_discount_amt#16, cs_sold_date_sk#17]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#18), dynamicpruningexpression(cs_sold_date_sk#18 IN dynamicpruning#6)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#17), dynamicpruningexpression(cs_sold_date_sk#17 IN dynamicpruning#6)]
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_ext_discount_amt)]
 ReadSchema: struct<cs_item_sk:int,cs_ext_discount_amt:decimal(7,2)>
 
 (20) ColumnarToRow
-Input [3]: [cs_item_sk#16, cs_ext_discount_amt#17, cs_sold_date_sk#18]
+Input [3]: [cs_item_sk#15, cs_ext_discount_amt#16, cs_sold_date_sk#17]
 
 (21) Filter
-Input [3]: [cs_item_sk#16, cs_ext_discount_amt#17, cs_sold_date_sk#18]
-Condition : (isnotnull(cs_item_sk#16) AND isnotnull(cs_ext_discount_amt#17))
+Input [3]: [cs_item_sk#15, cs_ext_discount_amt#16, cs_sold_date_sk#17]
+Condition : (isnotnull(cs_item_sk#15) AND isnotnull(cs_ext_discount_amt#16))
 
 (22) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [i_item_sk#1]
-Right keys [1]: [cs_item_sk#16]
+Right keys [1]: [cs_item_sk#15]
 Join type: Inner
-Join condition: (cast(cs_ext_discount_amt#17 as decimal(14,7)) > (1.3 * avg(cs_ext_discount_amt))#15)
+Join condition: (cast(cs_ext_discount_amt#16 as decimal(14,7)) > (1.3 * avg(cs_ext_discount_amt))#14)
 
 (23) Project [codegen id : 6]
-Output [2]: [cs_ext_discount_amt#17, cs_sold_date_sk#18]
-Input [5]: [i_item_sk#1, (1.3 * avg(cs_ext_discount_amt))#15, cs_item_sk#16, cs_ext_discount_amt#17, cs_sold_date_sk#18]
+Output [2]: [cs_ext_discount_amt#16, cs_sold_date_sk#17]
+Input [5]: [i_item_sk#1, (1.3 * avg(cs_ext_discount_amt))#14, cs_item_sk#15, cs_ext_discount_amt#16, cs_sold_date_sk#17]
 
 (24) ReusedExchange [Reuses operator id: 41]
-Output [1]: [d_date_sk#19]
+Output [1]: [d_date_sk#18]
 
 (25) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [cs_sold_date_sk#18]
-Right keys [1]: [d_date_sk#19]
+Left keys [1]: [cs_sold_date_sk#17]
+Right keys [1]: [d_date_sk#18]
 Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 6]
-Output [1]: [cs_ext_discount_amt#17]
-Input [3]: [cs_ext_discount_amt#17, cs_sold_date_sk#18, d_date_sk#19]
+Output [1]: [cs_ext_discount_amt#16]
+Input [3]: [cs_ext_discount_amt#16, cs_sold_date_sk#17, d_date_sk#18]
 
 (27) HashAggregate [codegen id : 6]
-Input [1]: [cs_ext_discount_amt#17]
+Input [1]: [cs_ext_discount_amt#16]
 Keys: []
-Functions [1]: [partial_sum(UnscaledValue(cs_ext_discount_amt#17))]
-Aggregate Attributes [1]: [sum#20]
-Results [1]: [sum#21]
+Functions [1]: [partial_sum(UnscaledValue(cs_ext_discount_amt#16))]
+Aggregate Attributes [1]: [sum#19]
+Results [1]: [sum#20]
 
 (28) Exchange
-Input [1]: [sum#21]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=4]
+Input [1]: [sum#20]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
 
 (29) HashAggregate [codegen id : 7]
-Input [1]: [sum#21]
+Input [1]: [sum#20]
 Keys: []
-Functions [1]: [sum(UnscaledValue(cs_ext_discount_amt#17))]
-Aggregate Attributes [1]: [sum(UnscaledValue(cs_ext_discount_amt#17))#22]
-Results [1]: [MakeDecimal(sum(UnscaledValue(cs_ext_discount_amt#17))#22,17,2) AS excess discount amount#23]
+Functions [1]: [sum(UnscaledValue(cs_ext_discount_amt#16))]
+Aggregate Attributes [1]: [sum(UnscaledValue(cs_ext_discount_amt#16))#21]
+Results [1]: [MakeDecimal(sum(UnscaledValue(cs_ext_discount_amt#16))#21,17,2) AS excess discount amount#22]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 8 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+Subquery:1 Hosting operator id = 8 Hosting Expression = Subquery scalar-subquery#7, [id=#2]
 ObjectHashAggregate (36)
 +- Exchange (35)
    +- ObjectHashAggregate (34)
@@ -206,19 +206,19 @@ Input [2]: [i_item_sk#1, i_manufact_id#2]
 Input [1]: [i_item_sk#1]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)]
-Aggregate Attributes [1]: [buf#24]
-Results [1]: [buf#25]
+Aggregate Attributes [1]: [buf#23]
+Results [1]: [buf#24]
 
 (35) Exchange
-Input [1]: [buf#25]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
+Input [1]: [buf#24]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
 
 (36) ObjectHashAggregate
-Input [1]: [buf#25]
+Input [1]: [buf#24]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)#26]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)#26 AS bloomFilter#27]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)#25]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)#25 AS bloomFilter#26]
 
 Subquery:2 Hosting operator id = 6 Hosting Expression = cs_sold_date_sk#5 IN dynamicpruning#6
 BroadcastExchange (41)
@@ -229,27 +229,27 @@ BroadcastExchange (41)
 
 
 (37) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#9, d_date#28]
+Output [2]: [d_date_sk#8, d_date#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-01-27), LessThanOrEqual(d_date,2000-04-26), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (38) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#9, d_date#28]
+Input [2]: [d_date_sk#8, d_date#27]
 
 (39) Filter [codegen id : 1]
-Input [2]: [d_date_sk#9, d_date#28]
-Condition : (((isnotnull(d_date#28) AND (d_date#28 >= 2000-01-27)) AND (d_date#28 <= 2000-04-26)) AND isnotnull(d_date_sk#9))
+Input [2]: [d_date_sk#8, d_date#27]
+Condition : (((isnotnull(d_date#27) AND (d_date#27 >= 2000-01-27)) AND (d_date#27 <= 2000-04-26)) AND isnotnull(d_date_sk#8))
 
 (40) Project [codegen id : 1]
-Output [1]: [d_date_sk#9]
-Input [2]: [d_date_sk#9, d_date#28]
+Output [1]: [d_date_sk#8]
+Input [2]: [d_date_sk#8, d_date#27]
 
 (41) BroadcastExchange
-Input [1]: [d_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+Input [1]: [d_date_sk#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
-Subquery:3 Hosting operator id = 19 Hosting Expression = cs_sold_date_sk#18 IN dynamicpruning#6
+Subquery:3 Hosting operator id = 19 Hosting Expression = cs_sold_date_sk#17 IN dynamicpruning#6
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
@@ -113,7 +113,7 @@ Input [2]: [cs_item_sk#11, cs_sold_date_sk#12]
 
 (19) Filter [codegen id : 5]
 Input [2]: [cs_item_sk#11, cs_sold_date_sk#12]
-Condition : (isnotnull(cs_item_sk#11) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(cs_item_sk#11, 42)))
+Condition : (isnotnull(cs_item_sk#11) AND might_contain(Subquery scalar-subquery#13, [id=#3], xxhash64(cs_item_sk#11, 42)))
 
 (20) Project [codegen id : 5]
 Output [1]: [cs_item_sk#11]
@@ -121,7 +121,7 @@ Input [2]: [cs_item_sk#11, cs_sold_date_sk#12]
 
 (21) Exchange
 Input [1]: [cs_item_sk#11]
-Arguments: hashpartitioning(cs_item_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Arguments: hashpartitioning(cs_item_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (22) Sort [codegen id : 6]
 Input [1]: [cs_item_sk#11]
@@ -146,7 +146,7 @@ Results [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 
 (26) Exchange
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
-Arguments: hashpartitioning(i_item_id#2, i_item_desc#3, i_current_price#4, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Arguments: hashpartitioning(i_item_id#2, i_item_desc#3, i_current_price#4, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (27) HashAggregate [codegen id : 8]
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
@@ -170,28 +170,28 @@ BroadcastExchange (33)
 
 
 (29) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#10, d_date#15]
+Output [2]: [d_date_sk#10, d_date#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-02-01), LessThanOrEqual(d_date,2000-04-01), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#15]
+Input [2]: [d_date_sk#10, d_date#14]
 
 (31) Filter [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#15]
-Condition : (((isnotnull(d_date#15) AND (d_date#15 >= 2000-02-01)) AND (d_date#15 <= 2000-04-01)) AND isnotnull(d_date_sk#10))
+Input [2]: [d_date_sk#10, d_date#14]
+Condition : (((isnotnull(d_date#14) AND (d_date#14 >= 2000-02-01)) AND (d_date#14 <= 2000-04-01)) AND isnotnull(d_date_sk#10))
 
 (32) Project [codegen id : 1]
 Output [1]: [d_date_sk#10]
-Input [2]: [d_date_sk#10, d_date#15]
+Input [2]: [d_date_sk#10, d_date#14]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
-Subquery:2 Hosting operator id = 19 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
+Subquery:2 Hosting operator id = 19 Hosting Expression = Subquery scalar-subquery#13, [id=#3]
 ObjectHashAggregate (40)
 +- Exchange (39)
    +- ObjectHashAggregate (38)
@@ -223,18 +223,18 @@ Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
 Input [1]: [i_item_sk#1]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)]
-Aggregate Attributes [1]: [buf#16]
-Results [1]: [buf#17]
+Aggregate Attributes [1]: [buf#15]
+Results [1]: [buf#16]
 
 (39) Exchange
-Input [1]: [buf#17]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
+Input [1]: [buf#16]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
 (40) ObjectHashAggregate
-Input [1]: [buf#17]
+Input [1]: [buf#16]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#18]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#18 AS bloomFilter#19]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#17]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#17 AS bloomFilter#18]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40.sf100/explain.txt
@@ -47,150 +47,150 @@ Input [5]: [cs_warehouse_sk#1, cs_item_sk#2, cs_order_number#3, cs_sales_price#4
 
 (3) Filter [codegen id : 1]
 Input [5]: [cs_warehouse_sk#1, cs_item_sk#2, cs_order_number#3, cs_sales_price#4, cs_sold_date_sk#5]
-Condition : ((isnotnull(cs_warehouse_sk#1) AND isnotnull(cs_item_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(cs_item_sk#2, 42)))
+Condition : ((isnotnull(cs_warehouse_sk#1) AND isnotnull(cs_item_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#1], xxhash64(cs_item_sk#2, 42)))
 
 (4) Exchange
 Input [5]: [cs_warehouse_sk#1, cs_item_sk#2, cs_order_number#3, cs_sales_price#4, cs_sold_date_sk#5]
-Arguments: hashpartitioning(cs_order_number#3, cs_item_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=1]
+Arguments: hashpartitioning(cs_order_number#3, cs_item_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (5) Sort [codegen id : 2]
 Input [5]: [cs_warehouse_sk#1, cs_item_sk#2, cs_order_number#3, cs_sales_price#4, cs_sold_date_sk#5]
 Arguments: [cs_order_number#3 ASC NULLS FIRST, cs_item_sk#2 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.catalog_returns
-Output [4]: [cr_item_sk#9, cr_order_number#10, cr_refunded_cash#11, cr_returned_date_sk#12]
+Output [4]: [cr_item_sk#8, cr_order_number#9, cr_refunded_cash#10, cr_returned_date_sk#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
 PushedFilters: [IsNotNull(cr_order_number), IsNotNull(cr_item_sk)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_refunded_cash:decimal(7,2)>
 
 (7) ColumnarToRow [codegen id : 3]
-Input [4]: [cr_item_sk#9, cr_order_number#10, cr_refunded_cash#11, cr_returned_date_sk#12]
+Input [4]: [cr_item_sk#8, cr_order_number#9, cr_refunded_cash#10, cr_returned_date_sk#11]
 
 (8) Filter [codegen id : 3]
-Input [4]: [cr_item_sk#9, cr_order_number#10, cr_refunded_cash#11, cr_returned_date_sk#12]
-Condition : (isnotnull(cr_order_number#10) AND isnotnull(cr_item_sk#9))
+Input [4]: [cr_item_sk#8, cr_order_number#9, cr_refunded_cash#10, cr_returned_date_sk#11]
+Condition : (isnotnull(cr_order_number#9) AND isnotnull(cr_item_sk#8))
 
 (9) Project [codegen id : 3]
-Output [3]: [cr_item_sk#9, cr_order_number#10, cr_refunded_cash#11]
-Input [4]: [cr_item_sk#9, cr_order_number#10, cr_refunded_cash#11, cr_returned_date_sk#12]
+Output [3]: [cr_item_sk#8, cr_order_number#9, cr_refunded_cash#10]
+Input [4]: [cr_item_sk#8, cr_order_number#9, cr_refunded_cash#10, cr_returned_date_sk#11]
 
 (10) Exchange
-Input [3]: [cr_item_sk#9, cr_order_number#10, cr_refunded_cash#11]
-Arguments: hashpartitioning(cr_order_number#10, cr_item_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [3]: [cr_item_sk#8, cr_order_number#9, cr_refunded_cash#10]
+Arguments: hashpartitioning(cr_order_number#9, cr_item_sk#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (11) Sort [codegen id : 4]
-Input [3]: [cr_item_sk#9, cr_order_number#10, cr_refunded_cash#11]
-Arguments: [cr_order_number#10 ASC NULLS FIRST, cr_item_sk#9 ASC NULLS FIRST], false, 0
+Input [3]: [cr_item_sk#8, cr_order_number#9, cr_refunded_cash#10]
+Arguments: [cr_order_number#9 ASC NULLS FIRST, cr_item_sk#8 ASC NULLS FIRST], false, 0
 
 (12) SortMergeJoin [codegen id : 8]
 Left keys [2]: [cs_order_number#3, cs_item_sk#2]
-Right keys [2]: [cr_order_number#10, cr_item_sk#9]
+Right keys [2]: [cr_order_number#9, cr_item_sk#8]
 Join type: LeftOuter
 Join condition: None
 
 (13) Project [codegen id : 8]
-Output [5]: [cs_warehouse_sk#1, cs_item_sk#2, cs_sales_price#4, cs_sold_date_sk#5, cr_refunded_cash#11]
-Input [8]: [cs_warehouse_sk#1, cs_item_sk#2, cs_order_number#3, cs_sales_price#4, cs_sold_date_sk#5, cr_item_sk#9, cr_order_number#10, cr_refunded_cash#11]
+Output [5]: [cs_warehouse_sk#1, cs_item_sk#2, cs_sales_price#4, cs_sold_date_sk#5, cr_refunded_cash#10]
+Input [8]: [cs_warehouse_sk#1, cs_item_sk#2, cs_order_number#3, cs_sales_price#4, cs_sold_date_sk#5, cr_item_sk#8, cr_order_number#9, cr_refunded_cash#10]
 
 (14) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#13, i_item_id#14, i_current_price#15]
+Output [3]: [i_item_sk#12, i_item_id#13, i_current_price#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_current_price), GreaterThanOrEqual(i_current_price,0.99), LessThanOrEqual(i_current_price,1.49), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_current_price:decimal(7,2)>
 
 (15) ColumnarToRow [codegen id : 5]
-Input [3]: [i_item_sk#13, i_item_id#14, i_current_price#15]
+Input [3]: [i_item_sk#12, i_item_id#13, i_current_price#14]
 
 (16) Filter [codegen id : 5]
-Input [3]: [i_item_sk#13, i_item_id#14, i_current_price#15]
-Condition : (((isnotnull(i_current_price#15) AND (i_current_price#15 >= 0.99)) AND (i_current_price#15 <= 1.49)) AND isnotnull(i_item_sk#13))
+Input [3]: [i_item_sk#12, i_item_id#13, i_current_price#14]
+Condition : (((isnotnull(i_current_price#14) AND (i_current_price#14 >= 0.99)) AND (i_current_price#14 <= 1.49)) AND isnotnull(i_item_sk#12))
 
 (17) Project [codegen id : 5]
-Output [2]: [i_item_sk#13, i_item_id#14]
-Input [3]: [i_item_sk#13, i_item_id#14, i_current_price#15]
+Output [2]: [i_item_sk#12, i_item_id#13]
+Input [3]: [i_item_sk#12, i_item_id#13, i_current_price#14]
 
 (18) BroadcastExchange
-Input [2]: [i_item_sk#13, i_item_id#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
+Input [2]: [i_item_sk#12, i_item_id#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
 (19) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_item_sk#2]
-Right keys [1]: [i_item_sk#13]
+Right keys [1]: [i_item_sk#12]
 Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 8]
-Output [5]: [cs_warehouse_sk#1, cs_sales_price#4, cs_sold_date_sk#5, cr_refunded_cash#11, i_item_id#14]
-Input [7]: [cs_warehouse_sk#1, cs_item_sk#2, cs_sales_price#4, cs_sold_date_sk#5, cr_refunded_cash#11, i_item_sk#13, i_item_id#14]
+Output [5]: [cs_warehouse_sk#1, cs_sales_price#4, cs_sold_date_sk#5, cr_refunded_cash#10, i_item_id#13]
+Input [7]: [cs_warehouse_sk#1, cs_item_sk#2, cs_sales_price#4, cs_sold_date_sk#5, cr_refunded_cash#10, i_item_sk#12, i_item_id#13]
 
 (21) ReusedExchange [Reuses operator id: 44]
-Output [2]: [d_date_sk#16, d_date#17]
+Output [2]: [d_date_sk#15, d_date#16]
 
 (22) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_sold_date_sk#5]
-Right keys [1]: [d_date_sk#16]
+Right keys [1]: [d_date_sk#15]
 Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 8]
-Output [5]: [cs_warehouse_sk#1, cs_sales_price#4, cr_refunded_cash#11, i_item_id#14, d_date#17]
-Input [7]: [cs_warehouse_sk#1, cs_sales_price#4, cs_sold_date_sk#5, cr_refunded_cash#11, i_item_id#14, d_date_sk#16, d_date#17]
+Output [5]: [cs_warehouse_sk#1, cs_sales_price#4, cr_refunded_cash#10, i_item_id#13, d_date#16]
+Input [7]: [cs_warehouse_sk#1, cs_sales_price#4, cs_sold_date_sk#5, cr_refunded_cash#10, i_item_id#13, d_date_sk#15, d_date#16]
 
 (24) Scan parquet spark_catalog.default.warehouse
-Output [2]: [w_warehouse_sk#18, w_state#19]
+Output [2]: [w_warehouse_sk#17, w_state#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/warehouse]
 PushedFilters: [IsNotNull(w_warehouse_sk)]
 ReadSchema: struct<w_warehouse_sk:int,w_state:string>
 
 (25) ColumnarToRow [codegen id : 7]
-Input [2]: [w_warehouse_sk#18, w_state#19]
+Input [2]: [w_warehouse_sk#17, w_state#18]
 
 (26) Filter [codegen id : 7]
-Input [2]: [w_warehouse_sk#18, w_state#19]
-Condition : isnotnull(w_warehouse_sk#18)
+Input [2]: [w_warehouse_sk#17, w_state#18]
+Condition : isnotnull(w_warehouse_sk#17)
 
 (27) BroadcastExchange
-Input [2]: [w_warehouse_sk#18, w_state#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
+Input [2]: [w_warehouse_sk#17, w_state#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
 
 (28) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_warehouse_sk#1]
-Right keys [1]: [w_warehouse_sk#18]
+Right keys [1]: [w_warehouse_sk#17]
 Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 8]
-Output [5]: [cs_sales_price#4, cr_refunded_cash#11, w_state#19, i_item_id#14, d_date#17]
-Input [7]: [cs_warehouse_sk#1, cs_sales_price#4, cr_refunded_cash#11, i_item_id#14, d_date#17, w_warehouse_sk#18, w_state#19]
+Output [5]: [cs_sales_price#4, cr_refunded_cash#10, w_state#18, i_item_id#13, d_date#16]
+Input [7]: [cs_warehouse_sk#1, cs_sales_price#4, cr_refunded_cash#10, i_item_id#13, d_date#16, w_warehouse_sk#17, w_state#18]
 
 (30) HashAggregate [codegen id : 8]
-Input [5]: [cs_sales_price#4, cr_refunded_cash#11, w_state#19, i_item_id#14, d_date#17]
-Keys [2]: [w_state#19, i_item_id#14]
-Functions [2]: [partial_sum(CASE WHEN (d_date#17 < 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END), partial_sum(CASE WHEN (d_date#17 >= 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)]
-Aggregate Attributes [4]: [sum#20, isEmpty#21, sum#22, isEmpty#23]
-Results [6]: [w_state#19, i_item_id#14, sum#24, isEmpty#25, sum#26, isEmpty#27]
+Input [5]: [cs_sales_price#4, cr_refunded_cash#10, w_state#18, i_item_id#13, d_date#16]
+Keys [2]: [w_state#18, i_item_id#13]
+Functions [2]: [partial_sum(CASE WHEN (d_date#16 < 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#10 as decimal(12,2)), 0.00)) ELSE 0.00 END), partial_sum(CASE WHEN (d_date#16 >= 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#10 as decimal(12,2)), 0.00)) ELSE 0.00 END)]
+Aggregate Attributes [4]: [sum#19, isEmpty#20, sum#21, isEmpty#22]
+Results [6]: [w_state#18, i_item_id#13, sum#23, isEmpty#24, sum#25, isEmpty#26]
 
 (31) Exchange
-Input [6]: [w_state#19, i_item_id#14, sum#24, isEmpty#25, sum#26, isEmpty#27]
-Arguments: hashpartitioning(w_state#19, i_item_id#14, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [6]: [w_state#18, i_item_id#13, sum#23, isEmpty#24, sum#25, isEmpty#26]
+Arguments: hashpartitioning(w_state#18, i_item_id#13, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (32) HashAggregate [codegen id : 9]
-Input [6]: [w_state#19, i_item_id#14, sum#24, isEmpty#25, sum#26, isEmpty#27]
-Keys [2]: [w_state#19, i_item_id#14]
-Functions [2]: [sum(CASE WHEN (d_date#17 < 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END), sum(CASE WHEN (d_date#17 >= 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)]
-Aggregate Attributes [2]: [sum(CASE WHEN (d_date#17 < 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)#28, sum(CASE WHEN (d_date#17 >= 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)#29]
-Results [4]: [w_state#19, i_item_id#14, sum(CASE WHEN (d_date#17 < 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)#28 AS sales_before#30, sum(CASE WHEN (d_date#17 >= 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)#29 AS sales_after#31]
+Input [6]: [w_state#18, i_item_id#13, sum#23, isEmpty#24, sum#25, isEmpty#26]
+Keys [2]: [w_state#18, i_item_id#13]
+Functions [2]: [sum(CASE WHEN (d_date#16 < 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#10 as decimal(12,2)), 0.00)) ELSE 0.00 END), sum(CASE WHEN (d_date#16 >= 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#10 as decimal(12,2)), 0.00)) ELSE 0.00 END)]
+Aggregate Attributes [2]: [sum(CASE WHEN (d_date#16 < 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#10 as decimal(12,2)), 0.00)) ELSE 0.00 END)#27, sum(CASE WHEN (d_date#16 >= 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#10 as decimal(12,2)), 0.00)) ELSE 0.00 END)#28]
+Results [4]: [w_state#18, i_item_id#13, sum(CASE WHEN (d_date#16 < 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#10 as decimal(12,2)), 0.00)) ELSE 0.00 END)#27 AS sales_before#29, sum(CASE WHEN (d_date#16 >= 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#10 as decimal(12,2)), 0.00)) ELSE 0.00 END)#28 AS sales_after#30]
 
 (33) TakeOrderedAndProject
-Input [4]: [w_state#19, i_item_id#14, sales_before#30, sales_after#31]
-Arguments: 100, [w_state#19 ASC NULLS FIRST, i_item_id#14 ASC NULLS FIRST], [w_state#19, i_item_id#14, sales_before#30, sales_after#31]
+Input [4]: [w_state#18, i_item_id#13, sales_before#29, sales_after#30]
+Arguments: 100, [w_state#18 ASC NULLS FIRST, i_item_id#13 ASC NULLS FIRST], [w_state#18, i_item_id#13, sales_before#29, sales_after#30]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#1]
 ObjectHashAggregate (40)
 +- Exchange (39)
    +- ObjectHashAggregate (38)
@@ -201,40 +201,40 @@ ObjectHashAggregate (40)
 
 
 (34) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#13, i_current_price#15]
+Output [2]: [i_item_sk#12, i_current_price#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_current_price), GreaterThanOrEqual(i_current_price,0.99), LessThanOrEqual(i_current_price,1.49), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2)>
 
 (35) ColumnarToRow [codegen id : 1]
-Input [2]: [i_item_sk#13, i_current_price#15]
+Input [2]: [i_item_sk#12, i_current_price#14]
 
 (36) Filter [codegen id : 1]
-Input [2]: [i_item_sk#13, i_current_price#15]
-Condition : (((isnotnull(i_current_price#15) AND (i_current_price#15 >= 0.99)) AND (i_current_price#15 <= 1.49)) AND isnotnull(i_item_sk#13))
+Input [2]: [i_item_sk#12, i_current_price#14]
+Condition : (((isnotnull(i_current_price#14) AND (i_current_price#14 >= 0.99)) AND (i_current_price#14 <= 1.49)) AND isnotnull(i_item_sk#12))
 
 (37) Project [codegen id : 1]
-Output [1]: [i_item_sk#13]
-Input [2]: [i_item_sk#13, i_current_price#15]
+Output [1]: [i_item_sk#12]
+Input [2]: [i_item_sk#12, i_current_price#14]
 
 (38) ObjectHashAggregate
-Input [1]: [i_item_sk#13]
+Input [1]: [i_item_sk#12]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#13, 42), 1019, 24988, 0, 0)]
-Aggregate Attributes [1]: [buf#32]
-Results [1]: [buf#33]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#12, 42), 1019, 24988, 0, 0)]
+Aggregate Attributes [1]: [buf#31]
+Results [1]: [buf#32]
 
 (39) Exchange
-Input [1]: [buf#33]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
+Input [1]: [buf#32]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
 (40) ObjectHashAggregate
-Input [1]: [buf#33]
+Input [1]: [buf#32]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#13, 42), 1019, 24988, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#13, 42), 1019, 24988, 0, 0)#34]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#13, 42), 1019, 24988, 0, 0)#34 AS bloomFilter#35]
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#12, 42), 1019, 24988, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#12, 42), 1019, 24988, 0, 0)#33]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#12, 42), 1019, 24988, 0, 0)#33 AS bloomFilter#34]
 
 Subquery:2 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#5 IN dynamicpruning#6
 BroadcastExchange (44)
@@ -244,21 +244,21 @@ BroadcastExchange (44)
 
 
 (41) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#16, d_date#17]
+Output [2]: [d_date_sk#15, d_date#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-02-10), LessThanOrEqual(d_date,2000-04-10), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (42) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#16, d_date#17]
+Input [2]: [d_date_sk#15, d_date#16]
 
 (43) Filter [codegen id : 1]
-Input [2]: [d_date_sk#16, d_date#17]
-Condition : (((isnotnull(d_date#17) AND (d_date#17 >= 2000-02-10)) AND (d_date#17 <= 2000-04-10)) AND isnotnull(d_date_sk#16))
+Input [2]: [d_date_sk#15, d_date#16]
+Condition : (((isnotnull(d_date#16) AND (d_date#16 >= 2000-02-10)) AND (d_date#16 <= 2000-04-10)) AND isnotnull(d_date_sk#15))
 
 (44) BroadcastExchange
-Input [2]: [d_date_sk#16, d_date#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
+Input [2]: [d_date_sk#15, d_date#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44.sf100/explain.txt
@@ -79,7 +79,7 @@ Results [2]: [ss_item_sk#1 AS item_sk#10, cast((avg(UnscaledValue(ss_net_profit#
 
 (8) Filter [codegen id : 2]
 Input [2]: [item_sk#10, rank_col#11]
-Condition : (isnotnull(rank_col#11) AND (cast(rank_col#11 as decimal(13,7)) > (0.9 * Subquery scalar-subquery#12, [id=#13])))
+Condition : (isnotnull(rank_col#11) AND (cast(rank_col#11 as decimal(13,7)) > (0.9 * Subquery scalar-subquery#12, [id=#2])))
 
 (9) Sort [codegen id : 2]
 Input [2]: [item_sk#10, rank_col#11]
@@ -91,7 +91,7 @@ Arguments: [rank_col#11 ASC NULLS FIRST], rank(rank_col#11), 10, Partial
 
 (11) Exchange
 Input [2]: [item_sk#10, rank_col#11]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=2]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=3]
 
 (12) Sort [codegen id : 3]
 Input [2]: [item_sk#10, rank_col#11]
@@ -103,124 +103,124 @@ Arguments: [rank_col#11 ASC NULLS FIRST], rank(rank_col#11), 10, Final
 
 (14) Window
 Input [2]: [item_sk#10, rank_col#11]
-Arguments: [rank(rank_col#11) windowspecdefinition(rank_col#11 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#14], [rank_col#11 ASC NULLS FIRST]
+Arguments: [rank(rank_col#11) windowspecdefinition(rank_col#11 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#13], [rank_col#11 ASC NULLS FIRST]
 
 (15) Filter [codegen id : 10]
-Input [3]: [item_sk#10, rank_col#11, rnk#14]
-Condition : ((rnk#14 < 11) AND isnotnull(item_sk#10))
+Input [3]: [item_sk#10, rank_col#11, rnk#13]
+Condition : ((rnk#13 < 11) AND isnotnull(item_sk#10))
 
 (16) Project [codegen id : 10]
-Output [2]: [item_sk#10, rnk#14]
-Input [3]: [item_sk#10, rank_col#11, rnk#14]
+Output [2]: [item_sk#10, rnk#13]
+Input [3]: [item_sk#10, rank_col#11, rnk#13]
 
 (17) ReusedExchange [Reuses operator id: 6]
-Output [3]: [ss_item_sk#15, sum#16, count#17]
+Output [3]: [ss_item_sk#14, sum#15, count#16]
 
 (18) HashAggregate [codegen id : 5]
-Input [3]: [ss_item_sk#15, sum#16, count#17]
-Keys [1]: [ss_item_sk#15]
-Functions [1]: [avg(UnscaledValue(ss_net_profit#18))]
-Aggregate Attributes [1]: [avg(UnscaledValue(ss_net_profit#18))#19]
-Results [2]: [ss_item_sk#15 AS item_sk#20, cast((avg(UnscaledValue(ss_net_profit#18))#19 / 100.0) as decimal(11,6)) AS rank_col#21]
+Input [3]: [ss_item_sk#14, sum#15, count#16]
+Keys [1]: [ss_item_sk#14]
+Functions [1]: [avg(UnscaledValue(ss_net_profit#17))]
+Aggregate Attributes [1]: [avg(UnscaledValue(ss_net_profit#17))#18]
+Results [2]: [ss_item_sk#14 AS item_sk#19, cast((avg(UnscaledValue(ss_net_profit#17))#18 / 100.0) as decimal(11,6)) AS rank_col#20]
 
 (19) Filter [codegen id : 5]
-Input [2]: [item_sk#20, rank_col#21]
-Condition : (isnotnull(rank_col#21) AND (cast(rank_col#21 as decimal(13,7)) > (0.9 * ReusedSubquery Subquery scalar-subquery#12, [id=#13])))
+Input [2]: [item_sk#19, rank_col#20]
+Condition : (isnotnull(rank_col#20) AND (cast(rank_col#20 as decimal(13,7)) > (0.9 * ReusedSubquery Subquery scalar-subquery#12, [id=#2])))
 
 (20) Sort [codegen id : 5]
-Input [2]: [item_sk#20, rank_col#21]
-Arguments: [rank_col#21 DESC NULLS LAST], false, 0
+Input [2]: [item_sk#19, rank_col#20]
+Arguments: [rank_col#20 DESC NULLS LAST], false, 0
 
 (21) WindowGroupLimit
-Input [2]: [item_sk#20, rank_col#21]
-Arguments: [rank_col#21 DESC NULLS LAST], rank(rank_col#21), 10, Partial
+Input [2]: [item_sk#19, rank_col#20]
+Arguments: [rank_col#20 DESC NULLS LAST], rank(rank_col#20), 10, Partial
 
 (22) Exchange
-Input [2]: [item_sk#20, rank_col#21]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=3]
+Input [2]: [item_sk#19, rank_col#20]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=4]
 
 (23) Sort [codegen id : 6]
-Input [2]: [item_sk#20, rank_col#21]
-Arguments: [rank_col#21 DESC NULLS LAST], false, 0
+Input [2]: [item_sk#19, rank_col#20]
+Arguments: [rank_col#20 DESC NULLS LAST], false, 0
 
 (24) WindowGroupLimit
-Input [2]: [item_sk#20, rank_col#21]
-Arguments: [rank_col#21 DESC NULLS LAST], rank(rank_col#21), 10, Final
+Input [2]: [item_sk#19, rank_col#20]
+Arguments: [rank_col#20 DESC NULLS LAST], rank(rank_col#20), 10, Final
 
 (25) Window
-Input [2]: [item_sk#20, rank_col#21]
-Arguments: [rank(rank_col#21) windowspecdefinition(rank_col#21 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#22], [rank_col#21 DESC NULLS LAST]
+Input [2]: [item_sk#19, rank_col#20]
+Arguments: [rank(rank_col#20) windowspecdefinition(rank_col#20 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#21], [rank_col#20 DESC NULLS LAST]
 
 (26) Filter [codegen id : 7]
-Input [3]: [item_sk#20, rank_col#21, rnk#22]
-Condition : ((rnk#22 < 11) AND isnotnull(item_sk#20))
+Input [3]: [item_sk#19, rank_col#20, rnk#21]
+Condition : ((rnk#21 < 11) AND isnotnull(item_sk#19))
 
 (27) Project [codegen id : 7]
-Output [2]: [item_sk#20, rnk#22]
-Input [3]: [item_sk#20, rank_col#21, rnk#22]
+Output [2]: [item_sk#19, rnk#21]
+Input [3]: [item_sk#19, rank_col#20, rnk#21]
 
 (28) BroadcastExchange
-Input [2]: [item_sk#20, rnk#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false), [plan_id=4]
+Input [2]: [item_sk#19, rnk#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false), [plan_id=5]
 
 (29) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [rnk#14]
-Right keys [1]: [rnk#22]
+Left keys [1]: [rnk#13]
+Right keys [1]: [rnk#21]
 Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 10]
-Output [3]: [item_sk#10, rnk#14, item_sk#20]
-Input [4]: [item_sk#10, rnk#14, item_sk#20, rnk#22]
+Output [3]: [item_sk#10, rnk#13, item_sk#19]
+Input [4]: [item_sk#10, rnk#13, item_sk#19, rnk#21]
 
 (31) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#23, i_product_name#24]
+Output [2]: [i_item_sk#22, i_product_name#23]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_product_name:string>
 
 (32) ColumnarToRow [codegen id : 8]
-Input [2]: [i_item_sk#23, i_product_name#24]
+Input [2]: [i_item_sk#22, i_product_name#23]
 
 (33) Filter [codegen id : 8]
-Input [2]: [i_item_sk#23, i_product_name#24]
-Condition : isnotnull(i_item_sk#23)
+Input [2]: [i_item_sk#22, i_product_name#23]
+Condition : isnotnull(i_item_sk#22)
 
 (34) BroadcastExchange
-Input [2]: [i_item_sk#23, i_product_name#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
+Input [2]: [i_item_sk#22, i_product_name#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=6]
 
 (35) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [item_sk#10]
-Right keys [1]: [i_item_sk#23]
+Right keys [1]: [i_item_sk#22]
 Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 10]
-Output [3]: [rnk#14, item_sk#20, i_product_name#24]
-Input [5]: [item_sk#10, rnk#14, item_sk#20, i_item_sk#23, i_product_name#24]
+Output [3]: [rnk#13, item_sk#19, i_product_name#23]
+Input [5]: [item_sk#10, rnk#13, item_sk#19, i_item_sk#22, i_product_name#23]
 
 (37) ReusedExchange [Reuses operator id: 34]
-Output [2]: [i_item_sk#25, i_product_name#26]
+Output [2]: [i_item_sk#24, i_product_name#25]
 
 (38) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [item_sk#20]
-Right keys [1]: [i_item_sk#25]
+Left keys [1]: [item_sk#19]
+Right keys [1]: [i_item_sk#24]
 Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 10]
-Output [3]: [rnk#14, i_product_name#24 AS best_performing#27, i_product_name#26 AS worst_performing#28]
-Input [5]: [rnk#14, item_sk#20, i_product_name#24, i_item_sk#25, i_product_name#26]
+Output [3]: [rnk#13, i_product_name#23 AS best_performing#26, i_product_name#25 AS worst_performing#27]
+Input [5]: [rnk#13, item_sk#19, i_product_name#23, i_item_sk#24, i_product_name#25]
 
 (40) TakeOrderedAndProject
-Input [3]: [rnk#14, best_performing#27, worst_performing#28]
-Arguments: 100, [rnk#14 ASC NULLS FIRST], [rnk#14, best_performing#27, worst_performing#28]
+Input [3]: [rnk#13, best_performing#26, worst_performing#27]
+Arguments: 100, [rnk#13 ASC NULLS FIRST], [rnk#13, best_performing#26, worst_performing#27]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 8 Hosting Expression = Subquery scalar-subquery#12, [id=#13]
+Subquery:1 Hosting operator id = 8 Hosting Expression = Subquery scalar-subquery#12, [id=#2]
 * HashAggregate (47)
 +- Exchange (46)
    +- * HashAggregate (45)
@@ -231,41 +231,41 @@ Subquery:1 Hosting operator id = 8 Hosting Expression = Subquery scalar-subquery
 
 
 (41) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
+Output [4]: [ss_addr_sk#28, ss_store_sk#29, ss_net_profit#30, ss_sold_date_sk#31]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_store_sk), EqualTo(ss_store_sk,4), IsNull(ss_addr_sk)]
 ReadSchema: struct<ss_addr_sk:int,ss_store_sk:int,ss_net_profit:decimal(7,2)>
 
 (42) ColumnarToRow [codegen id : 1]
-Input [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
+Input [4]: [ss_addr_sk#28, ss_store_sk#29, ss_net_profit#30, ss_sold_date_sk#31]
 
 (43) Filter [codegen id : 1]
-Input [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
-Condition : ((isnotnull(ss_store_sk#30) AND (ss_store_sk#30 = 4)) AND isnull(ss_addr_sk#29))
+Input [4]: [ss_addr_sk#28, ss_store_sk#29, ss_net_profit#30, ss_sold_date_sk#31]
+Condition : ((isnotnull(ss_store_sk#29) AND (ss_store_sk#29 = 4)) AND isnull(ss_addr_sk#28))
 
 (44) Project [codegen id : 1]
-Output [2]: [ss_store_sk#30, ss_net_profit#31]
-Input [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
+Output [2]: [ss_store_sk#29, ss_net_profit#30]
+Input [4]: [ss_addr_sk#28, ss_store_sk#29, ss_net_profit#30, ss_sold_date_sk#31]
 
 (45) HashAggregate [codegen id : 1]
-Input [2]: [ss_store_sk#30, ss_net_profit#31]
-Keys [1]: [ss_store_sk#30]
-Functions [1]: [partial_avg(UnscaledValue(ss_net_profit#31))]
-Aggregate Attributes [2]: [sum#33, count#34]
-Results [3]: [ss_store_sk#30, sum#35, count#36]
+Input [2]: [ss_store_sk#29, ss_net_profit#30]
+Keys [1]: [ss_store_sk#29]
+Functions [1]: [partial_avg(UnscaledValue(ss_net_profit#30))]
+Aggregate Attributes [2]: [sum#32, count#33]
+Results [3]: [ss_store_sk#29, sum#34, count#35]
 
 (46) Exchange
-Input [3]: [ss_store_sk#30, sum#35, count#36]
-Arguments: hashpartitioning(ss_store_sk#30, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [3]: [ss_store_sk#29, sum#34, count#35]
+Arguments: hashpartitioning(ss_store_sk#29, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
 (47) HashAggregate [codegen id : 2]
-Input [3]: [ss_store_sk#30, sum#35, count#36]
-Keys [1]: [ss_store_sk#30]
-Functions [1]: [avg(UnscaledValue(ss_net_profit#31))]
-Aggregate Attributes [1]: [avg(UnscaledValue(ss_net_profit#31))#37]
-Results [1]: [cast((avg(UnscaledValue(ss_net_profit#31))#37 / 100.0) as decimal(11,6)) AS rank_col#38]
+Input [3]: [ss_store_sk#29, sum#34, count#35]
+Keys [1]: [ss_store_sk#29]
+Functions [1]: [avg(UnscaledValue(ss_net_profit#30))]
+Aggregate Attributes [1]: [avg(UnscaledValue(ss_net_profit#30))#36]
+Results [1]: [cast((avg(UnscaledValue(ss_net_profit#30))#36 / 100.0) as decimal(11,6)) AS rank_col#37]
 
-Subquery:2 Hosting operator id = 19 Hosting Expression = ReusedSubquery Subquery scalar-subquery#12, [id=#13]
+Subquery:2 Hosting operator id = 19 Hosting Expression = ReusedSubquery Subquery scalar-subquery#12, [id=#2]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/explain.txt
@@ -82,7 +82,7 @@ Results [2]: [ss_item_sk#1 AS item_sk#10, cast((avg(UnscaledValue(ss_net_profit#
 
 (8) Filter [codegen id : 2]
 Input [2]: [item_sk#10, rank_col#11]
-Condition : (isnotnull(rank_col#11) AND (cast(rank_col#11 as decimal(13,7)) > (0.9 * Subquery scalar-subquery#12, [id=#13])))
+Condition : (isnotnull(rank_col#11) AND (cast(rank_col#11 as decimal(13,7)) > (0.9 * Subquery scalar-subquery#12, [id=#2])))
 
 (9) Sort [codegen id : 2]
 Input [2]: [item_sk#10, rank_col#11]
@@ -94,7 +94,7 @@ Arguments: [rank_col#11 ASC NULLS FIRST], rank(rank_col#11), 10, Partial
 
 (11) Exchange
 Input [2]: [item_sk#10, rank_col#11]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=2]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=3]
 
 (12) Sort [codegen id : 3]
 Input [2]: [item_sk#10, rank_col#11]
@@ -106,136 +106,136 @@ Arguments: [rank_col#11 ASC NULLS FIRST], rank(rank_col#11), 10, Final
 
 (14) Window
 Input [2]: [item_sk#10, rank_col#11]
-Arguments: [rank(rank_col#11) windowspecdefinition(rank_col#11 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#14], [rank_col#11 ASC NULLS FIRST]
+Arguments: [rank(rank_col#11) windowspecdefinition(rank_col#11 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#13], [rank_col#11 ASC NULLS FIRST]
 
 (15) Filter [codegen id : 4]
-Input [3]: [item_sk#10, rank_col#11, rnk#14]
-Condition : ((rnk#14 < 11) AND isnotnull(item_sk#10))
+Input [3]: [item_sk#10, rank_col#11, rnk#13]
+Condition : ((rnk#13 < 11) AND isnotnull(item_sk#10))
 
 (16) Project [codegen id : 4]
-Output [2]: [item_sk#10, rnk#14]
-Input [3]: [item_sk#10, rank_col#11, rnk#14]
+Output [2]: [item_sk#10, rnk#13]
+Input [3]: [item_sk#10, rank_col#11, rnk#13]
 
 (17) Exchange
-Input [2]: [item_sk#10, rnk#14]
-Arguments: hashpartitioning(rnk#14, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [2]: [item_sk#10, rnk#13]
+Arguments: hashpartitioning(rnk#13, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (18) Sort [codegen id : 5]
-Input [2]: [item_sk#10, rnk#14]
-Arguments: [rnk#14 ASC NULLS FIRST], false, 0
+Input [2]: [item_sk#10, rnk#13]
+Arguments: [rnk#13 ASC NULLS FIRST], false, 0
 
 (19) ReusedExchange [Reuses operator id: 6]
-Output [3]: [ss_item_sk#15, sum#16, count#17]
+Output [3]: [ss_item_sk#14, sum#15, count#16]
 
 (20) HashAggregate [codegen id : 7]
-Input [3]: [ss_item_sk#15, sum#16, count#17]
-Keys [1]: [ss_item_sk#15]
-Functions [1]: [avg(UnscaledValue(ss_net_profit#18))]
-Aggregate Attributes [1]: [avg(UnscaledValue(ss_net_profit#18))#19]
-Results [2]: [ss_item_sk#15 AS item_sk#20, cast((avg(UnscaledValue(ss_net_profit#18))#19 / 100.0) as decimal(11,6)) AS rank_col#21]
+Input [3]: [ss_item_sk#14, sum#15, count#16]
+Keys [1]: [ss_item_sk#14]
+Functions [1]: [avg(UnscaledValue(ss_net_profit#17))]
+Aggregate Attributes [1]: [avg(UnscaledValue(ss_net_profit#17))#18]
+Results [2]: [ss_item_sk#14 AS item_sk#19, cast((avg(UnscaledValue(ss_net_profit#17))#18 / 100.0) as decimal(11,6)) AS rank_col#20]
 
 (21) Filter [codegen id : 7]
-Input [2]: [item_sk#20, rank_col#21]
-Condition : (isnotnull(rank_col#21) AND (cast(rank_col#21 as decimal(13,7)) > (0.9 * ReusedSubquery Subquery scalar-subquery#12, [id=#13])))
+Input [2]: [item_sk#19, rank_col#20]
+Condition : (isnotnull(rank_col#20) AND (cast(rank_col#20 as decimal(13,7)) > (0.9 * ReusedSubquery Subquery scalar-subquery#12, [id=#2])))
 
 (22) Sort [codegen id : 7]
-Input [2]: [item_sk#20, rank_col#21]
-Arguments: [rank_col#21 DESC NULLS LAST], false, 0
+Input [2]: [item_sk#19, rank_col#20]
+Arguments: [rank_col#20 DESC NULLS LAST], false, 0
 
 (23) WindowGroupLimit
-Input [2]: [item_sk#20, rank_col#21]
-Arguments: [rank_col#21 DESC NULLS LAST], rank(rank_col#21), 10, Partial
+Input [2]: [item_sk#19, rank_col#20]
+Arguments: [rank_col#20 DESC NULLS LAST], rank(rank_col#20), 10, Partial
 
 (24) Exchange
-Input [2]: [item_sk#20, rank_col#21]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=4]
+Input [2]: [item_sk#19, rank_col#20]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
 
 (25) Sort [codegen id : 8]
-Input [2]: [item_sk#20, rank_col#21]
-Arguments: [rank_col#21 DESC NULLS LAST], false, 0
+Input [2]: [item_sk#19, rank_col#20]
+Arguments: [rank_col#20 DESC NULLS LAST], false, 0
 
 (26) WindowGroupLimit
-Input [2]: [item_sk#20, rank_col#21]
-Arguments: [rank_col#21 DESC NULLS LAST], rank(rank_col#21), 10, Final
+Input [2]: [item_sk#19, rank_col#20]
+Arguments: [rank_col#20 DESC NULLS LAST], rank(rank_col#20), 10, Final
 
 (27) Window
-Input [2]: [item_sk#20, rank_col#21]
-Arguments: [rank(rank_col#21) windowspecdefinition(rank_col#21 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#22], [rank_col#21 DESC NULLS LAST]
+Input [2]: [item_sk#19, rank_col#20]
+Arguments: [rank(rank_col#20) windowspecdefinition(rank_col#20 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#21], [rank_col#20 DESC NULLS LAST]
 
 (28) Filter [codegen id : 9]
-Input [3]: [item_sk#20, rank_col#21, rnk#22]
-Condition : ((rnk#22 < 11) AND isnotnull(item_sk#20))
+Input [3]: [item_sk#19, rank_col#20, rnk#21]
+Condition : ((rnk#21 < 11) AND isnotnull(item_sk#19))
 
 (29) Project [codegen id : 9]
-Output [2]: [item_sk#20, rnk#22]
-Input [3]: [item_sk#20, rank_col#21, rnk#22]
+Output [2]: [item_sk#19, rnk#21]
+Input [3]: [item_sk#19, rank_col#20, rnk#21]
 
 (30) Exchange
-Input [2]: [item_sk#20, rnk#22]
-Arguments: hashpartitioning(rnk#22, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [2]: [item_sk#19, rnk#21]
+Arguments: hashpartitioning(rnk#21, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (31) Sort [codegen id : 10]
-Input [2]: [item_sk#20, rnk#22]
-Arguments: [rnk#22 ASC NULLS FIRST], false, 0
+Input [2]: [item_sk#19, rnk#21]
+Arguments: [rnk#21 ASC NULLS FIRST], false, 0
 
 (32) SortMergeJoin [codegen id : 13]
-Left keys [1]: [rnk#14]
-Right keys [1]: [rnk#22]
+Left keys [1]: [rnk#13]
+Right keys [1]: [rnk#21]
 Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 13]
-Output [3]: [item_sk#10, rnk#14, item_sk#20]
-Input [4]: [item_sk#10, rnk#14, item_sk#20, rnk#22]
+Output [3]: [item_sk#10, rnk#13, item_sk#19]
+Input [4]: [item_sk#10, rnk#13, item_sk#19, rnk#21]
 
 (34) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#23, i_product_name#24]
+Output [2]: [i_item_sk#22, i_product_name#23]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_product_name:string>
 
 (35) ColumnarToRow [codegen id : 11]
-Input [2]: [i_item_sk#23, i_product_name#24]
+Input [2]: [i_item_sk#22, i_product_name#23]
 
 (36) Filter [codegen id : 11]
-Input [2]: [i_item_sk#23, i_product_name#24]
-Condition : isnotnull(i_item_sk#23)
+Input [2]: [i_item_sk#22, i_product_name#23]
+Condition : isnotnull(i_item_sk#22)
 
 (37) BroadcastExchange
-Input [2]: [i_item_sk#23, i_product_name#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=6]
+Input [2]: [i_item_sk#22, i_product_name#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
 (38) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [item_sk#10]
-Right keys [1]: [i_item_sk#23]
+Right keys [1]: [i_item_sk#22]
 Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 13]
-Output [3]: [rnk#14, item_sk#20, i_product_name#24]
-Input [5]: [item_sk#10, rnk#14, item_sk#20, i_item_sk#23, i_product_name#24]
+Output [3]: [rnk#13, item_sk#19, i_product_name#23]
+Input [5]: [item_sk#10, rnk#13, item_sk#19, i_item_sk#22, i_product_name#23]
 
 (40) ReusedExchange [Reuses operator id: 37]
-Output [2]: [i_item_sk#25, i_product_name#26]
+Output [2]: [i_item_sk#24, i_product_name#25]
 
 (41) BroadcastHashJoin [codegen id : 13]
-Left keys [1]: [item_sk#20]
-Right keys [1]: [i_item_sk#25]
+Left keys [1]: [item_sk#19]
+Right keys [1]: [i_item_sk#24]
 Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 13]
-Output [3]: [rnk#14, i_product_name#24 AS best_performing#27, i_product_name#26 AS worst_performing#28]
-Input [5]: [rnk#14, item_sk#20, i_product_name#24, i_item_sk#25, i_product_name#26]
+Output [3]: [rnk#13, i_product_name#23 AS best_performing#26, i_product_name#25 AS worst_performing#27]
+Input [5]: [rnk#13, item_sk#19, i_product_name#23, i_item_sk#24, i_product_name#25]
 
 (43) TakeOrderedAndProject
-Input [3]: [rnk#14, best_performing#27, worst_performing#28]
-Arguments: 100, [rnk#14 ASC NULLS FIRST], [rnk#14, best_performing#27, worst_performing#28]
+Input [3]: [rnk#13, best_performing#26, worst_performing#27]
+Arguments: 100, [rnk#13 ASC NULLS FIRST], [rnk#13, best_performing#26, worst_performing#27]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 8 Hosting Expression = Subquery scalar-subquery#12, [id=#13]
+Subquery:1 Hosting operator id = 8 Hosting Expression = Subquery scalar-subquery#12, [id=#2]
 * HashAggregate (50)
 +- Exchange (49)
    +- * HashAggregate (48)
@@ -246,41 +246,41 @@ Subquery:1 Hosting operator id = 8 Hosting Expression = Subquery scalar-subquery
 
 
 (44) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
+Output [4]: [ss_addr_sk#28, ss_store_sk#29, ss_net_profit#30, ss_sold_date_sk#31]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_store_sk), EqualTo(ss_store_sk,4), IsNull(ss_addr_sk)]
 ReadSchema: struct<ss_addr_sk:int,ss_store_sk:int,ss_net_profit:decimal(7,2)>
 
 (45) ColumnarToRow [codegen id : 1]
-Input [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
+Input [4]: [ss_addr_sk#28, ss_store_sk#29, ss_net_profit#30, ss_sold_date_sk#31]
 
 (46) Filter [codegen id : 1]
-Input [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
-Condition : ((isnotnull(ss_store_sk#30) AND (ss_store_sk#30 = 4)) AND isnull(ss_addr_sk#29))
+Input [4]: [ss_addr_sk#28, ss_store_sk#29, ss_net_profit#30, ss_sold_date_sk#31]
+Condition : ((isnotnull(ss_store_sk#29) AND (ss_store_sk#29 = 4)) AND isnull(ss_addr_sk#28))
 
 (47) Project [codegen id : 1]
-Output [2]: [ss_store_sk#30, ss_net_profit#31]
-Input [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
+Output [2]: [ss_store_sk#29, ss_net_profit#30]
+Input [4]: [ss_addr_sk#28, ss_store_sk#29, ss_net_profit#30, ss_sold_date_sk#31]
 
 (48) HashAggregate [codegen id : 1]
-Input [2]: [ss_store_sk#30, ss_net_profit#31]
-Keys [1]: [ss_store_sk#30]
-Functions [1]: [partial_avg(UnscaledValue(ss_net_profit#31))]
-Aggregate Attributes [2]: [sum#33, count#34]
-Results [3]: [ss_store_sk#30, sum#35, count#36]
+Input [2]: [ss_store_sk#29, ss_net_profit#30]
+Keys [1]: [ss_store_sk#29]
+Functions [1]: [partial_avg(UnscaledValue(ss_net_profit#30))]
+Aggregate Attributes [2]: [sum#32, count#33]
+Results [3]: [ss_store_sk#29, sum#34, count#35]
 
 (49) Exchange
-Input [3]: [ss_store_sk#30, sum#35, count#36]
-Arguments: hashpartitioning(ss_store_sk#30, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Input [3]: [ss_store_sk#29, sum#34, count#35]
+Arguments: hashpartitioning(ss_store_sk#29, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (50) HashAggregate [codegen id : 2]
-Input [3]: [ss_store_sk#30, sum#35, count#36]
-Keys [1]: [ss_store_sk#30]
-Functions [1]: [avg(UnscaledValue(ss_net_profit#31))]
-Aggregate Attributes [1]: [avg(UnscaledValue(ss_net_profit#31))#37]
-Results [1]: [cast((avg(UnscaledValue(ss_net_profit#31))#37 / 100.0) as decimal(11,6)) AS rank_col#38]
+Input [3]: [ss_store_sk#29, sum#34, count#35]
+Keys [1]: [ss_store_sk#29]
+Functions [1]: [avg(UnscaledValue(ss_net_profit#30))]
+Aggregate Attributes [1]: [avg(UnscaledValue(ss_net_profit#30))#36]
+Results [1]: [cast((avg(UnscaledValue(ss_net_profit#30))#36 / 100.0) as decimal(11,6)) AS rank_col#37]
 
-Subquery:2 Hosting operator id = 21 Hosting Expression = ReusedSubquery Subquery scalar-subquery#12, [id=#13]
+Subquery:2 Hosting operator id = 21 Hosting Expression = ReusedSubquery Subquery scalar-subquery#12, [id=#2]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/explain.txt
@@ -395,7 +395,7 @@ Input [2]: [d_date_sk#29, d_month_seq#41]
 
 (67) Filter [codegen id : 1]
 Input [2]: [d_date_sk#29, d_month_seq#41]
-Condition : (((isnotnull(d_month_seq#41) AND (d_month_seq#41 >= ReusedSubquery Subquery scalar-subquery#42, [id=#44])) AND (d_month_seq#41 <= ReusedSubquery Subquery scalar-subquery#43, [id=#45])) AND isnotnull(d_date_sk#29))
+Condition : (((isnotnull(d_month_seq#41) AND (d_month_seq#41 >= ReusedSubquery Subquery scalar-subquery#42, [id=#9])) AND (d_month_seq#41 <= ReusedSubquery Subquery scalar-subquery#43, [id=#10])) AND isnotnull(d_date_sk#29))
 
 (68) Project [codegen id : 1]
 Output [1]: [d_date_sk#29]
@@ -403,13 +403,13 @@ Input [2]: [d_date_sk#29, d_month_seq#41]
 
 (69) BroadcastExchange
 Input [1]: [d_date_sk#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-Subquery:4 Hosting operator id = 67 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#44]
+Subquery:4 Hosting operator id = 67 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#9]
 
-Subquery:5 Hosting operator id = 67 Hosting Expression = ReusedSubquery Subquery scalar-subquery#43, [id=#45]
+Subquery:5 Hosting operator id = 67 Hosting Expression = ReusedSubquery Subquery scalar-subquery#43, [id=#10]
 
-Subquery:6 Hosting operator id = 65 Hosting Expression = Subquery scalar-subquery#42, [id=#44]
+Subquery:6 Hosting operator id = 65 Hosting Expression = Subquery scalar-subquery#42, [id=#9]
 * HashAggregate (76)
 +- Exchange (75)
    +- * HashAggregate (74)
@@ -420,42 +420,42 @@ Subquery:6 Hosting operator id = 65 Hosting Expression = Subquery scalar-subquer
 
 
 (70) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_month_seq#46, d_year#47, d_moy#48]
+Output [3]: [d_month_seq#44, d_year#45, d_moy#46]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,1998), EqualTo(d_moy,12)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
 (71) ColumnarToRow [codegen id : 1]
-Input [3]: [d_month_seq#46, d_year#47, d_moy#48]
+Input [3]: [d_month_seq#44, d_year#45, d_moy#46]
 
 (72) Filter [codegen id : 1]
-Input [3]: [d_month_seq#46, d_year#47, d_moy#48]
-Condition : (((isnotnull(d_year#47) AND isnotnull(d_moy#48)) AND (d_year#47 = 1998)) AND (d_moy#48 = 12))
+Input [3]: [d_month_seq#44, d_year#45, d_moy#46]
+Condition : (((isnotnull(d_year#45) AND isnotnull(d_moy#46)) AND (d_year#45 = 1998)) AND (d_moy#46 = 12))
 
 (73) Project [codegen id : 1]
-Output [1]: [(d_month_seq#46 + 1) AS (d_month_seq + 1)#49]
-Input [3]: [d_month_seq#46, d_year#47, d_moy#48]
+Output [1]: [(d_month_seq#44 + 1) AS (d_month_seq + 1)#47]
+Input [3]: [d_month_seq#44, d_year#45, d_moy#46]
 
 (74) HashAggregate [codegen id : 1]
-Input [1]: [(d_month_seq + 1)#49]
-Keys [1]: [(d_month_seq + 1)#49]
+Input [1]: [(d_month_seq + 1)#47]
+Keys [1]: [(d_month_seq + 1)#47]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [(d_month_seq + 1)#49]
+Results [1]: [(d_month_seq + 1)#47]
 
 (75) Exchange
-Input [1]: [(d_month_seq + 1)#49]
-Arguments: hashpartitioning((d_month_seq + 1)#49, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [1]: [(d_month_seq + 1)#47]
+Arguments: hashpartitioning((d_month_seq + 1)#47, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (76) HashAggregate [codegen id : 2]
-Input [1]: [(d_month_seq + 1)#49]
-Keys [1]: [(d_month_seq + 1)#49]
+Input [1]: [(d_month_seq + 1)#47]
+Keys [1]: [(d_month_seq + 1)#47]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [(d_month_seq + 1)#49]
+Results [1]: [(d_month_seq + 1)#47]
 
-Subquery:7 Hosting operator id = 65 Hosting Expression = Subquery scalar-subquery#43, [id=#45]
+Subquery:7 Hosting operator id = 65 Hosting Expression = Subquery scalar-subquery#43, [id=#10]
 * HashAggregate (83)
 +- Exchange (82)
    +- * HashAggregate (81)
@@ -466,39 +466,39 @@ Subquery:7 Hosting operator id = 65 Hosting Expression = Subquery scalar-subquer
 
 
 (77) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_month_seq#50, d_year#51, d_moy#52]
+Output [3]: [d_month_seq#48, d_year#49, d_moy#50]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,1998), EqualTo(d_moy,12)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
 (78) ColumnarToRow [codegen id : 1]
-Input [3]: [d_month_seq#50, d_year#51, d_moy#52]
+Input [3]: [d_month_seq#48, d_year#49, d_moy#50]
 
 (79) Filter [codegen id : 1]
-Input [3]: [d_month_seq#50, d_year#51, d_moy#52]
-Condition : (((isnotnull(d_year#51) AND isnotnull(d_moy#52)) AND (d_year#51 = 1998)) AND (d_moy#52 = 12))
+Input [3]: [d_month_seq#48, d_year#49, d_moy#50]
+Condition : (((isnotnull(d_year#49) AND isnotnull(d_moy#50)) AND (d_year#49 = 1998)) AND (d_moy#50 = 12))
 
 (80) Project [codegen id : 1]
-Output [1]: [(d_month_seq#50 + 3) AS (d_month_seq + 3)#53]
-Input [3]: [d_month_seq#50, d_year#51, d_moy#52]
+Output [1]: [(d_month_seq#48 + 3) AS (d_month_seq + 3)#51]
+Input [3]: [d_month_seq#48, d_year#49, d_moy#50]
 
 (81) HashAggregate [codegen id : 1]
-Input [1]: [(d_month_seq + 3)#53]
-Keys [1]: [(d_month_seq + 3)#53]
+Input [1]: [(d_month_seq + 3)#51]
+Keys [1]: [(d_month_seq + 3)#51]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [(d_month_seq + 3)#53]
+Results [1]: [(d_month_seq + 3)#51]
 
 (82) Exchange
-Input [1]: [(d_month_seq + 3)#53]
-Arguments: hashpartitioning((d_month_seq + 3)#53, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [1]: [(d_month_seq + 3)#51]
+Arguments: hashpartitioning((d_month_seq + 3)#51, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (83) HashAggregate [codegen id : 2]
-Input [1]: [(d_month_seq + 3)#53]
-Keys [1]: [(d_month_seq + 3)#53]
+Input [1]: [(d_month_seq + 3)#51]
+Keys [1]: [(d_month_seq + 3)#51]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [(d_month_seq + 3)#53]
+Results [1]: [(d_month_seq + 3)#51]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54/explain.txt
@@ -380,7 +380,7 @@ Input [2]: [d_date_sk#29, d_month_seq#41]
 
 (64) Filter [codegen id : 1]
 Input [2]: [d_date_sk#29, d_month_seq#41]
-Condition : (((isnotnull(d_month_seq#41) AND (d_month_seq#41 >= ReusedSubquery Subquery scalar-subquery#42, [id=#44])) AND (d_month_seq#41 <= ReusedSubquery Subquery scalar-subquery#43, [id=#45])) AND isnotnull(d_date_sk#29))
+Condition : (((isnotnull(d_month_seq#41) AND (d_month_seq#41 >= ReusedSubquery Subquery scalar-subquery#42, [id=#10])) AND (d_month_seq#41 <= ReusedSubquery Subquery scalar-subquery#43, [id=#11])) AND isnotnull(d_date_sk#29))
 
 (65) Project [codegen id : 1]
 Output [1]: [d_date_sk#29]
@@ -388,13 +388,13 @@ Input [2]: [d_date_sk#29, d_month_seq#41]
 
 (66) BroadcastExchange
 Input [1]: [d_date_sk#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=12]
 
-Subquery:4 Hosting operator id = 64 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#44]
+Subquery:4 Hosting operator id = 64 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#10]
 
-Subquery:5 Hosting operator id = 64 Hosting Expression = ReusedSubquery Subquery scalar-subquery#43, [id=#45]
+Subquery:5 Hosting operator id = 64 Hosting Expression = ReusedSubquery Subquery scalar-subquery#43, [id=#11]
 
-Subquery:6 Hosting operator id = 62 Hosting Expression = Subquery scalar-subquery#42, [id=#44]
+Subquery:6 Hosting operator id = 62 Hosting Expression = Subquery scalar-subquery#42, [id=#10]
 * HashAggregate (73)
 +- Exchange (72)
    +- * HashAggregate (71)
@@ -405,42 +405,42 @@ Subquery:6 Hosting operator id = 62 Hosting Expression = Subquery scalar-subquer
 
 
 (67) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_month_seq#46, d_year#47, d_moy#48]
+Output [3]: [d_month_seq#44, d_year#45, d_moy#46]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,1998), EqualTo(d_moy,12)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
 (68) ColumnarToRow [codegen id : 1]
-Input [3]: [d_month_seq#46, d_year#47, d_moy#48]
+Input [3]: [d_month_seq#44, d_year#45, d_moy#46]
 
 (69) Filter [codegen id : 1]
-Input [3]: [d_month_seq#46, d_year#47, d_moy#48]
-Condition : (((isnotnull(d_year#47) AND isnotnull(d_moy#48)) AND (d_year#47 = 1998)) AND (d_moy#48 = 12))
+Input [3]: [d_month_seq#44, d_year#45, d_moy#46]
+Condition : (((isnotnull(d_year#45) AND isnotnull(d_moy#46)) AND (d_year#45 = 1998)) AND (d_moy#46 = 12))
 
 (70) Project [codegen id : 1]
-Output [1]: [(d_month_seq#46 + 1) AS (d_month_seq + 1)#49]
-Input [3]: [d_month_seq#46, d_year#47, d_moy#48]
+Output [1]: [(d_month_seq#44 + 1) AS (d_month_seq + 1)#47]
+Input [3]: [d_month_seq#44, d_year#45, d_moy#46]
 
 (71) HashAggregate [codegen id : 1]
-Input [1]: [(d_month_seq + 1)#49]
-Keys [1]: [(d_month_seq + 1)#49]
+Input [1]: [(d_month_seq + 1)#47]
+Keys [1]: [(d_month_seq + 1)#47]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [(d_month_seq + 1)#49]
+Results [1]: [(d_month_seq + 1)#47]
 
 (72) Exchange
-Input [1]: [(d_month_seq + 1)#49]
-Arguments: hashpartitioning((d_month_seq + 1)#49, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [1]: [(d_month_seq + 1)#47]
+Arguments: hashpartitioning((d_month_seq + 1)#47, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (73) HashAggregate [codegen id : 2]
-Input [1]: [(d_month_seq + 1)#49]
-Keys [1]: [(d_month_seq + 1)#49]
+Input [1]: [(d_month_seq + 1)#47]
+Keys [1]: [(d_month_seq + 1)#47]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [(d_month_seq + 1)#49]
+Results [1]: [(d_month_seq + 1)#47]
 
-Subquery:7 Hosting operator id = 62 Hosting Expression = Subquery scalar-subquery#43, [id=#45]
+Subquery:7 Hosting operator id = 62 Hosting Expression = Subquery scalar-subquery#43, [id=#11]
 * HashAggregate (80)
 +- Exchange (79)
    +- * HashAggregate (78)
@@ -451,39 +451,39 @@ Subquery:7 Hosting operator id = 62 Hosting Expression = Subquery scalar-subquer
 
 
 (74) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_month_seq#50, d_year#51, d_moy#52]
+Output [3]: [d_month_seq#48, d_year#49, d_moy#50]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,1998), EqualTo(d_moy,12)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
 (75) ColumnarToRow [codegen id : 1]
-Input [3]: [d_month_seq#50, d_year#51, d_moy#52]
+Input [3]: [d_month_seq#48, d_year#49, d_moy#50]
 
 (76) Filter [codegen id : 1]
-Input [3]: [d_month_seq#50, d_year#51, d_moy#52]
-Condition : (((isnotnull(d_year#51) AND isnotnull(d_moy#52)) AND (d_year#51 = 1998)) AND (d_moy#52 = 12))
+Input [3]: [d_month_seq#48, d_year#49, d_moy#50]
+Condition : (((isnotnull(d_year#49) AND isnotnull(d_moy#50)) AND (d_year#49 = 1998)) AND (d_moy#50 = 12))
 
 (77) Project [codegen id : 1]
-Output [1]: [(d_month_seq#50 + 3) AS (d_month_seq + 3)#53]
-Input [3]: [d_month_seq#50, d_year#51, d_moy#52]
+Output [1]: [(d_month_seq#48 + 3) AS (d_month_seq + 3)#51]
+Input [3]: [d_month_seq#48, d_year#49, d_moy#50]
 
 (78) HashAggregate [codegen id : 1]
-Input [1]: [(d_month_seq + 3)#53]
-Keys [1]: [(d_month_seq + 3)#53]
+Input [1]: [(d_month_seq + 3)#51]
+Keys [1]: [(d_month_seq + 3)#51]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [(d_month_seq + 3)#53]
+Results [1]: [(d_month_seq + 3)#51]
 
 (79) Exchange
-Input [1]: [(d_month_seq + 3)#53]
-Arguments: hashpartitioning((d_month_seq + 3)#53, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [1]: [(d_month_seq + 3)#51]
+Arguments: hashpartitioning((d_month_seq + 3)#51, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (80) HashAggregate [codegen id : 2]
-Input [1]: [(d_month_seq + 3)#53]
-Keys [1]: [(d_month_seq + 3)#53]
+Input [1]: [(d_month_seq + 3)#51]
+Keys [1]: [(d_month_seq + 3)#51]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [(d_month_seq + 3)#53]
+Results [1]: [(d_month_seq + 3)#51]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58.sf100/explain.txt
@@ -328,7 +328,7 @@ Input [2]: [d_date#40, d_week_seq#41]
 
 (55) Filter [codegen id : 1]
 Input [2]: [d_date#40, d_week_seq#41]
-Condition : (isnotnull(d_week_seq#41) AND (d_week_seq#41 = ReusedSubquery Subquery scalar-subquery#42, [id=#43]))
+Condition : (isnotnull(d_week_seq#41) AND (d_week_seq#41 = ReusedSubquery Subquery scalar-subquery#42, [id=#7]))
 
 (56) Project [codegen id : 1]
 Output [1]: [d_date#40]
@@ -336,7 +336,7 @@ Input [2]: [d_date#40, d_week_seq#41]
 
 (57) BroadcastExchange
 Input [1]: [d_date#40]
-Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false), [plan_id=7]
+Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false), [plan_id=8]
 
 (58) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [d_date#39]
@@ -350,11 +350,11 @@ Input [2]: [d_date_sk#5, d_date#39]
 
 (60) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
-Subquery:2 Hosting operator id = 55 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
+Subquery:2 Hosting operator id = 55 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#7]
 
-Subquery:3 Hosting operator id = 53 Hosting Expression = Subquery scalar-subquery#42, [id=#43]
+Subquery:3 Hosting operator id = 53 Hosting Expression = Subquery scalar-subquery#42, [id=#7]
 * Project (64)
 +- * Filter (63)
    +- * ColumnarToRow (62)
@@ -362,22 +362,22 @@ Subquery:3 Hosting operator id = 53 Hosting Expression = Subquery scalar-subquer
 
 
 (61) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date#44, d_week_seq#45]
+Output [2]: [d_date#43, d_week_seq#44]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), EqualTo(d_date,2000-01-03)]
 ReadSchema: struct<d_date:date,d_week_seq:int>
 
 (62) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date#44, d_week_seq#45]
+Input [2]: [d_date#43, d_week_seq#44]
 
 (63) Filter [codegen id : 1]
-Input [2]: [d_date#44, d_week_seq#45]
-Condition : (isnotnull(d_date#44) AND (d_date#44 = 2000-01-03))
+Input [2]: [d_date#43, d_week_seq#44]
+Condition : (isnotnull(d_date#43) AND (d_date#43 = 2000-01-03))
 
 (64) Project [codegen id : 1]
-Output [1]: [d_week_seq#45]
-Input [2]: [d_date#44, d_week_seq#45]
+Output [1]: [d_week_seq#44]
+Input [2]: [d_date#43, d_week_seq#44]
 
 Subquery:4 Hosting operator id = 17 Hosting Expression = cs_sold_date_sk#15 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58/explain.txt
@@ -328,7 +328,7 @@ Input [2]: [d_date#40, d_week_seq#41]
 
 (55) Filter [codegen id : 1]
 Input [2]: [d_date#40, d_week_seq#41]
-Condition : (isnotnull(d_week_seq#41) AND (d_week_seq#41 = ReusedSubquery Subquery scalar-subquery#42, [id=#43]))
+Condition : (isnotnull(d_week_seq#41) AND (d_week_seq#41 = ReusedSubquery Subquery scalar-subquery#42, [id=#7]))
 
 (56) Project [codegen id : 1]
 Output [1]: [d_date#40]
@@ -336,7 +336,7 @@ Input [2]: [d_date#40, d_week_seq#41]
 
 (57) BroadcastExchange
 Input [1]: [d_date#40]
-Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false), [plan_id=7]
+Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false), [plan_id=8]
 
 (58) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [d_date#39]
@@ -350,11 +350,11 @@ Input [2]: [d_date_sk#7, d_date#39]
 
 (60) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
-Subquery:2 Hosting operator id = 55 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
+Subquery:2 Hosting operator id = 55 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#7]
 
-Subquery:3 Hosting operator id = 53 Hosting Expression = Subquery scalar-subquery#42, [id=#43]
+Subquery:3 Hosting operator id = 53 Hosting Expression = Subquery scalar-subquery#42, [id=#7]
 * Project (64)
 +- * Filter (63)
    +- * ColumnarToRow (62)
@@ -362,22 +362,22 @@ Subquery:3 Hosting operator id = 53 Hosting Expression = Subquery scalar-subquer
 
 
 (61) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date#44, d_week_seq#45]
+Output [2]: [d_date#43, d_week_seq#44]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), EqualTo(d_date,2000-01-03)]
 ReadSchema: struct<d_date:date,d_week_seq:int>
 
 (62) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date#44, d_week_seq#45]
+Input [2]: [d_date#43, d_week_seq#44]
 
 (63) Filter [codegen id : 1]
-Input [2]: [d_date#44, d_week_seq#45]
-Condition : (isnotnull(d_date#44) AND (d_date#44 = 2000-01-03))
+Input [2]: [d_date#43, d_week_seq#44]
+Condition : (isnotnull(d_date#43) AND (d_date#43 = 2000-01-03))
 
 (64) Project [codegen id : 1]
-Output [1]: [d_week_seq#45]
-Input [2]: [d_date#44, d_week_seq#45]
+Output [1]: [d_week_seq#44]
+Input [2]: [d_date#43, d_week_seq#44]
 
 Subquery:4 Hosting operator id = 17 Hosting Expression = cs_sold_date_sk#15 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59.sf100/explain.txt
@@ -82,11 +82,11 @@ Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
 
 (6) Filter [codegen id : 1]
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
-Condition : ((isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(d_week_seq#5, 42)))
+Condition : ((isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5)) AND might_contain(Subquery scalar-subquery#7, [id=#1], xxhash64(d_week_seq#5, 42)))
 
 (7) BroadcastExchange
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
@@ -102,222 +102,222 @@ Input [6]: [ss_store_sk#1, ss_sales_price#2, ss_sold_date_sk#3, d_date_sk#4, d_w
 Input [4]: [ss_store_sk#1, ss_sales_price#2, d_week_seq#5, d_day_name#6]
 Keys [2]: [d_week_seq#5, ss_store_sk#1]
 Functions [7]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#6 = Sunday   ) THEN ss_sales_price#2 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#6 = Monday   ) THEN ss_sales_price#2 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#6 = Tuesday  ) THEN ss_sales_price#2 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#6 = Wednesday) THEN ss_sales_price#2 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#6 = Thursday ) THEN ss_sales_price#2 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#6 = Friday   ) THEN ss_sales_price#2 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#6 = Saturday ) THEN ss_sales_price#2 END))]
-Aggregate Attributes [7]: [sum#9, sum#10, sum#11, sum#12, sum#13, sum#14, sum#15]
-Results [9]: [d_week_seq#5, ss_store_sk#1, sum#16, sum#17, sum#18, sum#19, sum#20, sum#21, sum#22]
+Aggregate Attributes [7]: [sum#8, sum#9, sum#10, sum#11, sum#12, sum#13, sum#14]
+Results [9]: [d_week_seq#5, ss_store_sk#1, sum#15, sum#16, sum#17, sum#18, sum#19, sum#20, sum#21]
 
 (11) Exchange
-Input [9]: [d_week_seq#5, ss_store_sk#1, sum#16, sum#17, sum#18, sum#19, sum#20, sum#21, sum#22]
-Arguments: hashpartitioning(d_week_seq#5, ss_store_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [9]: [d_week_seq#5, ss_store_sk#1, sum#15, sum#16, sum#17, sum#18, sum#19, sum#20, sum#21]
+Arguments: hashpartitioning(d_week_seq#5, ss_store_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (12) HashAggregate [codegen id : 10]
-Input [9]: [d_week_seq#5, ss_store_sk#1, sum#16, sum#17, sum#18, sum#19, sum#20, sum#21, sum#22]
+Input [9]: [d_week_seq#5, ss_store_sk#1, sum#15, sum#16, sum#17, sum#18, sum#19, sum#20, sum#21]
 Keys [2]: [d_week_seq#5, ss_store_sk#1]
 Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#6 = Sunday   ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Monday   ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Tuesday  ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Wednesday) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Thursday ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Friday   ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Saturday ) THEN ss_sales_price#2 END))]
-Aggregate Attributes [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#6 = Sunday   ) THEN ss_sales_price#2 END))#23, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Monday   ) THEN ss_sales_price#2 END))#24, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Tuesday  ) THEN ss_sales_price#2 END))#25, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Wednesday) THEN ss_sales_price#2 END))#26, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Thursday ) THEN ss_sales_price#2 END))#27, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Friday   ) THEN ss_sales_price#2 END))#28, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Saturday ) THEN ss_sales_price#2 END))#29]
-Results [9]: [d_week_seq#5, ss_store_sk#1, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Sunday   ) THEN ss_sales_price#2 END))#23,17,2) AS sun_sales#30, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Monday   ) THEN ss_sales_price#2 END))#24,17,2) AS mon_sales#31, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Tuesday  ) THEN ss_sales_price#2 END))#25,17,2) AS tue_sales#32, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Wednesday) THEN ss_sales_price#2 END))#26,17,2) AS wed_sales#33, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Thursday ) THEN ss_sales_price#2 END))#27,17,2) AS thu_sales#34, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Friday   ) THEN ss_sales_price#2 END))#28,17,2) AS fri_sales#35, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Saturday ) THEN ss_sales_price#2 END))#29,17,2) AS sat_sales#36]
+Aggregate Attributes [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#6 = Sunday   ) THEN ss_sales_price#2 END))#22, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Monday   ) THEN ss_sales_price#2 END))#23, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Tuesday  ) THEN ss_sales_price#2 END))#24, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Wednesday) THEN ss_sales_price#2 END))#25, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Thursday ) THEN ss_sales_price#2 END))#26, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Friday   ) THEN ss_sales_price#2 END))#27, sum(UnscaledValue(CASE WHEN (d_day_name#6 = Saturday ) THEN ss_sales_price#2 END))#28]
+Results [9]: [d_week_seq#5, ss_store_sk#1, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Sunday   ) THEN ss_sales_price#2 END))#22,17,2) AS sun_sales#29, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Monday   ) THEN ss_sales_price#2 END))#23,17,2) AS mon_sales#30, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Tuesday  ) THEN ss_sales_price#2 END))#24,17,2) AS tue_sales#31, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Wednesday) THEN ss_sales_price#2 END))#25,17,2) AS wed_sales#32, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Thursday ) THEN ss_sales_price#2 END))#26,17,2) AS thu_sales#33, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Friday   ) THEN ss_sales_price#2 END))#27,17,2) AS fri_sales#34, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#6 = Saturday ) THEN ss_sales_price#2 END))#28,17,2) AS sat_sales#35]
 
 (13) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#37, s_store_id#38, s_store_name#39]
+Output [3]: [s_store_sk#36, s_store_id#37, s_store_name#38]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_id)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string,s_store_name:string>
 
 (14) ColumnarToRow [codegen id : 3]
-Input [3]: [s_store_sk#37, s_store_id#38, s_store_name#39]
+Input [3]: [s_store_sk#36, s_store_id#37, s_store_name#38]
 
 (15) Filter [codegen id : 3]
-Input [3]: [s_store_sk#37, s_store_id#38, s_store_name#39]
-Condition : (isnotnull(s_store_sk#37) AND isnotnull(s_store_id#38))
+Input [3]: [s_store_sk#36, s_store_id#37, s_store_name#38]
+Condition : (isnotnull(s_store_sk#36) AND isnotnull(s_store_id#37))
 
 (16) BroadcastExchange
-Input [3]: [s_store_sk#37, s_store_id#38, s_store_name#39]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
+Input [3]: [s_store_sk#36, s_store_id#37, s_store_name#38]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
 
 (17) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#1]
-Right keys [1]: [s_store_sk#37]
+Right keys [1]: [s_store_sk#36]
 Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 10]
-Output [10]: [d_week_seq#5, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_id#38, s_store_name#39]
-Input [12]: [d_week_seq#5, ss_store_sk#1, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_sk#37, s_store_id#38, s_store_name#39]
+Output [10]: [d_week_seq#5, sun_sales#29, mon_sales#30, tue_sales#31, wed_sales#32, thu_sales#33, fri_sales#34, sat_sales#35, s_store_id#37, s_store_name#38]
+Input [12]: [d_week_seq#5, ss_store_sk#1, sun_sales#29, mon_sales#30, tue_sales#31, wed_sales#32, thu_sales#33, fri_sales#34, sat_sales#35, s_store_sk#36, s_store_id#37, s_store_name#38]
 
 (19) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_month_seq#40, d_week_seq#41]
+Output [2]: [d_month_seq#39, d_week_seq#40]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1212), LessThanOrEqual(d_month_seq,1223), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
 (20) ColumnarToRow [codegen id : 4]
-Input [2]: [d_month_seq#40, d_week_seq#41]
+Input [2]: [d_month_seq#39, d_week_seq#40]
 
 (21) Filter [codegen id : 4]
-Input [2]: [d_month_seq#40, d_week_seq#41]
-Condition : (((isnotnull(d_month_seq#40) AND (d_month_seq#40 >= 1212)) AND (d_month_seq#40 <= 1223)) AND isnotnull(d_week_seq#41))
+Input [2]: [d_month_seq#39, d_week_seq#40]
+Condition : (((isnotnull(d_month_seq#39) AND (d_month_seq#39 >= 1212)) AND (d_month_seq#39 <= 1223)) AND isnotnull(d_week_seq#40))
 
 (22) Project [codegen id : 4]
-Output [1]: [d_week_seq#41]
-Input [2]: [d_month_seq#40, d_week_seq#41]
+Output [1]: [d_week_seq#40]
+Input [2]: [d_month_seq#39, d_week_seq#40]
 
 (23) BroadcastExchange
-Input [1]: [d_week_seq#41]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+Input [1]: [d_week_seq#40]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 (24) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [d_week_seq#5]
-Right keys [1]: [d_week_seq#41]
+Right keys [1]: [d_week_seq#40]
 Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 10]
-Output [10]: [s_store_name#39 AS s_store_name1#42, d_week_seq#5 AS d_week_seq1#43, s_store_id#38 AS s_store_id1#44, sun_sales#30 AS sun_sales1#45, mon_sales#31 AS mon_sales1#46, tue_sales#32 AS tue_sales1#47, wed_sales#33 AS wed_sales1#48, thu_sales#34 AS thu_sales1#49, fri_sales#35 AS fri_sales1#50, sat_sales#36 AS sat_sales1#51]
-Input [11]: [d_week_seq#5, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_id#38, s_store_name#39, d_week_seq#41]
+Output [10]: [s_store_name#38 AS s_store_name1#41, d_week_seq#5 AS d_week_seq1#42, s_store_id#37 AS s_store_id1#43, sun_sales#29 AS sun_sales1#44, mon_sales#30 AS mon_sales1#45, tue_sales#31 AS tue_sales1#46, wed_sales#32 AS wed_sales1#47, thu_sales#33 AS thu_sales1#48, fri_sales#34 AS fri_sales1#49, sat_sales#35 AS sat_sales1#50]
+Input [11]: [d_week_seq#5, sun_sales#29, mon_sales#30, tue_sales#31, wed_sales#32, thu_sales#33, fri_sales#34, sat_sales#35, s_store_id#37, s_store_name#38, d_week_seq#40]
 
 (26) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
+Output [3]: [ss_store_sk#51, ss_sales_price#52, ss_sold_date_sk#53]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#54)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#53)]
 PushedFilters: [IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_store_sk:int,ss_sales_price:decimal(7,2)>
 
 (27) ColumnarToRow [codegen id : 6]
-Input [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
+Input [3]: [ss_store_sk#51, ss_sales_price#52, ss_sold_date_sk#53]
 
 (28) Filter [codegen id : 6]
-Input [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
-Condition : isnotnull(ss_store_sk#52)
+Input [3]: [ss_store_sk#51, ss_sales_price#52, ss_sold_date_sk#53]
+Condition : isnotnull(ss_store_sk#51)
 
 (29) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
+Output [3]: [d_date_sk#54, d_week_seq#55, d_day_name#56]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int,d_day_name:string>
 
 (30) ColumnarToRow [codegen id : 5]
-Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
+Input [3]: [d_date_sk#54, d_week_seq#55, d_day_name#56]
 
 (31) Filter [codegen id : 5]
-Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
-Condition : ((isnotnull(d_date_sk#55) AND isnotnull(d_week_seq#56)) AND might_contain(Subquery scalar-subquery#58, [id=#59], xxhash64(d_week_seq#56, 42)))
+Input [3]: [d_date_sk#54, d_week_seq#55, d_day_name#56]
+Condition : ((isnotnull(d_date_sk#54) AND isnotnull(d_week_seq#55)) AND might_contain(Subquery scalar-subquery#57, [id=#6], xxhash64(d_week_seq#55, 42)))
 
 (32) BroadcastExchange
-Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
+Input [3]: [d_date_sk#54, d_week_seq#55, d_day_name#56]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
 (33) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ss_sold_date_sk#54]
-Right keys [1]: [d_date_sk#55]
+Left keys [1]: [ss_sold_date_sk#53]
+Right keys [1]: [d_date_sk#54]
 Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 6]
-Output [4]: [ss_store_sk#52, ss_sales_price#53, d_week_seq#56, d_day_name#57]
-Input [6]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54, d_date_sk#55, d_week_seq#56, d_day_name#57]
+Output [4]: [ss_store_sk#51, ss_sales_price#52, d_week_seq#55, d_day_name#56]
+Input [6]: [ss_store_sk#51, ss_sales_price#52, ss_sold_date_sk#53, d_date_sk#54, d_week_seq#55, d_day_name#56]
 
 (35) HashAggregate [codegen id : 6]
-Input [4]: [ss_store_sk#52, ss_sales_price#53, d_week_seq#56, d_day_name#57]
-Keys [2]: [d_week_seq#56, ss_store_sk#52]
-Functions [7]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Tuesday  ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))]
-Aggregate Attributes [7]: [sum#60, sum#61, sum#62, sum#63, sum#64, sum#65, sum#66]
-Results [9]: [d_week_seq#56, ss_store_sk#52, sum#67, sum#68, sum#69, sum#70, sum#71, sum#72, sum#73]
+Input [4]: [ss_store_sk#51, ss_sales_price#52, d_week_seq#55, d_day_name#56]
+Keys [2]: [d_week_seq#55, ss_store_sk#51]
+Functions [7]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Sunday   ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Monday   ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Tuesday  ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Wednesday) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Thursday ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Friday   ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Saturday ) THEN ss_sales_price#52 END))]
+Aggregate Attributes [7]: [sum#58, sum#59, sum#60, sum#61, sum#62, sum#63, sum#64]
+Results [9]: [d_week_seq#55, ss_store_sk#51, sum#65, sum#66, sum#67, sum#68, sum#69, sum#70, sum#71]
 
 (36) Exchange
-Input [9]: [d_week_seq#56, ss_store_sk#52, sum#67, sum#68, sum#69, sum#70, sum#71, sum#72, sum#73]
-Arguments: hashpartitioning(d_week_seq#56, ss_store_sk#52, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [9]: [d_week_seq#55, ss_store_sk#51, sum#65, sum#66, sum#67, sum#68, sum#69, sum#70, sum#71]
+Arguments: hashpartitioning(d_week_seq#55, ss_store_sk#51, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (37) HashAggregate [codegen id : 9]
-Input [9]: [d_week_seq#56, ss_store_sk#52, sum#67, sum#68, sum#69, sum#70, sum#71, sum#72, sum#73]
-Keys [2]: [d_week_seq#56, ss_store_sk#52]
-Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Tuesday  ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))]
-Aggregate Attributes [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END))#23, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END))#24, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Tuesday  ) THEN ss_sales_price#53 END))#25, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END))#26, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END))#27, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END))#28, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))#29]
-Results [9]: [d_week_seq#56, ss_store_sk#52, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END))#23,17,2) AS sun_sales#74, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END))#24,17,2) AS mon_sales#75, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Tuesday  ) THEN ss_sales_price#53 END))#25,17,2) AS tue_sales#76, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END))#26,17,2) AS wed_sales#77, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END))#27,17,2) AS thu_sales#78, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END))#28,17,2) AS fri_sales#79, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))#29,17,2) AS sat_sales#80]
+Input [9]: [d_week_seq#55, ss_store_sk#51, sum#65, sum#66, sum#67, sum#68, sum#69, sum#70, sum#71]
+Keys [2]: [d_week_seq#55, ss_store_sk#51]
+Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#56 = Sunday   ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Monday   ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Tuesday  ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Wednesday) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Thursday ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Friday   ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Saturday ) THEN ss_sales_price#52 END))]
+Aggregate Attributes [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#56 = Sunday   ) THEN ss_sales_price#52 END))#22, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Monday   ) THEN ss_sales_price#52 END))#23, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Tuesday  ) THEN ss_sales_price#52 END))#24, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Wednesday) THEN ss_sales_price#52 END))#25, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Thursday ) THEN ss_sales_price#52 END))#26, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Friday   ) THEN ss_sales_price#52 END))#27, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Saturday ) THEN ss_sales_price#52 END))#28]
+Results [9]: [d_week_seq#55, ss_store_sk#51, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Sunday   ) THEN ss_sales_price#52 END))#22,17,2) AS sun_sales#72, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Monday   ) THEN ss_sales_price#52 END))#23,17,2) AS mon_sales#73, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Tuesday  ) THEN ss_sales_price#52 END))#24,17,2) AS tue_sales#74, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Wednesday) THEN ss_sales_price#52 END))#25,17,2) AS wed_sales#75, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Thursday ) THEN ss_sales_price#52 END))#26,17,2) AS thu_sales#76, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Friday   ) THEN ss_sales_price#52 END))#27,17,2) AS fri_sales#77, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Saturday ) THEN ss_sales_price#52 END))#28,17,2) AS sat_sales#78]
 
 (38) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#81, s_store_id#82]
+Output [2]: [s_store_sk#79, s_store_id#80]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_id)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
 (39) ColumnarToRow [codegen id : 7]
-Input [2]: [s_store_sk#81, s_store_id#82]
+Input [2]: [s_store_sk#79, s_store_id#80]
 
 (40) Filter [codegen id : 7]
-Input [2]: [s_store_sk#81, s_store_id#82]
-Condition : (isnotnull(s_store_sk#81) AND isnotnull(s_store_id#82))
+Input [2]: [s_store_sk#79, s_store_id#80]
+Condition : (isnotnull(s_store_sk#79) AND isnotnull(s_store_id#80))
 
 (41) BroadcastExchange
-Input [2]: [s_store_sk#81, s_store_id#82]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
+Input [2]: [s_store_sk#79, s_store_id#80]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
 
 (42) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ss_store_sk#52]
-Right keys [1]: [s_store_sk#81]
+Left keys [1]: [ss_store_sk#51]
+Right keys [1]: [s_store_sk#79]
 Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 9]
-Output [9]: [d_week_seq#56, sun_sales#74, mon_sales#75, tue_sales#76, wed_sales#77, thu_sales#78, fri_sales#79, sat_sales#80, s_store_id#82]
-Input [11]: [d_week_seq#56, ss_store_sk#52, sun_sales#74, mon_sales#75, tue_sales#76, wed_sales#77, thu_sales#78, fri_sales#79, sat_sales#80, s_store_sk#81, s_store_id#82]
+Output [9]: [d_week_seq#55, sun_sales#72, mon_sales#73, tue_sales#74, wed_sales#75, thu_sales#76, fri_sales#77, sat_sales#78, s_store_id#80]
+Input [11]: [d_week_seq#55, ss_store_sk#51, sun_sales#72, mon_sales#73, tue_sales#74, wed_sales#75, thu_sales#76, fri_sales#77, sat_sales#78, s_store_sk#79, s_store_id#80]
 
 (44) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_month_seq#83, d_week_seq#84]
+Output [2]: [d_month_seq#81, d_week_seq#82]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1224), LessThanOrEqual(d_month_seq,1235), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
 (45) ColumnarToRow [codegen id : 8]
-Input [2]: [d_month_seq#83, d_week_seq#84]
+Input [2]: [d_month_seq#81, d_week_seq#82]
 
 (46) Filter [codegen id : 8]
-Input [2]: [d_month_seq#83, d_week_seq#84]
-Condition : (((isnotnull(d_month_seq#83) AND (d_month_seq#83 >= 1224)) AND (d_month_seq#83 <= 1235)) AND isnotnull(d_week_seq#84))
+Input [2]: [d_month_seq#81, d_week_seq#82]
+Condition : (((isnotnull(d_month_seq#81) AND (d_month_seq#81 >= 1224)) AND (d_month_seq#81 <= 1235)) AND isnotnull(d_week_seq#82))
 
 (47) Project [codegen id : 8]
-Output [1]: [d_week_seq#84]
-Input [2]: [d_month_seq#83, d_week_seq#84]
+Output [1]: [d_week_seq#82]
+Input [2]: [d_month_seq#81, d_week_seq#82]
 
 (48) BroadcastExchange
-Input [1]: [d_week_seq#84]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+Input [1]: [d_week_seq#82]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
 (49) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [d_week_seq#56]
-Right keys [1]: [d_week_seq#84]
+Left keys [1]: [d_week_seq#55]
+Right keys [1]: [d_week_seq#82]
 Join type: Inner
 Join condition: None
 
 (50) Project [codegen id : 9]
-Output [9]: [d_week_seq#56 AS d_week_seq2#85, s_store_id#82 AS s_store_id2#86, sun_sales#74 AS sun_sales2#87, mon_sales#75 AS mon_sales2#88, tue_sales#76 AS tue_sales2#89, wed_sales#77 AS wed_sales2#90, thu_sales#78 AS thu_sales2#91, fri_sales#79 AS fri_sales2#92, sat_sales#80 AS sat_sales2#93]
-Input [10]: [d_week_seq#56, sun_sales#74, mon_sales#75, tue_sales#76, wed_sales#77, thu_sales#78, fri_sales#79, sat_sales#80, s_store_id#82, d_week_seq#84]
+Output [9]: [d_week_seq#55 AS d_week_seq2#83, s_store_id#80 AS s_store_id2#84, sun_sales#72 AS sun_sales2#85, mon_sales#73 AS mon_sales2#86, tue_sales#74 AS tue_sales2#87, wed_sales#75 AS wed_sales2#88, thu_sales#76 AS thu_sales2#89, fri_sales#77 AS fri_sales2#90, sat_sales#78 AS sat_sales2#91]
+Input [10]: [d_week_seq#55, sun_sales#72, mon_sales#73, tue_sales#74, wed_sales#75, thu_sales#76, fri_sales#77, sat_sales#78, s_store_id#80, d_week_seq#82]
 
 (51) BroadcastExchange
-Input [9]: [d_week_seq2#85, s_store_id2#86, sun_sales2#87, mon_sales2#88, tue_sales2#89, wed_sales2#90, thu_sales2#91, fri_sales2#92, sat_sales2#93]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false), [plan_id=9]
+Input [9]: [d_week_seq2#83, s_store_id2#84, sun_sales2#85, mon_sales2#86, tue_sales2#87, wed_sales2#88, thu_sales2#89, fri_sales2#90, sat_sales2#91]
+Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false), [plan_id=11]
 
 (52) BroadcastHashJoin [codegen id : 10]
-Left keys [2]: [s_store_id1#44, d_week_seq1#43]
-Right keys [2]: [s_store_id2#86, (d_week_seq2#85 - 52)]
+Left keys [2]: [s_store_id1#43, d_week_seq1#42]
+Right keys [2]: [s_store_id2#84, (d_week_seq2#83 - 52)]
 Join type: Inner
 Join condition: None
 
 (53) Project [codegen id : 10]
-Output [10]: [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1#45 / sun_sales2#87) AS (sun_sales1 / sun_sales2)#94, (mon_sales1#46 / mon_sales2#88) AS (mon_sales1 / mon_sales2)#95, (tue_sales1#47 / tue_sales2#89) AS (tue_sales1 / tue_sales2)#96, (wed_sales1#48 / wed_sales2#90) AS (wed_sales1 / wed_sales2)#97, (thu_sales1#49 / thu_sales2#91) AS (thu_sales1 / thu_sales2)#98, (fri_sales1#50 / fri_sales2#92) AS (fri_sales1 / fri_sales2)#99, (sat_sales1#51 / sat_sales2#93) AS (sat_sales1 / sat_sales2)#100]
-Input [19]: [s_store_name1#42, d_week_seq1#43, s_store_id1#44, sun_sales1#45, mon_sales1#46, tue_sales1#47, wed_sales1#48, thu_sales1#49, fri_sales1#50, sat_sales1#51, d_week_seq2#85, s_store_id2#86, sun_sales2#87, mon_sales2#88, tue_sales2#89, wed_sales2#90, thu_sales2#91, fri_sales2#92, sat_sales2#93]
+Output [10]: [s_store_name1#41, s_store_id1#43, d_week_seq1#42, (sun_sales1#44 / sun_sales2#85) AS (sun_sales1 / sun_sales2)#92, (mon_sales1#45 / mon_sales2#86) AS (mon_sales1 / mon_sales2)#93, (tue_sales1#46 / tue_sales2#87) AS (tue_sales1 / tue_sales2)#94, (wed_sales1#47 / wed_sales2#88) AS (wed_sales1 / wed_sales2)#95, (thu_sales1#48 / thu_sales2#89) AS (thu_sales1 / thu_sales2)#96, (fri_sales1#49 / fri_sales2#90) AS (fri_sales1 / fri_sales2)#97, (sat_sales1#50 / sat_sales2#91) AS (sat_sales1 / sat_sales2)#98]
+Input [19]: [s_store_name1#41, d_week_seq1#42, s_store_id1#43, sun_sales1#44, mon_sales1#45, tue_sales1#46, wed_sales1#47, thu_sales1#48, fri_sales1#49, sat_sales1#50, d_week_seq2#83, s_store_id2#84, sun_sales2#85, mon_sales2#86, tue_sales2#87, wed_sales2#88, thu_sales2#89, fri_sales2#90, sat_sales2#91]
 
 (54) TakeOrderedAndProject
-Input [10]: [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1 / sun_sales2)#94, (mon_sales1 / mon_sales2)#95, (tue_sales1 / tue_sales2)#96, (wed_sales1 / wed_sales2)#97, (thu_sales1 / thu_sales2)#98, (fri_sales1 / fri_sales2)#99, (sat_sales1 / sat_sales2)#100]
-Arguments: 100, [s_store_name1#42 ASC NULLS FIRST, s_store_id1#44 ASC NULLS FIRST, d_week_seq1#43 ASC NULLS FIRST], [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1 / sun_sales2)#94, (mon_sales1 / mon_sales2)#95, (tue_sales1 / tue_sales2)#96, (wed_sales1 / wed_sales2)#97, (thu_sales1 / thu_sales2)#98, (fri_sales1 / fri_sales2)#99, (sat_sales1 / sat_sales2)#100]
+Input [10]: [s_store_name1#41, s_store_id1#43, d_week_seq1#42, (sun_sales1 / sun_sales2)#92, (mon_sales1 / mon_sales2)#93, (tue_sales1 / tue_sales2)#94, (wed_sales1 / wed_sales2)#95, (thu_sales1 / thu_sales2)#96, (fri_sales1 / fri_sales2)#97, (sat_sales1 / sat_sales2)#98]
+Arguments: 100, [s_store_name1#41 ASC NULLS FIRST, s_store_id1#43 ASC NULLS FIRST, d_week_seq1#42 ASC NULLS FIRST], [s_store_name1#41, s_store_id1#43, d_week_seq1#42, (sun_sales1 / sun_sales2)#92, (mon_sales1 / mon_sales2)#93, (tue_sales1 / tue_sales2)#94, (wed_sales1 / wed_sales2)#95, (thu_sales1 / thu_sales2)#96, (fri_sales1 / fri_sales2)#97, (sat_sales1 / sat_sales2)#98]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 6 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+Subquery:1 Hosting operator id = 6 Hosting Expression = Subquery scalar-subquery#7, [id=#1]
 ObjectHashAggregate (61)
 +- Exchange (60)
    +- ObjectHashAggregate (59)
@@ -328,42 +328,42 @@ ObjectHashAggregate (61)
 
 
 (55) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_month_seq#40, d_week_seq#41]
+Output [2]: [d_month_seq#39, d_week_seq#40]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1212), LessThanOrEqual(d_month_seq,1223), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
 (56) ColumnarToRow [codegen id : 1]
-Input [2]: [d_month_seq#40, d_week_seq#41]
+Input [2]: [d_month_seq#39, d_week_seq#40]
 
 (57) Filter [codegen id : 1]
-Input [2]: [d_month_seq#40, d_week_seq#41]
-Condition : (((isnotnull(d_month_seq#40) AND (d_month_seq#40 >= 1212)) AND (d_month_seq#40 <= 1223)) AND isnotnull(d_week_seq#41))
+Input [2]: [d_month_seq#39, d_week_seq#40]
+Condition : (((isnotnull(d_month_seq#39) AND (d_month_seq#39 >= 1212)) AND (d_month_seq#39 <= 1223)) AND isnotnull(d_week_seq#40))
 
 (58) Project [codegen id : 1]
-Output [1]: [d_week_seq#41]
-Input [2]: [d_month_seq#40, d_week_seq#41]
+Output [1]: [d_week_seq#40]
+Input [2]: [d_month_seq#39, d_week_seq#40]
 
 (59) ObjectHashAggregate
-Input [1]: [d_week_seq#41]
+Input [1]: [d_week_seq#40]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)]
-Aggregate Attributes [1]: [buf#101]
-Results [1]: [buf#102]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#40, 42), 335, 8990, 0, 0)]
+Aggregate Attributes [1]: [buf#99]
+Results [1]: [buf#100]
 
 (60) Exchange
-Input [1]: [buf#102]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
+Input [1]: [buf#100]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
 
 (61) ObjectHashAggregate
-Input [1]: [buf#102]
+Input [1]: [buf#100]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)#103]
-Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)#103 AS bloomFilter#104]
+Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#40, 42), 335, 8990, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#40, 42), 335, 8990, 0, 0)#101]
+Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#40, 42), 335, 8990, 0, 0)#101 AS bloomFilter#102]
 
-Subquery:2 Hosting operator id = 31 Hosting Expression = Subquery scalar-subquery#58, [id=#59]
+Subquery:2 Hosting operator id = 31 Hosting Expression = Subquery scalar-subquery#57, [id=#6]
 ObjectHashAggregate (68)
 +- Exchange (67)
    +- ObjectHashAggregate (66)
@@ -374,39 +374,39 @@ ObjectHashAggregate (68)
 
 
 (62) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_month_seq#83, d_week_seq#84]
+Output [2]: [d_month_seq#81, d_week_seq#82]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1224), LessThanOrEqual(d_month_seq,1235), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
 (63) ColumnarToRow [codegen id : 1]
-Input [2]: [d_month_seq#83, d_week_seq#84]
+Input [2]: [d_month_seq#81, d_week_seq#82]
 
 (64) Filter [codegen id : 1]
-Input [2]: [d_month_seq#83, d_week_seq#84]
-Condition : (((isnotnull(d_month_seq#83) AND (d_month_seq#83 >= 1224)) AND (d_month_seq#83 <= 1235)) AND isnotnull(d_week_seq#84))
+Input [2]: [d_month_seq#81, d_week_seq#82]
+Condition : (((isnotnull(d_month_seq#81) AND (d_month_seq#81 >= 1224)) AND (d_month_seq#81 <= 1235)) AND isnotnull(d_week_seq#82))
 
 (65) Project [codegen id : 1]
-Output [1]: [d_week_seq#84]
-Input [2]: [d_month_seq#83, d_week_seq#84]
+Output [1]: [d_week_seq#82]
+Input [2]: [d_month_seq#81, d_week_seq#82]
 
 (66) ObjectHashAggregate
-Input [1]: [d_week_seq#84]
+Input [1]: [d_week_seq#82]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#84, 42), 335, 8990, 0, 0)]
-Aggregate Attributes [1]: [buf#105]
-Results [1]: [buf#106]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#82, 42), 335, 8990, 0, 0)]
+Aggregate Attributes [1]: [buf#103]
+Results [1]: [buf#104]
 
 (67) Exchange
-Input [1]: [buf#106]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
+Input [1]: [buf#104]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
 
 (68) ObjectHashAggregate
-Input [1]: [buf#106]
+Input [1]: [buf#104]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#84, 42), 335, 8990, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#84, 42), 335, 8990, 0, 0)#107]
-Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#84, 42), 335, 8990, 0, 0)#107 AS bloomFilter#108]
+Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#82, 42), 335, 8990, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#82, 42), 335, 8990, 0, 0)#105]
+Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#82, 42), 335, 8990, 0, 0)#105 AS bloomFilter#106]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6.sf100/explain.txt
@@ -280,7 +280,7 @@ Input [2]: [d_date_sk#16, d_month_seq#26]
 
 (48) Filter [codegen id : 1]
 Input [2]: [d_date_sk#16, d_month_seq#26]
-Condition : ((isnotnull(d_month_seq#26) AND (d_month_seq#26 = ReusedSubquery Subquery scalar-subquery#27, [id=#28])) AND isnotnull(d_date_sk#16))
+Condition : ((isnotnull(d_month_seq#26) AND (d_month_seq#26 = ReusedSubquery Subquery scalar-subquery#27, [id=#9])) AND isnotnull(d_date_sk#16))
 
 (49) Project [codegen id : 1]
 Output [1]: [d_date_sk#16]
@@ -288,11 +288,11 @@ Input [2]: [d_date_sk#16, d_month_seq#26]
 
 (50) BroadcastExchange
 Input [1]: [d_date_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
-Subquery:2 Hosting operator id = 48 Hosting Expression = ReusedSubquery Subquery scalar-subquery#27, [id=#28]
+Subquery:2 Hosting operator id = 48 Hosting Expression = ReusedSubquery Subquery scalar-subquery#27, [id=#9]
 
-Subquery:3 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquery#27, [id=#28]
+Subquery:3 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquery#27, [id=#9]
 * HashAggregate (57)
 +- Exchange (56)
    +- * HashAggregate (55)
@@ -303,39 +303,39 @@ Subquery:3 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquer
 
 
 (51) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_month_seq#29, d_year#30, d_moy#31]
+Output [3]: [d_month_seq#28, d_year#29, d_moy#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,1)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
 (52) ColumnarToRow [codegen id : 1]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
+Input [3]: [d_month_seq#28, d_year#29, d_moy#30]
 
 (53) Filter [codegen id : 1]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
-Condition : (((isnotnull(d_year#30) AND isnotnull(d_moy#31)) AND (d_year#30 = 2000)) AND (d_moy#31 = 1))
+Input [3]: [d_month_seq#28, d_year#29, d_moy#30]
+Condition : (((isnotnull(d_year#29) AND isnotnull(d_moy#30)) AND (d_year#29 = 2000)) AND (d_moy#30 = 1))
 
 (54) Project [codegen id : 1]
-Output [1]: [d_month_seq#29]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
+Output [1]: [d_month_seq#28]
+Input [3]: [d_month_seq#28, d_year#29, d_moy#30]
 
 (55) HashAggregate [codegen id : 1]
-Input [1]: [d_month_seq#29]
-Keys [1]: [d_month_seq#29]
+Input [1]: [d_month_seq#28]
+Keys [1]: [d_month_seq#28]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [d_month_seq#29]
+Results [1]: [d_month_seq#28]
 
 (56) Exchange
-Input [1]: [d_month_seq#29]
-Arguments: hashpartitioning(d_month_seq#29, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [1]: [d_month_seq#28]
+Arguments: hashpartitioning(d_month_seq#28, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (57) HashAggregate [codegen id : 2]
-Input [1]: [d_month_seq#29]
-Keys [1]: [d_month_seq#29]
+Input [1]: [d_month_seq#28]
+Keys [1]: [d_month_seq#28]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [d_month_seq#29]
+Results [1]: [d_month_seq#28]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6/explain.txt
@@ -250,7 +250,7 @@ Input [2]: [d_date_sk#9, d_month_seq#26]
 
 (42) Filter [codegen id : 1]
 Input [2]: [d_date_sk#9, d_month_seq#26]
-Condition : ((isnotnull(d_month_seq#26) AND (d_month_seq#26 = ReusedSubquery Subquery scalar-subquery#27, [id=#28])) AND isnotnull(d_date_sk#9))
+Condition : ((isnotnull(d_month_seq#26) AND (d_month_seq#26 = ReusedSubquery Subquery scalar-subquery#27, [id=#7])) AND isnotnull(d_date_sk#9))
 
 (43) Project [codegen id : 1]
 Output [1]: [d_date_sk#9]
@@ -258,11 +258,11 @@ Input [2]: [d_date_sk#9, d_month_seq#26]
 
 (44) BroadcastExchange
 Input [1]: [d_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
-Subquery:2 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#27, [id=#28]
+Subquery:2 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#27, [id=#7]
 
-Subquery:3 Hosting operator id = 40 Hosting Expression = Subquery scalar-subquery#27, [id=#28]
+Subquery:3 Hosting operator id = 40 Hosting Expression = Subquery scalar-subquery#27, [id=#7]
 * HashAggregate (51)
 +- Exchange (50)
    +- * HashAggregate (49)
@@ -273,39 +273,39 @@ Subquery:3 Hosting operator id = 40 Hosting Expression = Subquery scalar-subquer
 
 
 (45) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_month_seq#29, d_year#30, d_moy#31]
+Output [3]: [d_month_seq#28, d_year#29, d_moy#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,1)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
 (46) ColumnarToRow [codegen id : 1]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
+Input [3]: [d_month_seq#28, d_year#29, d_moy#30]
 
 (47) Filter [codegen id : 1]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
-Condition : (((isnotnull(d_year#30) AND isnotnull(d_moy#31)) AND (d_year#30 = 2000)) AND (d_moy#31 = 1))
+Input [3]: [d_month_seq#28, d_year#29, d_moy#30]
+Condition : (((isnotnull(d_year#29) AND isnotnull(d_moy#30)) AND (d_year#29 = 2000)) AND (d_moy#30 = 1))
 
 (48) Project [codegen id : 1]
-Output [1]: [d_month_seq#29]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
+Output [1]: [d_month_seq#28]
+Input [3]: [d_month_seq#28, d_year#29, d_moy#30]
 
 (49) HashAggregate [codegen id : 1]
-Input [1]: [d_month_seq#29]
-Keys [1]: [d_month_seq#29]
+Input [1]: [d_month_seq#28]
+Keys [1]: [d_month_seq#28]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [d_month_seq#29]
+Results [1]: [d_month_seq#28]
 
 (50) Exchange
-Input [1]: [d_month_seq#29]
-Arguments: hashpartitioning(d_month_seq#29, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [1]: [d_month_seq#28]
+Arguments: hashpartitioning(d_month_seq#28, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (51) HashAggregate [codegen id : 2]
-Input [1]: [d_month_seq#29]
-Keys [1]: [d_month_seq#29]
+Input [1]: [d_month_seq#28]
+Keys [1]: [d_month_seq#28]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [d_month_seq#29]
+Results [1]: [d_month_seq#28]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q64.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q64.sf100/explain.txt
@@ -223,929 +223,929 @@ Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_ad
 
 (3) Filter [codegen id : 1]
 Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
-Condition : ((((((((isnotnull(ss_item_sk#1) AND isnotnull(ss_ticket_number#8)) AND isnotnull(ss_store_sk#6)) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_cdemo_sk#3)) AND isnotnull(ss_promo_sk#7)) AND isnotnull(ss_hdemo_sk#4)) AND isnotnull(ss_addr_sk#5)) AND might_contain(Subquery scalar-subquery#14, [id=#15], xxhash64(ss_item_sk#1, 42)))
+Condition : ((((((((isnotnull(ss_item_sk#1) AND isnotnull(ss_ticket_number#8)) AND isnotnull(ss_store_sk#6)) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_cdemo_sk#3)) AND isnotnull(ss_promo_sk#7)) AND isnotnull(ss_hdemo_sk#4)) AND isnotnull(ss_addr_sk#5)) AND might_contain(Subquery scalar-subquery#14, [id=#1], xxhash64(ss_item_sk#1, 42)))
 
 (4) Exchange
 Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
-Arguments: hashpartitioning(ss_item_sk#1, ss_ticket_number#8, 5), ENSURE_REQUIREMENTS, [plan_id=1]
+Arguments: hashpartitioning(ss_item_sk#1, ss_ticket_number#8, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (5) Sort [codegen id : 2]
 Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#8 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.store_returns
-Output [3]: [sr_item_sk#16, sr_ticket_number#17, sr_returned_date_sk#18]
+Output [3]: [sr_item_sk#15, sr_ticket_number#16, sr_returned_date_sk#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
 
 (7) ColumnarToRow [codegen id : 3]
-Input [3]: [sr_item_sk#16, sr_ticket_number#17, sr_returned_date_sk#18]
+Input [3]: [sr_item_sk#15, sr_ticket_number#16, sr_returned_date_sk#17]
 
 (8) Filter [codegen id : 3]
-Input [3]: [sr_item_sk#16, sr_ticket_number#17, sr_returned_date_sk#18]
-Condition : (isnotnull(sr_item_sk#16) AND isnotnull(sr_ticket_number#17))
+Input [3]: [sr_item_sk#15, sr_ticket_number#16, sr_returned_date_sk#17]
+Condition : (isnotnull(sr_item_sk#15) AND isnotnull(sr_ticket_number#16))
 
 (9) Project [codegen id : 3]
-Output [2]: [sr_item_sk#16, sr_ticket_number#17]
-Input [3]: [sr_item_sk#16, sr_ticket_number#17, sr_returned_date_sk#18]
+Output [2]: [sr_item_sk#15, sr_ticket_number#16]
+Input [3]: [sr_item_sk#15, sr_ticket_number#16, sr_returned_date_sk#17]
 
 (10) Exchange
-Input [2]: [sr_item_sk#16, sr_ticket_number#17]
-Arguments: hashpartitioning(sr_item_sk#16, sr_ticket_number#17, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [2]: [sr_item_sk#15, sr_ticket_number#16]
+Arguments: hashpartitioning(sr_item_sk#15, sr_ticket_number#16, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (11) Sort [codegen id : 4]
-Input [2]: [sr_item_sk#16, sr_ticket_number#17]
-Arguments: [sr_item_sk#16 ASC NULLS FIRST, sr_ticket_number#17 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#15, sr_ticket_number#16]
+Arguments: [sr_item_sk#15 ASC NULLS FIRST, sr_ticket_number#16 ASC NULLS FIRST], false, 0
 
 (12) SortMergeJoin [codegen id : 13]
 Left keys [2]: [ss_item_sk#1, ss_ticket_number#8]
-Right keys [2]: [sr_item_sk#16, sr_ticket_number#17]
+Right keys [2]: [sr_item_sk#15, sr_ticket_number#16]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 13]
 Output [11]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, sr_item_sk#16, sr_ticket_number#17]
+Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, sr_item_sk#15, sr_ticket_number#16]
 
 (14) Scan parquet spark_catalog.default.catalog_sales
-Output [4]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cs_sold_date_sk#22]
+Output [4]: [cs_item_sk#18, cs_order_number#19, cs_ext_list_price#20, cs_sold_date_sk#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_order_number)]
 ReadSchema: struct<cs_item_sk:int,cs_order_number:int,cs_ext_list_price:decimal(7,2)>
 
 (15) ColumnarToRow [codegen id : 5]
-Input [4]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cs_sold_date_sk#22]
+Input [4]: [cs_item_sk#18, cs_order_number#19, cs_ext_list_price#20, cs_sold_date_sk#21]
 
 (16) Filter [codegen id : 5]
-Input [4]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cs_sold_date_sk#22]
-Condition : (isnotnull(cs_item_sk#19) AND isnotnull(cs_order_number#20))
+Input [4]: [cs_item_sk#18, cs_order_number#19, cs_ext_list_price#20, cs_sold_date_sk#21]
+Condition : (isnotnull(cs_item_sk#18) AND isnotnull(cs_order_number#19))
 
 (17) Project [codegen id : 5]
-Output [3]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21]
-Input [4]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cs_sold_date_sk#22]
+Output [3]: [cs_item_sk#18, cs_order_number#19, cs_ext_list_price#20]
+Input [4]: [cs_item_sk#18, cs_order_number#19, cs_ext_list_price#20, cs_sold_date_sk#21]
 
 (18) Exchange
-Input [3]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21]
-Arguments: hashpartitioning(cs_item_sk#19, cs_order_number#20, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [3]: [cs_item_sk#18, cs_order_number#19, cs_ext_list_price#20]
+Arguments: hashpartitioning(cs_item_sk#18, cs_order_number#19, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (19) Sort [codegen id : 6]
-Input [3]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21]
-Arguments: [cs_item_sk#19 ASC NULLS FIRST, cs_order_number#20 ASC NULLS FIRST], false, 0
+Input [3]: [cs_item_sk#18, cs_order_number#19, cs_ext_list_price#20]
+Arguments: [cs_item_sk#18 ASC NULLS FIRST, cs_order_number#19 ASC NULLS FIRST], false, 0
 
 (20) Scan parquet spark_catalog.default.catalog_returns
-Output [6]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27, cr_returned_date_sk#28]
+Output [6]: [cr_item_sk#22, cr_order_number#23, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26, cr_returned_date_sk#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
 PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_refunded_cash:decimal(7,2),cr_reversed_charge:decimal(7,2),cr_store_credit:decimal(7,2)>
 
 (21) ColumnarToRow [codegen id : 7]
-Input [6]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27, cr_returned_date_sk#28]
+Input [6]: [cr_item_sk#22, cr_order_number#23, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26, cr_returned_date_sk#27]
 
 (22) Filter [codegen id : 7]
-Input [6]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27, cr_returned_date_sk#28]
-Condition : (isnotnull(cr_item_sk#23) AND isnotnull(cr_order_number#24))
+Input [6]: [cr_item_sk#22, cr_order_number#23, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26, cr_returned_date_sk#27]
+Condition : (isnotnull(cr_item_sk#22) AND isnotnull(cr_order_number#23))
 
 (23) Project [codegen id : 7]
-Output [5]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Input [6]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27, cr_returned_date_sk#28]
+Output [5]: [cr_item_sk#22, cr_order_number#23, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26]
+Input [6]: [cr_item_sk#22, cr_order_number#23, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26, cr_returned_date_sk#27]
 
 (24) Exchange
-Input [5]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Arguments: hashpartitioning(cr_item_sk#23, cr_order_number#24, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [5]: [cr_item_sk#22, cr_order_number#23, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26]
+Arguments: hashpartitioning(cr_item_sk#22, cr_order_number#23, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (25) Sort [codegen id : 8]
-Input [5]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Arguments: [cr_item_sk#23 ASC NULLS FIRST, cr_order_number#24 ASC NULLS FIRST], false, 0
+Input [5]: [cr_item_sk#22, cr_order_number#23, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26]
+Arguments: [cr_item_sk#22 ASC NULLS FIRST, cr_order_number#23 ASC NULLS FIRST], false, 0
 
 (26) SortMergeJoin [codegen id : 9]
-Left keys [2]: [cs_item_sk#19, cs_order_number#20]
-Right keys [2]: [cr_item_sk#23, cr_order_number#24]
+Left keys [2]: [cs_item_sk#18, cs_order_number#19]
+Right keys [2]: [cr_item_sk#22, cr_order_number#23]
 Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 9]
-Output [5]: [cs_item_sk#19, cs_ext_list_price#21, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Input [8]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
+Output [5]: [cs_item_sk#18, cs_ext_list_price#20, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26]
+Input [8]: [cs_item_sk#18, cs_order_number#19, cs_ext_list_price#20, cr_item_sk#22, cr_order_number#23, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26]
 
 (28) HashAggregate [codegen id : 9]
-Input [5]: [cs_item_sk#19, cs_ext_list_price#21, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Keys [1]: [cs_item_sk#19]
-Functions [2]: [partial_sum(UnscaledValue(cs_ext_list_price#21)), partial_sum(((cr_refunded_cash#25 + cr_reversed_charge#26) + cr_store_credit#27))]
-Aggregate Attributes [3]: [sum#29, sum#30, isEmpty#31]
-Results [4]: [cs_item_sk#19, sum#32, sum#33, isEmpty#34]
+Input [5]: [cs_item_sk#18, cs_ext_list_price#20, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26]
+Keys [1]: [cs_item_sk#18]
+Functions [2]: [partial_sum(UnscaledValue(cs_ext_list_price#20)), partial_sum(((cr_refunded_cash#24 + cr_reversed_charge#25) + cr_store_credit#26))]
+Aggregate Attributes [3]: [sum#28, sum#29, isEmpty#30]
+Results [4]: [cs_item_sk#18, sum#31, sum#32, isEmpty#33]
 
 (29) Exchange
-Input [4]: [cs_item_sk#19, sum#32, sum#33, isEmpty#34]
-Arguments: hashpartitioning(cs_item_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [4]: [cs_item_sk#18, sum#31, sum#32, isEmpty#33]
+Arguments: hashpartitioning(cs_item_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (30) HashAggregate [codegen id : 10]
-Input [4]: [cs_item_sk#19, sum#32, sum#33, isEmpty#34]
-Keys [1]: [cs_item_sk#19]
-Functions [2]: [sum(UnscaledValue(cs_ext_list_price#21)), sum(((cr_refunded_cash#25 + cr_reversed_charge#26) + cr_store_credit#27))]
-Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_list_price#21))#35, sum(((cr_refunded_cash#25 + cr_reversed_charge#26) + cr_store_credit#27))#36]
-Results [3]: [cs_item_sk#19, MakeDecimal(sum(UnscaledValue(cs_ext_list_price#21))#35,17,2) AS sale#37, sum(((cr_refunded_cash#25 + cr_reversed_charge#26) + cr_store_credit#27))#36 AS refund#38]
+Input [4]: [cs_item_sk#18, sum#31, sum#32, isEmpty#33]
+Keys [1]: [cs_item_sk#18]
+Functions [2]: [sum(UnscaledValue(cs_ext_list_price#20)), sum(((cr_refunded_cash#24 + cr_reversed_charge#25) + cr_store_credit#26))]
+Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_list_price#20))#34, sum(((cr_refunded_cash#24 + cr_reversed_charge#25) + cr_store_credit#26))#35]
+Results [3]: [cs_item_sk#18, MakeDecimal(sum(UnscaledValue(cs_ext_list_price#20))#34,17,2) AS sale#36, sum(((cr_refunded_cash#24 + cr_reversed_charge#25) + cr_store_credit#26))#35 AS refund#37]
 
 (31) Filter [codegen id : 10]
-Input [3]: [cs_item_sk#19, sale#37, refund#38]
-Condition : ((isnotnull(sale#37) AND isnotnull(refund#38)) AND (cast(sale#37 as decimal(21,2)) > (2 * refund#38)))
+Input [3]: [cs_item_sk#18, sale#36, refund#37]
+Condition : ((isnotnull(sale#36) AND isnotnull(refund#37)) AND (cast(sale#36 as decimal(21,2)) > (2 * refund#37)))
 
 (32) Project [codegen id : 10]
-Output [1]: [cs_item_sk#19]
-Input [3]: [cs_item_sk#19, sale#37, refund#38]
+Output [1]: [cs_item_sk#18]
+Input [3]: [cs_item_sk#18, sale#36, refund#37]
 
 (33) BroadcastExchange
-Input [1]: [cs_item_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+Input [1]: [cs_item_sk#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 (34) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [cs_item_sk#19]
+Right keys [1]: [cs_item_sk#18]
 Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 13]
 Output [11]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, cs_item_sk#19]
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, cs_item_sk#18]
 
 (36) ReusedExchange [Reuses operator id: 220]
-Output [2]: [d_date_sk#39, d_year#40]
+Output [2]: [d_date_sk#38, d_year#39]
 
 (37) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_sold_date_sk#12]
-Right keys [1]: [d_date_sk#39]
+Right keys [1]: [d_date_sk#38]
 Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 13]
-Output [11]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40]
-Input [13]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, d_date_sk#39, d_year#40]
+Output [11]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39]
+Input [13]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, d_date_sk#38, d_year#39]
 
 (39) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#41, s_store_name#42, s_zip#43]
+Output [3]: [s_store_sk#40, s_store_name#41, s_zip#42]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_name), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_zip:string>
 
 (40) ColumnarToRow [codegen id : 12]
-Input [3]: [s_store_sk#41, s_store_name#42, s_zip#43]
+Input [3]: [s_store_sk#40, s_store_name#41, s_zip#42]
 
 (41) Filter [codegen id : 12]
-Input [3]: [s_store_sk#41, s_store_name#42, s_zip#43]
-Condition : ((isnotnull(s_store_sk#41) AND isnotnull(s_store_name#42)) AND isnotnull(s_zip#43))
+Input [3]: [s_store_sk#40, s_store_name#41, s_zip#42]
+Condition : ((isnotnull(s_store_sk#40) AND isnotnull(s_store_name#41)) AND isnotnull(s_zip#42))
 
 (42) BroadcastExchange
-Input [3]: [s_store_sk#41, s_store_name#42, s_zip#43]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
+Input [3]: [s_store_sk#40, s_store_name#41, s_zip#42]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
 
 (43) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_store_sk#6]
-Right keys [1]: [s_store_sk#41]
+Right keys [1]: [s_store_sk#40]
 Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 13]
-Output [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_sk#41, s_store_name#42, s_zip#43]
+Output [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42]
+Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_sk#40, s_store_name#41, s_zip#42]
 
 (45) Exchange
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43]
-Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42]
+Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (46) Sort [codegen id : 14]
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43]
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42]
 Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
 
 (47) Scan parquet spark_catalog.default.customer
-Output [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
+Output [6]: [c_customer_sk#43, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, c_first_sales_date_sk#48]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_first_sales_date_sk), IsNotNull(c_first_shipto_date_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_hdemo_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_hdemo_sk:int,c_current_addr_sk:int,c_first_shipto_date_sk:int,c_first_sales_date_sk:int>
 
 (48) ColumnarToRow [codegen id : 15]
-Input [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
+Input [6]: [c_customer_sk#43, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, c_first_sales_date_sk#48]
 
 (49) Filter [codegen id : 15]
-Input [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
-Condition : (((((isnotnull(c_customer_sk#44) AND isnotnull(c_first_sales_date_sk#49)) AND isnotnull(c_first_shipto_date_sk#48)) AND isnotnull(c_current_cdemo_sk#45)) AND isnotnull(c_current_hdemo_sk#46)) AND isnotnull(c_current_addr_sk#47))
+Input [6]: [c_customer_sk#43, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, c_first_sales_date_sk#48]
+Condition : (((((isnotnull(c_customer_sk#43) AND isnotnull(c_first_sales_date_sk#48)) AND isnotnull(c_first_shipto_date_sk#47)) AND isnotnull(c_current_cdemo_sk#44)) AND isnotnull(c_current_hdemo_sk#45)) AND isnotnull(c_current_addr_sk#46))
 
 (50) Exchange
-Input [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
-Arguments: hashpartitioning(c_customer_sk#44, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [6]: [c_customer_sk#43, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, c_first_sales_date_sk#48]
+Arguments: hashpartitioning(c_customer_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (51) Sort [codegen id : 16]
-Input [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
-Arguments: [c_customer_sk#44 ASC NULLS FIRST], false, 0
+Input [6]: [c_customer_sk#43, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, c_first_sales_date_sk#48]
+Arguments: [c_customer_sk#43 ASC NULLS FIRST], false, 0
 
 (52) SortMergeJoin [codegen id : 19]
 Left keys [1]: [ss_customer_sk#2]
-Right keys [1]: [c_customer_sk#44]
+Right keys [1]: [c_customer_sk#43]
 Join type: Inner
 Join condition: None
 
 (53) Project [codegen id : 19]
-Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
-Input [18]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
+Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, c_first_sales_date_sk#48]
+Input [18]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_customer_sk#43, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, c_first_sales_date_sk#48]
 
 (54) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#50, d_year#51]
+Output [2]: [d_date_sk#49, d_year#50]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (55) ColumnarToRow [codegen id : 17]
-Input [2]: [d_date_sk#50, d_year#51]
+Input [2]: [d_date_sk#49, d_year#50]
 
 (56) Filter [codegen id : 17]
-Input [2]: [d_date_sk#50, d_year#51]
-Condition : isnotnull(d_date_sk#50)
+Input [2]: [d_date_sk#49, d_year#50]
+Condition : isnotnull(d_date_sk#49)
 
 (57) BroadcastExchange
-Input [2]: [d_date_sk#50, d_year#51]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=10]
+Input [2]: [d_date_sk#49, d_year#50]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=11]
 
 (58) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [c_first_sales_date_sk#49]
-Right keys [1]: [d_date_sk#50]
+Left keys [1]: [c_first_sales_date_sk#48]
+Right keys [1]: [d_date_sk#49]
 Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 19]
-Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, d_year#51]
-Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49, d_date_sk#50, d_year#51]
+Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, d_year#50]
+Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, c_first_sales_date_sk#48, d_date_sk#49, d_year#50]
 
 (60) ReusedExchange [Reuses operator id: 57]
-Output [2]: [d_date_sk#52, d_year#53]
+Output [2]: [d_date_sk#51, d_year#52]
 
 (61) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [c_first_shipto_date_sk#48]
-Right keys [1]: [d_date_sk#52]
+Left keys [1]: [c_first_shipto_date_sk#47]
+Right keys [1]: [d_date_sk#51]
 Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 19]
-Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
-Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, d_year#51, d_date_sk#52, d_year#53]
+Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52]
+Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, d_year#50, d_date_sk#51, d_year#52]
 
 (63) Exchange
-Input [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
-Arguments: hashpartitioning(ss_cdemo_sk#3, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52]
+Arguments: hashpartitioning(ss_cdemo_sk#3, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (64) Sort [codegen id : 20]
-Input [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
+Input [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52]
 Arguments: [ss_cdemo_sk#3 ASC NULLS FIRST], false, 0
 
 (65) Scan parquet spark_catalog.default.customer_demographics
-Output [2]: [cd_demo_sk#54, cd_marital_status#55]
+Output [2]: [cd_demo_sk#53, cd_marital_status#54]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
 
 (66) ColumnarToRow [codegen id : 21]
-Input [2]: [cd_demo_sk#54, cd_marital_status#55]
+Input [2]: [cd_demo_sk#53, cd_marital_status#54]
 
 (67) Filter [codegen id : 21]
-Input [2]: [cd_demo_sk#54, cd_marital_status#55]
-Condition : (isnotnull(cd_demo_sk#54) AND isnotnull(cd_marital_status#55))
+Input [2]: [cd_demo_sk#53, cd_marital_status#54]
+Condition : (isnotnull(cd_demo_sk#53) AND isnotnull(cd_marital_status#54))
 
 (68) Exchange
-Input [2]: [cd_demo_sk#54, cd_marital_status#55]
-Arguments: hashpartitioning(cd_demo_sk#54, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [2]: [cd_demo_sk#53, cd_marital_status#54]
+Arguments: hashpartitioning(cd_demo_sk#53, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (69) Sort [codegen id : 22]
-Input [2]: [cd_demo_sk#54, cd_marital_status#55]
-Arguments: [cd_demo_sk#54 ASC NULLS FIRST], false, 0
+Input [2]: [cd_demo_sk#53, cd_marital_status#54]
+Arguments: [cd_demo_sk#53 ASC NULLS FIRST], false, 0
 
 (70) SortMergeJoin [codegen id : 23]
 Left keys [1]: [ss_cdemo_sk#3]
-Right keys [1]: [cd_demo_sk#54]
+Right keys [1]: [cd_demo_sk#53]
 Join type: Inner
 Join condition: None
 
 (71) Project [codegen id : 23]
-Output [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_marital_status#55]
-Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_demo_sk#54, cd_marital_status#55]
+Output [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, cd_marital_status#54]
+Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, cd_demo_sk#53, cd_marital_status#54]
 
 (72) Exchange
-Input [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_marital_status#55]
-Arguments: hashpartitioning(c_current_cdemo_sk#45, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+Input [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, cd_marital_status#54]
+Arguments: hashpartitioning(c_current_cdemo_sk#44, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (73) Sort [codegen id : 24]
-Input [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_marital_status#55]
-Arguments: [c_current_cdemo_sk#45 ASC NULLS FIRST], false, 0
+Input [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, cd_marital_status#54]
+Arguments: [c_current_cdemo_sk#44 ASC NULLS FIRST], false, 0
 
 (74) ReusedExchange [Reuses operator id: 68]
-Output [2]: [cd_demo_sk#56, cd_marital_status#57]
+Output [2]: [cd_demo_sk#55, cd_marital_status#56]
 
 (75) Sort [codegen id : 26]
-Input [2]: [cd_demo_sk#56, cd_marital_status#57]
-Arguments: [cd_demo_sk#56 ASC NULLS FIRST], false, 0
+Input [2]: [cd_demo_sk#55, cd_marital_status#56]
+Arguments: [cd_demo_sk#55 ASC NULLS FIRST], false, 0
 
 (76) SortMergeJoin [codegen id : 30]
-Left keys [1]: [c_current_cdemo_sk#45]
-Right keys [1]: [cd_demo_sk#56]
+Left keys [1]: [c_current_cdemo_sk#44]
+Right keys [1]: [cd_demo_sk#55]
 Join type: Inner
-Join condition: NOT (cd_marital_status#55 = cd_marital_status#57)
+Join condition: NOT (cd_marital_status#54 = cd_marital_status#56)
 
 (77) Project [codegen id : 30]
-Output [14]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
-Input [18]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_marital_status#55, cd_demo_sk#56, cd_marital_status#57]
+Output [14]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52]
+Input [18]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, cd_marital_status#54, cd_demo_sk#55, cd_marital_status#56]
 
 (78) Scan parquet spark_catalog.default.promotion
-Output [1]: [p_promo_sk#58]
+Output [1]: [p_promo_sk#57]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/promotion]
 PushedFilters: [IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int>
 
 (79) ColumnarToRow [codegen id : 27]
-Input [1]: [p_promo_sk#58]
+Input [1]: [p_promo_sk#57]
 
 (80) Filter [codegen id : 27]
-Input [1]: [p_promo_sk#58]
-Condition : isnotnull(p_promo_sk#58)
+Input [1]: [p_promo_sk#57]
+Condition : isnotnull(p_promo_sk#57)
 
 (81) BroadcastExchange
-Input [1]: [p_promo_sk#58]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=14]
+Input [1]: [p_promo_sk#57]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=15]
 
 (82) BroadcastHashJoin [codegen id : 30]
 Left keys [1]: [ss_promo_sk#7]
-Right keys [1]: [p_promo_sk#58]
+Right keys [1]: [p_promo_sk#57]
 Join type: Inner
 Join condition: None
 
 (83) Project [codegen id : 30]
-Output [13]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
-Input [15]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, p_promo_sk#58]
+Output [13]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52]
+Input [15]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, p_promo_sk#57]
 
 (84) Scan parquet spark_catalog.default.household_demographics
-Output [2]: [hd_demo_sk#59, hd_income_band_sk#60]
+Output [2]: [hd_demo_sk#58, hd_income_band_sk#59]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_demo_sk), IsNotNull(hd_income_band_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_income_band_sk:int>
 
 (85) ColumnarToRow [codegen id : 28]
-Input [2]: [hd_demo_sk#59, hd_income_band_sk#60]
+Input [2]: [hd_demo_sk#58, hd_income_band_sk#59]
 
 (86) Filter [codegen id : 28]
-Input [2]: [hd_demo_sk#59, hd_income_band_sk#60]
-Condition : (isnotnull(hd_demo_sk#59) AND isnotnull(hd_income_band_sk#60))
+Input [2]: [hd_demo_sk#58, hd_income_band_sk#59]
+Condition : (isnotnull(hd_demo_sk#58) AND isnotnull(hd_income_band_sk#59))
 
 (87) BroadcastExchange
-Input [2]: [hd_demo_sk#59, hd_income_band_sk#60]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=15]
+Input [2]: [hd_demo_sk#58, hd_income_band_sk#59]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=16]
 
 (88) BroadcastHashJoin [codegen id : 30]
 Left keys [1]: [ss_hdemo_sk#4]
-Right keys [1]: [hd_demo_sk#59]
+Right keys [1]: [hd_demo_sk#58]
 Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 30]
-Output [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60]
-Input [15]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, hd_demo_sk#59, hd_income_band_sk#60]
+Output [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59]
+Input [15]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, hd_demo_sk#58, hd_income_band_sk#59]
 
 (90) ReusedExchange [Reuses operator id: 87]
-Output [2]: [hd_demo_sk#61, hd_income_band_sk#62]
+Output [2]: [hd_demo_sk#60, hd_income_band_sk#61]
 
 (91) BroadcastHashJoin [codegen id : 30]
-Left keys [1]: [c_current_hdemo_sk#46]
-Right keys [1]: [hd_demo_sk#61]
+Left keys [1]: [c_current_hdemo_sk#45]
+Right keys [1]: [hd_demo_sk#60]
 Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 30]
-Output [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62]
-Input [15]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_demo_sk#61, hd_income_band_sk#62]
+Output [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61]
+Input [15]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_demo_sk#60, hd_income_band_sk#61]
 
 (93) Exchange
-Input [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62]
-Arguments: hashpartitioning(ss_addr_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+Input [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61]
+Arguments: hashpartitioning(ss_addr_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
 (94) Sort [codegen id : 31]
-Input [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62]
+Input [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61]
 Arguments: [ss_addr_sk#5 ASC NULLS FIRST], false, 0
 
 (95) Scan parquet spark_catalog.default.customer_address
-Output [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
+Output [5]: [ca_address_sk#62, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_street_number:string,ca_street_name:string,ca_city:string,ca_zip:string>
 
 (96) ColumnarToRow [codegen id : 32]
-Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
+Input [5]: [ca_address_sk#62, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
 
 (97) Filter [codegen id : 32]
-Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Condition : isnotnull(ca_address_sk#63)
+Input [5]: [ca_address_sk#62, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
+Condition : isnotnull(ca_address_sk#62)
 
 (98) Exchange
-Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Arguments: hashpartitioning(ca_address_sk#63, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+Input [5]: [ca_address_sk#62, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
+Arguments: hashpartitioning(ca_address_sk#62, 5), ENSURE_REQUIREMENTS, [plan_id=18]
 
 (99) Sort [codegen id : 33]
-Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Arguments: [ca_address_sk#63 ASC NULLS FIRST], false, 0
+Input [5]: [ca_address_sk#62, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
+Arguments: [ca_address_sk#62 ASC NULLS FIRST], false, 0
 
 (100) SortMergeJoin [codegen id : 34]
 Left keys [1]: [ss_addr_sk#5]
-Right keys [1]: [ca_address_sk#63]
+Right keys [1]: [ca_address_sk#62]
 Join type: Inner
 Join condition: None
 
 (101) Project [codegen id : 34]
-Output [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Input [18]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
+Output [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
+Input [18]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61, ca_address_sk#62, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
 
 (102) Exchange
-Input [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Arguments: hashpartitioning(c_current_addr_sk#47, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+Input [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
+Arguments: hashpartitioning(c_current_addr_sk#46, 5), ENSURE_REQUIREMENTS, [plan_id=19]
 
 (103) Sort [codegen id : 35]
-Input [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Arguments: [c_current_addr_sk#47 ASC NULLS FIRST], false, 0
+Input [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
+Arguments: [c_current_addr_sk#46 ASC NULLS FIRST], false, 0
 
 (104) ReusedExchange [Reuses operator id: 98]
-Output [5]: [ca_address_sk#68, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
+Output [5]: [ca_address_sk#67, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71]
 
 (105) Sort [codegen id : 37]
-Input [5]: [ca_address_sk#68, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
-Arguments: [ca_address_sk#68 ASC NULLS FIRST], false, 0
+Input [5]: [ca_address_sk#67, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71]
+Arguments: [ca_address_sk#67 ASC NULLS FIRST], false, 0
 
 (106) SortMergeJoin [codegen id : 41]
-Left keys [1]: [c_current_addr_sk#47]
-Right keys [1]: [ca_address_sk#68]
+Left keys [1]: [c_current_addr_sk#46]
+Right keys [1]: [ca_address_sk#67]
 Join type: Inner
 Join condition: None
 
 (107) Project [codegen id : 41]
-Output [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
-Input [21]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_address_sk#68, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
+Output [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71]
+Input [21]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_address_sk#67, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71]
 
 (108) Scan parquet spark_catalog.default.income_band
-Output [1]: [ib_income_band_sk#73]
+Output [1]: [ib_income_band_sk#72]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/income_band]
 PushedFilters: [IsNotNull(ib_income_band_sk)]
 ReadSchema: struct<ib_income_band_sk:int>
 
 (109) ColumnarToRow [codegen id : 38]
-Input [1]: [ib_income_band_sk#73]
+Input [1]: [ib_income_band_sk#72]
 
 (110) Filter [codegen id : 38]
-Input [1]: [ib_income_band_sk#73]
-Condition : isnotnull(ib_income_band_sk#73)
+Input [1]: [ib_income_band_sk#72]
+Condition : isnotnull(ib_income_band_sk#72)
 
 (111) BroadcastExchange
-Input [1]: [ib_income_band_sk#73]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=19]
+Input [1]: [ib_income_band_sk#72]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=20]
 
 (112) BroadcastHashJoin [codegen id : 41]
-Left keys [1]: [hd_income_band_sk#60]
-Right keys [1]: [ib_income_band_sk#73]
+Left keys [1]: [hd_income_band_sk#59]
+Right keys [1]: [ib_income_band_sk#72]
 Join type: Inner
 Join condition: None
 
 (113) Project [codegen id : 41]
-Output [18]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
-Input [20]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, ib_income_band_sk#73]
+Output [18]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, d_year#50, d_year#52, hd_income_band_sk#61, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71]
+Input [20]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, ib_income_band_sk#72]
 
 (114) ReusedExchange [Reuses operator id: 111]
-Output [1]: [ib_income_band_sk#74]
+Output [1]: [ib_income_band_sk#73]
 
 (115) BroadcastHashJoin [codegen id : 41]
-Left keys [1]: [hd_income_band_sk#62]
-Right keys [1]: [ib_income_band_sk#74]
+Left keys [1]: [hd_income_band_sk#61]
+Right keys [1]: [ib_income_band_sk#73]
 Join type: Inner
 Join condition: None
 
 (116) Project [codegen id : 41]
-Output [17]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
-Input [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, ib_income_band_sk#74]
+Output [17]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, d_year#50, d_year#52, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71]
+Input [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, d_year#50, d_year#52, hd_income_band_sk#61, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, ib_income_band_sk#73]
 
 (117) Scan parquet spark_catalog.default.item
-Output [4]: [i_item_sk#75, i_current_price#76, i_color#77, i_product_name#78]
+Output [4]: [i_item_sk#74, i_current_price#75, i_color#76, i_product_name#77]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_current_price), In(i_color, [burlywood           ,floral              ,indian              ,medium              ,purple              ,spring              ]), GreaterThanOrEqual(i_current_price,64.00), LessThanOrEqual(i_current_price,74.00), GreaterThanOrEqual(i_current_price,65.00), LessThanOrEqual(i_current_price,79.00), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_color:string,i_product_name:string>
 
 (118) ColumnarToRow [codegen id : 40]
-Input [4]: [i_item_sk#75, i_current_price#76, i_color#77, i_product_name#78]
+Input [4]: [i_item_sk#74, i_current_price#75, i_color#76, i_product_name#77]
 
 (119) Filter [codegen id : 40]
-Input [4]: [i_item_sk#75, i_current_price#76, i_color#77, i_product_name#78]
-Condition : ((((((isnotnull(i_current_price#76) AND i_color#77 IN (purple              ,burlywood           ,indian              ,spring              ,floral              ,medium              )) AND (i_current_price#76 >= 64.00)) AND (i_current_price#76 <= 74.00)) AND (i_current_price#76 >= 65.00)) AND (i_current_price#76 <= 79.00)) AND isnotnull(i_item_sk#75))
+Input [4]: [i_item_sk#74, i_current_price#75, i_color#76, i_product_name#77]
+Condition : ((((((isnotnull(i_current_price#75) AND i_color#76 IN (purple              ,burlywood           ,indian              ,spring              ,floral              ,medium              )) AND (i_current_price#75 >= 64.00)) AND (i_current_price#75 <= 74.00)) AND (i_current_price#75 >= 65.00)) AND (i_current_price#75 <= 79.00)) AND isnotnull(i_item_sk#74))
 
 (120) Project [codegen id : 40]
-Output [2]: [i_item_sk#75, i_product_name#78]
-Input [4]: [i_item_sk#75, i_current_price#76, i_color#77, i_product_name#78]
+Output [2]: [i_item_sk#74, i_product_name#77]
+Input [4]: [i_item_sk#74, i_current_price#75, i_color#76, i_product_name#77]
 
 (121) BroadcastExchange
-Input [2]: [i_item_sk#75, i_product_name#78]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=20]
+Input [2]: [i_item_sk#74, i_product_name#77]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=21]
 
 (122) BroadcastHashJoin [codegen id : 41]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#75]
+Right keys [1]: [i_item_sk#74]
 Join type: Inner
 Join condition: None
 
 (123) Project [codegen id : 41]
-Output [18]: [ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, d_year#51, d_year#53, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, i_item_sk#75, i_product_name#78]
-Input [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, i_item_sk#75, i_product_name#78]
+Output [18]: [ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, d_year#50, d_year#52, s_store_name#41, s_zip#42, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, i_item_sk#74, i_product_name#77]
+Input [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, d_year#50, d_year#52, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, i_item_sk#74, i_product_name#77]
 
 (124) HashAggregate [codegen id : 41]
-Input [18]: [ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, d_year#51, d_year#53, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, i_item_sk#75, i_product_name#78]
-Keys [15]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53]
+Input [18]: [ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, d_year#50, d_year#52, s_store_name#41, s_zip#42, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, i_item_sk#74, i_product_name#77]
+Keys [15]: [i_product_name#77, i_item_sk#74, s_store_name#41, s_zip#42, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, d_year#39, d_year#50, d_year#52]
 Functions [4]: [partial_count(1), partial_sum(UnscaledValue(ss_wholesale_cost#9)), partial_sum(UnscaledValue(ss_list_price#10)), partial_sum(UnscaledValue(ss_coupon_amt#11))]
-Aggregate Attributes [4]: [count#79, sum#80, sum#81, sum#82]
-Results [19]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53, count#83, sum#84, sum#85, sum#86]
+Aggregate Attributes [4]: [count#78, sum#79, sum#80, sum#81]
+Results [19]: [i_product_name#77, i_item_sk#74, s_store_name#41, s_zip#42, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, d_year#39, d_year#50, d_year#52, count#82, sum#83, sum#84, sum#85]
 
 (125) Exchange
-Input [19]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53, count#83, sum#84, sum#85, sum#86]
-Arguments: hashpartitioning(i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53, 5), ENSURE_REQUIREMENTS, [plan_id=21]
+Input [19]: [i_product_name#77, i_item_sk#74, s_store_name#41, s_zip#42, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, d_year#39, d_year#50, d_year#52, count#82, sum#83, sum#84, sum#85]
+Arguments: hashpartitioning(i_product_name#77, i_item_sk#74, s_store_name#41, s_zip#42, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, d_year#39, d_year#50, d_year#52, 5), ENSURE_REQUIREMENTS, [plan_id=22]
 
 (126) HashAggregate [codegen id : 42]
-Input [19]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53, count#83, sum#84, sum#85, sum#86]
-Keys [15]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53]
+Input [19]: [i_product_name#77, i_item_sk#74, s_store_name#41, s_zip#42, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, d_year#39, d_year#50, d_year#52, count#82, sum#83, sum#84, sum#85]
+Keys [15]: [i_product_name#77, i_item_sk#74, s_store_name#41, s_zip#42, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, d_year#39, d_year#50, d_year#52]
 Functions [4]: [count(1), sum(UnscaledValue(ss_wholesale_cost#9)), sum(UnscaledValue(ss_list_price#10)), sum(UnscaledValue(ss_coupon_amt#11))]
-Aggregate Attributes [4]: [count(1)#87, sum(UnscaledValue(ss_wholesale_cost#9))#88, sum(UnscaledValue(ss_list_price#10))#89, sum(UnscaledValue(ss_coupon_amt#11))#90]
-Results [17]: [i_product_name#78 AS product_name#91, i_item_sk#75 AS item_sk#92, s_store_name#42 AS store_name#93, s_zip#43 AS store_zip#94, ca_street_number#64 AS b_street_number#95, ca_street_name#65 AS b_streen_name#96, ca_city#66 AS b_city#97, ca_zip#67 AS b_zip#98, ca_street_number#69 AS c_street_number#99, ca_street_name#70 AS c_street_name#100, ca_city#71 AS c_city#101, ca_zip#72 AS c_zip#102, d_year#40 AS syear#103, count(1)#87 AS cnt#104, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#9))#88,17,2) AS s1#105, MakeDecimal(sum(UnscaledValue(ss_list_price#10))#89,17,2) AS s2#106, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#11))#90,17,2) AS s3#107]
+Aggregate Attributes [4]: [count(1)#86, sum(UnscaledValue(ss_wholesale_cost#9))#87, sum(UnscaledValue(ss_list_price#10))#88, sum(UnscaledValue(ss_coupon_amt#11))#89]
+Results [17]: [i_product_name#77 AS product_name#90, i_item_sk#74 AS item_sk#91, s_store_name#41 AS store_name#92, s_zip#42 AS store_zip#93, ca_street_number#63 AS b_street_number#94, ca_street_name#64 AS b_streen_name#95, ca_city#65 AS b_city#96, ca_zip#66 AS b_zip#97, ca_street_number#68 AS c_street_number#98, ca_street_name#69 AS c_street_name#99, ca_city#70 AS c_city#100, ca_zip#71 AS c_zip#101, d_year#39 AS syear#102, count(1)#86 AS cnt#103, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#9))#87,17,2) AS s1#104, MakeDecimal(sum(UnscaledValue(ss_list_price#10))#88,17,2) AS s2#105, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#11))#89,17,2) AS s3#106]
 
 (127) Exchange
-Input [17]: [product_name#91, item_sk#92, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107]
-Arguments: hashpartitioning(item_sk#92, store_name#93, store_zip#94, 5), ENSURE_REQUIREMENTS, [plan_id=22]
+Input [17]: [product_name#90, item_sk#91, store_name#92, store_zip#93, b_street_number#94, b_streen_name#95, b_city#96, b_zip#97, c_street_number#98, c_street_name#99, c_city#100, c_zip#101, syear#102, cnt#103, s1#104, s2#105, s3#106]
+Arguments: hashpartitioning(item_sk#91, store_name#92, store_zip#93, 5), ENSURE_REQUIREMENTS, [plan_id=23]
 
 (128) Sort [codegen id : 43]
-Input [17]: [product_name#91, item_sk#92, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107]
-Arguments: [item_sk#92 ASC NULLS FIRST, store_name#93 ASC NULLS FIRST, store_zip#94 ASC NULLS FIRST], false, 0
+Input [17]: [product_name#90, item_sk#91, store_name#92, store_zip#93, b_street_number#94, b_streen_name#95, b_city#96, b_zip#97, c_street_number#98, c_street_name#99, c_city#100, c_zip#101, syear#102, cnt#103, s1#104, s2#105, s3#106]
+Arguments: [item_sk#91 ASC NULLS FIRST, store_name#92 ASC NULLS FIRST, store_zip#93 ASC NULLS FIRST], false, 0
 
 (129) Scan parquet spark_catalog.default.store_sales
-Output [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
+Output [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_ticket_number#114, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#119), dynamicpruningexpression(ss_sold_date_sk#119 IN dynamicpruning#120)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#118), dynamicpruningexpression(ss_sold_date_sk#118 IN dynamicpruning#119)]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_ticket_number), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk), IsNotNull(ss_cdemo_sk), IsNotNull(ss_promo_sk), IsNotNull(ss_hdemo_sk), IsNotNull(ss_addr_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_cdemo_sk:int,ss_hdemo_sk:int,ss_addr_sk:int,ss_store_sk:int,ss_promo_sk:int,ss_ticket_number:int,ss_wholesale_cost:decimal(7,2),ss_list_price:decimal(7,2),ss_coupon_amt:decimal(7,2)>
 
 (130) ColumnarToRow [codegen id : 44]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
+Input [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_ticket_number#114, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118]
 
 (131) Filter [codegen id : 44]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Condition : ((((((((isnotnull(ss_item_sk#108) AND isnotnull(ss_ticket_number#115)) AND isnotnull(ss_store_sk#113)) AND isnotnull(ss_customer_sk#109)) AND isnotnull(ss_cdemo_sk#110)) AND isnotnull(ss_promo_sk#114)) AND isnotnull(ss_hdemo_sk#111)) AND isnotnull(ss_addr_sk#112)) AND might_contain(ReusedSubquery Subquery scalar-subquery#14, [id=#15], xxhash64(ss_item_sk#108, 42)))
+Input [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_ticket_number#114, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118]
+Condition : ((((((((isnotnull(ss_item_sk#107) AND isnotnull(ss_ticket_number#114)) AND isnotnull(ss_store_sk#112)) AND isnotnull(ss_customer_sk#108)) AND isnotnull(ss_cdemo_sk#109)) AND isnotnull(ss_promo_sk#113)) AND isnotnull(ss_hdemo_sk#110)) AND isnotnull(ss_addr_sk#111)) AND might_contain(ReusedSubquery Subquery scalar-subquery#14, [id=#1], xxhash64(ss_item_sk#107, 42)))
 
 (132) Exchange
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Arguments: hashpartitioning(ss_item_sk#108, ss_ticket_number#115, 5), ENSURE_REQUIREMENTS, [plan_id=23]
+Input [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_ticket_number#114, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118]
+Arguments: hashpartitioning(ss_item_sk#107, ss_ticket_number#114, 5), ENSURE_REQUIREMENTS, [plan_id=24]
 
 (133) Sort [codegen id : 45]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Arguments: [ss_item_sk#108 ASC NULLS FIRST, ss_ticket_number#115 ASC NULLS FIRST], false, 0
+Input [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_ticket_number#114, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118]
+Arguments: [ss_item_sk#107 ASC NULLS FIRST, ss_ticket_number#114 ASC NULLS FIRST], false, 0
 
 (134) ReusedExchange [Reuses operator id: 10]
-Output [2]: [sr_item_sk#121, sr_ticket_number#122]
+Output [2]: [sr_item_sk#120, sr_ticket_number#121]
 
 (135) Sort [codegen id : 47]
-Input [2]: [sr_item_sk#121, sr_ticket_number#122]
-Arguments: [sr_item_sk#121 ASC NULLS FIRST, sr_ticket_number#122 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#120, sr_ticket_number#121]
+Arguments: [sr_item_sk#120 ASC NULLS FIRST, sr_ticket_number#121 ASC NULLS FIRST], false, 0
 
 (136) SortMergeJoin [codegen id : 56]
-Left keys [2]: [ss_item_sk#108, ss_ticket_number#115]
-Right keys [2]: [sr_item_sk#121, sr_ticket_number#122]
+Left keys [2]: [ss_item_sk#107, ss_ticket_number#114]
+Right keys [2]: [sr_item_sk#120, sr_ticket_number#121]
 Join type: Inner
 Join condition: None
 
 (137) Project [codegen id : 56]
-Output [11]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Input [14]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119, sr_item_sk#121, sr_ticket_number#122]
+Output [11]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118]
+Input [14]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_ticket_number#114, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118, sr_item_sk#120, sr_ticket_number#121]
 
 (138) ReusedExchange [Reuses operator id: 33]
-Output [1]: [cs_item_sk#123]
+Output [1]: [cs_item_sk#122]
 
 (139) BroadcastHashJoin [codegen id : 56]
-Left keys [1]: [ss_item_sk#108]
-Right keys [1]: [cs_item_sk#123]
+Left keys [1]: [ss_item_sk#107]
+Right keys [1]: [cs_item_sk#122]
 Join type: Inner
 Join condition: None
 
 (140) Project [codegen id : 56]
-Output [11]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119, cs_item_sk#123]
+Output [11]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118]
+Input [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118, cs_item_sk#122]
 
 (141) ReusedExchange [Reuses operator id: 224]
-Output [2]: [d_date_sk#124, d_year#125]
+Output [2]: [d_date_sk#123, d_year#124]
 
 (142) BroadcastHashJoin [codegen id : 56]
-Left keys [1]: [ss_sold_date_sk#119]
-Right keys [1]: [d_date_sk#124]
+Left keys [1]: [ss_sold_date_sk#118]
+Right keys [1]: [d_date_sk#123]
 Join type: Inner
 Join condition: None
 
 (143) Project [codegen id : 56]
-Output [11]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125]
-Input [13]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119, d_date_sk#124, d_year#125]
+Output [11]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124]
+Input [13]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118, d_date_sk#123, d_year#124]
 
 (144) ReusedExchange [Reuses operator id: 42]
-Output [3]: [s_store_sk#126, s_store_name#127, s_zip#128]
+Output [3]: [s_store_sk#125, s_store_name#126, s_zip#127]
 
 (145) BroadcastHashJoin [codegen id : 56]
-Left keys [1]: [ss_store_sk#113]
-Right keys [1]: [s_store_sk#126]
+Left keys [1]: [ss_store_sk#112]
+Right keys [1]: [s_store_sk#125]
 Join type: Inner
 Join condition: None
 
 (146) Project [codegen id : 56]
-Output [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128]
-Input [14]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_sk#126, s_store_name#127, s_zip#128]
+Output [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127]
+Input [14]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_sk#125, s_store_name#126, s_zip#127]
 
 (147) Exchange
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128]
-Arguments: hashpartitioning(ss_customer_sk#109, 5), ENSURE_REQUIREMENTS, [plan_id=24]
+Input [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127]
+Arguments: hashpartitioning(ss_customer_sk#108, 5), ENSURE_REQUIREMENTS, [plan_id=25]
 
 (148) Sort [codegen id : 57]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128]
-Arguments: [ss_customer_sk#109 ASC NULLS FIRST], false, 0
+Input [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127]
+Arguments: [ss_customer_sk#108 ASC NULLS FIRST], false, 0
 
 (149) ReusedExchange [Reuses operator id: 50]
-Output [6]: [c_customer_sk#129, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134]
+Output [6]: [c_customer_sk#128, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, c_first_shipto_date_sk#132, c_first_sales_date_sk#133]
 
 (150) Sort [codegen id : 59]
-Input [6]: [c_customer_sk#129, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134]
-Arguments: [c_customer_sk#129 ASC NULLS FIRST], false, 0
+Input [6]: [c_customer_sk#128, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, c_first_shipto_date_sk#132, c_first_sales_date_sk#133]
+Arguments: [c_customer_sk#128 ASC NULLS FIRST], false, 0
 
 (151) SortMergeJoin [codegen id : 62]
-Left keys [1]: [ss_customer_sk#109]
-Right keys [1]: [c_customer_sk#129]
+Left keys [1]: [ss_customer_sk#108]
+Right keys [1]: [c_customer_sk#128]
 Join type: Inner
 Join condition: None
 
 (152) Project [codegen id : 62]
-Output [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134]
-Input [18]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_customer_sk#129, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134]
+Output [16]: [ss_item_sk#107, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, c_first_shipto_date_sk#132, c_first_sales_date_sk#133]
+Input [18]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_customer_sk#128, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, c_first_shipto_date_sk#132, c_first_sales_date_sk#133]
 
 (153) ReusedExchange [Reuses operator id: 57]
-Output [2]: [d_date_sk#135, d_year#136]
+Output [2]: [d_date_sk#134, d_year#135]
 
 (154) BroadcastHashJoin [codegen id : 62]
-Left keys [1]: [c_first_sales_date_sk#134]
-Right keys [1]: [d_date_sk#135]
+Left keys [1]: [c_first_sales_date_sk#133]
+Right keys [1]: [d_date_sk#134]
 Join type: Inner
 Join condition: None
 
 (155) Project [codegen id : 62]
-Output [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, d_year#136]
-Input [18]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134, d_date_sk#135, d_year#136]
+Output [16]: [ss_item_sk#107, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, c_first_shipto_date_sk#132, d_year#135]
+Input [18]: [ss_item_sk#107, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, c_first_shipto_date_sk#132, c_first_sales_date_sk#133, d_date_sk#134, d_year#135]
 
 (156) ReusedExchange [Reuses operator id: 57]
-Output [2]: [d_date_sk#137, d_year#138]
+Output [2]: [d_date_sk#136, d_year#137]
 
 (157) BroadcastHashJoin [codegen id : 62]
-Left keys [1]: [c_first_shipto_date_sk#133]
-Right keys [1]: [d_date_sk#137]
+Left keys [1]: [c_first_shipto_date_sk#132]
+Right keys [1]: [d_date_sk#136]
 Join type: Inner
 Join condition: None
 
 (158) Project [codegen id : 62]
-Output [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Input [18]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, d_year#136, d_date_sk#137, d_year#138]
+Output [16]: [ss_item_sk#107, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137]
+Input [18]: [ss_item_sk#107, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, c_first_shipto_date_sk#132, d_year#135, d_date_sk#136, d_year#137]
 
 (159) Exchange
-Input [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Arguments: hashpartitioning(ss_cdemo_sk#110, 5), ENSURE_REQUIREMENTS, [plan_id=25]
+Input [16]: [ss_item_sk#107, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137]
+Arguments: hashpartitioning(ss_cdemo_sk#109, 5), ENSURE_REQUIREMENTS, [plan_id=26]
 
 (160) Sort [codegen id : 63]
-Input [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Arguments: [ss_cdemo_sk#110 ASC NULLS FIRST], false, 0
+Input [16]: [ss_item_sk#107, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137]
+Arguments: [ss_cdemo_sk#109 ASC NULLS FIRST], false, 0
 
 (161) ReusedExchange [Reuses operator id: 68]
-Output [2]: [cd_demo_sk#139, cd_marital_status#140]
+Output [2]: [cd_demo_sk#138, cd_marital_status#139]
 
 (162) Sort [codegen id : 65]
-Input [2]: [cd_demo_sk#139, cd_marital_status#140]
-Arguments: [cd_demo_sk#139 ASC NULLS FIRST], false, 0
+Input [2]: [cd_demo_sk#138, cd_marital_status#139]
+Arguments: [cd_demo_sk#138 ASC NULLS FIRST], false, 0
 
 (163) SortMergeJoin [codegen id : 66]
-Left keys [1]: [ss_cdemo_sk#110]
-Right keys [1]: [cd_demo_sk#139]
+Left keys [1]: [ss_cdemo_sk#109]
+Right keys [1]: [cd_demo_sk#138]
 Join type: Inner
 Join condition: None
 
 (164) Project [codegen id : 66]
-Output [16]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_marital_status#140]
-Input [18]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_demo_sk#139, cd_marital_status#140]
+Output [16]: [ss_item_sk#107, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, cd_marital_status#139]
+Input [18]: [ss_item_sk#107, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, cd_demo_sk#138, cd_marital_status#139]
 
 (165) Exchange
-Input [16]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_marital_status#140]
-Arguments: hashpartitioning(c_current_cdemo_sk#130, 5), ENSURE_REQUIREMENTS, [plan_id=26]
+Input [16]: [ss_item_sk#107, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, cd_marital_status#139]
+Arguments: hashpartitioning(c_current_cdemo_sk#129, 5), ENSURE_REQUIREMENTS, [plan_id=27]
 
 (166) Sort [codegen id : 67]
-Input [16]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_marital_status#140]
-Arguments: [c_current_cdemo_sk#130 ASC NULLS FIRST], false, 0
+Input [16]: [ss_item_sk#107, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, cd_marital_status#139]
+Arguments: [c_current_cdemo_sk#129 ASC NULLS FIRST], false, 0
 
 (167) ReusedExchange [Reuses operator id: 68]
-Output [2]: [cd_demo_sk#141, cd_marital_status#142]
+Output [2]: [cd_demo_sk#140, cd_marital_status#141]
 
 (168) Sort [codegen id : 69]
-Input [2]: [cd_demo_sk#141, cd_marital_status#142]
-Arguments: [cd_demo_sk#141 ASC NULLS FIRST], false, 0
+Input [2]: [cd_demo_sk#140, cd_marital_status#141]
+Arguments: [cd_demo_sk#140 ASC NULLS FIRST], false, 0
 
 (169) SortMergeJoin [codegen id : 73]
-Left keys [1]: [c_current_cdemo_sk#130]
-Right keys [1]: [cd_demo_sk#141]
+Left keys [1]: [c_current_cdemo_sk#129]
+Right keys [1]: [cd_demo_sk#140]
 Join type: Inner
-Join condition: NOT (cd_marital_status#140 = cd_marital_status#142)
+Join condition: NOT (cd_marital_status#139 = cd_marital_status#141)
 
 (170) Project [codegen id : 73]
-Output [14]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Input [18]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_marital_status#140, cd_demo_sk#141, cd_marital_status#142]
+Output [14]: [ss_item_sk#107, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137]
+Input [18]: [ss_item_sk#107, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, cd_marital_status#139, cd_demo_sk#140, cd_marital_status#141]
 
 (171) ReusedExchange [Reuses operator id: 81]
-Output [1]: [p_promo_sk#143]
+Output [1]: [p_promo_sk#142]
 
 (172) BroadcastHashJoin [codegen id : 73]
-Left keys [1]: [ss_promo_sk#114]
-Right keys [1]: [p_promo_sk#143]
+Left keys [1]: [ss_promo_sk#113]
+Right keys [1]: [p_promo_sk#142]
 Join type: Inner
 Join condition: None
 
 (173) Project [codegen id : 73]
-Output [13]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Input [15]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, p_promo_sk#143]
+Output [13]: [ss_item_sk#107, ss_hdemo_sk#110, ss_addr_sk#111, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137]
+Input [15]: [ss_item_sk#107, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, p_promo_sk#142]
 
 (174) ReusedExchange [Reuses operator id: 87]
-Output [2]: [hd_demo_sk#144, hd_income_band_sk#145]
+Output [2]: [hd_demo_sk#143, hd_income_band_sk#144]
 
 (175) BroadcastHashJoin [codegen id : 73]
-Left keys [1]: [ss_hdemo_sk#111]
-Right keys [1]: [hd_demo_sk#144]
+Left keys [1]: [ss_hdemo_sk#110]
+Right keys [1]: [hd_demo_sk#143]
 Join type: Inner
 Join condition: None
 
 (176) Project [codegen id : 73]
-Output [13]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145]
-Input [15]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, hd_demo_sk#144, hd_income_band_sk#145]
+Output [13]: [ss_item_sk#107, ss_addr_sk#111, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144]
+Input [15]: [ss_item_sk#107, ss_hdemo_sk#110, ss_addr_sk#111, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, hd_demo_sk#143, hd_income_band_sk#144]
 
 (177) ReusedExchange [Reuses operator id: 87]
-Output [2]: [hd_demo_sk#146, hd_income_band_sk#147]
+Output [2]: [hd_demo_sk#145, hd_income_band_sk#146]
 
 (178) BroadcastHashJoin [codegen id : 73]
-Left keys [1]: [c_current_hdemo_sk#131]
-Right keys [1]: [hd_demo_sk#146]
+Left keys [1]: [c_current_hdemo_sk#130]
+Right keys [1]: [hd_demo_sk#145]
 Join type: Inner
 Join condition: None
 
 (179) Project [codegen id : 73]
-Output [13]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147]
-Input [15]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_demo_sk#146, hd_income_band_sk#147]
+Output [13]: [ss_item_sk#107, ss_addr_sk#111, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146]
+Input [15]: [ss_item_sk#107, ss_addr_sk#111, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_demo_sk#145, hd_income_band_sk#146]
 
 (180) Exchange
-Input [13]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147]
-Arguments: hashpartitioning(ss_addr_sk#112, 5), ENSURE_REQUIREMENTS, [plan_id=27]
+Input [13]: [ss_item_sk#107, ss_addr_sk#111, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146]
+Arguments: hashpartitioning(ss_addr_sk#111, 5), ENSURE_REQUIREMENTS, [plan_id=28]
 
 (181) Sort [codegen id : 74]
-Input [13]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147]
-Arguments: [ss_addr_sk#112 ASC NULLS FIRST], false, 0
+Input [13]: [ss_item_sk#107, ss_addr_sk#111, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146]
+Arguments: [ss_addr_sk#111 ASC NULLS FIRST], false, 0
 
 (182) ReusedExchange [Reuses operator id: 98]
-Output [5]: [ca_address_sk#148, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
+Output [5]: [ca_address_sk#147, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151]
 
 (183) Sort [codegen id : 76]
-Input [5]: [ca_address_sk#148, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
-Arguments: [ca_address_sk#148 ASC NULLS FIRST], false, 0
+Input [5]: [ca_address_sk#147, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151]
+Arguments: [ca_address_sk#147 ASC NULLS FIRST], false, 0
 
 (184) SortMergeJoin [codegen id : 77]
-Left keys [1]: [ss_addr_sk#112]
-Right keys [1]: [ca_address_sk#148]
+Left keys [1]: [ss_addr_sk#111]
+Right keys [1]: [ca_address_sk#147]
 Join type: Inner
 Join condition: None
 
 (185) Project [codegen id : 77]
-Output [16]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
-Input [18]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_address_sk#148, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
+Output [16]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151]
+Input [18]: [ss_item_sk#107, ss_addr_sk#111, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146, ca_address_sk#147, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151]
 
 (186) Exchange
-Input [16]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
-Arguments: hashpartitioning(c_current_addr_sk#132, 5), ENSURE_REQUIREMENTS, [plan_id=28]
+Input [16]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151]
+Arguments: hashpartitioning(c_current_addr_sk#131, 5), ENSURE_REQUIREMENTS, [plan_id=29]
 
 (187) Sort [codegen id : 78]
-Input [16]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
-Arguments: [c_current_addr_sk#132 ASC NULLS FIRST], false, 0
+Input [16]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151]
+Arguments: [c_current_addr_sk#131 ASC NULLS FIRST], false, 0
 
 (188) ReusedExchange [Reuses operator id: 98]
-Output [5]: [ca_address_sk#153, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
+Output [5]: [ca_address_sk#152, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156]
 
 (189) Sort [codegen id : 80]
-Input [5]: [ca_address_sk#153, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-Arguments: [ca_address_sk#153 ASC NULLS FIRST], false, 0
+Input [5]: [ca_address_sk#152, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156]
+Arguments: [ca_address_sk#152 ASC NULLS FIRST], false, 0
 
 (190) SortMergeJoin [codegen id : 84]
-Left keys [1]: [c_current_addr_sk#132]
-Right keys [1]: [ca_address_sk#153]
+Left keys [1]: [c_current_addr_sk#131]
+Right keys [1]: [ca_address_sk#152]
 Join type: Inner
 Join condition: None
 
 (191) Project [codegen id : 84]
-Output [19]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-Input [21]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_address_sk#153, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
+Output [19]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156]
+Input [21]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_address_sk#152, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156]
 
 (192) ReusedExchange [Reuses operator id: 111]
-Output [1]: [ib_income_band_sk#158]
+Output [1]: [ib_income_band_sk#157]
 
 (193) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [hd_income_band_sk#145]
-Right keys [1]: [ib_income_band_sk#158]
+Left keys [1]: [hd_income_band_sk#144]
+Right keys [1]: [ib_income_band_sk#157]
 Join type: Inner
 Join condition: None
 
 (194) Project [codegen id : 84]
-Output [18]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-Input [20]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, ib_income_band_sk#158]
+Output [18]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, d_year#135, d_year#137, hd_income_band_sk#146, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156]
+Input [20]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, ib_income_band_sk#157]
 
 (195) ReusedExchange [Reuses operator id: 111]
-Output [1]: [ib_income_band_sk#159]
+Output [1]: [ib_income_band_sk#158]
 
 (196) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [hd_income_band_sk#147]
-Right keys [1]: [ib_income_band_sk#159]
+Left keys [1]: [hd_income_band_sk#146]
+Right keys [1]: [ib_income_band_sk#158]
 Join type: Inner
 Join condition: None
 
 (197) Project [codegen id : 84]
-Output [17]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-Input [19]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, ib_income_band_sk#159]
+Output [17]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, d_year#135, d_year#137, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156]
+Input [19]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, d_year#135, d_year#137, hd_income_band_sk#146, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, ib_income_band_sk#158]
 
 (198) ReusedExchange [Reuses operator id: 121]
-Output [2]: [i_item_sk#160, i_product_name#161]
+Output [2]: [i_item_sk#159, i_product_name#160]
 
 (199) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [ss_item_sk#108]
-Right keys [1]: [i_item_sk#160]
+Left keys [1]: [ss_item_sk#107]
+Right keys [1]: [i_item_sk#159]
 Join type: Inner
 Join condition: None
 
 (200) Project [codegen id : 84]
-Output [18]: [ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, d_year#136, d_year#138, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, i_item_sk#160, i_product_name#161]
-Input [19]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, i_item_sk#160, i_product_name#161]
+Output [18]: [ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, d_year#135, d_year#137, s_store_name#126, s_zip#127, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, i_item_sk#159, i_product_name#160]
+Input [19]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, d_year#135, d_year#137, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, i_item_sk#159, i_product_name#160]
 
 (201) HashAggregate [codegen id : 84]
-Input [18]: [ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, d_year#136, d_year#138, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, i_item_sk#160, i_product_name#161]
-Keys [15]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138]
-Functions [4]: [partial_count(1), partial_sum(UnscaledValue(ss_wholesale_cost#116)), partial_sum(UnscaledValue(ss_list_price#117)), partial_sum(UnscaledValue(ss_coupon_amt#118))]
-Aggregate Attributes [4]: [count#79, sum#162, sum#163, sum#164]
-Results [19]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138, count#83, sum#165, sum#166, sum#167]
+Input [18]: [ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, d_year#135, d_year#137, s_store_name#126, s_zip#127, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, i_item_sk#159, i_product_name#160]
+Keys [15]: [i_product_name#160, i_item_sk#159, s_store_name#126, s_zip#127, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, d_year#124, d_year#135, d_year#137]
+Functions [4]: [partial_count(1), partial_sum(UnscaledValue(ss_wholesale_cost#115)), partial_sum(UnscaledValue(ss_list_price#116)), partial_sum(UnscaledValue(ss_coupon_amt#117))]
+Aggregate Attributes [4]: [count#78, sum#161, sum#162, sum#163]
+Results [19]: [i_product_name#160, i_item_sk#159, s_store_name#126, s_zip#127, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, d_year#124, d_year#135, d_year#137, count#82, sum#164, sum#165, sum#166]
 
 (202) Exchange
-Input [19]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138, count#83, sum#165, sum#166, sum#167]
-Arguments: hashpartitioning(i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138, 5), ENSURE_REQUIREMENTS, [plan_id=29]
+Input [19]: [i_product_name#160, i_item_sk#159, s_store_name#126, s_zip#127, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, d_year#124, d_year#135, d_year#137, count#82, sum#164, sum#165, sum#166]
+Arguments: hashpartitioning(i_product_name#160, i_item_sk#159, s_store_name#126, s_zip#127, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, d_year#124, d_year#135, d_year#137, 5), ENSURE_REQUIREMENTS, [plan_id=30]
 
 (203) HashAggregate [codegen id : 85]
-Input [19]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138, count#83, sum#165, sum#166, sum#167]
-Keys [15]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138]
-Functions [4]: [count(1), sum(UnscaledValue(ss_wholesale_cost#116)), sum(UnscaledValue(ss_list_price#117)), sum(UnscaledValue(ss_coupon_amt#118))]
-Aggregate Attributes [4]: [count(1)#87, sum(UnscaledValue(ss_wholesale_cost#116))#88, sum(UnscaledValue(ss_list_price#117))#89, sum(UnscaledValue(ss_coupon_amt#118))#90]
-Results [8]: [i_item_sk#160 AS item_sk#168, s_store_name#127 AS store_name#169, s_zip#128 AS store_zip#170, d_year#125 AS syear#171, count(1)#87 AS cnt#172, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#116))#88,17,2) AS s1#173, MakeDecimal(sum(UnscaledValue(ss_list_price#117))#89,17,2) AS s2#174, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#118))#90,17,2) AS s3#175]
+Input [19]: [i_product_name#160, i_item_sk#159, s_store_name#126, s_zip#127, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, d_year#124, d_year#135, d_year#137, count#82, sum#164, sum#165, sum#166]
+Keys [15]: [i_product_name#160, i_item_sk#159, s_store_name#126, s_zip#127, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, d_year#124, d_year#135, d_year#137]
+Functions [4]: [count(1), sum(UnscaledValue(ss_wholesale_cost#115)), sum(UnscaledValue(ss_list_price#116)), sum(UnscaledValue(ss_coupon_amt#117))]
+Aggregate Attributes [4]: [count(1)#86, sum(UnscaledValue(ss_wholesale_cost#115))#87, sum(UnscaledValue(ss_list_price#116))#88, sum(UnscaledValue(ss_coupon_amt#117))#89]
+Results [8]: [i_item_sk#159 AS item_sk#167, s_store_name#126 AS store_name#168, s_zip#127 AS store_zip#169, d_year#124 AS syear#170, count(1)#86 AS cnt#171, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#115))#87,17,2) AS s1#172, MakeDecimal(sum(UnscaledValue(ss_list_price#116))#88,17,2) AS s2#173, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#117))#89,17,2) AS s3#174]
 
 (204) Exchange
-Input [8]: [item_sk#168, store_name#169, store_zip#170, syear#171, cnt#172, s1#173, s2#174, s3#175]
-Arguments: hashpartitioning(item_sk#168, store_name#169, store_zip#170, 5), ENSURE_REQUIREMENTS, [plan_id=30]
+Input [8]: [item_sk#167, store_name#168, store_zip#169, syear#170, cnt#171, s1#172, s2#173, s3#174]
+Arguments: hashpartitioning(item_sk#167, store_name#168, store_zip#169, 5), ENSURE_REQUIREMENTS, [plan_id=31]
 
 (205) Sort [codegen id : 86]
-Input [8]: [item_sk#168, store_name#169, store_zip#170, syear#171, cnt#172, s1#173, s2#174, s3#175]
-Arguments: [item_sk#168 ASC NULLS FIRST, store_name#169 ASC NULLS FIRST, store_zip#170 ASC NULLS FIRST], false, 0
+Input [8]: [item_sk#167, store_name#168, store_zip#169, syear#170, cnt#171, s1#172, s2#173, s3#174]
+Arguments: [item_sk#167 ASC NULLS FIRST, store_name#168 ASC NULLS FIRST, store_zip#169 ASC NULLS FIRST], false, 0
 
 (206) SortMergeJoin [codegen id : 87]
-Left keys [3]: [item_sk#92, store_name#93, store_zip#94]
-Right keys [3]: [item_sk#168, store_name#169, store_zip#170]
+Left keys [3]: [item_sk#91, store_name#92, store_zip#93]
+Right keys [3]: [item_sk#167, store_name#168, store_zip#169]
 Join type: Inner
-Join condition: (cnt#172 <= cnt#104)
+Join condition: (cnt#171 <= cnt#103)
 
 (207) Project [codegen id : 87]
-Output [21]: [product_name#91, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107, s1#173, s2#174, s3#175, syear#171, cnt#172]
-Input [25]: [product_name#91, item_sk#92, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107, item_sk#168, store_name#169, store_zip#170, syear#171, cnt#172, s1#173, s2#174, s3#175]
+Output [21]: [product_name#90, store_name#92, store_zip#93, b_street_number#94, b_streen_name#95, b_city#96, b_zip#97, c_street_number#98, c_street_name#99, c_city#100, c_zip#101, syear#102, cnt#103, s1#104, s2#105, s3#106, s1#172, s2#173, s3#174, syear#170, cnt#171]
+Input [25]: [product_name#90, item_sk#91, store_name#92, store_zip#93, b_street_number#94, b_streen_name#95, b_city#96, b_zip#97, c_street_number#98, c_street_name#99, c_city#100, c_zip#101, syear#102, cnt#103, s1#104, s2#105, s3#106, item_sk#167, store_name#168, store_zip#169, syear#170, cnt#171, s1#172, s2#173, s3#174]
 
 (208) Exchange
-Input [21]: [product_name#91, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107, s1#173, s2#174, s3#175, syear#171, cnt#172]
-Arguments: rangepartitioning(product_name#91 ASC NULLS FIRST, store_name#93 ASC NULLS FIRST, cnt#172 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=31]
+Input [21]: [product_name#90, store_name#92, store_zip#93, b_street_number#94, b_streen_name#95, b_city#96, b_zip#97, c_street_number#98, c_street_name#99, c_city#100, c_zip#101, syear#102, cnt#103, s1#104, s2#105, s3#106, s1#172, s2#173, s3#174, syear#170, cnt#171]
+Arguments: rangepartitioning(product_name#90 ASC NULLS FIRST, store_name#92 ASC NULLS FIRST, cnt#171 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=32]
 
 (209) Sort [codegen id : 88]
-Input [21]: [product_name#91, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107, s1#173, s2#174, s3#175, syear#171, cnt#172]
-Arguments: [product_name#91 ASC NULLS FIRST, store_name#93 ASC NULLS FIRST, cnt#172 ASC NULLS FIRST], true, 0
+Input [21]: [product_name#90, store_name#92, store_zip#93, b_street_number#94, b_streen_name#95, b_city#96, b_zip#97, c_street_number#98, c_street_name#99, c_city#100, c_zip#101, syear#102, cnt#103, s1#104, s2#105, s3#106, s1#172, s2#173, s3#174, syear#170, cnt#171]
+Arguments: [product_name#90 ASC NULLS FIRST, store_name#92 ASC NULLS FIRST, cnt#171 ASC NULLS FIRST], true, 0
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#14, [id=#15]
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#14, [id=#1]
 ObjectHashAggregate (216)
 +- Exchange (215)
    +- ObjectHashAggregate (214)
@@ -1156,40 +1156,40 @@ ObjectHashAggregate (216)
 
 
 (210) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#75, i_current_price#76, i_color#77]
+Output [3]: [i_item_sk#74, i_current_price#75, i_color#76]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_current_price), In(i_color, [burlywood           ,floral              ,indian              ,medium              ,purple              ,spring              ]), GreaterThanOrEqual(i_current_price,64.00), LessThanOrEqual(i_current_price,74.00), GreaterThanOrEqual(i_current_price,65.00), LessThanOrEqual(i_current_price,79.00), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_color:string>
 
 (211) ColumnarToRow [codegen id : 1]
-Input [3]: [i_item_sk#75, i_current_price#76, i_color#77]
+Input [3]: [i_item_sk#74, i_current_price#75, i_color#76]
 
 (212) Filter [codegen id : 1]
-Input [3]: [i_item_sk#75, i_current_price#76, i_color#77]
-Condition : ((((((isnotnull(i_current_price#76) AND i_color#77 IN (purple              ,burlywood           ,indian              ,spring              ,floral              ,medium              )) AND (i_current_price#76 >= 64.00)) AND (i_current_price#76 <= 74.00)) AND (i_current_price#76 >= 65.00)) AND (i_current_price#76 <= 79.00)) AND isnotnull(i_item_sk#75))
+Input [3]: [i_item_sk#74, i_current_price#75, i_color#76]
+Condition : ((((((isnotnull(i_current_price#75) AND i_color#76 IN (purple              ,burlywood           ,indian              ,spring              ,floral              ,medium              )) AND (i_current_price#75 >= 64.00)) AND (i_current_price#75 <= 74.00)) AND (i_current_price#75 >= 65.00)) AND (i_current_price#75 <= 79.00)) AND isnotnull(i_item_sk#74))
 
 (213) Project [codegen id : 1]
-Output [1]: [i_item_sk#75]
-Input [3]: [i_item_sk#75, i_current_price#76, i_color#77]
+Output [1]: [i_item_sk#74]
+Input [3]: [i_item_sk#74, i_current_price#75, i_color#76]
 
 (214) ObjectHashAggregate
-Input [1]: [i_item_sk#75]
+Input [1]: [i_item_sk#74]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#75, 42), 1250, 30121, 0, 0)]
-Aggregate Attributes [1]: [buf#176]
-Results [1]: [buf#177]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#74, 42), 1250, 30121, 0, 0)]
+Aggregate Attributes [1]: [buf#175]
+Results [1]: [buf#176]
 
 (215) Exchange
-Input [1]: [buf#177]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=32]
+Input [1]: [buf#176]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=33]
 
 (216) ObjectHashAggregate
-Input [1]: [buf#177]
+Input [1]: [buf#176]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#75, 42), 1250, 30121, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#75, 42), 1250, 30121, 0, 0)#178]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#75, 42), 1250, 30121, 0, 0)#178 AS bloomFilter#179]
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#74, 42), 1250, 30121, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#74, 42), 1250, 30121, 0, 0)#177]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#74, 42), 1250, 30121, 0, 0)#177 AS bloomFilter#178]
 
 Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#12 IN dynamicpruning#13
 BroadcastExchange (220)
@@ -1199,26 +1199,26 @@ BroadcastExchange (220)
 
 
 (217) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#39, d_year#40]
+Output [2]: [d_date_sk#38, d_year#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1999), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (218) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#39, d_year#40]
+Input [2]: [d_date_sk#38, d_year#39]
 
 (219) Filter [codegen id : 1]
-Input [2]: [d_date_sk#39, d_year#40]
-Condition : ((isnotnull(d_year#40) AND (d_year#40 = 1999)) AND isnotnull(d_date_sk#39))
+Input [2]: [d_date_sk#38, d_year#39]
+Condition : ((isnotnull(d_year#39) AND (d_year#39 = 1999)) AND isnotnull(d_date_sk#38))
 
 (220) BroadcastExchange
-Input [2]: [d_date_sk#39, d_year#40]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=33]
+Input [2]: [d_date_sk#38, d_year#39]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=34]
 
-Subquery:3 Hosting operator id = 131 Hosting Expression = ReusedSubquery Subquery scalar-subquery#14, [id=#15]
+Subquery:3 Hosting operator id = 131 Hosting Expression = ReusedSubquery Subquery scalar-subquery#14, [id=#1]
 
-Subquery:4 Hosting operator id = 129 Hosting Expression = ss_sold_date_sk#119 IN dynamicpruning#120
+Subquery:4 Hosting operator id = 129 Hosting Expression = ss_sold_date_sk#118 IN dynamicpruning#119
 BroadcastExchange (224)
 +- * Filter (223)
    +- * ColumnarToRow (222)
@@ -1226,21 +1226,21 @@ BroadcastExchange (224)
 
 
 (221) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#124, d_year#125]
+Output [2]: [d_date_sk#123, d_year#124]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (222) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#124, d_year#125]
+Input [2]: [d_date_sk#123, d_year#124]
 
 (223) Filter [codegen id : 1]
-Input [2]: [d_date_sk#124, d_year#125]
-Condition : ((isnotnull(d_year#125) AND (d_year#125 = 2000)) AND isnotnull(d_date_sk#124))
+Input [2]: [d_date_sk#123, d_year#124]
+Condition : ((isnotnull(d_year#124) AND (d_year#124 = 2000)) AND isnotnull(d_date_sk#123))
 
 (224) BroadcastExchange
-Input [2]: [d_date_sk#124, d_year#125]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=34]
+Input [2]: [d_date_sk#123, d_year#124]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=35]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/explain.txt
@@ -60,124 +60,124 @@ Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
-Condition : ((isnotnull(c_current_addr_sk#3) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(Subquery scalar-subquery#4, [id=#5], xxhash64(c_current_addr_sk#3, 42)))
+Condition : ((isnotnull(c_current_addr_sk#3) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(Subquery scalar-subquery#4, [id=#1], xxhash64(c_current_addr_sk#3, 42)))
 
 (4) Exchange
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
-Arguments: hashpartitioning(c_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
+Arguments: hashpartitioning(c_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (5) Sort [codegen id : 2]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 Arguments: [c_customer_sk#1 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.store_sales
-Output [2]: [ss_customer_sk#6, ss_sold_date_sk#7]
+Output [2]: [ss_customer_sk#5, ss_sold_date_sk#6]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#7), dynamicpruningexpression(ss_sold_date_sk#7 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#6), dynamicpruningexpression(ss_sold_date_sk#6 IN dynamicpruning#7)]
 ReadSchema: struct<ss_customer_sk:int>
 
 (7) ColumnarToRow [codegen id : 4]
-Input [2]: [ss_customer_sk#6, ss_sold_date_sk#7]
+Input [2]: [ss_customer_sk#5, ss_sold_date_sk#6]
 
 (8) ReusedExchange [Reuses operator id: 59]
-Output [1]: [d_date_sk#9]
+Output [1]: [d_date_sk#8]
 
 (9) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#7]
-Right keys [1]: [d_date_sk#9]
+Left keys [1]: [ss_sold_date_sk#6]
+Right keys [1]: [d_date_sk#8]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
-Output [1]: [ss_customer_sk#6]
-Input [3]: [ss_customer_sk#6, ss_sold_date_sk#7, d_date_sk#9]
+Output [1]: [ss_customer_sk#5]
+Input [3]: [ss_customer_sk#5, ss_sold_date_sk#6, d_date_sk#8]
 
 (11) Exchange
-Input [1]: [ss_customer_sk#6]
-Arguments: hashpartitioning(ss_customer_sk#6, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [1]: [ss_customer_sk#5]
+Arguments: hashpartitioning(ss_customer_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (12) Sort [codegen id : 5]
-Input [1]: [ss_customer_sk#6]
-Arguments: [ss_customer_sk#6 ASC NULLS FIRST], false, 0
+Input [1]: [ss_customer_sk#5]
+Arguments: [ss_customer_sk#5 ASC NULLS FIRST], false, 0
 
 (13) SortMergeJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#1]
-Right keys [1]: [ss_customer_sk#6]
+Right keys [1]: [ss_customer_sk#5]
 Join type: LeftSemi
 Join condition: None
 
 (14) Scan parquet spark_catalog.default.web_sales
-Output [2]: [ws_bill_customer_sk#10, ws_sold_date_sk#11]
+Output [2]: [ws_bill_customer_sk#9, ws_sold_date_sk#10]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#11), dynamicpruningexpression(ws_sold_date_sk#11 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#10), dynamicpruningexpression(ws_sold_date_sk#10 IN dynamicpruning#7)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
 (15) ColumnarToRow [codegen id : 8]
-Input [2]: [ws_bill_customer_sk#10, ws_sold_date_sk#11]
+Input [2]: [ws_bill_customer_sk#9, ws_sold_date_sk#10]
 
 (16) ReusedExchange [Reuses operator id: 59]
-Output [1]: [d_date_sk#12]
+Output [1]: [d_date_sk#11]
 
 (17) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ws_sold_date_sk#11]
-Right keys [1]: [d_date_sk#12]
+Left keys [1]: [ws_sold_date_sk#10]
+Right keys [1]: [d_date_sk#11]
 Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 8]
-Output [1]: [ws_bill_customer_sk#10]
-Input [3]: [ws_bill_customer_sk#10, ws_sold_date_sk#11, d_date_sk#12]
+Output [1]: [ws_bill_customer_sk#9]
+Input [3]: [ws_bill_customer_sk#9, ws_sold_date_sk#10, d_date_sk#11]
 
 (19) Exchange
-Input [1]: [ws_bill_customer_sk#10]
-Arguments: hashpartitioning(ws_bill_customer_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [1]: [ws_bill_customer_sk#9]
+Arguments: hashpartitioning(ws_bill_customer_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (20) Sort [codegen id : 9]
-Input [1]: [ws_bill_customer_sk#10]
-Arguments: [ws_bill_customer_sk#10 ASC NULLS FIRST], false, 0
+Input [1]: [ws_bill_customer_sk#9]
+Arguments: [ws_bill_customer_sk#9 ASC NULLS FIRST], false, 0
 
 (21) SortMergeJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#1]
-Right keys [1]: [ws_bill_customer_sk#10]
+Right keys [1]: [ws_bill_customer_sk#9]
 Join type: LeftAnti
 Join condition: None
 
 (22) Scan parquet spark_catalog.default.catalog_sales
-Output [2]: [cs_ship_customer_sk#13, cs_sold_date_sk#14]
+Output [2]: [cs_ship_customer_sk#12, cs_sold_date_sk#13]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#14), dynamicpruningexpression(cs_sold_date_sk#14 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#13), dynamicpruningexpression(cs_sold_date_sk#13 IN dynamicpruning#7)]
 ReadSchema: struct<cs_ship_customer_sk:int>
 
 (23) ColumnarToRow [codegen id : 12]
-Input [2]: [cs_ship_customer_sk#13, cs_sold_date_sk#14]
+Input [2]: [cs_ship_customer_sk#12, cs_sold_date_sk#13]
 
 (24) ReusedExchange [Reuses operator id: 59]
-Output [1]: [d_date_sk#15]
+Output [1]: [d_date_sk#14]
 
 (25) BroadcastHashJoin [codegen id : 12]
-Left keys [1]: [cs_sold_date_sk#14]
-Right keys [1]: [d_date_sk#15]
+Left keys [1]: [cs_sold_date_sk#13]
+Right keys [1]: [d_date_sk#14]
 Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 12]
-Output [1]: [cs_ship_customer_sk#13]
-Input [3]: [cs_ship_customer_sk#13, cs_sold_date_sk#14, d_date_sk#15]
+Output [1]: [cs_ship_customer_sk#12]
+Input [3]: [cs_ship_customer_sk#12, cs_sold_date_sk#13, d_date_sk#14]
 
 (27) Exchange
-Input [1]: [cs_ship_customer_sk#13]
-Arguments: hashpartitioning(cs_ship_customer_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [1]: [cs_ship_customer_sk#12]
+Arguments: hashpartitioning(cs_ship_customer_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (28) Sort [codegen id : 13]
-Input [1]: [cs_ship_customer_sk#13]
-Arguments: [cs_ship_customer_sk#13 ASC NULLS FIRST], false, 0
+Input [1]: [cs_ship_customer_sk#12]
+Arguments: [cs_ship_customer_sk#12 ASC NULLS FIRST], false, 0
 
 (29) SortMergeJoin [codegen id : 15]
 Left keys [1]: [c_customer_sk#1]
-Right keys [1]: [cs_ship_customer_sk#13]
+Right keys [1]: [cs_ship_customer_sk#12]
 Join type: LeftAnti
 Join condition: None
 
@@ -186,90 +186,90 @@ Output [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
 (31) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#16, ca_state#17]
+Output [2]: [ca_address_sk#15, ca_state#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_state, [GA,KY,NM]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
 (32) ColumnarToRow [codegen id : 14]
-Input [2]: [ca_address_sk#16, ca_state#17]
+Input [2]: [ca_address_sk#15, ca_state#16]
 
 (33) Filter [codegen id : 14]
-Input [2]: [ca_address_sk#16, ca_state#17]
-Condition : (ca_state#17 IN (KY,GA,NM) AND isnotnull(ca_address_sk#16))
+Input [2]: [ca_address_sk#15, ca_state#16]
+Condition : (ca_state#16 IN (KY,GA,NM) AND isnotnull(ca_address_sk#15))
 
 (34) Project [codegen id : 14]
-Output [1]: [ca_address_sk#16]
-Input [2]: [ca_address_sk#16, ca_state#17]
+Output [1]: [ca_address_sk#15]
+Input [2]: [ca_address_sk#15, ca_state#16]
 
 (35) BroadcastExchange
-Input [1]: [ca_address_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+Input [1]: [ca_address_sk#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
 (36) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [c_current_addr_sk#3]
-Right keys [1]: [ca_address_sk#16]
+Right keys [1]: [ca_address_sk#15]
 Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 15]
 Output [1]: [c_current_cdemo_sk#2]
-Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#16]
+Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#15]
 
 (38) BroadcastExchange
 Input [1]: [c_current_cdemo_sk#2]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 (39) Scan parquet spark_catalog.default.customer_demographics
-Output [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
+Output [6]: [cd_demo_sk#17, cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string,cd_purchase_estimate:int,cd_credit_rating:string>
 
 (40) ColumnarToRow
-Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
+Input [6]: [cd_demo_sk#17, cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22]
 
 (41) Filter
-Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
-Condition : isnotnull(cd_demo_sk#18)
+Input [6]: [cd_demo_sk#17, cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22]
+Condition : isnotnull(cd_demo_sk#17)
 
 (42) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [c_current_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#18]
+Right keys [1]: [cd_demo_sk#17]
 Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 16]
-Output [5]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
-Input [7]: [c_current_cdemo_sk#2, cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
+Output [5]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22]
+Input [7]: [c_current_cdemo_sk#2, cd_demo_sk#17, cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22]
 
 (44) HashAggregate [codegen id : 16]
-Input [5]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
-Keys [5]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
+Input [5]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22]
+Keys [5]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#24]
-Results [6]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, count#25]
+Aggregate Attributes [1]: [count#23]
+Results [6]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22, count#24]
 
 (45) Exchange
-Input [6]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, count#25]
-Arguments: hashpartitioning(cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Input [6]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22, count#24]
+Arguments: hashpartitioning(cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (46) HashAggregate [codegen id : 17]
-Input [6]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, count#25]
-Keys [5]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
+Input [6]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22, count#24]
+Keys [5]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#26]
-Results [8]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, count(1)#26 AS cnt1#27, cd_purchase_estimate#22, count(1)#26 AS cnt2#28, cd_credit_rating#23, count(1)#26 AS cnt3#29]
+Aggregate Attributes [1]: [count(1)#25]
+Results [8]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, count(1)#25 AS cnt1#26, cd_purchase_estimate#21, count(1)#25 AS cnt2#27, cd_credit_rating#22, count(1)#25 AS cnt3#28]
 
 (47) TakeOrderedAndProject
-Input [8]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cnt1#27, cd_purchase_estimate#22, cnt2#28, cd_credit_rating#23, cnt3#29]
-Arguments: 100, [cd_gender#19 ASC NULLS FIRST, cd_marital_status#20 ASC NULLS FIRST, cd_education_status#21 ASC NULLS FIRST, cd_purchase_estimate#22 ASC NULLS FIRST, cd_credit_rating#23 ASC NULLS FIRST], [cd_gender#19, cd_marital_status#20, cd_education_status#21, cnt1#27, cd_purchase_estimate#22, cnt2#28, cd_credit_rating#23, cnt3#29]
+Input [8]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, cnt1#26, cd_purchase_estimate#21, cnt2#27, cd_credit_rating#22, cnt3#28]
+Arguments: 100, [cd_gender#18 ASC NULLS FIRST, cd_marital_status#19 ASC NULLS FIRST, cd_education_status#20 ASC NULLS FIRST, cd_purchase_estimate#21 ASC NULLS FIRST, cd_credit_rating#22 ASC NULLS FIRST], [cd_gender#18, cd_marital_status#19, cd_education_status#20, cnt1#26, cd_purchase_estimate#21, cnt2#27, cd_credit_rating#22, cnt3#28]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#4, [id=#5]
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#4, [id=#1]
 ObjectHashAggregate (54)
 +- Exchange (53)
    +- ObjectHashAggregate (52)
@@ -280,42 +280,42 @@ ObjectHashAggregate (54)
 
 
 (48) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#16, ca_state#17]
+Output [2]: [ca_address_sk#15, ca_state#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_state, [GA,KY,NM]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
 (49) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#16, ca_state#17]
+Input [2]: [ca_address_sk#15, ca_state#16]
 
 (50) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#16, ca_state#17]
-Condition : (ca_state#17 IN (KY,GA,NM) AND isnotnull(ca_address_sk#16))
+Input [2]: [ca_address_sk#15, ca_state#16]
+Condition : (ca_state#16 IN (KY,GA,NM) AND isnotnull(ca_address_sk#15))
 
 (51) Project [codegen id : 1]
-Output [1]: [ca_address_sk#16]
-Input [2]: [ca_address_sk#16, ca_state#17]
+Output [1]: [ca_address_sk#15]
+Input [2]: [ca_address_sk#15, ca_state#16]
 
 (52) ObjectHashAggregate
-Input [1]: [ca_address_sk#16]
+Input [1]: [ca_address_sk#15]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 55556, 899992, 0, 0)]
-Aggregate Attributes [1]: [buf#30]
-Results [1]: [buf#31]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#15, 42), 55556, 899992, 0, 0)]
+Aggregate Attributes [1]: [buf#29]
+Results [1]: [buf#30]
 
 (53) Exchange
-Input [1]: [buf#31]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
+Input [1]: [buf#30]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
 
 (54) ObjectHashAggregate
-Input [1]: [buf#31]
+Input [1]: [buf#30]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 55556, 899992, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 55556, 899992, 0, 0)#32]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 55556, 899992, 0, 0)#32 AS bloomFilter#33]
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#15, 42), 55556, 899992, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#15, 42), 55556, 899992, 0, 0)#31]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#15, 42), 55556, 899992, 0, 0)#31 AS bloomFilter#32]
 
-Subquery:2 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#7 IN dynamicpruning#8
+Subquery:2 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#6 IN dynamicpruning#7
 BroadcastExchange (59)
 +- * Project (58)
    +- * Filter (57)
@@ -324,29 +324,29 @@ BroadcastExchange (59)
 
 
 (55) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#9, d_year#34, d_moy#35]
+Output [3]: [d_date_sk#8, d_year#33, d_moy#34]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2001), GreaterThanOrEqual(d_moy,4), LessThanOrEqual(d_moy,6), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (56) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#34, d_moy#35]
+Input [3]: [d_date_sk#8, d_year#33, d_moy#34]
 
 (57) Filter [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#34, d_moy#35]
-Condition : (((((isnotnull(d_year#34) AND isnotnull(d_moy#35)) AND (d_year#34 = 2001)) AND (d_moy#35 >= 4)) AND (d_moy#35 <= 6)) AND isnotnull(d_date_sk#9))
+Input [3]: [d_date_sk#8, d_year#33, d_moy#34]
+Condition : (((((isnotnull(d_year#33) AND isnotnull(d_moy#34)) AND (d_year#33 = 2001)) AND (d_moy#34 >= 4)) AND (d_moy#34 <= 6)) AND isnotnull(d_date_sk#8))
 
 (58) Project [codegen id : 1]
-Output [1]: [d_date_sk#9]
-Input [3]: [d_date_sk#9, d_year#34, d_moy#35]
+Output [1]: [d_date_sk#8]
+Input [3]: [d_date_sk#8, d_year#33, d_moy#34]
 
 (59) BroadcastExchange
-Input [1]: [d_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+Input [1]: [d_date_sk#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
-Subquery:3 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#11 IN dynamicpruning#8
+Subquery:3 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#10 IN dynamicpruning#7
 
-Subquery:4 Hosting operator id = 22 Hosting Expression = cs_sold_date_sk#14 IN dynamicpruning#8
+Subquery:4 Hosting operator id = 22 Hosting Expression = cs_sold_date_sk#13 IN dynamicpruning#7
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80.sf100/explain.txt
@@ -121,494 +121,494 @@ Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_e
 
 (3) Filter [codegen id : 1]
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7]
-Condition : ((((isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_promo_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(ss_item_sk#1, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(ss_promo_sk#3, 42)))
+Condition : ((((isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_promo_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#1], xxhash64(ss_item_sk#1, 42))) AND might_contain(Subquery scalar-subquery#10, [id=#2], xxhash64(ss_promo_sk#3, 42)))
 
 (4) Exchange
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7]
-Arguments: hashpartitioning(ss_item_sk#1, ss_ticket_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=1]
+Arguments: hashpartitioning(ss_item_sk#1, ss_ticket_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (5) Sort [codegen id : 2]
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#4 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.store_returns
-Output [5]: [sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16, sr_returned_date_sk#17]
+Output [5]: [sr_item_sk#11, sr_ticket_number#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int,sr_return_amt:decimal(7,2),sr_net_loss:decimal(7,2)>
 
 (7) ColumnarToRow [codegen id : 3]
-Input [5]: [sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16, sr_returned_date_sk#17]
+Input [5]: [sr_item_sk#11, sr_ticket_number#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 
 (8) Filter [codegen id : 3]
-Input [5]: [sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16, sr_returned_date_sk#17]
-Condition : (isnotnull(sr_item_sk#13) AND isnotnull(sr_ticket_number#14))
+Input [5]: [sr_item_sk#11, sr_ticket_number#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
+Condition : (isnotnull(sr_item_sk#11) AND isnotnull(sr_ticket_number#12))
 
 (9) Project [codegen id : 3]
-Output [4]: [sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16]
-Input [5]: [sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16, sr_returned_date_sk#17]
+Output [4]: [sr_item_sk#11, sr_ticket_number#12, sr_return_amt#13, sr_net_loss#14]
+Input [5]: [sr_item_sk#11, sr_ticket_number#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 
 (10) Exchange
-Input [4]: [sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16]
-Arguments: hashpartitioning(sr_item_sk#13, sr_ticket_number#14, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [4]: [sr_item_sk#11, sr_ticket_number#12, sr_return_amt#13, sr_net_loss#14]
+Arguments: hashpartitioning(sr_item_sk#11, sr_ticket_number#12, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (11) Sort [codegen id : 4]
-Input [4]: [sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16]
-Arguments: [sr_item_sk#13 ASC NULLS FIRST, sr_ticket_number#14 ASC NULLS FIRST], false, 0
+Input [4]: [sr_item_sk#11, sr_ticket_number#12, sr_return_amt#13, sr_net_loss#14]
+Arguments: [sr_item_sk#11 ASC NULLS FIRST, sr_ticket_number#12 ASC NULLS FIRST], false, 0
 
 (12) SortMergeJoin [codegen id : 9]
 Left keys [2]: [ss_item_sk#1, ss_ticket_number#4]
-Right keys [2]: [sr_item_sk#13, sr_ticket_number#14]
+Right keys [2]: [sr_item_sk#11, sr_ticket_number#12]
 Join type: LeftOuter
 Join condition: None
 
 (13) Project [codegen id : 9]
-Output [8]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16]
-Input [11]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16]
+Output [8]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#13, sr_net_loss#14]
+Input [11]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_item_sk#11, sr_ticket_number#12, sr_return_amt#13, sr_net_loss#14]
 
 (14) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#18, i_current_price#19]
+Output [2]: [i_item_sk#16, i_current_price#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_current_price), GreaterThan(i_current_price,50.00), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2)>
 
 (15) ColumnarToRow [codegen id : 5]
-Input [2]: [i_item_sk#18, i_current_price#19]
+Input [2]: [i_item_sk#16, i_current_price#17]
 
 (16) Filter [codegen id : 5]
-Input [2]: [i_item_sk#18, i_current_price#19]
-Condition : ((isnotnull(i_current_price#19) AND (i_current_price#19 > 50.00)) AND isnotnull(i_item_sk#18))
+Input [2]: [i_item_sk#16, i_current_price#17]
+Condition : ((isnotnull(i_current_price#17) AND (i_current_price#17 > 50.00)) AND isnotnull(i_item_sk#16))
 
 (17) Project [codegen id : 5]
-Output [1]: [i_item_sk#18]
-Input [2]: [i_item_sk#18, i_current_price#19]
+Output [1]: [i_item_sk#16]
+Input [2]: [i_item_sk#16, i_current_price#17]
 
 (18) BroadcastExchange
-Input [1]: [i_item_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
+Input [1]: [i_item_sk#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 (19) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#18]
+Right keys [1]: [i_item_sk#16]
 Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 9]
-Output [7]: [ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16]
-Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, i_item_sk#18]
+Output [7]: [ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#13, sr_net_loss#14]
+Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#13, sr_net_loss#14, i_item_sk#16]
 
 (21) Scan parquet spark_catalog.default.promotion
-Output [2]: [p_promo_sk#20, p_channel_tv#21]
+Output [2]: [p_promo_sk#18, p_channel_tv#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/promotion]
 PushedFilters: [IsNotNull(p_channel_tv), EqualTo(p_channel_tv,N), IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int,p_channel_tv:string>
 
 (22) ColumnarToRow [codegen id : 6]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
+Input [2]: [p_promo_sk#18, p_channel_tv#19]
 
 (23) Filter [codegen id : 6]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
-Condition : ((isnotnull(p_channel_tv#21) AND (p_channel_tv#21 = N)) AND isnotnull(p_promo_sk#20))
+Input [2]: [p_promo_sk#18, p_channel_tv#19]
+Condition : ((isnotnull(p_channel_tv#19) AND (p_channel_tv#19 = N)) AND isnotnull(p_promo_sk#18))
 
 (24) Project [codegen id : 6]
-Output [1]: [p_promo_sk#20]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
+Output [1]: [p_promo_sk#18]
+Input [2]: [p_promo_sk#18, p_channel_tv#19]
 
 (25) BroadcastExchange
-Input [1]: [p_promo_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+Input [1]: [p_promo_sk#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
 (26) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_promo_sk#3]
-Right keys [1]: [p_promo_sk#20]
+Right keys [1]: [p_promo_sk#18]
 Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 9]
-Output [6]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16]
-Input [8]: [ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, p_promo_sk#20]
+Output [6]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#13, sr_net_loss#14]
+Input [8]: [ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#13, sr_net_loss#14, p_promo_sk#18]
 
 (28) ReusedExchange [Reuses operator id: 126]
-Output [1]: [d_date_sk#22]
+Output [1]: [d_date_sk#20]
 
 (29) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_sold_date_sk#7]
-Right keys [1]: [d_date_sk#22]
+Right keys [1]: [d_date_sk#20]
 Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 9]
-Output [5]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16]
-Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, d_date_sk#22]
+Output [5]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#13, sr_net_loss#14]
+Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#13, sr_net_loss#14, d_date_sk#20]
 
 (31) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#23, s_store_id#24]
+Output [2]: [s_store_sk#21, s_store_id#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
 (32) ColumnarToRow [codegen id : 8]
-Input [2]: [s_store_sk#23, s_store_id#24]
+Input [2]: [s_store_sk#21, s_store_id#22]
 
 (33) Filter [codegen id : 8]
-Input [2]: [s_store_sk#23, s_store_id#24]
-Condition : isnotnull(s_store_sk#23)
+Input [2]: [s_store_sk#21, s_store_id#22]
+Condition : isnotnull(s_store_sk#21)
 
 (34) BroadcastExchange
-Input [2]: [s_store_sk#23, s_store_id#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
+Input [2]: [s_store_sk#21, s_store_id#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
 (35) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#23]
+Right keys [1]: [s_store_sk#21]
 Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 9]
-Output [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#24]
-Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_sk#23, s_store_id#24]
+Output [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#13, sr_net_loss#14, s_store_id#22]
+Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#13, sr_net_loss#14, s_store_sk#21, s_store_id#22]
 
 (37) HashAggregate [codegen id : 9]
-Input [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#24]
-Keys [1]: [s_store_id#24]
-Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#5)), partial_sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00)), partial_sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#25, sum#26, isEmpty#27, sum#28, isEmpty#29]
-Results [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
+Input [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#13, sr_net_loss#14, s_store_id#22]
+Keys [1]: [s_store_id#22]
+Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#5)), partial_sum(coalesce(cast(sr_return_amt#13 as decimal(12,2)), 0.00)), partial_sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#14 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [5]: [sum#23, sum#24, isEmpty#25, sum#26, isEmpty#27]
+Results [6]: [s_store_id#22, sum#28, sum#29, isEmpty#30, sum#31, isEmpty#32]
 
 (38) Exchange
-Input [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
-Arguments: hashpartitioning(s_store_id#24, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [6]: [s_store_id#22, sum#28, sum#29, isEmpty#30, sum#31, isEmpty#32]
+Arguments: hashpartitioning(s_store_id#22, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (39) HashAggregate [codegen id : 10]
-Input [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
-Keys [1]: [s_store_id#24]
-Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#5)), sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00)), sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#5))#35, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#36, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#37]
-Results [5]: [MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#5))#35,17,2) AS sales#38, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#36 AS returns#39, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#37 AS profit#40, store channel AS channel#41, concat(store, s_store_id#24) AS id#42]
+Input [6]: [s_store_id#22, sum#28, sum#29, isEmpty#30, sum#31, isEmpty#32]
+Keys [1]: [s_store_id#22]
+Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#5)), sum(coalesce(cast(sr_return_amt#13 as decimal(12,2)), 0.00)), sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#14 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#5))#33, sum(coalesce(cast(sr_return_amt#13 as decimal(12,2)), 0.00))#34, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#14 as decimal(12,2)), 0.00)))#35]
+Results [5]: [MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#5))#33,17,2) AS sales#36, sum(coalesce(cast(sr_return_amt#13 as decimal(12,2)), 0.00))#34 AS returns#37, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#14 as decimal(12,2)), 0.00)))#35 AS profit#38, store channel AS channel#39, concat(store, s_store_id#22) AS id#40]
 
 (40) Scan parquet spark_catalog.default.catalog_sales
-Output [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
+Output [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#49), dynamicpruningexpression(cs_sold_date_sk#49 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#47), dynamicpruningexpression(cs_sold_date_sk#47 IN dynamicpruning#8)]
 PushedFilters: [IsNotNull(cs_catalog_page_sk), IsNotNull(cs_item_sk), IsNotNull(cs_promo_sk)]
 ReadSchema: struct<cs_catalog_page_sk:int,cs_item_sk:int,cs_promo_sk:int,cs_order_number:int,cs_ext_sales_price:decimal(7,2),cs_net_profit:decimal(7,2)>
 
 (41) ColumnarToRow [codegen id : 11]
-Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
+Input [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
 
 (42) Filter [codegen id : 11]
-Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
-Condition : ((((isnotnull(cs_catalog_page_sk#43) AND isnotnull(cs_item_sk#44)) AND isnotnull(cs_promo_sk#45)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(cs_item_sk#44, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(cs_promo_sk#45, 42)))
+Input [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
+Condition : ((((isnotnull(cs_catalog_page_sk#41) AND isnotnull(cs_item_sk#42)) AND isnotnull(cs_promo_sk#43)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#1], xxhash64(cs_item_sk#42, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#10, [id=#2], xxhash64(cs_promo_sk#43, 42)))
 
 (43) Exchange
-Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
-Arguments: hashpartitioning(cs_item_sk#44, cs_order_number#46, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Input [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
+Arguments: hashpartitioning(cs_item_sk#42, cs_order_number#44, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (44) Sort [codegen id : 12]
-Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
-Arguments: [cs_item_sk#44 ASC NULLS FIRST, cs_order_number#46 ASC NULLS FIRST], false, 0
+Input [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
+Arguments: [cs_item_sk#42 ASC NULLS FIRST, cs_order_number#44 ASC NULLS FIRST], false, 0
 
 (45) Scan parquet spark_catalog.default.catalog_returns
-Output [5]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53, cr_returned_date_sk#54]
+Output [5]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51, cr_returned_date_sk#52]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
 PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_return_amount:decimal(7,2),cr_net_loss:decimal(7,2)>
 
 (46) ColumnarToRow [codegen id : 13]
-Input [5]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53, cr_returned_date_sk#54]
+Input [5]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51, cr_returned_date_sk#52]
 
 (47) Filter [codegen id : 13]
-Input [5]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53, cr_returned_date_sk#54]
-Condition : (isnotnull(cr_item_sk#50) AND isnotnull(cr_order_number#51))
+Input [5]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51, cr_returned_date_sk#52]
+Condition : (isnotnull(cr_item_sk#48) AND isnotnull(cr_order_number#49))
 
 (48) Project [codegen id : 13]
-Output [4]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
-Input [5]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53, cr_returned_date_sk#54]
+Output [4]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51]
+Input [5]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51, cr_returned_date_sk#52]
 
 (49) Exchange
-Input [4]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
-Arguments: hashpartitioning(cr_item_sk#50, cr_order_number#51, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [4]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51]
+Arguments: hashpartitioning(cr_item_sk#48, cr_order_number#49, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (50) Sort [codegen id : 14]
-Input [4]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
-Arguments: [cr_item_sk#50 ASC NULLS FIRST, cr_order_number#51 ASC NULLS FIRST], false, 0
+Input [4]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51]
+Arguments: [cr_item_sk#48 ASC NULLS FIRST, cr_order_number#49 ASC NULLS FIRST], false, 0
 
 (51) SortMergeJoin [codegen id : 19]
-Left keys [2]: [cs_item_sk#44, cs_order_number#46]
-Right keys [2]: [cr_item_sk#50, cr_order_number#51]
+Left keys [2]: [cs_item_sk#42, cs_order_number#44]
+Right keys [2]: [cr_item_sk#48, cr_order_number#49]
 Join type: LeftOuter
 Join condition: None
 
 (52) Project [codegen id : 19]
-Output [8]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
-Input [11]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
+Output [8]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51]
+Input [11]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51]
 
 (53) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#55]
+Output [1]: [i_item_sk#53]
 
 (54) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_item_sk#44]
-Right keys [1]: [i_item_sk#55]
+Left keys [1]: [cs_item_sk#42]
+Right keys [1]: [i_item_sk#53]
 Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 19]
-Output [7]: [cs_catalog_page_sk#43, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
-Input [9]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, i_item_sk#55]
+Output [7]: [cs_catalog_page_sk#41, cs_promo_sk#43, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51]
+Input [9]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51, i_item_sk#53]
 
 (56) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#56]
+Output [1]: [p_promo_sk#54]
 
 (57) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_promo_sk#45]
-Right keys [1]: [p_promo_sk#56]
+Left keys [1]: [cs_promo_sk#43]
+Right keys [1]: [p_promo_sk#54]
 Join type: Inner
 Join condition: None
 
 (58) Project [codegen id : 19]
-Output [6]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
-Input [8]: [cs_catalog_page_sk#43, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, p_promo_sk#56]
+Output [6]: [cs_catalog_page_sk#41, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51]
+Input [8]: [cs_catalog_page_sk#41, cs_promo_sk#43, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51, p_promo_sk#54]
 
 (59) ReusedExchange [Reuses operator id: 126]
-Output [1]: [d_date_sk#57]
+Output [1]: [d_date_sk#55]
 
 (60) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_sold_date_sk#49]
-Right keys [1]: [d_date_sk#57]
+Left keys [1]: [cs_sold_date_sk#47]
+Right keys [1]: [d_date_sk#55]
 Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 19]
-Output [5]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53]
-Input [7]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, d_date_sk#57]
+Output [5]: [cs_catalog_page_sk#41, cs_ext_sales_price#45, cs_net_profit#46, cr_return_amount#50, cr_net_loss#51]
+Input [7]: [cs_catalog_page_sk#41, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51, d_date_sk#55]
 
 (62) Scan parquet spark_catalog.default.catalog_page
-Output [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
+Output [2]: [cp_catalog_page_sk#56, cp_catalog_page_id#57]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_page]
 PushedFilters: [IsNotNull(cp_catalog_page_sk)]
 ReadSchema: struct<cp_catalog_page_sk:int,cp_catalog_page_id:string>
 
 (63) ColumnarToRow [codegen id : 18]
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
+Input [2]: [cp_catalog_page_sk#56, cp_catalog_page_id#57]
 
 (64) Filter [codegen id : 18]
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
-Condition : isnotnull(cp_catalog_page_sk#58)
+Input [2]: [cp_catalog_page_sk#56, cp_catalog_page_id#57]
+Condition : isnotnull(cp_catalog_page_sk#56)
 
 (65) BroadcastExchange
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
+Input [2]: [cp_catalog_page_sk#56, cp_catalog_page_id#57]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=11]
 
 (66) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_catalog_page_sk#43]
-Right keys [1]: [cp_catalog_page_sk#58]
+Left keys [1]: [cs_catalog_page_sk#41]
+Right keys [1]: [cp_catalog_page_sk#56]
 Join type: Inner
 Join condition: None
 
 (67) Project [codegen id : 19]
-Output [5]: [cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#59]
-Input [7]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_sk#58, cp_catalog_page_id#59]
+Output [5]: [cs_ext_sales_price#45, cs_net_profit#46, cr_return_amount#50, cr_net_loss#51, cp_catalog_page_id#57]
+Input [7]: [cs_catalog_page_sk#41, cs_ext_sales_price#45, cs_net_profit#46, cr_return_amount#50, cr_net_loss#51, cp_catalog_page_sk#56, cp_catalog_page_id#57]
 
 (68) HashAggregate [codegen id : 19]
-Input [5]: [cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#59]
-Keys [1]: [cp_catalog_page_id#59]
-Functions [3]: [partial_sum(UnscaledValue(cs_ext_sales_price#47)), partial_sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00)), partial_sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#60, sum#61, isEmpty#62, sum#63, isEmpty#64]
-Results [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
+Input [5]: [cs_ext_sales_price#45, cs_net_profit#46, cr_return_amount#50, cr_net_loss#51, cp_catalog_page_id#57]
+Keys [1]: [cp_catalog_page_id#57]
+Functions [3]: [partial_sum(UnscaledValue(cs_ext_sales_price#45)), partial_sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00)), partial_sum((cs_net_profit#46 - coalesce(cast(cr_net_loss#51 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [5]: [sum#58, sum#59, isEmpty#60, sum#61, isEmpty#62]
+Results [6]: [cp_catalog_page_id#57, sum#63, sum#64, isEmpty#65, sum#66, isEmpty#67]
 
 (69) Exchange
-Input [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
-Arguments: hashpartitioning(cp_catalog_page_id#59, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [6]: [cp_catalog_page_id#57, sum#63, sum#64, isEmpty#65, sum#66, isEmpty#67]
+Arguments: hashpartitioning(cp_catalog_page_id#57, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (70) HashAggregate [codegen id : 20]
-Input [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
-Keys [1]: [cp_catalog_page_id#59]
-Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#47)), sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00)), sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#47))#70, sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00))#71, sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))#72]
-Results [5]: [MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#47))#70,17,2) AS sales#73, sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00))#71 AS returns#74, sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))#72 AS profit#75, catalog channel AS channel#76, concat(catalog_page, cp_catalog_page_id#59) AS id#77]
+Input [6]: [cp_catalog_page_id#57, sum#63, sum#64, isEmpty#65, sum#66, isEmpty#67]
+Keys [1]: [cp_catalog_page_id#57]
+Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#45)), sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00)), sum((cs_net_profit#46 - coalesce(cast(cr_net_loss#51 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#45))#68, sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00))#69, sum((cs_net_profit#46 - coalesce(cast(cr_net_loss#51 as decimal(12,2)), 0.00)))#70]
+Results [5]: [MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#45))#68,17,2) AS sales#71, sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00))#69 AS returns#72, sum((cs_net_profit#46 - coalesce(cast(cr_net_loss#51 as decimal(12,2)), 0.00)))#70 AS profit#73, catalog channel AS channel#74, concat(catalog_page, cp_catalog_page_id#57) AS id#75]
 
 (71) Scan parquet spark_catalog.default.web_sales
-Output [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
+Output [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#84), dynamicpruningexpression(ws_sold_date_sk#84 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#82), dynamicpruningexpression(ws_sold_date_sk#82 IN dynamicpruning#8)]
 PushedFilters: [IsNotNull(ws_web_site_sk), IsNotNull(ws_item_sk), IsNotNull(ws_promo_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_web_site_sk:int,ws_promo_sk:int,ws_order_number:int,ws_ext_sales_price:decimal(7,2),ws_net_profit:decimal(7,2)>
 
 (72) ColumnarToRow [codegen id : 21]
-Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
+Input [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
 
 (73) Filter [codegen id : 21]
-Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
-Condition : ((((isnotnull(ws_web_site_sk#79) AND isnotnull(ws_item_sk#78)) AND isnotnull(ws_promo_sk#80)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(ws_item_sk#78, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(ws_promo_sk#80, 42)))
+Input [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
+Condition : ((((isnotnull(ws_web_site_sk#77) AND isnotnull(ws_item_sk#76)) AND isnotnull(ws_promo_sk#78)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#1], xxhash64(ws_item_sk#76, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#10, [id=#2], xxhash64(ws_promo_sk#78, 42)))
 
 (74) Exchange
-Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
-Arguments: hashpartitioning(ws_item_sk#78, ws_order_number#81, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
+Arguments: hashpartitioning(ws_item_sk#76, ws_order_number#79, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (75) Sort [codegen id : 22]
-Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
-Arguments: [ws_item_sk#78 ASC NULLS FIRST, ws_order_number#81 ASC NULLS FIRST], false, 0
+Input [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
+Arguments: [ws_item_sk#76 ASC NULLS FIRST, ws_order_number#79 ASC NULLS FIRST], false, 0
 
 (76) Scan parquet spark_catalog.default.web_returns
-Output [5]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88, wr_returned_date_sk#89]
+Output [5]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86, wr_returned_date_sk#87]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_returns]
 PushedFilters: [IsNotNull(wr_item_sk), IsNotNull(wr_order_number)]
 ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_amt:decimal(7,2),wr_net_loss:decimal(7,2)>
 
 (77) ColumnarToRow [codegen id : 23]
-Input [5]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88, wr_returned_date_sk#89]
+Input [5]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86, wr_returned_date_sk#87]
 
 (78) Filter [codegen id : 23]
-Input [5]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88, wr_returned_date_sk#89]
-Condition : (isnotnull(wr_item_sk#85) AND isnotnull(wr_order_number#86))
+Input [5]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86, wr_returned_date_sk#87]
+Condition : (isnotnull(wr_item_sk#83) AND isnotnull(wr_order_number#84))
 
 (79) Project [codegen id : 23]
-Output [4]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
-Input [5]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88, wr_returned_date_sk#89]
+Output [4]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86]
+Input [5]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86, wr_returned_date_sk#87]
 
 (80) Exchange
-Input [4]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
-Arguments: hashpartitioning(wr_item_sk#85, wr_order_number#86, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [4]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86]
+Arguments: hashpartitioning(wr_item_sk#83, wr_order_number#84, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (81) Sort [codegen id : 24]
-Input [4]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
-Arguments: [wr_item_sk#85 ASC NULLS FIRST, wr_order_number#86 ASC NULLS FIRST], false, 0
+Input [4]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86]
+Arguments: [wr_item_sk#83 ASC NULLS FIRST, wr_order_number#84 ASC NULLS FIRST], false, 0
 
 (82) SortMergeJoin [codegen id : 29]
-Left keys [2]: [ws_item_sk#78, ws_order_number#81]
-Right keys [2]: [wr_item_sk#85, wr_order_number#86]
+Left keys [2]: [ws_item_sk#76, ws_order_number#79]
+Right keys [2]: [wr_item_sk#83, wr_order_number#84]
 Join type: LeftOuter
 Join condition: None
 
 (83) Project [codegen id : 29]
-Output [8]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
-Input [11]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
+Output [8]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86]
+Input [11]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86]
 
 (84) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#90]
+Output [1]: [i_item_sk#88]
 
 (85) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_item_sk#78]
-Right keys [1]: [i_item_sk#90]
+Left keys [1]: [ws_item_sk#76]
+Right keys [1]: [i_item_sk#88]
 Join type: Inner
 Join condition: None
 
 (86) Project [codegen id : 29]
-Output [7]: [ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
-Input [9]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, i_item_sk#90]
+Output [7]: [ws_web_site_sk#77, ws_promo_sk#78, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86]
+Input [9]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86, i_item_sk#88]
 
 (87) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#91]
+Output [1]: [p_promo_sk#89]
 
 (88) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_promo_sk#80]
-Right keys [1]: [p_promo_sk#91]
+Left keys [1]: [ws_promo_sk#78]
+Right keys [1]: [p_promo_sk#89]
 Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 29]
-Output [6]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
-Input [8]: [ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, p_promo_sk#91]
+Output [6]: [ws_web_site_sk#77, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86]
+Input [8]: [ws_web_site_sk#77, ws_promo_sk#78, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86, p_promo_sk#89]
 
 (90) ReusedExchange [Reuses operator id: 126]
-Output [1]: [d_date_sk#92]
+Output [1]: [d_date_sk#90]
 
 (91) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_sold_date_sk#84]
-Right keys [1]: [d_date_sk#92]
+Left keys [1]: [ws_sold_date_sk#82]
+Right keys [1]: [d_date_sk#90]
 Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 29]
-Output [5]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88]
-Input [7]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, d_date_sk#92]
+Output [5]: [ws_web_site_sk#77, ws_ext_sales_price#80, ws_net_profit#81, wr_return_amt#85, wr_net_loss#86]
+Input [7]: [ws_web_site_sk#77, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86, d_date_sk#90]
 
 (93) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#93, web_site_id#94]
+Output [2]: [web_site_sk#91, web_site_id#92]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_site_id:string>
 
 (94) ColumnarToRow [codegen id : 28]
-Input [2]: [web_site_sk#93, web_site_id#94]
+Input [2]: [web_site_sk#91, web_site_id#92]
 
 (95) Filter [codegen id : 28]
-Input [2]: [web_site_sk#93, web_site_id#94]
-Condition : isnotnull(web_site_sk#93)
+Input [2]: [web_site_sk#91, web_site_id#92]
+Condition : isnotnull(web_site_sk#91)
 
 (96) BroadcastExchange
-Input [2]: [web_site_sk#93, web_site_id#94]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=13]
+Input [2]: [web_site_sk#91, web_site_id#92]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=15]
 
 (97) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_web_site_sk#79]
-Right keys [1]: [web_site_sk#93]
+Left keys [1]: [ws_web_site_sk#77]
+Right keys [1]: [web_site_sk#91]
 Join type: Inner
 Join condition: None
 
 (98) Project [codegen id : 29]
-Output [5]: [ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_id#94]
-Input [7]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_sk#93, web_site_id#94]
+Output [5]: [ws_ext_sales_price#80, ws_net_profit#81, wr_return_amt#85, wr_net_loss#86, web_site_id#92]
+Input [7]: [ws_web_site_sk#77, ws_ext_sales_price#80, ws_net_profit#81, wr_return_amt#85, wr_net_loss#86, web_site_sk#91, web_site_id#92]
 
 (99) HashAggregate [codegen id : 29]
-Input [5]: [ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_id#94]
-Keys [1]: [web_site_id#94]
-Functions [3]: [partial_sum(UnscaledValue(ws_ext_sales_price#82)), partial_sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00)), partial_sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#95, sum#96, isEmpty#97, sum#98, isEmpty#99]
-Results [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
+Input [5]: [ws_ext_sales_price#80, ws_net_profit#81, wr_return_amt#85, wr_net_loss#86, web_site_id#92]
+Keys [1]: [web_site_id#92]
+Functions [3]: [partial_sum(UnscaledValue(ws_ext_sales_price#80)), partial_sum(coalesce(cast(wr_return_amt#85 as decimal(12,2)), 0.00)), partial_sum((ws_net_profit#81 - coalesce(cast(wr_net_loss#86 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [5]: [sum#93, sum#94, isEmpty#95, sum#96, isEmpty#97]
+Results [6]: [web_site_id#92, sum#98, sum#99, isEmpty#100, sum#101, isEmpty#102]
 
 (100) Exchange
-Input [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
-Arguments: hashpartitioning(web_site_id#94, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [6]: [web_site_id#92, sum#98, sum#99, isEmpty#100, sum#101, isEmpty#102]
+Arguments: hashpartitioning(web_site_id#92, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
 (101) HashAggregate [codegen id : 30]
-Input [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
-Keys [1]: [web_site_id#94]
-Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#82)), sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00)), sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#82))#105, sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00))#106, sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))#107]
-Results [5]: [MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#82))#105,17,2) AS sales#108, sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00))#106 AS returns#109, sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))#107 AS profit#110, web channel AS channel#111, concat(web_site, web_site_id#94) AS id#112]
+Input [6]: [web_site_id#92, sum#98, sum#99, isEmpty#100, sum#101, isEmpty#102]
+Keys [1]: [web_site_id#92]
+Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#80)), sum(coalesce(cast(wr_return_amt#85 as decimal(12,2)), 0.00)), sum((ws_net_profit#81 - coalesce(cast(wr_net_loss#86 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#80))#103, sum(coalesce(cast(wr_return_amt#85 as decimal(12,2)), 0.00))#104, sum((ws_net_profit#81 - coalesce(cast(wr_net_loss#86 as decimal(12,2)), 0.00)))#105]
+Results [5]: [MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#80))#103,17,2) AS sales#106, sum(coalesce(cast(wr_return_amt#85 as decimal(12,2)), 0.00))#104 AS returns#107, sum((ws_net_profit#81 - coalesce(cast(wr_net_loss#86 as decimal(12,2)), 0.00)))#105 AS profit#108, web channel AS channel#109, concat(web_site, web_site_id#92) AS id#110]
 
 (102) Union
 
 (103) Expand [codegen id : 31]
-Input [5]: [sales#38, returns#39, profit#40, channel#41, id#42]
-Arguments: [[sales#38, returns#39, profit#40, channel#41, id#42, 0], [sales#38, returns#39, profit#40, channel#41, null, 1], [sales#38, returns#39, profit#40, null, null, 3]], [sales#38, returns#39, profit#40, channel#113, id#114, spark_grouping_id#115]
+Input [5]: [sales#36, returns#37, profit#38, channel#39, id#40]
+Arguments: [[sales#36, returns#37, profit#38, channel#39, id#40, 0], [sales#36, returns#37, profit#38, channel#39, null, 1], [sales#36, returns#37, profit#38, null, null, 3]], [sales#36, returns#37, profit#38, channel#111, id#112, spark_grouping_id#113]
 
 (104) HashAggregate [codegen id : 31]
-Input [6]: [sales#38, returns#39, profit#40, channel#113, id#114, spark_grouping_id#115]
-Keys [3]: [channel#113, id#114, spark_grouping_id#115]
-Functions [3]: [partial_sum(sales#38), partial_sum(returns#39), partial_sum(profit#40)]
-Aggregate Attributes [6]: [sum#116, isEmpty#117, sum#118, isEmpty#119, sum#120, isEmpty#121]
-Results [9]: [channel#113, id#114, spark_grouping_id#115, sum#122, isEmpty#123, sum#124, isEmpty#125, sum#126, isEmpty#127]
+Input [6]: [sales#36, returns#37, profit#38, channel#111, id#112, spark_grouping_id#113]
+Keys [3]: [channel#111, id#112, spark_grouping_id#113]
+Functions [3]: [partial_sum(sales#36), partial_sum(returns#37), partial_sum(profit#38)]
+Aggregate Attributes [6]: [sum#114, isEmpty#115, sum#116, isEmpty#117, sum#118, isEmpty#119]
+Results [9]: [channel#111, id#112, spark_grouping_id#113, sum#120, isEmpty#121, sum#122, isEmpty#123, sum#124, isEmpty#125]
 
 (105) Exchange
-Input [9]: [channel#113, id#114, spark_grouping_id#115, sum#122, isEmpty#123, sum#124, isEmpty#125, sum#126, isEmpty#127]
-Arguments: hashpartitioning(channel#113, id#114, spark_grouping_id#115, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Input [9]: [channel#111, id#112, spark_grouping_id#113, sum#120, isEmpty#121, sum#122, isEmpty#123, sum#124, isEmpty#125]
+Arguments: hashpartitioning(channel#111, id#112, spark_grouping_id#113, 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
 (106) HashAggregate [codegen id : 32]
-Input [9]: [channel#113, id#114, spark_grouping_id#115, sum#122, isEmpty#123, sum#124, isEmpty#125, sum#126, isEmpty#127]
-Keys [3]: [channel#113, id#114, spark_grouping_id#115]
-Functions [3]: [sum(sales#38), sum(returns#39), sum(profit#40)]
-Aggregate Attributes [3]: [sum(sales#38)#128, sum(returns#39)#129, sum(profit#40)#130]
-Results [5]: [channel#113, id#114, sum(sales#38)#128 AS sales#131, sum(returns#39)#129 AS returns#132, sum(profit#40)#130 AS profit#133]
+Input [9]: [channel#111, id#112, spark_grouping_id#113, sum#120, isEmpty#121, sum#122, isEmpty#123, sum#124, isEmpty#125]
+Keys [3]: [channel#111, id#112, spark_grouping_id#113]
+Functions [3]: [sum(sales#36), sum(returns#37), sum(profit#38)]
+Aggregate Attributes [3]: [sum(sales#36)#126, sum(returns#37)#127, sum(profit#38)#128]
+Results [5]: [channel#111, id#112, sum(sales#36)#126 AS sales#129, sum(returns#37)#127 AS returns#130, sum(profit#38)#128 AS profit#131]
 
 (107) TakeOrderedAndProject
-Input [5]: [channel#113, id#114, sales#131, returns#132, profit#133]
-Arguments: 100, [channel#113 ASC NULLS FIRST, id#114 ASC NULLS FIRST], [channel#113, id#114, sales#131, returns#132, profit#133]
+Input [5]: [channel#111, id#112, sales#129, returns#130, profit#131]
+Arguments: 100, [channel#111 ASC NULLS FIRST, id#112 ASC NULLS FIRST], [channel#111, id#112, sales#129, returns#130, profit#131]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#9, [id=#10]
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#9, [id=#1]
 ObjectHashAggregate (114)
 +- Exchange (113)
    +- ObjectHashAggregate (112)
@@ -619,42 +619,42 @@ ObjectHashAggregate (114)
 
 
 (108) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#18, i_current_price#19]
+Output [2]: [i_item_sk#16, i_current_price#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_current_price), GreaterThan(i_current_price,50.00), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2)>
 
 (109) ColumnarToRow [codegen id : 1]
-Input [2]: [i_item_sk#18, i_current_price#19]
+Input [2]: [i_item_sk#16, i_current_price#17]
 
 (110) Filter [codegen id : 1]
-Input [2]: [i_item_sk#18, i_current_price#19]
-Condition : ((isnotnull(i_current_price#19) AND (i_current_price#19 > 50.00)) AND isnotnull(i_item_sk#18))
+Input [2]: [i_item_sk#16, i_current_price#17]
+Condition : ((isnotnull(i_current_price#17) AND (i_current_price#17 > 50.00)) AND isnotnull(i_item_sk#16))
 
 (111) Project [codegen id : 1]
-Output [1]: [i_item_sk#18]
-Input [2]: [i_item_sk#18, i_current_price#19]
+Output [1]: [i_item_sk#16]
+Input [2]: [i_item_sk#16, i_current_price#17]
 
 (112) ObjectHashAggregate
-Input [1]: [i_item_sk#18]
+Input [1]: [i_item_sk#16]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)]
-Aggregate Attributes [1]: [buf#134]
-Results [1]: [buf#135]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#16, 42), 101823, 1521109, 0, 0)]
+Aggregate Attributes [1]: [buf#132]
+Results [1]: [buf#133]
 
 (113) Exchange
-Input [1]: [buf#135]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=16]
+Input [1]: [buf#133]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
 
 (114) ObjectHashAggregate
-Input [1]: [buf#135]
+Input [1]: [buf#133]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)#136]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)#136 AS bloomFilter#137]
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#16, 42), 101823, 1521109, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#16, 42), 101823, 1521109, 0, 0)#134]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#16, 42), 101823, 1521109, 0, 0)#134 AS bloomFilter#135]
 
-Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#11, [id=#12]
+Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#10, [id=#2]
 ObjectHashAggregate (121)
 +- Exchange (120)
    +- ObjectHashAggregate (119)
@@ -665,40 +665,40 @@ ObjectHashAggregate (121)
 
 
 (115) Scan parquet spark_catalog.default.promotion
-Output [2]: [p_promo_sk#20, p_channel_tv#21]
+Output [2]: [p_promo_sk#18, p_channel_tv#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/promotion]
 PushedFilters: [IsNotNull(p_channel_tv), EqualTo(p_channel_tv,N), IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int,p_channel_tv:string>
 
 (116) ColumnarToRow [codegen id : 1]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
+Input [2]: [p_promo_sk#18, p_channel_tv#19]
 
 (117) Filter [codegen id : 1]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
-Condition : ((isnotnull(p_channel_tv#21) AND (p_channel_tv#21 = N)) AND isnotnull(p_promo_sk#20))
+Input [2]: [p_promo_sk#18, p_channel_tv#19]
+Condition : ((isnotnull(p_channel_tv#19) AND (p_channel_tv#19 = N)) AND isnotnull(p_promo_sk#18))
 
 (118) Project [codegen id : 1]
-Output [1]: [p_promo_sk#20]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
+Output [1]: [p_promo_sk#18]
+Input [2]: [p_promo_sk#18, p_channel_tv#19]
 
 (119) ObjectHashAggregate
-Input [1]: [p_promo_sk#20]
+Input [1]: [p_promo_sk#18]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(p_promo_sk#20, 42), 986, 24246, 0, 0)]
-Aggregate Attributes [1]: [buf#138]
-Results [1]: [buf#139]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(p_promo_sk#18, 42), 986, 24246, 0, 0)]
+Aggregate Attributes [1]: [buf#136]
+Results [1]: [buf#137]
 
 (120) Exchange
-Input [1]: [buf#139]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
+Input [1]: [buf#137]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
 
 (121) ObjectHashAggregate
-Input [1]: [buf#139]
+Input [1]: [buf#137]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(p_promo_sk#20, 42), 986, 24246, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(p_promo_sk#20, 42), 986, 24246, 0, 0)#140]
-Results [1]: [bloom_filter_agg(xxhash64(p_promo_sk#20, 42), 986, 24246, 0, 0)#140 AS bloomFilter#141]
+Functions [1]: [bloom_filter_agg(xxhash64(p_promo_sk#18, 42), 986, 24246, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(p_promo_sk#18, 42), 986, 24246, 0, 0)#138]
+Results [1]: [bloom_filter_agg(xxhash64(p_promo_sk#18, 42), 986, 24246, 0, 0)#138 AS bloomFilter#139]
 
 Subquery:3 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#7 IN dynamicpruning#8
 BroadcastExchange (126)
@@ -709,37 +709,37 @@ BroadcastExchange (126)
 
 
 (122) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#22, d_date#142]
+Output [2]: [d_date_sk#20, d_date#140]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-08-23), LessThanOrEqual(d_date,2000-09-22), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (123) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#22, d_date#142]
+Input [2]: [d_date_sk#20, d_date#140]
 
 (124) Filter [codegen id : 1]
-Input [2]: [d_date_sk#22, d_date#142]
-Condition : (((isnotnull(d_date#142) AND (d_date#142 >= 2000-08-23)) AND (d_date#142 <= 2000-09-22)) AND isnotnull(d_date_sk#22))
+Input [2]: [d_date_sk#20, d_date#140]
+Condition : (((isnotnull(d_date#140) AND (d_date#140 >= 2000-08-23)) AND (d_date#140 <= 2000-09-22)) AND isnotnull(d_date_sk#20))
 
 (125) Project [codegen id : 1]
-Output [1]: [d_date_sk#22]
-Input [2]: [d_date_sk#22, d_date#142]
+Output [1]: [d_date_sk#20]
+Input [2]: [d_date_sk#20, d_date#140]
 
 (126) BroadcastExchange
-Input [1]: [d_date_sk#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=18]
+Input [1]: [d_date_sk#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=20]
 
-Subquery:4 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
+Subquery:4 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#1]
 
-Subquery:5 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
+Subquery:5 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#10, [id=#2]
 
-Subquery:6 Hosting operator id = 40 Hosting Expression = cs_sold_date_sk#49 IN dynamicpruning#8
+Subquery:6 Hosting operator id = 40 Hosting Expression = cs_sold_date_sk#47 IN dynamicpruning#8
 
-Subquery:7 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
+Subquery:7 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#1]
 
-Subquery:8 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
+Subquery:8 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#10, [id=#2]
 
-Subquery:9 Hosting operator id = 71 Hosting Expression = ws_sold_date_sk#84 IN dynamicpruning#8
+Subquery:9 Hosting operator id = 71 Hosting Expression = ws_sold_date_sk#82 IN dynamicpruning#8
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
@@ -113,7 +113,7 @@ Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
 
 (19) Filter [codegen id : 5]
 Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
-Condition : (isnotnull(ss_item_sk#11) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(ss_item_sk#11, 42)))
+Condition : (isnotnull(ss_item_sk#11) AND might_contain(Subquery scalar-subquery#13, [id=#3], xxhash64(ss_item_sk#11, 42)))
 
 (20) Project [codegen id : 5]
 Output [1]: [ss_item_sk#11]
@@ -121,7 +121,7 @@ Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
 
 (21) Exchange
 Input [1]: [ss_item_sk#11]
-Arguments: hashpartitioning(ss_item_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Arguments: hashpartitioning(ss_item_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (22) Sort [codegen id : 6]
 Input [1]: [ss_item_sk#11]
@@ -146,7 +146,7 @@ Results [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 
 (26) Exchange
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
-Arguments: hashpartitioning(i_item_id#2, i_item_desc#3, i_current_price#4, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Arguments: hashpartitioning(i_item_id#2, i_item_desc#3, i_current_price#4, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (27) HashAggregate [codegen id : 8]
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
@@ -170,28 +170,28 @@ BroadcastExchange (33)
 
 
 (29) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#10, d_date#15]
+Output [2]: [d_date_sk#10, d_date#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-05-25), LessThanOrEqual(d_date,2000-07-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#15]
+Input [2]: [d_date_sk#10, d_date#14]
 
 (31) Filter [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#15]
-Condition : (((isnotnull(d_date#15) AND (d_date#15 >= 2000-05-25)) AND (d_date#15 <= 2000-07-24)) AND isnotnull(d_date_sk#10))
+Input [2]: [d_date_sk#10, d_date#14]
+Condition : (((isnotnull(d_date#14) AND (d_date#14 >= 2000-05-25)) AND (d_date#14 <= 2000-07-24)) AND isnotnull(d_date_sk#10))
 
 (32) Project [codegen id : 1]
 Output [1]: [d_date_sk#10]
-Input [2]: [d_date_sk#10, d_date#15]
+Input [2]: [d_date_sk#10, d_date#14]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
-Subquery:2 Hosting operator id = 19 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
+Subquery:2 Hosting operator id = 19 Hosting Expression = Subquery scalar-subquery#13, [id=#3]
 ObjectHashAggregate (40)
 +- Exchange (39)
    +- ObjectHashAggregate (38)
@@ -223,18 +223,18 @@ Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
 Input [1]: [i_item_sk#1]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)]
-Aggregate Attributes [1]: [buf#16]
-Results [1]: [buf#17]
+Aggregate Attributes [1]: [buf#15]
+Results [1]: [buf#16]
 
 (39) Exchange
-Input [1]: [buf#17]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
+Input [1]: [buf#16]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
 (40) ObjectHashAggregate
-Input [1]: [buf#17]
+Input [1]: [buf#16]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#18]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#18 AS bloomFilter#19]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#17]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#17 AS bloomFilter#18]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85.sf100/explain.txt
@@ -118,7 +118,7 @@ Input [9]: [wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_r
 
 (14) Filter [codegen id : 4]
 Input [9]: [wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_order_number#15, wr_fee#16, wr_refunded_cash#17, wr_returned_date_sk#18]
-Condition : (((((((isnotnull(wr_item_sk#10) AND isnotnull(wr_order_number#15)) AND isnotnull(wr_refunded_cdemo_sk#11)) AND isnotnull(wr_returning_cdemo_sk#13)) AND isnotnull(wr_refunded_addr_sk#12)) AND isnotnull(wr_reason_sk#14)) AND might_contain(Subquery scalar-subquery#19, [id=#20], xxhash64(wr_refunded_cdemo_sk#11, 42))) AND might_contain(Subquery scalar-subquery#21, [id=#22], xxhash64(wr_refunded_addr_sk#12, 42)))
+Condition : (((((((isnotnull(wr_item_sk#10) AND isnotnull(wr_order_number#15)) AND isnotnull(wr_refunded_cdemo_sk#11)) AND isnotnull(wr_returning_cdemo_sk#13)) AND isnotnull(wr_refunded_addr_sk#12)) AND isnotnull(wr_reason_sk#14)) AND might_contain(Subquery scalar-subquery#19, [id=#3], xxhash64(wr_refunded_cdemo_sk#11, 42))) AND might_contain(Subquery scalar-subquery#20, [id=#4], xxhash64(wr_refunded_addr_sk#12, 42)))
 
 (15) Project [codegen id : 4]
 Output [8]: [wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_order_number#15, wr_fee#16, wr_refunded_cash#17]
@@ -126,7 +126,7 @@ Input [9]: [wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_r
 
 (16) Exchange
 Input [8]: [wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_order_number#15, wr_fee#16, wr_refunded_cash#17]
-Arguments: hashpartitioning(wr_item_sk#10, wr_order_number#15, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Arguments: hashpartitioning(wr_item_sk#10, wr_order_number#15, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (17) Sort [codegen id : 5]
 Input [8]: [wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_order_number#15, wr_fee#16, wr_refunded_cash#17]
@@ -143,167 +143,167 @@ Output [10]: [ws_quantity#4, ws_sales_price#5, ws_net_profit#6, ws_sold_date_sk#
 Input [14]: [ws_item_sk#1, ws_order_number#3, ws_quantity#4, ws_sales_price#5, ws_net_profit#6, ws_sold_date_sk#7, wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_order_number#15, wr_fee#16, wr_refunded_cash#17]
 
 (20) Scan parquet spark_catalog.default.customer_demographics
-Output [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
+Output [3]: [cd_demo_sk#21, cd_marital_status#22, cd_education_status#23]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status), IsNotNull(cd_education_status), Or(Or(And(EqualTo(cd_marital_status,M),EqualTo(cd_education_status,Advanced Degree     )),And(EqualTo(cd_marital_status,S),EqualTo(cd_education_status,College             ))),And(EqualTo(cd_marital_status,W),EqualTo(cd_education_status,2 yr Degree         )))]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
 
 (21) ColumnarToRow [codegen id : 6]
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
+Input [3]: [cd_demo_sk#21, cd_marital_status#22, cd_education_status#23]
 
 (22) Filter [codegen id : 6]
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
-Condition : (((isnotnull(cd_demo_sk#23) AND isnotnull(cd_marital_status#24)) AND isnotnull(cd_education_status#25)) AND ((((cd_marital_status#24 = M) AND (cd_education_status#25 = Advanced Degree     )) OR ((cd_marital_status#24 = S) AND (cd_education_status#25 = College             ))) OR ((cd_marital_status#24 = W) AND (cd_education_status#25 = 2 yr Degree         ))))
+Input [3]: [cd_demo_sk#21, cd_marital_status#22, cd_education_status#23]
+Condition : (((isnotnull(cd_demo_sk#21) AND isnotnull(cd_marital_status#22)) AND isnotnull(cd_education_status#23)) AND ((((cd_marital_status#22 = M) AND (cd_education_status#23 = Advanced Degree     )) OR ((cd_marital_status#22 = S) AND (cd_education_status#23 = College             ))) OR ((cd_marital_status#22 = W) AND (cd_education_status#23 = 2 yr Degree         ))))
 
 (23) BroadcastExchange
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
+Input [3]: [cd_demo_sk#21, cd_marital_status#22, cd_education_status#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=6]
 
 (24) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [wr_refunded_cdemo_sk#11]
-Right keys [1]: [cd_demo_sk#23]
+Right keys [1]: [cd_demo_sk#21]
 Join type: Inner
-Join condition: ((((((cd_marital_status#24 = M) AND (cd_education_status#25 = Advanced Degree     )) AND (ws_sales_price#5 >= 100.00)) AND (ws_sales_price#5 <= 150.00)) OR ((((cd_marital_status#24 = S) AND (cd_education_status#25 = College             )) AND (ws_sales_price#5 >= 50.00)) AND (ws_sales_price#5 <= 100.00))) OR ((((cd_marital_status#24 = W) AND (cd_education_status#25 = 2 yr Degree         )) AND (ws_sales_price#5 >= 150.00)) AND (ws_sales_price#5 <= 200.00)))
+Join condition: ((((((cd_marital_status#22 = M) AND (cd_education_status#23 = Advanced Degree     )) AND (ws_sales_price#5 >= 100.00)) AND (ws_sales_price#5 <= 150.00)) OR ((((cd_marital_status#22 = S) AND (cd_education_status#23 = College             )) AND (ws_sales_price#5 >= 50.00)) AND (ws_sales_price#5 <= 100.00))) OR ((((cd_marital_status#22 = W) AND (cd_education_status#23 = 2 yr Degree         )) AND (ws_sales_price#5 >= 150.00)) AND (ws_sales_price#5 <= 200.00)))
 
 (25) Project [codegen id : 7]
-Output [10]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#24, cd_education_status#25]
-Input [13]: [ws_quantity#4, ws_sales_price#5, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
+Output [10]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#22, cd_education_status#23]
+Input [13]: [ws_quantity#4, ws_sales_price#5, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_demo_sk#21, cd_marital_status#22, cd_education_status#23]
 
 (26) Exchange
-Input [10]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#24, cd_education_status#25]
-Arguments: hashpartitioning(wr_returning_cdemo_sk#13, cd_marital_status#24, cd_education_status#25, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [10]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#22, cd_education_status#23]
+Arguments: hashpartitioning(wr_returning_cdemo_sk#13, cd_marital_status#22, cd_education_status#23, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
 (27) Sort [codegen id : 8]
-Input [10]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#24, cd_education_status#25]
-Arguments: [wr_returning_cdemo_sk#13 ASC NULLS FIRST, cd_marital_status#24 ASC NULLS FIRST, cd_education_status#25 ASC NULLS FIRST], false, 0
+Input [10]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#22, cd_education_status#23]
+Arguments: [wr_returning_cdemo_sk#13 ASC NULLS FIRST, cd_marital_status#22 ASC NULLS FIRST, cd_education_status#23 ASC NULLS FIRST], false, 0
 
 (28) Scan parquet spark_catalog.default.customer_demographics
-Output [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
+Output [3]: [cd_demo_sk#24, cd_marital_status#25, cd_education_status#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status), IsNotNull(cd_education_status)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
 
 (29) ColumnarToRow [codegen id : 9]
-Input [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
+Input [3]: [cd_demo_sk#24, cd_marital_status#25, cd_education_status#26]
 
 (30) Filter [codegen id : 9]
-Input [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
-Condition : ((isnotnull(cd_demo_sk#26) AND isnotnull(cd_marital_status#27)) AND isnotnull(cd_education_status#28))
+Input [3]: [cd_demo_sk#24, cd_marital_status#25, cd_education_status#26]
+Condition : ((isnotnull(cd_demo_sk#24) AND isnotnull(cd_marital_status#25)) AND isnotnull(cd_education_status#26))
 
 (31) Exchange
-Input [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
-Arguments: hashpartitioning(cd_demo_sk#26, cd_marital_status#27, cd_education_status#28, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [3]: [cd_demo_sk#24, cd_marital_status#25, cd_education_status#26]
+Arguments: hashpartitioning(cd_demo_sk#24, cd_marital_status#25, cd_education_status#26, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (32) Sort [codegen id : 10]
-Input [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
-Arguments: [cd_demo_sk#26 ASC NULLS FIRST, cd_marital_status#27 ASC NULLS FIRST, cd_education_status#28 ASC NULLS FIRST], false, 0
+Input [3]: [cd_demo_sk#24, cd_marital_status#25, cd_education_status#26]
+Arguments: [cd_demo_sk#24 ASC NULLS FIRST, cd_marital_status#25 ASC NULLS FIRST, cd_education_status#26 ASC NULLS FIRST], false, 0
 
 (33) SortMergeJoin [codegen id : 14]
-Left keys [3]: [wr_returning_cdemo_sk#13, cd_marital_status#24, cd_education_status#25]
-Right keys [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
+Left keys [3]: [wr_returning_cdemo_sk#13, cd_marital_status#22, cd_education_status#23]
+Right keys [3]: [cd_demo_sk#24, cd_marital_status#25, cd_education_status#26]
 Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 14]
 Output [7]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17]
-Input [13]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#24, cd_education_status#25, cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
+Input [13]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#22, cd_education_status#23, cd_demo_sk#24, cd_marital_status#25, cd_education_status#26]
 
 (35) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+Output [3]: [ca_address_sk#27, ca_state#28, ca_country#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), EqualTo(ca_country,United States), IsNotNull(ca_address_sk), Or(Or(In(ca_state, [IN,NJ,OH]),In(ca_state, [CT,KY,WI])),In(ca_state, [AR,IA,LA]))]
 ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
 
 (36) ColumnarToRow [codegen id : 11]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+Input [3]: [ca_address_sk#27, ca_state#28, ca_country#29]
 
 (37) Filter [codegen id : 11]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
-Condition : (((isnotnull(ca_country#31) AND (ca_country#31 = United States)) AND isnotnull(ca_address_sk#29)) AND ((ca_state#30 IN (IN,OH,NJ) OR ca_state#30 IN (WI,CT,KY)) OR ca_state#30 IN (LA,IA,AR)))
+Input [3]: [ca_address_sk#27, ca_state#28, ca_country#29]
+Condition : (((isnotnull(ca_country#29) AND (ca_country#29 = United States)) AND isnotnull(ca_address_sk#27)) AND ((ca_state#28 IN (IN,OH,NJ) OR ca_state#28 IN (WI,CT,KY)) OR ca_state#28 IN (LA,IA,AR)))
 
 (38) Project [codegen id : 11]
-Output [2]: [ca_address_sk#29, ca_state#30]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+Output [2]: [ca_address_sk#27, ca_state#28]
+Input [3]: [ca_address_sk#27, ca_state#28, ca_country#29]
 
 (39) BroadcastExchange
-Input [2]: [ca_address_sk#29, ca_state#30]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
+Input [2]: [ca_address_sk#27, ca_state#28]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
 (40) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [wr_refunded_addr_sk#12]
-Right keys [1]: [ca_address_sk#29]
+Right keys [1]: [ca_address_sk#27]
 Join type: Inner
-Join condition: ((((ca_state#30 IN (IN,OH,NJ) AND (ws_net_profit#6 >= 100.00)) AND (ws_net_profit#6 <= 200.00)) OR ((ca_state#30 IN (WI,CT,KY) AND (ws_net_profit#6 >= 150.00)) AND (ws_net_profit#6 <= 300.00))) OR ((ca_state#30 IN (LA,IA,AR) AND (ws_net_profit#6 >= 50.00)) AND (ws_net_profit#6 <= 250.00)))
+Join condition: ((((ca_state#28 IN (IN,OH,NJ) AND (ws_net_profit#6 >= 100.00)) AND (ws_net_profit#6 <= 200.00)) OR ((ca_state#28 IN (WI,CT,KY) AND (ws_net_profit#6 >= 150.00)) AND (ws_net_profit#6 <= 300.00))) OR ((ca_state#28 IN (LA,IA,AR) AND (ws_net_profit#6 >= 50.00)) AND (ws_net_profit#6 <= 250.00)))
 
 (41) Project [codegen id : 14]
 Output [5]: [ws_quantity#4, ws_sold_date_sk#7, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17]
-Input [9]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, ca_address_sk#29, ca_state#30]
+Input [9]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, ca_address_sk#27, ca_state#28]
 
 (42) ReusedExchange [Reuses operator id: 59]
-Output [1]: [d_date_sk#32]
+Output [1]: [d_date_sk#30]
 
 (43) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [ws_sold_date_sk#7]
-Right keys [1]: [d_date_sk#32]
+Right keys [1]: [d_date_sk#30]
 Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 14]
 Output [4]: [ws_quantity#4, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17]
-Input [6]: [ws_quantity#4, ws_sold_date_sk#7, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, d_date_sk#32]
+Input [6]: [ws_quantity#4, ws_sold_date_sk#7, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, d_date_sk#30]
 
 (45) Scan parquet spark_catalog.default.reason
-Output [2]: [r_reason_sk#33, r_reason_desc#34]
+Output [2]: [r_reason_sk#31, r_reason_desc#32]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/reason]
 PushedFilters: [IsNotNull(r_reason_sk)]
 ReadSchema: struct<r_reason_sk:int,r_reason_desc:string>
 
 (46) ColumnarToRow [codegen id : 13]
-Input [2]: [r_reason_sk#33, r_reason_desc#34]
+Input [2]: [r_reason_sk#31, r_reason_desc#32]
 
 (47) Filter [codegen id : 13]
-Input [2]: [r_reason_sk#33, r_reason_desc#34]
-Condition : isnotnull(r_reason_sk#33)
+Input [2]: [r_reason_sk#31, r_reason_desc#32]
+Condition : isnotnull(r_reason_sk#31)
 
 (48) BroadcastExchange
-Input [2]: [r_reason_sk#33, r_reason_desc#34]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
+Input [2]: [r_reason_sk#31, r_reason_desc#32]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=10]
 
 (49) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [wr_reason_sk#14]
-Right keys [1]: [r_reason_sk#33]
+Right keys [1]: [r_reason_sk#31]
 Join type: Inner
 Join condition: None
 
 (50) Project [codegen id : 14]
-Output [4]: [ws_quantity#4, wr_fee#16, wr_refunded_cash#17, r_reason_desc#34]
-Input [6]: [ws_quantity#4, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, r_reason_sk#33, r_reason_desc#34]
+Output [4]: [ws_quantity#4, wr_fee#16, wr_refunded_cash#17, r_reason_desc#32]
+Input [6]: [ws_quantity#4, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, r_reason_sk#31, r_reason_desc#32]
 
 (51) HashAggregate [codegen id : 14]
-Input [4]: [ws_quantity#4, wr_fee#16, wr_refunded_cash#17, r_reason_desc#34]
-Keys [1]: [r_reason_desc#34]
+Input [4]: [ws_quantity#4, wr_fee#16, wr_refunded_cash#17, r_reason_desc#32]
+Keys [1]: [r_reason_desc#32]
 Functions [3]: [partial_avg(ws_quantity#4), partial_avg(UnscaledValue(wr_refunded_cash#17)), partial_avg(UnscaledValue(wr_fee#16))]
-Aggregate Attributes [6]: [sum#35, count#36, sum#37, count#38, sum#39, count#40]
-Results [7]: [r_reason_desc#34, sum#41, count#42, sum#43, count#44, sum#45, count#46]
+Aggregate Attributes [6]: [sum#33, count#34, sum#35, count#36, sum#37, count#38]
+Results [7]: [r_reason_desc#32, sum#39, count#40, sum#41, count#42, sum#43, count#44]
 
 (52) Exchange
-Input [7]: [r_reason_desc#34, sum#41, count#42, sum#43, count#44, sum#45, count#46]
-Arguments: hashpartitioning(r_reason_desc#34, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [7]: [r_reason_desc#32, sum#39, count#40, sum#41, count#42, sum#43, count#44]
+Arguments: hashpartitioning(r_reason_desc#32, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (53) HashAggregate [codegen id : 15]
-Input [7]: [r_reason_desc#34, sum#41, count#42, sum#43, count#44, sum#45, count#46]
-Keys [1]: [r_reason_desc#34]
+Input [7]: [r_reason_desc#32, sum#39, count#40, sum#41, count#42, sum#43, count#44]
+Keys [1]: [r_reason_desc#32]
 Functions [3]: [avg(ws_quantity#4), avg(UnscaledValue(wr_refunded_cash#17)), avg(UnscaledValue(wr_fee#16))]
-Aggregate Attributes [3]: [avg(ws_quantity#4)#47, avg(UnscaledValue(wr_refunded_cash#17))#48, avg(UnscaledValue(wr_fee#16))#49]
-Results [4]: [substr(r_reason_desc#34, 1, 20) AS substr(r_reason_desc, 1, 20)#50, avg(ws_quantity#4)#47 AS avg(ws_quantity)#51, cast((avg(UnscaledValue(wr_refunded_cash#17))#48 / 100.0) as decimal(11,6)) AS avg(wr_refunded_cash)#52, cast((avg(UnscaledValue(wr_fee#16))#49 / 100.0) as decimal(11,6)) AS avg(wr_fee)#53]
+Aggregate Attributes [3]: [avg(ws_quantity#4)#45, avg(UnscaledValue(wr_refunded_cash#17))#46, avg(UnscaledValue(wr_fee#16))#47]
+Results [4]: [substr(r_reason_desc#32, 1, 20) AS substr(r_reason_desc, 1, 20)#48, avg(ws_quantity#4)#45 AS avg(ws_quantity)#49, cast((avg(UnscaledValue(wr_refunded_cash#17))#46 / 100.0) as decimal(11,6)) AS avg(wr_refunded_cash)#50, cast((avg(UnscaledValue(wr_fee#16))#47 / 100.0) as decimal(11,6)) AS avg(wr_fee)#51]
 
 (54) TakeOrderedAndProject
-Input [4]: [substr(r_reason_desc, 1, 20)#50, avg(ws_quantity)#51, avg(wr_refunded_cash)#52, avg(wr_fee)#53]
-Arguments: 100, [substr(r_reason_desc, 1, 20)#50 ASC NULLS FIRST, avg(ws_quantity)#51 ASC NULLS FIRST, avg(wr_refunded_cash)#52 ASC NULLS FIRST, avg(wr_fee)#53 ASC NULLS FIRST], [substr(r_reason_desc, 1, 20)#50, avg(ws_quantity)#51, avg(wr_refunded_cash)#52, avg(wr_fee)#53]
+Input [4]: [substr(r_reason_desc, 1, 20)#48, avg(ws_quantity)#49, avg(wr_refunded_cash)#50, avg(wr_fee)#51]
+Arguments: 100, [substr(r_reason_desc, 1, 20)#48 ASC NULLS FIRST, avg(ws_quantity)#49 ASC NULLS FIRST, avg(wr_refunded_cash)#50 ASC NULLS FIRST, avg(wr_fee)#51 ASC NULLS FIRST], [substr(r_reason_desc, 1, 20)#48, avg(ws_quantity)#49, avg(wr_refunded_cash)#50, avg(wr_fee)#51]
 
 ===== Subqueries =====
 
@@ -316,28 +316,28 @@ BroadcastExchange (59)
 
 
 (55) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#32, d_year#54]
+Output [2]: [d_date_sk#30, d_year#52]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (56) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#32, d_year#54]
+Input [2]: [d_date_sk#30, d_year#52]
 
 (57) Filter [codegen id : 1]
-Input [2]: [d_date_sk#32, d_year#54]
-Condition : ((isnotnull(d_year#54) AND (d_year#54 = 2000)) AND isnotnull(d_date_sk#32))
+Input [2]: [d_date_sk#30, d_year#52]
+Condition : ((isnotnull(d_year#52) AND (d_year#52 = 2000)) AND isnotnull(d_date_sk#30))
 
 (58) Project [codegen id : 1]
-Output [1]: [d_date_sk#32]
-Input [2]: [d_date_sk#32, d_year#54]
+Output [1]: [d_date_sk#30]
+Input [2]: [d_date_sk#30, d_year#52]
 
 (59) BroadcastExchange
-Input [1]: [d_date_sk#32]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+Input [1]: [d_date_sk#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=12]
 
-Subquery:2 Hosting operator id = 14 Hosting Expression = Subquery scalar-subquery#19, [id=#20]
+Subquery:2 Hosting operator id = 14 Hosting Expression = Subquery scalar-subquery#19, [id=#3]
 ObjectHashAggregate (66)
 +- Exchange (65)
    +- ObjectHashAggregate (64)
@@ -348,42 +348,42 @@ ObjectHashAggregate (66)
 
 
 (60) Scan parquet spark_catalog.default.customer_demographics
-Output [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
+Output [3]: [cd_demo_sk#21, cd_marital_status#22, cd_education_status#23]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status), IsNotNull(cd_education_status), Or(Or(And(EqualTo(cd_marital_status,M),EqualTo(cd_education_status,Advanced Degree     )),And(EqualTo(cd_marital_status,S),EqualTo(cd_education_status,College             ))),And(EqualTo(cd_marital_status,W),EqualTo(cd_education_status,2 yr Degree         )))]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
 
 (61) ColumnarToRow [codegen id : 1]
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
+Input [3]: [cd_demo_sk#21, cd_marital_status#22, cd_education_status#23]
 
 (62) Filter [codegen id : 1]
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
-Condition : (((isnotnull(cd_demo_sk#23) AND isnotnull(cd_marital_status#24)) AND isnotnull(cd_education_status#25)) AND ((((cd_marital_status#24 = M) AND (cd_education_status#25 = Advanced Degree     )) OR ((cd_marital_status#24 = S) AND (cd_education_status#25 = College             ))) OR ((cd_marital_status#24 = W) AND (cd_education_status#25 = 2 yr Degree         ))))
+Input [3]: [cd_demo_sk#21, cd_marital_status#22, cd_education_status#23]
+Condition : (((isnotnull(cd_demo_sk#21) AND isnotnull(cd_marital_status#22)) AND isnotnull(cd_education_status#23)) AND ((((cd_marital_status#22 = M) AND (cd_education_status#23 = Advanced Degree     )) OR ((cd_marital_status#22 = S) AND (cd_education_status#23 = College             ))) OR ((cd_marital_status#22 = W) AND (cd_education_status#23 = 2 yr Degree         ))))
 
 (63) Project [codegen id : 1]
-Output [1]: [cd_demo_sk#23]
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
+Output [1]: [cd_demo_sk#21]
+Input [3]: [cd_demo_sk#21, cd_marital_status#22, cd_education_status#23]
 
 (64) ObjectHashAggregate
-Input [1]: [cd_demo_sk#23]
+Input [1]: [cd_demo_sk#21]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(cd_demo_sk#23, 42), 159981, 2239471, 0, 0)]
-Aggregate Attributes [1]: [buf#55]
-Results [1]: [buf#56]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cd_demo_sk#21, 42), 159981, 2239471, 0, 0)]
+Aggregate Attributes [1]: [buf#53]
+Results [1]: [buf#54]
 
 (65) Exchange
-Input [1]: [buf#56]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
+Input [1]: [buf#54]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
 
 (66) ObjectHashAggregate
-Input [1]: [buf#56]
+Input [1]: [buf#54]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#23, 42), 159981, 2239471, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#23, 42), 159981, 2239471, 0, 0)#57]
-Results [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#23, 42), 159981, 2239471, 0, 0)#57 AS bloomFilter#58]
+Functions [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#21, 42), 159981, 2239471, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#21, 42), 159981, 2239471, 0, 0)#55]
+Results [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#21, 42), 159981, 2239471, 0, 0)#55 AS bloomFilter#56]
 
-Subquery:3 Hosting operator id = 14 Hosting Expression = Subquery scalar-subquery#21, [id=#22]
+Subquery:3 Hosting operator id = 14 Hosting Expression = Subquery scalar-subquery#20, [id=#4]
 ObjectHashAggregate (73)
 +- Exchange (72)
    +- ObjectHashAggregate (71)
@@ -394,39 +394,39 @@ ObjectHashAggregate (73)
 
 
 (67) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+Output [3]: [ca_address_sk#27, ca_state#28, ca_country#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), EqualTo(ca_country,United States), IsNotNull(ca_address_sk), Or(Or(In(ca_state, [IN,NJ,OH]),In(ca_state, [CT,KY,WI])),In(ca_state, [AR,IA,LA]))]
 ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
 
 (68) ColumnarToRow [codegen id : 1]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+Input [3]: [ca_address_sk#27, ca_state#28, ca_country#29]
 
 (69) Filter [codegen id : 1]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
-Condition : (((isnotnull(ca_country#31) AND (ca_country#31 = United States)) AND isnotnull(ca_address_sk#29)) AND ((ca_state#30 IN (IN,OH,NJ) OR ca_state#30 IN (WI,CT,KY)) OR ca_state#30 IN (LA,IA,AR)))
+Input [3]: [ca_address_sk#27, ca_state#28, ca_country#29]
+Condition : (((isnotnull(ca_country#29) AND (ca_country#29 = United States)) AND isnotnull(ca_address_sk#27)) AND ((ca_state#28 IN (IN,OH,NJ) OR ca_state#28 IN (WI,CT,KY)) OR ca_state#28 IN (LA,IA,AR)))
 
 (70) Project [codegen id : 1]
-Output [1]: [ca_address_sk#29]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+Output [1]: [ca_address_sk#27]
+Input [3]: [ca_address_sk#27, ca_state#28, ca_country#29]
 
 (71) ObjectHashAggregate
-Input [1]: [ca_address_sk#29]
+Input [1]: [ca_address_sk#27]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#29, 42), 152837, 2153999, 0, 0)]
-Aggregate Attributes [1]: [buf#59]
-Results [1]: [buf#60]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#27, 42), 152837, 2153999, 0, 0)]
+Aggregate Attributes [1]: [buf#57]
+Results [1]: [buf#58]
 
 (72) Exchange
-Input [1]: [buf#60]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
+Input [1]: [buf#58]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
 
 (73) ObjectHashAggregate
-Input [1]: [buf#60]
+Input [1]: [buf#58]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#29, 42), 152837, 2153999, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#29, 42), 152837, 2153999, 0, 0)#61]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#29, 42), 152837, 2153999, 0, 0)#61 AS bloomFilter#62]
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#27, 42), 152837, 2153999, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#27, 42), 152837, 2153999, 0, 0)#59]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#27, 42), 152837, 2153999, 0, 0)#59 AS bloomFilter#60]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q9.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q9.sf100/explain.txt
@@ -20,12 +20,12 @@ Input [1]: [r_reason_sk#1]
 Condition : (isnotnull(r_reason_sk#1) AND (r_reason_sk#1 = 1))
 
 (4) Project [codegen id : 1]
-Output [5]: [CASE WHEN (Subquery scalar-subquery#2, [id=#3].count(1) > 62316685) THEN ReusedSubquery Subquery scalar-subquery#2, [id=#3].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#2, [id=#3].avg(ss_net_paid) END AS bucket1#4, CASE WHEN (Subquery scalar-subquery#5, [id=#6].count(1) > 19045798) THEN ReusedSubquery Subquery scalar-subquery#5, [id=#6].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#5, [id=#6].avg(ss_net_paid) END AS bucket2#7, CASE WHEN (Subquery scalar-subquery#8, [id=#9].count(1) > 365541424) THEN ReusedSubquery Subquery scalar-subquery#8, [id=#9].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#8, [id=#9].avg(ss_net_paid) END AS bucket3#10, CASE WHEN (Subquery scalar-subquery#11, [id=#12].count(1) > 216357808) THEN ReusedSubquery Subquery scalar-subquery#11, [id=#12].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#11, [id=#12].avg(ss_net_paid) END AS bucket4#13, CASE WHEN (Subquery scalar-subquery#14, [id=#15].count(1) > 184483884) THEN ReusedSubquery Subquery scalar-subquery#14, [id=#15].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#14, [id=#15].avg(ss_net_paid) END AS bucket5#16]
+Output [5]: [CASE WHEN (Subquery scalar-subquery#2, [id=#1].count(1) > 62316685) THEN ReusedSubquery Subquery scalar-subquery#2, [id=#1].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#2, [id=#1].avg(ss_net_paid) END AS bucket1#3, CASE WHEN (Subquery scalar-subquery#4, [id=#2].count(1) > 19045798) THEN ReusedSubquery Subquery scalar-subquery#4, [id=#2].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#4, [id=#2].avg(ss_net_paid) END AS bucket2#5, CASE WHEN (Subquery scalar-subquery#6, [id=#3].count(1) > 365541424) THEN ReusedSubquery Subquery scalar-subquery#6, [id=#3].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#6, [id=#3].avg(ss_net_paid) END AS bucket3#7, CASE WHEN (Subquery scalar-subquery#8, [id=#4].count(1) > 216357808) THEN ReusedSubquery Subquery scalar-subquery#8, [id=#4].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#8, [id=#4].avg(ss_net_paid) END AS bucket4#9, CASE WHEN (Subquery scalar-subquery#10, [id=#5].count(1) > 184483884) THEN ReusedSubquery Subquery scalar-subquery#10, [id=#5].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#10, [id=#5].avg(ss_net_paid) END AS bucket5#11]
 Input [1]: [r_reason_sk#1]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#2, [id=#3]
+Subquery:1 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#2, [id=#1]
 * Project (12)
 +- * HashAggregate (11)
    +- Exchange (10)
@@ -37,50 +37,50 @@ Subquery:1 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery
 
 
 (5) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_quantity#17, ss_ext_discount_amt#18, ss_net_paid#19, ss_sold_date_sk#20]
+Output [4]: [ss_quantity#12, ss_ext_discount_amt#13, ss_net_paid#14, ss_sold_date_sk#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_quantity), GreaterThanOrEqual(ss_quantity,1), LessThanOrEqual(ss_quantity,20)]
 ReadSchema: struct<ss_quantity:int,ss_ext_discount_amt:decimal(7,2),ss_net_paid:decimal(7,2)>
 
 (6) ColumnarToRow [codegen id : 1]
-Input [4]: [ss_quantity#17, ss_ext_discount_amt#18, ss_net_paid#19, ss_sold_date_sk#20]
+Input [4]: [ss_quantity#12, ss_ext_discount_amt#13, ss_net_paid#14, ss_sold_date_sk#15]
 
 (7) Filter [codegen id : 1]
-Input [4]: [ss_quantity#17, ss_ext_discount_amt#18, ss_net_paid#19, ss_sold_date_sk#20]
-Condition : ((isnotnull(ss_quantity#17) AND (ss_quantity#17 >= 1)) AND (ss_quantity#17 <= 20))
+Input [4]: [ss_quantity#12, ss_ext_discount_amt#13, ss_net_paid#14, ss_sold_date_sk#15]
+Condition : ((isnotnull(ss_quantity#12) AND (ss_quantity#12 >= 1)) AND (ss_quantity#12 <= 20))
 
 (8) Project [codegen id : 1]
-Output [2]: [ss_ext_discount_amt#18, ss_net_paid#19]
-Input [4]: [ss_quantity#17, ss_ext_discount_amt#18, ss_net_paid#19, ss_sold_date_sk#20]
+Output [2]: [ss_ext_discount_amt#13, ss_net_paid#14]
+Input [4]: [ss_quantity#12, ss_ext_discount_amt#13, ss_net_paid#14, ss_sold_date_sk#15]
 
 (9) HashAggregate [codegen id : 1]
-Input [2]: [ss_ext_discount_amt#18, ss_net_paid#19]
+Input [2]: [ss_ext_discount_amt#13, ss_net_paid#14]
 Keys: []
-Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#18)), partial_avg(UnscaledValue(ss_net_paid#19))]
-Aggregate Attributes [5]: [count#21, sum#22, count#23, sum#24, count#25]
-Results [5]: [count#26, sum#27, count#28, sum#29, count#30]
+Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#13)), partial_avg(UnscaledValue(ss_net_paid#14))]
+Aggregate Attributes [5]: [count#16, sum#17, count#18, sum#19, count#20]
+Results [5]: [count#21, sum#22, count#23, sum#24, count#25]
 
 (10) Exchange
-Input [5]: [count#26, sum#27, count#28, sum#29, count#30]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=1]
+Input [5]: [count#21, sum#22, count#23, sum#24, count#25]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
 
 (11) HashAggregate [codegen id : 2]
-Input [5]: [count#26, sum#27, count#28, sum#29, count#30]
+Input [5]: [count#21, sum#22, count#23, sum#24, count#25]
 Keys: []
-Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#18)), avg(UnscaledValue(ss_net_paid#19))]
-Aggregate Attributes [3]: [count(1)#31, avg(UnscaledValue(ss_ext_discount_amt#18))#32, avg(UnscaledValue(ss_net_paid#19))#33]
-Results [3]: [count(1)#31 AS count(1)#34, cast((avg(UnscaledValue(ss_ext_discount_amt#18))#32 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#35, cast((avg(UnscaledValue(ss_net_paid#19))#33 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#36]
+Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#13)), avg(UnscaledValue(ss_net_paid#14))]
+Aggregate Attributes [3]: [count(1)#26, avg(UnscaledValue(ss_ext_discount_amt#13))#27, avg(UnscaledValue(ss_net_paid#14))#28]
+Results [3]: [count(1)#26 AS count(1)#29, cast((avg(UnscaledValue(ss_ext_discount_amt#13))#27 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#30, cast((avg(UnscaledValue(ss_net_paid#14))#28 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#31]
 
 (12) Project [codegen id : 2]
-Output [1]: [named_struct(count(1), count(1)#34, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#35, avg(ss_net_paid), avg(ss_net_paid)#36) AS mergedValue#37]
-Input [3]: [count(1)#34, avg(ss_ext_discount_amt)#35, avg(ss_net_paid)#36]
+Output [1]: [named_struct(count(1), count(1)#29, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#30, avg(ss_net_paid), avg(ss_net_paid)#31) AS mergedValue#32]
+Input [3]: [count(1)#29, avg(ss_ext_discount_amt)#30, avg(ss_net_paid)#31]
 
-Subquery:2 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#2, [id=#3]
+Subquery:2 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#2, [id=#1]
 
-Subquery:3 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#2, [id=#3]
+Subquery:3 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#2, [id=#1]
 
-Subquery:4 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+Subquery:4 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#4, [id=#2]
 * Project (20)
 +- * HashAggregate (19)
    +- Exchange (18)
@@ -92,50 +92,50 @@ Subquery:4 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery
 
 
 (13) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_quantity#38, ss_ext_discount_amt#39, ss_net_paid#40, ss_sold_date_sk#41]
+Output [4]: [ss_quantity#33, ss_ext_discount_amt#34, ss_net_paid#35, ss_sold_date_sk#36]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_quantity), GreaterThanOrEqual(ss_quantity,21), LessThanOrEqual(ss_quantity,40)]
 ReadSchema: struct<ss_quantity:int,ss_ext_discount_amt:decimal(7,2),ss_net_paid:decimal(7,2)>
 
 (14) ColumnarToRow [codegen id : 1]
-Input [4]: [ss_quantity#38, ss_ext_discount_amt#39, ss_net_paid#40, ss_sold_date_sk#41]
+Input [4]: [ss_quantity#33, ss_ext_discount_amt#34, ss_net_paid#35, ss_sold_date_sk#36]
 
 (15) Filter [codegen id : 1]
-Input [4]: [ss_quantity#38, ss_ext_discount_amt#39, ss_net_paid#40, ss_sold_date_sk#41]
-Condition : ((isnotnull(ss_quantity#38) AND (ss_quantity#38 >= 21)) AND (ss_quantity#38 <= 40))
+Input [4]: [ss_quantity#33, ss_ext_discount_amt#34, ss_net_paid#35, ss_sold_date_sk#36]
+Condition : ((isnotnull(ss_quantity#33) AND (ss_quantity#33 >= 21)) AND (ss_quantity#33 <= 40))
 
 (16) Project [codegen id : 1]
-Output [2]: [ss_ext_discount_amt#39, ss_net_paid#40]
-Input [4]: [ss_quantity#38, ss_ext_discount_amt#39, ss_net_paid#40, ss_sold_date_sk#41]
+Output [2]: [ss_ext_discount_amt#34, ss_net_paid#35]
+Input [4]: [ss_quantity#33, ss_ext_discount_amt#34, ss_net_paid#35, ss_sold_date_sk#36]
 
 (17) HashAggregate [codegen id : 1]
-Input [2]: [ss_ext_discount_amt#39, ss_net_paid#40]
+Input [2]: [ss_ext_discount_amt#34, ss_net_paid#35]
 Keys: []
-Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#39)), partial_avg(UnscaledValue(ss_net_paid#40))]
-Aggregate Attributes [5]: [count#42, sum#43, count#44, sum#45, count#46]
-Results [5]: [count#47, sum#48, count#49, sum#50, count#51]
+Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#34)), partial_avg(UnscaledValue(ss_net_paid#35))]
+Aggregate Attributes [5]: [count#37, sum#38, count#39, sum#40, count#41]
+Results [5]: [count#42, sum#43, count#44, sum#45, count#46]
 
 (18) Exchange
-Input [5]: [count#47, sum#48, count#49, sum#50, count#51]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=2]
+Input [5]: [count#42, sum#43, count#44, sum#45, count#46]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
 (19) HashAggregate [codegen id : 2]
-Input [5]: [count#47, sum#48, count#49, sum#50, count#51]
+Input [5]: [count#42, sum#43, count#44, sum#45, count#46]
 Keys: []
-Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#39)), avg(UnscaledValue(ss_net_paid#40))]
-Aggregate Attributes [3]: [count(1)#52, avg(UnscaledValue(ss_ext_discount_amt#39))#53, avg(UnscaledValue(ss_net_paid#40))#54]
-Results [3]: [count(1)#52 AS count(1)#55, cast((avg(UnscaledValue(ss_ext_discount_amt#39))#53 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#56, cast((avg(UnscaledValue(ss_net_paid#40))#54 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#57]
+Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#34)), avg(UnscaledValue(ss_net_paid#35))]
+Aggregate Attributes [3]: [count(1)#47, avg(UnscaledValue(ss_ext_discount_amt#34))#48, avg(UnscaledValue(ss_net_paid#35))#49]
+Results [3]: [count(1)#47 AS count(1)#50, cast((avg(UnscaledValue(ss_ext_discount_amt#34))#48 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#51, cast((avg(UnscaledValue(ss_net_paid#35))#49 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#52]
 
 (20) Project [codegen id : 2]
-Output [1]: [named_struct(count(1), count(1)#55, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#56, avg(ss_net_paid), avg(ss_net_paid)#57) AS mergedValue#58]
-Input [3]: [count(1)#55, avg(ss_ext_discount_amt)#56, avg(ss_net_paid)#57]
+Output [1]: [named_struct(count(1), count(1)#50, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#51, avg(ss_net_paid), avg(ss_net_paid)#52) AS mergedValue#53]
+Input [3]: [count(1)#50, avg(ss_ext_discount_amt)#51, avg(ss_net_paid)#52]
 
-Subquery:5 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#5, [id=#6]
+Subquery:5 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#4, [id=#2]
 
-Subquery:6 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#5, [id=#6]
+Subquery:6 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#4, [id=#2]
 
-Subquery:7 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#8, [id=#9]
+Subquery:7 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#6, [id=#3]
 * Project (28)
 +- * HashAggregate (27)
    +- Exchange (26)
@@ -147,50 +147,50 @@ Subquery:7 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery
 
 
 (21) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_quantity#59, ss_ext_discount_amt#60, ss_net_paid#61, ss_sold_date_sk#62]
+Output [4]: [ss_quantity#54, ss_ext_discount_amt#55, ss_net_paid#56, ss_sold_date_sk#57]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_quantity), GreaterThanOrEqual(ss_quantity,41), LessThanOrEqual(ss_quantity,60)]
 ReadSchema: struct<ss_quantity:int,ss_ext_discount_amt:decimal(7,2),ss_net_paid:decimal(7,2)>
 
 (22) ColumnarToRow [codegen id : 1]
-Input [4]: [ss_quantity#59, ss_ext_discount_amt#60, ss_net_paid#61, ss_sold_date_sk#62]
+Input [4]: [ss_quantity#54, ss_ext_discount_amt#55, ss_net_paid#56, ss_sold_date_sk#57]
 
 (23) Filter [codegen id : 1]
-Input [4]: [ss_quantity#59, ss_ext_discount_amt#60, ss_net_paid#61, ss_sold_date_sk#62]
-Condition : ((isnotnull(ss_quantity#59) AND (ss_quantity#59 >= 41)) AND (ss_quantity#59 <= 60))
+Input [4]: [ss_quantity#54, ss_ext_discount_amt#55, ss_net_paid#56, ss_sold_date_sk#57]
+Condition : ((isnotnull(ss_quantity#54) AND (ss_quantity#54 >= 41)) AND (ss_quantity#54 <= 60))
 
 (24) Project [codegen id : 1]
-Output [2]: [ss_ext_discount_amt#60, ss_net_paid#61]
-Input [4]: [ss_quantity#59, ss_ext_discount_amt#60, ss_net_paid#61, ss_sold_date_sk#62]
+Output [2]: [ss_ext_discount_amt#55, ss_net_paid#56]
+Input [4]: [ss_quantity#54, ss_ext_discount_amt#55, ss_net_paid#56, ss_sold_date_sk#57]
 
 (25) HashAggregate [codegen id : 1]
-Input [2]: [ss_ext_discount_amt#60, ss_net_paid#61]
+Input [2]: [ss_ext_discount_amt#55, ss_net_paid#56]
 Keys: []
-Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#60)), partial_avg(UnscaledValue(ss_net_paid#61))]
-Aggregate Attributes [5]: [count#63, sum#64, count#65, sum#66, count#67]
-Results [5]: [count#68, sum#69, count#70, sum#71, count#72]
+Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#55)), partial_avg(UnscaledValue(ss_net_paid#56))]
+Aggregate Attributes [5]: [count#58, sum#59, count#60, sum#61, count#62]
+Results [5]: [count#63, sum#64, count#65, sum#66, count#67]
 
 (26) Exchange
-Input [5]: [count#68, sum#69, count#70, sum#71, count#72]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=3]
+Input [5]: [count#63, sum#64, count#65, sum#66, count#67]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
 (27) HashAggregate [codegen id : 2]
-Input [5]: [count#68, sum#69, count#70, sum#71, count#72]
+Input [5]: [count#63, sum#64, count#65, sum#66, count#67]
 Keys: []
-Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#60)), avg(UnscaledValue(ss_net_paid#61))]
-Aggregate Attributes [3]: [count(1)#73, avg(UnscaledValue(ss_ext_discount_amt#60))#74, avg(UnscaledValue(ss_net_paid#61))#75]
-Results [3]: [count(1)#73 AS count(1)#76, cast((avg(UnscaledValue(ss_ext_discount_amt#60))#74 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#77, cast((avg(UnscaledValue(ss_net_paid#61))#75 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#78]
+Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#55)), avg(UnscaledValue(ss_net_paid#56))]
+Aggregate Attributes [3]: [count(1)#68, avg(UnscaledValue(ss_ext_discount_amt#55))#69, avg(UnscaledValue(ss_net_paid#56))#70]
+Results [3]: [count(1)#68 AS count(1)#71, cast((avg(UnscaledValue(ss_ext_discount_amt#55))#69 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#72, cast((avg(UnscaledValue(ss_net_paid#56))#70 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#73]
 
 (28) Project [codegen id : 2]
-Output [1]: [named_struct(count(1), count(1)#76, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#77, avg(ss_net_paid), avg(ss_net_paid)#78) AS mergedValue#79]
-Input [3]: [count(1)#76, avg(ss_ext_discount_amt)#77, avg(ss_net_paid)#78]
+Output [1]: [named_struct(count(1), count(1)#71, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#72, avg(ss_net_paid), avg(ss_net_paid)#73) AS mergedValue#74]
+Input [3]: [count(1)#71, avg(ss_ext_discount_amt)#72, avg(ss_net_paid)#73]
 
-Subquery:8 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#8, [id=#9]
+Subquery:8 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#6, [id=#3]
 
-Subquery:9 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#8, [id=#9]
+Subquery:9 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#6, [id=#3]
 
-Subquery:10 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#11, [id=#12]
+Subquery:10 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#8, [id=#4]
 * Project (36)
 +- * HashAggregate (35)
    +- Exchange (34)
@@ -202,50 +202,50 @@ Subquery:10 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquer
 
 
 (29) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_quantity#80, ss_ext_discount_amt#81, ss_net_paid#82, ss_sold_date_sk#83]
+Output [4]: [ss_quantity#75, ss_ext_discount_amt#76, ss_net_paid#77, ss_sold_date_sk#78]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_quantity), GreaterThanOrEqual(ss_quantity,61), LessThanOrEqual(ss_quantity,80)]
 ReadSchema: struct<ss_quantity:int,ss_ext_discount_amt:decimal(7,2),ss_net_paid:decimal(7,2)>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [4]: [ss_quantity#80, ss_ext_discount_amt#81, ss_net_paid#82, ss_sold_date_sk#83]
+Input [4]: [ss_quantity#75, ss_ext_discount_amt#76, ss_net_paid#77, ss_sold_date_sk#78]
 
 (31) Filter [codegen id : 1]
-Input [4]: [ss_quantity#80, ss_ext_discount_amt#81, ss_net_paid#82, ss_sold_date_sk#83]
-Condition : ((isnotnull(ss_quantity#80) AND (ss_quantity#80 >= 61)) AND (ss_quantity#80 <= 80))
+Input [4]: [ss_quantity#75, ss_ext_discount_amt#76, ss_net_paid#77, ss_sold_date_sk#78]
+Condition : ((isnotnull(ss_quantity#75) AND (ss_quantity#75 >= 61)) AND (ss_quantity#75 <= 80))
 
 (32) Project [codegen id : 1]
-Output [2]: [ss_ext_discount_amt#81, ss_net_paid#82]
-Input [4]: [ss_quantity#80, ss_ext_discount_amt#81, ss_net_paid#82, ss_sold_date_sk#83]
+Output [2]: [ss_ext_discount_amt#76, ss_net_paid#77]
+Input [4]: [ss_quantity#75, ss_ext_discount_amt#76, ss_net_paid#77, ss_sold_date_sk#78]
 
 (33) HashAggregate [codegen id : 1]
-Input [2]: [ss_ext_discount_amt#81, ss_net_paid#82]
+Input [2]: [ss_ext_discount_amt#76, ss_net_paid#77]
 Keys: []
-Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#81)), partial_avg(UnscaledValue(ss_net_paid#82))]
-Aggregate Attributes [5]: [count#84, sum#85, count#86, sum#87, count#88]
-Results [5]: [count#89, sum#90, count#91, sum#92, count#93]
+Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#76)), partial_avg(UnscaledValue(ss_net_paid#77))]
+Aggregate Attributes [5]: [count#79, sum#80, count#81, sum#82, count#83]
+Results [5]: [count#84, sum#85, count#86, sum#87, count#88]
 
 (34) Exchange
-Input [5]: [count#89, sum#90, count#91, sum#92, count#93]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=4]
+Input [5]: [count#84, sum#85, count#86, sum#87, count#88]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
 
 (35) HashAggregate [codegen id : 2]
-Input [5]: [count#89, sum#90, count#91, sum#92, count#93]
+Input [5]: [count#84, sum#85, count#86, sum#87, count#88]
 Keys: []
-Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#81)), avg(UnscaledValue(ss_net_paid#82))]
-Aggregate Attributes [3]: [count(1)#94, avg(UnscaledValue(ss_ext_discount_amt#81))#95, avg(UnscaledValue(ss_net_paid#82))#96]
-Results [3]: [count(1)#94 AS count(1)#97, cast((avg(UnscaledValue(ss_ext_discount_amt#81))#95 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#98, cast((avg(UnscaledValue(ss_net_paid#82))#96 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#99]
+Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#76)), avg(UnscaledValue(ss_net_paid#77))]
+Aggregate Attributes [3]: [count(1)#89, avg(UnscaledValue(ss_ext_discount_amt#76))#90, avg(UnscaledValue(ss_net_paid#77))#91]
+Results [3]: [count(1)#89 AS count(1)#92, cast((avg(UnscaledValue(ss_ext_discount_amt#76))#90 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#93, cast((avg(UnscaledValue(ss_net_paid#77))#91 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#94]
 
 (36) Project [codegen id : 2]
-Output [1]: [named_struct(count(1), count(1)#97, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#98, avg(ss_net_paid), avg(ss_net_paid)#99) AS mergedValue#100]
-Input [3]: [count(1)#97, avg(ss_ext_discount_amt)#98, avg(ss_net_paid)#99]
+Output [1]: [named_struct(count(1), count(1)#92, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#93, avg(ss_net_paid), avg(ss_net_paid)#94) AS mergedValue#95]
+Input [3]: [count(1)#92, avg(ss_ext_discount_amt)#93, avg(ss_net_paid)#94]
 
-Subquery:11 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
+Subquery:11 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#8, [id=#4]
 
-Subquery:12 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
+Subquery:12 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#8, [id=#4]
 
-Subquery:13 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#14, [id=#15]
+Subquery:13 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#10, [id=#5]
 * Project (44)
 +- * HashAggregate (43)
    +- Exchange (42)
@@ -257,47 +257,47 @@ Subquery:13 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquer
 
 
 (37) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_quantity#101, ss_ext_discount_amt#102, ss_net_paid#103, ss_sold_date_sk#104]
+Output [4]: [ss_quantity#96, ss_ext_discount_amt#97, ss_net_paid#98, ss_sold_date_sk#99]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_quantity), GreaterThanOrEqual(ss_quantity,81), LessThanOrEqual(ss_quantity,100)]
 ReadSchema: struct<ss_quantity:int,ss_ext_discount_amt:decimal(7,2),ss_net_paid:decimal(7,2)>
 
 (38) ColumnarToRow [codegen id : 1]
-Input [4]: [ss_quantity#101, ss_ext_discount_amt#102, ss_net_paid#103, ss_sold_date_sk#104]
+Input [4]: [ss_quantity#96, ss_ext_discount_amt#97, ss_net_paid#98, ss_sold_date_sk#99]
 
 (39) Filter [codegen id : 1]
-Input [4]: [ss_quantity#101, ss_ext_discount_amt#102, ss_net_paid#103, ss_sold_date_sk#104]
-Condition : ((isnotnull(ss_quantity#101) AND (ss_quantity#101 >= 81)) AND (ss_quantity#101 <= 100))
+Input [4]: [ss_quantity#96, ss_ext_discount_amt#97, ss_net_paid#98, ss_sold_date_sk#99]
+Condition : ((isnotnull(ss_quantity#96) AND (ss_quantity#96 >= 81)) AND (ss_quantity#96 <= 100))
 
 (40) Project [codegen id : 1]
-Output [2]: [ss_ext_discount_amt#102, ss_net_paid#103]
-Input [4]: [ss_quantity#101, ss_ext_discount_amt#102, ss_net_paid#103, ss_sold_date_sk#104]
+Output [2]: [ss_ext_discount_amt#97, ss_net_paid#98]
+Input [4]: [ss_quantity#96, ss_ext_discount_amt#97, ss_net_paid#98, ss_sold_date_sk#99]
 
 (41) HashAggregate [codegen id : 1]
-Input [2]: [ss_ext_discount_amt#102, ss_net_paid#103]
+Input [2]: [ss_ext_discount_amt#97, ss_net_paid#98]
 Keys: []
-Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#102)), partial_avg(UnscaledValue(ss_net_paid#103))]
-Aggregate Attributes [5]: [count#105, sum#106, count#107, sum#108, count#109]
-Results [5]: [count#110, sum#111, count#112, sum#113, count#114]
+Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#97)), partial_avg(UnscaledValue(ss_net_paid#98))]
+Aggregate Attributes [5]: [count#100, sum#101, count#102, sum#103, count#104]
+Results [5]: [count#105, sum#106, count#107, sum#108, count#109]
 
 (42) Exchange
-Input [5]: [count#110, sum#111, count#112, sum#113, count#114]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
+Input [5]: [count#105, sum#106, count#107, sum#108, count#109]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
 
 (43) HashAggregate [codegen id : 2]
-Input [5]: [count#110, sum#111, count#112, sum#113, count#114]
+Input [5]: [count#105, sum#106, count#107, sum#108, count#109]
 Keys: []
-Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#102)), avg(UnscaledValue(ss_net_paid#103))]
-Aggregate Attributes [3]: [count(1)#115, avg(UnscaledValue(ss_ext_discount_amt#102))#116, avg(UnscaledValue(ss_net_paid#103))#117]
-Results [3]: [count(1)#115 AS count(1)#118, cast((avg(UnscaledValue(ss_ext_discount_amt#102))#116 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#119, cast((avg(UnscaledValue(ss_net_paid#103))#117 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#120]
+Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#97)), avg(UnscaledValue(ss_net_paid#98))]
+Aggregate Attributes [3]: [count(1)#110, avg(UnscaledValue(ss_ext_discount_amt#97))#111, avg(UnscaledValue(ss_net_paid#98))#112]
+Results [3]: [count(1)#110 AS count(1)#113, cast((avg(UnscaledValue(ss_ext_discount_amt#97))#111 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#114, cast((avg(UnscaledValue(ss_net_paid#98))#112 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#115]
 
 (44) Project [codegen id : 2]
-Output [1]: [named_struct(count(1), count(1)#118, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#119, avg(ss_net_paid), avg(ss_net_paid)#120) AS mergedValue#121]
-Input [3]: [count(1)#118, avg(ss_ext_discount_amt)#119, avg(ss_net_paid)#120]
+Output [1]: [named_struct(count(1), count(1)#113, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#114, avg(ss_net_paid), avg(ss_net_paid)#115) AS mergedValue#116]
+Input [3]: [count(1)#113, avg(ss_ext_discount_amt)#114, avg(ss_net_paid)#115]
 
-Subquery:14 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#14, [id=#15]
+Subquery:14 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#10, [id=#5]
 
-Subquery:15 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#14, [id=#15]
+Subquery:15 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#10, [id=#5]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q9/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q9/explain.txt
@@ -20,12 +20,12 @@ Input [1]: [r_reason_sk#1]
 Condition : (isnotnull(r_reason_sk#1) AND (r_reason_sk#1 = 1))
 
 (4) Project [codegen id : 1]
-Output [5]: [CASE WHEN (Subquery scalar-subquery#2, [id=#3].count(1) > 62316685) THEN ReusedSubquery Subquery scalar-subquery#2, [id=#3].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#2, [id=#3].avg(ss_net_paid) END AS bucket1#4, CASE WHEN (Subquery scalar-subquery#5, [id=#6].count(1) > 19045798) THEN ReusedSubquery Subquery scalar-subquery#5, [id=#6].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#5, [id=#6].avg(ss_net_paid) END AS bucket2#7, CASE WHEN (Subquery scalar-subquery#8, [id=#9].count(1) > 365541424) THEN ReusedSubquery Subquery scalar-subquery#8, [id=#9].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#8, [id=#9].avg(ss_net_paid) END AS bucket3#10, CASE WHEN (Subquery scalar-subquery#11, [id=#12].count(1) > 216357808) THEN ReusedSubquery Subquery scalar-subquery#11, [id=#12].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#11, [id=#12].avg(ss_net_paid) END AS bucket4#13, CASE WHEN (Subquery scalar-subquery#14, [id=#15].count(1) > 184483884) THEN ReusedSubquery Subquery scalar-subquery#14, [id=#15].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#14, [id=#15].avg(ss_net_paid) END AS bucket5#16]
+Output [5]: [CASE WHEN (Subquery scalar-subquery#2, [id=#1].count(1) > 62316685) THEN ReusedSubquery Subquery scalar-subquery#2, [id=#1].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#2, [id=#1].avg(ss_net_paid) END AS bucket1#3, CASE WHEN (Subquery scalar-subquery#4, [id=#2].count(1) > 19045798) THEN ReusedSubquery Subquery scalar-subquery#4, [id=#2].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#4, [id=#2].avg(ss_net_paid) END AS bucket2#5, CASE WHEN (Subquery scalar-subquery#6, [id=#3].count(1) > 365541424) THEN ReusedSubquery Subquery scalar-subquery#6, [id=#3].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#6, [id=#3].avg(ss_net_paid) END AS bucket3#7, CASE WHEN (Subquery scalar-subquery#8, [id=#4].count(1) > 216357808) THEN ReusedSubquery Subquery scalar-subquery#8, [id=#4].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#8, [id=#4].avg(ss_net_paid) END AS bucket4#9, CASE WHEN (Subquery scalar-subquery#10, [id=#5].count(1) > 184483884) THEN ReusedSubquery Subquery scalar-subquery#10, [id=#5].avg(ss_ext_discount_amt) ELSE ReusedSubquery Subquery scalar-subquery#10, [id=#5].avg(ss_net_paid) END AS bucket5#11]
 Input [1]: [r_reason_sk#1]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#2, [id=#3]
+Subquery:1 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#2, [id=#1]
 * Project (12)
 +- * HashAggregate (11)
    +- Exchange (10)
@@ -37,50 +37,50 @@ Subquery:1 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery
 
 
 (5) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_quantity#17, ss_ext_discount_amt#18, ss_net_paid#19, ss_sold_date_sk#20]
+Output [4]: [ss_quantity#12, ss_ext_discount_amt#13, ss_net_paid#14, ss_sold_date_sk#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_quantity), GreaterThanOrEqual(ss_quantity,1), LessThanOrEqual(ss_quantity,20)]
 ReadSchema: struct<ss_quantity:int,ss_ext_discount_amt:decimal(7,2),ss_net_paid:decimal(7,2)>
 
 (6) ColumnarToRow [codegen id : 1]
-Input [4]: [ss_quantity#17, ss_ext_discount_amt#18, ss_net_paid#19, ss_sold_date_sk#20]
+Input [4]: [ss_quantity#12, ss_ext_discount_amt#13, ss_net_paid#14, ss_sold_date_sk#15]
 
 (7) Filter [codegen id : 1]
-Input [4]: [ss_quantity#17, ss_ext_discount_amt#18, ss_net_paid#19, ss_sold_date_sk#20]
-Condition : ((isnotnull(ss_quantity#17) AND (ss_quantity#17 >= 1)) AND (ss_quantity#17 <= 20))
+Input [4]: [ss_quantity#12, ss_ext_discount_amt#13, ss_net_paid#14, ss_sold_date_sk#15]
+Condition : ((isnotnull(ss_quantity#12) AND (ss_quantity#12 >= 1)) AND (ss_quantity#12 <= 20))
 
 (8) Project [codegen id : 1]
-Output [2]: [ss_ext_discount_amt#18, ss_net_paid#19]
-Input [4]: [ss_quantity#17, ss_ext_discount_amt#18, ss_net_paid#19, ss_sold_date_sk#20]
+Output [2]: [ss_ext_discount_amt#13, ss_net_paid#14]
+Input [4]: [ss_quantity#12, ss_ext_discount_amt#13, ss_net_paid#14, ss_sold_date_sk#15]
 
 (9) HashAggregate [codegen id : 1]
-Input [2]: [ss_ext_discount_amt#18, ss_net_paid#19]
+Input [2]: [ss_ext_discount_amt#13, ss_net_paid#14]
 Keys: []
-Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#18)), partial_avg(UnscaledValue(ss_net_paid#19))]
-Aggregate Attributes [5]: [count#21, sum#22, count#23, sum#24, count#25]
-Results [5]: [count#26, sum#27, count#28, sum#29, count#30]
+Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#13)), partial_avg(UnscaledValue(ss_net_paid#14))]
+Aggregate Attributes [5]: [count#16, sum#17, count#18, sum#19, count#20]
+Results [5]: [count#21, sum#22, count#23, sum#24, count#25]
 
 (10) Exchange
-Input [5]: [count#26, sum#27, count#28, sum#29, count#30]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=1]
+Input [5]: [count#21, sum#22, count#23, sum#24, count#25]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
 
 (11) HashAggregate [codegen id : 2]
-Input [5]: [count#26, sum#27, count#28, sum#29, count#30]
+Input [5]: [count#21, sum#22, count#23, sum#24, count#25]
 Keys: []
-Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#18)), avg(UnscaledValue(ss_net_paid#19))]
-Aggregate Attributes [3]: [count(1)#31, avg(UnscaledValue(ss_ext_discount_amt#18))#32, avg(UnscaledValue(ss_net_paid#19))#33]
-Results [3]: [count(1)#31 AS count(1)#34, cast((avg(UnscaledValue(ss_ext_discount_amt#18))#32 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#35, cast((avg(UnscaledValue(ss_net_paid#19))#33 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#36]
+Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#13)), avg(UnscaledValue(ss_net_paid#14))]
+Aggregate Attributes [3]: [count(1)#26, avg(UnscaledValue(ss_ext_discount_amt#13))#27, avg(UnscaledValue(ss_net_paid#14))#28]
+Results [3]: [count(1)#26 AS count(1)#29, cast((avg(UnscaledValue(ss_ext_discount_amt#13))#27 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#30, cast((avg(UnscaledValue(ss_net_paid#14))#28 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#31]
 
 (12) Project [codegen id : 2]
-Output [1]: [named_struct(count(1), count(1)#34, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#35, avg(ss_net_paid), avg(ss_net_paid)#36) AS mergedValue#37]
-Input [3]: [count(1)#34, avg(ss_ext_discount_amt)#35, avg(ss_net_paid)#36]
+Output [1]: [named_struct(count(1), count(1)#29, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#30, avg(ss_net_paid), avg(ss_net_paid)#31) AS mergedValue#32]
+Input [3]: [count(1)#29, avg(ss_ext_discount_amt)#30, avg(ss_net_paid)#31]
 
-Subquery:2 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#2, [id=#3]
+Subquery:2 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#2, [id=#1]
 
-Subquery:3 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#2, [id=#3]
+Subquery:3 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#2, [id=#1]
 
-Subquery:4 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+Subquery:4 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#4, [id=#2]
 * Project (20)
 +- * HashAggregate (19)
    +- Exchange (18)
@@ -92,50 +92,50 @@ Subquery:4 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery
 
 
 (13) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_quantity#38, ss_ext_discount_amt#39, ss_net_paid#40, ss_sold_date_sk#41]
+Output [4]: [ss_quantity#33, ss_ext_discount_amt#34, ss_net_paid#35, ss_sold_date_sk#36]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_quantity), GreaterThanOrEqual(ss_quantity,21), LessThanOrEqual(ss_quantity,40)]
 ReadSchema: struct<ss_quantity:int,ss_ext_discount_amt:decimal(7,2),ss_net_paid:decimal(7,2)>
 
 (14) ColumnarToRow [codegen id : 1]
-Input [4]: [ss_quantity#38, ss_ext_discount_amt#39, ss_net_paid#40, ss_sold_date_sk#41]
+Input [4]: [ss_quantity#33, ss_ext_discount_amt#34, ss_net_paid#35, ss_sold_date_sk#36]
 
 (15) Filter [codegen id : 1]
-Input [4]: [ss_quantity#38, ss_ext_discount_amt#39, ss_net_paid#40, ss_sold_date_sk#41]
-Condition : ((isnotnull(ss_quantity#38) AND (ss_quantity#38 >= 21)) AND (ss_quantity#38 <= 40))
+Input [4]: [ss_quantity#33, ss_ext_discount_amt#34, ss_net_paid#35, ss_sold_date_sk#36]
+Condition : ((isnotnull(ss_quantity#33) AND (ss_quantity#33 >= 21)) AND (ss_quantity#33 <= 40))
 
 (16) Project [codegen id : 1]
-Output [2]: [ss_ext_discount_amt#39, ss_net_paid#40]
-Input [4]: [ss_quantity#38, ss_ext_discount_amt#39, ss_net_paid#40, ss_sold_date_sk#41]
+Output [2]: [ss_ext_discount_amt#34, ss_net_paid#35]
+Input [4]: [ss_quantity#33, ss_ext_discount_amt#34, ss_net_paid#35, ss_sold_date_sk#36]
 
 (17) HashAggregate [codegen id : 1]
-Input [2]: [ss_ext_discount_amt#39, ss_net_paid#40]
+Input [2]: [ss_ext_discount_amt#34, ss_net_paid#35]
 Keys: []
-Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#39)), partial_avg(UnscaledValue(ss_net_paid#40))]
-Aggregate Attributes [5]: [count#42, sum#43, count#44, sum#45, count#46]
-Results [5]: [count#47, sum#48, count#49, sum#50, count#51]
+Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#34)), partial_avg(UnscaledValue(ss_net_paid#35))]
+Aggregate Attributes [5]: [count#37, sum#38, count#39, sum#40, count#41]
+Results [5]: [count#42, sum#43, count#44, sum#45, count#46]
 
 (18) Exchange
-Input [5]: [count#47, sum#48, count#49, sum#50, count#51]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=2]
+Input [5]: [count#42, sum#43, count#44, sum#45, count#46]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
 (19) HashAggregate [codegen id : 2]
-Input [5]: [count#47, sum#48, count#49, sum#50, count#51]
+Input [5]: [count#42, sum#43, count#44, sum#45, count#46]
 Keys: []
-Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#39)), avg(UnscaledValue(ss_net_paid#40))]
-Aggregate Attributes [3]: [count(1)#52, avg(UnscaledValue(ss_ext_discount_amt#39))#53, avg(UnscaledValue(ss_net_paid#40))#54]
-Results [3]: [count(1)#52 AS count(1)#55, cast((avg(UnscaledValue(ss_ext_discount_amt#39))#53 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#56, cast((avg(UnscaledValue(ss_net_paid#40))#54 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#57]
+Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#34)), avg(UnscaledValue(ss_net_paid#35))]
+Aggregate Attributes [3]: [count(1)#47, avg(UnscaledValue(ss_ext_discount_amt#34))#48, avg(UnscaledValue(ss_net_paid#35))#49]
+Results [3]: [count(1)#47 AS count(1)#50, cast((avg(UnscaledValue(ss_ext_discount_amt#34))#48 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#51, cast((avg(UnscaledValue(ss_net_paid#35))#49 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#52]
 
 (20) Project [codegen id : 2]
-Output [1]: [named_struct(count(1), count(1)#55, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#56, avg(ss_net_paid), avg(ss_net_paid)#57) AS mergedValue#58]
-Input [3]: [count(1)#55, avg(ss_ext_discount_amt)#56, avg(ss_net_paid)#57]
+Output [1]: [named_struct(count(1), count(1)#50, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#51, avg(ss_net_paid), avg(ss_net_paid)#52) AS mergedValue#53]
+Input [3]: [count(1)#50, avg(ss_ext_discount_amt)#51, avg(ss_net_paid)#52]
 
-Subquery:5 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#5, [id=#6]
+Subquery:5 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#4, [id=#2]
 
-Subquery:6 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#5, [id=#6]
+Subquery:6 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#4, [id=#2]
 
-Subquery:7 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#8, [id=#9]
+Subquery:7 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#6, [id=#3]
 * Project (28)
 +- * HashAggregate (27)
    +- Exchange (26)
@@ -147,50 +147,50 @@ Subquery:7 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery
 
 
 (21) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_quantity#59, ss_ext_discount_amt#60, ss_net_paid#61, ss_sold_date_sk#62]
+Output [4]: [ss_quantity#54, ss_ext_discount_amt#55, ss_net_paid#56, ss_sold_date_sk#57]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_quantity), GreaterThanOrEqual(ss_quantity,41), LessThanOrEqual(ss_quantity,60)]
 ReadSchema: struct<ss_quantity:int,ss_ext_discount_amt:decimal(7,2),ss_net_paid:decimal(7,2)>
 
 (22) ColumnarToRow [codegen id : 1]
-Input [4]: [ss_quantity#59, ss_ext_discount_amt#60, ss_net_paid#61, ss_sold_date_sk#62]
+Input [4]: [ss_quantity#54, ss_ext_discount_amt#55, ss_net_paid#56, ss_sold_date_sk#57]
 
 (23) Filter [codegen id : 1]
-Input [4]: [ss_quantity#59, ss_ext_discount_amt#60, ss_net_paid#61, ss_sold_date_sk#62]
-Condition : ((isnotnull(ss_quantity#59) AND (ss_quantity#59 >= 41)) AND (ss_quantity#59 <= 60))
+Input [4]: [ss_quantity#54, ss_ext_discount_amt#55, ss_net_paid#56, ss_sold_date_sk#57]
+Condition : ((isnotnull(ss_quantity#54) AND (ss_quantity#54 >= 41)) AND (ss_quantity#54 <= 60))
 
 (24) Project [codegen id : 1]
-Output [2]: [ss_ext_discount_amt#60, ss_net_paid#61]
-Input [4]: [ss_quantity#59, ss_ext_discount_amt#60, ss_net_paid#61, ss_sold_date_sk#62]
+Output [2]: [ss_ext_discount_amt#55, ss_net_paid#56]
+Input [4]: [ss_quantity#54, ss_ext_discount_amt#55, ss_net_paid#56, ss_sold_date_sk#57]
 
 (25) HashAggregate [codegen id : 1]
-Input [2]: [ss_ext_discount_amt#60, ss_net_paid#61]
+Input [2]: [ss_ext_discount_amt#55, ss_net_paid#56]
 Keys: []
-Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#60)), partial_avg(UnscaledValue(ss_net_paid#61))]
-Aggregate Attributes [5]: [count#63, sum#64, count#65, sum#66, count#67]
-Results [5]: [count#68, sum#69, count#70, sum#71, count#72]
+Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#55)), partial_avg(UnscaledValue(ss_net_paid#56))]
+Aggregate Attributes [5]: [count#58, sum#59, count#60, sum#61, count#62]
+Results [5]: [count#63, sum#64, count#65, sum#66, count#67]
 
 (26) Exchange
-Input [5]: [count#68, sum#69, count#70, sum#71, count#72]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=3]
+Input [5]: [count#63, sum#64, count#65, sum#66, count#67]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
 (27) HashAggregate [codegen id : 2]
-Input [5]: [count#68, sum#69, count#70, sum#71, count#72]
+Input [5]: [count#63, sum#64, count#65, sum#66, count#67]
 Keys: []
-Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#60)), avg(UnscaledValue(ss_net_paid#61))]
-Aggregate Attributes [3]: [count(1)#73, avg(UnscaledValue(ss_ext_discount_amt#60))#74, avg(UnscaledValue(ss_net_paid#61))#75]
-Results [3]: [count(1)#73 AS count(1)#76, cast((avg(UnscaledValue(ss_ext_discount_amt#60))#74 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#77, cast((avg(UnscaledValue(ss_net_paid#61))#75 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#78]
+Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#55)), avg(UnscaledValue(ss_net_paid#56))]
+Aggregate Attributes [3]: [count(1)#68, avg(UnscaledValue(ss_ext_discount_amt#55))#69, avg(UnscaledValue(ss_net_paid#56))#70]
+Results [3]: [count(1)#68 AS count(1)#71, cast((avg(UnscaledValue(ss_ext_discount_amt#55))#69 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#72, cast((avg(UnscaledValue(ss_net_paid#56))#70 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#73]
 
 (28) Project [codegen id : 2]
-Output [1]: [named_struct(count(1), count(1)#76, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#77, avg(ss_net_paid), avg(ss_net_paid)#78) AS mergedValue#79]
-Input [3]: [count(1)#76, avg(ss_ext_discount_amt)#77, avg(ss_net_paid)#78]
+Output [1]: [named_struct(count(1), count(1)#71, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#72, avg(ss_net_paid), avg(ss_net_paid)#73) AS mergedValue#74]
+Input [3]: [count(1)#71, avg(ss_ext_discount_amt)#72, avg(ss_net_paid)#73]
 
-Subquery:8 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#8, [id=#9]
+Subquery:8 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#6, [id=#3]
 
-Subquery:9 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#8, [id=#9]
+Subquery:9 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#6, [id=#3]
 
-Subquery:10 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#11, [id=#12]
+Subquery:10 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#8, [id=#4]
 * Project (36)
 +- * HashAggregate (35)
    +- Exchange (34)
@@ -202,50 +202,50 @@ Subquery:10 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquer
 
 
 (29) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_quantity#80, ss_ext_discount_amt#81, ss_net_paid#82, ss_sold_date_sk#83]
+Output [4]: [ss_quantity#75, ss_ext_discount_amt#76, ss_net_paid#77, ss_sold_date_sk#78]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_quantity), GreaterThanOrEqual(ss_quantity,61), LessThanOrEqual(ss_quantity,80)]
 ReadSchema: struct<ss_quantity:int,ss_ext_discount_amt:decimal(7,2),ss_net_paid:decimal(7,2)>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [4]: [ss_quantity#80, ss_ext_discount_amt#81, ss_net_paid#82, ss_sold_date_sk#83]
+Input [4]: [ss_quantity#75, ss_ext_discount_amt#76, ss_net_paid#77, ss_sold_date_sk#78]
 
 (31) Filter [codegen id : 1]
-Input [4]: [ss_quantity#80, ss_ext_discount_amt#81, ss_net_paid#82, ss_sold_date_sk#83]
-Condition : ((isnotnull(ss_quantity#80) AND (ss_quantity#80 >= 61)) AND (ss_quantity#80 <= 80))
+Input [4]: [ss_quantity#75, ss_ext_discount_amt#76, ss_net_paid#77, ss_sold_date_sk#78]
+Condition : ((isnotnull(ss_quantity#75) AND (ss_quantity#75 >= 61)) AND (ss_quantity#75 <= 80))
 
 (32) Project [codegen id : 1]
-Output [2]: [ss_ext_discount_amt#81, ss_net_paid#82]
-Input [4]: [ss_quantity#80, ss_ext_discount_amt#81, ss_net_paid#82, ss_sold_date_sk#83]
+Output [2]: [ss_ext_discount_amt#76, ss_net_paid#77]
+Input [4]: [ss_quantity#75, ss_ext_discount_amt#76, ss_net_paid#77, ss_sold_date_sk#78]
 
 (33) HashAggregate [codegen id : 1]
-Input [2]: [ss_ext_discount_amt#81, ss_net_paid#82]
+Input [2]: [ss_ext_discount_amt#76, ss_net_paid#77]
 Keys: []
-Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#81)), partial_avg(UnscaledValue(ss_net_paid#82))]
-Aggregate Attributes [5]: [count#84, sum#85, count#86, sum#87, count#88]
-Results [5]: [count#89, sum#90, count#91, sum#92, count#93]
+Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#76)), partial_avg(UnscaledValue(ss_net_paid#77))]
+Aggregate Attributes [5]: [count#79, sum#80, count#81, sum#82, count#83]
+Results [5]: [count#84, sum#85, count#86, sum#87, count#88]
 
 (34) Exchange
-Input [5]: [count#89, sum#90, count#91, sum#92, count#93]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=4]
+Input [5]: [count#84, sum#85, count#86, sum#87, count#88]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
 
 (35) HashAggregate [codegen id : 2]
-Input [5]: [count#89, sum#90, count#91, sum#92, count#93]
+Input [5]: [count#84, sum#85, count#86, sum#87, count#88]
 Keys: []
-Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#81)), avg(UnscaledValue(ss_net_paid#82))]
-Aggregate Attributes [3]: [count(1)#94, avg(UnscaledValue(ss_ext_discount_amt#81))#95, avg(UnscaledValue(ss_net_paid#82))#96]
-Results [3]: [count(1)#94 AS count(1)#97, cast((avg(UnscaledValue(ss_ext_discount_amt#81))#95 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#98, cast((avg(UnscaledValue(ss_net_paid#82))#96 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#99]
+Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#76)), avg(UnscaledValue(ss_net_paid#77))]
+Aggregate Attributes [3]: [count(1)#89, avg(UnscaledValue(ss_ext_discount_amt#76))#90, avg(UnscaledValue(ss_net_paid#77))#91]
+Results [3]: [count(1)#89 AS count(1)#92, cast((avg(UnscaledValue(ss_ext_discount_amt#76))#90 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#93, cast((avg(UnscaledValue(ss_net_paid#77))#91 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#94]
 
 (36) Project [codegen id : 2]
-Output [1]: [named_struct(count(1), count(1)#97, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#98, avg(ss_net_paid), avg(ss_net_paid)#99) AS mergedValue#100]
-Input [3]: [count(1)#97, avg(ss_ext_discount_amt)#98, avg(ss_net_paid)#99]
+Output [1]: [named_struct(count(1), count(1)#92, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#93, avg(ss_net_paid), avg(ss_net_paid)#94) AS mergedValue#95]
+Input [3]: [count(1)#92, avg(ss_ext_discount_amt)#93, avg(ss_net_paid)#94]
 
-Subquery:11 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
+Subquery:11 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#8, [id=#4]
 
-Subquery:12 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
+Subquery:12 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#8, [id=#4]
 
-Subquery:13 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#14, [id=#15]
+Subquery:13 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquery#10, [id=#5]
 * Project (44)
 +- * HashAggregate (43)
    +- Exchange (42)
@@ -257,47 +257,47 @@ Subquery:13 Hosting operator id = 4 Hosting Expression = Subquery scalar-subquer
 
 
 (37) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_quantity#101, ss_ext_discount_amt#102, ss_net_paid#103, ss_sold_date_sk#104]
+Output [4]: [ss_quantity#96, ss_ext_discount_amt#97, ss_net_paid#98, ss_sold_date_sk#99]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_quantity), GreaterThanOrEqual(ss_quantity,81), LessThanOrEqual(ss_quantity,100)]
 ReadSchema: struct<ss_quantity:int,ss_ext_discount_amt:decimal(7,2),ss_net_paid:decimal(7,2)>
 
 (38) ColumnarToRow [codegen id : 1]
-Input [4]: [ss_quantity#101, ss_ext_discount_amt#102, ss_net_paid#103, ss_sold_date_sk#104]
+Input [4]: [ss_quantity#96, ss_ext_discount_amt#97, ss_net_paid#98, ss_sold_date_sk#99]
 
 (39) Filter [codegen id : 1]
-Input [4]: [ss_quantity#101, ss_ext_discount_amt#102, ss_net_paid#103, ss_sold_date_sk#104]
-Condition : ((isnotnull(ss_quantity#101) AND (ss_quantity#101 >= 81)) AND (ss_quantity#101 <= 100))
+Input [4]: [ss_quantity#96, ss_ext_discount_amt#97, ss_net_paid#98, ss_sold_date_sk#99]
+Condition : ((isnotnull(ss_quantity#96) AND (ss_quantity#96 >= 81)) AND (ss_quantity#96 <= 100))
 
 (40) Project [codegen id : 1]
-Output [2]: [ss_ext_discount_amt#102, ss_net_paid#103]
-Input [4]: [ss_quantity#101, ss_ext_discount_amt#102, ss_net_paid#103, ss_sold_date_sk#104]
+Output [2]: [ss_ext_discount_amt#97, ss_net_paid#98]
+Input [4]: [ss_quantity#96, ss_ext_discount_amt#97, ss_net_paid#98, ss_sold_date_sk#99]
 
 (41) HashAggregate [codegen id : 1]
-Input [2]: [ss_ext_discount_amt#102, ss_net_paid#103]
+Input [2]: [ss_ext_discount_amt#97, ss_net_paid#98]
 Keys: []
-Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#102)), partial_avg(UnscaledValue(ss_net_paid#103))]
-Aggregate Attributes [5]: [count#105, sum#106, count#107, sum#108, count#109]
-Results [5]: [count#110, sum#111, count#112, sum#113, count#114]
+Functions [3]: [partial_count(1), partial_avg(UnscaledValue(ss_ext_discount_amt#97)), partial_avg(UnscaledValue(ss_net_paid#98))]
+Aggregate Attributes [5]: [count#100, sum#101, count#102, sum#103, count#104]
+Results [5]: [count#105, sum#106, count#107, sum#108, count#109]
 
 (42) Exchange
-Input [5]: [count#110, sum#111, count#112, sum#113, count#114]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
+Input [5]: [count#105, sum#106, count#107, sum#108, count#109]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
 
 (43) HashAggregate [codegen id : 2]
-Input [5]: [count#110, sum#111, count#112, sum#113, count#114]
+Input [5]: [count#105, sum#106, count#107, sum#108, count#109]
 Keys: []
-Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#102)), avg(UnscaledValue(ss_net_paid#103))]
-Aggregate Attributes [3]: [count(1)#115, avg(UnscaledValue(ss_ext_discount_amt#102))#116, avg(UnscaledValue(ss_net_paid#103))#117]
-Results [3]: [count(1)#115 AS count(1)#118, cast((avg(UnscaledValue(ss_ext_discount_amt#102))#116 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#119, cast((avg(UnscaledValue(ss_net_paid#103))#117 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#120]
+Functions [3]: [count(1), avg(UnscaledValue(ss_ext_discount_amt#97)), avg(UnscaledValue(ss_net_paid#98))]
+Aggregate Attributes [3]: [count(1)#110, avg(UnscaledValue(ss_ext_discount_amt#97))#111, avg(UnscaledValue(ss_net_paid#98))#112]
+Results [3]: [count(1)#110 AS count(1)#113, cast((avg(UnscaledValue(ss_ext_discount_amt#97))#111 / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#114, cast((avg(UnscaledValue(ss_net_paid#98))#112 / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#115]
 
 (44) Project [codegen id : 2]
-Output [1]: [named_struct(count(1), count(1)#118, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#119, avg(ss_net_paid), avg(ss_net_paid)#120) AS mergedValue#121]
-Input [3]: [count(1)#118, avg(ss_ext_discount_amt)#119, avg(ss_net_paid)#120]
+Output [1]: [named_struct(count(1), count(1)#113, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#114, avg(ss_net_paid), avg(ss_net_paid)#115) AS mergedValue#116]
+Input [3]: [count(1)#113, avg(ss_ext_discount_amt)#114, avg(ss_net_paid)#115]
 
-Subquery:14 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#14, [id=#15]
+Subquery:14 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#10, [id=#5]
 
-Subquery:15 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#14, [id=#15]
+Subquery:15 Hosting operator id = 4 Hosting Expression = ReusedSubquery Subquery scalar-subquery#10, [id=#5]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92.sf100/explain.txt
@@ -65,42 +65,42 @@ Input [3]: [ws_item_sk#3, ws_ext_discount_amt#4, ws_sold_date_sk#5]
 
 (8) Filter [codegen id : 3]
 Input [3]: [ws_item_sk#3, ws_ext_discount_amt#4, ws_sold_date_sk#5]
-Condition : (isnotnull(ws_item_sk#3) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ws_item_sk#3, 42)))
+Condition : (isnotnull(ws_item_sk#3) AND might_contain(Subquery scalar-subquery#7, [id=#2], xxhash64(ws_item_sk#3, 42)))
 
 (9) ReusedExchange [Reuses operator id: 41]
-Output [1]: [d_date_sk#9]
+Output [1]: [d_date_sk#8]
 
 (10) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_sold_date_sk#5]
-Right keys [1]: [d_date_sk#9]
+Right keys [1]: [d_date_sk#8]
 Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 3]
 Output [2]: [ws_item_sk#3, ws_ext_discount_amt#4]
-Input [4]: [ws_item_sk#3, ws_ext_discount_amt#4, ws_sold_date_sk#5, d_date_sk#9]
+Input [4]: [ws_item_sk#3, ws_ext_discount_amt#4, ws_sold_date_sk#5, d_date_sk#8]
 
 (12) HashAggregate [codegen id : 3]
 Input [2]: [ws_item_sk#3, ws_ext_discount_amt#4]
 Keys [1]: [ws_item_sk#3]
 Functions [1]: [partial_avg(UnscaledValue(ws_ext_discount_amt#4))]
-Aggregate Attributes [2]: [sum#10, count#11]
-Results [3]: [ws_item_sk#3, sum#12, count#13]
+Aggregate Attributes [2]: [sum#9, count#10]
+Results [3]: [ws_item_sk#3, sum#11, count#12]
 
 (13) Exchange
-Input [3]: [ws_item_sk#3, sum#12, count#13]
-Arguments: hashpartitioning(ws_item_sk#3, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [3]: [ws_item_sk#3, sum#11, count#12]
+Arguments: hashpartitioning(ws_item_sk#3, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (14) HashAggregate
-Input [3]: [ws_item_sk#3, sum#12, count#13]
+Input [3]: [ws_item_sk#3, sum#11, count#12]
 Keys [1]: [ws_item_sk#3]
 Functions [1]: [avg(UnscaledValue(ws_ext_discount_amt#4))]
-Aggregate Attributes [1]: [avg(UnscaledValue(ws_ext_discount_amt#4))#14]
-Results [2]: [(1.3 * cast((avg(UnscaledValue(ws_ext_discount_amt#4))#14 / 100.0) as decimal(11,6))) AS (1.3 * avg(ws_ext_discount_amt))#15, ws_item_sk#3]
+Aggregate Attributes [1]: [avg(UnscaledValue(ws_ext_discount_amt#4))#13]
+Results [2]: [(1.3 * cast((avg(UnscaledValue(ws_ext_discount_amt#4))#13 / 100.0) as decimal(11,6))) AS (1.3 * avg(ws_ext_discount_amt))#14, ws_item_sk#3]
 
 (15) Filter
-Input [2]: [(1.3 * avg(ws_ext_discount_amt))#15, ws_item_sk#3]
-Condition : isnotnull((1.3 * avg(ws_ext_discount_amt))#15)
+Input [2]: [(1.3 * avg(ws_ext_discount_amt))#14, ws_item_sk#3]
+Condition : isnotnull((1.3 * avg(ws_ext_discount_amt))#14)
 
 (16) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
@@ -109,72 +109,72 @@ Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 4]
-Output [2]: [i_item_sk#1, (1.3 * avg(ws_ext_discount_amt))#15]
-Input [3]: [i_item_sk#1, (1.3 * avg(ws_ext_discount_amt))#15, ws_item_sk#3]
+Output [2]: [i_item_sk#1, (1.3 * avg(ws_ext_discount_amt))#14]
+Input [3]: [i_item_sk#1, (1.3 * avg(ws_ext_discount_amt))#14, ws_item_sk#3]
 
 (18) BroadcastExchange
-Input [2]: [i_item_sk#1, (1.3 * avg(ws_ext_discount_amt))#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
+Input [2]: [i_item_sk#1, (1.3 * avg(ws_ext_discount_amt))#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
 (19) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_item_sk#16, ws_ext_discount_amt#17, ws_sold_date_sk#18]
+Output [3]: [ws_item_sk#15, ws_ext_discount_amt#16, ws_sold_date_sk#17]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#18), dynamicpruningexpression(ws_sold_date_sk#18 IN dynamicpruning#6)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#17), dynamicpruningexpression(ws_sold_date_sk#17 IN dynamicpruning#6)]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_ext_discount_amt)]
 ReadSchema: struct<ws_item_sk:int,ws_ext_discount_amt:decimal(7,2)>
 
 (20) ColumnarToRow
-Input [3]: [ws_item_sk#16, ws_ext_discount_amt#17, ws_sold_date_sk#18]
+Input [3]: [ws_item_sk#15, ws_ext_discount_amt#16, ws_sold_date_sk#17]
 
 (21) Filter
-Input [3]: [ws_item_sk#16, ws_ext_discount_amt#17, ws_sold_date_sk#18]
-Condition : (isnotnull(ws_item_sk#16) AND isnotnull(ws_ext_discount_amt#17))
+Input [3]: [ws_item_sk#15, ws_ext_discount_amt#16, ws_sold_date_sk#17]
+Condition : (isnotnull(ws_item_sk#15) AND isnotnull(ws_ext_discount_amt#16))
 
 (22) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [i_item_sk#1]
-Right keys [1]: [ws_item_sk#16]
+Right keys [1]: [ws_item_sk#15]
 Join type: Inner
-Join condition: (cast(ws_ext_discount_amt#17 as decimal(14,7)) > (1.3 * avg(ws_ext_discount_amt))#15)
+Join condition: (cast(ws_ext_discount_amt#16 as decimal(14,7)) > (1.3 * avg(ws_ext_discount_amt))#14)
 
 (23) Project [codegen id : 6]
-Output [2]: [ws_ext_discount_amt#17, ws_sold_date_sk#18]
-Input [5]: [i_item_sk#1, (1.3 * avg(ws_ext_discount_amt))#15, ws_item_sk#16, ws_ext_discount_amt#17, ws_sold_date_sk#18]
+Output [2]: [ws_ext_discount_amt#16, ws_sold_date_sk#17]
+Input [5]: [i_item_sk#1, (1.3 * avg(ws_ext_discount_amt))#14, ws_item_sk#15, ws_ext_discount_amt#16, ws_sold_date_sk#17]
 
 (24) ReusedExchange [Reuses operator id: 41]
-Output [1]: [d_date_sk#19]
+Output [1]: [d_date_sk#18]
 
 (25) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#18]
-Right keys [1]: [d_date_sk#19]
+Left keys [1]: [ws_sold_date_sk#17]
+Right keys [1]: [d_date_sk#18]
 Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 6]
-Output [1]: [ws_ext_discount_amt#17]
-Input [3]: [ws_ext_discount_amt#17, ws_sold_date_sk#18, d_date_sk#19]
+Output [1]: [ws_ext_discount_amt#16]
+Input [3]: [ws_ext_discount_amt#16, ws_sold_date_sk#17, d_date_sk#18]
 
 (27) HashAggregate [codegen id : 6]
-Input [1]: [ws_ext_discount_amt#17]
+Input [1]: [ws_ext_discount_amt#16]
 Keys: []
-Functions [1]: [partial_sum(UnscaledValue(ws_ext_discount_amt#17))]
-Aggregate Attributes [1]: [sum#20]
-Results [1]: [sum#21]
+Functions [1]: [partial_sum(UnscaledValue(ws_ext_discount_amt#16))]
+Aggregate Attributes [1]: [sum#19]
+Results [1]: [sum#20]
 
 (28) Exchange
-Input [1]: [sum#21]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=4]
+Input [1]: [sum#20]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
 
 (29) HashAggregate [codegen id : 7]
-Input [1]: [sum#21]
+Input [1]: [sum#20]
 Keys: []
-Functions [1]: [sum(UnscaledValue(ws_ext_discount_amt#17))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_discount_amt#17))#22]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ws_ext_discount_amt#17))#22,17,2) AS Excess Discount Amount #23]
+Functions [1]: [sum(UnscaledValue(ws_ext_discount_amt#16))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_discount_amt#16))#21]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ws_ext_discount_amt#16))#21,17,2) AS Excess Discount Amount #22]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 8 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+Subquery:1 Hosting operator id = 8 Hosting Expression = Subquery scalar-subquery#7, [id=#2]
 ObjectHashAggregate (36)
 +- Exchange (35)
    +- ObjectHashAggregate (34)
@@ -206,19 +206,19 @@ Input [2]: [i_item_sk#1, i_manufact_id#2]
 Input [1]: [i_item_sk#1]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)]
-Aggregate Attributes [1]: [buf#24]
-Results [1]: [buf#25]
+Aggregate Attributes [1]: [buf#23]
+Results [1]: [buf#24]
 
 (35) Exchange
-Input [1]: [buf#25]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
+Input [1]: [buf#24]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
 
 (36) ObjectHashAggregate
-Input [1]: [buf#25]
+Input [1]: [buf#24]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)#26]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)#26 AS bloomFilter#27]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)#25]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)#25 AS bloomFilter#26]
 
 Subquery:2 Hosting operator id = 6 Hosting Expression = ws_sold_date_sk#5 IN dynamicpruning#6
 BroadcastExchange (41)
@@ -229,27 +229,27 @@ BroadcastExchange (41)
 
 
 (37) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#9, d_date#28]
+Output [2]: [d_date_sk#8, d_date#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-01-27), LessThanOrEqual(d_date,2000-04-26), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (38) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#9, d_date#28]
+Input [2]: [d_date_sk#8, d_date#27]
 
 (39) Filter [codegen id : 1]
-Input [2]: [d_date_sk#9, d_date#28]
-Condition : (((isnotnull(d_date#28) AND (d_date#28 >= 2000-01-27)) AND (d_date#28 <= 2000-04-26)) AND isnotnull(d_date_sk#9))
+Input [2]: [d_date_sk#8, d_date#27]
+Condition : (((isnotnull(d_date#27) AND (d_date#27 >= 2000-01-27)) AND (d_date#27 <= 2000-04-26)) AND isnotnull(d_date_sk#8))
 
 (40) Project [codegen id : 1]
-Output [1]: [d_date_sk#9]
-Input [2]: [d_date_sk#9, d_date#28]
+Output [1]: [d_date_sk#8]
+Input [2]: [d_date_sk#8, d_date#27]
 
 (41) BroadcastExchange
-Input [1]: [d_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+Input [1]: [d_date_sk#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
-Subquery:3 Hosting operator id = 19 Hosting Expression = ws_sold_date_sk#18 IN dynamicpruning#6
+Subquery:3 Hosting operator id = 19 Hosting Expression = ws_sold_date_sk#17 IN dynamicpruning#6
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/explain.txt
@@ -58,7 +58,7 @@ Input [8]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_warehouse
 
 (3) Filter [codegen id : 1]
 Input [8]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_warehouse_sk#4, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, ws_sold_date_sk#8]
-Condition : (((((isnotnull(ws_ship_date_sk#1) AND isnotnull(ws_ship_addr_sk#2)) AND isnotnull(ws_web_site_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(ws_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(ws_web_site_sk#3, 42))) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(ws_ship_date_sk#1, 42)))
+Condition : (((((isnotnull(ws_ship_date_sk#1) AND isnotnull(ws_ship_addr_sk#2)) AND isnotnull(ws_web_site_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#1], xxhash64(ws_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#10, [id=#2], xxhash64(ws_web_site_sk#3, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#3], xxhash64(ws_ship_date_sk#1, 42)))
 
 (4) Project [codegen id : 1]
 Output [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_warehouse_sk#4, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
@@ -66,201 +66,201 @@ Input [8]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_warehouse
 
 (5) Exchange
 Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_warehouse_sk#4, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
-Arguments: hashpartitioning(ws_order_number#5, 5), ENSURE_REQUIREMENTS, [plan_id=1]
+Arguments: hashpartitioning(ws_order_number#5, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (6) Sort [codegen id : 2]
 Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_warehouse_sk#4, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
 Arguments: [ws_order_number#5 ASC NULLS FIRST], false, 0
 
 (7) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_warehouse_sk#15, ws_order_number#16, ws_sold_date_sk#17]
+Output [3]: [ws_warehouse_sk#12, ws_order_number#13, ws_sold_date_sk#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 ReadSchema: struct<ws_warehouse_sk:int,ws_order_number:int>
 
 (8) ColumnarToRow [codegen id : 3]
-Input [3]: [ws_warehouse_sk#15, ws_order_number#16, ws_sold_date_sk#17]
+Input [3]: [ws_warehouse_sk#12, ws_order_number#13, ws_sold_date_sk#14]
 
 (9) Project [codegen id : 3]
-Output [2]: [ws_warehouse_sk#15, ws_order_number#16]
-Input [3]: [ws_warehouse_sk#15, ws_order_number#16, ws_sold_date_sk#17]
+Output [2]: [ws_warehouse_sk#12, ws_order_number#13]
+Input [3]: [ws_warehouse_sk#12, ws_order_number#13, ws_sold_date_sk#14]
 
 (10) Exchange
-Input [2]: [ws_warehouse_sk#15, ws_order_number#16]
-Arguments: hashpartitioning(ws_order_number#16, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [2]: [ws_warehouse_sk#12, ws_order_number#13]
+Arguments: hashpartitioning(ws_order_number#13, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (11) Sort [codegen id : 4]
-Input [2]: [ws_warehouse_sk#15, ws_order_number#16]
-Arguments: [ws_order_number#16 ASC NULLS FIRST], false, 0
+Input [2]: [ws_warehouse_sk#12, ws_order_number#13]
+Arguments: [ws_order_number#13 ASC NULLS FIRST], false, 0
 
 (12) SortMergeJoin [codegen id : 5]
 Left keys [1]: [ws_order_number#5]
-Right keys [1]: [ws_order_number#16]
+Right keys [1]: [ws_order_number#13]
 Join type: LeftSemi
-Join condition: NOT (ws_warehouse_sk#4 = ws_warehouse_sk#15)
+Join condition: NOT (ws_warehouse_sk#4 = ws_warehouse_sk#12)
 
 (13) Project [codegen id : 5]
 Output [6]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
 Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_warehouse_sk#4, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
 
 (14) Scan parquet spark_catalog.default.web_returns
-Output [2]: [wr_order_number#18, wr_returned_date_sk#19]
+Output [2]: [wr_order_number#15, wr_returned_date_sk#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_returns]
 ReadSchema: struct<wr_order_number:int>
 
 (15) ColumnarToRow [codegen id : 6]
-Input [2]: [wr_order_number#18, wr_returned_date_sk#19]
+Input [2]: [wr_order_number#15, wr_returned_date_sk#16]
 
 (16) Project [codegen id : 6]
-Output [1]: [wr_order_number#18]
-Input [2]: [wr_order_number#18, wr_returned_date_sk#19]
+Output [1]: [wr_order_number#15]
+Input [2]: [wr_order_number#15, wr_returned_date_sk#16]
 
 (17) Exchange
-Input [1]: [wr_order_number#18]
-Arguments: hashpartitioning(wr_order_number#18, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [1]: [wr_order_number#15]
+Arguments: hashpartitioning(wr_order_number#15, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (18) Sort [codegen id : 7]
-Input [1]: [wr_order_number#18]
-Arguments: [wr_order_number#18 ASC NULLS FIRST], false, 0
+Input [1]: [wr_order_number#15]
+Arguments: [wr_order_number#15 ASC NULLS FIRST], false, 0
 
 (19) SortMergeJoin [codegen id : 11]
 Left keys [1]: [ws_order_number#5]
-Right keys [1]: [wr_order_number#18]
+Right keys [1]: [wr_order_number#15]
 Join type: LeftAnti
 Join condition: None
 
 (20) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#20, ca_state#21]
+Output [2]: [ca_address_sk#17, ca_state#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
 (21) ColumnarToRow [codegen id : 8]
-Input [2]: [ca_address_sk#20, ca_state#21]
+Input [2]: [ca_address_sk#17, ca_state#18]
 
 (22) Filter [codegen id : 8]
-Input [2]: [ca_address_sk#20, ca_state#21]
-Condition : ((isnotnull(ca_state#21) AND (ca_state#21 = IL)) AND isnotnull(ca_address_sk#20))
+Input [2]: [ca_address_sk#17, ca_state#18]
+Condition : ((isnotnull(ca_state#18) AND (ca_state#18 = IL)) AND isnotnull(ca_address_sk#17))
 
 (23) Project [codegen id : 8]
-Output [1]: [ca_address_sk#20]
-Input [2]: [ca_address_sk#20, ca_state#21]
+Output [1]: [ca_address_sk#17]
+Input [2]: [ca_address_sk#17, ca_state#18]
 
 (24) BroadcastExchange
-Input [1]: [ca_address_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+Input [1]: [ca_address_sk#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 (25) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_ship_addr_sk#2]
-Right keys [1]: [ca_address_sk#20]
+Right keys [1]: [ca_address_sk#17]
 Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 11]
 Output [5]: [ws_ship_date_sk#1, ws_web_site_sk#3, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
-Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, ca_address_sk#20]
+Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, ca_address_sk#17]
 
 (27) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#22, web_company_name#23]
+Output [2]: [web_site_sk#19, web_company_name#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_company_name), EqualTo(web_company_name,pri                                               ), IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_company_name:string>
 
 (28) ColumnarToRow [codegen id : 9]
-Input [2]: [web_site_sk#22, web_company_name#23]
+Input [2]: [web_site_sk#19, web_company_name#20]
 
 (29) Filter [codegen id : 9]
-Input [2]: [web_site_sk#22, web_company_name#23]
-Condition : ((isnotnull(web_company_name#23) AND (web_company_name#23 = pri                                               )) AND isnotnull(web_site_sk#22))
+Input [2]: [web_site_sk#19, web_company_name#20]
+Condition : ((isnotnull(web_company_name#20) AND (web_company_name#20 = pri                                               )) AND isnotnull(web_site_sk#19))
 
 (30) Project [codegen id : 9]
-Output [1]: [web_site_sk#22]
-Input [2]: [web_site_sk#22, web_company_name#23]
+Output [1]: [web_site_sk#19]
+Input [2]: [web_site_sk#19, web_company_name#20]
 
 (31) BroadcastExchange
-Input [1]: [web_site_sk#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+Input [1]: [web_site_sk#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
 (32) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_web_site_sk#3]
-Right keys [1]: [web_site_sk#22]
+Right keys [1]: [web_site_sk#19]
 Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 11]
 Output [4]: [ws_ship_date_sk#1, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
-Input [6]: [ws_ship_date_sk#1, ws_web_site_sk#3, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, web_site_sk#22]
+Input [6]: [ws_ship_date_sk#1, ws_web_site_sk#3, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, web_site_sk#19]
 
 (34) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#24, d_date#25]
+Output [2]: [d_date_sk#21, d_date#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-01), LessThanOrEqual(d_date,1999-04-02), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (35) ColumnarToRow [codegen id : 10]
-Input [2]: [d_date_sk#24, d_date#25]
+Input [2]: [d_date_sk#21, d_date#22]
 
 (36) Filter [codegen id : 10]
-Input [2]: [d_date_sk#24, d_date#25]
-Condition : (((isnotnull(d_date#25) AND (d_date#25 >= 1999-02-01)) AND (d_date#25 <= 1999-04-02)) AND isnotnull(d_date_sk#24))
+Input [2]: [d_date_sk#21, d_date#22]
+Condition : (((isnotnull(d_date#22) AND (d_date#22 >= 1999-02-01)) AND (d_date#22 <= 1999-04-02)) AND isnotnull(d_date_sk#21))
 
 (37) Project [codegen id : 10]
-Output [1]: [d_date_sk#24]
-Input [2]: [d_date_sk#24, d_date#25]
+Output [1]: [d_date_sk#21]
+Input [2]: [d_date_sk#21, d_date#22]
 
 (38) BroadcastExchange
-Input [1]: [d_date_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+Input [1]: [d_date_sk#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_ship_date_sk#1]
-Right keys [1]: [d_date_sk#24]
+Right keys [1]: [d_date_sk#21]
 Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 11]
 Output [3]: [ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
-Input [5]: [ws_ship_date_sk#1, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, d_date_sk#24]
+Input [5]: [ws_ship_date_sk#1, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, d_date_sk#21]
 
 (41) HashAggregate [codegen id : 11]
 Input [3]: [ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
 Keys [1]: [ws_order_number#5]
 Functions [2]: [partial_sum(UnscaledValue(ws_ext_ship_cost#6)), partial_sum(UnscaledValue(ws_net_profit#7))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#6))#26, sum(UnscaledValue(ws_net_profit#7))#27]
-Results [3]: [ws_order_number#5, sum#28, sum#29]
+Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#6))#23, sum(UnscaledValue(ws_net_profit#7))#24]
+Results [3]: [ws_order_number#5, sum#25, sum#26]
 
 (42) HashAggregate [codegen id : 11]
-Input [3]: [ws_order_number#5, sum#28, sum#29]
+Input [3]: [ws_order_number#5, sum#25, sum#26]
 Keys [1]: [ws_order_number#5]
 Functions [2]: [merge_sum(UnscaledValue(ws_ext_ship_cost#6)), merge_sum(UnscaledValue(ws_net_profit#7))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#6))#26, sum(UnscaledValue(ws_net_profit#7))#27]
-Results [3]: [ws_order_number#5, sum#28, sum#29]
+Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#6))#23, sum(UnscaledValue(ws_net_profit#7))#24]
+Results [3]: [ws_order_number#5, sum#25, sum#26]
 
 (43) HashAggregate [codegen id : 11]
-Input [3]: [ws_order_number#5, sum#28, sum#29]
+Input [3]: [ws_order_number#5, sum#25, sum#26]
 Keys: []
 Functions [3]: [merge_sum(UnscaledValue(ws_ext_ship_cost#6)), merge_sum(UnscaledValue(ws_net_profit#7)), partial_count(distinct ws_order_number#5)]
-Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#6))#26, sum(UnscaledValue(ws_net_profit#7))#27, count(ws_order_number#5)#30]
-Results [3]: [sum#28, sum#29, count#31]
+Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#6))#23, sum(UnscaledValue(ws_net_profit#7))#24, count(ws_order_number#5)#27]
+Results [3]: [sum#25, sum#26, count#28]
 
 (44) Exchange
-Input [3]: [sum#28, sum#29, count#31]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
+Input [3]: [sum#25, sum#26, count#28]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
 
 (45) HashAggregate [codegen id : 12]
-Input [3]: [sum#28, sum#29, count#31]
+Input [3]: [sum#25, sum#26, count#28]
 Keys: []
 Functions [3]: [sum(UnscaledValue(ws_ext_ship_cost#6)), sum(UnscaledValue(ws_net_profit#7)), count(distinct ws_order_number#5)]
-Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#6))#26, sum(UnscaledValue(ws_net_profit#7))#27, count(ws_order_number#5)#30]
-Results [3]: [count(ws_order_number#5)#30 AS order count #32, MakeDecimal(sum(UnscaledValue(ws_ext_ship_cost#6))#26,17,2) AS total shipping cost #33, MakeDecimal(sum(UnscaledValue(ws_net_profit#7))#27,17,2) AS total net profit #34]
+Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#6))#23, sum(UnscaledValue(ws_net_profit#7))#24, count(ws_order_number#5)#27]
+Results [3]: [count(ws_order_number#5)#27 AS order count #29, MakeDecimal(sum(UnscaledValue(ws_ext_ship_cost#6))#23,17,2) AS total shipping cost #30, MakeDecimal(sum(UnscaledValue(ws_net_profit#7))#24,17,2) AS total net profit #31]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#9, [id=#10]
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#9, [id=#1]
 ObjectHashAggregate (52)
 +- Exchange (51)
    +- ObjectHashAggregate (50)
@@ -271,42 +271,42 @@ ObjectHashAggregate (52)
 
 
 (46) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#20, ca_state#21]
+Output [2]: [ca_address_sk#17, ca_state#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
 (47) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#20, ca_state#21]
+Input [2]: [ca_address_sk#17, ca_state#18]
 
 (48) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#20, ca_state#21]
-Condition : ((isnotnull(ca_state#21) AND (ca_state#21 = IL)) AND isnotnull(ca_address_sk#20))
+Input [2]: [ca_address_sk#17, ca_state#18]
+Condition : ((isnotnull(ca_state#18) AND (ca_state#18 = IL)) AND isnotnull(ca_address_sk#17))
 
 (49) Project [codegen id : 1]
-Output [1]: [ca_address_sk#20]
-Input [2]: [ca_address_sk#20, ca_state#21]
+Output [1]: [ca_address_sk#17]
+Input [2]: [ca_address_sk#17, ca_state#18]
 
 (50) ObjectHashAggregate
-Input [1]: [ca_address_sk#20]
+Input [1]: [ca_address_sk#17]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)]
-Aggregate Attributes [1]: [buf#35]
-Results [1]: [buf#36]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#17, 42), 17961, 333176, 0, 0)]
+Aggregate Attributes [1]: [buf#32]
+Results [1]: [buf#33]
 
 (51) Exchange
-Input [1]: [buf#36]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
+Input [1]: [buf#33]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
 
 (52) ObjectHashAggregate
-Input [1]: [buf#36]
+Input [1]: [buf#33]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)#37]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)#37 AS bloomFilter#38]
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#17, 42), 17961, 333176, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#17, 42), 17961, 333176, 0, 0)#34]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#17, 42), 17961, 333176, 0, 0)#34 AS bloomFilter#35]
 
-Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#11, [id=#12]
+Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#10, [id=#2]
 ObjectHashAggregate (59)
 +- Exchange (58)
    +- ObjectHashAggregate (57)
@@ -317,42 +317,42 @@ ObjectHashAggregate (59)
 
 
 (53) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#22, web_company_name#23]
+Output [2]: [web_site_sk#19, web_company_name#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_company_name), EqualTo(web_company_name,pri                                               ), IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_company_name:string>
 
 (54) ColumnarToRow [codegen id : 1]
-Input [2]: [web_site_sk#22, web_company_name#23]
+Input [2]: [web_site_sk#19, web_company_name#20]
 
 (55) Filter [codegen id : 1]
-Input [2]: [web_site_sk#22, web_company_name#23]
-Condition : ((isnotnull(web_company_name#23) AND (web_company_name#23 = pri                                               )) AND isnotnull(web_site_sk#22))
+Input [2]: [web_site_sk#19, web_company_name#20]
+Condition : ((isnotnull(web_company_name#20) AND (web_company_name#20 = pri                                               )) AND isnotnull(web_site_sk#19))
 
 (56) Project [codegen id : 1]
-Output [1]: [web_site_sk#22]
-Input [2]: [web_site_sk#22, web_company_name#23]
+Output [1]: [web_site_sk#19]
+Input [2]: [web_site_sk#19, web_company_name#20]
 
 (57) ObjectHashAggregate
-Input [1]: [web_site_sk#22]
+Input [1]: [web_site_sk#19]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(web_site_sk#22, 42), 4, 144, 0, 0)]
-Aggregate Attributes [1]: [buf#39]
-Results [1]: [buf#40]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(web_site_sk#19, 42), 4, 144, 0, 0)]
+Aggregate Attributes [1]: [buf#36]
+Results [1]: [buf#37]
 
 (58) Exchange
-Input [1]: [buf#40]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+Input [1]: [buf#37]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
 
 (59) ObjectHashAggregate
-Input [1]: [buf#40]
+Input [1]: [buf#37]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(web_site_sk#22, 42), 4, 144, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(web_site_sk#22, 42), 4, 144, 0, 0)#41]
-Results [1]: [bloom_filter_agg(xxhash64(web_site_sk#22, 42), 4, 144, 0, 0)#41 AS bloomFilter#42]
+Functions [1]: [bloom_filter_agg(xxhash64(web_site_sk#19, 42), 4, 144, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(web_site_sk#19, 42), 4, 144, 0, 0)#38]
+Results [1]: [bloom_filter_agg(xxhash64(web_site_sk#19, 42), 4, 144, 0, 0)#38 AS bloomFilter#39]
 
-Subquery:3 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
+Subquery:3 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#11, [id=#3]
 ObjectHashAggregate (66)
 +- Exchange (65)
    +- ObjectHashAggregate (64)
@@ -363,39 +363,39 @@ ObjectHashAggregate (66)
 
 
 (60) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#24, d_date#25]
+Output [2]: [d_date_sk#21, d_date#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-01), LessThanOrEqual(d_date,1999-04-02), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (61) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#24, d_date#25]
+Input [2]: [d_date_sk#21, d_date#22]
 
 (62) Filter [codegen id : 1]
-Input [2]: [d_date_sk#24, d_date#25]
-Condition : (((isnotnull(d_date#25) AND (d_date#25 >= 1999-02-01)) AND (d_date#25 <= 1999-04-02)) AND isnotnull(d_date_sk#24))
+Input [2]: [d_date_sk#21, d_date#22]
+Condition : (((isnotnull(d_date#22) AND (d_date#22 >= 1999-02-01)) AND (d_date#22 <= 1999-04-02)) AND isnotnull(d_date_sk#21))
 
 (63) Project [codegen id : 1]
-Output [1]: [d_date_sk#24]
-Input [2]: [d_date_sk#24, d_date#25]
+Output [1]: [d_date_sk#21]
+Input [2]: [d_date_sk#21, d_date#22]
 
 (64) ObjectHashAggregate
-Input [1]: [d_date_sk#24]
+Input [1]: [d_date_sk#21]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(d_date_sk#24, 42), 73049, 1141755, 0, 0)]
-Aggregate Attributes [1]: [buf#43]
-Results [1]: [buf#44]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(d_date_sk#21, 42), 73049, 1141755, 0, 0)]
+Aggregate Attributes [1]: [buf#40]
+Results [1]: [buf#41]
 
 (65) Exchange
-Input [1]: [buf#44]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
+Input [1]: [buf#41]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
 
 (66) ObjectHashAggregate
-Input [1]: [buf#44]
+Input [1]: [buf#41]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(d_date_sk#24, 42), 73049, 1141755, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_date_sk#24, 42), 73049, 1141755, 0, 0)#45]
-Results [1]: [bloom_filter_agg(xxhash64(d_date_sk#24, 42), 73049, 1141755, 0, 0)#45 AS bloomFilter#46]
+Functions [1]: [bloom_filter_agg(xxhash64(d_date_sk#21, 42), 73049, 1141755, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_date_sk#21, 42), 73049, 1141755, 0, 0)#42]
+Results [1]: [bloom_filter_agg(xxhash64(d_date_sk#21, 42), 73049, 1141755, 0, 0)#42 AS bloomFilter#43]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95.sf100/explain.txt
@@ -70,7 +70,7 @@ Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_num
 
 (3) Filter [codegen id : 1]
 Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, ws_sold_date_sk#7]
-Condition : (((((isnotnull(ws_ship_date_sk#1) AND isnotnull(ws_ship_addr_sk#2)) AND isnotnull(ws_web_site_sk#3)) AND might_contain(Subquery scalar-subquery#8, [id=#9], xxhash64(ws_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#10, [id=#11], xxhash64(ws_web_site_sk#3, 42))) AND might_contain(Subquery scalar-subquery#12, [id=#13], xxhash64(ws_ship_date_sk#1, 42)))
+Condition : (((((isnotnull(ws_ship_date_sk#1) AND isnotnull(ws_ship_addr_sk#2)) AND isnotnull(ws_web_site_sk#3)) AND might_contain(Subquery scalar-subquery#8, [id=#1], xxhash64(ws_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#9, [id=#2], xxhash64(ws_web_site_sk#3, 42))) AND might_contain(Subquery scalar-subquery#10, [id=#3], xxhash64(ws_ship_date_sk#1, 42)))
 
 (4) Project [codegen id : 1]
 Output [6]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
@@ -78,254 +78,254 @@ Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_num
 
 (5) Exchange
 Input [6]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
-Arguments: hashpartitioning(ws_order_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=1]
+Arguments: hashpartitioning(ws_order_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (6) Sort [codegen id : 2]
 Input [6]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Arguments: [ws_order_number#4 ASC NULLS FIRST], false, 0
 
 (7) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_warehouse_sk#14, ws_order_number#15, ws_sold_date_sk#16]
+Output [3]: [ws_warehouse_sk#11, ws_order_number#12, ws_sold_date_sk#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_order_number), IsNotNull(ws_warehouse_sk)]
 ReadSchema: struct<ws_warehouse_sk:int,ws_order_number:int>
 
 (8) ColumnarToRow [codegen id : 3]
-Input [3]: [ws_warehouse_sk#14, ws_order_number#15, ws_sold_date_sk#16]
+Input [3]: [ws_warehouse_sk#11, ws_order_number#12, ws_sold_date_sk#13]
 
 (9) Filter [codegen id : 3]
-Input [3]: [ws_warehouse_sk#14, ws_order_number#15, ws_sold_date_sk#16]
-Condition : (isnotnull(ws_order_number#15) AND isnotnull(ws_warehouse_sk#14))
+Input [3]: [ws_warehouse_sk#11, ws_order_number#12, ws_sold_date_sk#13]
+Condition : (isnotnull(ws_order_number#12) AND isnotnull(ws_warehouse_sk#11))
 
 (10) Project [codegen id : 3]
-Output [2]: [ws_warehouse_sk#14, ws_order_number#15]
-Input [3]: [ws_warehouse_sk#14, ws_order_number#15, ws_sold_date_sk#16]
+Output [2]: [ws_warehouse_sk#11, ws_order_number#12]
+Input [3]: [ws_warehouse_sk#11, ws_order_number#12, ws_sold_date_sk#13]
 
 (11) Exchange
-Input [2]: [ws_warehouse_sk#14, ws_order_number#15]
-Arguments: hashpartitioning(ws_order_number#15, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [2]: [ws_warehouse_sk#11, ws_order_number#12]
+Arguments: hashpartitioning(ws_order_number#12, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (12) Sort [codegen id : 4]
+Input [2]: [ws_warehouse_sk#11, ws_order_number#12]
+Arguments: [ws_order_number#12 ASC NULLS FIRST], false, 0
+
+(13) ReusedExchange [Reuses operator id: 11]
+Output [2]: [ws_warehouse_sk#14, ws_order_number#15]
+
+(14) Sort [codegen id : 6]
 Input [2]: [ws_warehouse_sk#14, ws_order_number#15]
 Arguments: [ws_order_number#15 ASC NULLS FIRST], false, 0
 
-(13) ReusedExchange [Reuses operator id: 11]
-Output [2]: [ws_warehouse_sk#17, ws_order_number#18]
-
-(14) Sort [codegen id : 6]
-Input [2]: [ws_warehouse_sk#17, ws_order_number#18]
-Arguments: [ws_order_number#18 ASC NULLS FIRST], false, 0
-
 (15) SortMergeJoin [codegen id : 7]
-Left keys [1]: [ws_order_number#15]
-Right keys [1]: [ws_order_number#18]
+Left keys [1]: [ws_order_number#12]
+Right keys [1]: [ws_order_number#15]
 Join type: Inner
-Join condition: NOT (ws_warehouse_sk#14 = ws_warehouse_sk#17)
+Join condition: NOT (ws_warehouse_sk#11 = ws_warehouse_sk#14)
 
 (16) Project [codegen id : 7]
-Output [1]: [ws_order_number#15]
-Input [4]: [ws_warehouse_sk#14, ws_order_number#15, ws_warehouse_sk#17, ws_order_number#18]
+Output [1]: [ws_order_number#12]
+Input [4]: [ws_warehouse_sk#11, ws_order_number#12, ws_warehouse_sk#14, ws_order_number#15]
 
 (17) SortMergeJoin [codegen id : 8]
 Left keys [1]: [ws_order_number#4]
-Right keys [1]: [ws_order_number#15]
+Right keys [1]: [ws_order_number#12]
 Join type: LeftSemi
 Join condition: None
 
 (18) Scan parquet spark_catalog.default.web_returns
-Output [2]: [wr_order_number#19, wr_returned_date_sk#20]
+Output [2]: [wr_order_number#16, wr_returned_date_sk#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_returns]
 PushedFilters: [IsNotNull(wr_order_number)]
 ReadSchema: struct<wr_order_number:int>
 
 (19) ColumnarToRow [codegen id : 9]
-Input [2]: [wr_order_number#19, wr_returned_date_sk#20]
+Input [2]: [wr_order_number#16, wr_returned_date_sk#17]
 
 (20) Filter [codegen id : 9]
-Input [2]: [wr_order_number#19, wr_returned_date_sk#20]
-Condition : isnotnull(wr_order_number#19)
+Input [2]: [wr_order_number#16, wr_returned_date_sk#17]
+Condition : isnotnull(wr_order_number#16)
 
 (21) Project [codegen id : 9]
-Output [1]: [wr_order_number#19]
-Input [2]: [wr_order_number#19, wr_returned_date_sk#20]
+Output [1]: [wr_order_number#16]
+Input [2]: [wr_order_number#16, wr_returned_date_sk#17]
 
 (22) Exchange
-Input [1]: [wr_order_number#19]
-Arguments: hashpartitioning(wr_order_number#19, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [1]: [wr_order_number#16]
+Arguments: hashpartitioning(wr_order_number#16, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (23) Sort [codegen id : 10]
-Input [1]: [wr_order_number#19]
-Arguments: [wr_order_number#19 ASC NULLS FIRST], false, 0
+Input [1]: [wr_order_number#16]
+Arguments: [wr_order_number#16 ASC NULLS FIRST], false, 0
 
 (24) ReusedExchange [Reuses operator id: 11]
-Output [2]: [ws_warehouse_sk#21, ws_order_number#22]
+Output [2]: [ws_warehouse_sk#18, ws_order_number#19]
 
 (25) Sort [codegen id : 12]
-Input [2]: [ws_warehouse_sk#21, ws_order_number#22]
-Arguments: [ws_order_number#22 ASC NULLS FIRST], false, 0
+Input [2]: [ws_warehouse_sk#18, ws_order_number#19]
+Arguments: [ws_order_number#19 ASC NULLS FIRST], false, 0
 
 (26) SortMergeJoin [codegen id : 13]
-Left keys [1]: [wr_order_number#19]
-Right keys [1]: [ws_order_number#22]
+Left keys [1]: [wr_order_number#16]
+Right keys [1]: [ws_order_number#19]
 Join type: Inner
 Join condition: None
 
 (27) ReusedExchange [Reuses operator id: 11]
-Output [2]: [ws_warehouse_sk#23, ws_order_number#24]
+Output [2]: [ws_warehouse_sk#20, ws_order_number#21]
 
 (28) Sort [codegen id : 15]
-Input [2]: [ws_warehouse_sk#23, ws_order_number#24]
-Arguments: [ws_order_number#24 ASC NULLS FIRST], false, 0
+Input [2]: [ws_warehouse_sk#20, ws_order_number#21]
+Arguments: [ws_order_number#21 ASC NULLS FIRST], false, 0
 
 (29) SortMergeJoin [codegen id : 16]
-Left keys [1]: [ws_order_number#22]
-Right keys [1]: [ws_order_number#24]
+Left keys [1]: [ws_order_number#19]
+Right keys [1]: [ws_order_number#21]
 Join type: Inner
-Join condition: NOT (ws_warehouse_sk#21 = ws_warehouse_sk#23)
+Join condition: NOT (ws_warehouse_sk#18 = ws_warehouse_sk#20)
 
 (30) Project [codegen id : 16]
-Output [1]: [wr_order_number#19]
-Input [5]: [wr_order_number#19, ws_warehouse_sk#21, ws_order_number#22, ws_warehouse_sk#23, ws_order_number#24]
+Output [1]: [wr_order_number#16]
+Input [5]: [wr_order_number#16, ws_warehouse_sk#18, ws_order_number#19, ws_warehouse_sk#20, ws_order_number#21]
 
 (31) SortMergeJoin [codegen id : 20]
 Left keys [1]: [ws_order_number#4]
-Right keys [1]: [wr_order_number#19]
+Right keys [1]: [wr_order_number#16]
 Join type: LeftSemi
 Join condition: None
 
 (32) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#25, ca_state#26]
+Output [2]: [ca_address_sk#22, ca_state#23]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
 (33) ColumnarToRow [codegen id : 17]
-Input [2]: [ca_address_sk#25, ca_state#26]
+Input [2]: [ca_address_sk#22, ca_state#23]
 
 (34) Filter [codegen id : 17]
-Input [2]: [ca_address_sk#25, ca_state#26]
-Condition : ((isnotnull(ca_state#26) AND (ca_state#26 = IL)) AND isnotnull(ca_address_sk#25))
+Input [2]: [ca_address_sk#22, ca_state#23]
+Condition : ((isnotnull(ca_state#23) AND (ca_state#23 = IL)) AND isnotnull(ca_address_sk#22))
 
 (35) Project [codegen id : 17]
-Output [1]: [ca_address_sk#25]
-Input [2]: [ca_address_sk#25, ca_state#26]
+Output [1]: [ca_address_sk#22]
+Input [2]: [ca_address_sk#22, ca_state#23]
 
 (36) BroadcastExchange
-Input [1]: [ca_address_sk#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+Input [1]: [ca_address_sk#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 (37) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_ship_addr_sk#2]
-Right keys [1]: [ca_address_sk#25]
+Right keys [1]: [ca_address_sk#22]
 Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 20]
 Output [5]: [ws_ship_date_sk#1, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
-Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, ca_address_sk#25]
+Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, ca_address_sk#22]
 
 (39) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#27, web_company_name#28]
+Output [2]: [web_site_sk#24, web_company_name#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_company_name), EqualTo(web_company_name,pri                                               ), IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_company_name:string>
 
 (40) ColumnarToRow [codegen id : 18]
-Input [2]: [web_site_sk#27, web_company_name#28]
+Input [2]: [web_site_sk#24, web_company_name#25]
 
 (41) Filter [codegen id : 18]
-Input [2]: [web_site_sk#27, web_company_name#28]
-Condition : ((isnotnull(web_company_name#28) AND (web_company_name#28 = pri                                               )) AND isnotnull(web_site_sk#27))
+Input [2]: [web_site_sk#24, web_company_name#25]
+Condition : ((isnotnull(web_company_name#25) AND (web_company_name#25 = pri                                               )) AND isnotnull(web_site_sk#24))
 
 (42) Project [codegen id : 18]
-Output [1]: [web_site_sk#27]
-Input [2]: [web_site_sk#27, web_company_name#28]
+Output [1]: [web_site_sk#24]
+Input [2]: [web_site_sk#24, web_company_name#25]
 
 (43) BroadcastExchange
-Input [1]: [web_site_sk#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+Input [1]: [web_site_sk#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
 (44) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_web_site_sk#3]
-Right keys [1]: [web_site_sk#27]
+Right keys [1]: [web_site_sk#24]
 Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 20]
 Output [4]: [ws_ship_date_sk#1, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
-Input [6]: [ws_ship_date_sk#1, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, web_site_sk#27]
+Input [6]: [ws_ship_date_sk#1, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, web_site_sk#24]
 
 (46) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#29, d_date#30]
+Output [2]: [d_date_sk#26, d_date#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-01), LessThanOrEqual(d_date,1999-04-02), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (47) ColumnarToRow [codegen id : 19]
-Input [2]: [d_date_sk#29, d_date#30]
+Input [2]: [d_date_sk#26, d_date#27]
 
 (48) Filter [codegen id : 19]
-Input [2]: [d_date_sk#29, d_date#30]
-Condition : (((isnotnull(d_date#30) AND (d_date#30 >= 1999-02-01)) AND (d_date#30 <= 1999-04-02)) AND isnotnull(d_date_sk#29))
+Input [2]: [d_date_sk#26, d_date#27]
+Condition : (((isnotnull(d_date#27) AND (d_date#27 >= 1999-02-01)) AND (d_date#27 <= 1999-04-02)) AND isnotnull(d_date_sk#26))
 
 (49) Project [codegen id : 19]
-Output [1]: [d_date_sk#29]
-Input [2]: [d_date_sk#29, d_date#30]
+Output [1]: [d_date_sk#26]
+Input [2]: [d_date_sk#26, d_date#27]
 
 (50) BroadcastExchange
-Input [1]: [d_date_sk#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+Input [1]: [d_date_sk#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
 (51) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_ship_date_sk#1]
-Right keys [1]: [d_date_sk#29]
+Right keys [1]: [d_date_sk#26]
 Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 20]
 Output [3]: [ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
-Input [5]: [ws_ship_date_sk#1, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, d_date_sk#29]
+Input [5]: [ws_ship_date_sk#1, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, d_date_sk#26]
 
 (53) HashAggregate [codegen id : 20]
 Input [3]: [ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Keys [1]: [ws_order_number#4]
 Functions [2]: [partial_sum(UnscaledValue(ws_ext_ship_cost#5)), partial_sum(UnscaledValue(ws_net_profit#6))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#5))#31, sum(UnscaledValue(ws_net_profit#6))#32]
-Results [3]: [ws_order_number#4, sum#33, sum#34]
+Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#5))#28, sum(UnscaledValue(ws_net_profit#6))#29]
+Results [3]: [ws_order_number#4, sum#30, sum#31]
 
 (54) HashAggregate [codegen id : 20]
-Input [3]: [ws_order_number#4, sum#33, sum#34]
+Input [3]: [ws_order_number#4, sum#30, sum#31]
 Keys [1]: [ws_order_number#4]
 Functions [2]: [merge_sum(UnscaledValue(ws_ext_ship_cost#5)), merge_sum(UnscaledValue(ws_net_profit#6))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#5))#31, sum(UnscaledValue(ws_net_profit#6))#32]
-Results [3]: [ws_order_number#4, sum#33, sum#34]
+Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#5))#28, sum(UnscaledValue(ws_net_profit#6))#29]
+Results [3]: [ws_order_number#4, sum#30, sum#31]
 
 (55) HashAggregate [codegen id : 20]
-Input [3]: [ws_order_number#4, sum#33, sum#34]
+Input [3]: [ws_order_number#4, sum#30, sum#31]
 Keys: []
 Functions [3]: [merge_sum(UnscaledValue(ws_ext_ship_cost#5)), merge_sum(UnscaledValue(ws_net_profit#6)), partial_count(distinct ws_order_number#4)]
-Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#5))#31, sum(UnscaledValue(ws_net_profit#6))#32, count(ws_order_number#4)#35]
-Results [3]: [sum#33, sum#34, count#36]
+Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#5))#28, sum(UnscaledValue(ws_net_profit#6))#29, count(ws_order_number#4)#32]
+Results [3]: [sum#30, sum#31, count#33]
 
 (56) Exchange
-Input [3]: [sum#33, sum#34, count#36]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
+Input [3]: [sum#30, sum#31, count#33]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
 
 (57) HashAggregate [codegen id : 21]
-Input [3]: [sum#33, sum#34, count#36]
+Input [3]: [sum#30, sum#31, count#33]
 Keys: []
 Functions [3]: [sum(UnscaledValue(ws_ext_ship_cost#5)), sum(UnscaledValue(ws_net_profit#6)), count(distinct ws_order_number#4)]
-Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#5))#31, sum(UnscaledValue(ws_net_profit#6))#32, count(ws_order_number#4)#35]
-Results [3]: [count(ws_order_number#4)#35 AS order count #37, MakeDecimal(sum(UnscaledValue(ws_ext_ship_cost#5))#31,17,2) AS total shipping cost #38, MakeDecimal(sum(UnscaledValue(ws_net_profit#6))#32,17,2) AS total net profit #39]
+Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#5))#28, sum(UnscaledValue(ws_net_profit#6))#29, count(ws_order_number#4)#32]
+Results [3]: [count(ws_order_number#4)#32 AS order count #34, MakeDecimal(sum(UnscaledValue(ws_ext_ship_cost#5))#28,17,2) AS total shipping cost #35, MakeDecimal(sum(UnscaledValue(ws_net_profit#6))#29,17,2) AS total net profit #36]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#8, [id=#9]
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#8, [id=#1]
 ObjectHashAggregate (64)
 +- Exchange (63)
    +- ObjectHashAggregate (62)
@@ -336,42 +336,42 @@ ObjectHashAggregate (64)
 
 
 (58) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#25, ca_state#26]
+Output [2]: [ca_address_sk#22, ca_state#23]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
 (59) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#25, ca_state#26]
+Input [2]: [ca_address_sk#22, ca_state#23]
 
 (60) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#25, ca_state#26]
-Condition : ((isnotnull(ca_state#26) AND (ca_state#26 = IL)) AND isnotnull(ca_address_sk#25))
+Input [2]: [ca_address_sk#22, ca_state#23]
+Condition : ((isnotnull(ca_state#23) AND (ca_state#23 = IL)) AND isnotnull(ca_address_sk#22))
 
 (61) Project [codegen id : 1]
-Output [1]: [ca_address_sk#25]
-Input [2]: [ca_address_sk#25, ca_state#26]
+Output [1]: [ca_address_sk#22]
+Input [2]: [ca_address_sk#22, ca_state#23]
 
 (62) ObjectHashAggregate
-Input [1]: [ca_address_sk#25]
+Input [1]: [ca_address_sk#22]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#25, 42), 17961, 333176, 0, 0)]
-Aggregate Attributes [1]: [buf#40]
-Results [1]: [buf#41]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#22, 42), 17961, 333176, 0, 0)]
+Aggregate Attributes [1]: [buf#37]
+Results [1]: [buf#38]
 
 (63) Exchange
-Input [1]: [buf#41]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
+Input [1]: [buf#38]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
 
 (64) ObjectHashAggregate
-Input [1]: [buf#41]
+Input [1]: [buf#38]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#25, 42), 17961, 333176, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#25, 42), 17961, 333176, 0, 0)#42]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#25, 42), 17961, 333176, 0, 0)#42 AS bloomFilter#43]
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#22, 42), 17961, 333176, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#22, 42), 17961, 333176, 0, 0)#39]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#22, 42), 17961, 333176, 0, 0)#39 AS bloomFilter#40]
 
-Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#10, [id=#11]
+Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#9, [id=#2]
 ObjectHashAggregate (71)
 +- Exchange (70)
    +- ObjectHashAggregate (69)
@@ -382,42 +382,42 @@ ObjectHashAggregate (71)
 
 
 (65) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#27, web_company_name#28]
+Output [2]: [web_site_sk#24, web_company_name#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_company_name), EqualTo(web_company_name,pri                                               ), IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_company_name:string>
 
 (66) ColumnarToRow [codegen id : 1]
-Input [2]: [web_site_sk#27, web_company_name#28]
+Input [2]: [web_site_sk#24, web_company_name#25]
 
 (67) Filter [codegen id : 1]
-Input [2]: [web_site_sk#27, web_company_name#28]
-Condition : ((isnotnull(web_company_name#28) AND (web_company_name#28 = pri                                               )) AND isnotnull(web_site_sk#27))
+Input [2]: [web_site_sk#24, web_company_name#25]
+Condition : ((isnotnull(web_company_name#25) AND (web_company_name#25 = pri                                               )) AND isnotnull(web_site_sk#24))
 
 (68) Project [codegen id : 1]
-Output [1]: [web_site_sk#27]
-Input [2]: [web_site_sk#27, web_company_name#28]
+Output [1]: [web_site_sk#24]
+Input [2]: [web_site_sk#24, web_company_name#25]
 
 (69) ObjectHashAggregate
-Input [1]: [web_site_sk#27]
+Input [1]: [web_site_sk#24]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(web_site_sk#27, 42), 4, 144, 0, 0)]
-Aggregate Attributes [1]: [buf#44]
-Results [1]: [buf#45]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(web_site_sk#24, 42), 4, 144, 0, 0)]
+Aggregate Attributes [1]: [buf#41]
+Results [1]: [buf#42]
 
 (70) Exchange
-Input [1]: [buf#45]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+Input [1]: [buf#42]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
 
 (71) ObjectHashAggregate
-Input [1]: [buf#45]
+Input [1]: [buf#42]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(web_site_sk#27, 42), 4, 144, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(web_site_sk#27, 42), 4, 144, 0, 0)#46]
-Results [1]: [bloom_filter_agg(xxhash64(web_site_sk#27, 42), 4, 144, 0, 0)#46 AS bloomFilter#47]
+Functions [1]: [bloom_filter_agg(xxhash64(web_site_sk#24, 42), 4, 144, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(web_site_sk#24, 42), 4, 144, 0, 0)#43]
+Results [1]: [bloom_filter_agg(xxhash64(web_site_sk#24, 42), 4, 144, 0, 0)#43 AS bloomFilter#44]
 
-Subquery:3 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#12, [id=#13]
+Subquery:3 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#10, [id=#3]
 ObjectHashAggregate (78)
 +- Exchange (77)
    +- ObjectHashAggregate (76)
@@ -428,39 +428,39 @@ ObjectHashAggregate (78)
 
 
 (72) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#29, d_date#30]
+Output [2]: [d_date_sk#26, d_date#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-01), LessThanOrEqual(d_date,1999-04-02), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (73) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#29, d_date#30]
+Input [2]: [d_date_sk#26, d_date#27]
 
 (74) Filter [codegen id : 1]
-Input [2]: [d_date_sk#29, d_date#30]
-Condition : (((isnotnull(d_date#30) AND (d_date#30 >= 1999-02-01)) AND (d_date#30 <= 1999-04-02)) AND isnotnull(d_date_sk#29))
+Input [2]: [d_date_sk#26, d_date#27]
+Condition : (((isnotnull(d_date#27) AND (d_date#27 >= 1999-02-01)) AND (d_date#27 <= 1999-04-02)) AND isnotnull(d_date_sk#26))
 
 (75) Project [codegen id : 1]
-Output [1]: [d_date_sk#29]
-Input [2]: [d_date_sk#29, d_date#30]
+Output [1]: [d_date_sk#26]
+Input [2]: [d_date_sk#26, d_date#27]
 
 (76) ObjectHashAggregate
-Input [1]: [d_date_sk#29]
+Input [1]: [d_date_sk#26]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(d_date_sk#29, 42), 73049, 1141755, 0, 0)]
-Aggregate Attributes [1]: [buf#48]
-Results [1]: [buf#49]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(d_date_sk#26, 42), 73049, 1141755, 0, 0)]
+Aggregate Attributes [1]: [buf#45]
+Results [1]: [buf#46]
 
 (77) Exchange
-Input [1]: [buf#49]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
+Input [1]: [buf#46]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
 
 (78) ObjectHashAggregate
-Input [1]: [buf#49]
+Input [1]: [buf#46]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(d_date_sk#29, 42), 73049, 1141755, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_date_sk#29, 42), 73049, 1141755, 0, 0)#50]
-Results [1]: [bloom_filter_agg(xxhash64(d_date_sk#29, 42), 73049, 1141755, 0, 0)#50 AS bloomFilter#51]
+Functions [1]: [bloom_filter_agg(xxhash64(d_date_sk#26, 42), 73049, 1141755, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_date_sk#26, 42), 73049, 1141755, 0, 0)#47]
+Results [1]: [bloom_filter_agg(xxhash64(d_date_sk#26, 42), 73049, 1141755, 0, 0)#47 AS bloomFilter#48]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/explain.txt
@@ -58,112 +58,112 @@ Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
-Condition : ((isnotnull(c_current_addr_sk#3) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(Subquery scalar-subquery#4, [id=#5], xxhash64(c_current_addr_sk#3, 42)))
+Condition : ((isnotnull(c_current_addr_sk#3) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(Subquery scalar-subquery#4, [id=#1], xxhash64(c_current_addr_sk#3, 42)))
 
 (4) Exchange
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
-Arguments: hashpartitioning(c_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
+Arguments: hashpartitioning(c_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (5) Sort [codegen id : 2]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 Arguments: [c_customer_sk#1 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.store_sales
-Output [2]: [ss_customer_sk#6, ss_sold_date_sk#7]
+Output [2]: [ss_customer_sk#5, ss_sold_date_sk#6]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#7), dynamicpruningexpression(ss_sold_date_sk#7 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#6), dynamicpruningexpression(ss_sold_date_sk#6 IN dynamicpruning#7)]
 ReadSchema: struct<ss_customer_sk:int>
 
 (7) ColumnarToRow [codegen id : 4]
-Input [2]: [ss_customer_sk#6, ss_sold_date_sk#7]
+Input [2]: [ss_customer_sk#5, ss_sold_date_sk#6]
 
 (8) ReusedExchange [Reuses operator id: 57]
-Output [1]: [d_date_sk#9]
+Output [1]: [d_date_sk#8]
 
 (9) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#7]
-Right keys [1]: [d_date_sk#9]
+Left keys [1]: [ss_sold_date_sk#6]
+Right keys [1]: [d_date_sk#8]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
-Output [1]: [ss_customer_sk#6]
-Input [3]: [ss_customer_sk#6, ss_sold_date_sk#7, d_date_sk#9]
+Output [1]: [ss_customer_sk#5]
+Input [3]: [ss_customer_sk#5, ss_sold_date_sk#6, d_date_sk#8]
 
 (11) Exchange
-Input [1]: [ss_customer_sk#6]
-Arguments: hashpartitioning(ss_customer_sk#6, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [1]: [ss_customer_sk#5]
+Arguments: hashpartitioning(ss_customer_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (12) Sort [codegen id : 5]
-Input [1]: [ss_customer_sk#6]
-Arguments: [ss_customer_sk#6 ASC NULLS FIRST], false, 0
+Input [1]: [ss_customer_sk#5]
+Arguments: [ss_customer_sk#5 ASC NULLS FIRST], false, 0
 
 (13) SortMergeJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#1]
-Right keys [1]: [ss_customer_sk#6]
+Right keys [1]: [ss_customer_sk#5]
 Join type: LeftSemi
 Join condition: None
 
 (14) Scan parquet spark_catalog.default.web_sales
-Output [2]: [ws_bill_customer_sk#10, ws_sold_date_sk#11]
+Output [2]: [ws_bill_customer_sk#9, ws_sold_date_sk#10]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#11), dynamicpruningexpression(ws_sold_date_sk#11 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#10), dynamicpruningexpression(ws_sold_date_sk#10 IN dynamicpruning#7)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
 (15) ColumnarToRow [codegen id : 8]
-Input [2]: [ws_bill_customer_sk#10, ws_sold_date_sk#11]
+Input [2]: [ws_bill_customer_sk#9, ws_sold_date_sk#10]
 
 (16) ReusedExchange [Reuses operator id: 57]
-Output [1]: [d_date_sk#12]
+Output [1]: [d_date_sk#11]
 
 (17) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ws_sold_date_sk#11]
-Right keys [1]: [d_date_sk#12]
+Left keys [1]: [ws_sold_date_sk#10]
+Right keys [1]: [d_date_sk#11]
 Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 8]
-Output [1]: [ws_bill_customer_sk#10 AS customer_sk#13]
-Input [3]: [ws_bill_customer_sk#10, ws_sold_date_sk#11, d_date_sk#12]
+Output [1]: [ws_bill_customer_sk#9 AS customer_sk#12]
+Input [3]: [ws_bill_customer_sk#9, ws_sold_date_sk#10, d_date_sk#11]
 
 (19) Scan parquet spark_catalog.default.catalog_sales
-Output [2]: [cs_ship_customer_sk#14, cs_sold_date_sk#15]
+Output [2]: [cs_ship_customer_sk#13, cs_sold_date_sk#14]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#15), dynamicpruningexpression(cs_sold_date_sk#15 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#14), dynamicpruningexpression(cs_sold_date_sk#14 IN dynamicpruning#7)]
 ReadSchema: struct<cs_ship_customer_sk:int>
 
 (20) ColumnarToRow [codegen id : 10]
-Input [2]: [cs_ship_customer_sk#14, cs_sold_date_sk#15]
+Input [2]: [cs_ship_customer_sk#13, cs_sold_date_sk#14]
 
 (21) ReusedExchange [Reuses operator id: 57]
-Output [1]: [d_date_sk#16]
+Output [1]: [d_date_sk#15]
 
 (22) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [cs_sold_date_sk#15]
-Right keys [1]: [d_date_sk#16]
+Left keys [1]: [cs_sold_date_sk#14]
+Right keys [1]: [d_date_sk#15]
 Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 10]
-Output [1]: [cs_ship_customer_sk#14 AS customer_sk#17]
-Input [3]: [cs_ship_customer_sk#14, cs_sold_date_sk#15, d_date_sk#16]
+Output [1]: [cs_ship_customer_sk#13 AS customer_sk#16]
+Input [3]: [cs_ship_customer_sk#13, cs_sold_date_sk#14, d_date_sk#15]
 
 (24) Union
 
 (25) Exchange
-Input [1]: [customer_sk#13]
-Arguments: hashpartitioning(customer_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [1]: [customer_sk#12]
+Arguments: hashpartitioning(customer_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (26) Sort [codegen id : 11]
-Input [1]: [customer_sk#13]
-Arguments: [customer_sk#13 ASC NULLS FIRST], false, 0
+Input [1]: [customer_sk#12]
+Arguments: [customer_sk#12 ASC NULLS FIRST], false, 0
 
 (27) SortMergeJoin [codegen id : 13]
 Left keys [1]: [c_customer_sk#1]
-Right keys [1]: [customer_sk#13]
+Right keys [1]: [customer_sk#12]
 Join type: LeftSemi
 Join condition: None
 
@@ -172,90 +172,90 @@ Output [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
 (29) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#18, ca_county#19]
+Output [2]: [ca_address_sk#17, ca_county#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Douglas County,Gaines County,Richland County,Walker County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
 (30) ColumnarToRow [codegen id : 12]
-Input [2]: [ca_address_sk#18, ca_county#19]
+Input [2]: [ca_address_sk#17, ca_county#18]
 
 (31) Filter [codegen id : 12]
-Input [2]: [ca_address_sk#18, ca_county#19]
-Condition : (ca_county#19 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#18))
+Input [2]: [ca_address_sk#17, ca_county#18]
+Condition : (ca_county#18 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#17))
 
 (32) Project [codegen id : 12]
-Output [1]: [ca_address_sk#18]
-Input [2]: [ca_address_sk#18, ca_county#19]
+Output [1]: [ca_address_sk#17]
+Input [2]: [ca_address_sk#17, ca_county#18]
 
 (33) BroadcastExchange
-Input [1]: [ca_address_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+Input [1]: [ca_address_sk#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 (34) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [c_current_addr_sk#3]
-Right keys [1]: [ca_address_sk#18]
+Right keys [1]: [ca_address_sk#17]
 Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 13]
 Output [1]: [c_current_cdemo_sk#2]
-Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#18]
+Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#17]
 
 (36) BroadcastExchange
 Input [1]: [c_current_cdemo_sk#2]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
 (37) Scan parquet spark_catalog.default.customer_demographics
-Output [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Output [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string,cd_purchase_estimate:int,cd_credit_rating:string,cd_dep_count:int,cd_dep_employed_count:int,cd_dep_college_count:int>
 
 (38) ColumnarToRow
-Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Input [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 
 (39) Filter
-Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Condition : isnotnull(cd_demo_sk#20)
+Input [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Condition : isnotnull(cd_demo_sk#19)
 
 (40) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_current_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#20]
+Right keys [1]: [cd_demo_sk#19]
 Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 14]
-Output [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Input [10]: [c_current_cdemo_sk#2, cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Output [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Input [10]: [c_current_cdemo_sk#2, cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 
 (42) HashAggregate [codegen id : 14]
-Input [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Input [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Keys [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#29]
-Results [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
+Aggregate Attributes [1]: [count#28]
+Results [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#29]
 
 (43) Exchange
-Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
-Arguments: hashpartitioning(cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#29]
+Arguments: hashpartitioning(cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
 (44) HashAggregate [codegen id : 15]
-Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
-Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Input [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#29]
+Keys [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#31]
-Results [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, count(1)#31 AS cnt1#32, cd_purchase_estimate#24, count(1)#31 AS cnt2#33, cd_credit_rating#25, count(1)#31 AS cnt3#34, cd_dep_count#26, count(1)#31 AS cnt4#35, cd_dep_employed_count#27, count(1)#31 AS cnt5#36, cd_dep_college_count#28, count(1)#31 AS cnt6#37]
+Aggregate Attributes [1]: [count(1)#30]
+Results [14]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, count(1)#30 AS cnt1#31, cd_purchase_estimate#23, count(1)#30 AS cnt2#32, cd_credit_rating#24, count(1)#30 AS cnt3#33, cd_dep_count#25, count(1)#30 AS cnt4#34, cd_dep_employed_count#26, count(1)#30 AS cnt5#35, cd_dep_college_count#27, count(1)#30 AS cnt6#36]
 
 (45) TakeOrderedAndProject
-Input [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
-Arguments: 100, [cd_gender#21 ASC NULLS FIRST, cd_marital_status#22 ASC NULLS FIRST, cd_education_status#23 ASC NULLS FIRST, cd_purchase_estimate#24 ASC NULLS FIRST, cd_credit_rating#25 ASC NULLS FIRST, cd_dep_count#26 ASC NULLS FIRST, cd_dep_employed_count#27 ASC NULLS FIRST, cd_dep_college_count#28 ASC NULLS FIRST], [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
+Input [14]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cnt1#31, cd_purchase_estimate#23, cnt2#32, cd_credit_rating#24, cnt3#33, cd_dep_count#25, cnt4#34, cd_dep_employed_count#26, cnt5#35, cd_dep_college_count#27, cnt6#36]
+Arguments: 100, [cd_gender#20 ASC NULLS FIRST, cd_marital_status#21 ASC NULLS FIRST, cd_education_status#22 ASC NULLS FIRST, cd_purchase_estimate#23 ASC NULLS FIRST, cd_credit_rating#24 ASC NULLS FIRST, cd_dep_count#25 ASC NULLS FIRST, cd_dep_employed_count#26 ASC NULLS FIRST, cd_dep_college_count#27 ASC NULLS FIRST], [cd_gender#20, cd_marital_status#21, cd_education_status#22, cnt1#31, cd_purchase_estimate#23, cnt2#32, cd_credit_rating#24, cnt3#33, cd_dep_count#25, cnt4#34, cd_dep_employed_count#26, cnt5#35, cd_dep_college_count#27, cnt6#36]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#4, [id=#5]
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#4, [id=#1]
 ObjectHashAggregate (52)
 +- Exchange (51)
    +- ObjectHashAggregate (50)
@@ -266,42 +266,42 @@ ObjectHashAggregate (52)
 
 
 (46) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#18, ca_county#19]
+Output [2]: [ca_address_sk#17, ca_county#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Douglas County,Gaines County,Richland County,Walker County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
 (47) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#18, ca_county#19]
+Input [2]: [ca_address_sk#17, ca_county#18]
 
 (48) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#18, ca_county#19]
-Condition : (ca_county#19 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#18))
+Input [2]: [ca_address_sk#17, ca_county#18]
+Condition : (ca_county#18 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#17))
 
 (49) Project [codegen id : 1]
-Output [1]: [ca_address_sk#18]
-Input [2]: [ca_address_sk#18, ca_county#19]
+Output [1]: [ca_address_sk#17]
+Input [2]: [ca_address_sk#17, ca_county#18]
 
 (50) ObjectHashAggregate
-Input [1]: [ca_address_sk#18]
+Input [1]: [ca_address_sk#17]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)]
-Aggregate Attributes [1]: [buf#38]
-Results [1]: [buf#39]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#17, 42), 2555, 57765, 0, 0)]
+Aggregate Attributes [1]: [buf#37]
+Results [1]: [buf#38]
 
 (51) Exchange
-Input [1]: [buf#39]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
+Input [1]: [buf#38]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
 (52) ObjectHashAggregate
-Input [1]: [buf#39]
+Input [1]: [buf#38]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)#40]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)#40 AS bloomFilter#41]
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#17, 42), 2555, 57765, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#17, 42), 2555, 57765, 0, 0)#39]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#17, 42), 2555, 57765, 0, 0)#39 AS bloomFilter#40]
 
-Subquery:2 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#7 IN dynamicpruning#8
+Subquery:2 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#6 IN dynamicpruning#7
 BroadcastExchange (57)
 +- * Project (56)
    +- * Filter (55)
@@ -310,29 +310,29 @@ BroadcastExchange (57)
 
 
 (53) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#9, d_year#42, d_moy#43]
+Output [3]: [d_date_sk#8, d_year#41, d_moy#42]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2002), GreaterThanOrEqual(d_moy,4), LessThanOrEqual(d_moy,7), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (54) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#42, d_moy#43]
+Input [3]: [d_date_sk#8, d_year#41, d_moy#42]
 
 (55) Filter [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#42, d_moy#43]
-Condition : (((((isnotnull(d_year#42) AND isnotnull(d_moy#43)) AND (d_year#42 = 2002)) AND (d_moy#43 >= 4)) AND (d_moy#43 <= 7)) AND isnotnull(d_date_sk#9))
+Input [3]: [d_date_sk#8, d_year#41, d_moy#42]
+Condition : (((((isnotnull(d_year#41) AND isnotnull(d_moy#42)) AND (d_year#41 = 2002)) AND (d_moy#42 >= 4)) AND (d_moy#42 <= 7)) AND isnotnull(d_date_sk#8))
 
 (56) Project [codegen id : 1]
-Output [1]: [d_date_sk#9]
-Input [3]: [d_date_sk#9, d_year#42, d_moy#43]
+Output [1]: [d_date_sk#8]
+Input [3]: [d_date_sk#8, d_year#41, d_moy#42]
 
 (57) BroadcastExchange
-Input [1]: [d_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+Input [1]: [d_date_sk#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
-Subquery:3 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#11 IN dynamicpruning#8
+Subquery:3 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#10 IN dynamicpruning#7
 
-Subquery:4 Hosting operator id = 19 Hosting Expression = cs_sold_date_sk#15 IN dynamicpruning#8
+Subquery:4 Hosting operator id = 19 Hosting Expression = cs_sold_date_sk#14 IN dynamicpruning#7
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/explain.txt
@@ -429,97 +429,97 @@ Results [6]: [store AS channel#49, i_brand_id#38, i_class_id#39, i_category_id#4
 
 (72) Filter [codegen id : 76]
 Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51]
-Condition : (isnotnull(sales#50) AND (cast(sales#50 as decimal(32,6)) > cast(Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
+Condition : (isnotnull(sales#50) AND (cast(sales#50 as decimal(32,6)) > cast(Subquery scalar-subquery#52, [id=#12] as decimal(32,6))))
 
 (73) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57]
+Output [4]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#57), dynamicpruningexpression(ss_sold_date_sk#57 IN dynamicpruning#58)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#56), dynamicpruningexpression(ss_sold_date_sk#56 IN dynamicpruning#57)]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (74) ColumnarToRow [codegen id : 74]
-Input [4]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57]
+Input [4]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56]
 
 (75) Filter [codegen id : 74]
-Input [4]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57]
-Condition : isnotnull(ss_item_sk#54)
+Input [4]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56]
+Condition : isnotnull(ss_item_sk#53)
 
 (76) ReusedExchange [Reuses operator id: 56]
-Output [1]: [ss_item_sk#59]
+Output [1]: [ss_item_sk#58]
 
 (77) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_item_sk#54]
-Right keys [1]: [ss_item_sk#59]
+Left keys [1]: [ss_item_sk#53]
+Right keys [1]: [ss_item_sk#58]
 Join type: LeftSemi
 Join condition: None
 
 (78) ReusedExchange [Reuses operator id: 128]
-Output [1]: [d_date_sk#60]
+Output [1]: [d_date_sk#59]
 
 (79) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_sold_date_sk#57]
-Right keys [1]: [d_date_sk#60]
+Left keys [1]: [ss_sold_date_sk#56]
+Right keys [1]: [d_date_sk#59]
 Join type: Inner
 Join condition: None
 
 (80) Project [codegen id : 74]
-Output [3]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56]
-Input [5]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57, d_date_sk#60]
+Output [3]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55]
+Input [5]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56, d_date_sk#59]
 
 (81) ReusedExchange [Reuses operator id: 66]
-Output [4]: [i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64]
+Output [4]: [i_item_sk#60, i_brand_id#61, i_class_id#62, i_category_id#63]
 
 (82) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_item_sk#54]
-Right keys [1]: [i_item_sk#61]
+Left keys [1]: [ss_item_sk#53]
+Right keys [1]: [i_item_sk#60]
 Join type: Inner
 Join condition: None
 
 (83) Project [codegen id : 74]
-Output [5]: [ss_quantity#55, ss_list_price#56, i_brand_id#62, i_class_id#63, i_category_id#64]
-Input [7]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64]
+Output [5]: [ss_quantity#54, ss_list_price#55, i_brand_id#61, i_class_id#62, i_category_id#63]
+Input [7]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, i_item_sk#60, i_brand_id#61, i_class_id#62, i_category_id#63]
 
 (84) HashAggregate [codegen id : 74]
-Input [5]: [ss_quantity#55, ss_list_price#56, i_brand_id#62, i_class_id#63, i_category_id#64]
-Keys [3]: [i_brand_id#62, i_class_id#63, i_category_id#64]
-Functions [2]: [partial_sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56)), partial_count(1)]
-Aggregate Attributes [3]: [sum#65, isEmpty#66, count#67]
-Results [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#68, isEmpty#69, count#70]
+Input [5]: [ss_quantity#54, ss_list_price#55, i_brand_id#61, i_class_id#62, i_category_id#63]
+Keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
+Functions [2]: [partial_sum((cast(ss_quantity#54 as decimal(10,0)) * ss_list_price#55)), partial_count(1)]
+Aggregate Attributes [3]: [sum#64, isEmpty#65, count#66]
+Results [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#67, isEmpty#68, count#69]
 
 (85) Exchange
-Input [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#68, isEmpty#69, count#70]
-Arguments: hashpartitioning(i_brand_id#62, i_class_id#63, i_category_id#64, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#67, isEmpty#68, count#69]
+Arguments: hashpartitioning(i_brand_id#61, i_class_id#62, i_category_id#63, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (86) HashAggregate [codegen id : 75]
-Input [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#68, isEmpty#69, count#70]
-Keys [3]: [i_brand_id#62, i_class_id#63, i_category_id#64]
-Functions [2]: [sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56)), count(1)]
-Aggregate Attributes [2]: [sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56))#71, count(1)#72]
-Results [6]: [store AS channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56))#71 AS sales#74, count(1)#72 AS number_sales#75]
+Input [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#67, isEmpty#68, count#69]
+Keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
+Functions [2]: [sum((cast(ss_quantity#54 as decimal(10,0)) * ss_list_price#55)), count(1)]
+Aggregate Attributes [2]: [sum((cast(ss_quantity#54 as decimal(10,0)) * ss_list_price#55))#70, count(1)#71]
+Results [6]: [store AS channel#72, i_brand_id#61, i_class_id#62, i_category_id#63, sum((cast(ss_quantity#54 as decimal(10,0)) * ss_list_price#55))#70 AS sales#73, count(1)#71 AS number_sales#74]
 
 (87) Filter [codegen id : 75]
-Input [6]: [channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
-Condition : (isnotnull(sales#74) AND (cast(sales#74 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
+Input [6]: [channel#72, i_brand_id#61, i_class_id#62, i_category_id#63, sales#73, number_sales#74]
+Condition : (isnotnull(sales#73) AND (cast(sales#73 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#12] as decimal(32,6))))
 
 (88) BroadcastExchange
-Input [6]: [channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
-Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [plan_id=13]
+Input [6]: [channel#72, i_brand_id#61, i_class_id#62, i_category_id#63, sales#73, number_sales#74]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [plan_id=14]
 
 (89) BroadcastHashJoin [codegen id : 76]
 Left keys [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
-Right keys [3]: [i_brand_id#62, i_class_id#63, i_category_id#64]
+Right keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
 Join type: Inner
 Join condition: None
 
 (90) TakeOrderedAndProject
-Input [12]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51, channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
-Arguments: 100, [i_brand_id#38 ASC NULLS FIRST, i_class_id#39 ASC NULLS FIRST, i_category_id#40 ASC NULLS FIRST], [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51, channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
+Input [12]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51, channel#72, i_brand_id#61, i_class_id#62, i_category_id#63, sales#73, number_sales#74]
+Arguments: 100, [i_brand_id#38 ASC NULLS FIRST, i_class_id#39 ASC NULLS FIRST, i_category_id#40 ASC NULLS FIRST], [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51, channel#72, i_brand_id#61, i_class_id#62, i_category_id#63, sales#73, number_sales#74]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 72 Hosting Expression = Subquery scalar-subquery#52, [id=#53]
+Subquery:1 Hosting operator id = 72 Hosting Expression = Subquery scalar-subquery#52, [id=#12]
 * HashAggregate (109)
 +- Exchange (108)
    +- * HashAggregate (107)
@@ -542,99 +542,99 @@ Subquery:1 Hosting operator id = 72 Hosting Expression = Subquery scalar-subquer
 
 
 (91) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_quantity#76, ss_list_price#77, ss_sold_date_sk#78]
+Output [3]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#78), dynamicpruningexpression(ss_sold_date_sk#78 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#77), dynamicpruningexpression(ss_sold_date_sk#77 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (92) ColumnarToRow [codegen id : 2]
-Input [3]: [ss_quantity#76, ss_list_price#77, ss_sold_date_sk#78]
+Input [3]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77]
 
 (93) ReusedExchange [Reuses operator id: 123]
-Output [1]: [d_date_sk#79]
+Output [1]: [d_date_sk#78]
 
 (94) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#78]
-Right keys [1]: [d_date_sk#79]
+Left keys [1]: [ss_sold_date_sk#77]
+Right keys [1]: [d_date_sk#78]
 Join type: Inner
 Join condition: None
 
 (95) Project [codegen id : 2]
-Output [2]: [ss_quantity#76 AS quantity#80, ss_list_price#77 AS list_price#81]
-Input [4]: [ss_quantity#76, ss_list_price#77, ss_sold_date_sk#78, d_date_sk#79]
+Output [2]: [ss_quantity#75 AS quantity#79, ss_list_price#76 AS list_price#80]
+Input [4]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77, d_date_sk#78]
 
 (96) Scan parquet spark_catalog.default.catalog_sales
-Output [3]: [cs_quantity#82, cs_list_price#83, cs_sold_date_sk#84]
+Output [3]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#84), dynamicpruningexpression(cs_sold_date_sk#84 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#83), dynamicpruningexpression(cs_sold_date_sk#83 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (97) ColumnarToRow [codegen id : 4]
-Input [3]: [cs_quantity#82, cs_list_price#83, cs_sold_date_sk#84]
+Input [3]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83]
 
 (98) ReusedExchange [Reuses operator id: 123]
-Output [1]: [d_date_sk#85]
+Output [1]: [d_date_sk#84]
 
 (99) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_sold_date_sk#84]
-Right keys [1]: [d_date_sk#85]
+Left keys [1]: [cs_sold_date_sk#83]
+Right keys [1]: [d_date_sk#84]
 Join type: Inner
 Join condition: None
 
 (100) Project [codegen id : 4]
-Output [2]: [cs_quantity#82 AS quantity#86, cs_list_price#83 AS list_price#87]
-Input [4]: [cs_quantity#82, cs_list_price#83, cs_sold_date_sk#84, d_date_sk#85]
+Output [2]: [cs_quantity#81 AS quantity#85, cs_list_price#82 AS list_price#86]
+Input [4]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83, d_date_sk#84]
 
 (101) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90]
+Output [3]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#90), dynamicpruningexpression(ws_sold_date_sk#90 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#89), dynamicpruningexpression(ws_sold_date_sk#89 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (102) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90]
+Input [3]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89]
 
 (103) ReusedExchange [Reuses operator id: 123]
-Output [1]: [d_date_sk#91]
+Output [1]: [d_date_sk#90]
 
 (104) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#90]
-Right keys [1]: [d_date_sk#91]
+Left keys [1]: [ws_sold_date_sk#89]
+Right keys [1]: [d_date_sk#90]
 Join type: Inner
 Join condition: None
 
 (105) Project [codegen id : 6]
-Output [2]: [ws_quantity#88 AS quantity#92, ws_list_price#89 AS list_price#93]
-Input [4]: [ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90, d_date_sk#91]
+Output [2]: [ws_quantity#87 AS quantity#91, ws_list_price#88 AS list_price#92]
+Input [4]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89, d_date_sk#90]
 
 (106) Union
 
 (107) HashAggregate [codegen id : 7]
-Input [2]: [quantity#80, list_price#81]
+Input [2]: [quantity#79, list_price#80]
 Keys: []
-Functions [1]: [partial_avg((cast(quantity#80 as decimal(10,0)) * list_price#81))]
-Aggregate Attributes [2]: [sum#94, count#95]
-Results [2]: [sum#96, count#97]
+Functions [1]: [partial_avg((cast(quantity#79 as decimal(10,0)) * list_price#80))]
+Aggregate Attributes [2]: [sum#93, count#94]
+Results [2]: [sum#95, count#96]
 
 (108) Exchange
-Input [2]: [sum#96, count#97]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
+Input [2]: [sum#95, count#96]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
 
 (109) HashAggregate [codegen id : 8]
-Input [2]: [sum#96, count#97]
+Input [2]: [sum#95, count#96]
 Keys: []
-Functions [1]: [avg((cast(quantity#80 as decimal(10,0)) * list_price#81))]
-Aggregate Attributes [1]: [avg((cast(quantity#80 as decimal(10,0)) * list_price#81))#98]
-Results [1]: [avg((cast(quantity#80 as decimal(10,0)) * list_price#81))#98 AS average_sales#99]
+Functions [1]: [avg((cast(quantity#79 as decimal(10,0)) * list_price#80))]
+Aggregate Attributes [1]: [avg((cast(quantity#79 as decimal(10,0)) * list_price#80))#97]
+Results [1]: [avg((cast(quantity#79 as decimal(10,0)) * list_price#80))#97 AS average_sales#98]
 
-Subquery:2 Hosting operator id = 91 Hosting Expression = ss_sold_date_sk#78 IN dynamicpruning#12
+Subquery:2 Hosting operator id = 91 Hosting Expression = ss_sold_date_sk#77 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 96 Hosting Expression = cs_sold_date_sk#84 IN dynamicpruning#12
+Subquery:3 Hosting operator id = 96 Hosting Expression = cs_sold_date_sk#83 IN dynamicpruning#12
 
-Subquery:4 Hosting operator id = 101 Hosting Expression = ws_sold_date_sk#90 IN dynamicpruning#12
+Subquery:4 Hosting operator id = 101 Hosting Expression = ws_sold_date_sk#89 IN dynamicpruning#12
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (114)
@@ -645,30 +645,30 @@ BroadcastExchange (114)
 
 
 (110) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#36, d_week_seq#100]
+Output [2]: [d_date_sk#36, d_week_seq#99]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#101), IsNotNull(d_date_sk)]
+PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#100), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
 (111) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#36, d_week_seq#100]
+Input [2]: [d_date_sk#36, d_week_seq#99]
 
 (112) Filter [codegen id : 1]
-Input [2]: [d_date_sk#36, d_week_seq#100]
-Condition : ((isnotnull(d_week_seq#100) AND (d_week_seq#100 = ReusedSubquery Subquery scalar-subquery#101, [id=#102])) AND isnotnull(d_date_sk#36))
+Input [2]: [d_date_sk#36, d_week_seq#99]
+Condition : ((isnotnull(d_week_seq#99) AND (d_week_seq#99 = ReusedSubquery Subquery scalar-subquery#100, [id=#16])) AND isnotnull(d_date_sk#36))
 
 (113) Project [codegen id : 1]
 Output [1]: [d_date_sk#36]
-Input [2]: [d_date_sk#36, d_week_seq#100]
+Input [2]: [d_date_sk#36, d_week_seq#99]
 
 (114) BroadcastExchange
 Input [1]: [d_date_sk#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=17]
 
-Subquery:6 Hosting operator id = 112 Hosting Expression = ReusedSubquery Subquery scalar-subquery#101, [id=#102]
+Subquery:6 Hosting operator id = 112 Hosting Expression = ReusedSubquery Subquery scalar-subquery#100, [id=#16]
 
-Subquery:7 Hosting operator id = 110 Hosting Expression = Subquery scalar-subquery#101, [id=#102]
+Subquery:7 Hosting operator id = 110 Hosting Expression = Subquery scalar-subquery#100, [id=#16]
 * Project (118)
 +- * Filter (117)
    +- * ColumnarToRow (116)
@@ -676,22 +676,22 @@ Subquery:7 Hosting operator id = 110 Hosting Expression = Subquery scalar-subque
 
 
 (115) Scan parquet spark_catalog.default.date_dim
-Output [4]: [d_week_seq#103, d_year#104, d_moy#105, d_dom#106]
+Output [4]: [d_week_seq#101, d_year#102, d_moy#103, d_dom#104]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,1999), EqualTo(d_moy,12), EqualTo(d_dom,16)]
 ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
 
 (116) ColumnarToRow [codegen id : 1]
-Input [4]: [d_week_seq#103, d_year#104, d_moy#105, d_dom#106]
+Input [4]: [d_week_seq#101, d_year#102, d_moy#103, d_dom#104]
 
 (117) Filter [codegen id : 1]
-Input [4]: [d_week_seq#103, d_year#104, d_moy#105, d_dom#106]
-Condition : (((((isnotnull(d_year#104) AND isnotnull(d_moy#105)) AND isnotnull(d_dom#106)) AND (d_year#104 = 1999)) AND (d_moy#105 = 12)) AND (d_dom#106 = 16))
+Input [4]: [d_week_seq#101, d_year#102, d_moy#103, d_dom#104]
+Condition : (((((isnotnull(d_year#102) AND isnotnull(d_moy#103)) AND isnotnull(d_dom#104)) AND (d_year#102 = 1999)) AND (d_moy#103 = 12)) AND (d_dom#104 = 16))
 
 (118) Project [codegen id : 1]
-Output [1]: [d_week_seq#103]
-Input [4]: [d_week_seq#103, d_year#104, d_moy#105, d_dom#106]
+Output [1]: [d_week_seq#101]
+Input [4]: [d_week_seq#101, d_year#102, d_moy#103, d_dom#104]
 
 Subquery:8 Hosting operator id = 7 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
 BroadcastExchange (123)
@@ -702,34 +702,34 @@ BroadcastExchange (123)
 
 
 (119) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#13, d_year#107]
+Output [2]: [d_date_sk#13, d_year#105]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1998), LessThanOrEqual(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (120) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#107]
+Input [2]: [d_date_sk#13, d_year#105]
 
 (121) Filter [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#107]
-Condition : (((isnotnull(d_year#107) AND (d_year#107 >= 1998)) AND (d_year#107 <= 2000)) AND isnotnull(d_date_sk#13))
+Input [2]: [d_date_sk#13, d_year#105]
+Condition : (((isnotnull(d_year#105) AND (d_year#105 >= 1998)) AND (d_year#105 <= 2000)) AND isnotnull(d_date_sk#13))
 
 (122) Project [codegen id : 1]
 Output [1]: [d_date_sk#13]
-Input [2]: [d_date_sk#13, d_year#107]
+Input [2]: [d_date_sk#13, d_year#105]
 
 (123) BroadcastExchange
 Input [1]: [d_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=18]
 
 Subquery:9 Hosting operator id = 18 Hosting Expression = cs_sold_date_sk#19 IN dynamicpruning#12
 
 Subquery:10 Hosting operator id = 41 Hosting Expression = ws_sold_date_sk#29 IN dynamicpruning#12
 
-Subquery:11 Hosting operator id = 87 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#53]
+Subquery:11 Hosting operator id = 87 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#12]
 
-Subquery:12 Hosting operator id = 73 Hosting Expression = ss_sold_date_sk#57 IN dynamicpruning#58
+Subquery:12 Hosting operator id = 73 Hosting Expression = ss_sold_date_sk#56 IN dynamicpruning#57
 BroadcastExchange (128)
 +- * Project (127)
    +- * Filter (126)
@@ -738,30 +738,30 @@ BroadcastExchange (128)
 
 
 (124) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#60, d_week_seq#108]
+Output [2]: [d_date_sk#59, d_week_seq#106]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#109), IsNotNull(d_date_sk)]
+PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#107), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
 (125) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#60, d_week_seq#108]
+Input [2]: [d_date_sk#59, d_week_seq#106]
 
 (126) Filter [codegen id : 1]
-Input [2]: [d_date_sk#60, d_week_seq#108]
-Condition : ((isnotnull(d_week_seq#108) AND (d_week_seq#108 = ReusedSubquery Subquery scalar-subquery#109, [id=#110])) AND isnotnull(d_date_sk#60))
+Input [2]: [d_date_sk#59, d_week_seq#106]
+Condition : ((isnotnull(d_week_seq#106) AND (d_week_seq#106 = ReusedSubquery Subquery scalar-subquery#107, [id=#19])) AND isnotnull(d_date_sk#59))
 
 (127) Project [codegen id : 1]
-Output [1]: [d_date_sk#60]
-Input [2]: [d_date_sk#60, d_week_seq#108]
+Output [1]: [d_date_sk#59]
+Input [2]: [d_date_sk#59, d_week_seq#106]
 
 (128) BroadcastExchange
-Input [1]: [d_date_sk#60]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=17]
+Input [1]: [d_date_sk#59]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=20]
 
-Subquery:13 Hosting operator id = 126 Hosting Expression = ReusedSubquery Subquery scalar-subquery#109, [id=#110]
+Subquery:13 Hosting operator id = 126 Hosting Expression = ReusedSubquery Subquery scalar-subquery#107, [id=#19]
 
-Subquery:14 Hosting operator id = 124 Hosting Expression = Subquery scalar-subquery#109, [id=#110]
+Subquery:14 Hosting operator id = 124 Hosting Expression = Subquery scalar-subquery#107, [id=#19]
 * Project (132)
 +- * Filter (131)
    +- * ColumnarToRow (130)
@@ -769,21 +769,21 @@ Subquery:14 Hosting operator id = 124 Hosting Expression = Subquery scalar-subqu
 
 
 (129) Scan parquet spark_catalog.default.date_dim
-Output [4]: [d_week_seq#111, d_year#112, d_moy#113, d_dom#114]
+Output [4]: [d_week_seq#108, d_year#109, d_moy#110, d_dom#111]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,1998), EqualTo(d_moy,12), EqualTo(d_dom,16)]
 ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
 
 (130) ColumnarToRow [codegen id : 1]
-Input [4]: [d_week_seq#111, d_year#112, d_moy#113, d_dom#114]
+Input [4]: [d_week_seq#108, d_year#109, d_moy#110, d_dom#111]
 
 (131) Filter [codegen id : 1]
-Input [4]: [d_week_seq#111, d_year#112, d_moy#113, d_dom#114]
-Condition : (((((isnotnull(d_year#112) AND isnotnull(d_moy#113)) AND isnotnull(d_dom#114)) AND (d_year#112 = 1998)) AND (d_moy#113 = 12)) AND (d_dom#114 = 16))
+Input [4]: [d_week_seq#108, d_year#109, d_moy#110, d_dom#111]
+Condition : (((((isnotnull(d_year#109) AND isnotnull(d_moy#110)) AND isnotnull(d_dom#111)) AND (d_year#109 = 1998)) AND (d_moy#110 = 12)) AND (d_dom#111 = 16))
 
 (132) Project [codegen id : 1]
-Output [1]: [d_week_seq#111]
-Input [4]: [d_week_seq#111, d_year#112, d_moy#113, d_dom#114]
+Output [1]: [d_week_seq#108]
+Input [4]: [d_week_seq#108, d_year#109, d_moy#110, d_dom#111]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14/explain.txt
@@ -399,97 +399,97 @@ Results [6]: [store AS channel#49, i_brand_id#37, i_class_id#38, i_category_id#3
 
 (66) Filter [codegen id : 52]
 Input [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51]
-Condition : (isnotnull(sales#50) AND (cast(sales#50 as decimal(32,6)) > cast(Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
+Condition : (isnotnull(sales#50) AND (cast(sales#50 as decimal(32,6)) > cast(Subquery scalar-subquery#52, [id=#10] as decimal(32,6))))
 
 (67) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57]
+Output [4]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#57), dynamicpruningexpression(ss_sold_date_sk#57 IN dynamicpruning#58)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#56), dynamicpruningexpression(ss_sold_date_sk#56 IN dynamicpruning#57)]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (68) ColumnarToRow [codegen id : 50]
-Input [4]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57]
+Input [4]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56]
 
 (69) Filter [codegen id : 50]
-Input [4]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57]
-Condition : isnotnull(ss_item_sk#54)
+Input [4]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56]
+Condition : isnotnull(ss_item_sk#53)
 
 (70) ReusedExchange [Reuses operator id: 50]
-Output [1]: [ss_item_sk#59]
+Output [1]: [ss_item_sk#58]
 
 (71) BroadcastHashJoin [codegen id : 50]
-Left keys [1]: [ss_item_sk#54]
-Right keys [1]: [ss_item_sk#59]
+Left keys [1]: [ss_item_sk#53]
+Right keys [1]: [ss_item_sk#58]
 Join type: LeftSemi
 Join condition: None
 
 (72) ReusedExchange [Reuses operator id: 57]
-Output [4]: [i_item_sk#60, i_brand_id#61, i_class_id#62, i_category_id#63]
+Output [4]: [i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
 
 (73) BroadcastHashJoin [codegen id : 50]
-Left keys [1]: [ss_item_sk#54]
-Right keys [1]: [i_item_sk#60]
+Left keys [1]: [ss_item_sk#53]
+Right keys [1]: [i_item_sk#59]
 Join type: Inner
 Join condition: None
 
 (74) Project [codegen id : 50]
-Output [6]: [ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57, i_brand_id#61, i_class_id#62, i_category_id#63]
-Input [8]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57, i_item_sk#60, i_brand_id#61, i_class_id#62, i_category_id#63]
+Output [6]: [ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56, i_brand_id#60, i_class_id#61, i_category_id#62]
+Input [8]: [ss_item_sk#53, ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56, i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
 
 (75) ReusedExchange [Reuses operator id: 122]
-Output [1]: [d_date_sk#64]
+Output [1]: [d_date_sk#63]
 
 (76) BroadcastHashJoin [codegen id : 50]
-Left keys [1]: [ss_sold_date_sk#57]
-Right keys [1]: [d_date_sk#64]
+Left keys [1]: [ss_sold_date_sk#56]
+Right keys [1]: [d_date_sk#63]
 Join type: Inner
 Join condition: None
 
 (77) Project [codegen id : 50]
-Output [5]: [ss_quantity#55, ss_list_price#56, i_brand_id#61, i_class_id#62, i_category_id#63]
-Input [7]: [ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57, i_brand_id#61, i_class_id#62, i_category_id#63, d_date_sk#64]
+Output [5]: [ss_quantity#54, ss_list_price#55, i_brand_id#60, i_class_id#61, i_category_id#62]
+Input [7]: [ss_quantity#54, ss_list_price#55, ss_sold_date_sk#56, i_brand_id#60, i_class_id#61, i_category_id#62, d_date_sk#63]
 
 (78) HashAggregate [codegen id : 50]
-Input [5]: [ss_quantity#55, ss_list_price#56, i_brand_id#61, i_class_id#62, i_category_id#63]
-Keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
-Functions [2]: [partial_sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56)), partial_count(1)]
-Aggregate Attributes [3]: [sum#65, isEmpty#66, count#67]
-Results [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#68, isEmpty#69, count#70]
+Input [5]: [ss_quantity#54, ss_list_price#55, i_brand_id#60, i_class_id#61, i_category_id#62]
+Keys [3]: [i_brand_id#60, i_class_id#61, i_category_id#62]
+Functions [2]: [partial_sum((cast(ss_quantity#54 as decimal(10,0)) * ss_list_price#55)), partial_count(1)]
+Aggregate Attributes [3]: [sum#64, isEmpty#65, count#66]
+Results [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#67, isEmpty#68, count#69]
 
 (79) Exchange
-Input [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#68, isEmpty#69, count#70]
-Arguments: hashpartitioning(i_brand_id#61, i_class_id#62, i_category_id#63, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#67, isEmpty#68, count#69]
+Arguments: hashpartitioning(i_brand_id#60, i_class_id#61, i_category_id#62, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (80) HashAggregate [codegen id : 51]
-Input [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#68, isEmpty#69, count#70]
-Keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
-Functions [2]: [sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56)), count(1)]
-Aggregate Attributes [2]: [sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56))#71, count(1)#72]
-Results [6]: [store AS channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56))#71 AS sales#74, count(1)#72 AS number_sales#75]
+Input [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#67, isEmpty#68, count#69]
+Keys [3]: [i_brand_id#60, i_class_id#61, i_category_id#62]
+Functions [2]: [sum((cast(ss_quantity#54 as decimal(10,0)) * ss_list_price#55)), count(1)]
+Aggregate Attributes [2]: [sum((cast(ss_quantity#54 as decimal(10,0)) * ss_list_price#55))#70, count(1)#71]
+Results [6]: [store AS channel#72, i_brand_id#60, i_class_id#61, i_category_id#62, sum((cast(ss_quantity#54 as decimal(10,0)) * ss_list_price#55))#70 AS sales#73, count(1)#71 AS number_sales#74]
 
 (81) Filter [codegen id : 51]
-Input [6]: [channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sales#74, number_sales#75]
-Condition : (isnotnull(sales#74) AND (cast(sales#74 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
+Input [6]: [channel#72, i_brand_id#60, i_class_id#61, i_category_id#62, sales#73, number_sales#74]
+Condition : (isnotnull(sales#73) AND (cast(sales#73 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#10] as decimal(32,6))))
 
 (82) BroadcastExchange
-Input [6]: [channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sales#74, number_sales#75]
-Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [plan_id=11]
+Input [6]: [channel#72, i_brand_id#60, i_class_id#61, i_category_id#62, sales#73, number_sales#74]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [plan_id=12]
 
 (83) BroadcastHashJoin [codegen id : 52]
 Left keys [3]: [i_brand_id#37, i_class_id#38, i_category_id#39]
-Right keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
+Right keys [3]: [i_brand_id#60, i_class_id#61, i_category_id#62]
 Join type: Inner
 Join condition: None
 
 (84) TakeOrderedAndProject
-Input [12]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51, channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sales#74, number_sales#75]
-Arguments: 100, [i_brand_id#37 ASC NULLS FIRST, i_class_id#38 ASC NULLS FIRST, i_category_id#39 ASC NULLS FIRST], [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51, channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sales#74, number_sales#75]
+Input [12]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51, channel#72, i_brand_id#60, i_class_id#61, i_category_id#62, sales#73, number_sales#74]
+Arguments: 100, [i_brand_id#37 ASC NULLS FIRST, i_class_id#38 ASC NULLS FIRST, i_category_id#39 ASC NULLS FIRST], [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51, channel#72, i_brand_id#60, i_class_id#61, i_category_id#62, sales#73, number_sales#74]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 66 Hosting Expression = Subquery scalar-subquery#52, [id=#53]
+Subquery:1 Hosting operator id = 66 Hosting Expression = Subquery scalar-subquery#52, [id=#10]
 * HashAggregate (103)
 +- Exchange (102)
    +- * HashAggregate (101)
@@ -512,99 +512,99 @@ Subquery:1 Hosting operator id = 66 Hosting Expression = Subquery scalar-subquer
 
 
 (85) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_quantity#76, ss_list_price#77, ss_sold_date_sk#78]
+Output [3]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#78), dynamicpruningexpression(ss_sold_date_sk#78 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#77), dynamicpruningexpression(ss_sold_date_sk#77 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (86) ColumnarToRow [codegen id : 2]
-Input [3]: [ss_quantity#76, ss_list_price#77, ss_sold_date_sk#78]
+Input [3]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77]
 
 (87) ReusedExchange [Reuses operator id: 117]
-Output [1]: [d_date_sk#79]
+Output [1]: [d_date_sk#78]
 
 (88) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#78]
-Right keys [1]: [d_date_sk#79]
+Left keys [1]: [ss_sold_date_sk#77]
+Right keys [1]: [d_date_sk#78]
 Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 2]
-Output [2]: [ss_quantity#76 AS quantity#80, ss_list_price#77 AS list_price#81]
-Input [4]: [ss_quantity#76, ss_list_price#77, ss_sold_date_sk#78, d_date_sk#79]
+Output [2]: [ss_quantity#75 AS quantity#79, ss_list_price#76 AS list_price#80]
+Input [4]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77, d_date_sk#78]
 
 (90) Scan parquet spark_catalog.default.catalog_sales
-Output [3]: [cs_quantity#82, cs_list_price#83, cs_sold_date_sk#84]
+Output [3]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#84), dynamicpruningexpression(cs_sold_date_sk#84 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#83), dynamicpruningexpression(cs_sold_date_sk#83 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (91) ColumnarToRow [codegen id : 4]
-Input [3]: [cs_quantity#82, cs_list_price#83, cs_sold_date_sk#84]
+Input [3]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83]
 
 (92) ReusedExchange [Reuses operator id: 117]
-Output [1]: [d_date_sk#85]
+Output [1]: [d_date_sk#84]
 
 (93) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_sold_date_sk#84]
-Right keys [1]: [d_date_sk#85]
+Left keys [1]: [cs_sold_date_sk#83]
+Right keys [1]: [d_date_sk#84]
 Join type: Inner
 Join condition: None
 
 (94) Project [codegen id : 4]
-Output [2]: [cs_quantity#82 AS quantity#86, cs_list_price#83 AS list_price#87]
-Input [4]: [cs_quantity#82, cs_list_price#83, cs_sold_date_sk#84, d_date_sk#85]
+Output [2]: [cs_quantity#81 AS quantity#85, cs_list_price#82 AS list_price#86]
+Input [4]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83, d_date_sk#84]
 
 (95) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90]
+Output [3]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#90), dynamicpruningexpression(ws_sold_date_sk#90 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#89), dynamicpruningexpression(ws_sold_date_sk#89 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (96) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90]
+Input [3]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89]
 
 (97) ReusedExchange [Reuses operator id: 117]
-Output [1]: [d_date_sk#91]
+Output [1]: [d_date_sk#90]
 
 (98) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#90]
-Right keys [1]: [d_date_sk#91]
+Left keys [1]: [ws_sold_date_sk#89]
+Right keys [1]: [d_date_sk#90]
 Join type: Inner
 Join condition: None
 
 (99) Project [codegen id : 6]
-Output [2]: [ws_quantity#88 AS quantity#92, ws_list_price#89 AS list_price#93]
-Input [4]: [ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90, d_date_sk#91]
+Output [2]: [ws_quantity#87 AS quantity#91, ws_list_price#88 AS list_price#92]
+Input [4]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89, d_date_sk#90]
 
 (100) Union
 
 (101) HashAggregate [codegen id : 7]
-Input [2]: [quantity#80, list_price#81]
+Input [2]: [quantity#79, list_price#80]
 Keys: []
-Functions [1]: [partial_avg((cast(quantity#80 as decimal(10,0)) * list_price#81))]
-Aggregate Attributes [2]: [sum#94, count#95]
-Results [2]: [sum#96, count#97]
+Functions [1]: [partial_avg((cast(quantity#79 as decimal(10,0)) * list_price#80))]
+Aggregate Attributes [2]: [sum#93, count#94]
+Results [2]: [sum#95, count#96]
 
 (102) Exchange
-Input [2]: [sum#96, count#97]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
+Input [2]: [sum#95, count#96]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
 
 (103) HashAggregate [codegen id : 8]
-Input [2]: [sum#96, count#97]
+Input [2]: [sum#95, count#96]
 Keys: []
-Functions [1]: [avg((cast(quantity#80 as decimal(10,0)) * list_price#81))]
-Aggregate Attributes [1]: [avg((cast(quantity#80 as decimal(10,0)) * list_price#81))#98]
-Results [1]: [avg((cast(quantity#80 as decimal(10,0)) * list_price#81))#98 AS average_sales#99]
+Functions [1]: [avg((cast(quantity#79 as decimal(10,0)) * list_price#80))]
+Aggregate Attributes [1]: [avg((cast(quantity#79 as decimal(10,0)) * list_price#80))#97]
+Results [1]: [avg((cast(quantity#79 as decimal(10,0)) * list_price#80))#97 AS average_sales#98]
 
-Subquery:2 Hosting operator id = 85 Hosting Expression = ss_sold_date_sk#78 IN dynamicpruning#12
+Subquery:2 Hosting operator id = 85 Hosting Expression = ss_sold_date_sk#77 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 90 Hosting Expression = cs_sold_date_sk#84 IN dynamicpruning#12
+Subquery:3 Hosting operator id = 90 Hosting Expression = cs_sold_date_sk#83 IN dynamicpruning#12
 
-Subquery:4 Hosting operator id = 95 Hosting Expression = ws_sold_date_sk#90 IN dynamicpruning#12
+Subquery:4 Hosting operator id = 95 Hosting Expression = ws_sold_date_sk#89 IN dynamicpruning#12
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (108)
@@ -615,30 +615,30 @@ BroadcastExchange (108)
 
 
 (104) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#40, d_week_seq#100]
+Output [2]: [d_date_sk#40, d_week_seq#99]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#101), IsNotNull(d_date_sk)]
+PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#100), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
 (105) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#40, d_week_seq#100]
+Input [2]: [d_date_sk#40, d_week_seq#99]
 
 (106) Filter [codegen id : 1]
-Input [2]: [d_date_sk#40, d_week_seq#100]
-Condition : ((isnotnull(d_week_seq#100) AND (d_week_seq#100 = ReusedSubquery Subquery scalar-subquery#101, [id=#102])) AND isnotnull(d_date_sk#40))
+Input [2]: [d_date_sk#40, d_week_seq#99]
+Condition : ((isnotnull(d_week_seq#99) AND (d_week_seq#99 = ReusedSubquery Subquery scalar-subquery#100, [id=#14])) AND isnotnull(d_date_sk#40))
 
 (107) Project [codegen id : 1]
 Output [1]: [d_date_sk#40]
-Input [2]: [d_date_sk#40, d_week_seq#100]
+Input [2]: [d_date_sk#40, d_week_seq#99]
 
 (108) BroadcastExchange
 Input [1]: [d_date_sk#40]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
 
-Subquery:6 Hosting operator id = 106 Hosting Expression = ReusedSubquery Subquery scalar-subquery#101, [id=#102]
+Subquery:6 Hosting operator id = 106 Hosting Expression = ReusedSubquery Subquery scalar-subquery#100, [id=#14]
 
-Subquery:7 Hosting operator id = 104 Hosting Expression = Subquery scalar-subquery#101, [id=#102]
+Subquery:7 Hosting operator id = 104 Hosting Expression = Subquery scalar-subquery#100, [id=#14]
 * Project (112)
 +- * Filter (111)
    +- * ColumnarToRow (110)
@@ -646,22 +646,22 @@ Subquery:7 Hosting operator id = 104 Hosting Expression = Subquery scalar-subque
 
 
 (109) Scan parquet spark_catalog.default.date_dim
-Output [4]: [d_week_seq#103, d_year#104, d_moy#105, d_dom#106]
+Output [4]: [d_week_seq#101, d_year#102, d_moy#103, d_dom#104]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,1999), EqualTo(d_moy,12), EqualTo(d_dom,16)]
 ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
 
 (110) ColumnarToRow [codegen id : 1]
-Input [4]: [d_week_seq#103, d_year#104, d_moy#105, d_dom#106]
+Input [4]: [d_week_seq#101, d_year#102, d_moy#103, d_dom#104]
 
 (111) Filter [codegen id : 1]
-Input [4]: [d_week_seq#103, d_year#104, d_moy#105, d_dom#106]
-Condition : (((((isnotnull(d_year#104) AND isnotnull(d_moy#105)) AND isnotnull(d_dom#106)) AND (d_year#104 = 1999)) AND (d_moy#105 = 12)) AND (d_dom#106 = 16))
+Input [4]: [d_week_seq#101, d_year#102, d_moy#103, d_dom#104]
+Condition : (((((isnotnull(d_year#102) AND isnotnull(d_moy#103)) AND isnotnull(d_dom#104)) AND (d_year#102 = 1999)) AND (d_moy#103 = 12)) AND (d_dom#104 = 16))
 
 (112) Project [codegen id : 1]
-Output [1]: [d_week_seq#103]
-Input [4]: [d_week_seq#103, d_year#104, d_moy#105, d_dom#106]
+Output [1]: [d_week_seq#101]
+Input [4]: [d_week_seq#101, d_year#102, d_moy#103, d_dom#104]
 
 Subquery:8 Hosting operator id = 7 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
 BroadcastExchange (117)
@@ -672,34 +672,34 @@ BroadcastExchange (117)
 
 
 (113) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#24, d_year#107]
+Output [2]: [d_date_sk#24, d_year#105]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1998), LessThanOrEqual(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (114) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#24, d_year#107]
+Input [2]: [d_date_sk#24, d_year#105]
 
 (115) Filter [codegen id : 1]
-Input [2]: [d_date_sk#24, d_year#107]
-Condition : (((isnotnull(d_year#107) AND (d_year#107 >= 1998)) AND (d_year#107 <= 2000)) AND isnotnull(d_date_sk#24))
+Input [2]: [d_date_sk#24, d_year#105]
+Condition : (((isnotnull(d_year#105) AND (d_year#105 >= 1998)) AND (d_year#105 <= 2000)) AND isnotnull(d_date_sk#24))
 
 (116) Project [codegen id : 1]
 Output [1]: [d_date_sk#24]
-Input [2]: [d_date_sk#24, d_year#107]
+Input [2]: [d_date_sk#24, d_year#105]
 
 (117) BroadcastExchange
 Input [1]: [d_date_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=16]
 
 Subquery:9 Hosting operator id = 13 Hosting Expression = cs_sold_date_sk#18 IN dynamicpruning#12
 
 Subquery:10 Hosting operator id = 36 Hosting Expression = ws_sold_date_sk#29 IN dynamicpruning#12
 
-Subquery:11 Hosting operator id = 81 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#53]
+Subquery:11 Hosting operator id = 81 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#10]
 
-Subquery:12 Hosting operator id = 67 Hosting Expression = ss_sold_date_sk#57 IN dynamicpruning#58
+Subquery:12 Hosting operator id = 67 Hosting Expression = ss_sold_date_sk#56 IN dynamicpruning#57
 BroadcastExchange (122)
 +- * Project (121)
    +- * Filter (120)
@@ -708,30 +708,30 @@ BroadcastExchange (122)
 
 
 (118) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#64, d_week_seq#108]
+Output [2]: [d_date_sk#63, d_week_seq#106]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#109), IsNotNull(d_date_sk)]
+PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#107), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
 (119) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#64, d_week_seq#108]
+Input [2]: [d_date_sk#63, d_week_seq#106]
 
 (120) Filter [codegen id : 1]
-Input [2]: [d_date_sk#64, d_week_seq#108]
-Condition : ((isnotnull(d_week_seq#108) AND (d_week_seq#108 = ReusedSubquery Subquery scalar-subquery#109, [id=#110])) AND isnotnull(d_date_sk#64))
+Input [2]: [d_date_sk#63, d_week_seq#106]
+Condition : ((isnotnull(d_week_seq#106) AND (d_week_seq#106 = ReusedSubquery Subquery scalar-subquery#107, [id=#17])) AND isnotnull(d_date_sk#63))
 
 (121) Project [codegen id : 1]
-Output [1]: [d_date_sk#64]
-Input [2]: [d_date_sk#64, d_week_seq#108]
+Output [1]: [d_date_sk#63]
+Input [2]: [d_date_sk#63, d_week_seq#106]
 
 (122) BroadcastExchange
-Input [1]: [d_date_sk#64]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
+Input [1]: [d_date_sk#63]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=18]
 
-Subquery:13 Hosting operator id = 120 Hosting Expression = ReusedSubquery Subquery scalar-subquery#109, [id=#110]
+Subquery:13 Hosting operator id = 120 Hosting Expression = ReusedSubquery Subquery scalar-subquery#107, [id=#17]
 
-Subquery:14 Hosting operator id = 118 Hosting Expression = Subquery scalar-subquery#109, [id=#110]
+Subquery:14 Hosting operator id = 118 Hosting Expression = Subquery scalar-subquery#107, [id=#17]
 * Project (126)
 +- * Filter (125)
    +- * ColumnarToRow (124)
@@ -739,21 +739,21 @@ Subquery:14 Hosting operator id = 118 Hosting Expression = Subquery scalar-subqu
 
 
 (123) Scan parquet spark_catalog.default.date_dim
-Output [4]: [d_week_seq#111, d_year#112, d_moy#113, d_dom#114]
+Output [4]: [d_week_seq#108, d_year#109, d_moy#110, d_dom#111]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,1998), EqualTo(d_moy,12), EqualTo(d_dom,16)]
 ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
 
 (124) ColumnarToRow [codegen id : 1]
-Input [4]: [d_week_seq#111, d_year#112, d_moy#113, d_dom#114]
+Input [4]: [d_week_seq#108, d_year#109, d_moy#110, d_dom#111]
 
 (125) Filter [codegen id : 1]
-Input [4]: [d_week_seq#111, d_year#112, d_moy#113, d_dom#114]
-Condition : (((((isnotnull(d_year#112) AND isnotnull(d_moy#113)) AND isnotnull(d_dom#114)) AND (d_year#112 = 1998)) AND (d_moy#113 = 12)) AND (d_dom#114 = 16))
+Input [4]: [d_week_seq#108, d_year#109, d_moy#110, d_dom#111]
+Condition : (((((isnotnull(d_year#109) AND isnotnull(d_moy#110)) AND isnotnull(d_dom#111)) AND (d_year#109 = 1998)) AND (d_moy#110 = 12)) AND (d_dom#111 = 16))
 
 (126) Project [codegen id : 1]
-Output [1]: [d_week_seq#111]
-Input [4]: [d_week_seq#111, d_year#112, d_moy#113, d_dom#114]
+Output [1]: [d_week_seq#108]
+Input [4]: [d_week_seq#108, d_year#109, d_moy#110, d_dom#111]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/explain.txt
@@ -470,151 +470,151 @@ Results [6]: [store AS channel#49, i_brand_id#38, i_class_id#39, i_category_id#4
 
 (72) Filter [codegen id : 38]
 Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51]
-Condition : (isnotnull(sales#50) AND (cast(sales#50 as decimal(32,6)) > cast(Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
+Condition : (isnotnull(sales#50) AND (cast(sales#50 as decimal(32,6)) > cast(Subquery scalar-subquery#52, [id=#12] as decimal(32,6))))
 
 (73) Scan parquet spark_catalog.default.catalog_sales
-Output [4]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57]
+Output [4]: [cs_item_sk#53, cs_quantity#54, cs_list_price#55, cs_sold_date_sk#56]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#57), dynamicpruningexpression(cs_sold_date_sk#57 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#56), dynamicpruningexpression(cs_sold_date_sk#56 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (74) ColumnarToRow [codegen id : 75]
-Input [4]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57]
+Input [4]: [cs_item_sk#53, cs_quantity#54, cs_list_price#55, cs_sold_date_sk#56]
 
 (75) Filter [codegen id : 75]
-Input [4]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57]
-Condition : isnotnull(cs_item_sk#54)
+Input [4]: [cs_item_sk#53, cs_quantity#54, cs_list_price#55, cs_sold_date_sk#56]
+Condition : isnotnull(cs_item_sk#53)
 
 (76) ReusedExchange [Reuses operator id: 56]
-Output [1]: [ss_item_sk#58]
+Output [1]: [ss_item_sk#57]
 
 (77) BroadcastHashJoin [codegen id : 75]
-Left keys [1]: [cs_item_sk#54]
-Right keys [1]: [ss_item_sk#58]
+Left keys [1]: [cs_item_sk#53]
+Right keys [1]: [ss_item_sk#57]
 Join type: LeftSemi
 Join condition: None
 
 (78) ReusedExchange [Reuses operator id: 160]
-Output [1]: [d_date_sk#59]
+Output [1]: [d_date_sk#58]
 
 (79) BroadcastHashJoin [codegen id : 75]
-Left keys [1]: [cs_sold_date_sk#57]
-Right keys [1]: [d_date_sk#59]
+Left keys [1]: [cs_sold_date_sk#56]
+Right keys [1]: [d_date_sk#58]
 Join type: Inner
 Join condition: None
 
 (80) Project [codegen id : 75]
-Output [3]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56]
-Input [5]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57, d_date_sk#59]
+Output [3]: [cs_item_sk#53, cs_quantity#54, cs_list_price#55]
+Input [5]: [cs_item_sk#53, cs_quantity#54, cs_list_price#55, cs_sold_date_sk#56, d_date_sk#58]
 
 (81) ReusedExchange [Reuses operator id: 66]
-Output [4]: [i_item_sk#60, i_brand_id#61, i_class_id#62, i_category_id#63]
+Output [4]: [i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
 
 (82) BroadcastHashJoin [codegen id : 75]
-Left keys [1]: [cs_item_sk#54]
-Right keys [1]: [i_item_sk#60]
+Left keys [1]: [cs_item_sk#53]
+Right keys [1]: [i_item_sk#59]
 Join type: Inner
 Join condition: None
 
 (83) Project [codegen id : 75]
-Output [5]: [cs_quantity#55, cs_list_price#56, i_brand_id#61, i_class_id#62, i_category_id#63]
-Input [7]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, i_item_sk#60, i_brand_id#61, i_class_id#62, i_category_id#63]
+Output [5]: [cs_quantity#54, cs_list_price#55, i_brand_id#60, i_class_id#61, i_category_id#62]
+Input [7]: [cs_item_sk#53, cs_quantity#54, cs_list_price#55, i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
 
 (84) HashAggregate [codegen id : 75]
-Input [5]: [cs_quantity#55, cs_list_price#56, i_brand_id#61, i_class_id#62, i_category_id#63]
-Keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
-Functions [2]: [partial_sum((cast(cs_quantity#55 as decimal(10,0)) * cs_list_price#56)), partial_count(1)]
-Aggregate Attributes [3]: [sum#64, isEmpty#65, count#66]
-Results [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#67, isEmpty#68, count#69]
+Input [5]: [cs_quantity#54, cs_list_price#55, i_brand_id#60, i_class_id#61, i_category_id#62]
+Keys [3]: [i_brand_id#60, i_class_id#61, i_category_id#62]
+Functions [2]: [partial_sum((cast(cs_quantity#54 as decimal(10,0)) * cs_list_price#55)), partial_count(1)]
+Aggregate Attributes [3]: [sum#63, isEmpty#64, count#65]
+Results [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#66, isEmpty#67, count#68]
 
 (85) Exchange
-Input [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#67, isEmpty#68, count#69]
-Arguments: hashpartitioning(i_brand_id#61, i_class_id#62, i_category_id#63, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#66, isEmpty#67, count#68]
+Arguments: hashpartitioning(i_brand_id#60, i_class_id#61, i_category_id#62, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (86) HashAggregate [codegen id : 76]
-Input [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#67, isEmpty#68, count#69]
-Keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
-Functions [2]: [sum((cast(cs_quantity#55 as decimal(10,0)) * cs_list_price#56)), count(1)]
-Aggregate Attributes [2]: [sum((cast(cs_quantity#55 as decimal(10,0)) * cs_list_price#56))#70, count(1)#71]
-Results [6]: [catalog AS channel#72, i_brand_id#61, i_class_id#62, i_category_id#63, sum((cast(cs_quantity#55 as decimal(10,0)) * cs_list_price#56))#70 AS sales#73, count(1)#71 AS number_sales#74]
+Input [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#66, isEmpty#67, count#68]
+Keys [3]: [i_brand_id#60, i_class_id#61, i_category_id#62]
+Functions [2]: [sum((cast(cs_quantity#54 as decimal(10,0)) * cs_list_price#55)), count(1)]
+Aggregate Attributes [2]: [sum((cast(cs_quantity#54 as decimal(10,0)) * cs_list_price#55))#69, count(1)#70]
+Results [6]: [catalog AS channel#71, i_brand_id#60, i_class_id#61, i_category_id#62, sum((cast(cs_quantity#54 as decimal(10,0)) * cs_list_price#55))#69 AS sales#72, count(1)#70 AS number_sales#73]
 
 (87) Filter [codegen id : 76]
-Input [6]: [channel#72, i_brand_id#61, i_class_id#62, i_category_id#63, sales#73, number_sales#74]
-Condition : (isnotnull(sales#73) AND (cast(sales#73 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
+Input [6]: [channel#71, i_brand_id#60, i_class_id#61, i_category_id#62, sales#72, number_sales#73]
+Condition : (isnotnull(sales#72) AND (cast(sales#72 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#12] as decimal(32,6))))
 
 (88) Scan parquet spark_catalog.default.web_sales
-Output [4]: [ws_item_sk#75, ws_quantity#76, ws_list_price#77, ws_sold_date_sk#78]
+Output [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#78), dynamicpruningexpression(ws_sold_date_sk#78 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#77), dynamicpruningexpression(ws_sold_date_sk#77 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (89) ColumnarToRow [codegen id : 113]
-Input [4]: [ws_item_sk#75, ws_quantity#76, ws_list_price#77, ws_sold_date_sk#78]
+Input [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
 
 (90) Filter [codegen id : 113]
-Input [4]: [ws_item_sk#75, ws_quantity#76, ws_list_price#77, ws_sold_date_sk#78]
-Condition : isnotnull(ws_item_sk#75)
+Input [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
+Condition : isnotnull(ws_item_sk#74)
 
 (91) ReusedExchange [Reuses operator id: 56]
-Output [1]: [ss_item_sk#79]
+Output [1]: [ss_item_sk#78]
 
 (92) BroadcastHashJoin [codegen id : 113]
-Left keys [1]: [ws_item_sk#75]
-Right keys [1]: [ss_item_sk#79]
+Left keys [1]: [ws_item_sk#74]
+Right keys [1]: [ss_item_sk#78]
 Join type: LeftSemi
 Join condition: None
 
 (93) ReusedExchange [Reuses operator id: 160]
-Output [1]: [d_date_sk#80]
+Output [1]: [d_date_sk#79]
 
 (94) BroadcastHashJoin [codegen id : 113]
-Left keys [1]: [ws_sold_date_sk#78]
-Right keys [1]: [d_date_sk#80]
+Left keys [1]: [ws_sold_date_sk#77]
+Right keys [1]: [d_date_sk#79]
 Join type: Inner
 Join condition: None
 
 (95) Project [codegen id : 113]
-Output [3]: [ws_item_sk#75, ws_quantity#76, ws_list_price#77]
-Input [5]: [ws_item_sk#75, ws_quantity#76, ws_list_price#77, ws_sold_date_sk#78, d_date_sk#80]
+Output [3]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76]
+Input [5]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77, d_date_sk#79]
 
 (96) ReusedExchange [Reuses operator id: 66]
-Output [4]: [i_item_sk#81, i_brand_id#82, i_class_id#83, i_category_id#84]
+Output [4]: [i_item_sk#80, i_brand_id#81, i_class_id#82, i_category_id#83]
 
 (97) BroadcastHashJoin [codegen id : 113]
-Left keys [1]: [ws_item_sk#75]
-Right keys [1]: [i_item_sk#81]
+Left keys [1]: [ws_item_sk#74]
+Right keys [1]: [i_item_sk#80]
 Join type: Inner
 Join condition: None
 
 (98) Project [codegen id : 113]
-Output [5]: [ws_quantity#76, ws_list_price#77, i_brand_id#82, i_class_id#83, i_category_id#84]
-Input [7]: [ws_item_sk#75, ws_quantity#76, ws_list_price#77, i_item_sk#81, i_brand_id#82, i_class_id#83, i_category_id#84]
+Output [5]: [ws_quantity#75, ws_list_price#76, i_brand_id#81, i_class_id#82, i_category_id#83]
+Input [7]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, i_item_sk#80, i_brand_id#81, i_class_id#82, i_category_id#83]
 
 (99) HashAggregate [codegen id : 113]
-Input [5]: [ws_quantity#76, ws_list_price#77, i_brand_id#82, i_class_id#83, i_category_id#84]
-Keys [3]: [i_brand_id#82, i_class_id#83, i_category_id#84]
-Functions [2]: [partial_sum((cast(ws_quantity#76 as decimal(10,0)) * ws_list_price#77)), partial_count(1)]
-Aggregate Attributes [3]: [sum#85, isEmpty#86, count#87]
-Results [6]: [i_brand_id#82, i_class_id#83, i_category_id#84, sum#88, isEmpty#89, count#90]
+Input [5]: [ws_quantity#75, ws_list_price#76, i_brand_id#81, i_class_id#82, i_category_id#83]
+Keys [3]: [i_brand_id#81, i_class_id#82, i_category_id#83]
+Functions [2]: [partial_sum((cast(ws_quantity#75 as decimal(10,0)) * ws_list_price#76)), partial_count(1)]
+Aggregate Attributes [3]: [sum#84, isEmpty#85, count#86]
+Results [6]: [i_brand_id#81, i_class_id#82, i_category_id#83, sum#87, isEmpty#88, count#89]
 
 (100) Exchange
-Input [6]: [i_brand_id#82, i_class_id#83, i_category_id#84, sum#88, isEmpty#89, count#90]
-Arguments: hashpartitioning(i_brand_id#82, i_class_id#83, i_category_id#84, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+Input [6]: [i_brand_id#81, i_class_id#82, i_category_id#83, sum#87, isEmpty#88, count#89]
+Arguments: hashpartitioning(i_brand_id#81, i_class_id#82, i_category_id#83, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (101) HashAggregate [codegen id : 114]
-Input [6]: [i_brand_id#82, i_class_id#83, i_category_id#84, sum#88, isEmpty#89, count#90]
-Keys [3]: [i_brand_id#82, i_class_id#83, i_category_id#84]
-Functions [2]: [sum((cast(ws_quantity#76 as decimal(10,0)) * ws_list_price#77)), count(1)]
-Aggregate Attributes [2]: [sum((cast(ws_quantity#76 as decimal(10,0)) * ws_list_price#77))#91, count(1)#92]
-Results [6]: [web AS channel#93, i_brand_id#82, i_class_id#83, i_category_id#84, sum((cast(ws_quantity#76 as decimal(10,0)) * ws_list_price#77))#91 AS sales#94, count(1)#92 AS number_sales#95]
+Input [6]: [i_brand_id#81, i_class_id#82, i_category_id#83, sum#87, isEmpty#88, count#89]
+Keys [3]: [i_brand_id#81, i_class_id#82, i_category_id#83]
+Functions [2]: [sum((cast(ws_quantity#75 as decimal(10,0)) * ws_list_price#76)), count(1)]
+Aggregate Attributes [2]: [sum((cast(ws_quantity#75 as decimal(10,0)) * ws_list_price#76))#90, count(1)#91]
+Results [6]: [web AS channel#92, i_brand_id#81, i_class_id#82, i_category_id#83, sum((cast(ws_quantity#75 as decimal(10,0)) * ws_list_price#76))#90 AS sales#93, count(1)#91 AS number_sales#94]
 
 (102) Filter [codegen id : 114]
-Input [6]: [channel#93, i_brand_id#82, i_class_id#83, i_category_id#84, sales#94, number_sales#95]
-Condition : (isnotnull(sales#94) AND (cast(sales#94 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
+Input [6]: [channel#92, i_brand_id#81, i_class_id#82, i_category_id#83, sales#93, number_sales#94]
+Condition : (isnotnull(sales#93) AND (cast(sales#93 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#12] as decimal(32,6))))
 
 (103) Union
 
@@ -622,159 +622,159 @@ Condition : (isnotnull(sales#94) AND (cast(sales#94 as decimal(32,6)) > cast(Reu
 Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51]
 Keys [4]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40]
 Functions [2]: [partial_sum(sales#50), partial_sum(number_sales#51)]
-Aggregate Attributes [3]: [sum#96, isEmpty#97, sum#98]
-Results [7]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum#99, isEmpty#100, sum#101]
+Aggregate Attributes [3]: [sum#95, isEmpty#96, sum#97]
+Results [7]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum#98, isEmpty#99, sum#100]
 
 (105) Exchange
-Input [7]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum#99, isEmpty#100, sum#101]
-Arguments: hashpartitioning(channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [7]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum#98, isEmpty#99, sum#100]
+Arguments: hashpartitioning(channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
 (106) HashAggregate [codegen id : 116]
-Input [7]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum#99, isEmpty#100, sum#101]
+Input [7]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum#98, isEmpty#99, sum#100]
 Keys [4]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40]
 Functions [2]: [sum(sales#50), sum(number_sales#51)]
-Aggregate Attributes [2]: [sum(sales#50)#102, sum(number_sales#51)#103]
-Results [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum(sales#50)#102 AS sum_sales#104, sum(number_sales#51)#103 AS number_sales#105]
+Aggregate Attributes [2]: [sum(sales#50)#101, sum(number_sales#51)#102]
+Results [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum(sales#50)#101 AS sum_sales#103, sum(number_sales#51)#102 AS number_sales#104]
 
 (107) ReusedExchange [Reuses operator id: 105]
-Output [7]: [channel#106, i_brand_id#107, i_class_id#108, i_category_id#109, sum#110, isEmpty#111, sum#112]
+Output [7]: [channel#105, i_brand_id#106, i_class_id#107, i_category_id#108, sum#109, isEmpty#110, sum#111]
 
 (108) HashAggregate [codegen id : 232]
-Input [7]: [channel#106, i_brand_id#107, i_class_id#108, i_category_id#109, sum#110, isEmpty#111, sum#112]
-Keys [4]: [channel#106, i_brand_id#107, i_class_id#108, i_category_id#109]
-Functions [2]: [sum(sales#113), sum(number_sales#114)]
-Aggregate Attributes [2]: [sum(sales#113)#102, sum(number_sales#114)#103]
-Results [5]: [channel#106, i_brand_id#107, i_class_id#108, sum(sales#113)#102 AS sum_sales#115, sum(number_sales#114)#103 AS number_sales#116]
+Input [7]: [channel#105, i_brand_id#106, i_class_id#107, i_category_id#108, sum#109, isEmpty#110, sum#111]
+Keys [4]: [channel#105, i_brand_id#106, i_class_id#107, i_category_id#108]
+Functions [2]: [sum(sales#112), sum(number_sales#113)]
+Aggregate Attributes [2]: [sum(sales#112)#101, sum(number_sales#113)#102]
+Results [5]: [channel#105, i_brand_id#106, i_class_id#107, sum(sales#112)#101 AS sum_sales#114, sum(number_sales#113)#102 AS number_sales#115]
 
 (109) HashAggregate [codegen id : 232]
-Input [5]: [channel#106, i_brand_id#107, i_class_id#108, sum_sales#115, number_sales#116]
-Keys [3]: [channel#106, i_brand_id#107, i_class_id#108]
-Functions [2]: [partial_sum(sum_sales#115), partial_sum(number_sales#116)]
-Aggregate Attributes [3]: [sum#117, isEmpty#118, sum#119]
-Results [6]: [channel#106, i_brand_id#107, i_class_id#108, sum#120, isEmpty#121, sum#122]
+Input [5]: [channel#105, i_brand_id#106, i_class_id#107, sum_sales#114, number_sales#115]
+Keys [3]: [channel#105, i_brand_id#106, i_class_id#107]
+Functions [2]: [partial_sum(sum_sales#114), partial_sum(number_sales#115)]
+Aggregate Attributes [3]: [sum#116, isEmpty#117, sum#118]
+Results [6]: [channel#105, i_brand_id#106, i_class_id#107, sum#119, isEmpty#120, sum#121]
 
 (110) Exchange
-Input [6]: [channel#106, i_brand_id#107, i_class_id#108, sum#120, isEmpty#121, sum#122]
-Arguments: hashpartitioning(channel#106, i_brand_id#107, i_class_id#108, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Input [6]: [channel#105, i_brand_id#106, i_class_id#107, sum#119, isEmpty#120, sum#121]
+Arguments: hashpartitioning(channel#105, i_brand_id#106, i_class_id#107, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
 (111) HashAggregate [codegen id : 233]
-Input [6]: [channel#106, i_brand_id#107, i_class_id#108, sum#120, isEmpty#121, sum#122]
-Keys [3]: [channel#106, i_brand_id#107, i_class_id#108]
-Functions [2]: [sum(sum_sales#115), sum(number_sales#116)]
-Aggregate Attributes [2]: [sum(sum_sales#115)#123, sum(number_sales#116)#124]
-Results [6]: [channel#106, i_brand_id#107, i_class_id#108, null AS i_category_id#125, sum(sum_sales#115)#123 AS sum(sum_sales)#126, sum(number_sales#116)#124 AS sum(number_sales)#127]
+Input [6]: [channel#105, i_brand_id#106, i_class_id#107, sum#119, isEmpty#120, sum#121]
+Keys [3]: [channel#105, i_brand_id#106, i_class_id#107]
+Functions [2]: [sum(sum_sales#114), sum(number_sales#115)]
+Aggregate Attributes [2]: [sum(sum_sales#114)#122, sum(number_sales#115)#123]
+Results [6]: [channel#105, i_brand_id#106, i_class_id#107, null AS i_category_id#124, sum(sum_sales#114)#122 AS sum(sum_sales)#125, sum(number_sales#115)#123 AS sum(number_sales)#126]
 
 (112) ReusedExchange [Reuses operator id: 105]
-Output [7]: [channel#128, i_brand_id#129, i_class_id#130, i_category_id#131, sum#132, isEmpty#133, sum#134]
+Output [7]: [channel#127, i_brand_id#128, i_class_id#129, i_category_id#130, sum#131, isEmpty#132, sum#133]
 
 (113) HashAggregate [codegen id : 349]
-Input [7]: [channel#128, i_brand_id#129, i_class_id#130, i_category_id#131, sum#132, isEmpty#133, sum#134]
-Keys [4]: [channel#128, i_brand_id#129, i_class_id#130, i_category_id#131]
-Functions [2]: [sum(sales#135), sum(number_sales#136)]
-Aggregate Attributes [2]: [sum(sales#135)#102, sum(number_sales#136)#103]
-Results [4]: [channel#128, i_brand_id#129, sum(sales#135)#102 AS sum_sales#137, sum(number_sales#136)#103 AS number_sales#138]
+Input [7]: [channel#127, i_brand_id#128, i_class_id#129, i_category_id#130, sum#131, isEmpty#132, sum#133]
+Keys [4]: [channel#127, i_brand_id#128, i_class_id#129, i_category_id#130]
+Functions [2]: [sum(sales#134), sum(number_sales#135)]
+Aggregate Attributes [2]: [sum(sales#134)#101, sum(number_sales#135)#102]
+Results [4]: [channel#127, i_brand_id#128, sum(sales#134)#101 AS sum_sales#136, sum(number_sales#135)#102 AS number_sales#137]
 
 (114) HashAggregate [codegen id : 349]
-Input [4]: [channel#128, i_brand_id#129, sum_sales#137, number_sales#138]
-Keys [2]: [channel#128, i_brand_id#129]
-Functions [2]: [partial_sum(sum_sales#137), partial_sum(number_sales#138)]
-Aggregate Attributes [3]: [sum#139, isEmpty#140, sum#141]
-Results [5]: [channel#128, i_brand_id#129, sum#142, isEmpty#143, sum#144]
+Input [4]: [channel#127, i_brand_id#128, sum_sales#136, number_sales#137]
+Keys [2]: [channel#127, i_brand_id#128]
+Functions [2]: [partial_sum(sum_sales#136), partial_sum(number_sales#137)]
+Aggregate Attributes [3]: [sum#138, isEmpty#139, sum#140]
+Results [5]: [channel#127, i_brand_id#128, sum#141, isEmpty#142, sum#143]
 
 (115) Exchange
-Input [5]: [channel#128, i_brand_id#129, sum#142, isEmpty#143, sum#144]
-Arguments: hashpartitioning(channel#128, i_brand_id#129, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+Input [5]: [channel#127, i_brand_id#128, sum#141, isEmpty#142, sum#143]
+Arguments: hashpartitioning(channel#127, i_brand_id#128, 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
 (116) HashAggregate [codegen id : 350]
-Input [5]: [channel#128, i_brand_id#129, sum#142, isEmpty#143, sum#144]
-Keys [2]: [channel#128, i_brand_id#129]
-Functions [2]: [sum(sum_sales#137), sum(number_sales#138)]
-Aggregate Attributes [2]: [sum(sum_sales#137)#145, sum(number_sales#138)#146]
-Results [6]: [channel#128, i_brand_id#129, null AS i_class_id#147, null AS i_category_id#148, sum(sum_sales#137)#145 AS sum(sum_sales)#149, sum(number_sales#138)#146 AS sum(number_sales)#150]
+Input [5]: [channel#127, i_brand_id#128, sum#141, isEmpty#142, sum#143]
+Keys [2]: [channel#127, i_brand_id#128]
+Functions [2]: [sum(sum_sales#136), sum(number_sales#137)]
+Aggregate Attributes [2]: [sum(sum_sales#136)#144, sum(number_sales#137)#145]
+Results [6]: [channel#127, i_brand_id#128, null AS i_class_id#146, null AS i_category_id#147, sum(sum_sales#136)#144 AS sum(sum_sales)#148, sum(number_sales#137)#145 AS sum(number_sales)#149]
 
 (117) ReusedExchange [Reuses operator id: 105]
-Output [7]: [channel#151, i_brand_id#152, i_class_id#153, i_category_id#154, sum#155, isEmpty#156, sum#157]
+Output [7]: [channel#150, i_brand_id#151, i_class_id#152, i_category_id#153, sum#154, isEmpty#155, sum#156]
 
 (118) HashAggregate [codegen id : 466]
-Input [7]: [channel#151, i_brand_id#152, i_class_id#153, i_category_id#154, sum#155, isEmpty#156, sum#157]
-Keys [4]: [channel#151, i_brand_id#152, i_class_id#153, i_category_id#154]
-Functions [2]: [sum(sales#158), sum(number_sales#159)]
-Aggregate Attributes [2]: [sum(sales#158)#102, sum(number_sales#159)#103]
-Results [3]: [channel#151, sum(sales#158)#102 AS sum_sales#160, sum(number_sales#159)#103 AS number_sales#161]
+Input [7]: [channel#150, i_brand_id#151, i_class_id#152, i_category_id#153, sum#154, isEmpty#155, sum#156]
+Keys [4]: [channel#150, i_brand_id#151, i_class_id#152, i_category_id#153]
+Functions [2]: [sum(sales#157), sum(number_sales#158)]
+Aggregate Attributes [2]: [sum(sales#157)#101, sum(number_sales#158)#102]
+Results [3]: [channel#150, sum(sales#157)#101 AS sum_sales#159, sum(number_sales#158)#102 AS number_sales#160]
 
 (119) HashAggregate [codegen id : 466]
-Input [3]: [channel#151, sum_sales#160, number_sales#161]
-Keys [1]: [channel#151]
-Functions [2]: [partial_sum(sum_sales#160), partial_sum(number_sales#161)]
-Aggregate Attributes [3]: [sum#162, isEmpty#163, sum#164]
-Results [4]: [channel#151, sum#165, isEmpty#166, sum#167]
+Input [3]: [channel#150, sum_sales#159, number_sales#160]
+Keys [1]: [channel#150]
+Functions [2]: [partial_sum(sum_sales#159), partial_sum(number_sales#160)]
+Aggregate Attributes [3]: [sum#161, isEmpty#162, sum#163]
+Results [4]: [channel#150, sum#164, isEmpty#165, sum#166]
 
 (120) Exchange
-Input [4]: [channel#151, sum#165, isEmpty#166, sum#167]
-Arguments: hashpartitioning(channel#151, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+Input [4]: [channel#150, sum#164, isEmpty#165, sum#166]
+Arguments: hashpartitioning(channel#150, 5), ENSURE_REQUIREMENTS, [plan_id=18]
 
 (121) HashAggregate [codegen id : 467]
-Input [4]: [channel#151, sum#165, isEmpty#166, sum#167]
-Keys [1]: [channel#151]
-Functions [2]: [sum(sum_sales#160), sum(number_sales#161)]
-Aggregate Attributes [2]: [sum(sum_sales#160)#168, sum(number_sales#161)#169]
-Results [6]: [channel#151, null AS i_brand_id#170, null AS i_class_id#171, null AS i_category_id#172, sum(sum_sales#160)#168 AS sum(sum_sales)#173, sum(number_sales#161)#169 AS sum(number_sales)#174]
+Input [4]: [channel#150, sum#164, isEmpty#165, sum#166]
+Keys [1]: [channel#150]
+Functions [2]: [sum(sum_sales#159), sum(number_sales#160)]
+Aggregate Attributes [2]: [sum(sum_sales#159)#167, sum(number_sales#160)#168]
+Results [6]: [channel#150, null AS i_brand_id#169, null AS i_class_id#170, null AS i_category_id#171, sum(sum_sales#159)#167 AS sum(sum_sales)#172, sum(number_sales#160)#168 AS sum(number_sales)#173]
 
 (122) ReusedExchange [Reuses operator id: 105]
-Output [7]: [channel#175, i_brand_id#176, i_class_id#177, i_category_id#178, sum#179, isEmpty#180, sum#181]
+Output [7]: [channel#174, i_brand_id#175, i_class_id#176, i_category_id#177, sum#178, isEmpty#179, sum#180]
 
 (123) HashAggregate [codegen id : 583]
-Input [7]: [channel#175, i_brand_id#176, i_class_id#177, i_category_id#178, sum#179, isEmpty#180, sum#181]
-Keys [4]: [channel#175, i_brand_id#176, i_class_id#177, i_category_id#178]
-Functions [2]: [sum(sales#182), sum(number_sales#183)]
-Aggregate Attributes [2]: [sum(sales#182)#102, sum(number_sales#183)#103]
-Results [2]: [sum(sales#182)#102 AS sum_sales#184, sum(number_sales#183)#103 AS number_sales#185]
+Input [7]: [channel#174, i_brand_id#175, i_class_id#176, i_category_id#177, sum#178, isEmpty#179, sum#180]
+Keys [4]: [channel#174, i_brand_id#175, i_class_id#176, i_category_id#177]
+Functions [2]: [sum(sales#181), sum(number_sales#182)]
+Aggregate Attributes [2]: [sum(sales#181)#101, sum(number_sales#182)#102]
+Results [2]: [sum(sales#181)#101 AS sum_sales#183, sum(number_sales#182)#102 AS number_sales#184]
 
 (124) HashAggregate [codegen id : 583]
-Input [2]: [sum_sales#184, number_sales#185]
+Input [2]: [sum_sales#183, number_sales#184]
 Keys: []
-Functions [2]: [partial_sum(sum_sales#184), partial_sum(number_sales#185)]
-Aggregate Attributes [3]: [sum#186, isEmpty#187, sum#188]
-Results [3]: [sum#189, isEmpty#190, sum#191]
+Functions [2]: [partial_sum(sum_sales#183), partial_sum(number_sales#184)]
+Aggregate Attributes [3]: [sum#185, isEmpty#186, sum#187]
+Results [3]: [sum#188, isEmpty#189, sum#190]
 
 (125) Exchange
-Input [3]: [sum#189, isEmpty#190, sum#191]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
+Input [3]: [sum#188, isEmpty#189, sum#190]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
 
 (126) HashAggregate [codegen id : 584]
-Input [3]: [sum#189, isEmpty#190, sum#191]
+Input [3]: [sum#188, isEmpty#189, sum#190]
 Keys: []
-Functions [2]: [sum(sum_sales#184), sum(number_sales#185)]
-Aggregate Attributes [2]: [sum(sum_sales#184)#192, sum(number_sales#185)#193]
-Results [6]: [null AS channel#194, null AS i_brand_id#195, null AS i_class_id#196, null AS i_category_id#197, sum(sum_sales#184)#192 AS sum(sum_sales)#198, sum(number_sales#185)#193 AS sum(number_sales)#199]
+Functions [2]: [sum(sum_sales#183), sum(number_sales#184)]
+Aggregate Attributes [2]: [sum(sum_sales#183)#191, sum(number_sales#184)#192]
+Results [6]: [null AS channel#193, null AS i_brand_id#194, null AS i_class_id#195, null AS i_category_id#196, sum(sum_sales#183)#191 AS sum(sum_sales)#197, sum(number_sales#184)#192 AS sum(number_sales)#198]
 
 (127) Union
 
 (128) HashAggregate [codegen id : 585]
-Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#104, number_sales#105]
-Keys [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#104, number_sales#105]
+Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#103, number_sales#104]
+Keys [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#103, number_sales#104]
 Functions: []
 Aggregate Attributes: []
-Results [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#104, number_sales#105]
+Results [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#103, number_sales#104]
 
 (129) Exchange
-Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#104, number_sales#105]
-Arguments: hashpartitioning(channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#104, number_sales#105, 5), ENSURE_REQUIREMENTS, [plan_id=19]
+Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#103, number_sales#104]
+Arguments: hashpartitioning(channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#103, number_sales#104, 5), ENSURE_REQUIREMENTS, [plan_id=20]
 
 (130) HashAggregate [codegen id : 586]
-Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#104, number_sales#105]
-Keys [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#104, number_sales#105]
+Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#103, number_sales#104]
+Keys [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#103, number_sales#104]
 Functions: []
 Aggregate Attributes: []
-Results [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#104, number_sales#105]
+Results [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#103, number_sales#104]
 
 (131) TakeOrderedAndProject
-Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#104, number_sales#105]
-Arguments: 100, [channel#49 ASC NULLS FIRST, i_brand_id#38 ASC NULLS FIRST, i_class_id#39 ASC NULLS FIRST, i_category_id#40 ASC NULLS FIRST], [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#104, number_sales#105]
+Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#103, number_sales#104]
+Arguments: 100, [channel#49 ASC NULLS FIRST, i_brand_id#38 ASC NULLS FIRST, i_class_id#39 ASC NULLS FIRST, i_category_id#40 ASC NULLS FIRST], [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#103, number_sales#104]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 72 Hosting Expression = Subquery scalar-subquery#52, [id=#53]
+Subquery:1 Hosting operator id = 72 Hosting Expression = Subquery scalar-subquery#52, [id=#12]
 * HashAggregate (150)
 +- Exchange (149)
    +- * HashAggregate (148)
@@ -797,97 +797,97 @@ Subquery:1 Hosting operator id = 72 Hosting Expression = Subquery scalar-subquer
 
 
 (132) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_quantity#200, ss_list_price#201, ss_sold_date_sk#202]
+Output [3]: [ss_quantity#199, ss_list_price#200, ss_sold_date_sk#201]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#202), dynamicpruningexpression(ss_sold_date_sk#202 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#201), dynamicpruningexpression(ss_sold_date_sk#201 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (133) ColumnarToRow [codegen id : 2]
-Input [3]: [ss_quantity#200, ss_list_price#201, ss_sold_date_sk#202]
+Input [3]: [ss_quantity#199, ss_list_price#200, ss_sold_date_sk#201]
 
 (134) ReusedExchange [Reuses operator id: 165]
-Output [1]: [d_date_sk#203]
+Output [1]: [d_date_sk#202]
 
 (135) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#202]
-Right keys [1]: [d_date_sk#203]
+Left keys [1]: [ss_sold_date_sk#201]
+Right keys [1]: [d_date_sk#202]
 Join type: Inner
 Join condition: None
 
 (136) Project [codegen id : 2]
-Output [2]: [ss_quantity#200 AS quantity#204, ss_list_price#201 AS list_price#205]
-Input [4]: [ss_quantity#200, ss_list_price#201, ss_sold_date_sk#202, d_date_sk#203]
+Output [2]: [ss_quantity#199 AS quantity#203, ss_list_price#200 AS list_price#204]
+Input [4]: [ss_quantity#199, ss_list_price#200, ss_sold_date_sk#201, d_date_sk#202]
 
 (137) Scan parquet spark_catalog.default.catalog_sales
-Output [3]: [cs_quantity#206, cs_list_price#207, cs_sold_date_sk#208]
+Output [3]: [cs_quantity#205, cs_list_price#206, cs_sold_date_sk#207]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#208), dynamicpruningexpression(cs_sold_date_sk#208 IN dynamicpruning#209)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#207), dynamicpruningexpression(cs_sold_date_sk#207 IN dynamicpruning#208)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (138) ColumnarToRow [codegen id : 4]
-Input [3]: [cs_quantity#206, cs_list_price#207, cs_sold_date_sk#208]
+Input [3]: [cs_quantity#205, cs_list_price#206, cs_sold_date_sk#207]
 
 (139) ReusedExchange [Reuses operator id: 155]
-Output [1]: [d_date_sk#210]
+Output [1]: [d_date_sk#209]
 
 (140) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_sold_date_sk#208]
-Right keys [1]: [d_date_sk#210]
+Left keys [1]: [cs_sold_date_sk#207]
+Right keys [1]: [d_date_sk#209]
 Join type: Inner
 Join condition: None
 
 (141) Project [codegen id : 4]
-Output [2]: [cs_quantity#206 AS quantity#211, cs_list_price#207 AS list_price#212]
-Input [4]: [cs_quantity#206, cs_list_price#207, cs_sold_date_sk#208, d_date_sk#210]
+Output [2]: [cs_quantity#205 AS quantity#210, cs_list_price#206 AS list_price#211]
+Input [4]: [cs_quantity#205, cs_list_price#206, cs_sold_date_sk#207, d_date_sk#209]
 
 (142) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_quantity#213, ws_list_price#214, ws_sold_date_sk#215]
+Output [3]: [ws_quantity#212, ws_list_price#213, ws_sold_date_sk#214]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#215), dynamicpruningexpression(ws_sold_date_sk#215 IN dynamicpruning#209)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#214), dynamicpruningexpression(ws_sold_date_sk#214 IN dynamicpruning#208)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (143) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_quantity#213, ws_list_price#214, ws_sold_date_sk#215]
+Input [3]: [ws_quantity#212, ws_list_price#213, ws_sold_date_sk#214]
 
 (144) ReusedExchange [Reuses operator id: 155]
-Output [1]: [d_date_sk#216]
+Output [1]: [d_date_sk#215]
 
 (145) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#215]
-Right keys [1]: [d_date_sk#216]
+Left keys [1]: [ws_sold_date_sk#214]
+Right keys [1]: [d_date_sk#215]
 Join type: Inner
 Join condition: None
 
 (146) Project [codegen id : 6]
-Output [2]: [ws_quantity#213 AS quantity#217, ws_list_price#214 AS list_price#218]
-Input [4]: [ws_quantity#213, ws_list_price#214, ws_sold_date_sk#215, d_date_sk#216]
+Output [2]: [ws_quantity#212 AS quantity#216, ws_list_price#213 AS list_price#217]
+Input [4]: [ws_quantity#212, ws_list_price#213, ws_sold_date_sk#214, d_date_sk#215]
 
 (147) Union
 
 (148) HashAggregate [codegen id : 7]
-Input [2]: [quantity#204, list_price#205]
+Input [2]: [quantity#203, list_price#204]
 Keys: []
-Functions [1]: [partial_avg((cast(quantity#204 as decimal(10,0)) * list_price#205))]
-Aggregate Attributes [2]: [sum#219, count#220]
-Results [2]: [sum#221, count#222]
+Functions [1]: [partial_avg((cast(quantity#203 as decimal(10,0)) * list_price#204))]
+Aggregate Attributes [2]: [sum#218, count#219]
+Results [2]: [sum#220, count#221]
 
 (149) Exchange
-Input [2]: [sum#221, count#222]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=20]
+Input [2]: [sum#220, count#221]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=21]
 
 (150) HashAggregate [codegen id : 8]
-Input [2]: [sum#221, count#222]
+Input [2]: [sum#220, count#221]
 Keys: []
-Functions [1]: [avg((cast(quantity#204 as decimal(10,0)) * list_price#205))]
-Aggregate Attributes [1]: [avg((cast(quantity#204 as decimal(10,0)) * list_price#205))#223]
-Results [1]: [avg((cast(quantity#204 as decimal(10,0)) * list_price#205))#223 AS average_sales#224]
+Functions [1]: [avg((cast(quantity#203 as decimal(10,0)) * list_price#204))]
+Aggregate Attributes [1]: [avg((cast(quantity#203 as decimal(10,0)) * list_price#204))#222]
+Results [1]: [avg((cast(quantity#203 as decimal(10,0)) * list_price#204))#222 AS average_sales#223]
 
-Subquery:2 Hosting operator id = 132 Hosting Expression = ss_sold_date_sk#202 IN dynamicpruning#12
+Subquery:2 Hosting operator id = 132 Hosting Expression = ss_sold_date_sk#201 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 137 Hosting Expression = cs_sold_date_sk#208 IN dynamicpruning#209
+Subquery:3 Hosting operator id = 137 Hosting Expression = cs_sold_date_sk#207 IN dynamicpruning#208
 BroadcastExchange (155)
 +- * Project (154)
    +- * Filter (153)
@@ -896,28 +896,28 @@ BroadcastExchange (155)
 
 
 (151) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#210, d_year#225]
+Output [2]: [d_date_sk#209, d_year#224]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1998), LessThanOrEqual(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (152) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#210, d_year#225]
+Input [2]: [d_date_sk#209, d_year#224]
 
 (153) Filter [codegen id : 1]
-Input [2]: [d_date_sk#210, d_year#225]
-Condition : (((isnotnull(d_year#225) AND (d_year#225 >= 1998)) AND (d_year#225 <= 2000)) AND isnotnull(d_date_sk#210))
+Input [2]: [d_date_sk#209, d_year#224]
+Condition : (((isnotnull(d_year#224) AND (d_year#224 >= 1998)) AND (d_year#224 <= 2000)) AND isnotnull(d_date_sk#209))
 
 (154) Project [codegen id : 1]
-Output [1]: [d_date_sk#210]
-Input [2]: [d_date_sk#210, d_year#225]
+Output [1]: [d_date_sk#209]
+Input [2]: [d_date_sk#209, d_year#224]
 
 (155) BroadcastExchange
-Input [1]: [d_date_sk#210]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=21]
+Input [1]: [d_date_sk#209]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=22]
 
-Subquery:4 Hosting operator id = 142 Hosting Expression = ws_sold_date_sk#215 IN dynamicpruning#209
+Subquery:4 Hosting operator id = 142 Hosting Expression = ws_sold_date_sk#214 IN dynamicpruning#208
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (160)
@@ -928,26 +928,26 @@ BroadcastExchange (160)
 
 
 (156) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#36, d_year#226, d_moy#227]
+Output [3]: [d_date_sk#36, d_year#225, d_moy#226]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,11), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (157) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#36, d_year#226, d_moy#227]
+Input [3]: [d_date_sk#36, d_year#225, d_moy#226]
 
 (158) Filter [codegen id : 1]
-Input [3]: [d_date_sk#36, d_year#226, d_moy#227]
-Condition : ((((isnotnull(d_year#226) AND isnotnull(d_moy#227)) AND (d_year#226 = 2000)) AND (d_moy#227 = 11)) AND isnotnull(d_date_sk#36))
+Input [3]: [d_date_sk#36, d_year#225, d_moy#226]
+Condition : ((((isnotnull(d_year#225) AND isnotnull(d_moy#226)) AND (d_year#225 = 2000)) AND (d_moy#226 = 11)) AND isnotnull(d_date_sk#36))
 
 (159) Project [codegen id : 1]
 Output [1]: [d_date_sk#36]
-Input [3]: [d_date_sk#36, d_year#226, d_moy#227]
+Input [3]: [d_date_sk#36, d_year#225, d_moy#226]
 
 (160) BroadcastExchange
 Input [1]: [d_date_sk#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=23]
 
 Subquery:6 Hosting operator id = 7 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
 BroadcastExchange (165)
@@ -958,37 +958,37 @@ BroadcastExchange (165)
 
 
 (161) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#13, d_year#228]
+Output [2]: [d_date_sk#13, d_year#227]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (162) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#228]
+Input [2]: [d_date_sk#13, d_year#227]
 
 (163) Filter [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#228]
-Condition : (((isnotnull(d_year#228) AND (d_year#228 >= 1999)) AND (d_year#228 <= 2001)) AND isnotnull(d_date_sk#13))
+Input [2]: [d_date_sk#13, d_year#227]
+Condition : (((isnotnull(d_year#227) AND (d_year#227 >= 1999)) AND (d_year#227 <= 2001)) AND isnotnull(d_date_sk#13))
 
 (164) Project [codegen id : 1]
 Output [1]: [d_date_sk#13]
-Input [2]: [d_date_sk#13, d_year#228]
+Input [2]: [d_date_sk#13, d_year#227]
 
 (165) BroadcastExchange
 Input [1]: [d_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=24]
 
 Subquery:7 Hosting operator id = 18 Hosting Expression = cs_sold_date_sk#19 IN dynamicpruning#12
 
 Subquery:8 Hosting operator id = 41 Hosting Expression = ws_sold_date_sk#29 IN dynamicpruning#12
 
-Subquery:9 Hosting operator id = 87 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#53]
+Subquery:9 Hosting operator id = 87 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#12]
 
-Subquery:10 Hosting operator id = 73 Hosting Expression = cs_sold_date_sk#57 IN dynamicpruning#5
+Subquery:10 Hosting operator id = 73 Hosting Expression = cs_sold_date_sk#56 IN dynamicpruning#5
 
-Subquery:11 Hosting operator id = 102 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#53]
+Subquery:11 Hosting operator id = 102 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#12]
 
-Subquery:12 Hosting operator id = 88 Hosting Expression = ws_sold_date_sk#78 IN dynamicpruning#5
+Subquery:12 Hosting operator id = 88 Hosting Expression = ws_sold_date_sk#77 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/explain.txt
@@ -440,151 +440,151 @@ Results [6]: [store AS channel#49, i_brand_id#37, i_class_id#38, i_category_id#3
 
 (66) Filter [codegen id : 26]
 Input [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51]
-Condition : (isnotnull(sales#50) AND (cast(sales#50 as decimal(32,6)) > cast(Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
+Condition : (isnotnull(sales#50) AND (cast(sales#50 as decimal(32,6)) > cast(Subquery scalar-subquery#52, [id=#10] as decimal(32,6))))
 
 (67) Scan parquet spark_catalog.default.catalog_sales
-Output [4]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57]
+Output [4]: [cs_item_sk#53, cs_quantity#54, cs_list_price#55, cs_sold_date_sk#56]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#57), dynamicpruningexpression(cs_sold_date_sk#57 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#56), dynamicpruningexpression(cs_sold_date_sk#56 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (68) ColumnarToRow [codegen id : 51]
-Input [4]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57]
+Input [4]: [cs_item_sk#53, cs_quantity#54, cs_list_price#55, cs_sold_date_sk#56]
 
 (69) Filter [codegen id : 51]
-Input [4]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57]
-Condition : isnotnull(cs_item_sk#54)
+Input [4]: [cs_item_sk#53, cs_quantity#54, cs_list_price#55, cs_sold_date_sk#56]
+Condition : isnotnull(cs_item_sk#53)
 
 (70) ReusedExchange [Reuses operator id: 50]
-Output [1]: [ss_item_sk#58]
+Output [1]: [ss_item_sk#57]
 
 (71) BroadcastHashJoin [codegen id : 51]
-Left keys [1]: [cs_item_sk#54]
-Right keys [1]: [ss_item_sk#58]
+Left keys [1]: [cs_item_sk#53]
+Right keys [1]: [ss_item_sk#57]
 Join type: LeftSemi
 Join condition: None
 
 (72) ReusedExchange [Reuses operator id: 57]
-Output [4]: [i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
+Output [4]: [i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61]
 
 (73) BroadcastHashJoin [codegen id : 51]
-Left keys [1]: [cs_item_sk#54]
-Right keys [1]: [i_item_sk#59]
+Left keys [1]: [cs_item_sk#53]
+Right keys [1]: [i_item_sk#58]
 Join type: Inner
 Join condition: None
 
 (74) Project [codegen id : 51]
-Output [6]: [cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57, i_brand_id#60, i_class_id#61, i_category_id#62]
-Input [8]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57, i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
+Output [6]: [cs_quantity#54, cs_list_price#55, cs_sold_date_sk#56, i_brand_id#59, i_class_id#60, i_category_id#61]
+Input [8]: [cs_item_sk#53, cs_quantity#54, cs_list_price#55, cs_sold_date_sk#56, i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61]
 
 (75) ReusedExchange [Reuses operator id: 154]
-Output [1]: [d_date_sk#63]
+Output [1]: [d_date_sk#62]
 
 (76) BroadcastHashJoin [codegen id : 51]
-Left keys [1]: [cs_sold_date_sk#57]
-Right keys [1]: [d_date_sk#63]
+Left keys [1]: [cs_sold_date_sk#56]
+Right keys [1]: [d_date_sk#62]
 Join type: Inner
 Join condition: None
 
 (77) Project [codegen id : 51]
-Output [5]: [cs_quantity#55, cs_list_price#56, i_brand_id#60, i_class_id#61, i_category_id#62]
-Input [7]: [cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57, i_brand_id#60, i_class_id#61, i_category_id#62, d_date_sk#63]
+Output [5]: [cs_quantity#54, cs_list_price#55, i_brand_id#59, i_class_id#60, i_category_id#61]
+Input [7]: [cs_quantity#54, cs_list_price#55, cs_sold_date_sk#56, i_brand_id#59, i_class_id#60, i_category_id#61, d_date_sk#62]
 
 (78) HashAggregate [codegen id : 51]
-Input [5]: [cs_quantity#55, cs_list_price#56, i_brand_id#60, i_class_id#61, i_category_id#62]
-Keys [3]: [i_brand_id#60, i_class_id#61, i_category_id#62]
-Functions [2]: [partial_sum((cast(cs_quantity#55 as decimal(10,0)) * cs_list_price#56)), partial_count(1)]
-Aggregate Attributes [3]: [sum#64, isEmpty#65, count#66]
-Results [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#67, isEmpty#68, count#69]
+Input [5]: [cs_quantity#54, cs_list_price#55, i_brand_id#59, i_class_id#60, i_category_id#61]
+Keys [3]: [i_brand_id#59, i_class_id#60, i_category_id#61]
+Functions [2]: [partial_sum((cast(cs_quantity#54 as decimal(10,0)) * cs_list_price#55)), partial_count(1)]
+Aggregate Attributes [3]: [sum#63, isEmpty#64, count#65]
+Results [6]: [i_brand_id#59, i_class_id#60, i_category_id#61, sum#66, isEmpty#67, count#68]
 
 (79) Exchange
-Input [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#67, isEmpty#68, count#69]
-Arguments: hashpartitioning(i_brand_id#60, i_class_id#61, i_category_id#62, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [6]: [i_brand_id#59, i_class_id#60, i_category_id#61, sum#66, isEmpty#67, count#68]
+Arguments: hashpartitioning(i_brand_id#59, i_class_id#60, i_category_id#61, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (80) HashAggregate [codegen id : 52]
-Input [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#67, isEmpty#68, count#69]
-Keys [3]: [i_brand_id#60, i_class_id#61, i_category_id#62]
-Functions [2]: [sum((cast(cs_quantity#55 as decimal(10,0)) * cs_list_price#56)), count(1)]
-Aggregate Attributes [2]: [sum((cast(cs_quantity#55 as decimal(10,0)) * cs_list_price#56))#70, count(1)#71]
-Results [6]: [catalog AS channel#72, i_brand_id#60, i_class_id#61, i_category_id#62, sum((cast(cs_quantity#55 as decimal(10,0)) * cs_list_price#56))#70 AS sales#73, count(1)#71 AS number_sales#74]
+Input [6]: [i_brand_id#59, i_class_id#60, i_category_id#61, sum#66, isEmpty#67, count#68]
+Keys [3]: [i_brand_id#59, i_class_id#60, i_category_id#61]
+Functions [2]: [sum((cast(cs_quantity#54 as decimal(10,0)) * cs_list_price#55)), count(1)]
+Aggregate Attributes [2]: [sum((cast(cs_quantity#54 as decimal(10,0)) * cs_list_price#55))#69, count(1)#70]
+Results [6]: [catalog AS channel#71, i_brand_id#59, i_class_id#60, i_category_id#61, sum((cast(cs_quantity#54 as decimal(10,0)) * cs_list_price#55))#69 AS sales#72, count(1)#70 AS number_sales#73]
 
 (81) Filter [codegen id : 52]
-Input [6]: [channel#72, i_brand_id#60, i_class_id#61, i_category_id#62, sales#73, number_sales#74]
-Condition : (isnotnull(sales#73) AND (cast(sales#73 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
+Input [6]: [channel#71, i_brand_id#59, i_class_id#60, i_category_id#61, sales#72, number_sales#73]
+Condition : (isnotnull(sales#72) AND (cast(sales#72 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#10] as decimal(32,6))))
 
 (82) Scan parquet spark_catalog.default.web_sales
-Output [4]: [ws_item_sk#75, ws_quantity#76, ws_list_price#77, ws_sold_date_sk#78]
+Output [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#78), dynamicpruningexpression(ws_sold_date_sk#78 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#77), dynamicpruningexpression(ws_sold_date_sk#77 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (83) ColumnarToRow [codegen id : 77]
-Input [4]: [ws_item_sk#75, ws_quantity#76, ws_list_price#77, ws_sold_date_sk#78]
+Input [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
 
 (84) Filter [codegen id : 77]
-Input [4]: [ws_item_sk#75, ws_quantity#76, ws_list_price#77, ws_sold_date_sk#78]
-Condition : isnotnull(ws_item_sk#75)
+Input [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
+Condition : isnotnull(ws_item_sk#74)
 
 (85) ReusedExchange [Reuses operator id: 50]
-Output [1]: [ss_item_sk#79]
+Output [1]: [ss_item_sk#78]
 
 (86) BroadcastHashJoin [codegen id : 77]
-Left keys [1]: [ws_item_sk#75]
-Right keys [1]: [ss_item_sk#79]
+Left keys [1]: [ws_item_sk#74]
+Right keys [1]: [ss_item_sk#78]
 Join type: LeftSemi
 Join condition: None
 
 (87) ReusedExchange [Reuses operator id: 57]
-Output [4]: [i_item_sk#80, i_brand_id#81, i_class_id#82, i_category_id#83]
+Output [4]: [i_item_sk#79, i_brand_id#80, i_class_id#81, i_category_id#82]
 
 (88) BroadcastHashJoin [codegen id : 77]
-Left keys [1]: [ws_item_sk#75]
-Right keys [1]: [i_item_sk#80]
+Left keys [1]: [ws_item_sk#74]
+Right keys [1]: [i_item_sk#79]
 Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 77]
-Output [6]: [ws_quantity#76, ws_list_price#77, ws_sold_date_sk#78, i_brand_id#81, i_class_id#82, i_category_id#83]
-Input [8]: [ws_item_sk#75, ws_quantity#76, ws_list_price#77, ws_sold_date_sk#78, i_item_sk#80, i_brand_id#81, i_class_id#82, i_category_id#83]
+Output [6]: [ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77, i_brand_id#80, i_class_id#81, i_category_id#82]
+Input [8]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77, i_item_sk#79, i_brand_id#80, i_class_id#81, i_category_id#82]
 
 (90) ReusedExchange [Reuses operator id: 154]
-Output [1]: [d_date_sk#84]
+Output [1]: [d_date_sk#83]
 
 (91) BroadcastHashJoin [codegen id : 77]
-Left keys [1]: [ws_sold_date_sk#78]
-Right keys [1]: [d_date_sk#84]
+Left keys [1]: [ws_sold_date_sk#77]
+Right keys [1]: [d_date_sk#83]
 Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 77]
-Output [5]: [ws_quantity#76, ws_list_price#77, i_brand_id#81, i_class_id#82, i_category_id#83]
-Input [7]: [ws_quantity#76, ws_list_price#77, ws_sold_date_sk#78, i_brand_id#81, i_class_id#82, i_category_id#83, d_date_sk#84]
+Output [5]: [ws_quantity#75, ws_list_price#76, i_brand_id#80, i_class_id#81, i_category_id#82]
+Input [7]: [ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77, i_brand_id#80, i_class_id#81, i_category_id#82, d_date_sk#83]
 
 (93) HashAggregate [codegen id : 77]
-Input [5]: [ws_quantity#76, ws_list_price#77, i_brand_id#81, i_class_id#82, i_category_id#83]
-Keys [3]: [i_brand_id#81, i_class_id#82, i_category_id#83]
-Functions [2]: [partial_sum((cast(ws_quantity#76 as decimal(10,0)) * ws_list_price#77)), partial_count(1)]
-Aggregate Attributes [3]: [sum#85, isEmpty#86, count#87]
-Results [6]: [i_brand_id#81, i_class_id#82, i_category_id#83, sum#88, isEmpty#89, count#90]
+Input [5]: [ws_quantity#75, ws_list_price#76, i_brand_id#80, i_class_id#81, i_category_id#82]
+Keys [3]: [i_brand_id#80, i_class_id#81, i_category_id#82]
+Functions [2]: [partial_sum((cast(ws_quantity#75 as decimal(10,0)) * ws_list_price#76)), partial_count(1)]
+Aggregate Attributes [3]: [sum#84, isEmpty#85, count#86]
+Results [6]: [i_brand_id#80, i_class_id#81, i_category_id#82, sum#87, isEmpty#88, count#89]
 
 (94) Exchange
-Input [6]: [i_brand_id#81, i_class_id#82, i_category_id#83, sum#88, isEmpty#89, count#90]
-Arguments: hashpartitioning(i_brand_id#81, i_class_id#82, i_category_id#83, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [6]: [i_brand_id#80, i_class_id#81, i_category_id#82, sum#87, isEmpty#88, count#89]
+Arguments: hashpartitioning(i_brand_id#80, i_class_id#81, i_category_id#82, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (95) HashAggregate [codegen id : 78]
-Input [6]: [i_brand_id#81, i_class_id#82, i_category_id#83, sum#88, isEmpty#89, count#90]
-Keys [3]: [i_brand_id#81, i_class_id#82, i_category_id#83]
-Functions [2]: [sum((cast(ws_quantity#76 as decimal(10,0)) * ws_list_price#77)), count(1)]
-Aggregate Attributes [2]: [sum((cast(ws_quantity#76 as decimal(10,0)) * ws_list_price#77))#91, count(1)#92]
-Results [6]: [web AS channel#93, i_brand_id#81, i_class_id#82, i_category_id#83, sum((cast(ws_quantity#76 as decimal(10,0)) * ws_list_price#77))#91 AS sales#94, count(1)#92 AS number_sales#95]
+Input [6]: [i_brand_id#80, i_class_id#81, i_category_id#82, sum#87, isEmpty#88, count#89]
+Keys [3]: [i_brand_id#80, i_class_id#81, i_category_id#82]
+Functions [2]: [sum((cast(ws_quantity#75 as decimal(10,0)) * ws_list_price#76)), count(1)]
+Aggregate Attributes [2]: [sum((cast(ws_quantity#75 as decimal(10,0)) * ws_list_price#76))#90, count(1)#91]
+Results [6]: [web AS channel#92, i_brand_id#80, i_class_id#81, i_category_id#82, sum((cast(ws_quantity#75 as decimal(10,0)) * ws_list_price#76))#90 AS sales#93, count(1)#91 AS number_sales#94]
 
 (96) Filter [codegen id : 78]
-Input [6]: [channel#93, i_brand_id#81, i_class_id#82, i_category_id#83, sales#94, number_sales#95]
-Condition : (isnotnull(sales#94) AND (cast(sales#94 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
+Input [6]: [channel#92, i_brand_id#80, i_class_id#81, i_category_id#82, sales#93, number_sales#94]
+Condition : (isnotnull(sales#93) AND (cast(sales#93 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#10] as decimal(32,6))))
 
 (97) Union
 
@@ -592,159 +592,159 @@ Condition : (isnotnull(sales#94) AND (cast(sales#94 as decimal(32,6)) > cast(Reu
 Input [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51]
 Keys [4]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39]
 Functions [2]: [partial_sum(sales#50), partial_sum(number_sales#51)]
-Aggregate Attributes [3]: [sum#96, isEmpty#97, sum#98]
-Results [7]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum#99, isEmpty#100, sum#101]
+Aggregate Attributes [3]: [sum#95, isEmpty#96, sum#97]
+Results [7]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum#98, isEmpty#99, sum#100]
 
 (99) Exchange
-Input [7]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum#99, isEmpty#100, sum#101]
-Arguments: hashpartitioning(channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [7]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum#98, isEmpty#99, sum#100]
+Arguments: hashpartitioning(channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (100) HashAggregate [codegen id : 80]
-Input [7]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum#99, isEmpty#100, sum#101]
+Input [7]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum#98, isEmpty#99, sum#100]
 Keys [4]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39]
 Functions [2]: [sum(sales#50), sum(number_sales#51)]
-Aggregate Attributes [2]: [sum(sales#50)#102, sum(number_sales#51)#103]
-Results [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum(sales#50)#102 AS sum_sales#104, sum(number_sales#51)#103 AS number_sales#105]
+Aggregate Attributes [2]: [sum(sales#50)#101, sum(number_sales#51)#102]
+Results [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum(sales#50)#101 AS sum_sales#103, sum(number_sales#51)#102 AS number_sales#104]
 
 (101) ReusedExchange [Reuses operator id: 99]
-Output [7]: [channel#106, i_brand_id#107, i_class_id#108, i_category_id#109, sum#110, isEmpty#111, sum#112]
+Output [7]: [channel#105, i_brand_id#106, i_class_id#107, i_category_id#108, sum#109, isEmpty#110, sum#111]
 
 (102) HashAggregate [codegen id : 160]
-Input [7]: [channel#106, i_brand_id#107, i_class_id#108, i_category_id#109, sum#110, isEmpty#111, sum#112]
-Keys [4]: [channel#106, i_brand_id#107, i_class_id#108, i_category_id#109]
-Functions [2]: [sum(sales#113), sum(number_sales#114)]
-Aggregate Attributes [2]: [sum(sales#113)#102, sum(number_sales#114)#103]
-Results [5]: [channel#106, i_brand_id#107, i_class_id#108, sum(sales#113)#102 AS sum_sales#115, sum(number_sales#114)#103 AS number_sales#116]
+Input [7]: [channel#105, i_brand_id#106, i_class_id#107, i_category_id#108, sum#109, isEmpty#110, sum#111]
+Keys [4]: [channel#105, i_brand_id#106, i_class_id#107, i_category_id#108]
+Functions [2]: [sum(sales#112), sum(number_sales#113)]
+Aggregate Attributes [2]: [sum(sales#112)#101, sum(number_sales#113)#102]
+Results [5]: [channel#105, i_brand_id#106, i_class_id#107, sum(sales#112)#101 AS sum_sales#114, sum(number_sales#113)#102 AS number_sales#115]
 
 (103) HashAggregate [codegen id : 160]
-Input [5]: [channel#106, i_brand_id#107, i_class_id#108, sum_sales#115, number_sales#116]
-Keys [3]: [channel#106, i_brand_id#107, i_class_id#108]
-Functions [2]: [partial_sum(sum_sales#115), partial_sum(number_sales#116)]
-Aggregate Attributes [3]: [sum#117, isEmpty#118, sum#119]
-Results [6]: [channel#106, i_brand_id#107, i_class_id#108, sum#120, isEmpty#121, sum#122]
+Input [5]: [channel#105, i_brand_id#106, i_class_id#107, sum_sales#114, number_sales#115]
+Keys [3]: [channel#105, i_brand_id#106, i_class_id#107]
+Functions [2]: [partial_sum(sum_sales#114), partial_sum(number_sales#115)]
+Aggregate Attributes [3]: [sum#116, isEmpty#117, sum#118]
+Results [6]: [channel#105, i_brand_id#106, i_class_id#107, sum#119, isEmpty#120, sum#121]
 
 (104) Exchange
-Input [6]: [channel#106, i_brand_id#107, i_class_id#108, sum#120, isEmpty#121, sum#122]
-Arguments: hashpartitioning(channel#106, i_brand_id#107, i_class_id#108, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+Input [6]: [channel#105, i_brand_id#106, i_class_id#107, sum#119, isEmpty#120, sum#121]
+Arguments: hashpartitioning(channel#105, i_brand_id#106, i_class_id#107, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (105) HashAggregate [codegen id : 161]
-Input [6]: [channel#106, i_brand_id#107, i_class_id#108, sum#120, isEmpty#121, sum#122]
-Keys [3]: [channel#106, i_brand_id#107, i_class_id#108]
-Functions [2]: [sum(sum_sales#115), sum(number_sales#116)]
-Aggregate Attributes [2]: [sum(sum_sales#115)#123, sum(number_sales#116)#124]
-Results [6]: [channel#106, i_brand_id#107, i_class_id#108, null AS i_category_id#125, sum(sum_sales#115)#123 AS sum(sum_sales)#126, sum(number_sales#116)#124 AS sum(number_sales)#127]
+Input [6]: [channel#105, i_brand_id#106, i_class_id#107, sum#119, isEmpty#120, sum#121]
+Keys [3]: [channel#105, i_brand_id#106, i_class_id#107]
+Functions [2]: [sum(sum_sales#114), sum(number_sales#115)]
+Aggregate Attributes [2]: [sum(sum_sales#114)#122, sum(number_sales#115)#123]
+Results [6]: [channel#105, i_brand_id#106, i_class_id#107, null AS i_category_id#124, sum(sum_sales#114)#122 AS sum(sum_sales)#125, sum(number_sales#115)#123 AS sum(number_sales)#126]
 
 (106) ReusedExchange [Reuses operator id: 99]
-Output [7]: [channel#128, i_brand_id#129, i_class_id#130, i_category_id#131, sum#132, isEmpty#133, sum#134]
+Output [7]: [channel#127, i_brand_id#128, i_class_id#129, i_category_id#130, sum#131, isEmpty#132, sum#133]
 
 (107) HashAggregate [codegen id : 241]
-Input [7]: [channel#128, i_brand_id#129, i_class_id#130, i_category_id#131, sum#132, isEmpty#133, sum#134]
-Keys [4]: [channel#128, i_brand_id#129, i_class_id#130, i_category_id#131]
-Functions [2]: [sum(sales#135), sum(number_sales#136)]
-Aggregate Attributes [2]: [sum(sales#135)#102, sum(number_sales#136)#103]
-Results [4]: [channel#128, i_brand_id#129, sum(sales#135)#102 AS sum_sales#137, sum(number_sales#136)#103 AS number_sales#138]
+Input [7]: [channel#127, i_brand_id#128, i_class_id#129, i_category_id#130, sum#131, isEmpty#132, sum#133]
+Keys [4]: [channel#127, i_brand_id#128, i_class_id#129, i_category_id#130]
+Functions [2]: [sum(sales#134), sum(number_sales#135)]
+Aggregate Attributes [2]: [sum(sales#134)#101, sum(number_sales#135)#102]
+Results [4]: [channel#127, i_brand_id#128, sum(sales#134)#101 AS sum_sales#136, sum(number_sales#135)#102 AS number_sales#137]
 
 (108) HashAggregate [codegen id : 241]
-Input [4]: [channel#128, i_brand_id#129, sum_sales#137, number_sales#138]
-Keys [2]: [channel#128, i_brand_id#129]
-Functions [2]: [partial_sum(sum_sales#137), partial_sum(number_sales#138)]
-Aggregate Attributes [3]: [sum#139, isEmpty#140, sum#141]
-Results [5]: [channel#128, i_brand_id#129, sum#142, isEmpty#143, sum#144]
+Input [4]: [channel#127, i_brand_id#128, sum_sales#136, number_sales#137]
+Keys [2]: [channel#127, i_brand_id#128]
+Functions [2]: [partial_sum(sum_sales#136), partial_sum(number_sales#137)]
+Aggregate Attributes [3]: [sum#138, isEmpty#139, sum#140]
+Results [5]: [channel#127, i_brand_id#128, sum#141, isEmpty#142, sum#143]
 
 (109) Exchange
-Input [5]: [channel#128, i_brand_id#129, sum#142, isEmpty#143, sum#144]
-Arguments: hashpartitioning(channel#128, i_brand_id#129, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [5]: [channel#127, i_brand_id#128, sum#141, isEmpty#142, sum#143]
+Arguments: hashpartitioning(channel#127, i_brand_id#128, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
 (110) HashAggregate [codegen id : 242]
-Input [5]: [channel#128, i_brand_id#129, sum#142, isEmpty#143, sum#144]
-Keys [2]: [channel#128, i_brand_id#129]
-Functions [2]: [sum(sum_sales#137), sum(number_sales#138)]
-Aggregate Attributes [2]: [sum(sum_sales#137)#145, sum(number_sales#138)#146]
-Results [6]: [channel#128, i_brand_id#129, null AS i_class_id#147, null AS i_category_id#148, sum(sum_sales#137)#145 AS sum(sum_sales)#149, sum(number_sales#138)#146 AS sum(number_sales)#150]
+Input [5]: [channel#127, i_brand_id#128, sum#141, isEmpty#142, sum#143]
+Keys [2]: [channel#127, i_brand_id#128]
+Functions [2]: [sum(sum_sales#136), sum(number_sales#137)]
+Aggregate Attributes [2]: [sum(sum_sales#136)#144, sum(number_sales#137)#145]
+Results [6]: [channel#127, i_brand_id#128, null AS i_class_id#146, null AS i_category_id#147, sum(sum_sales#136)#144 AS sum(sum_sales)#148, sum(number_sales#137)#145 AS sum(number_sales)#149]
 
 (111) ReusedExchange [Reuses operator id: 99]
-Output [7]: [channel#151, i_brand_id#152, i_class_id#153, i_category_id#154, sum#155, isEmpty#156, sum#157]
+Output [7]: [channel#150, i_brand_id#151, i_class_id#152, i_category_id#153, sum#154, isEmpty#155, sum#156]
 
 (112) HashAggregate [codegen id : 322]
-Input [7]: [channel#151, i_brand_id#152, i_class_id#153, i_category_id#154, sum#155, isEmpty#156, sum#157]
-Keys [4]: [channel#151, i_brand_id#152, i_class_id#153, i_category_id#154]
-Functions [2]: [sum(sales#158), sum(number_sales#159)]
-Aggregate Attributes [2]: [sum(sales#158)#102, sum(number_sales#159)#103]
-Results [3]: [channel#151, sum(sales#158)#102 AS sum_sales#160, sum(number_sales#159)#103 AS number_sales#161]
+Input [7]: [channel#150, i_brand_id#151, i_class_id#152, i_category_id#153, sum#154, isEmpty#155, sum#156]
+Keys [4]: [channel#150, i_brand_id#151, i_class_id#152, i_category_id#153]
+Functions [2]: [sum(sales#157), sum(number_sales#158)]
+Aggregate Attributes [2]: [sum(sales#157)#101, sum(number_sales#158)#102]
+Results [3]: [channel#150, sum(sales#157)#101 AS sum_sales#159, sum(number_sales#158)#102 AS number_sales#160]
 
 (113) HashAggregate [codegen id : 322]
-Input [3]: [channel#151, sum_sales#160, number_sales#161]
-Keys [1]: [channel#151]
-Functions [2]: [partial_sum(sum_sales#160), partial_sum(number_sales#161)]
-Aggregate Attributes [3]: [sum#162, isEmpty#163, sum#164]
-Results [4]: [channel#151, sum#165, isEmpty#166, sum#167]
+Input [3]: [channel#150, sum_sales#159, number_sales#160]
+Keys [1]: [channel#150]
+Functions [2]: [partial_sum(sum_sales#159), partial_sum(number_sales#160)]
+Aggregate Attributes [3]: [sum#161, isEmpty#162, sum#163]
+Results [4]: [channel#150, sum#164, isEmpty#165, sum#166]
 
 (114) Exchange
-Input [4]: [channel#151, sum#165, isEmpty#166, sum#167]
-Arguments: hashpartitioning(channel#151, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Input [4]: [channel#150, sum#164, isEmpty#165, sum#166]
+Arguments: hashpartitioning(channel#150, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
 (115) HashAggregate [codegen id : 323]
-Input [4]: [channel#151, sum#165, isEmpty#166, sum#167]
-Keys [1]: [channel#151]
-Functions [2]: [sum(sum_sales#160), sum(number_sales#161)]
-Aggregate Attributes [2]: [sum(sum_sales#160)#168, sum(number_sales#161)#169]
-Results [6]: [channel#151, null AS i_brand_id#170, null AS i_class_id#171, null AS i_category_id#172, sum(sum_sales#160)#168 AS sum(sum_sales)#173, sum(number_sales#161)#169 AS sum(number_sales)#174]
+Input [4]: [channel#150, sum#164, isEmpty#165, sum#166]
+Keys [1]: [channel#150]
+Functions [2]: [sum(sum_sales#159), sum(number_sales#160)]
+Aggregate Attributes [2]: [sum(sum_sales#159)#167, sum(number_sales#160)#168]
+Results [6]: [channel#150, null AS i_brand_id#169, null AS i_class_id#170, null AS i_category_id#171, sum(sum_sales#159)#167 AS sum(sum_sales)#172, sum(number_sales#160)#168 AS sum(number_sales)#173]
 
 (116) ReusedExchange [Reuses operator id: 99]
-Output [7]: [channel#175, i_brand_id#176, i_class_id#177, i_category_id#178, sum#179, isEmpty#180, sum#181]
+Output [7]: [channel#174, i_brand_id#175, i_class_id#176, i_category_id#177, sum#178, isEmpty#179, sum#180]
 
 (117) HashAggregate [codegen id : 403]
-Input [7]: [channel#175, i_brand_id#176, i_class_id#177, i_category_id#178, sum#179, isEmpty#180, sum#181]
-Keys [4]: [channel#175, i_brand_id#176, i_class_id#177, i_category_id#178]
-Functions [2]: [sum(sales#182), sum(number_sales#183)]
-Aggregate Attributes [2]: [sum(sales#182)#102, sum(number_sales#183)#103]
-Results [2]: [sum(sales#182)#102 AS sum_sales#184, sum(number_sales#183)#103 AS number_sales#185]
+Input [7]: [channel#174, i_brand_id#175, i_class_id#176, i_category_id#177, sum#178, isEmpty#179, sum#180]
+Keys [4]: [channel#174, i_brand_id#175, i_class_id#176, i_category_id#177]
+Functions [2]: [sum(sales#181), sum(number_sales#182)]
+Aggregate Attributes [2]: [sum(sales#181)#101, sum(number_sales#182)#102]
+Results [2]: [sum(sales#181)#101 AS sum_sales#183, sum(number_sales#182)#102 AS number_sales#184]
 
 (118) HashAggregate [codegen id : 403]
-Input [2]: [sum_sales#184, number_sales#185]
+Input [2]: [sum_sales#183, number_sales#184]
 Keys: []
-Functions [2]: [partial_sum(sum_sales#184), partial_sum(number_sales#185)]
-Aggregate Attributes [3]: [sum#186, isEmpty#187, sum#188]
-Results [3]: [sum#189, isEmpty#190, sum#191]
+Functions [2]: [partial_sum(sum_sales#183), partial_sum(number_sales#184)]
+Aggregate Attributes [3]: [sum#185, isEmpty#186, sum#187]
+Results [3]: [sum#188, isEmpty#189, sum#190]
 
 (119) Exchange
-Input [3]: [sum#189, isEmpty#190, sum#191]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=16]
+Input [3]: [sum#188, isEmpty#189, sum#190]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
 
 (120) HashAggregate [codegen id : 404]
-Input [3]: [sum#189, isEmpty#190, sum#191]
+Input [3]: [sum#188, isEmpty#189, sum#190]
 Keys: []
-Functions [2]: [sum(sum_sales#184), sum(number_sales#185)]
-Aggregate Attributes [2]: [sum(sum_sales#184)#192, sum(number_sales#185)#193]
-Results [6]: [null AS channel#194, null AS i_brand_id#195, null AS i_class_id#196, null AS i_category_id#197, sum(sum_sales#184)#192 AS sum(sum_sales)#198, sum(number_sales#185)#193 AS sum(number_sales)#199]
+Functions [2]: [sum(sum_sales#183), sum(number_sales#184)]
+Aggregate Attributes [2]: [sum(sum_sales#183)#191, sum(number_sales#184)#192]
+Results [6]: [null AS channel#193, null AS i_brand_id#194, null AS i_class_id#195, null AS i_category_id#196, sum(sum_sales#183)#191 AS sum(sum_sales)#197, sum(number_sales#184)#192 AS sum(number_sales)#198]
 
 (121) Union
 
 (122) HashAggregate [codegen id : 405]
-Input [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#104, number_sales#105]
-Keys [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#104, number_sales#105]
+Input [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#103, number_sales#104]
+Keys [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#103, number_sales#104]
 Functions: []
 Aggregate Attributes: []
-Results [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#104, number_sales#105]
+Results [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#103, number_sales#104]
 
 (123) Exchange
-Input [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#104, number_sales#105]
-Arguments: hashpartitioning(channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#104, number_sales#105, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+Input [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#103, number_sales#104]
+Arguments: hashpartitioning(channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#103, number_sales#104, 5), ENSURE_REQUIREMENTS, [plan_id=18]
 
 (124) HashAggregate [codegen id : 406]
-Input [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#104, number_sales#105]
-Keys [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#104, number_sales#105]
+Input [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#103, number_sales#104]
+Keys [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#103, number_sales#104]
 Functions: []
 Aggregate Attributes: []
-Results [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#104, number_sales#105]
+Results [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#103, number_sales#104]
 
 (125) TakeOrderedAndProject
-Input [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#104, number_sales#105]
-Arguments: 100, [channel#49 ASC NULLS FIRST, i_brand_id#37 ASC NULLS FIRST, i_class_id#38 ASC NULLS FIRST, i_category_id#39 ASC NULLS FIRST], [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#104, number_sales#105]
+Input [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#103, number_sales#104]
+Arguments: 100, [channel#49 ASC NULLS FIRST, i_brand_id#37 ASC NULLS FIRST, i_class_id#38 ASC NULLS FIRST, i_category_id#39 ASC NULLS FIRST], [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum_sales#103, number_sales#104]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 66 Hosting Expression = Subquery scalar-subquery#52, [id=#53]
+Subquery:1 Hosting operator id = 66 Hosting Expression = Subquery scalar-subquery#52, [id=#10]
 * HashAggregate (144)
 +- Exchange (143)
    +- * HashAggregate (142)
@@ -767,97 +767,97 @@ Subquery:1 Hosting operator id = 66 Hosting Expression = Subquery scalar-subquer
 
 
 (126) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_quantity#200, ss_list_price#201, ss_sold_date_sk#202]
+Output [3]: [ss_quantity#199, ss_list_price#200, ss_sold_date_sk#201]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#202), dynamicpruningexpression(ss_sold_date_sk#202 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#201), dynamicpruningexpression(ss_sold_date_sk#201 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (127) ColumnarToRow [codegen id : 2]
-Input [3]: [ss_quantity#200, ss_list_price#201, ss_sold_date_sk#202]
+Input [3]: [ss_quantity#199, ss_list_price#200, ss_sold_date_sk#201]
 
 (128) ReusedExchange [Reuses operator id: 159]
-Output [1]: [d_date_sk#203]
+Output [1]: [d_date_sk#202]
 
 (129) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#202]
-Right keys [1]: [d_date_sk#203]
+Left keys [1]: [ss_sold_date_sk#201]
+Right keys [1]: [d_date_sk#202]
 Join type: Inner
 Join condition: None
 
 (130) Project [codegen id : 2]
-Output [2]: [ss_quantity#200 AS quantity#204, ss_list_price#201 AS list_price#205]
-Input [4]: [ss_quantity#200, ss_list_price#201, ss_sold_date_sk#202, d_date_sk#203]
+Output [2]: [ss_quantity#199 AS quantity#203, ss_list_price#200 AS list_price#204]
+Input [4]: [ss_quantity#199, ss_list_price#200, ss_sold_date_sk#201, d_date_sk#202]
 
 (131) Scan parquet spark_catalog.default.catalog_sales
-Output [3]: [cs_quantity#206, cs_list_price#207, cs_sold_date_sk#208]
+Output [3]: [cs_quantity#205, cs_list_price#206, cs_sold_date_sk#207]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#208), dynamicpruningexpression(cs_sold_date_sk#208 IN dynamicpruning#209)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#207), dynamicpruningexpression(cs_sold_date_sk#207 IN dynamicpruning#208)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (132) ColumnarToRow [codegen id : 4]
-Input [3]: [cs_quantity#206, cs_list_price#207, cs_sold_date_sk#208]
+Input [3]: [cs_quantity#205, cs_list_price#206, cs_sold_date_sk#207]
 
 (133) ReusedExchange [Reuses operator id: 149]
-Output [1]: [d_date_sk#210]
+Output [1]: [d_date_sk#209]
 
 (134) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_sold_date_sk#208]
-Right keys [1]: [d_date_sk#210]
+Left keys [1]: [cs_sold_date_sk#207]
+Right keys [1]: [d_date_sk#209]
 Join type: Inner
 Join condition: None
 
 (135) Project [codegen id : 4]
-Output [2]: [cs_quantity#206 AS quantity#211, cs_list_price#207 AS list_price#212]
-Input [4]: [cs_quantity#206, cs_list_price#207, cs_sold_date_sk#208, d_date_sk#210]
+Output [2]: [cs_quantity#205 AS quantity#210, cs_list_price#206 AS list_price#211]
+Input [4]: [cs_quantity#205, cs_list_price#206, cs_sold_date_sk#207, d_date_sk#209]
 
 (136) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_quantity#213, ws_list_price#214, ws_sold_date_sk#215]
+Output [3]: [ws_quantity#212, ws_list_price#213, ws_sold_date_sk#214]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#215), dynamicpruningexpression(ws_sold_date_sk#215 IN dynamicpruning#209)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#214), dynamicpruningexpression(ws_sold_date_sk#214 IN dynamicpruning#208)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (137) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_quantity#213, ws_list_price#214, ws_sold_date_sk#215]
+Input [3]: [ws_quantity#212, ws_list_price#213, ws_sold_date_sk#214]
 
 (138) ReusedExchange [Reuses operator id: 149]
-Output [1]: [d_date_sk#216]
+Output [1]: [d_date_sk#215]
 
 (139) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#215]
-Right keys [1]: [d_date_sk#216]
+Left keys [1]: [ws_sold_date_sk#214]
+Right keys [1]: [d_date_sk#215]
 Join type: Inner
 Join condition: None
 
 (140) Project [codegen id : 6]
-Output [2]: [ws_quantity#213 AS quantity#217, ws_list_price#214 AS list_price#218]
-Input [4]: [ws_quantity#213, ws_list_price#214, ws_sold_date_sk#215, d_date_sk#216]
+Output [2]: [ws_quantity#212 AS quantity#216, ws_list_price#213 AS list_price#217]
+Input [4]: [ws_quantity#212, ws_list_price#213, ws_sold_date_sk#214, d_date_sk#215]
 
 (141) Union
 
 (142) HashAggregate [codegen id : 7]
-Input [2]: [quantity#204, list_price#205]
+Input [2]: [quantity#203, list_price#204]
 Keys: []
-Functions [1]: [partial_avg((cast(quantity#204 as decimal(10,0)) * list_price#205))]
-Aggregate Attributes [2]: [sum#219, count#220]
-Results [2]: [sum#221, count#222]
+Functions [1]: [partial_avg((cast(quantity#203 as decimal(10,0)) * list_price#204))]
+Aggregate Attributes [2]: [sum#218, count#219]
+Results [2]: [sum#220, count#221]
 
 (143) Exchange
-Input [2]: [sum#221, count#222]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
+Input [2]: [sum#220, count#221]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
 
 (144) HashAggregate [codegen id : 8]
-Input [2]: [sum#221, count#222]
+Input [2]: [sum#220, count#221]
 Keys: []
-Functions [1]: [avg((cast(quantity#204 as decimal(10,0)) * list_price#205))]
-Aggregate Attributes [1]: [avg((cast(quantity#204 as decimal(10,0)) * list_price#205))#223]
-Results [1]: [avg((cast(quantity#204 as decimal(10,0)) * list_price#205))#223 AS average_sales#224]
+Functions [1]: [avg((cast(quantity#203 as decimal(10,0)) * list_price#204))]
+Aggregate Attributes [1]: [avg((cast(quantity#203 as decimal(10,0)) * list_price#204))#222]
+Results [1]: [avg((cast(quantity#203 as decimal(10,0)) * list_price#204))#222 AS average_sales#223]
 
-Subquery:2 Hosting operator id = 126 Hosting Expression = ss_sold_date_sk#202 IN dynamicpruning#12
+Subquery:2 Hosting operator id = 126 Hosting Expression = ss_sold_date_sk#201 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 131 Hosting Expression = cs_sold_date_sk#208 IN dynamicpruning#209
+Subquery:3 Hosting operator id = 131 Hosting Expression = cs_sold_date_sk#207 IN dynamicpruning#208
 BroadcastExchange (149)
 +- * Project (148)
    +- * Filter (147)
@@ -866,28 +866,28 @@ BroadcastExchange (149)
 
 
 (145) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#210, d_year#225]
+Output [2]: [d_date_sk#209, d_year#224]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1998), LessThanOrEqual(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (146) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#210, d_year#225]
+Input [2]: [d_date_sk#209, d_year#224]
 
 (147) Filter [codegen id : 1]
-Input [2]: [d_date_sk#210, d_year#225]
-Condition : (((isnotnull(d_year#225) AND (d_year#225 >= 1998)) AND (d_year#225 <= 2000)) AND isnotnull(d_date_sk#210))
+Input [2]: [d_date_sk#209, d_year#224]
+Condition : (((isnotnull(d_year#224) AND (d_year#224 >= 1998)) AND (d_year#224 <= 2000)) AND isnotnull(d_date_sk#209))
 
 (148) Project [codegen id : 1]
-Output [1]: [d_date_sk#210]
-Input [2]: [d_date_sk#210, d_year#225]
+Output [1]: [d_date_sk#209]
+Input [2]: [d_date_sk#209, d_year#224]
 
 (149) BroadcastExchange
-Input [1]: [d_date_sk#210]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=19]
+Input [1]: [d_date_sk#209]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=20]
 
-Subquery:4 Hosting operator id = 136 Hosting Expression = ws_sold_date_sk#215 IN dynamicpruning#209
+Subquery:4 Hosting operator id = 136 Hosting Expression = ws_sold_date_sk#214 IN dynamicpruning#208
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (154)
@@ -898,26 +898,26 @@ BroadcastExchange (154)
 
 
 (150) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#40, d_year#226, d_moy#227]
+Output [3]: [d_date_sk#40, d_year#225, d_moy#226]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,11), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (151) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#40, d_year#226, d_moy#227]
+Input [3]: [d_date_sk#40, d_year#225, d_moy#226]
 
 (152) Filter [codegen id : 1]
-Input [3]: [d_date_sk#40, d_year#226, d_moy#227]
-Condition : ((((isnotnull(d_year#226) AND isnotnull(d_moy#227)) AND (d_year#226 = 2000)) AND (d_moy#227 = 11)) AND isnotnull(d_date_sk#40))
+Input [3]: [d_date_sk#40, d_year#225, d_moy#226]
+Condition : ((((isnotnull(d_year#225) AND isnotnull(d_moy#226)) AND (d_year#225 = 2000)) AND (d_moy#226 = 11)) AND isnotnull(d_date_sk#40))
 
 (153) Project [codegen id : 1]
 Output [1]: [d_date_sk#40]
-Input [3]: [d_date_sk#40, d_year#226, d_moy#227]
+Input [3]: [d_date_sk#40, d_year#225, d_moy#226]
 
 (154) BroadcastExchange
 Input [1]: [d_date_sk#40]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=21]
 
 Subquery:6 Hosting operator id = 7 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
 BroadcastExchange (159)
@@ -928,37 +928,37 @@ BroadcastExchange (159)
 
 
 (155) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#24, d_year#228]
+Output [2]: [d_date_sk#24, d_year#227]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (156) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#24, d_year#228]
+Input [2]: [d_date_sk#24, d_year#227]
 
 (157) Filter [codegen id : 1]
-Input [2]: [d_date_sk#24, d_year#228]
-Condition : (((isnotnull(d_year#228) AND (d_year#228 >= 1999)) AND (d_year#228 <= 2001)) AND isnotnull(d_date_sk#24))
+Input [2]: [d_date_sk#24, d_year#227]
+Condition : (((isnotnull(d_year#227) AND (d_year#227 >= 1999)) AND (d_year#227 <= 2001)) AND isnotnull(d_date_sk#24))
 
 (158) Project [codegen id : 1]
 Output [1]: [d_date_sk#24]
-Input [2]: [d_date_sk#24, d_year#228]
+Input [2]: [d_date_sk#24, d_year#227]
 
 (159) BroadcastExchange
 Input [1]: [d_date_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=22]
 
 Subquery:7 Hosting operator id = 13 Hosting Expression = cs_sold_date_sk#18 IN dynamicpruning#12
 
 Subquery:8 Hosting operator id = 36 Hosting Expression = ws_sold_date_sk#29 IN dynamicpruning#12
 
-Subquery:9 Hosting operator id = 81 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#53]
+Subquery:9 Hosting operator id = 81 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#10]
 
-Subquery:10 Hosting operator id = 67 Hosting Expression = cs_sold_date_sk#57 IN dynamicpruning#5
+Subquery:10 Hosting operator id = 67 Hosting Expression = cs_sold_date_sk#56 IN dynamicpruning#5
 
-Subquery:11 Hosting operator id = 96 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#53]
+Subquery:11 Hosting operator id = 96 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#10]
 
-Subquery:12 Hosting operator id = 82 Hosting Expression = ws_sold_date_sk#78 IN dynamicpruning#5
+Subquery:12 Hosting operator id = 82 Hosting Expression = ws_sold_date_sk#77 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24.sf100/explain.txt
@@ -265,11 +265,11 @@ Results [4]: [c_last_name#13, c_first_name#12, s_store_name#2, sum(netpaid#33)#3
 
 (46) Filter [codegen id : 11]
 Input [4]: [c_last_name#13, c_first_name#12, s_store_name#2, paid#39]
-Condition : (isnotnull(paid#39) AND (cast(paid#39 as decimal(33,8)) > cast(Subquery scalar-subquery#40, [id=#41] as decimal(33,8))))
+Condition : (isnotnull(paid#39) AND (cast(paid#39 as decimal(33,8)) > cast(Subquery scalar-subquery#40, [id=#9] as decimal(33,8))))
 
 (47) Exchange
 Input [4]: [c_last_name#13, c_first_name#12, s_store_name#2, paid#39]
-Arguments: rangepartitioning(c_last_name#13 ASC NULLS FIRST, c_first_name#12 ASC NULLS FIRST, s_store_name#2 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Arguments: rangepartitioning(c_last_name#13 ASC NULLS FIRST, c_first_name#12 ASC NULLS FIRST, s_store_name#2 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (48) Sort [codegen id : 12]
 Input [4]: [c_last_name#13, c_first_name#12, s_store_name#2, paid#39]
@@ -277,7 +277,7 @@ Arguments: [c_last_name#13 ASC NULLS FIRST, c_first_name#12 ASC NULLS FIRST, s_s
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquery#40, [id=#41]
+Subquery:1 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquery#40, [id=#9]
 * HashAggregate (76)
 +- Exchange (75)
    +- * HashAggregate (74)
@@ -309,135 +309,135 @@ Subquery:1 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquer
 
 
 (49) ReusedExchange [Reuses operator id: 17]
-Output [7]: [s_store_sk#42, s_store_name#43, s_state#44, ca_state#45, c_customer_sk#46, c_first_name#47, c_last_name#48]
+Output [7]: [s_store_sk#41, s_store_name#42, s_state#43, ca_state#44, c_customer_sk#45, c_first_name#46, c_last_name#47]
 
 (50) Scan parquet spark_catalog.default.store_sales
-Output [6]: [ss_item_sk#49, ss_customer_sk#50, ss_store_sk#51, ss_ticket_number#52, ss_net_paid#53, ss_sold_date_sk#54]
+Output [6]: [ss_item_sk#48, ss_customer_sk#49, ss_store_sk#50, ss_ticket_number#51, ss_net_paid#52, ss_sold_date_sk#53]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_paid:decimal(7,2)>
 
 (51) ColumnarToRow
-Input [6]: [ss_item_sk#49, ss_customer_sk#50, ss_store_sk#51, ss_ticket_number#52, ss_net_paid#53, ss_sold_date_sk#54]
+Input [6]: [ss_item_sk#48, ss_customer_sk#49, ss_store_sk#50, ss_ticket_number#51, ss_net_paid#52, ss_sold_date_sk#53]
 
 (52) Filter
-Input [6]: [ss_item_sk#49, ss_customer_sk#50, ss_store_sk#51, ss_ticket_number#52, ss_net_paid#53, ss_sold_date_sk#54]
-Condition : (((isnotnull(ss_ticket_number#52) AND isnotnull(ss_item_sk#49)) AND isnotnull(ss_store_sk#51)) AND isnotnull(ss_customer_sk#50))
+Input [6]: [ss_item_sk#48, ss_customer_sk#49, ss_store_sk#50, ss_ticket_number#51, ss_net_paid#52, ss_sold_date_sk#53]
+Condition : (((isnotnull(ss_ticket_number#51) AND isnotnull(ss_item_sk#48)) AND isnotnull(ss_store_sk#50)) AND isnotnull(ss_customer_sk#49))
 
 (53) Project
-Output [5]: [ss_item_sk#49, ss_customer_sk#50, ss_store_sk#51, ss_ticket_number#52, ss_net_paid#53]
-Input [6]: [ss_item_sk#49, ss_customer_sk#50, ss_store_sk#51, ss_ticket_number#52, ss_net_paid#53, ss_sold_date_sk#54]
+Output [5]: [ss_item_sk#48, ss_customer_sk#49, ss_store_sk#50, ss_ticket_number#51, ss_net_paid#52]
+Input [6]: [ss_item_sk#48, ss_customer_sk#49, ss_store_sk#50, ss_ticket_number#51, ss_net_paid#52, ss_sold_date_sk#53]
 
 (54) BroadcastHashJoin [codegen id : 4]
-Left keys [2]: [s_store_sk#42, c_customer_sk#46]
-Right keys [2]: [ss_store_sk#51, ss_customer_sk#50]
+Left keys [2]: [s_store_sk#41, c_customer_sk#45]
+Right keys [2]: [ss_store_sk#50, ss_customer_sk#49]
 Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 4]
-Output [8]: [s_store_name#43, s_state#44, ca_state#45, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_ticket_number#52, ss_net_paid#53]
-Input [12]: [s_store_sk#42, s_store_name#43, s_state#44, ca_state#45, c_customer_sk#46, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_customer_sk#50, ss_store_sk#51, ss_ticket_number#52, ss_net_paid#53]
+Output [8]: [s_store_name#42, s_state#43, ca_state#44, c_first_name#46, c_last_name#47, ss_item_sk#48, ss_ticket_number#51, ss_net_paid#52]
+Input [12]: [s_store_sk#41, s_store_name#42, s_state#43, ca_state#44, c_customer_sk#45, c_first_name#46, c_last_name#47, ss_item_sk#48, ss_customer_sk#49, ss_store_sk#50, ss_ticket_number#51, ss_net_paid#52]
 
 (56) Exchange
-Input [8]: [s_store_name#43, s_state#44, ca_state#45, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_ticket_number#52, ss_net_paid#53]
-Arguments: hashpartitioning(ss_item_sk#49, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [8]: [s_store_name#42, s_state#43, ca_state#44, c_first_name#46, c_last_name#47, ss_item_sk#48, ss_ticket_number#51, ss_net_paid#52]
+Arguments: hashpartitioning(ss_item_sk#48, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (57) Sort [codegen id : 5]
-Input [8]: [s_store_name#43, s_state#44, ca_state#45, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_ticket_number#52, ss_net_paid#53]
-Arguments: [ss_item_sk#49 ASC NULLS FIRST], false, 0
+Input [8]: [s_store_name#42, s_state#43, ca_state#44, c_first_name#46, c_last_name#47, ss_item_sk#48, ss_ticket_number#51, ss_net_paid#52]
+Arguments: [ss_item_sk#48 ASC NULLS FIRST], false, 0
 
 (58) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#55, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
+Output [6]: [i_item_sk#54, i_current_price#55, i_size#56, i_color#57, i_units#58, i_manager_id#59]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (59) ColumnarToRow [codegen id : 6]
-Input [6]: [i_item_sk#55, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
+Input [6]: [i_item_sk#54, i_current_price#55, i_size#56, i_color#57, i_units#58, i_manager_id#59]
 
 (60) Filter [codegen id : 6]
-Input [6]: [i_item_sk#55, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
-Condition : isnotnull(i_item_sk#55)
+Input [6]: [i_item_sk#54, i_current_price#55, i_size#56, i_color#57, i_units#58, i_manager_id#59]
+Condition : isnotnull(i_item_sk#54)
 
 (61) Exchange
-Input [6]: [i_item_sk#55, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
-Arguments: hashpartitioning(i_item_sk#55, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [6]: [i_item_sk#54, i_current_price#55, i_size#56, i_color#57, i_units#58, i_manager_id#59]
+Arguments: hashpartitioning(i_item_sk#54, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (62) Sort [codegen id : 7]
-Input [6]: [i_item_sk#55, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
-Arguments: [i_item_sk#55 ASC NULLS FIRST], false, 0
+Input [6]: [i_item_sk#54, i_current_price#55, i_size#56, i_color#57, i_units#58, i_manager_id#59]
+Arguments: [i_item_sk#54 ASC NULLS FIRST], false, 0
 
 (63) SortMergeJoin [codegen id : 8]
-Left keys [1]: [ss_item_sk#49]
-Right keys [1]: [i_item_sk#55]
+Left keys [1]: [ss_item_sk#48]
+Right keys [1]: [i_item_sk#54]
 Join type: Inner
 Join condition: None
 
 (64) Project [codegen id : 8]
-Output [13]: [s_store_name#43, s_state#44, ca_state#45, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_ticket_number#52, ss_net_paid#53, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
-Input [14]: [s_store_name#43, s_state#44, ca_state#45, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_ticket_number#52, ss_net_paid#53, i_item_sk#55, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
+Output [13]: [s_store_name#42, s_state#43, ca_state#44, c_first_name#46, c_last_name#47, ss_item_sk#48, ss_ticket_number#51, ss_net_paid#52, i_current_price#55, i_size#56, i_color#57, i_units#58, i_manager_id#59]
+Input [14]: [s_store_name#42, s_state#43, ca_state#44, c_first_name#46, c_last_name#47, ss_item_sk#48, ss_ticket_number#51, ss_net_paid#52, i_item_sk#54, i_current_price#55, i_size#56, i_color#57, i_units#58, i_manager_id#59]
 
 (65) Exchange
-Input [13]: [s_store_name#43, s_state#44, ca_state#45, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_ticket_number#52, ss_net_paid#53, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
-Arguments: hashpartitioning(ss_ticket_number#52, ss_item_sk#49, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [13]: [s_store_name#42, s_state#43, ca_state#44, c_first_name#46, c_last_name#47, ss_item_sk#48, ss_ticket_number#51, ss_net_paid#52, i_current_price#55, i_size#56, i_color#57, i_units#58, i_manager_id#59]
+Arguments: hashpartitioning(ss_ticket_number#51, ss_item_sk#48, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (66) Sort [codegen id : 9]
-Input [13]: [s_store_name#43, s_state#44, ca_state#45, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_ticket_number#52, ss_net_paid#53, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
-Arguments: [ss_ticket_number#52 ASC NULLS FIRST, ss_item_sk#49 ASC NULLS FIRST], false, 0
+Input [13]: [s_store_name#42, s_state#43, ca_state#44, c_first_name#46, c_last_name#47, ss_item_sk#48, ss_ticket_number#51, ss_net_paid#52, i_current_price#55, i_size#56, i_color#57, i_units#58, i_manager_id#59]
+Arguments: [ss_ticket_number#51 ASC NULLS FIRST, ss_item_sk#48 ASC NULLS FIRST], false, 0
 
 (67) ReusedExchange [Reuses operator id: 36]
-Output [2]: [sr_item_sk#61, sr_ticket_number#62]
+Output [2]: [sr_item_sk#60, sr_ticket_number#61]
 
 (68) Sort [codegen id : 11]
-Input [2]: [sr_item_sk#61, sr_ticket_number#62]
-Arguments: [sr_ticket_number#62 ASC NULLS FIRST, sr_item_sk#61 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#60, sr_ticket_number#61]
+Arguments: [sr_ticket_number#61 ASC NULLS FIRST, sr_item_sk#60 ASC NULLS FIRST], false, 0
 
 (69) SortMergeJoin [codegen id : 12]
-Left keys [2]: [ss_ticket_number#52, ss_item_sk#49]
-Right keys [2]: [sr_ticket_number#62, sr_item_sk#61]
+Left keys [2]: [ss_ticket_number#51, ss_item_sk#48]
+Right keys [2]: [sr_ticket_number#61, sr_item_sk#60]
 Join type: Inner
 Join condition: None
 
 (70) Project [codegen id : 12]
-Output [11]: [ss_net_paid#53, s_store_name#43, s_state#44, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60, c_first_name#47, c_last_name#48, ca_state#45]
-Input [15]: [s_store_name#43, s_state#44, ca_state#45, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_ticket_number#52, ss_net_paid#53, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60, sr_item_sk#61, sr_ticket_number#62]
+Output [11]: [ss_net_paid#52, s_store_name#42, s_state#43, i_current_price#55, i_size#56, i_color#57, i_units#58, i_manager_id#59, c_first_name#46, c_last_name#47, ca_state#44]
+Input [15]: [s_store_name#42, s_state#43, ca_state#44, c_first_name#46, c_last_name#47, ss_item_sk#48, ss_ticket_number#51, ss_net_paid#52, i_current_price#55, i_size#56, i_color#57, i_units#58, i_manager_id#59, sr_item_sk#60, sr_ticket_number#61]
 
 (71) HashAggregate [codegen id : 12]
-Input [11]: [ss_net_paid#53, s_store_name#43, s_state#44, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60, c_first_name#47, c_last_name#48, ca_state#45]
-Keys [10]: [c_last_name#48, c_first_name#47, s_store_name#43, ca_state#45, s_state#44, i_color#58, i_current_price#56, i_manager_id#60, i_units#59, i_size#57]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#53))]
-Aggregate Attributes [1]: [sum#63]
-Results [11]: [c_last_name#48, c_first_name#47, s_store_name#43, ca_state#45, s_state#44, i_color#58, i_current_price#56, i_manager_id#60, i_units#59, i_size#57, sum#64]
+Input [11]: [ss_net_paid#52, s_store_name#42, s_state#43, i_current_price#55, i_size#56, i_color#57, i_units#58, i_manager_id#59, c_first_name#46, c_last_name#47, ca_state#44]
+Keys [10]: [c_last_name#47, c_first_name#46, s_store_name#42, ca_state#44, s_state#43, i_color#57, i_current_price#55, i_manager_id#59, i_units#58, i_size#56]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#52))]
+Aggregate Attributes [1]: [sum#62]
+Results [11]: [c_last_name#47, c_first_name#46, s_store_name#42, ca_state#44, s_state#43, i_color#57, i_current_price#55, i_manager_id#59, i_units#58, i_size#56, sum#63]
 
 (72) Exchange
-Input [11]: [c_last_name#48, c_first_name#47, s_store_name#43, ca_state#45, s_state#44, i_color#58, i_current_price#56, i_manager_id#60, i_units#59, i_size#57, sum#64]
-Arguments: hashpartitioning(c_last_name#48, c_first_name#47, s_store_name#43, ca_state#45, s_state#44, i_color#58, i_current_price#56, i_manager_id#60, i_units#59, i_size#57, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+Input [11]: [c_last_name#47, c_first_name#46, s_store_name#42, ca_state#44, s_state#43, i_color#57, i_current_price#55, i_manager_id#59, i_units#58, i_size#56, sum#63]
+Arguments: hashpartitioning(c_last_name#47, c_first_name#46, s_store_name#42, ca_state#44, s_state#43, i_color#57, i_current_price#55, i_manager_id#59, i_units#58, i_size#56, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (73) HashAggregate [codegen id : 13]
-Input [11]: [c_last_name#48, c_first_name#47, s_store_name#43, ca_state#45, s_state#44, i_color#58, i_current_price#56, i_manager_id#60, i_units#59, i_size#57, sum#64]
-Keys [10]: [c_last_name#48, c_first_name#47, s_store_name#43, ca_state#45, s_state#44, i_color#58, i_current_price#56, i_manager_id#60, i_units#59, i_size#57]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#53))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#53))#32]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#53))#32,17,2) AS netpaid#65]
+Input [11]: [c_last_name#47, c_first_name#46, s_store_name#42, ca_state#44, s_state#43, i_color#57, i_current_price#55, i_manager_id#59, i_units#58, i_size#56, sum#63]
+Keys [10]: [c_last_name#47, c_first_name#46, s_store_name#42, ca_state#44, s_state#43, i_color#57, i_current_price#55, i_manager_id#59, i_units#58, i_size#56]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#52))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#52))#32]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#52))#32,17,2) AS netpaid#64]
 
 (74) HashAggregate [codegen id : 13]
-Input [1]: [netpaid#65]
+Input [1]: [netpaid#64]
 Keys: []
-Functions [1]: [partial_avg(netpaid#65)]
-Aggregate Attributes [2]: [sum#66, count#67]
-Results [2]: [sum#68, count#69]
+Functions [1]: [partial_avg(netpaid#64)]
+Aggregate Attributes [2]: [sum#65, count#66]
+Results [2]: [sum#67, count#68]
 
 (75) Exchange
-Input [2]: [sum#68, count#69]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
+Input [2]: [sum#67, count#68]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
 
 (76) HashAggregate [codegen id : 14]
-Input [2]: [sum#68, count#69]
+Input [2]: [sum#67, count#68]
 Keys: []
-Functions [1]: [avg(netpaid#65)]
-Aggregate Attributes [1]: [avg(netpaid#65)#70]
-Results [1]: [(0.05 * avg(netpaid#65)#70) AS (0.05 * avg(netpaid))#71]
+Functions [1]: [avg(netpaid#64)]
+Aggregate Attributes [1]: [avg(netpaid#64)#69]
+Results [1]: [(0.05 * avg(netpaid#64)#69) AS (0.05 * avg(netpaid))#70]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24/explain.txt
@@ -265,11 +265,11 @@ Results [4]: [c_last_name#24, c_first_name#23, s_store_name#11, sum(netpaid#33)#
 
 (46) Filter [codegen id : 11]
 Input [4]: [c_last_name#24, c_first_name#23, s_store_name#11, paid#39]
-Condition : (isnotnull(paid#39) AND (cast(paid#39 as decimal(33,8)) > cast(Subquery scalar-subquery#40, [id=#41] as decimal(33,8))))
+Condition : (isnotnull(paid#39) AND (cast(paid#39 as decimal(33,8)) > cast(Subquery scalar-subquery#40, [id=#9] as decimal(33,8))))
 
 (47) Exchange
 Input [4]: [c_last_name#24, c_first_name#23, s_store_name#11, paid#39]
-Arguments: rangepartitioning(c_last_name#24 ASC NULLS FIRST, c_first_name#23 ASC NULLS FIRST, s_store_name#11 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Arguments: rangepartitioning(c_last_name#24 ASC NULLS FIRST, c_first_name#23 ASC NULLS FIRST, s_store_name#11 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (48) Sort [codegen id : 12]
 Input [4]: [c_last_name#24, c_first_name#23, s_store_name#11, paid#39]
@@ -277,7 +277,7 @@ Arguments: [c_last_name#24 ASC NULLS FIRST, c_first_name#23 ASC NULLS FIRST, s_s
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquery#40, [id=#41]
+Subquery:1 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquery#40, [id=#9]
 * HashAggregate (75)
 +- Exchange (74)
    +- * HashAggregate (73)
@@ -308,130 +308,130 @@ Subquery:1 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquer
 
 
 (49) ReusedExchange [Reuses operator id: 5]
-Output [5]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46]
+Output [5]: [ss_item_sk#41, ss_customer_sk#42, ss_store_sk#43, ss_ticket_number#44, ss_net_paid#45]
 
 (50) Sort [codegen id : 2]
-Input [5]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46]
-Arguments: [ss_ticket_number#45 ASC NULLS FIRST, ss_item_sk#42 ASC NULLS FIRST], false, 0
+Input [5]: [ss_item_sk#41, ss_customer_sk#42, ss_store_sk#43, ss_ticket_number#44, ss_net_paid#45]
+Arguments: [ss_ticket_number#44 ASC NULLS FIRST, ss_item_sk#41 ASC NULLS FIRST], false, 0
 
 (51) ReusedExchange [Reuses operator id: 11]
-Output [2]: [sr_item_sk#47, sr_ticket_number#48]
+Output [2]: [sr_item_sk#46, sr_ticket_number#47]
 
 (52) Sort [codegen id : 4]
-Input [2]: [sr_item_sk#47, sr_ticket_number#48]
-Arguments: [sr_ticket_number#48 ASC NULLS FIRST, sr_item_sk#47 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#46, sr_ticket_number#47]
+Arguments: [sr_ticket_number#47 ASC NULLS FIRST, sr_item_sk#46 ASC NULLS FIRST], false, 0
 
 (53) SortMergeJoin [codegen id : 9]
-Left keys [2]: [ss_ticket_number#45, ss_item_sk#42]
-Right keys [2]: [sr_ticket_number#48, sr_item_sk#47]
+Left keys [2]: [ss_ticket_number#44, ss_item_sk#41]
+Right keys [2]: [sr_ticket_number#47, sr_item_sk#46]
 Join type: Inner
 Join condition: None
 
 (54) Project [codegen id : 9]
-Output [4]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_net_paid#46]
-Input [7]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, sr_item_sk#47, sr_ticket_number#48]
+Output [4]: [ss_item_sk#41, ss_customer_sk#42, ss_store_sk#43, ss_net_paid#45]
+Input [7]: [ss_item_sk#41, ss_customer_sk#42, ss_store_sk#43, ss_ticket_number#44, ss_net_paid#45, sr_item_sk#46, sr_ticket_number#47]
 
 (55) ReusedExchange [Reuses operator id: 19]
-Output [4]: [s_store_sk#49, s_store_name#50, s_state#51, s_zip#52]
+Output [4]: [s_store_sk#48, s_store_name#49, s_state#50, s_zip#51]
 
 (56) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ss_store_sk#44]
-Right keys [1]: [s_store_sk#49]
+Left keys [1]: [ss_store_sk#43]
+Right keys [1]: [s_store_sk#48]
 Join type: Inner
 Join condition: None
 
 (57) Project [codegen id : 9]
-Output [6]: [ss_item_sk#42, ss_customer_sk#43, ss_net_paid#46, s_store_name#50, s_state#51, s_zip#52]
-Input [8]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_net_paid#46, s_store_sk#49, s_store_name#50, s_state#51, s_zip#52]
+Output [6]: [ss_item_sk#41, ss_customer_sk#42, ss_net_paid#45, s_store_name#49, s_state#50, s_zip#51]
+Input [8]: [ss_item_sk#41, ss_customer_sk#42, ss_store_sk#43, ss_net_paid#45, s_store_sk#48, s_store_name#49, s_state#50, s_zip#51]
 
 (58) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Output [6]: [i_item_sk#52, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (59) ColumnarToRow [codegen id : 6]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Input [6]: [i_item_sk#52, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
 
 (60) Filter [codegen id : 6]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Condition : isnotnull(i_item_sk#53)
+Input [6]: [i_item_sk#52, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
+Condition : isnotnull(i_item_sk#52)
 
 (61) BroadcastExchange
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=10]
+Input [6]: [i_item_sk#52, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=11]
 
 (62) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ss_item_sk#42]
-Right keys [1]: [i_item_sk#53]
+Left keys [1]: [ss_item_sk#41]
+Right keys [1]: [i_item_sk#52]
 Join type: Inner
 Join condition: None
 
 (63) Project [codegen id : 9]
-Output [10]: [ss_customer_sk#43, ss_net_paid#46, s_store_name#50, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Input [12]: [ss_item_sk#42, ss_customer_sk#43, ss_net_paid#46, s_store_name#50, s_state#51, s_zip#52, i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Output [10]: [ss_customer_sk#42, ss_net_paid#45, s_store_name#49, s_state#50, s_zip#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
+Input [12]: [ss_item_sk#41, ss_customer_sk#42, ss_net_paid#45, s_store_name#49, s_state#50, s_zip#51, i_item_sk#52, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
 
 (64) ReusedExchange [Reuses operator id: 31]
-Output [5]: [c_customer_sk#59, c_current_addr_sk#60, c_first_name#61, c_last_name#62, c_birth_country#63]
+Output [5]: [c_customer_sk#58, c_current_addr_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
 
 (65) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ss_customer_sk#43]
-Right keys [1]: [c_customer_sk#59]
+Left keys [1]: [ss_customer_sk#42]
+Right keys [1]: [c_customer_sk#58]
 Join type: Inner
 Join condition: None
 
 (66) Project [codegen id : 9]
-Output [13]: [ss_net_paid#46, s_store_name#50, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_current_addr_sk#60, c_first_name#61, c_last_name#62, c_birth_country#63]
-Input [15]: [ss_customer_sk#43, ss_net_paid#46, s_store_name#50, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_customer_sk#59, c_current_addr_sk#60, c_first_name#61, c_last_name#62, c_birth_country#63]
+Output [13]: [ss_net_paid#45, s_store_name#49, s_state#50, s_zip#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57, c_current_addr_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
+Input [15]: [ss_customer_sk#42, ss_net_paid#45, s_store_name#49, s_state#50, s_zip#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57, c_customer_sk#58, c_current_addr_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
 
 (67) ReusedExchange [Reuses operator id: 37]
-Output [4]: [ca_address_sk#64, ca_state#65, ca_zip#66, ca_country#67]
+Output [4]: [ca_address_sk#63, ca_state#64, ca_zip#65, ca_country#66]
 
 (68) BroadcastHashJoin [codegen id : 9]
-Left keys [3]: [c_current_addr_sk#60, c_birth_country#63, s_zip#52]
-Right keys [3]: [ca_address_sk#64, upper(ca_country#67), ca_zip#66]
+Left keys [3]: [c_current_addr_sk#59, c_birth_country#62, s_zip#51]
+Right keys [3]: [ca_address_sk#63, upper(ca_country#66), ca_zip#65]
 Join type: Inner
 Join condition: None
 
 (69) Project [codegen id : 9]
-Output [11]: [ss_net_paid#46, s_store_name#50, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#61, c_last_name#62, ca_state#65]
-Input [17]: [ss_net_paid#46, s_store_name#50, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_current_addr_sk#60, c_first_name#61, c_last_name#62, c_birth_country#63, ca_address_sk#64, ca_state#65, ca_zip#66, ca_country#67]
+Output [11]: [ss_net_paid#45, s_store_name#49, s_state#50, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57, c_first_name#60, c_last_name#61, ca_state#64]
+Input [17]: [ss_net_paid#45, s_store_name#49, s_state#50, s_zip#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57, c_current_addr_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62, ca_address_sk#63, ca_state#64, ca_zip#65, ca_country#66]
 
 (70) HashAggregate [codegen id : 9]
-Input [11]: [ss_net_paid#46, s_store_name#50, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#61, c_last_name#62, ca_state#65]
-Keys [10]: [c_last_name#62, c_first_name#61, s_store_name#50, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#46))]
-Aggregate Attributes [1]: [sum#68]
-Results [11]: [c_last_name#62, c_first_name#61, s_store_name#50, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
+Input [11]: [ss_net_paid#45, s_store_name#49, s_state#50, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57, c_first_name#60, c_last_name#61, ca_state#64]
+Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#64, s_state#50, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#45))]
+Aggregate Attributes [1]: [sum#67]
+Results [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#64, s_state#50, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54, sum#68]
 
 (71) Exchange
-Input [11]: [c_last_name#62, c_first_name#61, s_store_name#50, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
-Arguments: hashpartitioning(c_last_name#62, c_first_name#61, s_store_name#50, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#64, s_state#50, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54, sum#68]
+Arguments: hashpartitioning(c_last_name#61, c_first_name#60, s_store_name#49, ca_state#64, s_state#50, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (72) HashAggregate [codegen id : 10]
-Input [11]: [c_last_name#62, c_first_name#61, s_store_name#50, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
-Keys [10]: [c_last_name#62, c_first_name#61, s_store_name#50, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#46))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#46))#32]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#46))#32,17,2) AS netpaid#70]
+Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#64, s_state#50, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54, sum#68]
+Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#64, s_state#50, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#45))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#45))#32]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#45))#32,17,2) AS netpaid#69]
 
 (73) HashAggregate [codegen id : 10]
-Input [1]: [netpaid#70]
+Input [1]: [netpaid#69]
 Keys: []
-Functions [1]: [partial_avg(netpaid#70)]
-Aggregate Attributes [2]: [sum#71, count#72]
-Results [2]: [sum#73, count#74]
+Functions [1]: [partial_avg(netpaid#69)]
+Aggregate Attributes [2]: [sum#70, count#71]
+Results [2]: [sum#72, count#73]
 
 (74) Exchange
-Input [2]: [sum#73, count#74]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
+Input [2]: [sum#72, count#73]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
 
 (75) HashAggregate [codegen id : 11]
-Input [2]: [sum#73, count#74]
+Input [2]: [sum#72, count#73]
 Keys: []
-Functions [1]: [avg(netpaid#70)]
-Aggregate Attributes [1]: [avg(netpaid#70)#75]
-Results [1]: [(0.05 * avg(netpaid#70)#75) AS (0.05 * avg(netpaid))#76]
+Functions [1]: [avg(netpaid#69)]
+Aggregate Attributes [1]: [avg(netpaid#69)#74]
+Results [1]: [(0.05 * avg(netpaid#69)#74) AS (0.05 * avg(netpaid))#75]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/explain.txt
@@ -280,7 +280,7 @@ Input [2]: [d_date_sk#16, d_month_seq#26]
 
 (48) Filter [codegen id : 1]
 Input [2]: [d_date_sk#16, d_month_seq#26]
-Condition : ((isnotnull(d_month_seq#26) AND (d_month_seq#26 = ReusedSubquery Subquery scalar-subquery#27, [id=#28])) AND isnotnull(d_date_sk#16))
+Condition : ((isnotnull(d_month_seq#26) AND (d_month_seq#26 = ReusedSubquery Subquery scalar-subquery#27, [id=#9])) AND isnotnull(d_date_sk#16))
 
 (49) Project [codegen id : 1]
 Output [1]: [d_date_sk#16]
@@ -288,11 +288,11 @@ Input [2]: [d_date_sk#16, d_month_seq#26]
 
 (50) BroadcastExchange
 Input [1]: [d_date_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
-Subquery:2 Hosting operator id = 48 Hosting Expression = ReusedSubquery Subquery scalar-subquery#27, [id=#28]
+Subquery:2 Hosting operator id = 48 Hosting Expression = ReusedSubquery Subquery scalar-subquery#27, [id=#9]
 
-Subquery:3 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquery#27, [id=#28]
+Subquery:3 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquery#27, [id=#9]
 * HashAggregate (57)
 +- Exchange (56)
    +- * HashAggregate (55)
@@ -303,39 +303,39 @@ Subquery:3 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquer
 
 
 (51) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_month_seq#29, d_year#30, d_moy#31]
+Output [3]: [d_month_seq#28, d_year#29, d_moy#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,1)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
 (52) ColumnarToRow [codegen id : 1]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
+Input [3]: [d_month_seq#28, d_year#29, d_moy#30]
 
 (53) Filter [codegen id : 1]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
-Condition : (((isnotnull(d_year#30) AND isnotnull(d_moy#31)) AND (d_year#30 = 2000)) AND (d_moy#31 = 1))
+Input [3]: [d_month_seq#28, d_year#29, d_moy#30]
+Condition : (((isnotnull(d_year#29) AND isnotnull(d_moy#30)) AND (d_year#29 = 2000)) AND (d_moy#30 = 1))
 
 (54) Project [codegen id : 1]
-Output [1]: [d_month_seq#29]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
+Output [1]: [d_month_seq#28]
+Input [3]: [d_month_seq#28, d_year#29, d_moy#30]
 
 (55) HashAggregate [codegen id : 1]
-Input [1]: [d_month_seq#29]
-Keys [1]: [d_month_seq#29]
+Input [1]: [d_month_seq#28]
+Keys [1]: [d_month_seq#28]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [d_month_seq#29]
+Results [1]: [d_month_seq#28]
 
 (56) Exchange
-Input [1]: [d_month_seq#29]
-Arguments: hashpartitioning(d_month_seq#29, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [1]: [d_month_seq#28]
+Arguments: hashpartitioning(d_month_seq#28, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (57) HashAggregate [codegen id : 2]
-Input [1]: [d_month_seq#29]
-Keys [1]: [d_month_seq#29]
+Input [1]: [d_month_seq#28]
+Keys [1]: [d_month_seq#28]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [d_month_seq#29]
+Results [1]: [d_month_seq#28]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6/explain.txt
@@ -250,7 +250,7 @@ Input [2]: [d_date_sk#9, d_month_seq#26]
 
 (42) Filter [codegen id : 1]
 Input [2]: [d_date_sk#9, d_month_seq#26]
-Condition : ((isnotnull(d_month_seq#26) AND (d_month_seq#26 = ReusedSubquery Subquery scalar-subquery#27, [id=#28])) AND isnotnull(d_date_sk#9))
+Condition : ((isnotnull(d_month_seq#26) AND (d_month_seq#26 = ReusedSubquery Subquery scalar-subquery#27, [id=#7])) AND isnotnull(d_date_sk#9))
 
 (43) Project [codegen id : 1]
 Output [1]: [d_date_sk#9]
@@ -258,11 +258,11 @@ Input [2]: [d_date_sk#9, d_month_seq#26]
 
 (44) BroadcastExchange
 Input [1]: [d_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
-Subquery:2 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#27, [id=#28]
+Subquery:2 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#27, [id=#7]
 
-Subquery:3 Hosting operator id = 40 Hosting Expression = Subquery scalar-subquery#27, [id=#28]
+Subquery:3 Hosting operator id = 40 Hosting Expression = Subquery scalar-subquery#27, [id=#7]
 * HashAggregate (51)
 +- Exchange (50)
    +- * HashAggregate (49)
@@ -273,39 +273,39 @@ Subquery:3 Hosting operator id = 40 Hosting Expression = Subquery scalar-subquer
 
 
 (45) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_month_seq#29, d_year#30, d_moy#31]
+Output [3]: [d_month_seq#28, d_year#29, d_moy#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,1)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
 (46) ColumnarToRow [codegen id : 1]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
+Input [3]: [d_month_seq#28, d_year#29, d_moy#30]
 
 (47) Filter [codegen id : 1]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
-Condition : (((isnotnull(d_year#30) AND isnotnull(d_moy#31)) AND (d_year#30 = 2000)) AND (d_moy#31 = 1))
+Input [3]: [d_month_seq#28, d_year#29, d_moy#30]
+Condition : (((isnotnull(d_year#29) AND isnotnull(d_moy#30)) AND (d_year#29 = 2000)) AND (d_moy#30 = 1))
 
 (48) Project [codegen id : 1]
-Output [1]: [d_month_seq#29]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
+Output [1]: [d_month_seq#28]
+Input [3]: [d_month_seq#28, d_year#29, d_moy#30]
 
 (49) HashAggregate [codegen id : 1]
-Input [1]: [d_month_seq#29]
-Keys [1]: [d_month_seq#29]
+Input [1]: [d_month_seq#28]
+Keys [1]: [d_month_seq#28]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [d_month_seq#29]
+Results [1]: [d_month_seq#28]
 
 (50) Exchange
-Input [1]: [d_month_seq#29]
-Arguments: hashpartitioning(d_month_seq#29, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [1]: [d_month_seq#28]
+Arguments: hashpartitioning(d_month_seq#28, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (51) HashAggregate [codegen id : 2]
-Input [1]: [d_month_seq#29]
-Keys [1]: [d_month_seq#29]
+Input [1]: [d_month_seq#28]
+Keys [1]: [d_month_seq#28]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [d_month_seq#29]
+Results [1]: [d_month_seq#28]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64.sf100/explain.txt
@@ -223,929 +223,929 @@ Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_ad
 
 (3) Filter [codegen id : 1]
 Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
-Condition : ((((((((isnotnull(ss_item_sk#1) AND isnotnull(ss_ticket_number#8)) AND isnotnull(ss_store_sk#6)) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_cdemo_sk#3)) AND isnotnull(ss_promo_sk#7)) AND isnotnull(ss_hdemo_sk#4)) AND isnotnull(ss_addr_sk#5)) AND might_contain(Subquery scalar-subquery#14, [id=#15], xxhash64(ss_item_sk#1, 42)))
+Condition : ((((((((isnotnull(ss_item_sk#1) AND isnotnull(ss_ticket_number#8)) AND isnotnull(ss_store_sk#6)) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_cdemo_sk#3)) AND isnotnull(ss_promo_sk#7)) AND isnotnull(ss_hdemo_sk#4)) AND isnotnull(ss_addr_sk#5)) AND might_contain(Subquery scalar-subquery#14, [id=#1], xxhash64(ss_item_sk#1, 42)))
 
 (4) Exchange
 Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
-Arguments: hashpartitioning(ss_item_sk#1, ss_ticket_number#8, 5), ENSURE_REQUIREMENTS, [plan_id=1]
+Arguments: hashpartitioning(ss_item_sk#1, ss_ticket_number#8, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (5) Sort [codegen id : 2]
 Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#8 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.store_returns
-Output [3]: [sr_item_sk#16, sr_ticket_number#17, sr_returned_date_sk#18]
+Output [3]: [sr_item_sk#15, sr_ticket_number#16, sr_returned_date_sk#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
 
 (7) ColumnarToRow [codegen id : 3]
-Input [3]: [sr_item_sk#16, sr_ticket_number#17, sr_returned_date_sk#18]
+Input [3]: [sr_item_sk#15, sr_ticket_number#16, sr_returned_date_sk#17]
 
 (8) Filter [codegen id : 3]
-Input [3]: [sr_item_sk#16, sr_ticket_number#17, sr_returned_date_sk#18]
-Condition : (isnotnull(sr_item_sk#16) AND isnotnull(sr_ticket_number#17))
+Input [3]: [sr_item_sk#15, sr_ticket_number#16, sr_returned_date_sk#17]
+Condition : (isnotnull(sr_item_sk#15) AND isnotnull(sr_ticket_number#16))
 
 (9) Project [codegen id : 3]
-Output [2]: [sr_item_sk#16, sr_ticket_number#17]
-Input [3]: [sr_item_sk#16, sr_ticket_number#17, sr_returned_date_sk#18]
+Output [2]: [sr_item_sk#15, sr_ticket_number#16]
+Input [3]: [sr_item_sk#15, sr_ticket_number#16, sr_returned_date_sk#17]
 
 (10) Exchange
-Input [2]: [sr_item_sk#16, sr_ticket_number#17]
-Arguments: hashpartitioning(sr_item_sk#16, sr_ticket_number#17, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [2]: [sr_item_sk#15, sr_ticket_number#16]
+Arguments: hashpartitioning(sr_item_sk#15, sr_ticket_number#16, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (11) Sort [codegen id : 4]
-Input [2]: [sr_item_sk#16, sr_ticket_number#17]
-Arguments: [sr_item_sk#16 ASC NULLS FIRST, sr_ticket_number#17 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#15, sr_ticket_number#16]
+Arguments: [sr_item_sk#15 ASC NULLS FIRST, sr_ticket_number#16 ASC NULLS FIRST], false, 0
 
 (12) SortMergeJoin [codegen id : 13]
 Left keys [2]: [ss_item_sk#1, ss_ticket_number#8]
-Right keys [2]: [sr_item_sk#16, sr_ticket_number#17]
+Right keys [2]: [sr_item_sk#15, sr_ticket_number#16]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 13]
 Output [11]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, sr_item_sk#16, sr_ticket_number#17]
+Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, sr_item_sk#15, sr_ticket_number#16]
 
 (14) Scan parquet spark_catalog.default.catalog_sales
-Output [4]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cs_sold_date_sk#22]
+Output [4]: [cs_item_sk#18, cs_order_number#19, cs_ext_list_price#20, cs_sold_date_sk#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_order_number)]
 ReadSchema: struct<cs_item_sk:int,cs_order_number:int,cs_ext_list_price:decimal(7,2)>
 
 (15) ColumnarToRow [codegen id : 5]
-Input [4]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cs_sold_date_sk#22]
+Input [4]: [cs_item_sk#18, cs_order_number#19, cs_ext_list_price#20, cs_sold_date_sk#21]
 
 (16) Filter [codegen id : 5]
-Input [4]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cs_sold_date_sk#22]
-Condition : (isnotnull(cs_item_sk#19) AND isnotnull(cs_order_number#20))
+Input [4]: [cs_item_sk#18, cs_order_number#19, cs_ext_list_price#20, cs_sold_date_sk#21]
+Condition : (isnotnull(cs_item_sk#18) AND isnotnull(cs_order_number#19))
 
 (17) Project [codegen id : 5]
-Output [3]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21]
-Input [4]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cs_sold_date_sk#22]
+Output [3]: [cs_item_sk#18, cs_order_number#19, cs_ext_list_price#20]
+Input [4]: [cs_item_sk#18, cs_order_number#19, cs_ext_list_price#20, cs_sold_date_sk#21]
 
 (18) Exchange
-Input [3]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21]
-Arguments: hashpartitioning(cs_item_sk#19, cs_order_number#20, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [3]: [cs_item_sk#18, cs_order_number#19, cs_ext_list_price#20]
+Arguments: hashpartitioning(cs_item_sk#18, cs_order_number#19, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (19) Sort [codegen id : 6]
-Input [3]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21]
-Arguments: [cs_item_sk#19 ASC NULLS FIRST, cs_order_number#20 ASC NULLS FIRST], false, 0
+Input [3]: [cs_item_sk#18, cs_order_number#19, cs_ext_list_price#20]
+Arguments: [cs_item_sk#18 ASC NULLS FIRST, cs_order_number#19 ASC NULLS FIRST], false, 0
 
 (20) Scan parquet spark_catalog.default.catalog_returns
-Output [6]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27, cr_returned_date_sk#28]
+Output [6]: [cr_item_sk#22, cr_order_number#23, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26, cr_returned_date_sk#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
 PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_refunded_cash:decimal(7,2),cr_reversed_charge:decimal(7,2),cr_store_credit:decimal(7,2)>
 
 (21) ColumnarToRow [codegen id : 7]
-Input [6]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27, cr_returned_date_sk#28]
+Input [6]: [cr_item_sk#22, cr_order_number#23, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26, cr_returned_date_sk#27]
 
 (22) Filter [codegen id : 7]
-Input [6]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27, cr_returned_date_sk#28]
-Condition : (isnotnull(cr_item_sk#23) AND isnotnull(cr_order_number#24))
+Input [6]: [cr_item_sk#22, cr_order_number#23, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26, cr_returned_date_sk#27]
+Condition : (isnotnull(cr_item_sk#22) AND isnotnull(cr_order_number#23))
 
 (23) Project [codegen id : 7]
-Output [5]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Input [6]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27, cr_returned_date_sk#28]
+Output [5]: [cr_item_sk#22, cr_order_number#23, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26]
+Input [6]: [cr_item_sk#22, cr_order_number#23, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26, cr_returned_date_sk#27]
 
 (24) Exchange
-Input [5]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Arguments: hashpartitioning(cr_item_sk#23, cr_order_number#24, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [5]: [cr_item_sk#22, cr_order_number#23, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26]
+Arguments: hashpartitioning(cr_item_sk#22, cr_order_number#23, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (25) Sort [codegen id : 8]
-Input [5]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Arguments: [cr_item_sk#23 ASC NULLS FIRST, cr_order_number#24 ASC NULLS FIRST], false, 0
+Input [5]: [cr_item_sk#22, cr_order_number#23, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26]
+Arguments: [cr_item_sk#22 ASC NULLS FIRST, cr_order_number#23 ASC NULLS FIRST], false, 0
 
 (26) SortMergeJoin [codegen id : 9]
-Left keys [2]: [cs_item_sk#19, cs_order_number#20]
-Right keys [2]: [cr_item_sk#23, cr_order_number#24]
+Left keys [2]: [cs_item_sk#18, cs_order_number#19]
+Right keys [2]: [cr_item_sk#22, cr_order_number#23]
 Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 9]
-Output [5]: [cs_item_sk#19, cs_ext_list_price#21, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Input [8]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
+Output [5]: [cs_item_sk#18, cs_ext_list_price#20, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26]
+Input [8]: [cs_item_sk#18, cs_order_number#19, cs_ext_list_price#20, cr_item_sk#22, cr_order_number#23, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26]
 
 (28) HashAggregate [codegen id : 9]
-Input [5]: [cs_item_sk#19, cs_ext_list_price#21, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Keys [1]: [cs_item_sk#19]
-Functions [2]: [partial_sum(UnscaledValue(cs_ext_list_price#21)), partial_sum(((cr_refunded_cash#25 + cr_reversed_charge#26) + cr_store_credit#27))]
-Aggregate Attributes [3]: [sum#29, sum#30, isEmpty#31]
-Results [4]: [cs_item_sk#19, sum#32, sum#33, isEmpty#34]
+Input [5]: [cs_item_sk#18, cs_ext_list_price#20, cr_refunded_cash#24, cr_reversed_charge#25, cr_store_credit#26]
+Keys [1]: [cs_item_sk#18]
+Functions [2]: [partial_sum(UnscaledValue(cs_ext_list_price#20)), partial_sum(((cr_refunded_cash#24 + cr_reversed_charge#25) + cr_store_credit#26))]
+Aggregate Attributes [3]: [sum#28, sum#29, isEmpty#30]
+Results [4]: [cs_item_sk#18, sum#31, sum#32, isEmpty#33]
 
 (29) Exchange
-Input [4]: [cs_item_sk#19, sum#32, sum#33, isEmpty#34]
-Arguments: hashpartitioning(cs_item_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [4]: [cs_item_sk#18, sum#31, sum#32, isEmpty#33]
+Arguments: hashpartitioning(cs_item_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (30) HashAggregate [codegen id : 10]
-Input [4]: [cs_item_sk#19, sum#32, sum#33, isEmpty#34]
-Keys [1]: [cs_item_sk#19]
-Functions [2]: [sum(UnscaledValue(cs_ext_list_price#21)), sum(((cr_refunded_cash#25 + cr_reversed_charge#26) + cr_store_credit#27))]
-Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_list_price#21))#35, sum(((cr_refunded_cash#25 + cr_reversed_charge#26) + cr_store_credit#27))#36]
-Results [3]: [cs_item_sk#19, MakeDecimal(sum(UnscaledValue(cs_ext_list_price#21))#35,17,2) AS sale#37, sum(((cr_refunded_cash#25 + cr_reversed_charge#26) + cr_store_credit#27))#36 AS refund#38]
+Input [4]: [cs_item_sk#18, sum#31, sum#32, isEmpty#33]
+Keys [1]: [cs_item_sk#18]
+Functions [2]: [sum(UnscaledValue(cs_ext_list_price#20)), sum(((cr_refunded_cash#24 + cr_reversed_charge#25) + cr_store_credit#26))]
+Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_list_price#20))#34, sum(((cr_refunded_cash#24 + cr_reversed_charge#25) + cr_store_credit#26))#35]
+Results [3]: [cs_item_sk#18, MakeDecimal(sum(UnscaledValue(cs_ext_list_price#20))#34,17,2) AS sale#36, sum(((cr_refunded_cash#24 + cr_reversed_charge#25) + cr_store_credit#26))#35 AS refund#37]
 
 (31) Filter [codegen id : 10]
-Input [3]: [cs_item_sk#19, sale#37, refund#38]
-Condition : ((isnotnull(sale#37) AND isnotnull(refund#38)) AND (cast(sale#37 as decimal(21,2)) > (2 * refund#38)))
+Input [3]: [cs_item_sk#18, sale#36, refund#37]
+Condition : ((isnotnull(sale#36) AND isnotnull(refund#37)) AND (cast(sale#36 as decimal(21,2)) > (2 * refund#37)))
 
 (32) Project [codegen id : 10]
-Output [1]: [cs_item_sk#19]
-Input [3]: [cs_item_sk#19, sale#37, refund#38]
+Output [1]: [cs_item_sk#18]
+Input [3]: [cs_item_sk#18, sale#36, refund#37]
 
 (33) BroadcastExchange
-Input [1]: [cs_item_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+Input [1]: [cs_item_sk#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 (34) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [cs_item_sk#19]
+Right keys [1]: [cs_item_sk#18]
 Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 13]
 Output [11]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, cs_item_sk#19]
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, cs_item_sk#18]
 
 (36) ReusedExchange [Reuses operator id: 220]
-Output [2]: [d_date_sk#39, d_year#40]
+Output [2]: [d_date_sk#38, d_year#39]
 
 (37) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_sold_date_sk#12]
-Right keys [1]: [d_date_sk#39]
+Right keys [1]: [d_date_sk#38]
 Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 13]
-Output [11]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40]
-Input [13]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, d_date_sk#39, d_year#40]
+Output [11]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39]
+Input [13]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, d_date_sk#38, d_year#39]
 
 (39) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#41, s_store_name#42, s_zip#43]
+Output [3]: [s_store_sk#40, s_store_name#41, s_zip#42]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_name), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_zip:string>
 
 (40) ColumnarToRow [codegen id : 12]
-Input [3]: [s_store_sk#41, s_store_name#42, s_zip#43]
+Input [3]: [s_store_sk#40, s_store_name#41, s_zip#42]
 
 (41) Filter [codegen id : 12]
-Input [3]: [s_store_sk#41, s_store_name#42, s_zip#43]
-Condition : ((isnotnull(s_store_sk#41) AND isnotnull(s_store_name#42)) AND isnotnull(s_zip#43))
+Input [3]: [s_store_sk#40, s_store_name#41, s_zip#42]
+Condition : ((isnotnull(s_store_sk#40) AND isnotnull(s_store_name#41)) AND isnotnull(s_zip#42))
 
 (42) BroadcastExchange
-Input [3]: [s_store_sk#41, s_store_name#42, s_zip#43]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
+Input [3]: [s_store_sk#40, s_store_name#41, s_zip#42]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
 
 (43) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_store_sk#6]
-Right keys [1]: [s_store_sk#41]
+Right keys [1]: [s_store_sk#40]
 Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 13]
-Output [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_sk#41, s_store_name#42, s_zip#43]
+Output [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42]
+Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_sk#40, s_store_name#41, s_zip#42]
 
 (45) Exchange
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43]
-Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42]
+Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (46) Sort [codegen id : 14]
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43]
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42]
 Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
 
 (47) Scan parquet spark_catalog.default.customer
-Output [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
+Output [6]: [c_customer_sk#43, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, c_first_sales_date_sk#48]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_first_sales_date_sk), IsNotNull(c_first_shipto_date_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_hdemo_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_hdemo_sk:int,c_current_addr_sk:int,c_first_shipto_date_sk:int,c_first_sales_date_sk:int>
 
 (48) ColumnarToRow [codegen id : 15]
-Input [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
+Input [6]: [c_customer_sk#43, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, c_first_sales_date_sk#48]
 
 (49) Filter [codegen id : 15]
-Input [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
-Condition : (((((isnotnull(c_customer_sk#44) AND isnotnull(c_first_sales_date_sk#49)) AND isnotnull(c_first_shipto_date_sk#48)) AND isnotnull(c_current_cdemo_sk#45)) AND isnotnull(c_current_hdemo_sk#46)) AND isnotnull(c_current_addr_sk#47))
+Input [6]: [c_customer_sk#43, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, c_first_sales_date_sk#48]
+Condition : (((((isnotnull(c_customer_sk#43) AND isnotnull(c_first_sales_date_sk#48)) AND isnotnull(c_first_shipto_date_sk#47)) AND isnotnull(c_current_cdemo_sk#44)) AND isnotnull(c_current_hdemo_sk#45)) AND isnotnull(c_current_addr_sk#46))
 
 (50) Exchange
-Input [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
-Arguments: hashpartitioning(c_customer_sk#44, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [6]: [c_customer_sk#43, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, c_first_sales_date_sk#48]
+Arguments: hashpartitioning(c_customer_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (51) Sort [codegen id : 16]
-Input [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
-Arguments: [c_customer_sk#44 ASC NULLS FIRST], false, 0
+Input [6]: [c_customer_sk#43, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, c_first_sales_date_sk#48]
+Arguments: [c_customer_sk#43 ASC NULLS FIRST], false, 0
 
 (52) SortMergeJoin [codegen id : 19]
 Left keys [1]: [ss_customer_sk#2]
-Right keys [1]: [c_customer_sk#44]
+Right keys [1]: [c_customer_sk#43]
 Join type: Inner
 Join condition: None
 
 (53) Project [codegen id : 19]
-Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
-Input [18]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
+Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, c_first_sales_date_sk#48]
+Input [18]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_customer_sk#43, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, c_first_sales_date_sk#48]
 
 (54) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#50, d_year#51]
+Output [2]: [d_date_sk#49, d_year#50]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (55) ColumnarToRow [codegen id : 17]
-Input [2]: [d_date_sk#50, d_year#51]
+Input [2]: [d_date_sk#49, d_year#50]
 
 (56) Filter [codegen id : 17]
-Input [2]: [d_date_sk#50, d_year#51]
-Condition : isnotnull(d_date_sk#50)
+Input [2]: [d_date_sk#49, d_year#50]
+Condition : isnotnull(d_date_sk#49)
 
 (57) BroadcastExchange
-Input [2]: [d_date_sk#50, d_year#51]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=10]
+Input [2]: [d_date_sk#49, d_year#50]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=11]
 
 (58) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [c_first_sales_date_sk#49]
-Right keys [1]: [d_date_sk#50]
+Left keys [1]: [c_first_sales_date_sk#48]
+Right keys [1]: [d_date_sk#49]
 Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 19]
-Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, d_year#51]
-Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49, d_date_sk#50, d_year#51]
+Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, d_year#50]
+Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, c_first_sales_date_sk#48, d_date_sk#49, d_year#50]
 
 (60) ReusedExchange [Reuses operator id: 57]
-Output [2]: [d_date_sk#52, d_year#53]
+Output [2]: [d_date_sk#51, d_year#52]
 
 (61) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [c_first_shipto_date_sk#48]
-Right keys [1]: [d_date_sk#52]
+Left keys [1]: [c_first_shipto_date_sk#47]
+Right keys [1]: [d_date_sk#51]
 Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 19]
-Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
-Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, d_year#51, d_date_sk#52, d_year#53]
+Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52]
+Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, c_first_shipto_date_sk#47, d_year#50, d_date_sk#51, d_year#52]
 
 (63) Exchange
-Input [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
-Arguments: hashpartitioning(ss_cdemo_sk#3, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52]
+Arguments: hashpartitioning(ss_cdemo_sk#3, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (64) Sort [codegen id : 20]
-Input [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
+Input [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52]
 Arguments: [ss_cdemo_sk#3 ASC NULLS FIRST], false, 0
 
 (65) Scan parquet spark_catalog.default.customer_demographics
-Output [2]: [cd_demo_sk#54, cd_marital_status#55]
+Output [2]: [cd_demo_sk#53, cd_marital_status#54]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
 
 (66) ColumnarToRow [codegen id : 21]
-Input [2]: [cd_demo_sk#54, cd_marital_status#55]
+Input [2]: [cd_demo_sk#53, cd_marital_status#54]
 
 (67) Filter [codegen id : 21]
-Input [2]: [cd_demo_sk#54, cd_marital_status#55]
-Condition : (isnotnull(cd_demo_sk#54) AND isnotnull(cd_marital_status#55))
+Input [2]: [cd_demo_sk#53, cd_marital_status#54]
+Condition : (isnotnull(cd_demo_sk#53) AND isnotnull(cd_marital_status#54))
 
 (68) Exchange
-Input [2]: [cd_demo_sk#54, cd_marital_status#55]
-Arguments: hashpartitioning(cd_demo_sk#54, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [2]: [cd_demo_sk#53, cd_marital_status#54]
+Arguments: hashpartitioning(cd_demo_sk#53, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (69) Sort [codegen id : 22]
-Input [2]: [cd_demo_sk#54, cd_marital_status#55]
-Arguments: [cd_demo_sk#54 ASC NULLS FIRST], false, 0
+Input [2]: [cd_demo_sk#53, cd_marital_status#54]
+Arguments: [cd_demo_sk#53 ASC NULLS FIRST], false, 0
 
 (70) SortMergeJoin [codegen id : 23]
 Left keys [1]: [ss_cdemo_sk#3]
-Right keys [1]: [cd_demo_sk#54]
+Right keys [1]: [cd_demo_sk#53]
 Join type: Inner
 Join condition: None
 
 (71) Project [codegen id : 23]
-Output [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_marital_status#55]
-Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_demo_sk#54, cd_marital_status#55]
+Output [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, cd_marital_status#54]
+Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, cd_demo_sk#53, cd_marital_status#54]
 
 (72) Exchange
-Input [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_marital_status#55]
-Arguments: hashpartitioning(c_current_cdemo_sk#45, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+Input [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, cd_marital_status#54]
+Arguments: hashpartitioning(c_current_cdemo_sk#44, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (73) Sort [codegen id : 24]
-Input [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_marital_status#55]
-Arguments: [c_current_cdemo_sk#45 ASC NULLS FIRST], false, 0
+Input [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, cd_marital_status#54]
+Arguments: [c_current_cdemo_sk#44 ASC NULLS FIRST], false, 0
 
 (74) ReusedExchange [Reuses operator id: 68]
-Output [2]: [cd_demo_sk#56, cd_marital_status#57]
+Output [2]: [cd_demo_sk#55, cd_marital_status#56]
 
 (75) Sort [codegen id : 26]
-Input [2]: [cd_demo_sk#56, cd_marital_status#57]
-Arguments: [cd_demo_sk#56 ASC NULLS FIRST], false, 0
+Input [2]: [cd_demo_sk#55, cd_marital_status#56]
+Arguments: [cd_demo_sk#55 ASC NULLS FIRST], false, 0
 
 (76) SortMergeJoin [codegen id : 30]
-Left keys [1]: [c_current_cdemo_sk#45]
-Right keys [1]: [cd_demo_sk#56]
+Left keys [1]: [c_current_cdemo_sk#44]
+Right keys [1]: [cd_demo_sk#55]
 Join type: Inner
-Join condition: NOT (cd_marital_status#55 = cd_marital_status#57)
+Join condition: NOT (cd_marital_status#54 = cd_marital_status#56)
 
 (77) Project [codegen id : 30]
-Output [14]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
-Input [18]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_marital_status#55, cd_demo_sk#56, cd_marital_status#57]
+Output [14]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52]
+Input [18]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_cdemo_sk#44, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, cd_marital_status#54, cd_demo_sk#55, cd_marital_status#56]
 
 (78) Scan parquet spark_catalog.default.promotion
-Output [1]: [p_promo_sk#58]
+Output [1]: [p_promo_sk#57]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/promotion]
 PushedFilters: [IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int>
 
 (79) ColumnarToRow [codegen id : 27]
-Input [1]: [p_promo_sk#58]
+Input [1]: [p_promo_sk#57]
 
 (80) Filter [codegen id : 27]
-Input [1]: [p_promo_sk#58]
-Condition : isnotnull(p_promo_sk#58)
+Input [1]: [p_promo_sk#57]
+Condition : isnotnull(p_promo_sk#57)
 
 (81) BroadcastExchange
-Input [1]: [p_promo_sk#58]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=14]
+Input [1]: [p_promo_sk#57]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=15]
 
 (82) BroadcastHashJoin [codegen id : 30]
 Left keys [1]: [ss_promo_sk#7]
-Right keys [1]: [p_promo_sk#58]
+Right keys [1]: [p_promo_sk#57]
 Join type: Inner
 Join condition: None
 
 (83) Project [codegen id : 30]
-Output [13]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
-Input [15]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, p_promo_sk#58]
+Output [13]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52]
+Input [15]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, p_promo_sk#57]
 
 (84) Scan parquet spark_catalog.default.household_demographics
-Output [2]: [hd_demo_sk#59, hd_income_band_sk#60]
+Output [2]: [hd_demo_sk#58, hd_income_band_sk#59]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_demo_sk), IsNotNull(hd_income_band_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_income_band_sk:int>
 
 (85) ColumnarToRow [codegen id : 28]
-Input [2]: [hd_demo_sk#59, hd_income_band_sk#60]
+Input [2]: [hd_demo_sk#58, hd_income_band_sk#59]
 
 (86) Filter [codegen id : 28]
-Input [2]: [hd_demo_sk#59, hd_income_band_sk#60]
-Condition : (isnotnull(hd_demo_sk#59) AND isnotnull(hd_income_band_sk#60))
+Input [2]: [hd_demo_sk#58, hd_income_band_sk#59]
+Condition : (isnotnull(hd_demo_sk#58) AND isnotnull(hd_income_band_sk#59))
 
 (87) BroadcastExchange
-Input [2]: [hd_demo_sk#59, hd_income_band_sk#60]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=15]
+Input [2]: [hd_demo_sk#58, hd_income_band_sk#59]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=16]
 
 (88) BroadcastHashJoin [codegen id : 30]
 Left keys [1]: [ss_hdemo_sk#4]
-Right keys [1]: [hd_demo_sk#59]
+Right keys [1]: [hd_demo_sk#58]
 Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 30]
-Output [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60]
-Input [15]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, hd_demo_sk#59, hd_income_band_sk#60]
+Output [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59]
+Input [15]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, hd_demo_sk#58, hd_income_band_sk#59]
 
 (90) ReusedExchange [Reuses operator id: 87]
-Output [2]: [hd_demo_sk#61, hd_income_band_sk#62]
+Output [2]: [hd_demo_sk#60, hd_income_band_sk#61]
 
 (91) BroadcastHashJoin [codegen id : 30]
-Left keys [1]: [c_current_hdemo_sk#46]
-Right keys [1]: [hd_demo_sk#61]
+Left keys [1]: [c_current_hdemo_sk#45]
+Right keys [1]: [hd_demo_sk#60]
 Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 30]
-Output [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62]
-Input [15]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_demo_sk#61, hd_income_band_sk#62]
+Output [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61]
+Input [15]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_hdemo_sk#45, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_demo_sk#60, hd_income_band_sk#61]
 
 (93) Exchange
-Input [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62]
-Arguments: hashpartitioning(ss_addr_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+Input [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61]
+Arguments: hashpartitioning(ss_addr_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
 (94) Sort [codegen id : 31]
-Input [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62]
+Input [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61]
 Arguments: [ss_addr_sk#5 ASC NULLS FIRST], false, 0
 
 (95) Scan parquet spark_catalog.default.customer_address
-Output [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
+Output [5]: [ca_address_sk#62, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_street_number:string,ca_street_name:string,ca_city:string,ca_zip:string>
 
 (96) ColumnarToRow [codegen id : 32]
-Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
+Input [5]: [ca_address_sk#62, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
 
 (97) Filter [codegen id : 32]
-Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Condition : isnotnull(ca_address_sk#63)
+Input [5]: [ca_address_sk#62, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
+Condition : isnotnull(ca_address_sk#62)
 
 (98) Exchange
-Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Arguments: hashpartitioning(ca_address_sk#63, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+Input [5]: [ca_address_sk#62, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
+Arguments: hashpartitioning(ca_address_sk#62, 5), ENSURE_REQUIREMENTS, [plan_id=18]
 
 (99) Sort [codegen id : 33]
-Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Arguments: [ca_address_sk#63 ASC NULLS FIRST], false, 0
+Input [5]: [ca_address_sk#62, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
+Arguments: [ca_address_sk#62 ASC NULLS FIRST], false, 0
 
 (100) SortMergeJoin [codegen id : 34]
 Left keys [1]: [ss_addr_sk#5]
-Right keys [1]: [ca_address_sk#63]
+Right keys [1]: [ca_address_sk#62]
 Join type: Inner
 Join condition: None
 
 (101) Project [codegen id : 34]
-Output [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Input [18]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
+Output [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
+Input [18]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61, ca_address_sk#62, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
 
 (102) Exchange
-Input [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Arguments: hashpartitioning(c_current_addr_sk#47, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+Input [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
+Arguments: hashpartitioning(c_current_addr_sk#46, 5), ENSURE_REQUIREMENTS, [plan_id=19]
 
 (103) Sort [codegen id : 35]
-Input [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Arguments: [c_current_addr_sk#47 ASC NULLS FIRST], false, 0
+Input [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66]
+Arguments: [c_current_addr_sk#46 ASC NULLS FIRST], false, 0
 
 (104) ReusedExchange [Reuses operator id: 98]
-Output [5]: [ca_address_sk#68, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
+Output [5]: [ca_address_sk#67, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71]
 
 (105) Sort [codegen id : 37]
-Input [5]: [ca_address_sk#68, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
-Arguments: [ca_address_sk#68 ASC NULLS FIRST], false, 0
+Input [5]: [ca_address_sk#67, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71]
+Arguments: [ca_address_sk#67 ASC NULLS FIRST], false, 0
 
 (106) SortMergeJoin [codegen id : 41]
-Left keys [1]: [c_current_addr_sk#47]
-Right keys [1]: [ca_address_sk#68]
+Left keys [1]: [c_current_addr_sk#46]
+Right keys [1]: [ca_address_sk#67]
 Join type: Inner
 Join condition: None
 
 (107) Project [codegen id : 41]
-Output [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
-Input [21]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_address_sk#68, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
+Output [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71]
+Input [21]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, c_current_addr_sk#46, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_address_sk#67, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71]
 
 (108) Scan parquet spark_catalog.default.income_band
-Output [1]: [ib_income_band_sk#73]
+Output [1]: [ib_income_band_sk#72]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/income_band]
 PushedFilters: [IsNotNull(ib_income_band_sk)]
 ReadSchema: struct<ib_income_band_sk:int>
 
 (109) ColumnarToRow [codegen id : 38]
-Input [1]: [ib_income_band_sk#73]
+Input [1]: [ib_income_band_sk#72]
 
 (110) Filter [codegen id : 38]
-Input [1]: [ib_income_band_sk#73]
-Condition : isnotnull(ib_income_band_sk#73)
+Input [1]: [ib_income_band_sk#72]
+Condition : isnotnull(ib_income_band_sk#72)
 
 (111) BroadcastExchange
-Input [1]: [ib_income_band_sk#73]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=19]
+Input [1]: [ib_income_band_sk#72]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=20]
 
 (112) BroadcastHashJoin [codegen id : 41]
-Left keys [1]: [hd_income_band_sk#60]
-Right keys [1]: [ib_income_band_sk#73]
+Left keys [1]: [hd_income_band_sk#59]
+Right keys [1]: [ib_income_band_sk#72]
 Join type: Inner
 Join condition: None
 
 (113) Project [codegen id : 41]
-Output [18]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
-Input [20]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, ib_income_band_sk#73]
+Output [18]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, d_year#50, d_year#52, hd_income_band_sk#61, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71]
+Input [20]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, d_year#50, d_year#52, hd_income_band_sk#59, hd_income_band_sk#61, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, ib_income_band_sk#72]
 
 (114) ReusedExchange [Reuses operator id: 111]
-Output [1]: [ib_income_band_sk#74]
+Output [1]: [ib_income_band_sk#73]
 
 (115) BroadcastHashJoin [codegen id : 41]
-Left keys [1]: [hd_income_band_sk#62]
-Right keys [1]: [ib_income_band_sk#74]
+Left keys [1]: [hd_income_band_sk#61]
+Right keys [1]: [ib_income_band_sk#73]
 Join type: Inner
 Join condition: None
 
 (116) Project [codegen id : 41]
-Output [17]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
-Input [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, ib_income_band_sk#74]
+Output [17]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, d_year#50, d_year#52, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71]
+Input [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, d_year#50, d_year#52, hd_income_band_sk#61, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, ib_income_band_sk#73]
 
 (117) Scan parquet spark_catalog.default.item
-Output [4]: [i_item_sk#75, i_current_price#76, i_color#77, i_product_name#78]
+Output [4]: [i_item_sk#74, i_current_price#75, i_color#76, i_product_name#77]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_current_price), In(i_color, [burlywood           ,floral              ,indian              ,medium              ,purple              ,spring              ]), GreaterThanOrEqual(i_current_price,64.00), LessThanOrEqual(i_current_price,74.00), GreaterThanOrEqual(i_current_price,65.00), LessThanOrEqual(i_current_price,79.00), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_color:string,i_product_name:string>
 
 (118) ColumnarToRow [codegen id : 40]
-Input [4]: [i_item_sk#75, i_current_price#76, i_color#77, i_product_name#78]
+Input [4]: [i_item_sk#74, i_current_price#75, i_color#76, i_product_name#77]
 
 (119) Filter [codegen id : 40]
-Input [4]: [i_item_sk#75, i_current_price#76, i_color#77, i_product_name#78]
-Condition : ((((((isnotnull(i_current_price#76) AND i_color#77 IN (purple              ,burlywood           ,indian              ,spring              ,floral              ,medium              )) AND (i_current_price#76 >= 64.00)) AND (i_current_price#76 <= 74.00)) AND (i_current_price#76 >= 65.00)) AND (i_current_price#76 <= 79.00)) AND isnotnull(i_item_sk#75))
+Input [4]: [i_item_sk#74, i_current_price#75, i_color#76, i_product_name#77]
+Condition : ((((((isnotnull(i_current_price#75) AND i_color#76 IN (purple              ,burlywood           ,indian              ,spring              ,floral              ,medium              )) AND (i_current_price#75 >= 64.00)) AND (i_current_price#75 <= 74.00)) AND (i_current_price#75 >= 65.00)) AND (i_current_price#75 <= 79.00)) AND isnotnull(i_item_sk#74))
 
 (120) Project [codegen id : 40]
-Output [2]: [i_item_sk#75, i_product_name#78]
-Input [4]: [i_item_sk#75, i_current_price#76, i_color#77, i_product_name#78]
+Output [2]: [i_item_sk#74, i_product_name#77]
+Input [4]: [i_item_sk#74, i_current_price#75, i_color#76, i_product_name#77]
 
 (121) BroadcastExchange
-Input [2]: [i_item_sk#75, i_product_name#78]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=20]
+Input [2]: [i_item_sk#74, i_product_name#77]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=21]
 
 (122) BroadcastHashJoin [codegen id : 41]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#75]
+Right keys [1]: [i_item_sk#74]
 Join type: Inner
 Join condition: None
 
 (123) Project [codegen id : 41]
-Output [18]: [ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, d_year#51, d_year#53, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, i_item_sk#75, i_product_name#78]
-Input [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, i_item_sk#75, i_product_name#78]
+Output [18]: [ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, d_year#50, d_year#52, s_store_name#41, s_zip#42, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, i_item_sk#74, i_product_name#77]
+Input [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, s_store_name#41, s_zip#42, d_year#50, d_year#52, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, i_item_sk#74, i_product_name#77]
 
 (124) HashAggregate [codegen id : 41]
-Input [18]: [ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, d_year#51, d_year#53, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, i_item_sk#75, i_product_name#78]
-Keys [15]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53]
+Input [18]: [ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#39, d_year#50, d_year#52, s_store_name#41, s_zip#42, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, i_item_sk#74, i_product_name#77]
+Keys [15]: [i_product_name#77, i_item_sk#74, s_store_name#41, s_zip#42, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, d_year#39, d_year#50, d_year#52]
 Functions [4]: [partial_count(1), partial_sum(UnscaledValue(ss_wholesale_cost#9)), partial_sum(UnscaledValue(ss_list_price#10)), partial_sum(UnscaledValue(ss_coupon_amt#11))]
-Aggregate Attributes [4]: [count#79, sum#80, sum#81, sum#82]
-Results [19]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53, count#83, sum#84, sum#85, sum#86]
+Aggregate Attributes [4]: [count#78, sum#79, sum#80, sum#81]
+Results [19]: [i_product_name#77, i_item_sk#74, s_store_name#41, s_zip#42, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, d_year#39, d_year#50, d_year#52, count#82, sum#83, sum#84, sum#85]
 
 (125) Exchange
-Input [19]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53, count#83, sum#84, sum#85, sum#86]
-Arguments: hashpartitioning(i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53, 5), ENSURE_REQUIREMENTS, [plan_id=21]
+Input [19]: [i_product_name#77, i_item_sk#74, s_store_name#41, s_zip#42, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, d_year#39, d_year#50, d_year#52, count#82, sum#83, sum#84, sum#85]
+Arguments: hashpartitioning(i_product_name#77, i_item_sk#74, s_store_name#41, s_zip#42, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, d_year#39, d_year#50, d_year#52, 5), ENSURE_REQUIREMENTS, [plan_id=22]
 
 (126) HashAggregate [codegen id : 42]
-Input [19]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53, count#83, sum#84, sum#85, sum#86]
-Keys [15]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53]
+Input [19]: [i_product_name#77, i_item_sk#74, s_store_name#41, s_zip#42, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, d_year#39, d_year#50, d_year#52, count#82, sum#83, sum#84, sum#85]
+Keys [15]: [i_product_name#77, i_item_sk#74, s_store_name#41, s_zip#42, ca_street_number#63, ca_street_name#64, ca_city#65, ca_zip#66, ca_street_number#68, ca_street_name#69, ca_city#70, ca_zip#71, d_year#39, d_year#50, d_year#52]
 Functions [4]: [count(1), sum(UnscaledValue(ss_wholesale_cost#9)), sum(UnscaledValue(ss_list_price#10)), sum(UnscaledValue(ss_coupon_amt#11))]
-Aggregate Attributes [4]: [count(1)#87, sum(UnscaledValue(ss_wholesale_cost#9))#88, sum(UnscaledValue(ss_list_price#10))#89, sum(UnscaledValue(ss_coupon_amt#11))#90]
-Results [17]: [i_product_name#78 AS product_name#91, i_item_sk#75 AS item_sk#92, s_store_name#42 AS store_name#93, s_zip#43 AS store_zip#94, ca_street_number#64 AS b_street_number#95, ca_street_name#65 AS b_streen_name#96, ca_city#66 AS b_city#97, ca_zip#67 AS b_zip#98, ca_street_number#69 AS c_street_number#99, ca_street_name#70 AS c_street_name#100, ca_city#71 AS c_city#101, ca_zip#72 AS c_zip#102, d_year#40 AS syear#103, count(1)#87 AS cnt#104, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#9))#88,17,2) AS s1#105, MakeDecimal(sum(UnscaledValue(ss_list_price#10))#89,17,2) AS s2#106, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#11))#90,17,2) AS s3#107]
+Aggregate Attributes [4]: [count(1)#86, sum(UnscaledValue(ss_wholesale_cost#9))#87, sum(UnscaledValue(ss_list_price#10))#88, sum(UnscaledValue(ss_coupon_amt#11))#89]
+Results [17]: [i_product_name#77 AS product_name#90, i_item_sk#74 AS item_sk#91, s_store_name#41 AS store_name#92, s_zip#42 AS store_zip#93, ca_street_number#63 AS b_street_number#94, ca_street_name#64 AS b_streen_name#95, ca_city#65 AS b_city#96, ca_zip#66 AS b_zip#97, ca_street_number#68 AS c_street_number#98, ca_street_name#69 AS c_street_name#99, ca_city#70 AS c_city#100, ca_zip#71 AS c_zip#101, d_year#39 AS syear#102, count(1)#86 AS cnt#103, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#9))#87,17,2) AS s1#104, MakeDecimal(sum(UnscaledValue(ss_list_price#10))#88,17,2) AS s2#105, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#11))#89,17,2) AS s3#106]
 
 (127) Exchange
-Input [17]: [product_name#91, item_sk#92, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107]
-Arguments: hashpartitioning(item_sk#92, store_name#93, store_zip#94, 5), ENSURE_REQUIREMENTS, [plan_id=22]
+Input [17]: [product_name#90, item_sk#91, store_name#92, store_zip#93, b_street_number#94, b_streen_name#95, b_city#96, b_zip#97, c_street_number#98, c_street_name#99, c_city#100, c_zip#101, syear#102, cnt#103, s1#104, s2#105, s3#106]
+Arguments: hashpartitioning(item_sk#91, store_name#92, store_zip#93, 5), ENSURE_REQUIREMENTS, [plan_id=23]
 
 (128) Sort [codegen id : 43]
-Input [17]: [product_name#91, item_sk#92, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107]
-Arguments: [item_sk#92 ASC NULLS FIRST, store_name#93 ASC NULLS FIRST, store_zip#94 ASC NULLS FIRST], false, 0
+Input [17]: [product_name#90, item_sk#91, store_name#92, store_zip#93, b_street_number#94, b_streen_name#95, b_city#96, b_zip#97, c_street_number#98, c_street_name#99, c_city#100, c_zip#101, syear#102, cnt#103, s1#104, s2#105, s3#106]
+Arguments: [item_sk#91 ASC NULLS FIRST, store_name#92 ASC NULLS FIRST, store_zip#93 ASC NULLS FIRST], false, 0
 
 (129) Scan parquet spark_catalog.default.store_sales
-Output [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
+Output [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_ticket_number#114, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#119), dynamicpruningexpression(ss_sold_date_sk#119 IN dynamicpruning#120)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#118), dynamicpruningexpression(ss_sold_date_sk#118 IN dynamicpruning#119)]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_ticket_number), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk), IsNotNull(ss_cdemo_sk), IsNotNull(ss_promo_sk), IsNotNull(ss_hdemo_sk), IsNotNull(ss_addr_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_cdemo_sk:int,ss_hdemo_sk:int,ss_addr_sk:int,ss_store_sk:int,ss_promo_sk:int,ss_ticket_number:int,ss_wholesale_cost:decimal(7,2),ss_list_price:decimal(7,2),ss_coupon_amt:decimal(7,2)>
 
 (130) ColumnarToRow [codegen id : 44]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
+Input [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_ticket_number#114, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118]
 
 (131) Filter [codegen id : 44]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Condition : ((((((((isnotnull(ss_item_sk#108) AND isnotnull(ss_ticket_number#115)) AND isnotnull(ss_store_sk#113)) AND isnotnull(ss_customer_sk#109)) AND isnotnull(ss_cdemo_sk#110)) AND isnotnull(ss_promo_sk#114)) AND isnotnull(ss_hdemo_sk#111)) AND isnotnull(ss_addr_sk#112)) AND might_contain(ReusedSubquery Subquery scalar-subquery#14, [id=#15], xxhash64(ss_item_sk#108, 42)))
+Input [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_ticket_number#114, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118]
+Condition : ((((((((isnotnull(ss_item_sk#107) AND isnotnull(ss_ticket_number#114)) AND isnotnull(ss_store_sk#112)) AND isnotnull(ss_customer_sk#108)) AND isnotnull(ss_cdemo_sk#109)) AND isnotnull(ss_promo_sk#113)) AND isnotnull(ss_hdemo_sk#110)) AND isnotnull(ss_addr_sk#111)) AND might_contain(ReusedSubquery Subquery scalar-subquery#14, [id=#1], xxhash64(ss_item_sk#107, 42)))
 
 (132) Exchange
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Arguments: hashpartitioning(ss_item_sk#108, ss_ticket_number#115, 5), ENSURE_REQUIREMENTS, [plan_id=23]
+Input [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_ticket_number#114, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118]
+Arguments: hashpartitioning(ss_item_sk#107, ss_ticket_number#114, 5), ENSURE_REQUIREMENTS, [plan_id=24]
 
 (133) Sort [codegen id : 45]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Arguments: [ss_item_sk#108 ASC NULLS FIRST, ss_ticket_number#115 ASC NULLS FIRST], false, 0
+Input [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_ticket_number#114, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118]
+Arguments: [ss_item_sk#107 ASC NULLS FIRST, ss_ticket_number#114 ASC NULLS FIRST], false, 0
 
 (134) ReusedExchange [Reuses operator id: 10]
-Output [2]: [sr_item_sk#121, sr_ticket_number#122]
+Output [2]: [sr_item_sk#120, sr_ticket_number#121]
 
 (135) Sort [codegen id : 47]
-Input [2]: [sr_item_sk#121, sr_ticket_number#122]
-Arguments: [sr_item_sk#121 ASC NULLS FIRST, sr_ticket_number#122 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#120, sr_ticket_number#121]
+Arguments: [sr_item_sk#120 ASC NULLS FIRST, sr_ticket_number#121 ASC NULLS FIRST], false, 0
 
 (136) SortMergeJoin [codegen id : 56]
-Left keys [2]: [ss_item_sk#108, ss_ticket_number#115]
-Right keys [2]: [sr_item_sk#121, sr_ticket_number#122]
+Left keys [2]: [ss_item_sk#107, ss_ticket_number#114]
+Right keys [2]: [sr_item_sk#120, sr_ticket_number#121]
 Join type: Inner
 Join condition: None
 
 (137) Project [codegen id : 56]
-Output [11]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Input [14]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119, sr_item_sk#121, sr_ticket_number#122]
+Output [11]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118]
+Input [14]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_ticket_number#114, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118, sr_item_sk#120, sr_ticket_number#121]
 
 (138) ReusedExchange [Reuses operator id: 33]
-Output [1]: [cs_item_sk#123]
+Output [1]: [cs_item_sk#122]
 
 (139) BroadcastHashJoin [codegen id : 56]
-Left keys [1]: [ss_item_sk#108]
-Right keys [1]: [cs_item_sk#123]
+Left keys [1]: [ss_item_sk#107]
+Right keys [1]: [cs_item_sk#122]
 Join type: Inner
 Join condition: None
 
 (140) Project [codegen id : 56]
-Output [11]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119, cs_item_sk#123]
+Output [11]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118]
+Input [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118, cs_item_sk#122]
 
 (141) ReusedExchange [Reuses operator id: 224]
-Output [2]: [d_date_sk#124, d_year#125]
+Output [2]: [d_date_sk#123, d_year#124]
 
 (142) BroadcastHashJoin [codegen id : 56]
-Left keys [1]: [ss_sold_date_sk#119]
-Right keys [1]: [d_date_sk#124]
+Left keys [1]: [ss_sold_date_sk#118]
+Right keys [1]: [d_date_sk#123]
 Join type: Inner
 Join condition: None
 
 (143) Project [codegen id : 56]
-Output [11]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125]
-Input [13]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119, d_date_sk#124, d_year#125]
+Output [11]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124]
+Input [13]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, ss_sold_date_sk#118, d_date_sk#123, d_year#124]
 
 (144) ReusedExchange [Reuses operator id: 42]
-Output [3]: [s_store_sk#126, s_store_name#127, s_zip#128]
+Output [3]: [s_store_sk#125, s_store_name#126, s_zip#127]
 
 (145) BroadcastHashJoin [codegen id : 56]
-Left keys [1]: [ss_store_sk#113]
-Right keys [1]: [s_store_sk#126]
+Left keys [1]: [ss_store_sk#112]
+Right keys [1]: [s_store_sk#125]
 Join type: Inner
 Join condition: None
 
 (146) Project [codegen id : 56]
-Output [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128]
-Input [14]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_sk#126, s_store_name#127, s_zip#128]
+Output [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127]
+Input [14]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_store_sk#112, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_sk#125, s_store_name#126, s_zip#127]
 
 (147) Exchange
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128]
-Arguments: hashpartitioning(ss_customer_sk#109, 5), ENSURE_REQUIREMENTS, [plan_id=24]
+Input [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127]
+Arguments: hashpartitioning(ss_customer_sk#108, 5), ENSURE_REQUIREMENTS, [plan_id=25]
 
 (148) Sort [codegen id : 57]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128]
-Arguments: [ss_customer_sk#109 ASC NULLS FIRST], false, 0
+Input [12]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127]
+Arguments: [ss_customer_sk#108 ASC NULLS FIRST], false, 0
 
 (149) ReusedExchange [Reuses operator id: 50]
-Output [6]: [c_customer_sk#129, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134]
+Output [6]: [c_customer_sk#128, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, c_first_shipto_date_sk#132, c_first_sales_date_sk#133]
 
 (150) Sort [codegen id : 59]
-Input [6]: [c_customer_sk#129, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134]
-Arguments: [c_customer_sk#129 ASC NULLS FIRST], false, 0
+Input [6]: [c_customer_sk#128, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, c_first_shipto_date_sk#132, c_first_sales_date_sk#133]
+Arguments: [c_customer_sk#128 ASC NULLS FIRST], false, 0
 
 (151) SortMergeJoin [codegen id : 62]
-Left keys [1]: [ss_customer_sk#109]
-Right keys [1]: [c_customer_sk#129]
+Left keys [1]: [ss_customer_sk#108]
+Right keys [1]: [c_customer_sk#128]
 Join type: Inner
 Join condition: None
 
 (152) Project [codegen id : 62]
-Output [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134]
-Input [18]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_customer_sk#129, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134]
+Output [16]: [ss_item_sk#107, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, c_first_shipto_date_sk#132, c_first_sales_date_sk#133]
+Input [18]: [ss_item_sk#107, ss_customer_sk#108, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_customer_sk#128, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, c_first_shipto_date_sk#132, c_first_sales_date_sk#133]
 
 (153) ReusedExchange [Reuses operator id: 57]
-Output [2]: [d_date_sk#135, d_year#136]
+Output [2]: [d_date_sk#134, d_year#135]
 
 (154) BroadcastHashJoin [codegen id : 62]
-Left keys [1]: [c_first_sales_date_sk#134]
-Right keys [1]: [d_date_sk#135]
+Left keys [1]: [c_first_sales_date_sk#133]
+Right keys [1]: [d_date_sk#134]
 Join type: Inner
 Join condition: None
 
 (155) Project [codegen id : 62]
-Output [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, d_year#136]
-Input [18]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134, d_date_sk#135, d_year#136]
+Output [16]: [ss_item_sk#107, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, c_first_shipto_date_sk#132, d_year#135]
+Input [18]: [ss_item_sk#107, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, c_first_shipto_date_sk#132, c_first_sales_date_sk#133, d_date_sk#134, d_year#135]
 
 (156) ReusedExchange [Reuses operator id: 57]
-Output [2]: [d_date_sk#137, d_year#138]
+Output [2]: [d_date_sk#136, d_year#137]
 
 (157) BroadcastHashJoin [codegen id : 62]
-Left keys [1]: [c_first_shipto_date_sk#133]
-Right keys [1]: [d_date_sk#137]
+Left keys [1]: [c_first_shipto_date_sk#132]
+Right keys [1]: [d_date_sk#136]
 Join type: Inner
 Join condition: None
 
 (158) Project [codegen id : 62]
-Output [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Input [18]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, d_year#136, d_date_sk#137, d_year#138]
+Output [16]: [ss_item_sk#107, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137]
+Input [18]: [ss_item_sk#107, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, c_first_shipto_date_sk#132, d_year#135, d_date_sk#136, d_year#137]
 
 (159) Exchange
-Input [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Arguments: hashpartitioning(ss_cdemo_sk#110, 5), ENSURE_REQUIREMENTS, [plan_id=25]
+Input [16]: [ss_item_sk#107, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137]
+Arguments: hashpartitioning(ss_cdemo_sk#109, 5), ENSURE_REQUIREMENTS, [plan_id=26]
 
 (160) Sort [codegen id : 63]
-Input [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Arguments: [ss_cdemo_sk#110 ASC NULLS FIRST], false, 0
+Input [16]: [ss_item_sk#107, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137]
+Arguments: [ss_cdemo_sk#109 ASC NULLS FIRST], false, 0
 
 (161) ReusedExchange [Reuses operator id: 68]
-Output [2]: [cd_demo_sk#139, cd_marital_status#140]
+Output [2]: [cd_demo_sk#138, cd_marital_status#139]
 
 (162) Sort [codegen id : 65]
-Input [2]: [cd_demo_sk#139, cd_marital_status#140]
-Arguments: [cd_demo_sk#139 ASC NULLS FIRST], false, 0
+Input [2]: [cd_demo_sk#138, cd_marital_status#139]
+Arguments: [cd_demo_sk#138 ASC NULLS FIRST], false, 0
 
 (163) SortMergeJoin [codegen id : 66]
-Left keys [1]: [ss_cdemo_sk#110]
-Right keys [1]: [cd_demo_sk#139]
+Left keys [1]: [ss_cdemo_sk#109]
+Right keys [1]: [cd_demo_sk#138]
 Join type: Inner
 Join condition: None
 
 (164) Project [codegen id : 66]
-Output [16]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_marital_status#140]
-Input [18]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_demo_sk#139, cd_marital_status#140]
+Output [16]: [ss_item_sk#107, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, cd_marital_status#139]
+Input [18]: [ss_item_sk#107, ss_cdemo_sk#109, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, cd_demo_sk#138, cd_marital_status#139]
 
 (165) Exchange
-Input [16]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_marital_status#140]
-Arguments: hashpartitioning(c_current_cdemo_sk#130, 5), ENSURE_REQUIREMENTS, [plan_id=26]
+Input [16]: [ss_item_sk#107, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, cd_marital_status#139]
+Arguments: hashpartitioning(c_current_cdemo_sk#129, 5), ENSURE_REQUIREMENTS, [plan_id=27]
 
 (166) Sort [codegen id : 67]
-Input [16]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_marital_status#140]
-Arguments: [c_current_cdemo_sk#130 ASC NULLS FIRST], false, 0
+Input [16]: [ss_item_sk#107, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, cd_marital_status#139]
+Arguments: [c_current_cdemo_sk#129 ASC NULLS FIRST], false, 0
 
 (167) ReusedExchange [Reuses operator id: 68]
-Output [2]: [cd_demo_sk#141, cd_marital_status#142]
+Output [2]: [cd_demo_sk#140, cd_marital_status#141]
 
 (168) Sort [codegen id : 69]
-Input [2]: [cd_demo_sk#141, cd_marital_status#142]
-Arguments: [cd_demo_sk#141 ASC NULLS FIRST], false, 0
+Input [2]: [cd_demo_sk#140, cd_marital_status#141]
+Arguments: [cd_demo_sk#140 ASC NULLS FIRST], false, 0
 
 (169) SortMergeJoin [codegen id : 73]
-Left keys [1]: [c_current_cdemo_sk#130]
-Right keys [1]: [cd_demo_sk#141]
+Left keys [1]: [c_current_cdemo_sk#129]
+Right keys [1]: [cd_demo_sk#140]
 Join type: Inner
-Join condition: NOT (cd_marital_status#140 = cd_marital_status#142)
+Join condition: NOT (cd_marital_status#139 = cd_marital_status#141)
 
 (170) Project [codegen id : 73]
-Output [14]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Input [18]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_marital_status#140, cd_demo_sk#141, cd_marital_status#142]
+Output [14]: [ss_item_sk#107, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137]
+Input [18]: [ss_item_sk#107, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_cdemo_sk#129, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, cd_marital_status#139, cd_demo_sk#140, cd_marital_status#141]
 
 (171) ReusedExchange [Reuses operator id: 81]
-Output [1]: [p_promo_sk#143]
+Output [1]: [p_promo_sk#142]
 
 (172) BroadcastHashJoin [codegen id : 73]
-Left keys [1]: [ss_promo_sk#114]
-Right keys [1]: [p_promo_sk#143]
+Left keys [1]: [ss_promo_sk#113]
+Right keys [1]: [p_promo_sk#142]
 Join type: Inner
 Join condition: None
 
 (173) Project [codegen id : 73]
-Output [13]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Input [15]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, p_promo_sk#143]
+Output [13]: [ss_item_sk#107, ss_hdemo_sk#110, ss_addr_sk#111, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137]
+Input [15]: [ss_item_sk#107, ss_hdemo_sk#110, ss_addr_sk#111, ss_promo_sk#113, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, p_promo_sk#142]
 
 (174) ReusedExchange [Reuses operator id: 87]
-Output [2]: [hd_demo_sk#144, hd_income_band_sk#145]
+Output [2]: [hd_demo_sk#143, hd_income_band_sk#144]
 
 (175) BroadcastHashJoin [codegen id : 73]
-Left keys [1]: [ss_hdemo_sk#111]
-Right keys [1]: [hd_demo_sk#144]
+Left keys [1]: [ss_hdemo_sk#110]
+Right keys [1]: [hd_demo_sk#143]
 Join type: Inner
 Join condition: None
 
 (176) Project [codegen id : 73]
-Output [13]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145]
-Input [15]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, hd_demo_sk#144, hd_income_band_sk#145]
+Output [13]: [ss_item_sk#107, ss_addr_sk#111, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144]
+Input [15]: [ss_item_sk#107, ss_hdemo_sk#110, ss_addr_sk#111, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, hd_demo_sk#143, hd_income_band_sk#144]
 
 (177) ReusedExchange [Reuses operator id: 87]
-Output [2]: [hd_demo_sk#146, hd_income_band_sk#147]
+Output [2]: [hd_demo_sk#145, hd_income_band_sk#146]
 
 (178) BroadcastHashJoin [codegen id : 73]
-Left keys [1]: [c_current_hdemo_sk#131]
-Right keys [1]: [hd_demo_sk#146]
+Left keys [1]: [c_current_hdemo_sk#130]
+Right keys [1]: [hd_demo_sk#145]
 Join type: Inner
 Join condition: None
 
 (179) Project [codegen id : 73]
-Output [13]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147]
-Input [15]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_demo_sk#146, hd_income_band_sk#147]
+Output [13]: [ss_item_sk#107, ss_addr_sk#111, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146]
+Input [15]: [ss_item_sk#107, ss_addr_sk#111, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_hdemo_sk#130, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_demo_sk#145, hd_income_band_sk#146]
 
 (180) Exchange
-Input [13]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147]
-Arguments: hashpartitioning(ss_addr_sk#112, 5), ENSURE_REQUIREMENTS, [plan_id=27]
+Input [13]: [ss_item_sk#107, ss_addr_sk#111, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146]
+Arguments: hashpartitioning(ss_addr_sk#111, 5), ENSURE_REQUIREMENTS, [plan_id=28]
 
 (181) Sort [codegen id : 74]
-Input [13]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147]
-Arguments: [ss_addr_sk#112 ASC NULLS FIRST], false, 0
+Input [13]: [ss_item_sk#107, ss_addr_sk#111, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146]
+Arguments: [ss_addr_sk#111 ASC NULLS FIRST], false, 0
 
 (182) ReusedExchange [Reuses operator id: 98]
-Output [5]: [ca_address_sk#148, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
+Output [5]: [ca_address_sk#147, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151]
 
 (183) Sort [codegen id : 76]
-Input [5]: [ca_address_sk#148, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
-Arguments: [ca_address_sk#148 ASC NULLS FIRST], false, 0
+Input [5]: [ca_address_sk#147, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151]
+Arguments: [ca_address_sk#147 ASC NULLS FIRST], false, 0
 
 (184) SortMergeJoin [codegen id : 77]
-Left keys [1]: [ss_addr_sk#112]
-Right keys [1]: [ca_address_sk#148]
+Left keys [1]: [ss_addr_sk#111]
+Right keys [1]: [ca_address_sk#147]
 Join type: Inner
 Join condition: None
 
 (185) Project [codegen id : 77]
-Output [16]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
-Input [18]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_address_sk#148, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
+Output [16]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151]
+Input [18]: [ss_item_sk#107, ss_addr_sk#111, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146, ca_address_sk#147, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151]
 
 (186) Exchange
-Input [16]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
-Arguments: hashpartitioning(c_current_addr_sk#132, 5), ENSURE_REQUIREMENTS, [plan_id=28]
+Input [16]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151]
+Arguments: hashpartitioning(c_current_addr_sk#131, 5), ENSURE_REQUIREMENTS, [plan_id=29]
 
 (187) Sort [codegen id : 78]
-Input [16]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
-Arguments: [c_current_addr_sk#132 ASC NULLS FIRST], false, 0
+Input [16]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151]
+Arguments: [c_current_addr_sk#131 ASC NULLS FIRST], false, 0
 
 (188) ReusedExchange [Reuses operator id: 98]
-Output [5]: [ca_address_sk#153, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
+Output [5]: [ca_address_sk#152, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156]
 
 (189) Sort [codegen id : 80]
-Input [5]: [ca_address_sk#153, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-Arguments: [ca_address_sk#153 ASC NULLS FIRST], false, 0
+Input [5]: [ca_address_sk#152, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156]
+Arguments: [ca_address_sk#152 ASC NULLS FIRST], false, 0
 
 (190) SortMergeJoin [codegen id : 84]
-Left keys [1]: [c_current_addr_sk#132]
-Right keys [1]: [ca_address_sk#153]
+Left keys [1]: [c_current_addr_sk#131]
+Right keys [1]: [ca_address_sk#152]
 Join type: Inner
 Join condition: None
 
 (191) Project [codegen id : 84]
-Output [19]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-Input [21]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_address_sk#153, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
+Output [19]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156]
+Input [21]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, c_current_addr_sk#131, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_address_sk#152, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156]
 
 (192) ReusedExchange [Reuses operator id: 111]
-Output [1]: [ib_income_band_sk#158]
+Output [1]: [ib_income_band_sk#157]
 
 (193) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [hd_income_band_sk#145]
-Right keys [1]: [ib_income_band_sk#158]
+Left keys [1]: [hd_income_band_sk#144]
+Right keys [1]: [ib_income_band_sk#157]
 Join type: Inner
 Join condition: None
 
 (194) Project [codegen id : 84]
-Output [18]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-Input [20]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, ib_income_band_sk#158]
+Output [18]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, d_year#135, d_year#137, hd_income_band_sk#146, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156]
+Input [20]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, d_year#135, d_year#137, hd_income_band_sk#144, hd_income_band_sk#146, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, ib_income_band_sk#157]
 
 (195) ReusedExchange [Reuses operator id: 111]
-Output [1]: [ib_income_band_sk#159]
+Output [1]: [ib_income_band_sk#158]
 
 (196) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [hd_income_band_sk#147]
-Right keys [1]: [ib_income_band_sk#159]
+Left keys [1]: [hd_income_band_sk#146]
+Right keys [1]: [ib_income_band_sk#158]
 Join type: Inner
 Join condition: None
 
 (197) Project [codegen id : 84]
-Output [17]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-Input [19]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, ib_income_band_sk#159]
+Output [17]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, d_year#135, d_year#137, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156]
+Input [19]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, d_year#135, d_year#137, hd_income_band_sk#146, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, ib_income_band_sk#158]
 
 (198) ReusedExchange [Reuses operator id: 121]
-Output [2]: [i_item_sk#160, i_product_name#161]
+Output [2]: [i_item_sk#159, i_product_name#160]
 
 (199) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [ss_item_sk#108]
-Right keys [1]: [i_item_sk#160]
+Left keys [1]: [ss_item_sk#107]
+Right keys [1]: [i_item_sk#159]
 Join type: Inner
 Join condition: None
 
 (200) Project [codegen id : 84]
-Output [18]: [ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, d_year#136, d_year#138, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, i_item_sk#160, i_product_name#161]
-Input [19]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, i_item_sk#160, i_product_name#161]
+Output [18]: [ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, d_year#135, d_year#137, s_store_name#126, s_zip#127, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, i_item_sk#159, i_product_name#160]
+Input [19]: [ss_item_sk#107, ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, s_store_name#126, s_zip#127, d_year#135, d_year#137, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, i_item_sk#159, i_product_name#160]
 
 (201) HashAggregate [codegen id : 84]
-Input [18]: [ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, d_year#136, d_year#138, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, i_item_sk#160, i_product_name#161]
-Keys [15]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138]
-Functions [4]: [partial_count(1), partial_sum(UnscaledValue(ss_wholesale_cost#116)), partial_sum(UnscaledValue(ss_list_price#117)), partial_sum(UnscaledValue(ss_coupon_amt#118))]
-Aggregate Attributes [4]: [count#79, sum#162, sum#163, sum#164]
-Results [19]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138, count#83, sum#165, sum#166, sum#167]
+Input [18]: [ss_wholesale_cost#115, ss_list_price#116, ss_coupon_amt#117, d_year#124, d_year#135, d_year#137, s_store_name#126, s_zip#127, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, i_item_sk#159, i_product_name#160]
+Keys [15]: [i_product_name#160, i_item_sk#159, s_store_name#126, s_zip#127, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, d_year#124, d_year#135, d_year#137]
+Functions [4]: [partial_count(1), partial_sum(UnscaledValue(ss_wholesale_cost#115)), partial_sum(UnscaledValue(ss_list_price#116)), partial_sum(UnscaledValue(ss_coupon_amt#117))]
+Aggregate Attributes [4]: [count#78, sum#161, sum#162, sum#163]
+Results [19]: [i_product_name#160, i_item_sk#159, s_store_name#126, s_zip#127, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, d_year#124, d_year#135, d_year#137, count#82, sum#164, sum#165, sum#166]
 
 (202) Exchange
-Input [19]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138, count#83, sum#165, sum#166, sum#167]
-Arguments: hashpartitioning(i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138, 5), ENSURE_REQUIREMENTS, [plan_id=29]
+Input [19]: [i_product_name#160, i_item_sk#159, s_store_name#126, s_zip#127, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, d_year#124, d_year#135, d_year#137, count#82, sum#164, sum#165, sum#166]
+Arguments: hashpartitioning(i_product_name#160, i_item_sk#159, s_store_name#126, s_zip#127, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, d_year#124, d_year#135, d_year#137, 5), ENSURE_REQUIREMENTS, [plan_id=30]
 
 (203) HashAggregate [codegen id : 85]
-Input [19]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138, count#83, sum#165, sum#166, sum#167]
-Keys [15]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138]
-Functions [4]: [count(1), sum(UnscaledValue(ss_wholesale_cost#116)), sum(UnscaledValue(ss_list_price#117)), sum(UnscaledValue(ss_coupon_amt#118))]
-Aggregate Attributes [4]: [count(1)#87, sum(UnscaledValue(ss_wholesale_cost#116))#88, sum(UnscaledValue(ss_list_price#117))#89, sum(UnscaledValue(ss_coupon_amt#118))#90]
-Results [8]: [i_item_sk#160 AS item_sk#168, s_store_name#127 AS store_name#169, s_zip#128 AS store_zip#170, d_year#125 AS syear#171, count(1)#87 AS cnt#172, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#116))#88,17,2) AS s1#173, MakeDecimal(sum(UnscaledValue(ss_list_price#117))#89,17,2) AS s2#174, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#118))#90,17,2) AS s3#175]
+Input [19]: [i_product_name#160, i_item_sk#159, s_store_name#126, s_zip#127, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, d_year#124, d_year#135, d_year#137, count#82, sum#164, sum#165, sum#166]
+Keys [15]: [i_product_name#160, i_item_sk#159, s_store_name#126, s_zip#127, ca_street_number#148, ca_street_name#149, ca_city#150, ca_zip#151, ca_street_number#153, ca_street_name#154, ca_city#155, ca_zip#156, d_year#124, d_year#135, d_year#137]
+Functions [4]: [count(1), sum(UnscaledValue(ss_wholesale_cost#115)), sum(UnscaledValue(ss_list_price#116)), sum(UnscaledValue(ss_coupon_amt#117))]
+Aggregate Attributes [4]: [count(1)#86, sum(UnscaledValue(ss_wholesale_cost#115))#87, sum(UnscaledValue(ss_list_price#116))#88, sum(UnscaledValue(ss_coupon_amt#117))#89]
+Results [8]: [i_item_sk#159 AS item_sk#167, s_store_name#126 AS store_name#168, s_zip#127 AS store_zip#169, d_year#124 AS syear#170, count(1)#86 AS cnt#171, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#115))#87,17,2) AS s1#172, MakeDecimal(sum(UnscaledValue(ss_list_price#116))#88,17,2) AS s2#173, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#117))#89,17,2) AS s3#174]
 
 (204) Exchange
-Input [8]: [item_sk#168, store_name#169, store_zip#170, syear#171, cnt#172, s1#173, s2#174, s3#175]
-Arguments: hashpartitioning(item_sk#168, store_name#169, store_zip#170, 5), ENSURE_REQUIREMENTS, [plan_id=30]
+Input [8]: [item_sk#167, store_name#168, store_zip#169, syear#170, cnt#171, s1#172, s2#173, s3#174]
+Arguments: hashpartitioning(item_sk#167, store_name#168, store_zip#169, 5), ENSURE_REQUIREMENTS, [plan_id=31]
 
 (205) Sort [codegen id : 86]
-Input [8]: [item_sk#168, store_name#169, store_zip#170, syear#171, cnt#172, s1#173, s2#174, s3#175]
-Arguments: [item_sk#168 ASC NULLS FIRST, store_name#169 ASC NULLS FIRST, store_zip#170 ASC NULLS FIRST], false, 0
+Input [8]: [item_sk#167, store_name#168, store_zip#169, syear#170, cnt#171, s1#172, s2#173, s3#174]
+Arguments: [item_sk#167 ASC NULLS FIRST, store_name#168 ASC NULLS FIRST, store_zip#169 ASC NULLS FIRST], false, 0
 
 (206) SortMergeJoin [codegen id : 87]
-Left keys [3]: [item_sk#92, store_name#93, store_zip#94]
-Right keys [3]: [item_sk#168, store_name#169, store_zip#170]
+Left keys [3]: [item_sk#91, store_name#92, store_zip#93]
+Right keys [3]: [item_sk#167, store_name#168, store_zip#169]
 Join type: Inner
-Join condition: (cnt#172 <= cnt#104)
+Join condition: (cnt#171 <= cnt#103)
 
 (207) Project [codegen id : 87]
-Output [21]: [product_name#91, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107, s1#173, s2#174, s3#175, syear#171, cnt#172]
-Input [25]: [product_name#91, item_sk#92, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107, item_sk#168, store_name#169, store_zip#170, syear#171, cnt#172, s1#173, s2#174, s3#175]
+Output [21]: [product_name#90, store_name#92, store_zip#93, b_street_number#94, b_streen_name#95, b_city#96, b_zip#97, c_street_number#98, c_street_name#99, c_city#100, c_zip#101, syear#102, cnt#103, s1#104, s2#105, s3#106, s1#172, s2#173, s3#174, syear#170, cnt#171]
+Input [25]: [product_name#90, item_sk#91, store_name#92, store_zip#93, b_street_number#94, b_streen_name#95, b_city#96, b_zip#97, c_street_number#98, c_street_name#99, c_city#100, c_zip#101, syear#102, cnt#103, s1#104, s2#105, s3#106, item_sk#167, store_name#168, store_zip#169, syear#170, cnt#171, s1#172, s2#173, s3#174]
 
 (208) Exchange
-Input [21]: [product_name#91, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107, s1#173, s2#174, s3#175, syear#171, cnt#172]
-Arguments: rangepartitioning(product_name#91 ASC NULLS FIRST, store_name#93 ASC NULLS FIRST, cnt#172 ASC NULLS FIRST, s1#105 ASC NULLS FIRST, s1#173 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=31]
+Input [21]: [product_name#90, store_name#92, store_zip#93, b_street_number#94, b_streen_name#95, b_city#96, b_zip#97, c_street_number#98, c_street_name#99, c_city#100, c_zip#101, syear#102, cnt#103, s1#104, s2#105, s3#106, s1#172, s2#173, s3#174, syear#170, cnt#171]
+Arguments: rangepartitioning(product_name#90 ASC NULLS FIRST, store_name#92 ASC NULLS FIRST, cnt#171 ASC NULLS FIRST, s1#104 ASC NULLS FIRST, s1#172 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=32]
 
 (209) Sort [codegen id : 88]
-Input [21]: [product_name#91, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107, s1#173, s2#174, s3#175, syear#171, cnt#172]
-Arguments: [product_name#91 ASC NULLS FIRST, store_name#93 ASC NULLS FIRST, cnt#172 ASC NULLS FIRST, s1#105 ASC NULLS FIRST, s1#173 ASC NULLS FIRST], true, 0
+Input [21]: [product_name#90, store_name#92, store_zip#93, b_street_number#94, b_streen_name#95, b_city#96, b_zip#97, c_street_number#98, c_street_name#99, c_city#100, c_zip#101, syear#102, cnt#103, s1#104, s2#105, s3#106, s1#172, s2#173, s3#174, syear#170, cnt#171]
+Arguments: [product_name#90 ASC NULLS FIRST, store_name#92 ASC NULLS FIRST, cnt#171 ASC NULLS FIRST, s1#104 ASC NULLS FIRST, s1#172 ASC NULLS FIRST], true, 0
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#14, [id=#15]
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#14, [id=#1]
 ObjectHashAggregate (216)
 +- Exchange (215)
    +- ObjectHashAggregate (214)
@@ -1156,40 +1156,40 @@ ObjectHashAggregate (216)
 
 
 (210) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#75, i_current_price#76, i_color#77]
+Output [3]: [i_item_sk#74, i_current_price#75, i_color#76]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_current_price), In(i_color, [burlywood           ,floral              ,indian              ,medium              ,purple              ,spring              ]), GreaterThanOrEqual(i_current_price,64.00), LessThanOrEqual(i_current_price,74.00), GreaterThanOrEqual(i_current_price,65.00), LessThanOrEqual(i_current_price,79.00), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_color:string>
 
 (211) ColumnarToRow [codegen id : 1]
-Input [3]: [i_item_sk#75, i_current_price#76, i_color#77]
+Input [3]: [i_item_sk#74, i_current_price#75, i_color#76]
 
 (212) Filter [codegen id : 1]
-Input [3]: [i_item_sk#75, i_current_price#76, i_color#77]
-Condition : ((((((isnotnull(i_current_price#76) AND i_color#77 IN (purple              ,burlywood           ,indian              ,spring              ,floral              ,medium              )) AND (i_current_price#76 >= 64.00)) AND (i_current_price#76 <= 74.00)) AND (i_current_price#76 >= 65.00)) AND (i_current_price#76 <= 79.00)) AND isnotnull(i_item_sk#75))
+Input [3]: [i_item_sk#74, i_current_price#75, i_color#76]
+Condition : ((((((isnotnull(i_current_price#75) AND i_color#76 IN (purple              ,burlywood           ,indian              ,spring              ,floral              ,medium              )) AND (i_current_price#75 >= 64.00)) AND (i_current_price#75 <= 74.00)) AND (i_current_price#75 >= 65.00)) AND (i_current_price#75 <= 79.00)) AND isnotnull(i_item_sk#74))
 
 (213) Project [codegen id : 1]
-Output [1]: [i_item_sk#75]
-Input [3]: [i_item_sk#75, i_current_price#76, i_color#77]
+Output [1]: [i_item_sk#74]
+Input [3]: [i_item_sk#74, i_current_price#75, i_color#76]
 
 (214) ObjectHashAggregate
-Input [1]: [i_item_sk#75]
+Input [1]: [i_item_sk#74]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#75, 42), 1250, 30121, 0, 0)]
-Aggregate Attributes [1]: [buf#176]
-Results [1]: [buf#177]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#74, 42), 1250, 30121, 0, 0)]
+Aggregate Attributes [1]: [buf#175]
+Results [1]: [buf#176]
 
 (215) Exchange
-Input [1]: [buf#177]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=32]
+Input [1]: [buf#176]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=33]
 
 (216) ObjectHashAggregate
-Input [1]: [buf#177]
+Input [1]: [buf#176]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#75, 42), 1250, 30121, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#75, 42), 1250, 30121, 0, 0)#178]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#75, 42), 1250, 30121, 0, 0)#178 AS bloomFilter#179]
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#74, 42), 1250, 30121, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#74, 42), 1250, 30121, 0, 0)#177]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#74, 42), 1250, 30121, 0, 0)#177 AS bloomFilter#178]
 
 Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#12 IN dynamicpruning#13
 BroadcastExchange (220)
@@ -1199,26 +1199,26 @@ BroadcastExchange (220)
 
 
 (217) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#39, d_year#40]
+Output [2]: [d_date_sk#38, d_year#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1999), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (218) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#39, d_year#40]
+Input [2]: [d_date_sk#38, d_year#39]
 
 (219) Filter [codegen id : 1]
-Input [2]: [d_date_sk#39, d_year#40]
-Condition : ((isnotnull(d_year#40) AND (d_year#40 = 1999)) AND isnotnull(d_date_sk#39))
+Input [2]: [d_date_sk#38, d_year#39]
+Condition : ((isnotnull(d_year#39) AND (d_year#39 = 1999)) AND isnotnull(d_date_sk#38))
 
 (220) BroadcastExchange
-Input [2]: [d_date_sk#39, d_year#40]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=33]
+Input [2]: [d_date_sk#38, d_year#39]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=34]
 
-Subquery:3 Hosting operator id = 131 Hosting Expression = ReusedSubquery Subquery scalar-subquery#14, [id=#15]
+Subquery:3 Hosting operator id = 131 Hosting Expression = ReusedSubquery Subquery scalar-subquery#14, [id=#1]
 
-Subquery:4 Hosting operator id = 129 Hosting Expression = ss_sold_date_sk#119 IN dynamicpruning#120
+Subquery:4 Hosting operator id = 129 Hosting Expression = ss_sold_date_sk#118 IN dynamicpruning#119
 BroadcastExchange (224)
 +- * Filter (223)
    +- * ColumnarToRow (222)
@@ -1226,21 +1226,21 @@ BroadcastExchange (224)
 
 
 (221) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#124, d_year#125]
+Output [2]: [d_date_sk#123, d_year#124]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (222) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#124, d_year#125]
+Input [2]: [d_date_sk#123, d_year#124]
 
 (223) Filter [codegen id : 1]
-Input [2]: [d_date_sk#124, d_year#125]
-Condition : ((isnotnull(d_year#125) AND (d_year#125 = 2000)) AND isnotnull(d_date_sk#124))
+Input [2]: [d_date_sk#123, d_year#124]
+Condition : ((isnotnull(d_year#124) AND (d_year#124 = 2000)) AND isnotnull(d_date_sk#123))
 
 (224) BroadcastExchange
-Input [2]: [d_date_sk#124, d_year#125]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=34]
+Input [2]: [d_date_sk#123, d_year#124]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=35]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/explain.txt
@@ -216,946 +216,946 @@ Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_e
 
 (3) Filter [codegen id : 1]
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7]
-Condition : ((((isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_promo_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(ss_item_sk#1, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(ss_promo_sk#3, 42)))
+Condition : ((((isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_promo_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#1], xxhash64(ss_item_sk#1, 42))) AND might_contain(Subquery scalar-subquery#10, [id=#2], xxhash64(ss_promo_sk#3, 42)))
 
 (4) Exchange
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7]
-Arguments: hashpartitioning(ss_item_sk#1, ss_ticket_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=1]
+Arguments: hashpartitioning(ss_item_sk#1, ss_ticket_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (5) Sort [codegen id : 2]
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#4 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.store_returns
-Output [5]: [sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16, sr_returned_date_sk#17]
+Output [5]: [sr_item_sk#11, sr_ticket_number#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int,sr_return_amt:decimal(7,2),sr_net_loss:decimal(7,2)>
 
 (7) ColumnarToRow [codegen id : 3]
-Input [5]: [sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16, sr_returned_date_sk#17]
+Input [5]: [sr_item_sk#11, sr_ticket_number#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 
 (8) Filter [codegen id : 3]
-Input [5]: [sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16, sr_returned_date_sk#17]
-Condition : (isnotnull(sr_item_sk#13) AND isnotnull(sr_ticket_number#14))
+Input [5]: [sr_item_sk#11, sr_ticket_number#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
+Condition : (isnotnull(sr_item_sk#11) AND isnotnull(sr_ticket_number#12))
 
 (9) Project [codegen id : 3]
-Output [4]: [sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16]
-Input [5]: [sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16, sr_returned_date_sk#17]
+Output [4]: [sr_item_sk#11, sr_ticket_number#12, sr_return_amt#13, sr_net_loss#14]
+Input [5]: [sr_item_sk#11, sr_ticket_number#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 
 (10) Exchange
-Input [4]: [sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16]
-Arguments: hashpartitioning(sr_item_sk#13, sr_ticket_number#14, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [4]: [sr_item_sk#11, sr_ticket_number#12, sr_return_amt#13, sr_net_loss#14]
+Arguments: hashpartitioning(sr_item_sk#11, sr_ticket_number#12, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (11) Sort [codegen id : 4]
-Input [4]: [sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16]
-Arguments: [sr_item_sk#13 ASC NULLS FIRST, sr_ticket_number#14 ASC NULLS FIRST], false, 0
+Input [4]: [sr_item_sk#11, sr_ticket_number#12, sr_return_amt#13, sr_net_loss#14]
+Arguments: [sr_item_sk#11 ASC NULLS FIRST, sr_ticket_number#12 ASC NULLS FIRST], false, 0
 
 (12) SortMergeJoin [codegen id : 9]
 Left keys [2]: [ss_item_sk#1, ss_ticket_number#4]
-Right keys [2]: [sr_item_sk#13, sr_ticket_number#14]
+Right keys [2]: [sr_item_sk#11, sr_ticket_number#12]
 Join type: LeftOuter
 Join condition: None
 
 (13) Project [codegen id : 9]
-Output [8]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16]
-Input [11]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16]
+Output [8]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#13, sr_net_loss#14]
+Input [11]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_item_sk#11, sr_ticket_number#12, sr_return_amt#13, sr_net_loss#14]
 
 (14) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#18, i_current_price#19]
+Output [2]: [i_item_sk#16, i_current_price#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_current_price), GreaterThan(i_current_price,50.00), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2)>
 
 (15) ColumnarToRow [codegen id : 5]
-Input [2]: [i_item_sk#18, i_current_price#19]
+Input [2]: [i_item_sk#16, i_current_price#17]
 
 (16) Filter [codegen id : 5]
-Input [2]: [i_item_sk#18, i_current_price#19]
-Condition : ((isnotnull(i_current_price#19) AND (i_current_price#19 > 50.00)) AND isnotnull(i_item_sk#18))
+Input [2]: [i_item_sk#16, i_current_price#17]
+Condition : ((isnotnull(i_current_price#17) AND (i_current_price#17 > 50.00)) AND isnotnull(i_item_sk#16))
 
 (17) Project [codegen id : 5]
-Output [1]: [i_item_sk#18]
-Input [2]: [i_item_sk#18, i_current_price#19]
+Output [1]: [i_item_sk#16]
+Input [2]: [i_item_sk#16, i_current_price#17]
 
 (18) BroadcastExchange
-Input [1]: [i_item_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
+Input [1]: [i_item_sk#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 (19) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#18]
+Right keys [1]: [i_item_sk#16]
 Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 9]
-Output [7]: [ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16]
-Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, i_item_sk#18]
+Output [7]: [ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#13, sr_net_loss#14]
+Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#13, sr_net_loss#14, i_item_sk#16]
 
 (21) Scan parquet spark_catalog.default.promotion
-Output [2]: [p_promo_sk#20, p_channel_tv#21]
+Output [2]: [p_promo_sk#18, p_channel_tv#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/promotion]
 PushedFilters: [IsNotNull(p_channel_tv), EqualTo(p_channel_tv,N), IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int,p_channel_tv:string>
 
 (22) ColumnarToRow [codegen id : 6]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
+Input [2]: [p_promo_sk#18, p_channel_tv#19]
 
 (23) Filter [codegen id : 6]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
-Condition : ((isnotnull(p_channel_tv#21) AND (p_channel_tv#21 = N)) AND isnotnull(p_promo_sk#20))
+Input [2]: [p_promo_sk#18, p_channel_tv#19]
+Condition : ((isnotnull(p_channel_tv#19) AND (p_channel_tv#19 = N)) AND isnotnull(p_promo_sk#18))
 
 (24) Project [codegen id : 6]
-Output [1]: [p_promo_sk#20]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
+Output [1]: [p_promo_sk#18]
+Input [2]: [p_promo_sk#18, p_channel_tv#19]
 
 (25) BroadcastExchange
-Input [1]: [p_promo_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+Input [1]: [p_promo_sk#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
 (26) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_promo_sk#3]
-Right keys [1]: [p_promo_sk#20]
+Right keys [1]: [p_promo_sk#18]
 Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 9]
-Output [6]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16]
-Input [8]: [ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, p_promo_sk#20]
+Output [6]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#13, sr_net_loss#14]
+Input [8]: [ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#13, sr_net_loss#14, p_promo_sk#18]
 
 (28) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#22]
+Output [1]: [d_date_sk#20]
 
 (29) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_sold_date_sk#7]
-Right keys [1]: [d_date_sk#22]
+Right keys [1]: [d_date_sk#20]
 Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 9]
-Output [5]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16]
-Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, d_date_sk#22]
+Output [5]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#13, sr_net_loss#14]
+Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#13, sr_net_loss#14, d_date_sk#20]
 
 (31) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#23, s_store_id#24]
+Output [2]: [s_store_sk#21, s_store_id#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
 (32) ColumnarToRow [codegen id : 8]
-Input [2]: [s_store_sk#23, s_store_id#24]
+Input [2]: [s_store_sk#21, s_store_id#22]
 
 (33) Filter [codegen id : 8]
-Input [2]: [s_store_sk#23, s_store_id#24]
-Condition : isnotnull(s_store_sk#23)
+Input [2]: [s_store_sk#21, s_store_id#22]
+Condition : isnotnull(s_store_sk#21)
 
 (34) BroadcastExchange
-Input [2]: [s_store_sk#23, s_store_id#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
+Input [2]: [s_store_sk#21, s_store_id#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
 (35) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#23]
+Right keys [1]: [s_store_sk#21]
 Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 9]
-Output [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#24]
-Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_sk#23, s_store_id#24]
+Output [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#13, sr_net_loss#14, s_store_id#22]
+Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#13, sr_net_loss#14, s_store_sk#21, s_store_id#22]
 
 (37) HashAggregate [codegen id : 9]
-Input [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#24]
-Keys [1]: [s_store_id#24]
-Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#5)), partial_sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00)), partial_sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#25, sum#26, isEmpty#27, sum#28, isEmpty#29]
-Results [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
+Input [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#13, sr_net_loss#14, s_store_id#22]
+Keys [1]: [s_store_id#22]
+Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#5)), partial_sum(coalesce(cast(sr_return_amt#13 as decimal(12,2)), 0.00)), partial_sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#14 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [5]: [sum#23, sum#24, isEmpty#25, sum#26, isEmpty#27]
+Results [6]: [s_store_id#22, sum#28, sum#29, isEmpty#30, sum#31, isEmpty#32]
 
 (38) Exchange
-Input [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
-Arguments: hashpartitioning(s_store_id#24, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [6]: [s_store_id#22, sum#28, sum#29, isEmpty#30, sum#31, isEmpty#32]
+Arguments: hashpartitioning(s_store_id#22, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (39) HashAggregate [codegen id : 10]
-Input [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
-Keys [1]: [s_store_id#24]
-Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#5)), sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00)), sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#5))#35, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#36, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#37]
-Results [5]: [store channel AS channel#38, concat(store, s_store_id#24) AS id#39, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#5))#35,17,2) AS sales#40, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#36 AS returns#41, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#37 AS profit#42]
+Input [6]: [s_store_id#22, sum#28, sum#29, isEmpty#30, sum#31, isEmpty#32]
+Keys [1]: [s_store_id#22]
+Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#5)), sum(coalesce(cast(sr_return_amt#13 as decimal(12,2)), 0.00)), sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#14 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#5))#33, sum(coalesce(cast(sr_return_amt#13 as decimal(12,2)), 0.00))#34, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#14 as decimal(12,2)), 0.00)))#35]
+Results [5]: [store channel AS channel#36, concat(store, s_store_id#22) AS id#37, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#5))#33,17,2) AS sales#38, sum(coalesce(cast(sr_return_amt#13 as decimal(12,2)), 0.00))#34 AS returns#39, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#14 as decimal(12,2)), 0.00)))#35 AS profit#40]
 
 (40) Scan parquet spark_catalog.default.catalog_sales
-Output [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
+Output [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#49), dynamicpruningexpression(cs_sold_date_sk#49 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#47), dynamicpruningexpression(cs_sold_date_sk#47 IN dynamicpruning#8)]
 PushedFilters: [IsNotNull(cs_catalog_page_sk), IsNotNull(cs_item_sk), IsNotNull(cs_promo_sk)]
 ReadSchema: struct<cs_catalog_page_sk:int,cs_item_sk:int,cs_promo_sk:int,cs_order_number:int,cs_ext_sales_price:decimal(7,2),cs_net_profit:decimal(7,2)>
 
 (41) ColumnarToRow [codegen id : 11]
-Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
+Input [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
 
 (42) Filter [codegen id : 11]
-Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
-Condition : ((((isnotnull(cs_catalog_page_sk#43) AND isnotnull(cs_item_sk#44)) AND isnotnull(cs_promo_sk#45)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(cs_item_sk#44, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(cs_promo_sk#45, 42)))
+Input [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
+Condition : ((((isnotnull(cs_catalog_page_sk#41) AND isnotnull(cs_item_sk#42)) AND isnotnull(cs_promo_sk#43)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#1], xxhash64(cs_item_sk#42, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#10, [id=#2], xxhash64(cs_promo_sk#43, 42)))
 
 (43) Exchange
-Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
-Arguments: hashpartitioning(cs_item_sk#44, cs_order_number#46, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Input [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
+Arguments: hashpartitioning(cs_item_sk#42, cs_order_number#44, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (44) Sort [codegen id : 12]
-Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
-Arguments: [cs_item_sk#44 ASC NULLS FIRST, cs_order_number#46 ASC NULLS FIRST], false, 0
+Input [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
+Arguments: [cs_item_sk#42 ASC NULLS FIRST, cs_order_number#44 ASC NULLS FIRST], false, 0
 
 (45) Scan parquet spark_catalog.default.catalog_returns
-Output [5]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53, cr_returned_date_sk#54]
+Output [5]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51, cr_returned_date_sk#52]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
 PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_return_amount:decimal(7,2),cr_net_loss:decimal(7,2)>
 
 (46) ColumnarToRow [codegen id : 13]
-Input [5]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53, cr_returned_date_sk#54]
+Input [5]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51, cr_returned_date_sk#52]
 
 (47) Filter [codegen id : 13]
-Input [5]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53, cr_returned_date_sk#54]
-Condition : (isnotnull(cr_item_sk#50) AND isnotnull(cr_order_number#51))
+Input [5]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51, cr_returned_date_sk#52]
+Condition : (isnotnull(cr_item_sk#48) AND isnotnull(cr_order_number#49))
 
 (48) Project [codegen id : 13]
-Output [4]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
-Input [5]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53, cr_returned_date_sk#54]
+Output [4]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51]
+Input [5]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51, cr_returned_date_sk#52]
 
 (49) Exchange
-Input [4]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
-Arguments: hashpartitioning(cr_item_sk#50, cr_order_number#51, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [4]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51]
+Arguments: hashpartitioning(cr_item_sk#48, cr_order_number#49, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (50) Sort [codegen id : 14]
-Input [4]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
-Arguments: [cr_item_sk#50 ASC NULLS FIRST, cr_order_number#51 ASC NULLS FIRST], false, 0
+Input [4]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51]
+Arguments: [cr_item_sk#48 ASC NULLS FIRST, cr_order_number#49 ASC NULLS FIRST], false, 0
 
 (51) SortMergeJoin [codegen id : 19]
-Left keys [2]: [cs_item_sk#44, cs_order_number#46]
-Right keys [2]: [cr_item_sk#50, cr_order_number#51]
+Left keys [2]: [cs_item_sk#42, cs_order_number#44]
+Right keys [2]: [cr_item_sk#48, cr_order_number#49]
 Join type: LeftOuter
 Join condition: None
 
 (52) Project [codegen id : 19]
-Output [8]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
-Input [11]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
+Output [8]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51]
+Input [11]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51]
 
 (53) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#55]
+Output [1]: [i_item_sk#53]
 
 (54) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_item_sk#44]
-Right keys [1]: [i_item_sk#55]
+Left keys [1]: [cs_item_sk#42]
+Right keys [1]: [i_item_sk#53]
 Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 19]
-Output [7]: [cs_catalog_page_sk#43, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
-Input [9]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, i_item_sk#55]
+Output [7]: [cs_catalog_page_sk#41, cs_promo_sk#43, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51]
+Input [9]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51, i_item_sk#53]
 
 (56) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#56]
+Output [1]: [p_promo_sk#54]
 
 (57) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_promo_sk#45]
-Right keys [1]: [p_promo_sk#56]
+Left keys [1]: [cs_promo_sk#43]
+Right keys [1]: [p_promo_sk#54]
 Join type: Inner
 Join condition: None
 
 (58) Project [codegen id : 19]
-Output [6]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
-Input [8]: [cs_catalog_page_sk#43, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, p_promo_sk#56]
+Output [6]: [cs_catalog_page_sk#41, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51]
+Input [8]: [cs_catalog_page_sk#41, cs_promo_sk#43, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51, p_promo_sk#54]
 
 (59) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#57]
+Output [1]: [d_date_sk#55]
 
 (60) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_sold_date_sk#49]
-Right keys [1]: [d_date_sk#57]
+Left keys [1]: [cs_sold_date_sk#47]
+Right keys [1]: [d_date_sk#55]
 Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 19]
-Output [5]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53]
-Input [7]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, d_date_sk#57]
+Output [5]: [cs_catalog_page_sk#41, cs_ext_sales_price#45, cs_net_profit#46, cr_return_amount#50, cr_net_loss#51]
+Input [7]: [cs_catalog_page_sk#41, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51, d_date_sk#55]
 
 (62) Scan parquet spark_catalog.default.catalog_page
-Output [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
+Output [2]: [cp_catalog_page_sk#56, cp_catalog_page_id#57]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_page]
 PushedFilters: [IsNotNull(cp_catalog_page_sk)]
 ReadSchema: struct<cp_catalog_page_sk:int,cp_catalog_page_id:string>
 
 (63) ColumnarToRow [codegen id : 18]
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
+Input [2]: [cp_catalog_page_sk#56, cp_catalog_page_id#57]
 
 (64) Filter [codegen id : 18]
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
-Condition : isnotnull(cp_catalog_page_sk#58)
+Input [2]: [cp_catalog_page_sk#56, cp_catalog_page_id#57]
+Condition : isnotnull(cp_catalog_page_sk#56)
 
 (65) BroadcastExchange
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
+Input [2]: [cp_catalog_page_sk#56, cp_catalog_page_id#57]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=11]
 
 (66) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_catalog_page_sk#43]
-Right keys [1]: [cp_catalog_page_sk#58]
+Left keys [1]: [cs_catalog_page_sk#41]
+Right keys [1]: [cp_catalog_page_sk#56]
 Join type: Inner
 Join condition: None
 
 (67) Project [codegen id : 19]
-Output [5]: [cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#59]
-Input [7]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_sk#58, cp_catalog_page_id#59]
+Output [5]: [cs_ext_sales_price#45, cs_net_profit#46, cr_return_amount#50, cr_net_loss#51, cp_catalog_page_id#57]
+Input [7]: [cs_catalog_page_sk#41, cs_ext_sales_price#45, cs_net_profit#46, cr_return_amount#50, cr_net_loss#51, cp_catalog_page_sk#56, cp_catalog_page_id#57]
 
 (68) HashAggregate [codegen id : 19]
-Input [5]: [cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#59]
-Keys [1]: [cp_catalog_page_id#59]
-Functions [3]: [partial_sum(UnscaledValue(cs_ext_sales_price#47)), partial_sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00)), partial_sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#60, sum#61, isEmpty#62, sum#63, isEmpty#64]
-Results [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
+Input [5]: [cs_ext_sales_price#45, cs_net_profit#46, cr_return_amount#50, cr_net_loss#51, cp_catalog_page_id#57]
+Keys [1]: [cp_catalog_page_id#57]
+Functions [3]: [partial_sum(UnscaledValue(cs_ext_sales_price#45)), partial_sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00)), partial_sum((cs_net_profit#46 - coalesce(cast(cr_net_loss#51 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [5]: [sum#58, sum#59, isEmpty#60, sum#61, isEmpty#62]
+Results [6]: [cp_catalog_page_id#57, sum#63, sum#64, isEmpty#65, sum#66, isEmpty#67]
 
 (69) Exchange
-Input [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
-Arguments: hashpartitioning(cp_catalog_page_id#59, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [6]: [cp_catalog_page_id#57, sum#63, sum#64, isEmpty#65, sum#66, isEmpty#67]
+Arguments: hashpartitioning(cp_catalog_page_id#57, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (70) HashAggregate [codegen id : 20]
-Input [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
-Keys [1]: [cp_catalog_page_id#59]
-Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#47)), sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00)), sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#47))#70, sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00))#71, sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))#72]
-Results [5]: [catalog channel AS channel#73, concat(catalog_page, cp_catalog_page_id#59) AS id#74, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#47))#70,17,2) AS sales#75, sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00))#71 AS returns#76, sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))#72 AS profit#77]
+Input [6]: [cp_catalog_page_id#57, sum#63, sum#64, isEmpty#65, sum#66, isEmpty#67]
+Keys [1]: [cp_catalog_page_id#57]
+Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#45)), sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00)), sum((cs_net_profit#46 - coalesce(cast(cr_net_loss#51 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#45))#68, sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00))#69, sum((cs_net_profit#46 - coalesce(cast(cr_net_loss#51 as decimal(12,2)), 0.00)))#70]
+Results [5]: [catalog channel AS channel#71, concat(catalog_page, cp_catalog_page_id#57) AS id#72, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#45))#68,17,2) AS sales#73, sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00))#69 AS returns#74, sum((cs_net_profit#46 - coalesce(cast(cr_net_loss#51 as decimal(12,2)), 0.00)))#70 AS profit#75]
 
 (71) Scan parquet spark_catalog.default.web_sales
-Output [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
+Output [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#84), dynamicpruningexpression(ws_sold_date_sk#84 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#82), dynamicpruningexpression(ws_sold_date_sk#82 IN dynamicpruning#8)]
 PushedFilters: [IsNotNull(ws_web_site_sk), IsNotNull(ws_item_sk), IsNotNull(ws_promo_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_web_site_sk:int,ws_promo_sk:int,ws_order_number:int,ws_ext_sales_price:decimal(7,2),ws_net_profit:decimal(7,2)>
 
 (72) ColumnarToRow [codegen id : 21]
-Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
+Input [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
 
 (73) Filter [codegen id : 21]
-Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
-Condition : ((((isnotnull(ws_web_site_sk#79) AND isnotnull(ws_item_sk#78)) AND isnotnull(ws_promo_sk#80)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(ws_item_sk#78, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(ws_promo_sk#80, 42)))
+Input [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
+Condition : ((((isnotnull(ws_web_site_sk#77) AND isnotnull(ws_item_sk#76)) AND isnotnull(ws_promo_sk#78)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#1], xxhash64(ws_item_sk#76, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#10, [id=#2], xxhash64(ws_promo_sk#78, 42)))
 
 (74) Exchange
-Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
-Arguments: hashpartitioning(ws_item_sk#78, ws_order_number#81, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
+Arguments: hashpartitioning(ws_item_sk#76, ws_order_number#79, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (75) Sort [codegen id : 22]
-Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
-Arguments: [ws_item_sk#78 ASC NULLS FIRST, ws_order_number#81 ASC NULLS FIRST], false, 0
+Input [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
+Arguments: [ws_item_sk#76 ASC NULLS FIRST, ws_order_number#79 ASC NULLS FIRST], false, 0
 
 (76) Scan parquet spark_catalog.default.web_returns
-Output [5]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88, wr_returned_date_sk#89]
+Output [5]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86, wr_returned_date_sk#87]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_returns]
 PushedFilters: [IsNotNull(wr_item_sk), IsNotNull(wr_order_number)]
 ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_amt:decimal(7,2),wr_net_loss:decimal(7,2)>
 
 (77) ColumnarToRow [codegen id : 23]
-Input [5]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88, wr_returned_date_sk#89]
+Input [5]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86, wr_returned_date_sk#87]
 
 (78) Filter [codegen id : 23]
-Input [5]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88, wr_returned_date_sk#89]
-Condition : (isnotnull(wr_item_sk#85) AND isnotnull(wr_order_number#86))
+Input [5]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86, wr_returned_date_sk#87]
+Condition : (isnotnull(wr_item_sk#83) AND isnotnull(wr_order_number#84))
 
 (79) Project [codegen id : 23]
-Output [4]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
-Input [5]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88, wr_returned_date_sk#89]
+Output [4]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86]
+Input [5]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86, wr_returned_date_sk#87]
 
 (80) Exchange
-Input [4]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
-Arguments: hashpartitioning(wr_item_sk#85, wr_order_number#86, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [4]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86]
+Arguments: hashpartitioning(wr_item_sk#83, wr_order_number#84, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (81) Sort [codegen id : 24]
-Input [4]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
-Arguments: [wr_item_sk#85 ASC NULLS FIRST, wr_order_number#86 ASC NULLS FIRST], false, 0
+Input [4]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86]
+Arguments: [wr_item_sk#83 ASC NULLS FIRST, wr_order_number#84 ASC NULLS FIRST], false, 0
 
 (82) SortMergeJoin [codegen id : 29]
-Left keys [2]: [ws_item_sk#78, ws_order_number#81]
-Right keys [2]: [wr_item_sk#85, wr_order_number#86]
+Left keys [2]: [ws_item_sk#76, ws_order_number#79]
+Right keys [2]: [wr_item_sk#83, wr_order_number#84]
 Join type: LeftOuter
 Join condition: None
 
 (83) Project [codegen id : 29]
-Output [8]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
-Input [11]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
+Output [8]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86]
+Input [11]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86]
 
 (84) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#90]
+Output [1]: [i_item_sk#88]
 
 (85) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_item_sk#78]
-Right keys [1]: [i_item_sk#90]
+Left keys [1]: [ws_item_sk#76]
+Right keys [1]: [i_item_sk#88]
 Join type: Inner
 Join condition: None
 
 (86) Project [codegen id : 29]
-Output [7]: [ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
-Input [9]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, i_item_sk#90]
+Output [7]: [ws_web_site_sk#77, ws_promo_sk#78, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86]
+Input [9]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86, i_item_sk#88]
 
 (87) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#91]
+Output [1]: [p_promo_sk#89]
 
 (88) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_promo_sk#80]
-Right keys [1]: [p_promo_sk#91]
+Left keys [1]: [ws_promo_sk#78]
+Right keys [1]: [p_promo_sk#89]
 Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 29]
-Output [6]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
-Input [8]: [ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, p_promo_sk#91]
+Output [6]: [ws_web_site_sk#77, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86]
+Input [8]: [ws_web_site_sk#77, ws_promo_sk#78, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86, p_promo_sk#89]
 
 (90) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#92]
+Output [1]: [d_date_sk#90]
 
 (91) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_sold_date_sk#84]
-Right keys [1]: [d_date_sk#92]
+Left keys [1]: [ws_sold_date_sk#82]
+Right keys [1]: [d_date_sk#90]
 Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 29]
-Output [5]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88]
-Input [7]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, d_date_sk#92]
+Output [5]: [ws_web_site_sk#77, ws_ext_sales_price#80, ws_net_profit#81, wr_return_amt#85, wr_net_loss#86]
+Input [7]: [ws_web_site_sk#77, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86, d_date_sk#90]
 
 (93) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#93, web_site_id#94]
+Output [2]: [web_site_sk#91, web_site_id#92]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_site_id:string>
 
 (94) ColumnarToRow [codegen id : 28]
-Input [2]: [web_site_sk#93, web_site_id#94]
+Input [2]: [web_site_sk#91, web_site_id#92]
 
 (95) Filter [codegen id : 28]
-Input [2]: [web_site_sk#93, web_site_id#94]
-Condition : isnotnull(web_site_sk#93)
+Input [2]: [web_site_sk#91, web_site_id#92]
+Condition : isnotnull(web_site_sk#91)
 
 (96) BroadcastExchange
-Input [2]: [web_site_sk#93, web_site_id#94]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=13]
+Input [2]: [web_site_sk#91, web_site_id#92]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=15]
 
 (97) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_web_site_sk#79]
-Right keys [1]: [web_site_sk#93]
+Left keys [1]: [ws_web_site_sk#77]
+Right keys [1]: [web_site_sk#91]
 Join type: Inner
 Join condition: None
 
 (98) Project [codegen id : 29]
-Output [5]: [ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_id#94]
-Input [7]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_sk#93, web_site_id#94]
+Output [5]: [ws_ext_sales_price#80, ws_net_profit#81, wr_return_amt#85, wr_net_loss#86, web_site_id#92]
+Input [7]: [ws_web_site_sk#77, ws_ext_sales_price#80, ws_net_profit#81, wr_return_amt#85, wr_net_loss#86, web_site_sk#91, web_site_id#92]
 
 (99) HashAggregate [codegen id : 29]
-Input [5]: [ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_id#94]
-Keys [1]: [web_site_id#94]
-Functions [3]: [partial_sum(UnscaledValue(ws_ext_sales_price#82)), partial_sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00)), partial_sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#95, sum#96, isEmpty#97, sum#98, isEmpty#99]
-Results [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
+Input [5]: [ws_ext_sales_price#80, ws_net_profit#81, wr_return_amt#85, wr_net_loss#86, web_site_id#92]
+Keys [1]: [web_site_id#92]
+Functions [3]: [partial_sum(UnscaledValue(ws_ext_sales_price#80)), partial_sum(coalesce(cast(wr_return_amt#85 as decimal(12,2)), 0.00)), partial_sum((ws_net_profit#81 - coalesce(cast(wr_net_loss#86 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [5]: [sum#93, sum#94, isEmpty#95, sum#96, isEmpty#97]
+Results [6]: [web_site_id#92, sum#98, sum#99, isEmpty#100, sum#101, isEmpty#102]
 
 (100) Exchange
-Input [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
-Arguments: hashpartitioning(web_site_id#94, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [6]: [web_site_id#92, sum#98, sum#99, isEmpty#100, sum#101, isEmpty#102]
+Arguments: hashpartitioning(web_site_id#92, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
 (101) HashAggregate [codegen id : 30]
-Input [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
-Keys [1]: [web_site_id#94]
-Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#82)), sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00)), sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#82))#105, sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00))#106, sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))#107]
-Results [5]: [web channel AS channel#108, concat(web_site, web_site_id#94) AS id#109, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#82))#105,17,2) AS sales#110, sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00))#106 AS returns#111, sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))#107 AS profit#112]
+Input [6]: [web_site_id#92, sum#98, sum#99, isEmpty#100, sum#101, isEmpty#102]
+Keys [1]: [web_site_id#92]
+Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#80)), sum(coalesce(cast(wr_return_amt#85 as decimal(12,2)), 0.00)), sum((ws_net_profit#81 - coalesce(cast(wr_net_loss#86 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#80))#103, sum(coalesce(cast(wr_return_amt#85 as decimal(12,2)), 0.00))#104, sum((ws_net_profit#81 - coalesce(cast(wr_net_loss#86 as decimal(12,2)), 0.00)))#105]
+Results [5]: [web channel AS channel#106, concat(web_site, web_site_id#92) AS id#107, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#80))#103,17,2) AS sales#108, sum(coalesce(cast(wr_return_amt#85 as decimal(12,2)), 0.00))#104 AS returns#109, sum((ws_net_profit#81 - coalesce(cast(wr_net_loss#86 as decimal(12,2)), 0.00)))#105 AS profit#110]
 
 (102) Union
 
 (103) HashAggregate [codegen id : 31]
-Input [5]: [channel#38, id#39, sales#40, returns#41, profit#42]
-Keys [2]: [channel#38, id#39]
-Functions [3]: [partial_sum(sales#40), partial_sum(returns#41), partial_sum(profit#42)]
-Aggregate Attributes [6]: [sum#113, isEmpty#114, sum#115, isEmpty#116, sum#117, isEmpty#118]
-Results [8]: [channel#38, id#39, sum#119, isEmpty#120, sum#121, isEmpty#122, sum#123, isEmpty#124]
+Input [5]: [channel#36, id#37, sales#38, returns#39, profit#40]
+Keys [2]: [channel#36, id#37]
+Functions [3]: [partial_sum(sales#38), partial_sum(returns#39), partial_sum(profit#40)]
+Aggregate Attributes [6]: [sum#111, isEmpty#112, sum#113, isEmpty#114, sum#115, isEmpty#116]
+Results [8]: [channel#36, id#37, sum#117, isEmpty#118, sum#119, isEmpty#120, sum#121, isEmpty#122]
 
 (104) Exchange
-Input [8]: [channel#38, id#39, sum#119, isEmpty#120, sum#121, isEmpty#122, sum#123, isEmpty#124]
-Arguments: hashpartitioning(channel#38, id#39, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Input [8]: [channel#36, id#37, sum#117, isEmpty#118, sum#119, isEmpty#120, sum#121, isEmpty#122]
+Arguments: hashpartitioning(channel#36, id#37, 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
 (105) HashAggregate [codegen id : 32]
-Input [8]: [channel#38, id#39, sum#119, isEmpty#120, sum#121, isEmpty#122, sum#123, isEmpty#124]
-Keys [2]: [channel#38, id#39]
-Functions [3]: [sum(sales#40), sum(returns#41), sum(profit#42)]
-Aggregate Attributes [3]: [sum(sales#40)#125, sum(returns#41)#126, sum(profit#42)#127]
-Results [5]: [channel#38, id#39, cast(sum(sales#40)#125 as decimal(37,2)) AS sales#128, cast(sum(returns#41)#126 as decimal(38,2)) AS returns#129, cast(sum(profit#42)#127 as decimal(38,2)) AS profit#130]
+Input [8]: [channel#36, id#37, sum#117, isEmpty#118, sum#119, isEmpty#120, sum#121, isEmpty#122]
+Keys [2]: [channel#36, id#37]
+Functions [3]: [sum(sales#38), sum(returns#39), sum(profit#40)]
+Aggregate Attributes [3]: [sum(sales#38)#123, sum(returns#39)#124, sum(profit#40)#125]
+Results [5]: [channel#36, id#37, cast(sum(sales#38)#123 as decimal(37,2)) AS sales#126, cast(sum(returns#39)#124 as decimal(38,2)) AS returns#127, cast(sum(profit#40)#125 as decimal(38,2)) AS profit#128]
 
 (106) ReusedExchange [Reuses operator id: 38]
-Output [6]: [s_store_id#131, sum#132, sum#133, isEmpty#134, sum#135, isEmpty#136]
+Output [6]: [s_store_id#129, sum#130, sum#131, isEmpty#132, sum#133, isEmpty#134]
 
 (107) HashAggregate [codegen id : 42]
-Input [6]: [s_store_id#131, sum#132, sum#133, isEmpty#134, sum#135, isEmpty#136]
-Keys [1]: [s_store_id#131]
-Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#137)), sum(coalesce(cast(sr_return_amt#138 as decimal(12,2)), 0.00)), sum((ss_net_profit#139 - coalesce(cast(sr_net_loss#140 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#137))#35, sum(coalesce(cast(sr_return_amt#138 as decimal(12,2)), 0.00))#36, sum((ss_net_profit#139 - coalesce(cast(sr_net_loss#140 as decimal(12,2)), 0.00)))#37]
-Results [5]: [store channel AS channel#141, concat(store, s_store_id#131) AS id#142, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#137))#35,17,2) AS sales#143, sum(coalesce(cast(sr_return_amt#138 as decimal(12,2)), 0.00))#36 AS returns#144, sum((ss_net_profit#139 - coalesce(cast(sr_net_loss#140 as decimal(12,2)), 0.00)))#37 AS profit#145]
+Input [6]: [s_store_id#129, sum#130, sum#131, isEmpty#132, sum#133, isEmpty#134]
+Keys [1]: [s_store_id#129]
+Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#135)), sum(coalesce(cast(sr_return_amt#136 as decimal(12,2)), 0.00)), sum((ss_net_profit#137 - coalesce(cast(sr_net_loss#138 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#135))#33, sum(coalesce(cast(sr_return_amt#136 as decimal(12,2)), 0.00))#34, sum((ss_net_profit#137 - coalesce(cast(sr_net_loss#138 as decimal(12,2)), 0.00)))#35]
+Results [5]: [store channel AS channel#139, concat(store, s_store_id#129) AS id#140, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#135))#33,17,2) AS sales#141, sum(coalesce(cast(sr_return_amt#136 as decimal(12,2)), 0.00))#34 AS returns#142, sum((ss_net_profit#137 - coalesce(cast(sr_net_loss#138 as decimal(12,2)), 0.00)))#35 AS profit#143]
 
 (108) ReusedExchange [Reuses operator id: 69]
-Output [6]: [cp_catalog_page_id#146, sum#147, sum#148, isEmpty#149, sum#150, isEmpty#151]
+Output [6]: [cp_catalog_page_id#144, sum#145, sum#146, isEmpty#147, sum#148, isEmpty#149]
 
 (109) HashAggregate [codegen id : 52]
-Input [6]: [cp_catalog_page_id#146, sum#147, sum#148, isEmpty#149, sum#150, isEmpty#151]
-Keys [1]: [cp_catalog_page_id#146]
-Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#152)), sum(coalesce(cast(cr_return_amount#153 as decimal(12,2)), 0.00)), sum((cs_net_profit#154 - coalesce(cast(cr_net_loss#155 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#152))#70, sum(coalesce(cast(cr_return_amount#153 as decimal(12,2)), 0.00))#71, sum((cs_net_profit#154 - coalesce(cast(cr_net_loss#155 as decimal(12,2)), 0.00)))#72]
-Results [5]: [catalog channel AS channel#156, concat(catalog_page, cp_catalog_page_id#146) AS id#157, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#152))#70,17,2) AS sales#158, sum(coalesce(cast(cr_return_amount#153 as decimal(12,2)), 0.00))#71 AS returns#159, sum((cs_net_profit#154 - coalesce(cast(cr_net_loss#155 as decimal(12,2)), 0.00)))#72 AS profit#160]
+Input [6]: [cp_catalog_page_id#144, sum#145, sum#146, isEmpty#147, sum#148, isEmpty#149]
+Keys [1]: [cp_catalog_page_id#144]
+Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#150)), sum(coalesce(cast(cr_return_amount#151 as decimal(12,2)), 0.00)), sum((cs_net_profit#152 - coalesce(cast(cr_net_loss#153 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#150))#68, sum(coalesce(cast(cr_return_amount#151 as decimal(12,2)), 0.00))#69, sum((cs_net_profit#152 - coalesce(cast(cr_net_loss#153 as decimal(12,2)), 0.00)))#70]
+Results [5]: [catalog channel AS channel#154, concat(catalog_page, cp_catalog_page_id#144) AS id#155, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#150))#68,17,2) AS sales#156, sum(coalesce(cast(cr_return_amount#151 as decimal(12,2)), 0.00))#69 AS returns#157, sum((cs_net_profit#152 - coalesce(cast(cr_net_loss#153 as decimal(12,2)), 0.00)))#70 AS profit#158]
 
 (110) Scan parquet spark_catalog.default.web_sales
-Output [7]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_order_number#164, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167]
+Output [7]: [ws_item_sk#159, ws_web_site_sk#160, ws_promo_sk#161, ws_order_number#162, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#167), dynamicpruningexpression(ws_sold_date_sk#167 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#165), dynamicpruningexpression(ws_sold_date_sk#165 IN dynamicpruning#8)]
 PushedFilters: [IsNotNull(ws_web_site_sk), IsNotNull(ws_item_sk), IsNotNull(ws_promo_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_web_site_sk:int,ws_promo_sk:int,ws_order_number:int,ws_ext_sales_price:decimal(7,2),ws_net_profit:decimal(7,2)>
 
 (111) ColumnarToRow [codegen id : 53]
-Input [7]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_order_number#164, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167]
+Input [7]: [ws_item_sk#159, ws_web_site_sk#160, ws_promo_sk#161, ws_order_number#162, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165]
 
 (112) Filter [codegen id : 53]
-Input [7]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_order_number#164, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167]
-Condition : ((isnotnull(ws_web_site_sk#162) AND isnotnull(ws_item_sk#161)) AND isnotnull(ws_promo_sk#163))
+Input [7]: [ws_item_sk#159, ws_web_site_sk#160, ws_promo_sk#161, ws_order_number#162, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165]
+Condition : ((isnotnull(ws_web_site_sk#160) AND isnotnull(ws_item_sk#159)) AND isnotnull(ws_promo_sk#161))
 
 (113) Exchange
-Input [7]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_order_number#164, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167]
-Arguments: hashpartitioning(ws_item_sk#161, ws_order_number#164, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+Input [7]: [ws_item_sk#159, ws_web_site_sk#160, ws_promo_sk#161, ws_order_number#162, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165]
+Arguments: hashpartitioning(ws_item_sk#159, ws_order_number#162, 5), ENSURE_REQUIREMENTS, [plan_id=18]
 
 (114) Sort [codegen id : 54]
-Input [7]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_order_number#164, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167]
-Arguments: [ws_item_sk#161 ASC NULLS FIRST, ws_order_number#164 ASC NULLS FIRST], false, 0
+Input [7]: [ws_item_sk#159, ws_web_site_sk#160, ws_promo_sk#161, ws_order_number#162, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165]
+Arguments: [ws_item_sk#159 ASC NULLS FIRST, ws_order_number#162 ASC NULLS FIRST], false, 0
 
 (115) ReusedExchange [Reuses operator id: 80]
-Output [4]: [wr_item_sk#168, wr_order_number#169, wr_return_amt#170, wr_net_loss#171]
+Output [4]: [wr_item_sk#166, wr_order_number#167, wr_return_amt#168, wr_net_loss#169]
 
 (116) Sort [codegen id : 56]
-Input [4]: [wr_item_sk#168, wr_order_number#169, wr_return_amt#170, wr_net_loss#171]
-Arguments: [wr_item_sk#168 ASC NULLS FIRST, wr_order_number#169 ASC NULLS FIRST], false, 0
+Input [4]: [wr_item_sk#166, wr_order_number#167, wr_return_amt#168, wr_net_loss#169]
+Arguments: [wr_item_sk#166 ASC NULLS FIRST, wr_order_number#167 ASC NULLS FIRST], false, 0
 
 (117) SortMergeJoin [codegen id : 61]
-Left keys [2]: [ws_item_sk#161, ws_order_number#164]
-Right keys [2]: [wr_item_sk#168, wr_order_number#169]
+Left keys [2]: [ws_item_sk#159, ws_order_number#162]
+Right keys [2]: [wr_item_sk#166, wr_order_number#167]
 Join type: LeftOuter
 Join condition: None
 
 (118) Project [codegen id : 61]
-Output [8]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171]
-Input [11]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_order_number#164, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_item_sk#168, wr_order_number#169, wr_return_amt#170, wr_net_loss#171]
+Output [8]: [ws_item_sk#159, ws_web_site_sk#160, ws_promo_sk#161, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165, wr_return_amt#168, wr_net_loss#169]
+Input [11]: [ws_item_sk#159, ws_web_site_sk#160, ws_promo_sk#161, ws_order_number#162, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165, wr_item_sk#166, wr_order_number#167, wr_return_amt#168, wr_net_loss#169]
 
 (119) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#172]
+Output [1]: [i_item_sk#170]
 
 (120) BroadcastHashJoin [codegen id : 61]
-Left keys [1]: [ws_item_sk#161]
-Right keys [1]: [i_item_sk#172]
+Left keys [1]: [ws_item_sk#159]
+Right keys [1]: [i_item_sk#170]
 Join type: Inner
 Join condition: None
 
 (121) Project [codegen id : 61]
-Output [7]: [ws_web_site_sk#162, ws_promo_sk#163, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171]
-Input [9]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171, i_item_sk#172]
+Output [7]: [ws_web_site_sk#160, ws_promo_sk#161, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165, wr_return_amt#168, wr_net_loss#169]
+Input [9]: [ws_item_sk#159, ws_web_site_sk#160, ws_promo_sk#161, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165, wr_return_amt#168, wr_net_loss#169, i_item_sk#170]
 
 (122) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#173]
+Output [1]: [p_promo_sk#171]
 
 (123) BroadcastHashJoin [codegen id : 61]
-Left keys [1]: [ws_promo_sk#163]
-Right keys [1]: [p_promo_sk#173]
+Left keys [1]: [ws_promo_sk#161]
+Right keys [1]: [p_promo_sk#171]
 Join type: Inner
 Join condition: None
 
 (124) Project [codegen id : 61]
-Output [6]: [ws_web_site_sk#162, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171]
-Input [8]: [ws_web_site_sk#162, ws_promo_sk#163, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171, p_promo_sk#173]
+Output [6]: [ws_web_site_sk#160, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165, wr_return_amt#168, wr_net_loss#169]
+Input [8]: [ws_web_site_sk#160, ws_promo_sk#161, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165, wr_return_amt#168, wr_net_loss#169, p_promo_sk#171]
 
 (125) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#174]
+Output [1]: [d_date_sk#172]
 
 (126) BroadcastHashJoin [codegen id : 61]
-Left keys [1]: [ws_sold_date_sk#167]
-Right keys [1]: [d_date_sk#174]
+Left keys [1]: [ws_sold_date_sk#165]
+Right keys [1]: [d_date_sk#172]
 Join type: Inner
 Join condition: None
 
 (127) Project [codegen id : 61]
-Output [5]: [ws_web_site_sk#162, ws_ext_sales_price#165, ws_net_profit#166, wr_return_amt#170, wr_net_loss#171]
-Input [7]: [ws_web_site_sk#162, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171, d_date_sk#174]
+Output [5]: [ws_web_site_sk#160, ws_ext_sales_price#163, ws_net_profit#164, wr_return_amt#168, wr_net_loss#169]
+Input [7]: [ws_web_site_sk#160, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165, wr_return_amt#168, wr_net_loss#169, d_date_sk#172]
 
 (128) ReusedExchange [Reuses operator id: 96]
-Output [2]: [web_site_sk#175, web_site_id#176]
+Output [2]: [web_site_sk#173, web_site_id#174]
 
 (129) BroadcastHashJoin [codegen id : 61]
-Left keys [1]: [ws_web_site_sk#162]
-Right keys [1]: [web_site_sk#175]
+Left keys [1]: [ws_web_site_sk#160]
+Right keys [1]: [web_site_sk#173]
 Join type: Inner
 Join condition: None
 
 (130) Project [codegen id : 61]
-Output [5]: [ws_ext_sales_price#165, ws_net_profit#166, wr_return_amt#170, wr_net_loss#171, web_site_id#176]
-Input [7]: [ws_web_site_sk#162, ws_ext_sales_price#165, ws_net_profit#166, wr_return_amt#170, wr_net_loss#171, web_site_sk#175, web_site_id#176]
+Output [5]: [ws_ext_sales_price#163, ws_net_profit#164, wr_return_amt#168, wr_net_loss#169, web_site_id#174]
+Input [7]: [ws_web_site_sk#160, ws_ext_sales_price#163, ws_net_profit#164, wr_return_amt#168, wr_net_loss#169, web_site_sk#173, web_site_id#174]
 
 (131) HashAggregate [codegen id : 61]
-Input [5]: [ws_ext_sales_price#165, ws_net_profit#166, wr_return_amt#170, wr_net_loss#171, web_site_id#176]
-Keys [1]: [web_site_id#176]
-Functions [3]: [partial_sum(UnscaledValue(ws_ext_sales_price#165)), partial_sum(coalesce(cast(wr_return_amt#170 as decimal(12,2)), 0.00)), partial_sum((ws_net_profit#166 - coalesce(cast(wr_net_loss#171 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#177, sum#178, isEmpty#179, sum#180, isEmpty#181]
-Results [6]: [web_site_id#176, sum#182, sum#183, isEmpty#184, sum#185, isEmpty#186]
+Input [5]: [ws_ext_sales_price#163, ws_net_profit#164, wr_return_amt#168, wr_net_loss#169, web_site_id#174]
+Keys [1]: [web_site_id#174]
+Functions [3]: [partial_sum(UnscaledValue(ws_ext_sales_price#163)), partial_sum(coalesce(cast(wr_return_amt#168 as decimal(12,2)), 0.00)), partial_sum((ws_net_profit#164 - coalesce(cast(wr_net_loss#169 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [5]: [sum#175, sum#176, isEmpty#177, sum#178, isEmpty#179]
+Results [6]: [web_site_id#174, sum#180, sum#181, isEmpty#182, sum#183, isEmpty#184]
 
 (132) Exchange
-Input [6]: [web_site_id#176, sum#182, sum#183, isEmpty#184, sum#185, isEmpty#186]
-Arguments: hashpartitioning(web_site_id#176, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+Input [6]: [web_site_id#174, sum#180, sum#181, isEmpty#182, sum#183, isEmpty#184]
+Arguments: hashpartitioning(web_site_id#174, 5), ENSURE_REQUIREMENTS, [plan_id=19]
 
 (133) HashAggregate [codegen id : 62]
-Input [6]: [web_site_id#176, sum#182, sum#183, isEmpty#184, sum#185, isEmpty#186]
-Keys [1]: [web_site_id#176]
-Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#165)), sum(coalesce(cast(wr_return_amt#170 as decimal(12,2)), 0.00)), sum((ws_net_profit#166 - coalesce(cast(wr_net_loss#171 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#165))#105, sum(coalesce(cast(wr_return_amt#170 as decimal(12,2)), 0.00))#106, sum((ws_net_profit#166 - coalesce(cast(wr_net_loss#171 as decimal(12,2)), 0.00)))#107]
-Results [5]: [web channel AS channel#187, concat(web_site, web_site_id#176) AS id#188, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#165))#105,17,2) AS sales#189, sum(coalesce(cast(wr_return_amt#170 as decimal(12,2)), 0.00))#106 AS returns#190, sum((ws_net_profit#166 - coalesce(cast(wr_net_loss#171 as decimal(12,2)), 0.00)))#107 AS profit#191]
+Input [6]: [web_site_id#174, sum#180, sum#181, isEmpty#182, sum#183, isEmpty#184]
+Keys [1]: [web_site_id#174]
+Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#163)), sum(coalesce(cast(wr_return_amt#168 as decimal(12,2)), 0.00)), sum((ws_net_profit#164 - coalesce(cast(wr_net_loss#169 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#163))#103, sum(coalesce(cast(wr_return_amt#168 as decimal(12,2)), 0.00))#104, sum((ws_net_profit#164 - coalesce(cast(wr_net_loss#169 as decimal(12,2)), 0.00)))#105]
+Results [5]: [web channel AS channel#185, concat(web_site, web_site_id#174) AS id#186, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#163))#103,17,2) AS sales#187, sum(coalesce(cast(wr_return_amt#168 as decimal(12,2)), 0.00))#104 AS returns#188, sum((ws_net_profit#164 - coalesce(cast(wr_net_loss#169 as decimal(12,2)), 0.00)))#105 AS profit#189]
 
 (134) Union
 
 (135) HashAggregate [codegen id : 63]
-Input [5]: [channel#141, id#142, sales#143, returns#144, profit#145]
-Keys [2]: [channel#141, id#142]
-Functions [3]: [partial_sum(sales#143), partial_sum(returns#144), partial_sum(profit#145)]
-Aggregate Attributes [6]: [sum#192, isEmpty#193, sum#194, isEmpty#195, sum#196, isEmpty#197]
-Results [8]: [channel#141, id#142, sum#198, isEmpty#199, sum#200, isEmpty#201, sum#202, isEmpty#203]
+Input [5]: [channel#139, id#140, sales#141, returns#142, profit#143]
+Keys [2]: [channel#139, id#140]
+Functions [3]: [partial_sum(sales#141), partial_sum(returns#142), partial_sum(profit#143)]
+Aggregate Attributes [6]: [sum#190, isEmpty#191, sum#192, isEmpty#193, sum#194, isEmpty#195]
+Results [8]: [channel#139, id#140, sum#196, isEmpty#197, sum#198, isEmpty#199, sum#200, isEmpty#201]
 
 (136) Exchange
-Input [8]: [channel#141, id#142, sum#198, isEmpty#199, sum#200, isEmpty#201, sum#202, isEmpty#203]
-Arguments: hashpartitioning(channel#141, id#142, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+Input [8]: [channel#139, id#140, sum#196, isEmpty#197, sum#198, isEmpty#199, sum#200, isEmpty#201]
+Arguments: hashpartitioning(channel#139, id#140, 5), ENSURE_REQUIREMENTS, [plan_id=20]
 
 (137) HashAggregate [codegen id : 64]
-Input [8]: [channel#141, id#142, sum#198, isEmpty#199, sum#200, isEmpty#201, sum#202, isEmpty#203]
-Keys [2]: [channel#141, id#142]
-Functions [3]: [sum(sales#143), sum(returns#144), sum(profit#145)]
-Aggregate Attributes [3]: [sum(sales#143)#125, sum(returns#144)#126, sum(profit#145)#127]
-Results [4]: [channel#141, sum(sales#143)#125 AS sales#204, sum(returns#144)#126 AS returns#205, sum(profit#145)#127 AS profit#206]
+Input [8]: [channel#139, id#140, sum#196, isEmpty#197, sum#198, isEmpty#199, sum#200, isEmpty#201]
+Keys [2]: [channel#139, id#140]
+Functions [3]: [sum(sales#141), sum(returns#142), sum(profit#143)]
+Aggregate Attributes [3]: [sum(sales#141)#123, sum(returns#142)#124, sum(profit#143)#125]
+Results [4]: [channel#139, sum(sales#141)#123 AS sales#202, sum(returns#142)#124 AS returns#203, sum(profit#143)#125 AS profit#204]
 
 (138) HashAggregate [codegen id : 64]
-Input [4]: [channel#141, sales#204, returns#205, profit#206]
-Keys [1]: [channel#141]
-Functions [3]: [partial_sum(sales#204), partial_sum(returns#205), partial_sum(profit#206)]
-Aggregate Attributes [6]: [sum#207, isEmpty#208, sum#209, isEmpty#210, sum#211, isEmpty#212]
-Results [7]: [channel#141, sum#213, isEmpty#214, sum#215, isEmpty#216, sum#217, isEmpty#218]
+Input [4]: [channel#139, sales#202, returns#203, profit#204]
+Keys [1]: [channel#139]
+Functions [3]: [partial_sum(sales#202), partial_sum(returns#203), partial_sum(profit#204)]
+Aggregate Attributes [6]: [sum#205, isEmpty#206, sum#207, isEmpty#208, sum#209, isEmpty#210]
+Results [7]: [channel#139, sum#211, isEmpty#212, sum#213, isEmpty#214, sum#215, isEmpty#216]
 
 (139) Exchange
-Input [7]: [channel#141, sum#213, isEmpty#214, sum#215, isEmpty#216, sum#217, isEmpty#218]
-Arguments: hashpartitioning(channel#141, 5), ENSURE_REQUIREMENTS, [plan_id=19]
+Input [7]: [channel#139, sum#211, isEmpty#212, sum#213, isEmpty#214, sum#215, isEmpty#216]
+Arguments: hashpartitioning(channel#139, 5), ENSURE_REQUIREMENTS, [plan_id=21]
 
 (140) HashAggregate [codegen id : 65]
-Input [7]: [channel#141, sum#213, isEmpty#214, sum#215, isEmpty#216, sum#217, isEmpty#218]
-Keys [1]: [channel#141]
-Functions [3]: [sum(sales#204), sum(returns#205), sum(profit#206)]
-Aggregate Attributes [3]: [sum(sales#204)#219, sum(returns#205)#220, sum(profit#206)#221]
-Results [5]: [channel#141, null AS id#222, sum(sales#204)#219 AS sales#223, sum(returns#205)#220 AS returns#224, sum(profit#206)#221 AS profit#225]
+Input [7]: [channel#139, sum#211, isEmpty#212, sum#213, isEmpty#214, sum#215, isEmpty#216]
+Keys [1]: [channel#139]
+Functions [3]: [sum(sales#202), sum(returns#203), sum(profit#204)]
+Aggregate Attributes [3]: [sum(sales#202)#217, sum(returns#203)#218, sum(profit#204)#219]
+Results [5]: [channel#139, null AS id#220, sum(sales#202)#217 AS sales#221, sum(returns#203)#218 AS returns#222, sum(profit#204)#219 AS profit#223]
 
 (141) Scan parquet spark_catalog.default.store_sales
-Output [7]: [ss_item_sk#226, ss_store_sk#227, ss_promo_sk#228, ss_ticket_number#229, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232]
+Output [7]: [ss_item_sk#224, ss_store_sk#225, ss_promo_sk#226, ss_ticket_number#227, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#232), dynamicpruningexpression(ss_sold_date_sk#232 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#230), dynamicpruningexpression(ss_sold_date_sk#230 IN dynamicpruning#8)]
 PushedFilters: [IsNotNull(ss_store_sk), IsNotNull(ss_item_sk), IsNotNull(ss_promo_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_promo_sk:int,ss_ticket_number:int,ss_ext_sales_price:decimal(7,2),ss_net_profit:decimal(7,2)>
 
 (142) ColumnarToRow [codegen id : 66]
-Input [7]: [ss_item_sk#226, ss_store_sk#227, ss_promo_sk#228, ss_ticket_number#229, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232]
+Input [7]: [ss_item_sk#224, ss_store_sk#225, ss_promo_sk#226, ss_ticket_number#227, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230]
 
 (143) Filter [codegen id : 66]
-Input [7]: [ss_item_sk#226, ss_store_sk#227, ss_promo_sk#228, ss_ticket_number#229, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232]
-Condition : ((isnotnull(ss_store_sk#227) AND isnotnull(ss_item_sk#226)) AND isnotnull(ss_promo_sk#228))
+Input [7]: [ss_item_sk#224, ss_store_sk#225, ss_promo_sk#226, ss_ticket_number#227, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230]
+Condition : ((isnotnull(ss_store_sk#225) AND isnotnull(ss_item_sk#224)) AND isnotnull(ss_promo_sk#226))
 
 (144) Exchange
-Input [7]: [ss_item_sk#226, ss_store_sk#227, ss_promo_sk#228, ss_ticket_number#229, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232]
-Arguments: hashpartitioning(ss_item_sk#226, ss_ticket_number#229, 5), ENSURE_REQUIREMENTS, [plan_id=20]
+Input [7]: [ss_item_sk#224, ss_store_sk#225, ss_promo_sk#226, ss_ticket_number#227, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230]
+Arguments: hashpartitioning(ss_item_sk#224, ss_ticket_number#227, 5), ENSURE_REQUIREMENTS, [plan_id=22]
 
 (145) Sort [codegen id : 67]
-Input [7]: [ss_item_sk#226, ss_store_sk#227, ss_promo_sk#228, ss_ticket_number#229, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232]
-Arguments: [ss_item_sk#226 ASC NULLS FIRST, ss_ticket_number#229 ASC NULLS FIRST], false, 0
+Input [7]: [ss_item_sk#224, ss_store_sk#225, ss_promo_sk#226, ss_ticket_number#227, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230]
+Arguments: [ss_item_sk#224 ASC NULLS FIRST, ss_ticket_number#227 ASC NULLS FIRST], false, 0
 
 (146) ReusedExchange [Reuses operator id: 10]
-Output [4]: [sr_item_sk#233, sr_ticket_number#234, sr_return_amt#235, sr_net_loss#236]
+Output [4]: [sr_item_sk#231, sr_ticket_number#232, sr_return_amt#233, sr_net_loss#234]
 
 (147) Sort [codegen id : 69]
-Input [4]: [sr_item_sk#233, sr_ticket_number#234, sr_return_amt#235, sr_net_loss#236]
-Arguments: [sr_item_sk#233 ASC NULLS FIRST, sr_ticket_number#234 ASC NULLS FIRST], false, 0
+Input [4]: [sr_item_sk#231, sr_ticket_number#232, sr_return_amt#233, sr_net_loss#234]
+Arguments: [sr_item_sk#231 ASC NULLS FIRST, sr_ticket_number#232 ASC NULLS FIRST], false, 0
 
 (148) SortMergeJoin [codegen id : 74]
-Left keys [2]: [ss_item_sk#226, ss_ticket_number#229]
-Right keys [2]: [sr_item_sk#233, sr_ticket_number#234]
+Left keys [2]: [ss_item_sk#224, ss_ticket_number#227]
+Right keys [2]: [sr_item_sk#231, sr_ticket_number#232]
 Join type: LeftOuter
 Join condition: None
 
 (149) Project [codegen id : 74]
-Output [8]: [ss_item_sk#226, ss_store_sk#227, ss_promo_sk#228, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236]
-Input [11]: [ss_item_sk#226, ss_store_sk#227, ss_promo_sk#228, ss_ticket_number#229, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_item_sk#233, sr_ticket_number#234, sr_return_amt#235, sr_net_loss#236]
+Output [8]: [ss_item_sk#224, ss_store_sk#225, ss_promo_sk#226, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230, sr_return_amt#233, sr_net_loss#234]
+Input [11]: [ss_item_sk#224, ss_store_sk#225, ss_promo_sk#226, ss_ticket_number#227, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230, sr_item_sk#231, sr_ticket_number#232, sr_return_amt#233, sr_net_loss#234]
 
 (150) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#237]
+Output [1]: [i_item_sk#235]
 
 (151) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_item_sk#226]
-Right keys [1]: [i_item_sk#237]
+Left keys [1]: [ss_item_sk#224]
+Right keys [1]: [i_item_sk#235]
 Join type: Inner
 Join condition: None
 
 (152) Project [codegen id : 74]
-Output [7]: [ss_store_sk#227, ss_promo_sk#228, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236]
-Input [9]: [ss_item_sk#226, ss_store_sk#227, ss_promo_sk#228, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236, i_item_sk#237]
+Output [7]: [ss_store_sk#225, ss_promo_sk#226, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230, sr_return_amt#233, sr_net_loss#234]
+Input [9]: [ss_item_sk#224, ss_store_sk#225, ss_promo_sk#226, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230, sr_return_amt#233, sr_net_loss#234, i_item_sk#235]
 
 (153) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#238]
+Output [1]: [p_promo_sk#236]
 
 (154) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_promo_sk#228]
-Right keys [1]: [p_promo_sk#238]
+Left keys [1]: [ss_promo_sk#226]
+Right keys [1]: [p_promo_sk#236]
 Join type: Inner
 Join condition: None
 
 (155) Project [codegen id : 74]
-Output [6]: [ss_store_sk#227, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236]
-Input [8]: [ss_store_sk#227, ss_promo_sk#228, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236, p_promo_sk#238]
+Output [6]: [ss_store_sk#225, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230, sr_return_amt#233, sr_net_loss#234]
+Input [8]: [ss_store_sk#225, ss_promo_sk#226, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230, sr_return_amt#233, sr_net_loss#234, p_promo_sk#236]
 
 (156) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#239]
+Output [1]: [d_date_sk#237]
 
 (157) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_sold_date_sk#232]
-Right keys [1]: [d_date_sk#239]
+Left keys [1]: [ss_sold_date_sk#230]
+Right keys [1]: [d_date_sk#237]
 Join type: Inner
 Join condition: None
 
 (158) Project [codegen id : 74]
-Output [5]: [ss_store_sk#227, ss_ext_sales_price#230, ss_net_profit#231, sr_return_amt#235, sr_net_loss#236]
-Input [7]: [ss_store_sk#227, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236, d_date_sk#239]
+Output [5]: [ss_store_sk#225, ss_ext_sales_price#228, ss_net_profit#229, sr_return_amt#233, sr_net_loss#234]
+Input [7]: [ss_store_sk#225, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230, sr_return_amt#233, sr_net_loss#234, d_date_sk#237]
 
 (159) ReusedExchange [Reuses operator id: 34]
-Output [2]: [s_store_sk#240, s_store_id#241]
+Output [2]: [s_store_sk#238, s_store_id#239]
 
 (160) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_store_sk#227]
-Right keys [1]: [s_store_sk#240]
+Left keys [1]: [ss_store_sk#225]
+Right keys [1]: [s_store_sk#238]
 Join type: Inner
 Join condition: None
 
 (161) Project [codegen id : 74]
-Output [5]: [ss_ext_sales_price#230, ss_net_profit#231, sr_return_amt#235, sr_net_loss#236, s_store_id#241]
-Input [7]: [ss_store_sk#227, ss_ext_sales_price#230, ss_net_profit#231, sr_return_amt#235, sr_net_loss#236, s_store_sk#240, s_store_id#241]
+Output [5]: [ss_ext_sales_price#228, ss_net_profit#229, sr_return_amt#233, sr_net_loss#234, s_store_id#239]
+Input [7]: [ss_store_sk#225, ss_ext_sales_price#228, ss_net_profit#229, sr_return_amt#233, sr_net_loss#234, s_store_sk#238, s_store_id#239]
 
 (162) HashAggregate [codegen id : 74]
-Input [5]: [ss_ext_sales_price#230, ss_net_profit#231, sr_return_amt#235, sr_net_loss#236, s_store_id#241]
-Keys [1]: [s_store_id#241]
-Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#230)), partial_sum(coalesce(cast(sr_return_amt#235 as decimal(12,2)), 0.00)), partial_sum((ss_net_profit#231 - coalesce(cast(sr_net_loss#236 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#242, sum#243, isEmpty#244, sum#245, isEmpty#246]
-Results [6]: [s_store_id#241, sum#247, sum#248, isEmpty#249, sum#250, isEmpty#251]
+Input [5]: [ss_ext_sales_price#228, ss_net_profit#229, sr_return_amt#233, sr_net_loss#234, s_store_id#239]
+Keys [1]: [s_store_id#239]
+Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#228)), partial_sum(coalesce(cast(sr_return_amt#233 as decimal(12,2)), 0.00)), partial_sum((ss_net_profit#229 - coalesce(cast(sr_net_loss#234 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [5]: [sum#240, sum#241, isEmpty#242, sum#243, isEmpty#244]
+Results [6]: [s_store_id#239, sum#245, sum#246, isEmpty#247, sum#248, isEmpty#249]
 
 (163) Exchange
-Input [6]: [s_store_id#241, sum#247, sum#248, isEmpty#249, sum#250, isEmpty#251]
-Arguments: hashpartitioning(s_store_id#241, 5), ENSURE_REQUIREMENTS, [plan_id=21]
+Input [6]: [s_store_id#239, sum#245, sum#246, isEmpty#247, sum#248, isEmpty#249]
+Arguments: hashpartitioning(s_store_id#239, 5), ENSURE_REQUIREMENTS, [plan_id=23]
 
 (164) HashAggregate [codegen id : 75]
-Input [6]: [s_store_id#241, sum#247, sum#248, isEmpty#249, sum#250, isEmpty#251]
-Keys [1]: [s_store_id#241]
-Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#230)), sum(coalesce(cast(sr_return_amt#235 as decimal(12,2)), 0.00)), sum((ss_net_profit#231 - coalesce(cast(sr_net_loss#236 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#230))#35, sum(coalesce(cast(sr_return_amt#235 as decimal(12,2)), 0.00))#36, sum((ss_net_profit#231 - coalesce(cast(sr_net_loss#236 as decimal(12,2)), 0.00)))#37]
-Results [5]: [store channel AS channel#252, concat(store, s_store_id#241) AS id#253, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#230))#35,17,2) AS sales#254, sum(coalesce(cast(sr_return_amt#235 as decimal(12,2)), 0.00))#36 AS returns#255, sum((ss_net_profit#231 - coalesce(cast(sr_net_loss#236 as decimal(12,2)), 0.00)))#37 AS profit#256]
+Input [6]: [s_store_id#239, sum#245, sum#246, isEmpty#247, sum#248, isEmpty#249]
+Keys [1]: [s_store_id#239]
+Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#228)), sum(coalesce(cast(sr_return_amt#233 as decimal(12,2)), 0.00)), sum((ss_net_profit#229 - coalesce(cast(sr_net_loss#234 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#228))#33, sum(coalesce(cast(sr_return_amt#233 as decimal(12,2)), 0.00))#34, sum((ss_net_profit#229 - coalesce(cast(sr_net_loss#234 as decimal(12,2)), 0.00)))#35]
+Results [5]: [store channel AS channel#250, concat(store, s_store_id#239) AS id#251, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#228))#33,17,2) AS sales#252, sum(coalesce(cast(sr_return_amt#233 as decimal(12,2)), 0.00))#34 AS returns#253, sum((ss_net_profit#229 - coalesce(cast(sr_net_loss#234 as decimal(12,2)), 0.00)))#35 AS profit#254]
 
 (165) Scan parquet spark_catalog.default.catalog_sales
-Output [7]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_order_number#260, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263]
+Output [7]: [cs_catalog_page_sk#255, cs_item_sk#256, cs_promo_sk#257, cs_order_number#258, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#263), dynamicpruningexpression(cs_sold_date_sk#263 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#261), dynamicpruningexpression(cs_sold_date_sk#261 IN dynamicpruning#8)]
 PushedFilters: [IsNotNull(cs_catalog_page_sk), IsNotNull(cs_item_sk), IsNotNull(cs_promo_sk)]
 ReadSchema: struct<cs_catalog_page_sk:int,cs_item_sk:int,cs_promo_sk:int,cs_order_number:int,cs_ext_sales_price:decimal(7,2),cs_net_profit:decimal(7,2)>
 
 (166) ColumnarToRow [codegen id : 76]
-Input [7]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_order_number#260, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263]
+Input [7]: [cs_catalog_page_sk#255, cs_item_sk#256, cs_promo_sk#257, cs_order_number#258, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261]
 
 (167) Filter [codegen id : 76]
-Input [7]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_order_number#260, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263]
-Condition : ((isnotnull(cs_catalog_page_sk#257) AND isnotnull(cs_item_sk#258)) AND isnotnull(cs_promo_sk#259))
+Input [7]: [cs_catalog_page_sk#255, cs_item_sk#256, cs_promo_sk#257, cs_order_number#258, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261]
+Condition : ((isnotnull(cs_catalog_page_sk#255) AND isnotnull(cs_item_sk#256)) AND isnotnull(cs_promo_sk#257))
 
 (168) Exchange
-Input [7]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_order_number#260, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263]
-Arguments: hashpartitioning(cs_item_sk#258, cs_order_number#260, 5), ENSURE_REQUIREMENTS, [plan_id=22]
+Input [7]: [cs_catalog_page_sk#255, cs_item_sk#256, cs_promo_sk#257, cs_order_number#258, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261]
+Arguments: hashpartitioning(cs_item_sk#256, cs_order_number#258, 5), ENSURE_REQUIREMENTS, [plan_id=24]
 
 (169) Sort [codegen id : 77]
-Input [7]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_order_number#260, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263]
-Arguments: [cs_item_sk#258 ASC NULLS FIRST, cs_order_number#260 ASC NULLS FIRST], false, 0
+Input [7]: [cs_catalog_page_sk#255, cs_item_sk#256, cs_promo_sk#257, cs_order_number#258, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261]
+Arguments: [cs_item_sk#256 ASC NULLS FIRST, cs_order_number#258 ASC NULLS FIRST], false, 0
 
 (170) ReusedExchange [Reuses operator id: 49]
-Output [4]: [cr_item_sk#264, cr_order_number#265, cr_return_amount#266, cr_net_loss#267]
+Output [4]: [cr_item_sk#262, cr_order_number#263, cr_return_amount#264, cr_net_loss#265]
 
 (171) Sort [codegen id : 79]
-Input [4]: [cr_item_sk#264, cr_order_number#265, cr_return_amount#266, cr_net_loss#267]
-Arguments: [cr_item_sk#264 ASC NULLS FIRST, cr_order_number#265 ASC NULLS FIRST], false, 0
+Input [4]: [cr_item_sk#262, cr_order_number#263, cr_return_amount#264, cr_net_loss#265]
+Arguments: [cr_item_sk#262 ASC NULLS FIRST, cr_order_number#263 ASC NULLS FIRST], false, 0
 
 (172) SortMergeJoin [codegen id : 84]
-Left keys [2]: [cs_item_sk#258, cs_order_number#260]
-Right keys [2]: [cr_item_sk#264, cr_order_number#265]
+Left keys [2]: [cs_item_sk#256, cs_order_number#258]
+Right keys [2]: [cr_item_sk#262, cr_order_number#263]
 Join type: LeftOuter
 Join condition: None
 
 (173) Project [codegen id : 84]
-Output [8]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267]
-Input [11]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_order_number#260, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_item_sk#264, cr_order_number#265, cr_return_amount#266, cr_net_loss#267]
+Output [8]: [cs_catalog_page_sk#255, cs_item_sk#256, cs_promo_sk#257, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261, cr_return_amount#264, cr_net_loss#265]
+Input [11]: [cs_catalog_page_sk#255, cs_item_sk#256, cs_promo_sk#257, cs_order_number#258, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261, cr_item_sk#262, cr_order_number#263, cr_return_amount#264, cr_net_loss#265]
 
 (174) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#268]
+Output [1]: [i_item_sk#266]
 
 (175) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [cs_item_sk#258]
-Right keys [1]: [i_item_sk#268]
+Left keys [1]: [cs_item_sk#256]
+Right keys [1]: [i_item_sk#266]
 Join type: Inner
 Join condition: None
 
 (176) Project [codegen id : 84]
-Output [7]: [cs_catalog_page_sk#257, cs_promo_sk#259, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267]
-Input [9]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267, i_item_sk#268]
+Output [7]: [cs_catalog_page_sk#255, cs_promo_sk#257, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261, cr_return_amount#264, cr_net_loss#265]
+Input [9]: [cs_catalog_page_sk#255, cs_item_sk#256, cs_promo_sk#257, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261, cr_return_amount#264, cr_net_loss#265, i_item_sk#266]
 
 (177) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#269]
+Output [1]: [p_promo_sk#267]
 
 (178) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [cs_promo_sk#259]
-Right keys [1]: [p_promo_sk#269]
+Left keys [1]: [cs_promo_sk#257]
+Right keys [1]: [p_promo_sk#267]
 Join type: Inner
 Join condition: None
 
 (179) Project [codegen id : 84]
-Output [6]: [cs_catalog_page_sk#257, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267]
-Input [8]: [cs_catalog_page_sk#257, cs_promo_sk#259, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267, p_promo_sk#269]
+Output [6]: [cs_catalog_page_sk#255, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261, cr_return_amount#264, cr_net_loss#265]
+Input [8]: [cs_catalog_page_sk#255, cs_promo_sk#257, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261, cr_return_amount#264, cr_net_loss#265, p_promo_sk#267]
 
 (180) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#270]
+Output [1]: [d_date_sk#268]
 
 (181) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [cs_sold_date_sk#263]
-Right keys [1]: [d_date_sk#270]
+Left keys [1]: [cs_sold_date_sk#261]
+Right keys [1]: [d_date_sk#268]
 Join type: Inner
 Join condition: None
 
 (182) Project [codegen id : 84]
-Output [5]: [cs_catalog_page_sk#257, cs_ext_sales_price#261, cs_net_profit#262, cr_return_amount#266, cr_net_loss#267]
-Input [7]: [cs_catalog_page_sk#257, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267, d_date_sk#270]
+Output [5]: [cs_catalog_page_sk#255, cs_ext_sales_price#259, cs_net_profit#260, cr_return_amount#264, cr_net_loss#265]
+Input [7]: [cs_catalog_page_sk#255, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261, cr_return_amount#264, cr_net_loss#265, d_date_sk#268]
 
 (183) ReusedExchange [Reuses operator id: 65]
-Output [2]: [cp_catalog_page_sk#271, cp_catalog_page_id#272]
+Output [2]: [cp_catalog_page_sk#269, cp_catalog_page_id#270]
 
 (184) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [cs_catalog_page_sk#257]
-Right keys [1]: [cp_catalog_page_sk#271]
+Left keys [1]: [cs_catalog_page_sk#255]
+Right keys [1]: [cp_catalog_page_sk#269]
 Join type: Inner
 Join condition: None
 
 (185) Project [codegen id : 84]
-Output [5]: [cs_ext_sales_price#261, cs_net_profit#262, cr_return_amount#266, cr_net_loss#267, cp_catalog_page_id#272]
-Input [7]: [cs_catalog_page_sk#257, cs_ext_sales_price#261, cs_net_profit#262, cr_return_amount#266, cr_net_loss#267, cp_catalog_page_sk#271, cp_catalog_page_id#272]
+Output [5]: [cs_ext_sales_price#259, cs_net_profit#260, cr_return_amount#264, cr_net_loss#265, cp_catalog_page_id#270]
+Input [7]: [cs_catalog_page_sk#255, cs_ext_sales_price#259, cs_net_profit#260, cr_return_amount#264, cr_net_loss#265, cp_catalog_page_sk#269, cp_catalog_page_id#270]
 
 (186) HashAggregate [codegen id : 84]
-Input [5]: [cs_ext_sales_price#261, cs_net_profit#262, cr_return_amount#266, cr_net_loss#267, cp_catalog_page_id#272]
-Keys [1]: [cp_catalog_page_id#272]
-Functions [3]: [partial_sum(UnscaledValue(cs_ext_sales_price#261)), partial_sum(coalesce(cast(cr_return_amount#266 as decimal(12,2)), 0.00)), partial_sum((cs_net_profit#262 - coalesce(cast(cr_net_loss#267 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#273, sum#274, isEmpty#275, sum#276, isEmpty#277]
-Results [6]: [cp_catalog_page_id#272, sum#278, sum#279, isEmpty#280, sum#281, isEmpty#282]
+Input [5]: [cs_ext_sales_price#259, cs_net_profit#260, cr_return_amount#264, cr_net_loss#265, cp_catalog_page_id#270]
+Keys [1]: [cp_catalog_page_id#270]
+Functions [3]: [partial_sum(UnscaledValue(cs_ext_sales_price#259)), partial_sum(coalesce(cast(cr_return_amount#264 as decimal(12,2)), 0.00)), partial_sum((cs_net_profit#260 - coalesce(cast(cr_net_loss#265 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [5]: [sum#271, sum#272, isEmpty#273, sum#274, isEmpty#275]
+Results [6]: [cp_catalog_page_id#270, sum#276, sum#277, isEmpty#278, sum#279, isEmpty#280]
 
 (187) Exchange
-Input [6]: [cp_catalog_page_id#272, sum#278, sum#279, isEmpty#280, sum#281, isEmpty#282]
-Arguments: hashpartitioning(cp_catalog_page_id#272, 5), ENSURE_REQUIREMENTS, [plan_id=23]
+Input [6]: [cp_catalog_page_id#270, sum#276, sum#277, isEmpty#278, sum#279, isEmpty#280]
+Arguments: hashpartitioning(cp_catalog_page_id#270, 5), ENSURE_REQUIREMENTS, [plan_id=25]
 
 (188) HashAggregate [codegen id : 85]
-Input [6]: [cp_catalog_page_id#272, sum#278, sum#279, isEmpty#280, sum#281, isEmpty#282]
-Keys [1]: [cp_catalog_page_id#272]
-Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#261)), sum(coalesce(cast(cr_return_amount#266 as decimal(12,2)), 0.00)), sum((cs_net_profit#262 - coalesce(cast(cr_net_loss#267 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#261))#70, sum(coalesce(cast(cr_return_amount#266 as decimal(12,2)), 0.00))#71, sum((cs_net_profit#262 - coalesce(cast(cr_net_loss#267 as decimal(12,2)), 0.00)))#72]
-Results [5]: [catalog channel AS channel#283, concat(catalog_page, cp_catalog_page_id#272) AS id#284, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#261))#70,17,2) AS sales#285, sum(coalesce(cast(cr_return_amount#266 as decimal(12,2)), 0.00))#71 AS returns#286, sum((cs_net_profit#262 - coalesce(cast(cr_net_loss#267 as decimal(12,2)), 0.00)))#72 AS profit#287]
+Input [6]: [cp_catalog_page_id#270, sum#276, sum#277, isEmpty#278, sum#279, isEmpty#280]
+Keys [1]: [cp_catalog_page_id#270]
+Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#259)), sum(coalesce(cast(cr_return_amount#264 as decimal(12,2)), 0.00)), sum((cs_net_profit#260 - coalesce(cast(cr_net_loss#265 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#259))#68, sum(coalesce(cast(cr_return_amount#264 as decimal(12,2)), 0.00))#69, sum((cs_net_profit#260 - coalesce(cast(cr_net_loss#265 as decimal(12,2)), 0.00)))#70]
+Results [5]: [catalog channel AS channel#281, concat(catalog_page, cp_catalog_page_id#270) AS id#282, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#259))#68,17,2) AS sales#283, sum(coalesce(cast(cr_return_amount#264 as decimal(12,2)), 0.00))#69 AS returns#284, sum((cs_net_profit#260 - coalesce(cast(cr_net_loss#265 as decimal(12,2)), 0.00)))#70 AS profit#285]
 
 (189) ReusedExchange [Reuses operator id: 132]
-Output [6]: [web_site_id#288, sum#289, sum#290, isEmpty#291, sum#292, isEmpty#293]
+Output [6]: [web_site_id#286, sum#287, sum#288, isEmpty#289, sum#290, isEmpty#291]
 
 (190) HashAggregate [codegen id : 95]
-Input [6]: [web_site_id#288, sum#289, sum#290, isEmpty#291, sum#292, isEmpty#293]
-Keys [1]: [web_site_id#288]
-Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#294)), sum(coalesce(cast(wr_return_amt#295 as decimal(12,2)), 0.00)), sum((ws_net_profit#296 - coalesce(cast(wr_net_loss#297 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#294))#105, sum(coalesce(cast(wr_return_amt#295 as decimal(12,2)), 0.00))#106, sum((ws_net_profit#296 - coalesce(cast(wr_net_loss#297 as decimal(12,2)), 0.00)))#107]
-Results [5]: [web channel AS channel#298, concat(web_site, web_site_id#288) AS id#299, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#294))#105,17,2) AS sales#300, sum(coalesce(cast(wr_return_amt#295 as decimal(12,2)), 0.00))#106 AS returns#301, sum((ws_net_profit#296 - coalesce(cast(wr_net_loss#297 as decimal(12,2)), 0.00)))#107 AS profit#302]
+Input [6]: [web_site_id#286, sum#287, sum#288, isEmpty#289, sum#290, isEmpty#291]
+Keys [1]: [web_site_id#286]
+Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#292)), sum(coalesce(cast(wr_return_amt#293 as decimal(12,2)), 0.00)), sum((ws_net_profit#294 - coalesce(cast(wr_net_loss#295 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#292))#103, sum(coalesce(cast(wr_return_amt#293 as decimal(12,2)), 0.00))#104, sum((ws_net_profit#294 - coalesce(cast(wr_net_loss#295 as decimal(12,2)), 0.00)))#105]
+Results [5]: [web channel AS channel#296, concat(web_site, web_site_id#286) AS id#297, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#292))#103,17,2) AS sales#298, sum(coalesce(cast(wr_return_amt#293 as decimal(12,2)), 0.00))#104 AS returns#299, sum((ws_net_profit#294 - coalesce(cast(wr_net_loss#295 as decimal(12,2)), 0.00)))#105 AS profit#300]
 
 (191) Union
 
 (192) HashAggregate [codegen id : 96]
-Input [5]: [channel#252, id#253, sales#254, returns#255, profit#256]
-Keys [2]: [channel#252, id#253]
-Functions [3]: [partial_sum(sales#254), partial_sum(returns#255), partial_sum(profit#256)]
-Aggregate Attributes [6]: [sum#303, isEmpty#304, sum#305, isEmpty#306, sum#307, isEmpty#308]
-Results [8]: [channel#252, id#253, sum#309, isEmpty#310, sum#311, isEmpty#312, sum#313, isEmpty#314]
+Input [5]: [channel#250, id#251, sales#252, returns#253, profit#254]
+Keys [2]: [channel#250, id#251]
+Functions [3]: [partial_sum(sales#252), partial_sum(returns#253), partial_sum(profit#254)]
+Aggregate Attributes [6]: [sum#301, isEmpty#302, sum#303, isEmpty#304, sum#305, isEmpty#306]
+Results [8]: [channel#250, id#251, sum#307, isEmpty#308, sum#309, isEmpty#310, sum#311, isEmpty#312]
 
 (193) Exchange
-Input [8]: [channel#252, id#253, sum#309, isEmpty#310, sum#311, isEmpty#312, sum#313, isEmpty#314]
-Arguments: hashpartitioning(channel#252, id#253, 5), ENSURE_REQUIREMENTS, [plan_id=24]
+Input [8]: [channel#250, id#251, sum#307, isEmpty#308, sum#309, isEmpty#310, sum#311, isEmpty#312]
+Arguments: hashpartitioning(channel#250, id#251, 5), ENSURE_REQUIREMENTS, [plan_id=26]
 
 (194) HashAggregate [codegen id : 97]
-Input [8]: [channel#252, id#253, sum#309, isEmpty#310, sum#311, isEmpty#312, sum#313, isEmpty#314]
-Keys [2]: [channel#252, id#253]
-Functions [3]: [sum(sales#254), sum(returns#255), sum(profit#256)]
-Aggregate Attributes [3]: [sum(sales#254)#125, sum(returns#255)#126, sum(profit#256)#127]
-Results [3]: [sum(sales#254)#125 AS sales#315, sum(returns#255)#126 AS returns#316, sum(profit#256)#127 AS profit#317]
+Input [8]: [channel#250, id#251, sum#307, isEmpty#308, sum#309, isEmpty#310, sum#311, isEmpty#312]
+Keys [2]: [channel#250, id#251]
+Functions [3]: [sum(sales#252), sum(returns#253), sum(profit#254)]
+Aggregate Attributes [3]: [sum(sales#252)#123, sum(returns#253)#124, sum(profit#254)#125]
+Results [3]: [sum(sales#252)#123 AS sales#313, sum(returns#253)#124 AS returns#314, sum(profit#254)#125 AS profit#315]
 
 (195) HashAggregate [codegen id : 97]
-Input [3]: [sales#315, returns#316, profit#317]
+Input [3]: [sales#313, returns#314, profit#315]
 Keys: []
-Functions [3]: [partial_sum(sales#315), partial_sum(returns#316), partial_sum(profit#317)]
-Aggregate Attributes [6]: [sum#318, isEmpty#319, sum#320, isEmpty#321, sum#322, isEmpty#323]
-Results [6]: [sum#324, isEmpty#325, sum#326, isEmpty#327, sum#328, isEmpty#329]
+Functions [3]: [partial_sum(sales#313), partial_sum(returns#314), partial_sum(profit#315)]
+Aggregate Attributes [6]: [sum#316, isEmpty#317, sum#318, isEmpty#319, sum#320, isEmpty#321]
+Results [6]: [sum#322, isEmpty#323, sum#324, isEmpty#325, sum#326, isEmpty#327]
 
 (196) Exchange
-Input [6]: [sum#324, isEmpty#325, sum#326, isEmpty#327, sum#328, isEmpty#329]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=25]
+Input [6]: [sum#322, isEmpty#323, sum#324, isEmpty#325, sum#326, isEmpty#327]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=27]
 
 (197) HashAggregate [codegen id : 98]
-Input [6]: [sum#324, isEmpty#325, sum#326, isEmpty#327, sum#328, isEmpty#329]
+Input [6]: [sum#322, isEmpty#323, sum#324, isEmpty#325, sum#326, isEmpty#327]
 Keys: []
-Functions [3]: [sum(sales#315), sum(returns#316), sum(profit#317)]
-Aggregate Attributes [3]: [sum(sales#315)#330, sum(returns#316)#331, sum(profit#317)#332]
-Results [5]: [null AS channel#333, null AS id#334, sum(sales#315)#330 AS sales#335, sum(returns#316)#331 AS returns#336, sum(profit#317)#332 AS profit#337]
+Functions [3]: [sum(sales#313), sum(returns#314), sum(profit#315)]
+Aggregate Attributes [3]: [sum(sales#313)#328, sum(returns#314)#329, sum(profit#315)#330]
+Results [5]: [null AS channel#331, null AS id#332, sum(sales#313)#328 AS sales#333, sum(returns#314)#329 AS returns#334, sum(profit#315)#330 AS profit#335]
 
 (198) Union
 
 (199) HashAggregate [codegen id : 99]
-Input [5]: [channel#38, id#39, sales#128, returns#129, profit#130]
-Keys [5]: [channel#38, id#39, sales#128, returns#129, profit#130]
+Input [5]: [channel#36, id#37, sales#126, returns#127, profit#128]
+Keys [5]: [channel#36, id#37, sales#126, returns#127, profit#128]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [channel#38, id#39, sales#128, returns#129, profit#130]
+Results [5]: [channel#36, id#37, sales#126, returns#127, profit#128]
 
 (200) Exchange
-Input [5]: [channel#38, id#39, sales#128, returns#129, profit#130]
-Arguments: hashpartitioning(channel#38, id#39, sales#128, returns#129, profit#130, 5), ENSURE_REQUIREMENTS, [plan_id=26]
+Input [5]: [channel#36, id#37, sales#126, returns#127, profit#128]
+Arguments: hashpartitioning(channel#36, id#37, sales#126, returns#127, profit#128, 5), ENSURE_REQUIREMENTS, [plan_id=28]
 
 (201) HashAggregate [codegen id : 100]
-Input [5]: [channel#38, id#39, sales#128, returns#129, profit#130]
-Keys [5]: [channel#38, id#39, sales#128, returns#129, profit#130]
+Input [5]: [channel#36, id#37, sales#126, returns#127, profit#128]
+Keys [5]: [channel#36, id#37, sales#126, returns#127, profit#128]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [channel#38, id#39, sales#128, returns#129, profit#130]
+Results [5]: [channel#36, id#37, sales#126, returns#127, profit#128]
 
 (202) TakeOrderedAndProject
-Input [5]: [channel#38, id#39, sales#128, returns#129, profit#130]
-Arguments: 100, [channel#38 ASC NULLS FIRST, id#39 ASC NULLS FIRST], [channel#38, id#39, sales#128, returns#129, profit#130]
+Input [5]: [channel#36, id#37, sales#126, returns#127, profit#128]
+Arguments: 100, [channel#36 ASC NULLS FIRST, id#37 ASC NULLS FIRST], [channel#36, id#37, sales#126, returns#127, profit#128]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#9, [id=#10]
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#9, [id=#1]
 ObjectHashAggregate (209)
 +- Exchange (208)
    +- ObjectHashAggregate (207)
@@ -1166,42 +1166,42 @@ ObjectHashAggregate (209)
 
 
 (203) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#18, i_current_price#19]
+Output [2]: [i_item_sk#16, i_current_price#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_current_price), GreaterThan(i_current_price,50.00), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2)>
 
 (204) ColumnarToRow [codegen id : 1]
-Input [2]: [i_item_sk#18, i_current_price#19]
+Input [2]: [i_item_sk#16, i_current_price#17]
 
 (205) Filter [codegen id : 1]
-Input [2]: [i_item_sk#18, i_current_price#19]
-Condition : ((isnotnull(i_current_price#19) AND (i_current_price#19 > 50.00)) AND isnotnull(i_item_sk#18))
+Input [2]: [i_item_sk#16, i_current_price#17]
+Condition : ((isnotnull(i_current_price#17) AND (i_current_price#17 > 50.00)) AND isnotnull(i_item_sk#16))
 
 (206) Project [codegen id : 1]
-Output [1]: [i_item_sk#18]
-Input [2]: [i_item_sk#18, i_current_price#19]
+Output [1]: [i_item_sk#16]
+Input [2]: [i_item_sk#16, i_current_price#17]
 
 (207) ObjectHashAggregate
-Input [1]: [i_item_sk#18]
+Input [1]: [i_item_sk#16]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)]
-Aggregate Attributes [1]: [buf#338]
-Results [1]: [buf#339]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#16, 42), 101823, 1521109, 0, 0)]
+Aggregate Attributes [1]: [buf#336]
+Results [1]: [buf#337]
 
 (208) Exchange
-Input [1]: [buf#339]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=27]
+Input [1]: [buf#337]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=29]
 
 (209) ObjectHashAggregate
-Input [1]: [buf#339]
+Input [1]: [buf#337]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)#340]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)#340 AS bloomFilter#341]
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#16, 42), 101823, 1521109, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#16, 42), 101823, 1521109, 0, 0)#338]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#16, 42), 101823, 1521109, 0, 0)#338 AS bloomFilter#339]
 
-Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#11, [id=#12]
+Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#10, [id=#2]
 ObjectHashAggregate (216)
 +- Exchange (215)
    +- ObjectHashAggregate (214)
@@ -1212,40 +1212,40 @@ ObjectHashAggregate (216)
 
 
 (210) Scan parquet spark_catalog.default.promotion
-Output [2]: [p_promo_sk#20, p_channel_tv#21]
+Output [2]: [p_promo_sk#18, p_channel_tv#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/promotion]
 PushedFilters: [IsNotNull(p_channel_tv), EqualTo(p_channel_tv,N), IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int,p_channel_tv:string>
 
 (211) ColumnarToRow [codegen id : 1]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
+Input [2]: [p_promo_sk#18, p_channel_tv#19]
 
 (212) Filter [codegen id : 1]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
-Condition : ((isnotnull(p_channel_tv#21) AND (p_channel_tv#21 = N)) AND isnotnull(p_promo_sk#20))
+Input [2]: [p_promo_sk#18, p_channel_tv#19]
+Condition : ((isnotnull(p_channel_tv#19) AND (p_channel_tv#19 = N)) AND isnotnull(p_promo_sk#18))
 
 (213) Project [codegen id : 1]
-Output [1]: [p_promo_sk#20]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
+Output [1]: [p_promo_sk#18]
+Input [2]: [p_promo_sk#18, p_channel_tv#19]
 
 (214) ObjectHashAggregate
-Input [1]: [p_promo_sk#20]
+Input [1]: [p_promo_sk#18]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(p_promo_sk#20, 42), 986, 24246, 0, 0)]
-Aggregate Attributes [1]: [buf#342]
-Results [1]: [buf#343]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(p_promo_sk#18, 42), 986, 24246, 0, 0)]
+Aggregate Attributes [1]: [buf#340]
+Results [1]: [buf#341]
 
 (215) Exchange
-Input [1]: [buf#343]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=28]
+Input [1]: [buf#341]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=30]
 
 (216) ObjectHashAggregate
-Input [1]: [buf#343]
+Input [1]: [buf#341]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(p_promo_sk#20, 42), 986, 24246, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(p_promo_sk#20, 42), 986, 24246, 0, 0)#344]
-Results [1]: [bloom_filter_agg(xxhash64(p_promo_sk#20, 42), 986, 24246, 0, 0)#344 AS bloomFilter#345]
+Functions [1]: [bloom_filter_agg(xxhash64(p_promo_sk#18, 42), 986, 24246, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(p_promo_sk#18, 42), 986, 24246, 0, 0)#342]
+Results [1]: [bloom_filter_agg(xxhash64(p_promo_sk#18, 42), 986, 24246, 0, 0)#342 AS bloomFilter#343]
 
 Subquery:3 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#7 IN dynamicpruning#8
 BroadcastExchange (221)
@@ -1256,43 +1256,43 @@ BroadcastExchange (221)
 
 
 (217) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#22, d_date#346]
+Output [2]: [d_date_sk#20, d_date#344]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1998-08-04), LessThanOrEqual(d_date,1998-09-03), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (218) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#22, d_date#346]
+Input [2]: [d_date_sk#20, d_date#344]
 
 (219) Filter [codegen id : 1]
-Input [2]: [d_date_sk#22, d_date#346]
-Condition : (((isnotnull(d_date#346) AND (d_date#346 >= 1998-08-04)) AND (d_date#346 <= 1998-09-03)) AND isnotnull(d_date_sk#22))
+Input [2]: [d_date_sk#20, d_date#344]
+Condition : (((isnotnull(d_date#344) AND (d_date#344 >= 1998-08-04)) AND (d_date#344 <= 1998-09-03)) AND isnotnull(d_date_sk#20))
 
 (220) Project [codegen id : 1]
-Output [1]: [d_date_sk#22]
-Input [2]: [d_date_sk#22, d_date#346]
+Output [1]: [d_date_sk#20]
+Input [2]: [d_date_sk#20, d_date#344]
 
 (221) BroadcastExchange
-Input [1]: [d_date_sk#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=29]
+Input [1]: [d_date_sk#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=31]
 
-Subquery:4 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
+Subquery:4 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#1]
 
-Subquery:5 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
+Subquery:5 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#10, [id=#2]
 
-Subquery:6 Hosting operator id = 40 Hosting Expression = cs_sold_date_sk#49 IN dynamicpruning#8
+Subquery:6 Hosting operator id = 40 Hosting Expression = cs_sold_date_sk#47 IN dynamicpruning#8
 
-Subquery:7 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
+Subquery:7 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#1]
 
-Subquery:8 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
+Subquery:8 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#10, [id=#2]
 
-Subquery:9 Hosting operator id = 71 Hosting Expression = ws_sold_date_sk#84 IN dynamicpruning#8
+Subquery:9 Hosting operator id = 71 Hosting Expression = ws_sold_date_sk#82 IN dynamicpruning#8
 
-Subquery:10 Hosting operator id = 110 Hosting Expression = ws_sold_date_sk#167 IN dynamicpruning#8
+Subquery:10 Hosting operator id = 110 Hosting Expression = ws_sold_date_sk#165 IN dynamicpruning#8
 
-Subquery:11 Hosting operator id = 141 Hosting Expression = ss_sold_date_sk#232 IN dynamicpruning#8
+Subquery:11 Hosting operator id = 141 Hosting Expression = ss_sold_date_sk#230 IN dynamicpruning#8
 
-Subquery:12 Hosting operator id = 165 Hosting Expression = cs_sold_date_sk#263 IN dynamicpruning#8
+Subquery:12 Hosting operator id = 165 Hosting Expression = cs_sold_date_sk#261 IN dynamicpruning#8
 
 

--- a/sql/core/src/test/resources/tpch-plan-stability/q11/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q11/explain.txt
@@ -117,11 +117,11 @@ Results [2]: [ps_partkey#1, sum((ps_supplycost#4 * cast(ps_availqty#3 as decimal
 
 (20) Filter [codegen id : 4]
 Input [2]: [ps_partkey#1, value#14]
-Condition : (isnotnull(value#14) AND (cast(value#14 as decimal(38,6)) > Subquery scalar-subquery#15, [id=#16]))
+Condition : (isnotnull(value#14) AND (cast(value#14 as decimal(38,6)) > Subquery scalar-subquery#15, [id=#4]))
 
 (21) Exchange
 Input [2]: [ps_partkey#1, value#14]
-Arguments: rangepartitioning(value#14 DESC NULLS LAST, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Arguments: rangepartitioning(value#14 DESC NULLS LAST, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (22) Sort [codegen id : 5]
 Input [2]: [ps_partkey#1, value#14]
@@ -129,7 +129,7 @@ Arguments: [value#14 DESC NULLS LAST], true, 0
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 20 Hosting Expression = Subquery scalar-subquery#15, [id=#16]
+Subquery:1 Hosting operator id = 20 Hosting Expression = Subquery scalar-subquery#15, [id=#4]
 * HashAggregate (34)
 +- Exchange (33)
    +- * HashAggregate (32)
@@ -145,61 +145,61 @@ Subquery:1 Hosting operator id = 20 Hosting Expression = Subquery scalar-subquer
 
 
 (23) Scan parquet spark_catalog.default.partsupp
-Output [3]: [ps_suppkey#17, ps_availqty#18, ps_supplycost#19]
+Output [3]: [ps_suppkey#16, ps_availqty#17, ps_supplycost#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/partsupp]
 PushedFilters: [IsNotNull(ps_suppkey)]
 ReadSchema: struct<ps_suppkey:bigint,ps_availqty:int,ps_supplycost:decimal(10,0)>
 
 (24) ColumnarToRow [codegen id : 3]
-Input [3]: [ps_suppkey#17, ps_availqty#18, ps_supplycost#19]
+Input [3]: [ps_suppkey#16, ps_availqty#17, ps_supplycost#18]
 
 (25) Filter [codegen id : 3]
-Input [3]: [ps_suppkey#17, ps_availqty#18, ps_supplycost#19]
-Condition : isnotnull(ps_suppkey#17)
+Input [3]: [ps_suppkey#16, ps_availqty#17, ps_supplycost#18]
+Condition : isnotnull(ps_suppkey#16)
 
 (26) ReusedExchange [Reuses operator id: 7]
-Output [2]: [s_suppkey#20, s_nationkey#21]
+Output [2]: [s_suppkey#19, s_nationkey#20]
 
 (27) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ps_suppkey#17]
-Right keys [1]: [s_suppkey#20]
+Left keys [1]: [ps_suppkey#16]
+Right keys [1]: [s_suppkey#19]
 Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 3]
-Output [3]: [ps_availqty#18, ps_supplycost#19, s_nationkey#21]
-Input [5]: [ps_suppkey#17, ps_availqty#18, ps_supplycost#19, s_suppkey#20, s_nationkey#21]
+Output [3]: [ps_availqty#17, ps_supplycost#18, s_nationkey#20]
+Input [5]: [ps_suppkey#16, ps_availqty#17, ps_supplycost#18, s_suppkey#19, s_nationkey#20]
 
 (29) ReusedExchange [Reuses operator id: 14]
-Output [1]: [n_nationkey#22]
+Output [1]: [n_nationkey#21]
 
 (30) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [s_nationkey#21]
-Right keys [1]: [n_nationkey#22]
+Left keys [1]: [s_nationkey#20]
+Right keys [1]: [n_nationkey#21]
 Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 3]
-Output [2]: [ps_availqty#18, ps_supplycost#19]
-Input [4]: [ps_availqty#18, ps_supplycost#19, s_nationkey#21, n_nationkey#22]
+Output [2]: [ps_availqty#17, ps_supplycost#18]
+Input [4]: [ps_availqty#17, ps_supplycost#18, s_nationkey#20, n_nationkey#21]
 
 (32) HashAggregate [codegen id : 3]
-Input [2]: [ps_availqty#18, ps_supplycost#19]
+Input [2]: [ps_availqty#17, ps_supplycost#18]
 Keys: []
-Functions [1]: [partial_sum((ps_supplycost#19 * cast(ps_availqty#18 as decimal(10,0))))]
-Aggregate Attributes [2]: [sum#23, isEmpty#24]
-Results [2]: [sum#25, isEmpty#26]
+Functions [1]: [partial_sum((ps_supplycost#18 * cast(ps_availqty#17 as decimal(10,0))))]
+Aggregate Attributes [2]: [sum#22, isEmpty#23]
+Results [2]: [sum#24, isEmpty#25]
 
 (33) Exchange
-Input [2]: [sum#25, isEmpty#26]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
+Input [2]: [sum#24, isEmpty#25]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
 
 (34) HashAggregate [codegen id : 4]
-Input [2]: [sum#25, isEmpty#26]
+Input [2]: [sum#24, isEmpty#25]
 Keys: []
-Functions [1]: [sum((ps_supplycost#19 * cast(ps_availqty#18 as decimal(10,0))))]
-Aggregate Attributes [1]: [sum((ps_supplycost#19 * cast(ps_availqty#18 as decimal(10,0))))#27]
-Results [1]: [(sum((ps_supplycost#19 * cast(ps_availqty#18 as decimal(10,0))))#27 * 0.0001000000) AS (sum((ps_supplycost * ps_availqty)) * 0.0001000000)#28]
+Functions [1]: [sum((ps_supplycost#18 * cast(ps_availqty#17 as decimal(10,0))))]
+Aggregate Attributes [1]: [sum((ps_supplycost#18 * cast(ps_availqty#17 as decimal(10,0))))#26]
+Results [1]: [(sum((ps_supplycost#18 * cast(ps_availqty#17 as decimal(10,0))))#26 * 0.0001000000) AS (sum((ps_supplycost * ps_availqty)) * 0.0001000000)#27]
 
 

--- a/sql/core/src/test/resources/tpch-plan-stability/q15/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q15/explain.txt
@@ -69,11 +69,11 @@ Results [2]: [l_suppkey#5 AS supplier_no#14, sum((l_extendedprice#6 * (1 - l_dis
 
 (11) Filter [codegen id : 2]
 Input [2]: [supplier_no#14, total_revenue#15]
-Condition : (isnotnull(total_revenue#15) AND (total_revenue#15 = Subquery scalar-subquery#16, [id=#17]))
+Condition : (isnotnull(total_revenue#15) AND (total_revenue#15 = Subquery scalar-subquery#16, [id=#2]))
 
 (12) BroadcastExchange
 Input [2]: [supplier_no#14, total_revenue#15]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [plan_id=2]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [plan_id=3]
 
 (13) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [s_suppkey#1]
@@ -87,7 +87,7 @@ Input [6]: [s_suppkey#1, s_name#2, s_address#3, s_phone#4, supplier_no#14, total
 
 (15) Exchange
 Input [5]: [s_suppkey#1, s_name#2, s_address#3, s_phone#4, total_revenue#15]
-Arguments: rangepartitioning(s_suppkey#1 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Arguments: rangepartitioning(s_suppkey#1 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (16) Sort [codegen id : 4]
 Input [5]: [s_suppkey#1, s_name#2, s_address#3, s_phone#4, total_revenue#15]
@@ -95,7 +95,7 @@ Arguments: [s_suppkey#1 ASC NULLS FIRST], true, 0
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 11 Hosting Expression = Subquery scalar-subquery#16, [id=#17]
+Subquery:1 Hosting operator id = 11 Hosting Expression = Subquery scalar-subquery#16, [id=#2]
 * HashAggregate (26)
 +- Exchange (25)
    +- * HashAggregate (24)
@@ -109,57 +109,57 @@ Subquery:1 Hosting operator id = 11 Hosting Expression = Subquery scalar-subquer
 
 
 (17) Scan parquet spark_catalog.default.lineitem
-Output [4]: [l_suppkey#18, l_extendedprice#19, l_discount#20, l_shipdate#21]
+Output [4]: [l_suppkey#17, l_extendedprice#18, l_discount#19, l_shipdate#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/lineitem]
 PushedFilters: [IsNotNull(l_shipdate), GreaterThanOrEqual(l_shipdate,1996-01-01), LessThan(l_shipdate,1996-04-01)]
 ReadSchema: struct<l_suppkey:bigint,l_extendedprice:decimal(10,0),l_discount:decimal(10,0),l_shipdate:date>
 
 (18) ColumnarToRow [codegen id : 1]
-Input [4]: [l_suppkey#18, l_extendedprice#19, l_discount#20, l_shipdate#21]
+Input [4]: [l_suppkey#17, l_extendedprice#18, l_discount#19, l_shipdate#20]
 
 (19) Filter [codegen id : 1]
-Input [4]: [l_suppkey#18, l_extendedprice#19, l_discount#20, l_shipdate#21]
-Condition : ((isnotnull(l_shipdate#21) AND (l_shipdate#21 >= 1996-01-01)) AND (l_shipdate#21 < 1996-04-01))
+Input [4]: [l_suppkey#17, l_extendedprice#18, l_discount#19, l_shipdate#20]
+Condition : ((isnotnull(l_shipdate#20) AND (l_shipdate#20 >= 1996-01-01)) AND (l_shipdate#20 < 1996-04-01))
 
 (20) Project [codegen id : 1]
-Output [3]: [l_suppkey#18, l_extendedprice#19, l_discount#20]
-Input [4]: [l_suppkey#18, l_extendedprice#19, l_discount#20, l_shipdate#21]
+Output [3]: [l_suppkey#17, l_extendedprice#18, l_discount#19]
+Input [4]: [l_suppkey#17, l_extendedprice#18, l_discount#19, l_shipdate#20]
 
 (21) HashAggregate [codegen id : 1]
-Input [3]: [l_suppkey#18, l_extendedprice#19, l_discount#20]
-Keys [1]: [l_suppkey#18]
-Functions [1]: [partial_sum((l_extendedprice#19 * (1 - l_discount#20)))]
-Aggregate Attributes [2]: [sum#22, isEmpty#23]
-Results [3]: [l_suppkey#18, sum#24, isEmpty#25]
+Input [3]: [l_suppkey#17, l_extendedprice#18, l_discount#19]
+Keys [1]: [l_suppkey#17]
+Functions [1]: [partial_sum((l_extendedprice#18 * (1 - l_discount#19)))]
+Aggregate Attributes [2]: [sum#21, isEmpty#22]
+Results [3]: [l_suppkey#17, sum#23, isEmpty#24]
 
 (22) Exchange
-Input [3]: [l_suppkey#18, sum#24, isEmpty#25]
-Arguments: hashpartitioning(l_suppkey#18, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [3]: [l_suppkey#17, sum#23, isEmpty#24]
+Arguments: hashpartitioning(l_suppkey#17, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (23) HashAggregate [codegen id : 2]
-Input [3]: [l_suppkey#18, sum#24, isEmpty#25]
-Keys [1]: [l_suppkey#18]
-Functions [1]: [sum((l_extendedprice#19 * (1 - l_discount#20)))]
-Aggregate Attributes [1]: [sum((l_extendedprice#19 * (1 - l_discount#20)))#13]
-Results [1]: [sum((l_extendedprice#19 * (1 - l_discount#20)))#13 AS total_revenue#26]
+Input [3]: [l_suppkey#17, sum#23, isEmpty#24]
+Keys [1]: [l_suppkey#17]
+Functions [1]: [sum((l_extendedprice#18 * (1 - l_discount#19)))]
+Aggregate Attributes [1]: [sum((l_extendedprice#18 * (1 - l_discount#19)))#13]
+Results [1]: [sum((l_extendedprice#18 * (1 - l_discount#19)))#13 AS total_revenue#25]
 
 (24) HashAggregate [codegen id : 2]
-Input [1]: [total_revenue#26]
+Input [1]: [total_revenue#25]
 Keys: []
-Functions [1]: [partial_max(total_revenue#26)]
-Aggregate Attributes [1]: [max#27]
-Results [1]: [max#28]
+Functions [1]: [partial_max(total_revenue#25)]
+Aggregate Attributes [1]: [max#26]
+Results [1]: [max#27]
 
 (25) Exchange
-Input [1]: [max#28]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
+Input [1]: [max#27]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
 
 (26) HashAggregate [codegen id : 3]
-Input [1]: [max#28]
+Input [1]: [max#27]
 Keys: []
-Functions [1]: [max(total_revenue#26)]
-Aggregate Attributes [1]: [max(total_revenue#26)#29]
-Results [1]: [max(total_revenue#26)#29 AS max(total_revenue)#30]
+Functions [1]: [max(total_revenue#25)]
+Aggregate Attributes [1]: [max(total_revenue#25)#28]
+Results [1]: [max(total_revenue#25)#28 AS max(total_revenue)#29]
 
 

--- a/sql/core/src/test/resources/tpch-plan-stability/q22/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q22/explain.txt
@@ -26,62 +26,62 @@ Input [3]: [c_custkey#1, c_phone#2, c_acctbal#3]
 
 (3) Filter [codegen id : 2]
 Input [3]: [c_custkey#1, c_phone#2, c_acctbal#3]
-Condition : ((isnotnull(c_acctbal#3) AND substring(c_phone#2, 1, 2) IN (13,31,23,29,30,18,17)) AND (cast(c_acctbal#3 as decimal(14,4)) > ReusedSubquery Subquery scalar-subquery#4, [id=#5]))
+Condition : ((isnotnull(c_acctbal#3) AND substring(c_phone#2, 1, 2) IN (13,31,23,29,30,18,17)) AND (cast(c_acctbal#3 as decimal(14,4)) > ReusedSubquery Subquery scalar-subquery#4, [id=#1]))
 
 (4) Scan parquet spark_catalog.default.orders
-Output [1]: [o_custkey#6]
+Output [1]: [o_custkey#5]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/orders]
 ReadSchema: struct<o_custkey:bigint>
 
 (5) ColumnarToRow [codegen id : 1]
-Input [1]: [o_custkey#6]
+Input [1]: [o_custkey#5]
 
 (6) BroadcastExchange
-Input [1]: [o_custkey#6]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [plan_id=1]
+Input [1]: [o_custkey#5]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [plan_id=2]
 
 (7) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [c_custkey#1]
-Right keys [1]: [o_custkey#6]
+Right keys [1]: [o_custkey#5]
 Join type: LeftAnti
 Join condition: None
 
 (8) Project [codegen id : 2]
-Output [2]: [substring(c_phone#2, 1, 2) AS cntrycode#7, c_acctbal#3]
+Output [2]: [substring(c_phone#2, 1, 2) AS cntrycode#6, c_acctbal#3]
 Input [3]: [c_custkey#1, c_phone#2, c_acctbal#3]
 
 (9) HashAggregate [codegen id : 2]
-Input [2]: [cntrycode#7, c_acctbal#3]
-Keys [1]: [cntrycode#7]
+Input [2]: [cntrycode#6, c_acctbal#3]
+Keys [1]: [cntrycode#6]
 Functions [2]: [partial_count(1), partial_sum(c_acctbal#3)]
-Aggregate Attributes [3]: [count#8, sum#9, isEmpty#10]
-Results [4]: [cntrycode#7, count#11, sum#12, isEmpty#13]
+Aggregate Attributes [3]: [count#7, sum#8, isEmpty#9]
+Results [4]: [cntrycode#6, count#10, sum#11, isEmpty#12]
 
 (10) Exchange
-Input [4]: [cntrycode#7, count#11, sum#12, isEmpty#13]
-Arguments: hashpartitioning(cntrycode#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [4]: [cntrycode#6, count#10, sum#11, isEmpty#12]
+Arguments: hashpartitioning(cntrycode#6, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (11) HashAggregate [codegen id : 3]
-Input [4]: [cntrycode#7, count#11, sum#12, isEmpty#13]
-Keys [1]: [cntrycode#7]
+Input [4]: [cntrycode#6, count#10, sum#11, isEmpty#12]
+Keys [1]: [cntrycode#6]
 Functions [2]: [count(1), sum(c_acctbal#3)]
-Aggregate Attributes [2]: [count(1)#14, sum(c_acctbal#3)#15]
-Results [3]: [cntrycode#7, count(1)#14 AS numcust#16, sum(c_acctbal#3)#15 AS totacctbal#17]
+Aggregate Attributes [2]: [count(1)#13, sum(c_acctbal#3)#14]
+Results [3]: [cntrycode#6, count(1)#13 AS numcust#15, sum(c_acctbal#3)#14 AS totacctbal#16]
 
 (12) Exchange
-Input [3]: [cntrycode#7, numcust#16, totacctbal#17]
-Arguments: rangepartitioning(cntrycode#7 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [3]: [cntrycode#6, numcust#15, totacctbal#16]
+Arguments: rangepartitioning(cntrycode#6 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (13) Sort [codegen id : 4]
-Input [3]: [cntrycode#7, numcust#16, totacctbal#17]
-Arguments: [cntrycode#7 ASC NULLS FIRST], true, 0
+Input [3]: [cntrycode#6, numcust#15, totacctbal#16]
+Arguments: [cntrycode#6 ASC NULLS FIRST], true, 0
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 3 Hosting Expression = ReusedSubquery Subquery scalar-subquery#4, [id=#5]
+Subquery:1 Hosting operator id = 3 Hosting Expression = ReusedSubquery Subquery scalar-subquery#4, [id=#1]
 
-Subquery:2 Hosting operator id = 1 Hosting Expression = Subquery scalar-subquery#4, [id=#5]
+Subquery:2 Hosting operator id = 1 Hosting Expression = Subquery scalar-subquery#4, [id=#1]
 * HashAggregate (20)
 +- Exchange (19)
    +- * HashAggregate (18)
@@ -92,39 +92,39 @@ Subquery:2 Hosting operator id = 1 Hosting Expression = Subquery scalar-subquery
 
 
 (14) Scan parquet spark_catalog.default.customer
-Output [2]: [c_phone#18, c_acctbal#19]
+Output [2]: [c_phone#17, c_acctbal#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_acctbal), GreaterThan(c_acctbal,0)]
 ReadSchema: struct<c_phone:string,c_acctbal:decimal(10,0)>
 
 (15) ColumnarToRow [codegen id : 1]
-Input [2]: [c_phone#18, c_acctbal#19]
+Input [2]: [c_phone#17, c_acctbal#18]
 
 (16) Filter [codegen id : 1]
-Input [2]: [c_phone#18, c_acctbal#19]
-Condition : ((isnotnull(c_acctbal#19) AND (c_acctbal#19 > 0)) AND substring(c_phone#18, 1, 2) IN (13,31,23,29,30,18,17))
+Input [2]: [c_phone#17, c_acctbal#18]
+Condition : ((isnotnull(c_acctbal#18) AND (c_acctbal#18 > 0)) AND substring(c_phone#17, 1, 2) IN (13,31,23,29,30,18,17))
 
 (17) Project [codegen id : 1]
-Output [1]: [c_acctbal#19]
-Input [2]: [c_phone#18, c_acctbal#19]
+Output [1]: [c_acctbal#18]
+Input [2]: [c_phone#17, c_acctbal#18]
 
 (18) HashAggregate [codegen id : 1]
-Input [1]: [c_acctbal#19]
+Input [1]: [c_acctbal#18]
 Keys: []
-Functions [1]: [partial_avg(UnscaledValue(c_acctbal#19))]
-Aggregate Attributes [2]: [sum#20, count#21]
-Results [2]: [sum#22, count#23]
+Functions [1]: [partial_avg(UnscaledValue(c_acctbal#18))]
+Aggregate Attributes [2]: [sum#19, count#20]
+Results [2]: [sum#21, count#22]
 
 (19) Exchange
-Input [2]: [sum#22, count#23]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=4]
+Input [2]: [sum#21, count#22]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
 
 (20) HashAggregate [codegen id : 2]
-Input [2]: [sum#22, count#23]
+Input [2]: [sum#21, count#22]
 Keys: []
-Functions [1]: [avg(UnscaledValue(c_acctbal#19))]
-Aggregate Attributes [1]: [avg(UnscaledValue(c_acctbal#19))#24]
-Results [1]: [cast((avg(UnscaledValue(c_acctbal#19))#24 / 1.0) as decimal(14,4)) AS avg(c_acctbal)#25]
+Functions [1]: [avg(UnscaledValue(c_acctbal#18))]
+Aggregate Attributes [1]: [avg(UnscaledValue(c_acctbal#18))#23]
+Results [1]: [cast((avg(UnscaledValue(c_acctbal#18))#23 / 1.0) as decimal(14,4)) AS avg(c_acctbal)#24]
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
@@ -78,6 +78,7 @@ trait PlanStabilitySuite extends DisableAdaptiveExecutionSuite {
   }
 
   private val referenceRegex = "#\\d+".r
+  // Do not match `id=#123` like ids as those are actually plan ids in `SubqueryExec` nodes.
   private val exprIdRegexp = "(?<prefix>(?<!id=)#)\\d+L?".r
   private val planIdRegex = "(?<prefix>(plan_id=|id=#))\\d+".r
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
@@ -78,8 +78,8 @@ trait PlanStabilitySuite extends DisableAdaptiveExecutionSuite {
   }
 
   private val referenceRegex = "#\\d+".r
-  private val normalizeRegex = "#\\d+L?".r
-  private val planIdRegex = "plan_id=\\d+".r
+  private val exprIdRegexp = "(?<prefix>(?<!id=)#)\\d+L?".r
+  private val planIdRegex = "(?<prefix>(plan_id=|id=#))\\d+".r
 
   private val clsName = this.getClass.getCanonicalName
 
@@ -231,18 +231,15 @@ trait PlanStabilitySuite extends DisableAdaptiveExecutionSuite {
   }
 
   private def normalizeIds(plan: String): String = {
-    val map = new mutable.HashMap[String, String]()
-    normalizeRegex.findAllMatchIn(plan).map(_.toString)
-      .foreach(map.getOrElseUpdate(_, (map.size + 1).toString))
-    val exprIdNormalized = normalizeRegex.replaceAllIn(
-      plan, regexMatch => s"#${map(regexMatch.toString)}")
+    val exprIdMap = new mutable.HashMap[String, String]()
+    val exprIdNormalized = exprIdRegexp.replaceAllIn(plan,
+      m => exprIdMap.getOrElseUpdate(m.toString(), s"${m.group("prefix")}${exprIdMap.size + 1}"))
 
-    // Normalize the plan id in Exchange nodes. See `Exchange.stringArgs`.
+    // Normalize the plan ids in Exchange and Subquery nodes.
+    // See `Exchange.stringArgs` and `SubqueryExec.stringArgs`
     val planIdMap = new mutable.HashMap[String, String]()
-    planIdRegex.findAllMatchIn(exprIdNormalized).map(_.toString)
-      .foreach(planIdMap.getOrElseUpdate(_, (planIdMap.size + 1).toString))
-    planIdRegex.replaceAllIn(
-      exprIdNormalized, regexMatch => s"plan_id=${planIdMap(regexMatch.toString)}")
+    planIdRegex.replaceAllIn(exprIdNormalized,
+      m => planIdMap.getOrElseUpdate(s"$m", s"${m.group("prefix")}${planIdMap.size + 1}"))
   }
 
   private def normalizeLocation(plan: String): String = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes and id normalization in `PlanStabilitySuite`s and 

### Why are the changes needed?
Currently if we run a subset of `PlanStabilitySuite`s then it might fail due to plan and expression id conflixts:
```
build/sbt "sql/testOnly *TPCDSV1_4_PlanStabilitySuite"
...
[info] - check simplified (tpcds-v1.4/q9) *** FAILED *** (81 milliseconds)
```
This is because the expr id regex doesn't skip and plan id regex doesn't take into account that the plan id is formatted as `id=#...` in `SubqueryExec` nodes.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs + manual subset run.

### Was this patch authored or co-authored using generative AI tooling?

No.