### PR TITLE
[SPARK-52875][SQL] Simplify V2 expression translation if the input is context-independent-foldable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -200,6 +200,8 @@ case class CaseWhen(
     branches.exists(_._2.nullable) || elseValue.map(_.nullable).getOrElse(true)
   }
 
+  override def contextIndependentFoldable: Boolean = children.forall(_.contextIndependentFoldable)
+
   override def checkInputDataTypes(): TypeCheckResult = {
     if (TypeCoercion.haveSameType(inputTypesForMerging)) {
       // Make sure all branch conditions are boolean types.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -59,7 +59,7 @@ object ConstantFolding extends Rule[LogicalPlan] {
     case _ => false
   }
 
-  private def constantFolding(
+  private[sql] def constantFolding(
       e: Expression,
       isConditionalBranch: Boolean = false): Expression = e match {
     case c: ConditionalExpression if !c.foldable =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -22,6 +22,7 @@ import org.apache.spark.internal.LogKeys.EXPR
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction, Complete}
 import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, StaticInvoke}
+import org.apache.spark.sql.catalyst.optimizer.ConstantFolding
 import org.apache.spark.sql.connector.catalog.functions.ScalarFunction
 import org.apache.spark.sql.connector.expressions.{Cast => V2Cast, Expression => V2Expression, Extract => V2Extract, FieldReference, GeneralScalarExpression, LiteralValue, NullOrdering, SortDirection, SortValue, UserDefinedScalarFunc}
 import org.apache.spark.sql.connector.expressions.aggregate.{AggregateFunc, Avg, Count, CountStar, GeneralAggregateFunc, Max, Min, Sum, UserDefinedAggregateFunc}
@@ -83,11 +84,20 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) extends L
     case _ => false
   }
 
-  private def generateExpression(
-      expr: Expression, isPredicate: Boolean = false): Option[V2Expression] = expr match {
+  private def translateLiteral(l: Literal): Option[V2Expression] = l match {
     case Literal(true, BooleanType) => Some(new AlwaysTrue())
     case Literal(false, BooleanType) => Some(new AlwaysFalse())
-    case Literal(value, dataType) => Some(LiteralValue(value, dataType))
+    case other => Some(LiteralValue(other.value, other.dataType))
+  }
+
+  private def generateExpression(
+      expr: Expression, isPredicate: Boolean = false): Option[V2Expression] = expr match {
+    case literal: Literal => translateLiteral(literal)
+    case _ if expr.contextIndependentFoldable =>
+      // If the expression is context independent foldable, we can convert it to a literal.
+      // This is useful for increasing the coverage of V2 expressions.
+      val constantExpr = ConstantFolding.constantFolding(expr)
+      generateExpression(constantExpr, isPredicate)
     case col @ ColumnOrField(nameParts) =>
       val ref = FieldReference(nameParts)
       if (isPredicate && col.dataType.isInstanceOf[BooleanType]) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -84,15 +84,15 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) extends L
     case _ => false
   }
 
