### PR TITLE
[SPARK-52432][SDP][SQL] Scope DataflowGraphRegistry to Session

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/DataflowGraphRegistry.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/DataflowGraphRegistry.scala
@@ -28,9 +28,6 @@ import org.apache.spark.sql.pipelines.graph.GraphRegistrationContext
  * PipelinesHandler when CreateDataflowGraph is called, and the PipelinesHandler also supports
  * attaching flows/datasets to a graph.
  */
-// TODO(SPARK-51727): Currently DataflowGraphRegistry is a singleton, but it should instead be
-//  scoped to a single SparkSession for proper isolation between pipelines that are run on the
-//  same cluster.
 class DataflowGraphRegistry {
 
   private val dataflowGraphs = new ConcurrentHashMap[String, GraphRegistrationContext]()

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/DataflowGraphRegistry.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/DataflowGraphRegistry.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.pipelines.graph.GraphRegistrationContext
 // TODO(SPARK-51727): Currently DataflowGraphRegistry is a singleton, but it should instead be
 //  scoped to a single SparkSession for proper isolation between pipelines that are run on the
 //  same cluster.
-object DataflowGraphRegistry {
+class DataflowGraphRegistry {
 
   private val dataflowGraphs = new ConcurrentHashMap[String, GraphRegistrationContext]()
 
@@ -55,7 +55,7 @@ object DataflowGraphRegistry {
 
   /** Retrieves the graph for a given id, and throws if the id could not be found. */
   def getDataflowGraphOrThrow(dataflowGraphId: String): GraphRegistrationContext =
-    DataflowGraphRegistry.getDataflowGraph(dataflowGraphId).getOrElse {
+    getDataflowGraph(dataflowGraphId).getOrElse {
       throw new SparkException(
         errorClass = "DATAFLOW_GRAPH_NOT_FOUND",
         messageParameters = Map("graphId" -> dataflowGraphId),

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
@@ -28,7 +28,6 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.connect.common.DataTypeProtoConverter
 import org.apache.spark.sql.connect.service.SessionHolder
 import org.apache.spark.sql.pipelines.Language.Python
@@ -68,7 +67,7 @@ private[connect] object PipelinesHandler extends Logging {
     cmd.getCommandTypeCase match {
       case proto.PipelineCommand.CommandTypeCase.CREATE_DATAFLOW_GRAPH =>
         val createdGraphId =
-          createDataflowGraph(cmd.getCreateDataflowGraph, sessionHolder.session)
+          createDataflowGraph(cmd.getCreateDataflowGraph, sessionHolder)
         PipelineCommandResult
           .newBuilder()
           .setCreateDataflowGraphResult(
@@ -78,15 +77,15 @@ private[connect] object PipelinesHandler extends Logging {
           .build()
       case proto.PipelineCommand.CommandTypeCase.DROP_DATAFLOW_GRAPH =>
         logInfo(s"Drop pipeline cmd received: $cmd")
-        DataflowGraphRegistry.dropDataflowGraph(cmd.getDropDataflowGraph.getDataflowGraphId)
+        sessionHolder.dropDataflowGraph(cmd.getDropDataflowGraph.getDataflowGraphId)
         defaultResponse
       case proto.PipelineCommand.CommandTypeCase.DEFINE_DATASET =>
         logInfo(s"Define pipelines dataset cmd received: $cmd")
-        defineDataset(cmd.getDefineDataset, sessionHolder.session)
+        defineDataset(cmd.getDefineDataset, sessionHolder)
         defaultResponse
       case proto.PipelineCommand.CommandTypeCase.DEFINE_FLOW =>
         logInfo(s"Define pipelines flow cmd received: $cmd")
-        defineFlow(cmd.getDefineFlow, transformRelationFunc, sessionHolder.session)
+        defineFlow(cmd.getDefineFlow, transformRelationFunc, sessionHolder)
         defaultResponse
       case proto.PipelineCommand.CommandTypeCase.START_RUN =>
         logInfo(s"Start pipeline cmd received: $cmd")
@@ -94,7 +93,7 @@ private[connect] object PipelinesHandler extends Logging {
         defaultResponse
       case proto.PipelineCommand.CommandTypeCase.DEFINE_SQL_GRAPH_ELEMENTS =>
         logInfo(s"Register sql datasets cmd received: $cmd")
-        defineSqlGraphElements(cmd.getDefineSqlGraphElements, sessionHolder.session)
+        defineSqlGraphElements(cmd.getDefineSqlGraphElements, sessionHolder)
         defaultResponse
       case other => throw new UnsupportedOperationException(s"$other not supported")
     }
@@ -102,24 +101,24 @@ private[connect] object PipelinesHandler extends Logging {
 
   private def createDataflowGraph(
       cmd: proto.PipelineCommand.CreateDataflowGraph,
-      spark: SparkSession): String = {
+      sessionHolder: SessionHolder): String = {
     val defaultCatalog = Option
       .when(cmd.hasDefaultCatalog)(cmd.getDefaultCatalog)
       .getOrElse {
         logInfo(s"No default catalog was supplied. Falling back to the current catalog.")
-        spark.catalog.currentCatalog()
+        sessionHolder.session.catalog.currentCatalog()
       }
 
     val defaultDatabase = Option
       .when(cmd.hasDefaultDatabase)(cmd.getDefaultDatabase)
       .getOrElse {
         logInfo(s"No default database was supplied. Falling back to the current database.")
-        spark.catalog.currentDatabase
+        sessionHolder.session.catalog.currentDatabase
       }
 
     val defaultSqlConf = cmd.getSqlConfMap.asScala.toMap
 
-    DataflowGraphRegistry.createDataflowGraph(
+    sessionHolder.createDataflowGraph(
       defaultCatalog = defaultCatalog,
       defaultDatabase = defaultDatabase,
       defaultSqlConf = defaultSqlConf)
@@ -127,24 +126,25 @@ private[connect] object PipelinesHandler extends Logging {
 
   private def defineSqlGraphElements(
       cmd: proto.PipelineCommand.DefineSqlGraphElements,
-      session: SparkSession): Unit = {
+      sessionHolder: SessionHolder): Unit = {
     val dataflowGraphId = cmd.getDataflowGraphId
 
-    val graphElementRegistry = DataflowGraphRegistry.getDataflowGraphOrThrow(dataflowGraphId)
+    val graphElementRegistry = sessionHolder.getDataflowGraphOrThrow(dataflowGraphId)
     val sqlGraphElementRegistrationContext = new SqlGraphRegistrationContext(graphElementRegistry)
-    sqlGraphElementRegistrationContext.processSqlFile(cmd.getSqlText, cmd.getSqlFilePath, session)
+    sqlGraphElementRegistrationContext.processSqlFile(
+      cmd.getSqlText, cmd.getSqlFilePath, sessionHolder.session)
   }
 
   private def defineDataset(
       dataset: proto.PipelineCommand.DefineDataset,
-      sparkSession: SparkSession): Unit = {
+      sessionHolder: SessionHolder): Unit = {
     val dataflowGraphId = dataset.getDataflowGraphId
-    val graphElementRegistry = DataflowGraphRegistry.getDataflowGraphOrThrow(dataflowGraphId)
+    val graphElementRegistry = sessionHolder.getDataflowGraphOrThrow(dataflowGraphId)
 
     dataset.getDatasetType match {
       case proto.DatasetType.MATERIALIZED_VIEW | proto.DatasetType.TABLE =>
         val tableIdentifier =
-          GraphIdentifierManager.parseTableIdentifier(dataset.getDatasetName, sparkSession)
+          GraphIdentifierManager.parseTableIdentifier(dataset.getDatasetName, sessionHolder.session)
         graphElementRegistry.registerTable(
           Table(
             identifier = tableIdentifier,
@@ -165,7 +165,7 @@ private[connect] object PipelinesHandler extends Logging {
             isStreamingTable = dataset.getDatasetType == proto.DatasetType.TABLE))
       case proto.DatasetType.TEMPORARY_VIEW =>
         val viewIdentifier =
-          GraphIdentifierManager.parseTableIdentifier(dataset.getDatasetName, sparkSession)
+          GraphIdentifierManager.parseTableIdentifier(dataset.getDatasetName, sessionHolder.session)
 
         graphElementRegistry.registerView(
           TemporaryView(
@@ -184,14 +184,14 @@ private[connect] object PipelinesHandler extends Logging {
   private def defineFlow(
       flow: proto.PipelineCommand.DefineFlow,
       transformRelationFunc: Relation => LogicalPlan,
-      sparkSession: SparkSession): Unit = {
+      sessionHolder: SessionHolder): Unit = {
     val dataflowGraphId = flow.getDataflowGraphId
-    val graphElementRegistry = DataflowGraphRegistry.getDataflowGraphOrThrow(dataflowGraphId)
+    val graphElementRegistry = sessionHolder.getDataflowGraphOrThrow(dataflowGraphId)
 
     val isImplicitFlow = flow.getFlowName == flow.getTargetDatasetName
 
     val flowIdentifier = GraphIdentifierManager
-      .parseTableIdentifier(name = flow.getFlowName, spark = sparkSession)
+      .parseTableIdentifier(name = flow.getFlowName, spark = sessionHolder.session)
 
     // If the flow is not an implicit flow (i.e. one defined as part of dataset creation), then
     // it must be a single-part identifier.
@@ -205,7 +205,7 @@ private[connect] object PipelinesHandler extends Logging {
       new UnresolvedFlow(
         identifier = flowIdentifier,
         destinationIdentifier = GraphIdentifierManager
-          .parseTableIdentifier(name = flow.getTargetDatasetName, spark = sparkSession),
+          .parseTableIdentifier(name = flow.getTargetDatasetName, spark = sessionHolder.session),
         func =
           FlowAnalysis.createFlowFunctionFromLogicalPlan(transformRelationFunc(flow.getRelation)),
         sqlConf = flow.getSqlConfMap.asScala.toMap,
@@ -224,7 +224,7 @@ private[connect] object PipelinesHandler extends Logging {
       responseObserver: StreamObserver[ExecutePlanResponse],
       sessionHolder: SessionHolder): Unit = {
     val dataflowGraphId = cmd.getDataflowGraphId
-    val graphElementRegistry = DataflowGraphRegistry.getDataflowGraphOrThrow(dataflowGraphId)
+    val graphElementRegistry = sessionHolder.getDataflowGraphOrThrow(dataflowGraphId)
     val tableFiltersResult = createTableFilters(cmd, graphElementRegistry, sessionHolder)
 
     // We will use this variable to store the run failure event if it occurs. This will be set

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
@@ -132,7 +132,9 @@ private[connect] object PipelinesHandler extends Logging {
     val graphElementRegistry = sessionHolder.getDataflowGraphOrThrow(dataflowGraphId)
     val sqlGraphElementRegistrationContext = new SqlGraphRegistrationContext(graphElementRegistry)
     sqlGraphElementRegistrationContext.processSqlFile(
-      cmd.getSqlText, cmd.getSqlFilePath, sessionHolder.session)
+      cmd.getSqlText,
+      cmd.getSqlFilePath,
+      sessionHolder.session)
   }
 
   private def defineDataset(
@@ -144,7 +146,9 @@ private[connect] object PipelinesHandler extends Logging {
     dataset.getDatasetType match {
       case proto.DatasetType.MATERIALIZED_VIEW | proto.DatasetType.TABLE =>
         val tableIdentifier =
-          GraphIdentifierManager.parseTableIdentifier(dataset.getDatasetName, sessionHolder.session)
+          GraphIdentifierManager.parseTableIdentifier(
+            dataset.getDatasetName,
+            sessionHolder.session)
         graphElementRegistry.registerTable(
           Table(
             identifier = tableIdentifier,
@@ -165,7 +169,9 @@ private[connect] object PipelinesHandler extends Logging {
             isStreamingTable = dataset.getDatasetType == proto.DatasetType.TABLE))
       case proto.DatasetType.TEMPORARY_VIEW =>
         val viewIdentifier =
-          GraphIdentifierManager.parseTableIdentifier(dataset.getDatasetName, sessionHolder.session)
+          GraphIdentifierManager.parseTableIdentifier(
+            dataset.getDatasetName,
+            sessionHolder.session)
 
         graphElementRegistry.registerView(
           TemporaryView(

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.connect.pipelines.DataflowGraphRegistry
 import org.apache.spark.sql.connect.planner.PythonStreamingQueryListener
 import org.apache.spark.sql.connect.planner.StreamingForeachBatchHelper
 import org.apache.spark.sql.connect.service.SessionHolder.{ERROR_CACHE_SIZE, ERROR_CACHE_TIMEOUT_SEC}
-import org.apache.spark.sql.pipelines.graph.{GraphRegistrationContext, PipelineUpdateContext}
+import org.apache.spark.sql.pipelines.graph.PipelineUpdateContext
 import org.apache.spark.sql.streaming.StreamingQueryListener
 import org.apache.spark.util.{SystemClock, Utils}
 
@@ -127,7 +127,7 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
     new ConcurrentHashMap[String, PipelineUpdateContext]()
 
   // Registry for dataflow graphs specific to this session
-  private lazy val dataflowGraphRegistry: DataflowGraphRegistry = new DataflowGraphRegistry()
+  private[connect] lazy val dataflowGraphRegistry = new DataflowGraphRegistry()
 
   // Handles Python process clean up for streaming queries. Initialized on first use in a query.
   private[connect] lazy val streamingForeachBatchRunnerCleanerCache =
@@ -325,7 +325,7 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
     removeAllPipelineExecutions()
 
     // Clean up dataflow graphs
-    dropAllDataflowGraphs()
+    dataflowGraphRegistry.dropAllDataflowGraphs()
 
     // if there is a server side listener, clean up related resources
     if (streamingServersideListenerHolder.isServerSideListenerRegistered) {
@@ -491,48 +491,6 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
    */
   private[connect] def getPipelineExecution(graphId: String): Option[PipelineUpdateContext] = {
     Option(pipelineExecutions.get(graphId))
-  }
-
-  private[connect] def createDataflowGraph(
-      defaultCatalog: String,
-      defaultDatabase: String,
-      defaultSqlConf: Map[String, String]): String = {
-    dataflowGraphRegistry.createDataflowGraph(defaultCatalog, defaultDatabase, defaultSqlConf)
-  }
-
-  /**
-   * Retrieves the dataflow graph for the given graph ID.
-   */
-  private[connect] def getDataflowGraph(graphId: String): Option[GraphRegistrationContext] = {
-    dataflowGraphRegistry.getDataflowGraph(graphId)
-  }
-
-  /**
-   * Retrieves the dataflow graph for the given graph ID, throwing if not found.
-   */
-  private[connect] def getDataflowGraphOrThrow(graphId: String): GraphRegistrationContext = {
-    dataflowGraphRegistry.getDataflowGraphOrThrow(graphId)
-  }
-
-  /**
-   * Removes the dataflow graph with the given ID.
-   */
-  private[connect] def dropDataflowGraph(graphId: String): Unit = {
-    dataflowGraphRegistry.dropDataflowGraph(graphId)
-  }
-
-  /**
-   * Returns all dataflow graphs in this session.
-   */
-  private[connect] def getAllDataflowGraphs: Seq[GraphRegistrationContext] = {
-    dataflowGraphRegistry.getAllDataflowGraphs
-  }
-
-  /**
-   * Removes all dataflow graphs from this session. Called during session cleanup.
-   */
-  private[connect] def dropAllDataflowGraphs(): Unit = {
-    dataflowGraphRegistry.dropAllDataflowGraphs()
   }
 
   /**

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -494,9 +494,9 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
   }
 
   private[connect] def createDataflowGraph(
-       defaultCatalog: String,
-       defaultDatabase: String,
-       defaultSqlConf: Map[String, String]): String = {
+      defaultCatalog: String,
+      defaultDatabase: String,
+      defaultSqlConf: Map[String, String]): String = {
     dataflowGraphRegistry.createDataflowGraph(defaultCatalog, defaultDatabase, defaultSqlConf)
   }
 
@@ -529,8 +529,7 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
   }
 
   /**
-   * Removes all dataflow graphs from this session.
-   * Called during session cleanup.
+   * Removes all dataflow graphs from this session. Called during session cleanup.
    */
   private[connect] def dropAllDataflowGraphs(): Unit = {
     dataflowGraphRegistry.dropAllDataflowGraphs()

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
@@ -85,10 +85,11 @@ class PythonPipelineSuite
 
     // get the session holder for the active session
     val sessionHolder =
-      SparkConnectService.sessionManager.getIsolatedSessionIfPresent(activateSessions.head.key)
+      SparkConnectService.sessionManager
+        .getIsolatedSessionIfPresent(activateSessions.head.key)
         .getOrElse {
-        throw new RuntimeException("Session not found")
-      }
+          throw new RuntimeException("Session not found")
+        }
 
     // get all dataflow graphs from the session holder
     val dataflowGraphContexts = sessionHolder.getAllDataflowGraphs

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
@@ -79,7 +79,7 @@ class PythonPipelineSuite
         s"Python process failed with exit code $exitCode. Output: ${output.mkString("\n")}")
     }
 
-    val dataflowGraphContexts = DataflowGraphRegistry.getAllDataflowGraphs
+    val dataflowGraphContexts = getSessionHolder.getAllDataflowGraphs
     assert(dataflowGraphContexts.size == 1)
 
     dataflowGraphContexts.head.toDataflowGraph

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerSuite.scala
@@ -17,10 +17,13 @@
 
 package org.apache.spark.sql.connect.pipelines
 
+import java.util.UUID
+
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.{DatasetType, Expression, PipelineCommand, Relation, UnresolvedTableValuedFunction}
 import org.apache.spark.connect.proto.PipelineCommand.{DefineDataset, DefineFlow}
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.connect.service.{SessionKey, SparkConnectService}
 
 class SparkDeclarativePipelinesServerSuite
     extends SparkDeclarativePipelinesServerTest
@@ -246,6 +249,245 @@ class SparkDeclarativePipelinesServerSuite
       assert(spark.table("spark_catalog.curr.tableA").count() == 5)
       assert(spark.table("spark_catalog.curr.tableB").count() == 5)
       assert(spark.table("spark_catalog.other.tableD").count() == 5)
+    }
+  }
+
+  test("dataflow graphs are session-specific") {
+    withRawBlockingStub { implicit stub =>
+      // Create a dataflow graph in the default session
+      val graphId1 = createDataflowGraph
+
+      // Register a dataset in the default session
+      sendPlan(
+        buildPlanFromPipelineCommand(
+          PipelineCommand
+            .newBuilder()
+            .setDefineDataset(
+              DefineDataset
+                .newBuilder()
+                .setDataflowGraphId(graphId1)
+                .setDatasetName("session1_table")
+                .setDatasetType(DatasetType.MATERIALIZED_VIEW))
+            .build()))
+
+      // Verify the graph exists in the default session
+      assert(getDefaultSessionHolder.getAllDataflowGraphs.size == 1)
+    }
+
+    // Create a second session with different user/session ID
+    val newSessionId = UUID.randomUUID().toString
+    val newSessionUserId = "session2_user"
+
+    withRawBlockingStub { implicit stub =>
+      // Override the test context to use different session
+      val newSessionExecuteRequest = buildExecutePlanRequest(
+        buildCreateDataflowGraphPlan(
+          proto.PipelineCommand.CreateDataflowGraph
+            .newBuilder()
+            .setDefaultCatalog("spark_catalog")
+            .setDefaultDatabase("default")
+            .build())).toBuilder
+        .setUserContext(proto.UserContext
+          .newBuilder()
+          .setUserId(newSessionUserId)
+          .build())
+        .setSessionId(newSessionId)
+        .build()
+
+      val response = stub.executePlan(newSessionExecuteRequest)
+      val graphId2 =
+        response.next().getPipelineCommandResult.getCreateDataflowGraphResult.getDataflowGraphId
+
+      // Register a different dataset in second session
+      val session2DefineRequest = buildExecutePlanRequest(
+        buildPlanFromPipelineCommand(
+          PipelineCommand
+            .newBuilder()
+            .setDefineDataset(
+              DefineDataset
+                .newBuilder()
+                .setDataflowGraphId(graphId2)
+                .setDatasetName("session2_table")
+                .setDatasetType(DatasetType.MATERIALIZED_VIEW))
+            .build())).toBuilder
+        .setUserContext(proto.UserContext
+          .newBuilder()
+          .setUserId(newSessionUserId)
+          .build())
+        .setSessionId(newSessionId)
+        .build()
+
+      stub.executePlan(session2DefineRequest).next()
+
+      // Verify session isolation - each session should only see its own graphs
+      val newSessionHolder = SparkConnectService.sessionManager
+        .getIsolatedSessionIfPresent(SessionKey(newSessionUserId, newSessionId))
+        .getOrElse(throw new RuntimeException("New session not found"))
+
+      val defaultSessionGraphs = getDefaultSessionHolder.getAllDataflowGraphs
+      val newSessionGraphs = newSessionHolder.getAllDataflowGraphs
+
+      assert(defaultSessionGraphs.size == 1)
+      assert(newSessionGraphs.size == 1)
+
+      assert(
+        defaultSessionGraphs.head.toDataflowGraph.tables
+          .exists(_.identifier.table == "session1_table"),
+        "Session 1 should have its own table")
+      assert(
+        newSessionGraphs.head.toDataflowGraph.tables
+          .exists(_.identifier.table == "session2_table"),
+        "Session 2 should have its own table")
+    }
+  }
+
+  test("dataflow graphs are cleaned up when session is closed") {
+    val testUserId = "test_user"
+    val testSessionId = UUID.randomUUID().toString
+
+    // Create a session and dataflow graph
+    withRawBlockingStub { implicit stub =>
+      val createGraphRequest = buildExecutePlanRequest(
+        buildCreateDataflowGraphPlan(
+          proto.PipelineCommand.CreateDataflowGraph
+            .newBuilder()
+            .setDefaultCatalog("spark_catalog")
+            .setDefaultDatabase("default")
+            .build())).toBuilder
+        .setUserContext(proto.UserContext
+          .newBuilder()
+          .setUserId(testUserId)
+          .build())
+        .setSessionId(testSessionId)
+        .build()
+
+      val response = stub.executePlan(createGraphRequest)
+      val graphId =
+        response.next().getPipelineCommandResult.getCreateDataflowGraphResult.getDataflowGraphId
+
+      // Register a dataset
+      val defineRequest = buildExecutePlanRequest(
+        buildPlanFromPipelineCommand(
+          PipelineCommand
+            .newBuilder()
+            .setDefineDataset(
+              DefineDataset
+                .newBuilder()
+                .setDataflowGraphId(graphId)
+                .setDatasetName("test_table")
+                .setDatasetType(DatasetType.MATERIALIZED_VIEW))
+            .build())).toBuilder
+        .setUserContext(proto.UserContext
+          .newBuilder()
+          .setUserId(testUserId)
+          .build())
+        .setSessionId(testSessionId)
+        .build()
+
+      stub.executePlan(defineRequest).next()
+
+      // Verify the graph exists
+      val sessionHolder = SparkConnectService.sessionManager
+        .getIsolatedSessionIfPresent(SessionKey(testUserId, testSessionId))
+        .get
+
+      val graphsBefore = sessionHolder.getAllDataflowGraphs
+      assert(graphsBefore.size == 1)
+
+      // Close the session
+      SparkConnectService.sessionManager.closeSession(SessionKey(testUserId, testSessionId))
+
+      // Verify the session is no longer available
+      val sessionAfterClose = SparkConnectService.sessionManager
+        .getIsolatedSessionIfPresent(SessionKey(testUserId, testSessionId))
+
+      assert(sessionAfterClose.isEmpty, "Session should be cleaned up after close")
+      // Verify the graph is removed
+      val graphsAfter = sessionHolder.getAllDataflowGraphs
+      assert(graphsAfter.isEmpty, "Graph should be removed after session close")
+    }
+  }
+
+  test("multiple dataflow graphs can exist in the same session") {
+    withRawBlockingStub { implicit stub =>
+      // Create two dataflow graphs in the same session
+      val graphId1 = createDataflowGraph
+      val graphId2 = createDataflowGraph
+
+      // Register datasets in both graphs
+      sendPlan(
+        buildPlanFromPipelineCommand(
+          PipelineCommand
+            .newBuilder()
+            .setDefineDataset(
+              DefineDataset
+                .newBuilder()
+                .setDataflowGraphId(graphId1)
+                .setDatasetName("graph1_table")
+                .setDatasetType(DatasetType.MATERIALIZED_VIEW))
+            .build()))
+
+      sendPlan(
+        buildPlanFromPipelineCommand(
+          PipelineCommand
+            .newBuilder()
+            .setDefineDataset(
+              DefineDataset
+                .newBuilder()
+                .setDataflowGraphId(graphId2)
+                .setDatasetName("graph2_table")
+                .setDatasetType(DatasetType.MATERIALIZED_VIEW))
+            .build()))
+
+      // Verify both graphs exist in the session
+      val sessionHolder = getDefaultSessionHolder
+      val graph1 = sessionHolder.getDataflowGraph(graphId1).getOrElse {
+        fail(s"Graph with ID $graphId1 not found in session")
+      }
+      val graph2 = sessionHolder.getDataflowGraph(graphId2).getOrElse {
+        fail(s"Graph with ID $graphId2 not found in session")
+      }
+      // Check that both graphs have their datasets registered
+      assert(graph1.toDataflowGraph.tables.exists(_.identifier.table == "graph1_table"))
+      assert(graph2.toDataflowGraph.tables.exists(_.identifier.table == "graph2_table"))
+    }
+  }
+
+  test("dropping a dataflow graph removes it from session") {
+    withRawBlockingStub { implicit stub =>
+      val graphId = createDataflowGraph
+
+      // Register a dataset
+      sendPlan(
+        buildPlanFromPipelineCommand(
+          PipelineCommand
+            .newBuilder()
+            .setDefineDataset(
+              DefineDataset
+                .newBuilder()
+                .setDataflowGraphId(graphId)
+                .setDatasetName("test_table")
+                .setDatasetType(DatasetType.MATERIALIZED_VIEW))
+            .build()))
+
+      // Verify the graph exists
+      val sessionHolder = getDefaultSessionHolder
+      val graphsBefore = sessionHolder.getAllDataflowGraphs
+      assert(graphsBefore.size == 1)
+
+      // Drop the graph
+      sendPlan(
+        buildPlanFromPipelineCommand(
+          PipelineCommand
+            .newBuilder()
+            .setDropDataflowGraph(PipelineCommand.DropDataflowGraph
+              .newBuilder()
+              .setDataflowGraphId(graphId))
+            .build()))
+
+      // Verify the graph is removed
+      val graphsAfter = sessionHolder.getAllDataflowGraphs
+      assert(graphsAfter.isEmpty, "Graph should be removed after drop")
     }
   }
 }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerSuite.scala
@@ -41,8 +41,7 @@ class SparkDeclarativePipelinesServerSuite
             .newBuilder()
             .build())).getPipelineCommandResult.getCreateDataflowGraphResult.getDataflowGraphId
       val definition =
-        DataflowGraphRegistry
-          .getDataflowGraphOrThrow(graphId)
+        getSessionHolder.getDataflowGraphOrThrow(graphId)
       assert(definition.defaultDatabase == "test_db")
     }
   }
@@ -115,8 +114,7 @@ class SparkDeclarativePipelinesServerSuite
                 |""".stripMargin)
 
       val definition =
-        DataflowGraphRegistry
-          .getDataflowGraphOrThrow(graphId)
+        getSessionHolder.getDataflowGraphOrThrow(graphId)
 
       val graph = definition.toDataflowGraph.resolve()
 
@@ -161,8 +159,7 @@ class SparkDeclarativePipelinesServerSuite
       }
 
       val definition =
-        DataflowGraphRegistry
-          .getDataflowGraphOrThrow(graphId)
+        getSessionHolder.getDataflowGraphOrThrow(graphId)
 
       registerPipelineDatasets(pipeline)
       val graph = definition.toDataflowGraph

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerSuite.scala
@@ -41,7 +41,7 @@ class SparkDeclarativePipelinesServerSuite
             .newBuilder()
             .build())).getPipelineCommandResult.getCreateDataflowGraphResult.getDataflowGraphId
       val definition =
-        getSessionHolder.getDataflowGraphOrThrow(graphId)
+        getDefaultSessionHolder.getDataflowGraphOrThrow(graphId)
       assert(definition.defaultDatabase == "test_db")
     }
   }
@@ -114,7 +114,7 @@ class SparkDeclarativePipelinesServerSuite
                 |""".stripMargin)
 
       val definition =
-        getSessionHolder.getDataflowGraphOrThrow(graphId)
+        getDefaultSessionHolder.getDataflowGraphOrThrow(graphId)
 
       val graph = definition.toDataflowGraph.resolve()
 
@@ -159,7 +159,7 @@ class SparkDeclarativePipelinesServerSuite
       }
 
       val definition =
-        getSessionHolder.getDataflowGraphOrThrow(graphId)
+        getDefaultSessionHolder.getDataflowGraphOrThrow(graphId)
 
       registerPipelineDatasets(pipeline)
       val graph = definition.toDataflowGraph

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerTest.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerTest.scala
@@ -29,14 +29,12 @@ import org.apache.spark.sql.pipelines.utils.PipelineTest
 class SparkDeclarativePipelinesServerTest extends SparkConnectServerTest {
 
   override def afterEach(): Unit = {
-    getSessionHolder.removeAllPipelineExecutions()
-    getSessionHolder.dropAllDataflowGraphs()
     PipelineTest.cleanupMetastore(spark)
     super.afterEach()
   }
 
   // Helper method to get the session holder
-  protected def getSessionHolder: SessionHolder = {
+  protected def getDefaultSessionHolder: SessionHolder = {
     SparkConnectService.sessionManager
       .getIsolatedSessionIfPresent(SessionKey(defaultUserId, defaultSessionId))
       .getOrElse(throw new RuntimeException("Session not found"))

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerTest.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerTest.scala
@@ -33,7 +33,7 @@ class SparkDeclarativePipelinesServerTest extends SparkConnectServerTest {
       .getIsolatedSessionIfPresent(SessionKey(defaultUserId, defaultSessionId))
       .foreach(s => {
         s.removeAllPipelineExecutions()
-        s.dropAllDataflowGraphs()
+        s.dataflowGraphRegistry.dropAllDataflowGraphs()
       })
     PipelineTest.cleanupMetastore(spark)
     super.afterEach()
@@ -42,8 +42,7 @@ class SparkDeclarativePipelinesServerTest extends SparkConnectServerTest {
   // Helper method to get the session holder
   protected def getDefaultSessionHolder: SessionHolder = {
     SparkConnectService.sessionManager
-      .getIsolatedSessionIfPresent(SessionKey(defaultUserId, defaultSessionId))
-      .getOrElse(throw new RuntimeException("Session not found"))
+      .getIsolatedSession(SessionKey(defaultUserId, defaultSessionId), None)
   }
 
   def buildPlanFromPipelineCommand(command: sc.PipelineCommand): sc.Plan = {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerTest.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerTest.scala
@@ -30,6 +30,12 @@ class SparkDeclarativePipelinesServerTest extends SparkConnectServerTest {
 
   override def afterEach(): Unit = {
     PipelineTest.cleanupMetastore(spark)
+    SparkConnectService.sessionManager
+      .getIsolatedSessionIfPresent(SessionKey(defaultUserId, defaultSessionId))
+      .foreach(s => {
+        s.removeAllPipelineExecutions()
+        s.dropAllDataflowGraphs()
+      })
     super.afterEach()
   }
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerTest.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerTest.scala
@@ -29,13 +29,13 @@ import org.apache.spark.sql.pipelines.utils.PipelineTest
 class SparkDeclarativePipelinesServerTest extends SparkConnectServerTest {
 
   override def afterEach(): Unit = {
-    PipelineTest.cleanupMetastore(spark)
     SparkConnectService.sessionManager
       .getIsolatedSessionIfPresent(SessionKey(defaultUserId, defaultSessionId))
       .foreach(s => {
         s.removeAllPipelineExecutions()
         s.dropAllDataflowGraphs()
       })
+    PipelineTest.cleanupMetastore(spark)
     super.afterEach()
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Scope `DataflowGraphRegistry` to spark connect session. This is done by adding it as a member to the spark connect [SessionHolder](https://github.com/apache/spark/blob/master/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala#L54). This is added here because pipeline executions are also [scoped](https://github.com/apache/spark/blob/master/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala#L125) to this class.

Added getter/setter methods to access dataflow graphs for the session. 

Added logic to drop all dataflow graphs when session is closed.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently `DataflowGraphRegistry` is a singleton, but it should instead be scoped to a single SparkSession for proper isolation between pipelines that are run on the same cluster.

This allows proper cleanup of pipeline resources when session is closed.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added new testcases to test data flow graph session isolation and proper clean up.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No