### PR TITLE
[SPARK-52896][SQL] Match attribute `ExprId` in `OuterReference` with `ExprId` of exposed outer attribute

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -259,6 +259,17 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val CORRELATE_OUTER_REFERENCES_TO_EXPOSED_OUTER_ATTRIBUTES =
+    buildConf("spark.sql.analyzer.correlateOuterReferencesToExposedOuterAttributes")
+    .internal()
+    .version("4.1.0")
+    .doc(
+      "When true, attributes in outer references must have same expression IDs as outer " +
+      "attributes exposed by subquery expression."
+    )
+    .booleanConf
+    .createWithDefault(true)
+
   val BLOCK_CREATE_TEMP_TABLE_USING_PROVIDER =
     buildConf("spark.sql.legacy.blockCreateTempTableUsingProvider")
       .doc("If enabled, we fail legacy CREATE TEMPORARY TABLE ... USING provider during parsing.")

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/udf/postgreSQL/udf-aggregates_part1.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/udf/postgreSQL/udf-aggregates_part1.sql.out
@@ -456,7 +456,7 @@ having exists (select 1 from onek b where udf(sum(distinct a.four)) = b.four)
 Project [ten#x, udf(sum(DISTINCT four))#xL]
 +- Filter exists#x [sum(DISTINCT four)#xL]
    :  +- Project [1 AS 1#x]
-   :     +- Filter (outer(udf(sum(DISTINCT four))#xL) = cast(four#x as bigint))
+   :     +- Filter (cast(udf(cast(outer(sum(DISTINCT four)#xL) as string)) as bigint) = cast(four#x as bigint))
    :        +- SubqueryAlias b
    :           +- SubqueryAlias spark_catalog.default.onek
    :              +- Relation spark_catalog.default.onek[unique1#x,unique2#x,two#x,four#x,ten#x,twenty#x,hundred#x,thousand#x,twothousand#x,fivethous#x,tenthous#x,odd#x,even#x,stringu1#x,stringu2#x,string4#x] parquet

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.SparkRuntimeException
-import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
+import org.apache.spark.sql.catalyst.expressions.{EqualTo, NamedExpression, OuterReference, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftSemi}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Join, LogicalPlan, Project, Sort, Union}
 import org.apache.spark.sql.execution._
@@ -2845,5 +2845,45 @@ class SubquerySuite extends QueryTest
       Row(false) :: Row(false) :: Row(false) :: Row(false) :: Row(false)
         :: Row(true) :: Row(true) :: Row(true) :: Nil
     )
+  }
+
+  test("SPARK-52896: Outer reference ExprId should match exposed attribute") {
+    for (confValue <- Seq(true, false)) {
+      withSQLConf(
+        SQLConf.CORRELATE_OUTER_REFERENCES_TO_EXPOSED_OUTER_ATTRIBUTES.key ->
+        confValue.toString
+      ) {
+        val plan =
+          sql(
+            """
+              | SELECT col1
+              | FROM VALUES(1,2)
+              | GROUP BY col1
+              | HAVING MAX(col2) == (SELECT 1 WHERE MAX(col2) = 1)
+              |
+          """.stripMargin).queryExecution.analyzed
+
+        // Expected plan:
+        // Project
+        // +- Filter (scalar-subquery)
+        // :  +- Project
+        // :     +- Filter
+        // :        +- OneRowRelation
+        // +- Aggregate
+        //   +- LocalRelation
+
+        val havingNode = plan.asInstanceOf[Project].child.asInstanceOf[Filter]
+        val subquery =
+          havingNode.condition.asInstanceOf[EqualTo].right.asInstanceOf[SubqueryExpression]
+        val subqueryFilter = subquery.plan.asInstanceOf[Project].child.asInstanceOf[Filter]
+
+        val exposedAttribute = subquery.getOuterAttrs.head.asInstanceOf[NamedExpression]
+        val outerReferenceAttribute = subqueryFilter.condition.asInstanceOf[EqualTo].collectFirst {
+          case outerReference: OuterReference => outerReference.e
+        }.get
+
+        assert(exposedAttribute.exprId == outerReferenceAttribute.exprId == confValue)
+      }
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Match attribute `ExprId` in `OuterReference` with `ExprId` of exposed outer attribute in `SubqueryExpression`.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
For a query like:

```
sql(
            """
              | SELECT col1
              | FROM VALUES(1,2)
              | GROUP BY col1
              | HAVING MAX(col2) == (SELECT 1 WHERE MAX(col2) = 1)
              |
          """.stripMargin)
```

without the proposed fix, the analyzed plan we get:

```
Project [col1#291]
+- Filter (max(col2)#297 = scalar-subquery#293 [max(col2)#298])
   :  +- Project [1 AS 1#296]
   :     +- Filter (outer(max(col2)#297) = 1)
   :        +- OneRowRelation
   +- Aggregate [col1#291], [col1#291, max(col2#292) AS max(col2)#297, max(col2#292) AS max(col2)#298]
      +- LocalRelation [col1#291, col2#292]
```

Because we had `max(col2)` in a subquery as an outer reference, in `ResolveAggregateFunctions` we have extracted this expression to the outer plan aggregate by adding `max(col2#292) AS max(col2)#298` and updating outer attribute of the subquery to `max(col2)#298`. However, in `UpdateOuterReferences` when updating outer references to point to outer aggregate expressions, we are going to find the first semantically equal expressions but not necessarily the one that we have already set as an outer attribute. This is why in the above plan we have a mismatch between outer reference and exposed outer attribute (`#297` and `#298`). This PR fixed that
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Added a test case
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
