### PR TITLE
[SPARK-52876][CORE] Fix a typo `buffer` to `body` in `ChunkFetchSuccess.toString`

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/ChunkFetchSuccess.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/ChunkFetchSuccess.java
@@ -85,7 +85,7 @@ public final class ChunkFetchSuccess extends AbstractResponseMessage {
   public String toString() {
     return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
       .append("streamChunkId", streamChunkId)
-      .append("buffer", body())
+      .append("body", body())
       .toString();
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix a typo `buffer` to `body` in `ChunkFetchSuccess.toString`.

https://github.com/apache/spark/blob/7cc28969bf27d57f6eda910a5e74b6cef00777b4/common/network-common/src/main/java/org/apache/spark/network/protocol/ChunkFetchSuccess.java#L88

Historically, 
- SPARK-3453 introduced `buffer` correct at Spark 1.2.0
- SPARK-11235 caused this mismatch at Spark 1.6.0.

### Why are the changes needed?

We have 4 classes derived from `AbstractResponseMessage` (which derived from `AbstractMessage`).

```
$ git grep 'extends AbstractResponseMessage' | wc -l
       4

$ git grep 'extends AbstractMessage' | wc -l
      13
```

Since the field name of `AbstractMessage` is `body`, all the other places show `body=...` instead of `buffer=...`. We had better fix this typo for consistency.

https://github.com/apache/spark/blob/7cc28969bf27d57f6eda910a5e74b6cef00777b4/common/network-common/src/main/java/org/apache/spark/network/protocol/AbstractMessage.java#L28

https://github.com/apache/spark/blob/7cc28969bf27d57f6eda910a5e74b6cef00777b4/common/network-common/src/main/java/org/apache/spark/network/protocol/OneWayMessage.java#L78

https://github.com/apache/spark/blob/7cc28969bf27d57f6eda910a5e74b6cef00777b4/common/network-common/src/main/java/org/apache/spark/network/protocol/StreamResponse.java#L89

https://github.com/apache/spark/blob/7cc28969bf27d57f6eda910a5e74b6cef00777b4/common/network-common/src/main/java/org/apache/spark/network/protocol/RpcResponse.java#L85

### Does this PR introduce _any_ user-facing change?

This is a result of `toString` used during debugging mainly.

### How was this patch tested?

Pass the CIs and manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.