### PR TITLE
[SPARK-52848][SQL] Avoid cast to `Double` in casting TIME/TIMESTAMP to DECIMAL

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
@@ -810,7 +810,7 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
         ),
         condition = "NUMERIC_VALUE_OUT_OF_RANGE.WITH_SUGGESTION",
         parameters = Map(
-          "value" -> "86399.123456",
+          "value" -> "86399.123456000",
           "precision" -> "2",
           "scale" -> "0",
           "config" -> """"spark.sql.ansi.enabled""""

--- a/sql/core/src/test/resources/sql-tests/results/cast.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cast.sql.out
@@ -2305,7 +2305,7 @@ org.apache.spark.SparkArithmeticException
     "config" : "\"spark.sql.ansi.enabled\"",
     "precision" : "1",
     "scale" : "0",
-    "value" : "60.0"
+    "value" : "60.000000000"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2330,7 +2330,7 @@ org.apache.spark.SparkArithmeticException
     "config" : "\"spark.sql.ansi.enabled\"",
     "precision" : "3",
     "scale" : "0",
-    "value" : "3600.0"
+    "value" : "3600.000000000"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2355,7 +2355,7 @@ org.apache.spark.SparkArithmeticException
     "config" : "\"spark.sql.ansi.enabled\"",
     "precision" : "5",
     "scale" : "2",
-    "value" : "36000.0"
+    "value" : "36000.000000000"
   },
   "queryContext" : [ {
     "objectType" : "",


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to simplify casting TIME/TIMESTAMP to DECIMAL, and avoid intermediate casting to Double.

### Why are the changes needed?
To avoid unnecessary arithmetic operations and to improve code maintenance.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the affected test suites:
```
$ build/sbt "test:testOnly *CastWithAnsiOnSuite"
$ build/sbt "test:testOnly *CastWithAnsiOffSuite"
$ build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z cast.sql"
```


### Was this patch authored or co-authored using generative AI tooling?
No.
