### PR TITLE
[SPARK-52865][SQL]Remove usage of deprecated FileCommitProtocol.newTaskTempFile method

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatDataWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatDataWriter.scala
@@ -172,7 +172,7 @@ class SingleDirectoryDataWriter(
     val currentPath = committer.newTaskTempFile(
       taskAttemptContext,
       None,
-      f"-c$fileCounter%03d" + ext)
+      FileNameSpec("", f"-c$fileCounter%03d" + ext))
 
     currentWriter = description.outputWriterFactory.newInstance(
       path = currentPath,


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR replaces deprecated FileCommitProtocol.newTaskTempFile method with non-deprecated alternative.


### Why are the changes needed?
To clean up deprecated APIs.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