-  private def translateLiteral(l: Literal): Option[V2Expression] = l match {
-    case Literal(true, BooleanType) => Some(new AlwaysTrue())
-    case Literal(false, BooleanType) => Some(new AlwaysFalse())
-    case other => Some(LiteralValue(other.value, other.dataType))
+  private def translateLiteral(l: Literal): V2Expression = l match {
+    case Literal(true, BooleanType) => new AlwaysTrue()
+    case Literal(false, BooleanType) => new AlwaysFalse()
+    case other => LiteralValue(other.value, other.dataType)
   }
 
   private def generateExpression(
       expr: Expression, isPredicate: Boolean = false): Option[V2Expression] = expr match {
-    case literal: Literal => translateLiteral(literal)
+    case literal: Literal => Some(translateLiteral(literal))
     case _ if expr.contextIndependentFoldable =>
       // If the expression is context independent foldable, we can convert it to a literal.
       // This is useful for increasing the coverage of V2 expressions.

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.catalog.{Column => ColumnV2, _}
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.connector.catalog.CatalogV2Util.withDefaultOwnership
-import org.apache.spark.sql.connector.expressions.{Cast => V2Cast, Expression, GeneralScalarExpression, LiteralValue, Transform}
+import org.apache.spark.sql.connector.expressions.{LiteralValue, Transform}
 import org.apache.spark.sql.errors.QueryErrorsBase
 import org.apache.spark.sql.execution.FilterExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
@@ -655,12 +655,7 @@ class DataSourceV2SQLSuiteV1Filter
         null, /* no comment */
         new ColumnDefaultValue(
           "41 + 1",
-          new V2Cast(
-            new GeneralScalarExpression(
-              "+",
-              Array[Expression](LiteralValue(41, IntegerType), LiteralValue(1, IntegerType))),
-            IntegerType,
-            LongType),
+          LiteralValue(42L, LongType),
           LiteralValue(42L, LongType)),
         null /* no metadata */)
       assert(actual === expected,

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/PushablePredicateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/PushablePredicateSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.connector.expressions.filter.{AlwaysTrue, Predicate 
 import org.apache.spark.sql.execution.datasources.v2.PushablePredicate
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.BooleanType
+import org.apache.spark.sql.types.{BooleanType, TimestampType}
 
 class PushablePredicateSuite extends QueryTest with SharedSparkSession {
 
@@ -70,7 +70,8 @@ class PushablePredicateSuite extends QueryTest with SharedSparkSession {
         withSQLConf(
           SQLConf.DATA_SOURCE_ALWAYS_CREATE_V2_PREDICATE.key -> createV2Predicate.toString,
           SQLConf.DATA_SOURCE_DONT_ASSERT_ON_PREDICATE.key -> noAssert.toString) {
-          val catalystExpr = Cast(Literal.create("true"), BooleanType)
+          val catalystExpr =
+            Cast(Cast(Literal.create("2025-01-01 00:00:00"), TimestampType), BooleanType)
           if (createV2Predicate) {
             val pushable = PushablePredicate.unapply(catalystExpr)
             assert(pushable.isDefined)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
@@ -328,42 +328,44 @@ class DataSourceV2StrategySuite extends PlanTest with SharedSparkSession {
   }
 
   test("round trip conversion of CASE_WHEN expression") {
+    val intCol = $"cint".int
+    val intColRef = FieldReference("cint")
     // CASE WHEN cond1 THEN value1 WHEN cond2 THEN value2
     checkRoundTripConversion(
       catalystExpr = CaseWhen(
         Seq(
-          (EqualTo(Literal(1), Literal(2)), Literal("a")),
-          (EqualTo(Literal(3), Literal(4)), Literal("b"))),
+          (EqualTo(intCol, Literal(2)), Literal("a")),
+          (EqualTo(intCol, Literal(4)), Literal("b"))),
         None),
       v2Expr = new GeneralScalarExpression(
         "CASE_WHEN",
         Array(
-          new Predicate("=", Array(LiteralValue(1, IntegerType), LiteralValue(2, IntegerType))),
+          new Predicate("=", Array(intColRef, LiteralValue(2, IntegerType))),
           LiteralValue(UTF8String.fromString("a"), StringType),
-          new Predicate("=", Array(LiteralValue(3, IntegerType), LiteralValue(4, IntegerType))),
+          new Predicate("=", Array(intColRef, LiteralValue(4, IntegerType))),
           LiteralValue(UTF8String.fromString("b"), StringType))))
 
     // CASE WHEN cond1 THEN value1 ELSE elseValue
     checkRoundTripConversion(
       catalystExpr = CaseWhen(
-        Seq((EqualTo(Literal(1), Literal(2)), Literal("yes"))),
+        Seq((EqualTo(intCol, Literal(2)), Literal("yes"))),
         Some(Literal("no"))),
       v2Expr = new GeneralScalarExpression(
         "CASE_WHEN",
         Array(
-          new Predicate("=", Array(LiteralValue(1, IntegerType), LiteralValue(2, IntegerType))),
+          new Predicate("=", Array(intColRef, LiteralValue(2, IntegerType))),
           LiteralValue(UTF8String.fromString("yes"), StringType),
           LiteralValue(UTF8String.fromString("no"), StringType))))
 
     // CASE WHEN cond1 THEN true ELSE false
     checkRoundTripConversion(
       catalystExpr = CaseWhen(
-        Seq((EqualTo(Literal(1), Literal(2)), Literal(true))),
+        Seq((EqualTo(intCol, Literal(2)), Literal(true))),
         Some(Literal(false))),
       v2Expr = new Predicate(
         "CASE_WHEN",
         Array(
-          new Predicate("=", Array(LiteralValue(1, IntegerType), LiteralValue(2, IntegerType))),
+          new Predicate("=", Array(intColRef, LiteralValue(2, IntegerType))),
           new AlwaysTrue,
           new AlwaysFalse)),
       isPredicate = true)
@@ -372,251 +374,260 @@ class DataSourceV2StrategySuite extends PlanTest with SharedSparkSession {
     checkRoundTripConversion(
       catalystExpr = CaseWhen(
         Seq(
-          (EqualTo(Literal(1), Literal(2)), Literal(true)),
-          (EqualTo(Literal(3), Literal(4)), Literal(false))),
+          (EqualTo(intCol, Literal(2)), Literal(true)),
+          (EqualTo(intCol, Literal(4)), Literal(false))),
         Some(Literal(true))),
       v2Expr = new Predicate(
         "CASE_WHEN",
         Array(
-          new Predicate("=", Array(LiteralValue(1, IntegerType), LiteralValue(2, IntegerType))),
+          new Predicate("=", Array(intColRef, LiteralValue(2, IntegerType))),
           new AlwaysTrue,
-          new Predicate("=", Array(LiteralValue(3, IntegerType), LiteralValue(4, IntegerType))),
+          new Predicate("=", Array(intColRef, LiteralValue(4, IntegerType))),
           new AlwaysFalse,
           new AlwaysTrue)),
       isPredicate = true)
   }
 
   test("round trip conversion of math functions") {
+    val intCol = $"cint".int
+    val intColRef = FieldReference("cint")
+    val doubleCol = $"cdouble".double
+    val doubleColRef = FieldReference("cdouble")
     checkRoundTripConversion(
-      catalystExpr = Log10(Literal(100)),
-      v2Expr = new GeneralScalarExpression("LOG10", Array(LiteralValue(100, IntegerType))))
+      catalystExpr = Log10(intCol),
+      v2Expr = new GeneralScalarExpression("LOG10", Array(intColRef)))
 
     checkRoundTripConversion(
       catalystExpr = new Rand(),
       v2Expr = new GeneralScalarExpression("RAND", Array()))
 
     checkRoundTripConversion(
-      catalystExpr = new Rand(Literal(17L)),
-      v2Expr = new GeneralScalarExpression("RAND", Array(LiteralValue(17L, LongType))))
+      catalystExpr = new Rand(intCol),
+      v2Expr = new GeneralScalarExpression("RAND", Array(intColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Abs(Literal(-5), failOnError = true),
-      v2Expr = new GeneralScalarExpression("ABS", Array(LiteralValue(-5, IntegerType))))
+      catalystExpr = Abs(intCol, failOnError = true),
+      v2Expr = new GeneralScalarExpression("ABS", Array(intColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = UnaryMinus(Literal(5), failOnError = true),
-      v2Expr = new GeneralScalarExpression("-", Array(LiteralValue(5, IntegerType))))
+      catalystExpr = UnaryMinus(intCol, failOnError = true),
+      v2Expr = new GeneralScalarExpression("-", Array(intColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Log2(Literal(8)),
-      v2Expr = new GeneralScalarExpression("LOG2", Array(LiteralValue(8, IntegerType))))
+      catalystExpr = Log2(intCol),
+      v2Expr = new GeneralScalarExpression("LOG2", Array(intColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Log(Literal(100)),
-      v2Expr = new GeneralScalarExpression("LN", Array(LiteralValue(100, IntegerType))))
+      catalystExpr = Log(intCol),
+      v2Expr = new GeneralScalarExpression("LN", Array(intColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Exp(Literal(1.0)),
-      v2Expr = new GeneralScalarExpression("EXP", Array(LiteralValue(1.0, DoubleType))))
+      catalystExpr = Exp(doubleCol),
+      v2Expr = new GeneralScalarExpression("EXP", Array(doubleColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Sqrt(Literal(4.0)),
-      v2Expr = new GeneralScalarExpression("SQRT", Array(LiteralValue(4.0, DoubleType))))
+      catalystExpr = Sqrt(doubleCol),
+      v2Expr = new GeneralScalarExpression("SQRT", Array(doubleColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Floor(Literal(4.7)),
-      v2Expr = new GeneralScalarExpression("FLOOR", Array(LiteralValue(4.7, DoubleType))))
+      catalystExpr = Floor(doubleCol),
+      v2Expr = new GeneralScalarExpression("FLOOR", Array(doubleColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Ceil(Literal(4.3)),
-      v2Expr = new GeneralScalarExpression("CEIL", Array(LiteralValue(4.3, DoubleType))))
+      catalystExpr = Ceil(doubleCol),
+      v2Expr = new GeneralScalarExpression("CEIL", Array(doubleColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Sin(Literal(0)),
-      v2Expr = new GeneralScalarExpression("SIN", Array(LiteralValue(0, IntegerType))))
+      catalystExpr = Sin(intCol),
+      v2Expr = new GeneralScalarExpression("SIN", Array(intColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Sinh(Literal(0)),
-      v2Expr = new GeneralScalarExpression("SINH", Array(LiteralValue(0, IntegerType))))
+      catalystExpr = Sinh(intCol),
+      v2Expr = new GeneralScalarExpression("SINH", Array(intColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Cos(Literal(0)),
-      v2Expr = new GeneralScalarExpression("COS", Array(LiteralValue(0, IntegerType))))
+      catalystExpr = Cos(intCol),
+      v2Expr = new GeneralScalarExpression("COS", Array(intColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Cosh(Literal(0)),
-      v2Expr = new GeneralScalarExpression("COSH", Array(LiteralValue(0, IntegerType))))
+      catalystExpr = Cosh(intCol),
+      v2Expr = new GeneralScalarExpression("COSH", Array(intColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Tan(Literal(0)),
-      v2Expr = new GeneralScalarExpression("TAN", Array(LiteralValue(0, IntegerType))))
+      catalystExpr = Tan(intCol),
+      v2Expr = new GeneralScalarExpression("TAN", Array(intColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Tanh(Literal(0)),
-      v2Expr = new GeneralScalarExpression("TANH", Array(LiteralValue(0, IntegerType))))
+      catalystExpr = Tanh(intCol),
+      v2Expr = new GeneralScalarExpression("TANH", Array(intColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Cot(Literal(1)),
-      v2Expr = new GeneralScalarExpression("COT", Array(LiteralValue(1, IntegerType))))
+      catalystExpr = Cot(intCol),
+      v2Expr = new GeneralScalarExpression("COT", Array(intColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Asin(Literal(1.0)),
-      v2Expr = new GeneralScalarExpression("ASIN", Array(LiteralValue(1.0, DoubleType))))
+      catalystExpr = Asin(doubleCol),
+      v2Expr = new GeneralScalarExpression("ASIN", Array(doubleColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Asinh(Literal(1.0)),
-      v2Expr = new GeneralScalarExpression("ASINH", Array(LiteralValue(1.0, DoubleType))))
+      catalystExpr = Asinh(doubleCol),
+      v2Expr = new GeneralScalarExpression("ASINH", Array(doubleColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Acos(Literal(1.0)),
-      v2Expr = new GeneralScalarExpression("ACOS", Array(LiteralValue(1.0, DoubleType))))
+      catalystExpr = Acos(doubleCol),
+      v2Expr = new GeneralScalarExpression("ACOS", Array(doubleColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Acosh(Literal(1.0)),
-      v2Expr = new GeneralScalarExpression("ACOSH", Array(LiteralValue(1.0, DoubleType))))
+      catalystExpr = Acosh(doubleCol),
+      v2Expr = new GeneralScalarExpression("ACOSH", Array(doubleColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Atan(Literal(1.0)),
-      v2Expr = new GeneralScalarExpression("ATAN", Array(LiteralValue(1.0, DoubleType))))
+      catalystExpr = Atan(doubleCol),
+      v2Expr = new GeneralScalarExpression("ATAN", Array(doubleColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Atanh(Literal(0.5)),
-      v2Expr = new GeneralScalarExpression("ATANH", Array(LiteralValue(0.5, DoubleType))))
+      catalystExpr = Atanh(doubleCol),
+      v2Expr = new GeneralScalarExpression("ATANH", Array(doubleColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Cbrt(Literal(8.0)),
-      v2Expr = new GeneralScalarExpression("CBRT", Array(LiteralValue(8.0, DoubleType))))
+      catalystExpr = Cbrt(doubleCol),
+      v2Expr = new GeneralScalarExpression("CBRT", Array(doubleColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = ToDegrees(Literal(3.14)),
-      v2Expr = new GeneralScalarExpression("DEGREES", Array(LiteralValue(3.14, DoubleType))))
+      catalystExpr = ToDegrees(doubleCol),
+      v2Expr = new GeneralScalarExpression("DEGREES", Array(doubleColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = ToRadians(Literal(180.0)),
-      v2Expr = new GeneralScalarExpression("RADIANS", Array(LiteralValue(180.0, DoubleType))))
+      catalystExpr = ToRadians(doubleCol),
+      v2Expr = new GeneralScalarExpression("RADIANS", Array(doubleColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Signum(Literal(-42)),
-      v2Expr = new GeneralScalarExpression("SIGN", Array(LiteralValue(-42, IntegerType))))
+      catalystExpr = Signum(intCol),
+      v2Expr = new GeneralScalarExpression("SIGN", Array(intColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Add(Literal(1), Literal(2), EvalMode.ANSI),
+      catalystExpr = Add(intCol, Literal(2), EvalMode.ANSI),
       v2Expr = new GeneralScalarExpression(
         "+",
-        Array(LiteralValue(1, IntegerType), LiteralValue(2, IntegerType))))
+        Array(intColRef, LiteralValue(2, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = Subtract(Literal(5), Literal(3), EvalMode.ANSI),
+      catalystExpr = Subtract(intCol, Literal(3), EvalMode.ANSI),
       v2Expr = new GeneralScalarExpression(
         "-",
-        Array(LiteralValue(5, IntegerType), LiteralValue(3, IntegerType))))
+        Array(intColRef, LiteralValue(3, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = Multiply(Literal(2), Literal(4), EvalMode.ANSI),
+      catalystExpr = Multiply(intCol, Literal(4), EvalMode.ANSI),
       v2Expr = new GeneralScalarExpression(
         "*",
-        Array(LiteralValue(2, IntegerType), LiteralValue(4, IntegerType))))
+        Array(intColRef, LiteralValue(4, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = Divide(Literal(10), Literal(2), EvalMode.ANSI),
+      catalystExpr = Divide(intCol, Literal(2), EvalMode.ANSI),
       v2Expr = new GeneralScalarExpression(
         "/",
-        Array(LiteralValue(10, IntegerType), LiteralValue(2, IntegerType))))
+        Array(intColRef, LiteralValue(2, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = Remainder(Literal(7), Literal(3), EvalMode.ANSI),
+      catalystExpr = Remainder(intCol, Literal(3), EvalMode.ANSI),
       v2Expr = new GeneralScalarExpression(
         "%",
-        Array(LiteralValue(7, IntegerType), LiteralValue(3, IntegerType))))
+        Array(intColRef, LiteralValue(3, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = Logarithm(Literal(10), Literal(100)),
+      catalystExpr = Logarithm(Literal(10), intCol),
       v2Expr = new GeneralScalarExpression(
         "LOG",
-        Array(LiteralValue(10, IntegerType), LiteralValue(100, IntegerType))))
+        Array(LiteralValue(10, IntegerType), intColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Pow(Literal(2), Literal(3)),
+      catalystExpr = Pow(intCol, Literal(3)),
       v2Expr = new GeneralScalarExpression(
         "POWER",
-        Array(LiteralValue(2, IntegerType), LiteralValue(3, IntegerType))))
+        Array(intColRef, LiteralValue(3, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = Round(Literal(123.456), Literal(2), ansiEnabled = true),
+      catalystExpr = Round(doubleCol, Literal(2), ansiEnabled = true),
       v2Expr = new GeneralScalarExpression(
         "ROUND",
-        Array(LiteralValue(123.456, DoubleType), LiteralValue(2, IntegerType))))
+        Array(doubleColRef, LiteralValue(2, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = Atan2(Literal(1.0), Literal(1.0)),
+      catalystExpr = Atan2(doubleCol, Literal(1.0)),
       v2Expr = new GeneralScalarExpression(
         "ATAN2",
-        Array(LiteralValue(1.0, DoubleType), LiteralValue(1.0, DoubleType))))
+        Array(doubleColRef, LiteralValue(1.0, DoubleType))))
 
     checkRoundTripConversion(
-      catalystExpr = Coalesce(Seq(Literal(null, IntegerType), Literal(5))),
+      catalystExpr = Coalesce(Seq(Literal(null, IntegerType), intCol)),
       v2Expr = new GeneralScalarExpression(
         "COALESCE",
-        Array(LiteralValue(null, IntegerType), LiteralValue(5, IntegerType))))
+        Array(LiteralValue(null, IntegerType), intColRef)))
 
     checkRoundTripConversion(
-      catalystExpr = Greatest(Seq(Literal(1), Literal(2))),
+      catalystExpr = Greatest(Seq(intCol, Literal(2))),
       v2Expr = new GeneralScalarExpression(
         "GREATEST",
-        Array(LiteralValue(1, IntegerType), LiteralValue(2, IntegerType))))
+        Array(intColRef, LiteralValue(2, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = Least(Seq(Literal(1), Literal(2))),
+      catalystExpr = Least(Seq(intCol, Literal(2))),
       v2Expr = new GeneralScalarExpression(
         "LEAST",
-        Array(LiteralValue(1, IntegerType), LiteralValue(2, IntegerType))))
+        Array(intColRef, LiteralValue(2, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = WidthBucket(Literal(5), Literal(0), Literal(10), Literal(5)),
+      catalystExpr = WidthBucket(intCol, Literal(0), Literal(10), Literal(5)),
       v2Expr = new GeneralScalarExpression(
         "WIDTH_BUCKET",
         Array(
-          LiteralValue(5, IntegerType),
+          intColRef,
           LiteralValue(0, IntegerType),
           LiteralValue(10, IntegerType),
           LiteralValue(5, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = Sqrt(Pow(Abs(Literal(-3), failOnError = true), Literal(2))),
+      catalystExpr = Sqrt(Pow(Abs(intCol, failOnError = true), Literal(2))),
       v2Expr = new GeneralScalarExpression(
         "SQRT",
         Array(
           new GeneralScalarExpression(
             "POWER",
-            Array(new GeneralScalarExpression("ABS", Array(LiteralValue(-3, IntegerType))),
-          LiteralValue(2, IntegerType))))))
+            Array(new GeneralScalarExpression("ABS", Array(intColRef)),
+              LiteralValue(2, IntegerType))))))
   }
 
   test("round trip conversion of bitwise functions") {
-    checkRoundTripConversion(
-      catalystExpr = BitwiseNot(Literal(5)),
-      v2Expr = new GeneralScalarExpression("~", Array(LiteralValue(5, IntegerType))))
+    val intCol = $"cint".int
+    val intColRef = FieldReference("cint")
 
     checkRoundTripConversion(
-      catalystExpr = BitwiseAnd(Literal(6), Literal(3)),
+      catalystExpr = BitwiseNot(intCol),
+      v2Expr = new GeneralScalarExpression("~", Array(intColRef)))
+
+    checkRoundTripConversion(
+      catalystExpr = BitwiseAnd(intCol, Literal(3)),
       v2Expr = new GeneralScalarExpression("&", Array(
-        LiteralValue(6, IntegerType),
+        intColRef,
         LiteralValue(3, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = BitwiseOr(Literal(4), Literal(1)),
+      catalystExpr = BitwiseOr(intCol, Literal(1)),
       v2Expr = new GeneralScalarExpression("|", Array(
-        LiteralValue(4, IntegerType),
+        intColRef,
         LiteralValue(1, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = BitwiseXor(Literal(12), Literal(5)),
+      catalystExpr = BitwiseXor(intCol, Literal(5)),
       v2Expr = new GeneralScalarExpression("^", Array(
-        LiteralValue(12, IntegerType),
+        intColRef,
         LiteralValue(5, IntegerType))))
   }
 
   test("round trip conversion of predicate expressions") {
+    val intCol = $"cint".int
+    val intColRef = FieldReference("cint")
     checkRoundTripConversion(
       catalystExpr = IsNull($"a".boolean),
       v2Expr = new Predicate("IS_NULL", Array(FieldReference("a"))))
@@ -636,56 +647,47 @@ class DataSourceV2StrategySuite extends PlanTest with SharedSparkSession {
         "=",
         Array(FieldReference("a"), LiteralValue(true, BooleanType)))),
       catalystExpr = Not(EqualTo($"a".boolean, Literal(true))))
-
     checkRoundTripConversion(
-      catalystExpr = EqualTo(Literal(1), Literal(2)),
+      catalystExpr = EqualTo(intCol, Literal(2)),
       v2Expr = new Predicate(
         "=",
-        Array(LiteralValue(1, IntegerType), LiteralValue(2, IntegerType))))
+        Array(intColRef, LiteralValue(2, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = EqualNullSafe(Literal(1), Literal(2)),
+      catalystExpr = EqualNullSafe(intCol, Literal(2)),
       v2Expr = new Predicate(
         "<=>",
-        Array(LiteralValue(1, IntegerType), LiteralValue(2, IntegerType))))
+        Array(intColRef, LiteralValue(2, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = GreaterThan(Literal(1), Literal(2)),
+      catalystExpr = GreaterThan(intCol, Literal(2)),
       v2Expr = new Predicate(
         ">",
-        Array(LiteralValue(1, IntegerType), LiteralValue(2, IntegerType))))
+        Array(intColRef, LiteralValue(2, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = GreaterThanOrEqual(Literal(1), Literal(2)),
+      catalystExpr = GreaterThanOrEqual(intCol, Literal(2)),
       v2Expr = new Predicate(
         ">=",
-        Array(LiteralValue(1, IntegerType), LiteralValue(2, IntegerType))))
+        Array(intColRef, LiteralValue(2, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = LessThan(Literal(1), Literal(2)),
+      catalystExpr = LessThan(intCol, Literal(2)),
       v2Expr = new Predicate(
         "<",
-        Array(LiteralValue(1, IntegerType), LiteralValue(2, IntegerType))))
+        Array(intColRef, LiteralValue(2, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = LessThanOrEqual(Literal(1), Literal(2)),
+      catalystExpr = LessThanOrEqual(intCol, Literal(2)),
       v2Expr = new Predicate(
         "<=",
-        Array(LiteralValue(1, IntegerType), LiteralValue(2, IntegerType))))
+        Array(intColRef, LiteralValue(2, IntegerType))))
 
     checkRoundTripConversion(
-      catalystExpr = Not(EqualTo(Literal(1), Literal(2))),
+      catalystExpr = Not(EqualTo(intCol, Literal(2))),
       v2Expr = new Predicate(
         "<>",
-        Array(LiteralValue(1, IntegerType), LiteralValue(2, IntegerType))))
-
-    checkRoundTripConversion(
-      catalystExpr = And(Literal.TrueLiteral, Literal.FalseLiteral),
-      v2Expr = new V2And(new AlwaysTrue, new AlwaysFalse))
-
-    checkRoundTripConversion(
-      catalystExpr = Or(Literal.TrueLiteral, Literal.FalseLiteral),
-      v2Expr = new V2Or(new AlwaysTrue, new AlwaysFalse))
+        Array(intColRef, LiteralValue(2, IntegerType))))
 
     checkRoundTripConversion(
       catalystExpr = StartsWith($"a".string, Literal("foo")),
@@ -712,6 +714,61 @@ class DataSourceV2StrategySuite extends PlanTest with SharedSparkSession {
         LiteralValue(1, IntegerType),
         LiteralValue(2, IntegerType),
         LiteralValue(3, IntegerType))))
+  }
+
+  test("Constant foldable CASE_WHEN expression") {
+    checkV2Conversion(
+      catalystExpr = CaseWhen(
+        Seq(
+          (EqualTo(Literal(1), Literal(2)), Literal("a")),
+          (EqualTo(Literal(3), Literal(3)), Literal("b"))),
+        None),
+      v2Expr = LiteralValue(UTF8String.fromString("b"), StringType)
+    )
+
+    checkV2Conversion(
+      catalystExpr = CaseWhen(
+        Seq((EqualTo(Literal(1), Literal(1)), Literal("yes"))),
+        Some(Literal("no"))),
+      v2Expr = LiteralValue(UTF8String.fromString("yes"), StringType)
+    )
+  }
+
+  test("Constant foldable math functions") {
+    checkV2Conversion(
+      catalystExpr = Log10(Literal(100.0)),
+      v2Expr = LiteralValue(2.0, DoubleType)
+    )
+
+    checkV2Conversion(
+      catalystExpr = Abs(Literal(-5), failOnError = true),
+      v2Expr = LiteralValue(5, IntegerType)
+    )
+
+    checkV2Conversion(
+      catalystExpr = UnaryMinus(Literal(5), failOnError = true),
+      v2Expr = LiteralValue(-5, IntegerType)
+    )
+
+    checkV2Conversion(
+      catalystExpr = Log2(Literal(8.0)),
+      v2Expr = LiteralValue(3.0, DoubleType)
+    )
+
+    checkV2Conversion(
+      catalystExpr = Sqrt(Literal(4.0)),
+      v2Expr = LiteralValue(2.0, DoubleType)
+    )
+
+    checkV2Conversion(
+      catalystExpr = Floor(Literal(3.7)),
+      v2Expr = LiteralValue(3L, LongType)
+    )
+
+    checkV2Conversion(
+      catalystExpr = Ceil(Literal(3.1)),
+      v2Expr = LiteralValue(4L, LongType)
+    )
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
@@ -771,6 +771,60 @@ class DataSourceV2StrategySuite extends PlanTest with SharedSparkSession {
     )
   }
 
+  test("Partial constant folding of math functions") {
+    checkV2Conversion(
+      catalystExpr = Log10(Literal(100.0)) + $"cint".int,
+      v2Expr = new GeneralScalarExpression("+", Array(
+        LiteralValue(2.0, DoubleType),
+        FieldReference("cint"))))
+
+    checkV2Conversion(
+      catalystExpr = Abs(Literal(-10), failOnError = true) * $"cdouble".double,
+      v2Expr = new GeneralScalarExpression("*", Array(
+        LiteralValue(10, IntegerType),
+        FieldReference("cdouble"))))
+
+    checkV2Conversion(
+      catalystExpr = Sqrt(Literal(16.0)) - $"cint".int,
+      v2Expr = new GeneralScalarExpression("-", Array(
+        LiteralValue(4.0, DoubleType),
+        FieldReference("cint"))))
+
+    checkV2Conversion(
+      catalystExpr = $"cdouble".double / Log2(Literal(32.0)),
+      v2Expr = new GeneralScalarExpression("/", Array(
+        FieldReference("cdouble"),
+        LiteralValue(5.0, DoubleType))))
+
+    checkV2Conversion(
+      catalystExpr = Floor(Literal(7.9)) + Ceil(Literal(2.1)),
+      v2Expr = LiteralValue(10L, LongType))
+
+    checkV2Conversion(
+      catalystExpr = $"cint".int % Abs(Literal(-3), failOnError = true),
+      v2Expr = new GeneralScalarExpression("%", Array(
+        FieldReference("cint"),
+        LiteralValue(3, IntegerType))))
+
+    checkV2Conversion(
+      catalystExpr = Exp(Literal(0.0)) * $"cdouble".double,
+      v2Expr = new GeneralScalarExpression("*", Array(
+        LiteralValue(1.0, DoubleType),
+        FieldReference("cdouble"))))
+  }
+
+  test("Current Like functions are not supported") {
+    val currentFunctions = Seq(
+      CurrentDate(),
+      CurrentTimestamp(),
+      CurrentUser()
+    )
+
+    currentFunctions.foreach { catalystExpr =>
+      assert(new V2ExpressionBuilder(catalystExpr).build().isEmpty)
+    }
+  }
+
   /**
    * Translate the given Catalyst [[Expression]] into data source V2 [[Predicate]]
    * then verify against the given [[Predicate]].


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
If the input to V2 expression translation is context-independent and foldable (see [PR #51282](https://github.com/apache/spark/pull/51282)), we perform constant folding on the input and use the evaluated result.

 For example:

* `1 + 1` becomes 2
* `a < log2(8)` becomes a < 3.0
 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This change broadens the coverage of V2 expression translation.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

New UT
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No