### PR TITLE
[MINOR] Remove unnecessary df.show() in tests

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -111,7 +111,6 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
   }
 
   test("SPARK-34678: describe functions for table-valued functions") {
-    sql("describe function range").show(false)
     checkKeywordsExist(sql("describe function range"),
       "Function: range",
       "Class: org.apache.spark.sql.catalyst.plans.logical.Range",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DescribeTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DescribeTableSuiteBase.scala
@@ -252,7 +252,6 @@ trait DescribeTableSuiteBase extends QueryTest with DDLCommandTestUtils {
       df.write.mode("append").clusterBy("col1", "col2.x").saveAsTable(tbl)
       val descriptionDf = sql(s"DESC $tbl")
 
-      descriptionDf.show(false)
       assert(descriptionDf.schema.map(field => (field.name, field.dataType)) === Seq(
         ("col_name", StringType),
         ("data_type", StringType),
@@ -277,7 +276,6 @@ trait DescribeTableSuiteBase extends QueryTest with DDLCommandTestUtils {
       df.writeTo(tbl).clusterBy("col1", "col2.x").create()
       val descriptionDf = sql(s"DESC $tbl")
 
-      descriptionDf.show(false)
       assert(descriptionDf.schema.map(field => (field.name, field.dataType)) === Seq(
         ("col_name", StringType),
         ("data_type", StringType),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove df.show() to avoid unnecessary output.


### Why are the changes needed?
It's not recommended to print anything in the output, we disallowed `println` in scalastyle, but it's difficult to make df.show() a scalastyle rule.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
No.


### Was this patch authored or co-authored using generative AI tooling?
No.
