### PR TITLE
[SPARK-52885][SPARK-52886][SPARK-52887][SQL] Implement the hour, minute, and second functions in Scala for the TIME type

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -872,23 +872,6 @@ object functions {
     Column.fn("last_value", e, ignoreNulls)
 
   /**
-   * Create time from hour, minute and second fields.
-   * For invalid inputs it will throw an error.
-   *
-   * @param hour
-   *   the hour to represent, from 0 to 23.
-   * @param minute
-   *   the minute to represent, from 0 to 59.
-   * @param second
-   *   the second to represent, from 0 to 59.999999.
-   * @group datetime_funcs
-   * @since 4.1.0
-   */
-  def make_time(hour: Column, minute: Column, second: Column): Column = {
-    Column.fn("make_time", hour, minute, second)
-  }
-
-  /**
    * Aggregate function: returns the most frequent value in a group.
    *
    * @group agg_funcs

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -872,6 +872,23 @@ object functions {
     Column.fn("last_value", e, ignoreNulls)
 
   /**
+   * Create time from hour, minute and second fields.
+   * For invalid inputs it will throw an error.
+   *
+   * @param hour
+   *   the hour to represent, from 0 to 23.
+   * @param minute
+   *   the minute to represent, from 0 to 59.
+   * @param second
+   *   the second to represent, from 0 to 59.999999.
+   * @group datetime_funcs
+   * @since 4.1.0
+   */
+  def make_time(hour: Column, minute: Column, second: Column): Column = {
+    Column.fn("make_time", hour, minute, second)
+  }
+
+  /**
    * Aggregate function: returns the most frequent value in a group.
    *
    * @group agg_funcs
@@ -5400,7 +5417,7 @@ object functions {
   def dayofyear(e: Column): Column = Column.fn("dayofyear", e)
 
   /**
-   * Extracts the hours as an integer from a given date/timestamp/string.
+   * Extracts the hours as an integer from a given date/time/timestamp/string.
    * @return
    *   An integer, or null if the input was a string that could not be cast to a date
    * @group datetime_funcs
@@ -5473,7 +5490,7 @@ object functions {
   def last_day(e: Column): Column = Column.fn("last_day", e)
 
   /**
-   * Extracts the minutes as an integer from a given date/timestamp/string.
+   * Extracts the minutes as an integer from a given date/time/timestamp/string.
    * @return
    *   An integer, or null if the input was a string that could not be cast to a date
    * @group datetime_funcs
@@ -5579,7 +5596,7 @@ object functions {
     Column.fn("next_day", date, dayOfWeek)
 
   /**
-   * Extracts the seconds as an integer from a given date/timestamp/string.
+   * Extracts the seconds as an integer from a given date/time/timestamp/string.
    * @return
    *   An integer, or null if the input was a string that could not be cast to a timestamp
    * @group datetime_funcs

--- a/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuite.scala
@@ -30,7 +30,7 @@ class TimeFunctionsSuite extends QueryTest with SharedSparkSession {
 
   override def sparkConf: SparkConf = super.sparkConf.set(SQLConf.ANSI_ENABLED.key, "false")
 
-  test("hour function") {
+  test("SPARK-52885: hour function") {
     // Input data for the function.
     val schema = StructType(Seq(
       StructField("time", TimeType(), nullable = false)
@@ -63,7 +63,7 @@ class TimeFunctionsSuite extends QueryTest with SharedSparkSession {
     checkAnswer(result2, expected)
   }
 
-  test("minute function") {
+  test("SPARK-52886: minute function") {
     // Input data for the function.
     val schema = StructType(Seq(
       StructField("time", TimeType(), nullable = false)
@@ -96,7 +96,7 @@ class TimeFunctionsSuite extends QueryTest with SharedSparkSession {
     checkAnswer(result2, expected)
   }
 
-  test("second function") {
+  test("SPARK-52887: second function") {
     // Input data for the function.
     val schema = StructType(Seq(
       StructField("time", TimeType(), nullable = false)

--- a/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuite.scala
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import java.time.LocalTime
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types._
+
+class TimeFunctionsSuite extends QueryTest with SharedSparkSession {
+  import testImplicits._
+
+  override def sparkConf: SparkConf = super.sparkConf.set(SQLConf.ANSI_ENABLED.key, "false")
+
+  test("hour function") {
+    // Input data for the function.
+    val schema = StructType(Seq(
+      StructField("time", TimeType(), nullable = false)
+    ))
+    val data = Seq(
+      Row(LocalTime.parse("00:00:00")),
+      Row(LocalTime.parse("01:02:03.4")),
+      Row(LocalTime.parse("23:59:59.999999"))
+    )
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+
+    // Test the function using both `selectExpr` and `select`.
+    val result1 = df.selectExpr(
+      "hour(time)"
+    )
+    val result2 = df.select(
+      hour(col("time"))
+    )
+    // Check that both methods produce the same result.
+    checkAnswer(result1, result2)
+
+    // Expected output of the function.
+    val expected = Seq(
+      0,
+      1,
+      23
+    ).toDF("hour").select(col("hour"))
+    // Check that the results match the expected output.
+    checkAnswer(result1, expected)
+    checkAnswer(result2, expected)
+  }
+
+  test("minute function") {
+    // Input data for the function.
+    val schema = StructType(Seq(
+      StructField("time", TimeType(), nullable = false)
+    ))
+    val data = Seq(
+      Row(LocalTime.parse("00:00:00")),
+      Row(LocalTime.parse("01:02:03.4")),
+      Row(LocalTime.parse("23:59:59.999999"))
+    )
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+
+    // Test the function using both `selectExpr` and `select`.
+    val result1 = df.selectExpr(
+      "minute(time)"
+    )
+    val result2 = df.select(
+      minute(col("time"))
+    )
+    // Check that both methods produce the same result.
+    checkAnswer(result1, result2)
+
+    // Expected output of the function.
+    val expected = Seq(
+      0,
+      2,
+      59
+    ).toDF("minute").select(col("minute"))
+    // Check that the results match the expected output.
+    checkAnswer(result1, expected)
+    checkAnswer(result2, expected)
+  }
+
+  test("second function") {
+    // Input data for the function.
+    val schema = StructType(Seq(
+      StructField("time", TimeType(), nullable = false)
+    ))
+    val data = Seq(
+      Row(LocalTime.parse("00:00:00")),
+      Row(LocalTime.parse("01:02:03.4")),
+      Row(LocalTime.parse("23:59:59.999999"))
+    )
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+
+    // Test the function using both `selectExpr` and `select`.
+    val result1 = df.selectExpr(
+      "second(time)"
+    )
+    val result2 = df.select(
+      second(col("time"))
+    )
+    // Check that both methods produce the same result.
+    checkAnswer(result1, result2)
+
+    // Expected output of the function.
+    val expected = Seq(
+      0,
+      3,
+      59
+    ).toDF("second").select(col("second"))
+    // Check that the results match the expected output.
+    checkAnswer(result1, expected)
+    checkAnswer(result2, expected)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuite.scala
@@ -28,8 +28,6 @@ import org.apache.spark.sql.types._
 class TimeFunctionsSuite extends QueryTest with SharedSparkSession {
   import testImplicits._
 
-  override def sparkConf: SparkConf = super.sparkConf.set(SQLConf.ANSI_ENABLED.key, "false")
-
   test("SPARK-52885: hour function") {
     // Input data for the function.
     val schema = StructType(Seq(
@@ -128,4 +126,14 @@ class TimeFunctionsSuite extends QueryTest with SharedSparkSession {
     checkAnswer(result1, expected)
     checkAnswer(result2, expected)
   }
+}
+
+// This class is used to run the same tests with ANSI mode enabled explicitly.
+class TimeFunctionsAnsiOnSuite extends TimeFunctionsSuite {
+  override def sparkConf: SparkConf = super.sparkConf.set(SQLConf.ANSI_ENABLED.key, "true")
+}
+
+// This class is used to run the same tests with ANSI mode disabled explicitly.
+class TimeFunctionsAnsiOffSuite extends TimeFunctionsSuite {
+  override def sparkConf: SparkConf = super.sparkConf.set(SQLConf.ANSI_ENABLED.key, "false")
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuiteBase.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class TimeFunctionsSuite extends QueryTest with SharedSparkSession {
+abstract class TimeFunctionsSuiteBase extends QueryTest with SharedSparkSession {
   import testImplicits._
 
   test("SPARK-52885: hour function") {
@@ -129,11 +129,11 @@ class TimeFunctionsSuite extends QueryTest with SharedSparkSession {
 }
 
 // This class is used to run the same tests with ANSI mode enabled explicitly.
-class TimeFunctionsAnsiOnSuite extends TimeFunctionsSuite {
+class TimeFunctionsAnsiOnSuite extends TimeFunctionsSuiteBase {
   override def sparkConf: SparkConf = super.sparkConf.set(SQLConf.ANSI_ENABLED.key, "true")
 }
 
 // This class is used to run the same tests with ANSI mode disabled explicitly.
-class TimeFunctionsAnsiOffSuite extends TimeFunctionsSuite {
+class TimeFunctionsAnsiOffSuite extends TimeFunctionsSuiteBase {
   override def sparkConf: SparkConf = super.sparkConf.set(SQLConf.ANSI_ENABLED.key, "false")
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add support for TIME type for the `hour`, `minute` and `second` functions in Scala API.


### Why are the changes needed?
Expand API support for the `hour`, `minute` and `second` expressions / functions for the TIME data type.

### Does this PR introduce _any_ user-facing change?
Yes, the support for TIME data type is now available with these functions in Scala API.


### How was this patch tested?
Added appropriate Scala functions tests in TimeFunctionsSuite.


### Was this patch authored or co-authored using generative AI tooling?
No.
