### PR TITLE
[SPARK-52901][SQL][K8S] Fix deprecated nested class shadowing warnings

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -128,17 +128,19 @@ object SparkKubernetesClientFactory extends Logging {
 
   object ClientType extends Enumeration {
     import scala.language.implicitConversions
-    val Driver = Val(DRIVER_CLIENT_REQUEST_TIMEOUT, DRIVER_CLIENT_CONNECTION_TIMEOUT)
-    val Submission = Val(SUBMISSION_CLIENT_REQUEST_TIMEOUT, SUBMISSION_CLIENT_CONNECTION_TIMEOUT)
+    val Driver: ClientTypeVal =
+      ClientTypeVal(DRIVER_CLIENT_REQUEST_TIMEOUT, DRIVER_CLIENT_CONNECTION_TIMEOUT)
+    val Submission: ClientTypeVal =
+      ClientTypeVal(SUBMISSION_CLIENT_REQUEST_TIMEOUT, SUBMISSION_CLIENT_CONNECTION_TIMEOUT)
 
-    protected case class Val(
+    protected case class ClientTypeVal(
         requestTimeoutEntry: ConfigEntry[Int],
         connectionTimeoutEntry: ConfigEntry[Int])
-      extends super.Val {
+      extends Val {
       def requestTimeout(conf: SparkConf): Int = conf.get(requestTimeoutEntry)
       def connectionTimeout(conf: SparkConf): Int = conf.get(connectionTimeoutEntry)
     }
 
-    implicit def convert(value: Value): Val = value.asInstanceOf[Val]
+    implicit def convert(value: Value): ClientTypeVal = value.asInstanceOf[ClientTypeVal]
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
@@ -1380,7 +1380,7 @@ class PartitionAwareDataSource extends TestingV2Source {
 
 class OrderAndPartitionAwareDataSource extends PartitionAwareDataSource {
 
-  class MyScanBuilder(
+  class OrderAwareScanBuilder(
       val partitionKeys: Option[Seq[String]],
       val orderKeys: Seq[String])
     extends SimpleScanBuilder
@@ -1414,7 +1414,7 @@ class OrderAndPartitionAwareDataSource extends PartitionAwareDataSource {
 
   override def getTable(options: CaseInsensitiveStringMap): Table = new SimpleBatchTable {
     override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
-      new MyScanBuilder(
+      new OrderAwareScanBuilder(
         Option(options.get("partitionKeys")).map(_.split(",").toImmutableArraySeq),
         Option(options.get("orderKeys")).map(_.split(",").toSeq).getOrElse(Seq.empty)
       )
@@ -1518,7 +1518,7 @@ class SupportsExternalMetadataWritableDataSource extends SimpleWritableDataSourc
 
 class ReportStatisticsDataSource extends SimpleWritableDataSource {
 
-  class MyScanBuilder extends SimpleScanBuilder
+  class ReportStatisticsScanBuilder extends SimpleScanBuilder
     with SupportsReportStatistics {
     override def estimateStatistics(): Statistics = {
       new Statistics {
@@ -1536,7 +1536,7 @@ class ReportStatisticsDataSource extends SimpleWritableDataSource {
   override def getTable(options: CaseInsensitiveStringMap): Table = {
     new SimpleBatchTable {
       override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
-        new MyScanBuilder
+        new ReportStatisticsScanBuilder
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr mainly fixes the following compilation warnings:

```
warn] /home/runner/work/spark/spark/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala:1383:9: shadowing a nested class of a parent is deprecated but class MyScanBuilder shadows class MyScanBuilder defined in class PartitionAwareDataSource; rename the class to something else
[warn] Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=deprecation, site=org.apache.spark.sql.connector.OrderAndPartitionAwareDataSource.MyScanBuilder, origin=org.apache.spark.sql.connector.OrderAndPartitionAwareDataSource.MyScanBuilder, version=2.13.2
[warn]   class MyScanBuilder(
[warn]         ^
[warn] /home/runner/work/spark/spark/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala:1521:9: shadowing a nested class of a parent is deprecated but class MyScanBuilder shadows class MyScanBuilder defined in class SimpleWritableDataSource; rename the class to something else
[warn] Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=deprecation, site=org.apache.spark.sql.connector.ReportStatisticsDataSource.MyScanBuilder, origin=org.apache.spark.sql.connector.ReportStatisticsDataSource.MyScanBuilder, version=2.13.2
[warn]   class MyScanBuilder extends SimpleScanBuilder
[warn]         ^
[warn] /home/runner/work/spark/spark/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala:134:26: shadowing a nested class of a parent is deprecated but class Val shadows class Val defined in class Enumeration; rename the class to something else
[warn] Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=deprecation, site=org.apache.spark.deploy.k8s.SparkKubernetesClientFactory.ClientType.Val, origin=org.apache.spark.deploy.k8s.SparkKubernetesClientFactory.ClientType.Val, version=2.13.2
[warn]     protected case class Val(
[warn]                          ^
```

### Why are the changes needed?
Clean up compilation warnings.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
