### PR TITLE
[SPARK-52862][PYTHON][CONNECT] Fix the nullability check of `Decimal('NaN')`

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -242,7 +242,11 @@ class LocalDataToArrowConversion:
                     return None
                 else:
                     assert isinstance(value, decimal.Decimal)
-                    return None if value.is_nan() else value
+                    if value.is_nan():
+                        if not nullable:
+                            raise PySparkValueError(f"input for {dataType} must not be None")
+                        return None
+                    return value
 
             return convert_decimal
 

--- a/python/pyspark/sql/tests/test_creation.py
+++ b/python/pyspark/sql/tests/test_creation.py
@@ -24,6 +24,7 @@ from typing import cast
 from pyspark.sql import Row
 import pyspark.sql.functions as F
 from pyspark.sql.types import (
+    DecimalType,
     StructType,
     StructField,
     StringType,
@@ -144,6 +145,12 @@ class DataFrameCreationTestsMixin:
             self.spark.createDataFrame(data=[Decimal("NaN")], schema="decimal").collect(),
             [Row(value=None)],
         )
+
+    def test_check_decimal_nan(self):
+        data = [Row(dec=Decimal("NaN"))]
+        schema = StructType([StructField("dec", DecimalType(), False)])
+        with self.assertRaises(PySparkValueError):
+            self.spark.createDataFrame(data=data, schema=schema)
 
     def test_invalid_argument_create_dataframe(self):
         with self.assertRaises(PySparkTypeError) as pe:

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2707,7 +2707,9 @@ def _make_type_verifier(
             return "field %s in %s" % (n, name)
 
     def verify_nullability(obj: Any) -> bool:
-        if obj is None:
+        if obj is None or (isinstance(obj, decimal.Decimal) and obj.is_nan()):
+            # Spark's DecimalType doesn't support NaN,
+            # casting DoubleType NaN to DecimalType will return Null.
             if nullable:
                 return True
             else:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix the nullability check of Decimal('NaN')


### Why are the changes needed?
It is a long-standing issue that the nullability check of Decimal('NaN') is not correct:

```py
from decimal import Decimal
from pyspark.sql.types import *

data = [Row(dec=Decimal("NaN"))]
schema = StructType([StructField("dec", DecimalType(), False)])
df = spark.createDataFrame(data=data, schema=schema)

In [4]: df.collect()
Out[4]: [Row(dec=None)]

In [5]: df.show()
...
Py4JJavaError: An error occurred while calling o67.showString.
: org.apache.spark.SparkException: Job aborted due to stage failure: Task 6 in stage 2.0 failed 1 times, most recent failure: Lost task 6.0 in stage 2.0 (TID 11) (localhost executor driver): java.lang.NullPointerException: Cannot invoke "org.apache.spark.sql.types.Decimal.toPlainString()" because "<local2>" is null
...
```

it should fail on creation, because `Decimal("NaN")` will be treated as `Null` value


### Does this PR introduce _any_ user-facing change?
The creation should fail

### How was this patch tested?
new tests

### Was this patch authored or co-authored using generative AI tooling?
No