### PR TITLE
[SPARK-52869][SQL] Add FrameLessOffsetWindowFunction validation to validateResolvedWindowExpression for reuse in single-pass analyzer

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -437,15 +437,6 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
               errorClass = "WINDOW_FUNCTION_WITHOUT_OVER_CLAUSE",
               messageParameters = Map("funcName" -> toSQLExpr(w)))
 
-          case w @ WindowExpression(wf: FrameLessOffsetWindowFunction,
-            WindowSpecDefinition(_, order, frame: SpecifiedWindowFrame))
-             if order.isEmpty || !frame.isOffset =>
-            w.failAnalysis(
-              errorClass = "WINDOW_FUNCTION_AND_FRAME_MISMATCH",
-              messageParameters = Map(
-                "funcName" -> toSQLExpr(wf),
-                "windowExpr" -> toSQLExpr(w)))
-
           case agg @ AggregateExpression(listAgg: ListAgg, _, _, _, _)
             if agg.isDistinct && listAgg.needSaveOrderValue =>
             throw QueryCompilationErrors.functionAndOrderExpressionMismatchError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/WindowResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/WindowResolution.scala
@@ -107,8 +107,11 @@ object WindowResolution {
    *
    * By checking the type and configuration of [[WindowExpression.windowFunction]] it enforces the
    * following rules:
+   * - Disallows [[FrameLessOffsetWindowFunction]] (e.g. [[Lag]]) without defined ordering or
+   *   one with a frame which is defined as something other than an offset frame (e.g.
+   *   `ROWS BETWEEN` is logically incompatible with offset functions).
    * - Disallows distinct aggregate expressions in window functions.
-   * - Disallows use of certain aggregate functions - [[ListaAgg]], [[PercentileCont]],
+   * - Disallows use of certain aggregate functions - [[ListAgg]], [[PercentileCont]],
    *   [[PercentileDisc]], [[Median]]
    * - Allows only window functions of following types:
    *   - [[AggregateExpression]] (non-distinct)
@@ -116,35 +119,64 @@ object WindowResolution {
    *   - [[AggregateWindowFunction]]
    */
   def validateResolvedWindowExpression(windowExpression: WindowExpression): Unit = {
-    windowExpression.windowFunction match {
-      case AggregateExpression(_, _, true, _, _) =>
+    windowExpression match {
+      case _ @ WindowExpression(
+        windowFunction: FrameLessOffsetWindowFunction,
+        WindowSpecDefinition(_, order, frame: SpecifiedWindowFrame)
+      ) if order.isEmpty || !frame.isOffset =>
         windowExpression.failAnalysis(
-          errorClass = "DISTINCT_WINDOW_FUNCTION_UNSUPPORTED",
-          messageParameters = Map("windowExpr" -> toSQLExpr(windowExpression))
+          errorClass = "WINDOW_FUNCTION_AND_FRAME_MISMATCH",
+          messageParameters = Map(
+            "funcName" -> toSQLExpr(windowFunction),
+            "windowExpr" -> toSQLExpr(windowExpression)
+          )
         )
-      case agg @ AggregateExpression(fun: ListAgg, _, _, _, _)
-        // listagg(...) WITHIN GROUP (ORDER BY ...) OVER (ORDER BY ...) is unsupported
-        if fun.orderingFilled && (windowExpression.windowSpec.orderSpec.nonEmpty ||
-          windowExpression.windowSpec.frameSpecification !=
-            SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)) =>
-        agg.failAnalysis(
-          errorClass = "INVALID_WINDOW_SPEC_FOR_AGGREGATION_FUNC",
-          messageParameters = Map("aggFunc" -> toSQLExpr(agg.aggregateFunction))
-        )
-      case agg @ AggregateExpression(_: PercentileCont | _: PercentileDisc | _: Median, _, _, _, _)
-        if windowExpression.windowSpec.orderSpec.nonEmpty ||
-          windowExpression.windowSpec.frameSpecification !=
-            SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing) =>
-        agg.failAnalysis(
-          errorClass = "INVALID_WINDOW_SPEC_FOR_AGGREGATION_FUNC",
-          messageParameters = Map("aggFunc" -> toSQLExpr(agg.aggregateFunction))
-        )
-      case _: AggregateExpression | _: FrameLessOffsetWindowFunction | _: AggregateWindowFunction =>
-      case other =>
-        other.failAnalysis(
-          errorClass = "UNSUPPORTED_EXPR_FOR_WINDOW",
-          messageParameters = Map("sqlExpr" -> toSQLExpr(other))
-        )
+      case _ @ WindowExpression(windowFunction, windowSpec) =>
+        windowFunction match {
+          case AggregateExpression(_, _, true, _, _) =>
+            windowExpression.failAnalysis(
+              errorClass = "DISTINCT_WINDOW_FUNCTION_UNSUPPORTED",
+              messageParameters = Map("windowExpr" -> toSQLExpr(windowExpression))
+            )
+          case frameLessOffsetWindowFunction: FrameLessOffsetWindowFunction
+            if windowSpec.orderSpec.isEmpty ||
+              (windowExpression.windowSpec.frameSpecification.isInstanceOf[SpecifiedWindowFrame] &&
+                !windowExpression.windowSpec.frameSpecification
+                  .asInstanceOf[SpecifiedWindowFrame]
+                  .isOffset) =>
+            frameLessOffsetWindowFunction.failAnalysis(
+              errorClass = "WINDOW_FUNCTION_AND_FRAME_MISMATCH",
+              messageParameters = Map(
+                "funcName" -> toSQLExpr(windowFunction),
+                "windowExpr" -> toSQLExpr(windowExpression)
+              )
+            )
+          case aggregateExpression @ AggregateExpression(fun: ListAgg, _, _, _, _)
+            if fun.orderingFilled && (windowSpec.orderSpec.nonEmpty ||
+              windowSpec.frameSpecification !=
+                SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)) =>
+            aggregateExpression.failAnalysis(
+              errorClass = "INVALID_WINDOW_SPEC_FOR_AGGREGATION_FUNC",
+              messageParameters = Map("aggFunc" -> toSQLExpr(aggregateExpression.aggregateFunction))
+            )
+          case aggregateExpression @ AggregateExpression(
+          _: PercentileCont | _: PercentileDisc | _: Median, _, _, _, _
+          )
+            if windowSpec.orderSpec.nonEmpty ||
+              windowSpec.frameSpecification !=
+                SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing) =>
+            aggregateExpression.failAnalysis(
+              errorClass = "INVALID_WINDOW_SPEC_FOR_AGGREGATION_FUNC",
+              messageParameters = Map("aggFunc" -> toSQLExpr(aggregateExpression.aggregateFunction))
+            )
+          case _: AggregateExpression | _: FrameLessOffsetWindowFunction |
+               _: AggregateWindowFunction =>
+          case other =>
+            other.failAnalysis(
+              errorClass = "UNSUPPORTED_EXPR_FOR_WINDOW",
+              messageParameters = Map("sqlExpr" -> toSQLExpr(other))
+            )
+        }
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/WindowResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/WindowResolution.scala
@@ -119,6 +119,11 @@ object WindowResolution {
    *   - [[AggregateWindowFunction]]
    */
   def validateResolvedWindowExpression(windowExpression: WindowExpression): Unit = {
+    checkWindowFunctionAndFrameMismatch(windowExpression)
+    checkWindowFunction(windowExpression)
+  }
+
+  def checkWindowFunctionAndFrameMismatch(windowExpression: WindowExpression): Unit = {
     windowExpression match {
       case _ @ WindowExpression(
       windowFunction: FrameLessOffsetWindowFunction,
@@ -133,6 +138,9 @@ object WindowResolution {
         )
       case _ =>
     }
+  }
+
+  def checkWindowFunction(windowExpression: WindowExpression): Unit = {
     windowExpression.windowFunction match {
       case AggregateExpression(_, _, true, _, _) =>
         windowExpression.failAnalysis(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
A check if `FrameLessOffsetWindowFunction` is compatible with its frame (it has to be ordered and can't be a `SpecifiedWindowFrame` other than an ordered frame) is added to `WindowResolver.validateResolvedWindowExpression`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The same repeating logic is required both in the fixed-point and single-pass analyzer implementations.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Using existing unit tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.