### PR TITLE
[SPARK-52867][SQL] Remove redundant GetTimestamp

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -668,6 +668,16 @@ class DateFunctionsSuite extends QueryTest with SharedSparkSession {
     assert(e.getCause.isInstanceOf[IllegalArgumentException])
     assert(e.getMessage.contains("You may get a different result due to the upgrading to Spark"))
 
+    // Format is invalid when input is not StringType.
+    checkAnswer(
+      df.select(to_date(col("t"), "yyyy-MM")),
+      Seq(Row(Date.valueOf("2015-07-22")), Row(Date.valueOf("2014-12-31")),
+        Row(Date.valueOf("2014-12-31"))))
+    checkAnswer(
+      df.select(to_date(col("d"), "yyyy-MM")),
+      Seq(Row(Date.valueOf("2015-07-22")), Row(Date.valueOf("2015-07-01")),
+        Row(Date.valueOf("2014-12-31"))))
+
     // February
     val x1 = "2016-02-29"
     val x2 = "2017-02-29"
@@ -1014,6 +1024,10 @@ class DateFunctionsSuite extends QueryTest with SharedSparkSession {
           Row(ts1), Row(ts2)))
         checkAnswer(df.select(to_timestamp(col("d"), "yyyy-MM-dd")), Seq(
           Row(ts_date1), Row(ts_date2)))
+
+        // Format is invalid when input is not StringType.
+        checkAnswer(df.select(to_timestamp(col("ts"), "yyyy-MM-dd")), Seq(
+          Row(ts1), Row(ts2)))
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove redundant `GetTimestamp` for `ParseToDate` when left's `dateType` is `TimestampType` and `ParseToTimestamp` when `dateType` is the same as left's `dateType`.


### Why are the changes needed?
Simplify plan.
```
select to_date(t, 'yyyy-MM') from time

before
*(1) Project [cast(gettimestamp(t#7, yyyy-MM, TimestampType, Some(America/Los_Angeles), false) as date) AS to_date(t, yyyy-MM)#9]
+- *(1) ColumnarToRow
   +- FileScan parquet

after
*(1) Project [cast(t#7 as date) AS to_date(t, yyyy-MM)#9]
+- *(1) ColumnarToRow
   +- FileScan parquet
```

```
select to_timestamp(t, 'yyyy-MM') from time

before
*(1) Project [gettimestamp(t#7, yyyy-MM, TimestampType, Some(America/Los_Angeles), false) AS to_timestamp(t, yyyy-MM)#11]
+- *(1) ColumnarToRow
   +- FileScan parquet

after
*(1) Project [t#7 AS to_timestamp(t, yyyy-MM)#11]
+- *(1) ColumnarToRow
   +- FileScan parquet
```


### Was this patch authored or co-authored using generative AI tooling?
No.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
UT.
