### PR TITLE
[SPARK-52908][Core] Prevent for iterator variable name clashing with names of labels in the path to the root of AST

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1816,6 +1816,12 @@
     ],
     "sqlState" : "39000"
   },
+  "FOR_VARIABLE_NAME_ALREADY_EXISTS_AS_LABEL_IN_SCOPE" : {
+    "message": [
+      "Found FOR variable name <varName> that already exists as a label in the scope."
+    ],
+    "sqlState" : "42734"
+  },
   "FORBIDDEN_OPERATION" : {
     "message" : [
       "The operation <statement> is not allowed on the <objectType>: <objectName>."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1816,10 +1816,17 @@
     ],
     "sqlState" : "39000"
   },
-  "FOR_VARIABLE_NAME_ALREADY_EXISTS_AS_LABEL_IN_SCOPE" : {
+  "FOR_VARIABLE_NAME_FORBIDDEN" : {
     "message": [
-      "Found FOR variable name <varName> that already exists as a label in the scope."
+      "An error regarding the naming of an iterator variable inside a for loop occurred."
     ],
+    "subClass" : {
+      "NAME_ALREADY_IN_USE": {
+        "message": [
+          "Variable name <varName> used in FOR statement is already used in another parenting FOR loop or as a label in parenting scope. This is forbidden to avoid issues with referencing variables/columns."
+        ]
+      }
+    },
     "sqlState" : "42734"
   },
   "FORBIDDEN_OPERATION" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4057,9 +4057,9 @@
     ],
     "sqlState" : "42K0L"
   },
-  "LABEL_NAME_FORBIDDEN" : {
+  "LABEL_OR_FOR_VARIABLE_NAME_FORBIDDEN" : {
     "message" : [
-      "The label name <label> is forbidden."
+      "The label or FOR variable name <label> is forbidden."
     ],
     "sqlState" : "42K0L"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1823,7 +1823,7 @@
     "subClass" : {
       "NAME_ALREADY_IN_USE": {
         "message": [
-          "Variable name <varName> used in FOR statement is already used in another parenting FOR loop or as a label in parenting scope. This is forbidden to avoid issues with referencing variables/columns."
+          "Variable name <varName> used in the FOR statement is already used in a parent FOR loop or as a label in the enclosing scope."
         ]
       }
     },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4051,7 +4051,7 @@
     ],
     "sqlState" : "42K0L"
   },
-  "LABEL_ALREADY_EXISTS" : {
+  "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS" : {
     "message" : [
       "The label or FOR variable <label> already exists. Choose another name or rename the existing one."
     ],

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4057,9 +4057,9 @@
     ],
     "sqlState" : "42K0L"
   },
-  "LABEL_ALREADY_EXISTS" : {
+  "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS" : {
     "message" : [
-      "The label <label> already exists. Choose another name or rename the existing label."
+      "The label or for variable <label> already exists. Choose another name or rename the existing label."
     ],
     "sqlState" : "42K0L"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1818,7 +1818,7 @@
   },
   "FOR_VARIABLE_NAME_FORBIDDEN" : {
     "message": [
-      "An error regarding the naming of an iterator variable inside a for loop occurred."
+      "Invalid iterator variable name used in a FOR loop."
     ],
     "subClass" : {
       "NAME_ALREADY_IN_USE": {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4064,7 +4064,7 @@
     ],
     "sqlState" : "42K0L"
   },
-  "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS" : {
+  "LABEL_ALREADY_EXISTS" : {
     "message" : [
       "The label or FOR variable <label> already exists. Choose another name or rename the existing one."
     ],

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1816,19 +1816,6 @@
     ],
     "sqlState" : "39000"
   },
-  "FOR_VARIABLE_NAME_FORBIDDEN" : {
-    "message": [
-      "Invalid iterator variable name used in a FOR loop."
-    ],
-    "subClass" : {
-      "NAME_ALREADY_IN_USE": {
-        "message": [
-          "Variable name <varName> used in the FOR statement is already used in a parent FOR loop or as a label in the enclosing scope."
-        ]
-      }
-    },
-    "sqlState" : "42734"
-  },
   "FORBIDDEN_OPERATION" : {
     "message" : [
       "The operation <statement> is not allowed on the <objectType>: <objectName>."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4066,7 +4066,7 @@
   },
   "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS" : {
     "message" : [
-      "The label or for variable <label> already exists. Choose another name or rename the existing label."
+      "The label or FOR variable <label> already exists. Choose another name or rename the existing one."
     ],
     "sqlState" : "42K0L"
   },

--- a/common/utils/src/main/resources/error/error-states.json
+++ b/common/utils/src/main/resources/error/error-states.json
@@ -3345,7 +3345,7 @@
         "description": "A duplicate parameter-name, SQL variable name, label, or condition-name was detected.",
         "origin": "DB2",
         "standard": "N",
-        "usedBy": ["DB2"]
+        "usedBy": ["DB2, Spark"]
     },
     "42736": {
         "description": "The label specified on the GOTO, ITERATE, or LEAVE statement is not found or not valid.",

--- a/common/utils/src/main/resources/error/error-states.json
+++ b/common/utils/src/main/resources/error/error-states.json
@@ -3345,7 +3345,7 @@
         "description": "A duplicate parameter-name, SQL variable name, label, or condition-name was detected.",
         "origin": "DB2",
         "standard": "N",
-        "usedBy": ["DB2, Spark"]
+        "usedBy": ["DB2"]
     },
     "42736": {
         "description": "The label specified on the GOTO, ITERATE, or LEAVE statement is not found or not valid.",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.SqlScriptingContextManager
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.SubExprUtils.wrapOuterReference
-import org.apache.spark.sql.catalyst.parser.SqlScriptingLabelContext.isForbiddenLabelName
+import org.apache.spark.sql.catalyst.parser.SqlScriptingLabelContext.isForbiddenLabelOrForVariableName
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.trees.CurrentOrigin.withOrigin
 import org.apache.spark.sql.catalyst.trees.TreePattern._
@@ -269,7 +269,7 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
       .filterNot(_ => AnalysisContext.get.isExecuteImmediate)
       // If variable name is qualified with session.<varName> treat it as a session variable.
       .filterNot(_ =>
-        nameParts.length > 2 || (nameParts.length == 2 && isForbiddenLabelName(nameParts.head)))
+        nameParts.length > 2 || (nameParts.length == 2 && isForbiddenLabelOrForVariableName(nameParts.head)))
       .flatMap(_.get(namePartsCaseAdjusted))
       .map { varDef =>
         VariableReference(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -269,7 +269,8 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
       .filterNot(_ => AnalysisContext.get.isExecuteImmediate)
       // If variable name is qualified with session.<varName> treat it as a session variable.
       .filterNot(_ =>
-        nameParts.length > 2 || (nameParts.length == 2 && isForbiddenLabelOrForVariableName(nameParts.head)))
+        nameParts.length > 2
+          || (nameParts.length == 2 && isForbiddenLabelOrForVariableName(nameParts.head)))
       .flatMap(_.get(namePartsCaseAdjusted))
       .map { varDef =>
         VariableReference(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -557,7 +557,7 @@ class AstBuilder extends DataTypeAstBuilder
     val query = withOrigin(queryCtx) {
       SingleStatement(visitQuery(queryCtx))
     }
-    parsingCtx.labelContext.assertIdentifierNotInSeenLabels(Option(ctx.multipartIdentifier()))
+    parsingCtx.labelContext.enterForScope(Option(ctx.multipartIdentifier()))
     val varName = Option(ctx.multipartIdentifier()).map(_.getText)
     val body = visitCompoundBodyImpl(
       ctx.compoundBody(),
@@ -566,6 +566,7 @@ class AstBuilder extends DataTypeAstBuilder
       isScope = false
     )
     parsingCtx.labelContext.exitLabeledScope(Option(ctx.beginLabel()))
+    parsingCtx.labelContext.exitForScope(Option(ctx.multipartIdentifier()))
 
     ForStatement(query, varName, body, Some(labelText))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -565,8 +565,8 @@ class AstBuilder extends DataTypeAstBuilder
       parsingCtx,
       isScope = false
     )
-    parsingCtx.labelContext.exitLabeledScope(Option(ctx.beginLabel()))
     parsingCtx.labelContext.exitForScope(Option(ctx.multipartIdentifier()))
+    parsingCtx.labelContext.exitLabeledScope(Option(ctx.beginLabel()))
 
     ForStatement(query, varName, body, Some(labelText))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -557,6 +557,7 @@ class AstBuilder extends DataTypeAstBuilder
     val query = withOrigin(queryCtx) {
       SingleStatement(visitQuery(queryCtx))
     }
+    parsingCtx.labelContext.assertIdentifierNotInSeenLabels(Option(ctx.multipartIdentifier()))
     val varName = Option(ctx.multipartIdentifier()).map(_.getText)
     val body = visitCompoundBodyImpl(
       ctx.compoundBody(),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -323,7 +323,7 @@ class SqlScriptingLabelContext {
   private def assertIdentifierNotInSeenLabels(identifierCtx: Option[MultipartIdentifierContext]): Unit = {
     val identifierName = identifierCtx.map(_.getText)
 
-    if(identifierName.isDefined && seenLabels.contains(identifierName.get.toLowerCase(Locale.ROOT)))) {
+    if(identifierName.isDefined && seenLabels.contains(identifierName.get.toLowerCase(Locale.ROOT))) {
       withOrigin(identifierCtx.get) {
         throw SqlScriptingErrors
           .forVariableNameAlreadyExistsAsLabelInScope(CurrentOrigin.get, identifierName.get)
@@ -385,7 +385,7 @@ class SqlScriptingLabelContext {
 
     if(identifierName.isDefined) {
       assertIdentifierNotInSeenLabels(identifierCtx)
-      seenLabels.add(identifierName.get.toLowerCase(Locale.ROOT)))
+      seenLabels.add(identifierName.get.toLowerCase(Locale.ROOT))
     }
   }
 
@@ -397,7 +397,7 @@ class SqlScriptingLabelContext {
     val identifierName = identifierCtx.map(_.getText)
 
     if(identifierName.isDefined) {
-      seenLabels.remove(identifierName.get.toLowerCase(Locale.ROOT)))
+      seenLabels.remove(identifierName.get.toLowerCase(Locale.ROOT))
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -327,7 +327,7 @@ class SqlScriptingLabelContext {
       if (seenLabels.contains(identifierName.toLowerCase(Locale.ROOT))) {
         withOrigin(ctx) {
           throw SqlScriptingErrors
-            .duplicateLabels(CurrentOrigin.get, identifierName)
+            .duplicateLabels(CurrentOrigin.get, identifierName.toLowerCase(Locale.ROOT))
         }
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -390,7 +390,9 @@ class SqlScriptingLabelContext {
 
       if (SqlScriptingLabelContext.isForbiddenLabelName(identifierName)) {
         withOrigin(ctx) {
-          throw SqlScriptingErrors.labelNameForbidden(CurrentOrigin.get, identifierName)
+          throw SqlScriptingErrors.labelNameForbidden(
+            CurrentOrigin.get,
+            identifierName.toLowerCase(Locale.ROOT))
         }
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -321,7 +321,7 @@ class SqlScriptingLabelContext {
    * If the identifier is contained within seenLabels, raise an exception.
    */
   private def assertIdentifierNotInSeenLabels(
-    identifierCtx: Option[MultipartIdentifierContext]): Unit = {
+      identifierCtx: Option[MultipartIdentifierContext]): Unit = {
     identifierCtx.foreach { ctx =>
       val identifierName = ctx.getText
       if (seenLabels.contains(identifierName.toLowerCase(Locale.ROOT))) {
@@ -359,9 +359,9 @@ class SqlScriptingLabelContext {
       // Do not add the label to the seenLabels set if it is not defined.
       java.util.UUID.randomUUID.toString.toLowerCase(Locale.ROOT)
     }
-    if (SqlScriptingLabelContext.isForbiddenLabelName(labelText)) {
+    if (SqlScriptingLabelContext.isForbiddenLabelOrForVariableName(labelText)) {
       withOrigin(beginLabelCtx.get) {
-        throw SqlScriptingErrors.labelNameForbidden(CurrentOrigin.get, labelText)
+        throw SqlScriptingErrors.labelOrForVariableNameForbidden(CurrentOrigin.get, labelText)
       }
     }
     labelText
@@ -388,9 +388,9 @@ class SqlScriptingLabelContext {
       assertIdentifierNotInSeenLabels(identifierCtx)
       seenLabels.add(identifierName.toLowerCase(Locale.ROOT))
 
-      if (SqlScriptingLabelContext.isForbiddenLabelName(identifierName)) {
+      if (SqlScriptingLabelContext.isForbiddenLabelOrForVariableName(identifierName)) {
         withOrigin(ctx) {
-          throw SqlScriptingErrors.labelNameForbidden(
+          throw SqlScriptingErrors.labelOrForVariableNameForbidden(
             CurrentOrigin.get,
             identifierName.toLowerCase(Locale.ROOT))
         }
@@ -415,7 +415,7 @@ object SqlScriptingLabelContext {
   private val forbiddenLabelNames: immutable.Set[Regex] =
     immutable.Set("builtin".r, "session".r, "sys.*".r)
 
-  def isForbiddenLabelName(labelName: String): Boolean = {
+  def isForbiddenLabelOrForVariableName(labelName: String): Boolean = {
     forbiddenLabelNames.exists(_.matches(labelName.toLowerCase(Locale.ROOT)))
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -320,10 +320,12 @@ class SqlScriptingLabelContext {
    * Assert the identifier is not contained within seenLabels.
    * If the identifier is contained within seenLabels, raise an exception.
    */
-  private def assertIdentifierNotInSeenLabels(identifierCtx: Option[MultipartIdentifierContext]): Unit = {
+  private def assertIdentifierNotInSeenLabels(
+    identifierCtx: Option[MultipartIdentifierContext]): Unit = {
     val identifierName = identifierCtx.map(_.getText)
 
-    if(identifierName.isDefined && seenLabels.contains(identifierName.get.toLowerCase(Locale.ROOT))) {
+    if(identifierName.isDefined
+      && seenLabels.contains(identifierName.get.toLowerCase(Locale.ROOT))) {
       withOrigin(identifierCtx.get) {
         throw SqlScriptingErrors
           .forVariableNameAlreadyExistsAsLabelInScope(CurrentOrigin.get, identifierName.get)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -324,11 +324,12 @@ class SqlScriptingLabelContext {
     identifierCtx: Option[MultipartIdentifierContext]): Unit = {
     val identifierName = identifierCtx.map(_.getText)
 
-    if(identifierName.isDefined
-      && seenLabels.contains(identifierName.get.toLowerCase(Locale.ROOT))) {
-      withOrigin(identifierCtx.get) {
+    identifierCtx.foreach { ctx =>
+      val identifierName = ctx.getText
+      if(seenLabels.contains(identifierName.toLowerCase(Locale.ROOT))) {
+      withOrigin(ctx) {
         throw SqlScriptingErrors
-          .forVariableNameAlreadyExistsAsLabelInScope(CurrentOrigin.get, identifierName.get)
+          .forVariableNameAlreadyExistsAsLabelInScope(CurrentOrigin.get, identifierName)
       }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -44,7 +44,7 @@ private[sql] object SqlScriptingErrors {
   def duplicateLabels(origin: Origin, label: String): Throwable = {
     new SqlScriptingException(
       origin = origin,
-      errorClass = "LABEL_ALREADY_EXISTS",
+      errorClass = "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS",
       cause = null,
       messageParameters = Map("label" -> toSQLId(label)))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -33,7 +33,7 @@ private[sql] object SqlScriptingErrors {
   def duplicateLabels(origin: Origin, label: String): Throwable = {
     new SqlScriptingException(
       origin = origin,
-      errorClass = "LABEL_ALREADY_EXISTS",
+      errorClass = "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS",
       cause = null,
       messageParameters = Map("label" -> toSQLId(label)))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -30,6 +30,17 @@ import org.apache.spark.sql.internal.SQLConf
  */
 private[sql] object SqlScriptingErrors {
 
+  def forVariableNameAlreadyExistsAsLabelInScope(
+    origin: Origin,
+    varName: String): Throwable = {
+    new SqlScriptingException(
+      origin = origin,
+      errorClass = "FOR_VARIABLE_NAME_ALREADY_EXISTS_AS_LABEL_IN_SCOPE",
+      cause = null,
+      messageParameters = Map("varName" -> toSQLId(varName)))
+  }
+
+
   def duplicateLabels(origin: Origin, label: String): Throwable = {
     new SqlScriptingException(
       origin = origin,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -35,7 +35,7 @@ private[sql] object SqlScriptingErrors {
     varName: String): Throwable = {
     new SqlScriptingException(
       origin = origin,
-      errorClass = "FOR_VARIABLE_NAME_ALREADY_EXISTS_AS_LABEL_IN_SCOPE",
+      errorClass = "FOR_VARIABLE_NAME_FORBIDDEN.NAME_ALREADY_IN_USE",
       cause = null,
       messageParameters = Map("varName" -> toSQLId(varName)))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -30,21 +30,10 @@ import org.apache.spark.sql.internal.SQLConf
  */
 private[sql] object SqlScriptingErrors {
 
-  def forVariableNameAlreadyExistsAsLabelInScope(
-    origin: Origin,
-    varName: String): Throwable = {
-    new SqlScriptingException(
-      origin = origin,
-      errorClass = "FOR_VARIABLE_NAME_FORBIDDEN.NAME_ALREADY_IN_USE",
-      cause = null,
-      messageParameters = Map("varName" -> toSQLId(varName)))
-  }
-
-
   def duplicateLabels(origin: Origin, label: String): Throwable = {
     new SqlScriptingException(
       origin = origin,
-      errorClass = "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS",
+      errorClass = "LABEL_ALREADY_EXISTS",
       cause = null,
       messageParameters = Map("label" -> toSQLId(label)))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -54,10 +54,10 @@ private[sql] object SqlScriptingErrors {
       messageParameters = Map("endLabel" -> toSQLId(endLabel)))
   }
 
-  def labelNameForbidden(origin: Origin, label: String): Throwable = {
+  def labelOrForVariableNameForbidden(origin: Origin, label: String): Throwable = {
     new SqlScriptingException(
       origin = origin,
-      errorClass = "LABEL_NAME_FORBIDDEN",
+      errorClass = "LABEL_OR_FOR_VARIABLE_NAME_FORBIDDEN",
       cause = null,
       messageParameters = Map("label" -> toSQLId(label))
     )

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -323,7 +323,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "LABEL_NAME_FORBIDDEN",
+      condition = "LABEL_OR_FOR_VARIABLE_NAME_FORBIDDEN",
       parameters = Map("label" -> toSQLId("system")))
     assert(exception.origin.line.contains(3))
   }
@@ -345,7 +345,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "LABEL_NAME_FORBIDDEN",
+      condition = "LABEL_OR_FOR_VARIABLE_NAME_FORBIDDEN",
       parameters = Map("label" -> toSQLId("sysxyz")))
     assert(exception.origin.line.contains(3))
   }
@@ -367,7 +367,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "LABEL_NAME_FORBIDDEN",
+      condition = "LABEL_OR_FOR_VARIABLE_NAME_FORBIDDEN",
       parameters = Map("label" -> toSQLId("session")))
     assert(exception.origin.line.contains(3))
   }
@@ -389,7 +389,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "LABEL_NAME_FORBIDDEN",
+      condition = "LABEL_OR_FOR_VARIABLE_NAME_FORBIDDEN",
       parameters = Map("label" -> toSQLId("builtin")))
     assert(exception.origin.line.contains(3))
   }
@@ -411,7 +411,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "LABEL_NAME_FORBIDDEN",
+      condition = "LABEL_OR_FOR_VARIABLE_NAME_FORBIDDEN",
       parameters = Map("label" -> toSQLId("system")))
     assert(exception.origin.line.contains(3))
   }
@@ -433,7 +433,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "LABEL_NAME_FORBIDDEN",
+      condition = "LABEL_OR_FOR_VARIABLE_NAME_FORBIDDEN",
       parameters = Map("label" -> toSQLId("session")))
     assert(exception.origin.line.contains(3))
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -2385,7 +2385,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
         parsePlan(sqlScriptText)
       },
       condition = "LABEL_ALREADY_EXISTS",
-      parameters = Map("label" -> "`L2`"))
+      parameters = Map("label" -> "`l2`"))
   }
 
   test("for variable name is the same as the label of the for loop - should fail") {
@@ -2402,7 +2402,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
         parsePlan(sqlScriptText)
       },
       condition = "LABEL_ALREADY_EXISTS",
-      parameters = Map("label" -> "`L1`"))
+      parameters = Map("label" -> "`l1`"))
   }
 
   test("label name is the same as the for loop variable name - should fail") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -2012,7 +2012,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "LABEL_ALREADY_EXISTS",
+      condition = "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS",
       parameters = Map("label" -> toSQLId("lbl")))
   }
 
@@ -2031,7 +2031,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "LABEL_ALREADY_EXISTS",
+      condition = "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS",
       parameters = Map("label" -> toSQLId("lbl")))
   }
 
@@ -2050,7 +2050,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "LABEL_ALREADY_EXISTS",
+      condition = "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS",
       parameters = Map("label" -> toSQLId("lbl")))
   }
 
@@ -2092,7 +2092,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "LABEL_ALREADY_EXISTS",
+      condition = "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS",
       parameters = Map("label" -> toSQLId("lbl_1")))
   }
 
@@ -2111,7 +2111,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "LABEL_ALREADY_EXISTS",
+      condition = "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS",
       parameters = Map("label" -> toSQLId("lbl")))
   }
 
@@ -2130,7 +2130,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "LABEL_ALREADY_EXISTS",
+      condition = "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS",
       parameters = Map("label" -> toSQLId("lbl")))
   }
 
@@ -2149,7 +2149,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "LABEL_ALREADY_EXISTS",
+      condition = "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS",
       parameters = Map("label" -> toSQLId("w_loop")))
   }
 
@@ -2170,7 +2170,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "LABEL_ALREADY_EXISTS",
+      condition = "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS",
       parameters = Map("label" -> toSQLId("r_loop")))
   }
 
@@ -2189,7 +2189,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "LABEL_ALREADY_EXISTS",
+      condition = "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS",
       parameters = Map("label" -> toSQLId("l_loop")))
   }
 
@@ -2208,7 +2208,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "LABEL_ALREADY_EXISTS",
+      condition = "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS",
       parameters = Map("label" -> toSQLId("f_loop")))
   }
 
@@ -2384,7 +2384,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
       exception = intercept[SqlScriptingException] {
         parsePlan(sqlScriptText)
       },
-      condition = "LABEL_ALREADY_EXISTS",
+      condition = "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS",
       parameters = Map("label" -> "`l2`"))
   }
 
@@ -2401,7 +2401,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
       exception = intercept[SqlScriptingException] {
         parsePlan(sqlScriptText)
       },
-      condition = "LABEL_ALREADY_EXISTS",
+      condition = "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS",
       parameters = Map("label" -> "`l1`"))
   }
 
@@ -2420,7 +2420,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
       exception = intercept[SqlScriptingException] {
         parsePlan(sqlScriptText)
       },
-      condition = "LABEL_ALREADY_EXISTS",
+      condition = "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS",
       parameters = Map("label" -> "`l1`"))
   }
 
@@ -2439,7 +2439,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
       exception = intercept[SqlScriptingException] {
         parsePlan(sqlScriptText)
       },
-      condition = "LABEL_ALREADY_EXISTS",
+      condition = "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS",
       parameters = Map("label" -> "`l1`"))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -2405,6 +2405,25 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     assert(e.getMessage.contains(" that already exists as a label name in scope."))
   }
 
+  test("label name is the same as the for loop variable - should fail") {
+    val sqlScriptText =
+      """
+        |BEGIN
+        |  FOR L1 AS SELECT 1 DO
+        |    L1: BEGIN
+        |      SELECT 2;
+        |    END L1;
+        |  END FOR;
+        |END""".stripMargin
+
+    val e = intercept[SqlScriptingException] {
+      parsePlan(sqlScriptText).asInstanceOf[CompoundBody]
+    }
+    assert(e.getCondition === "FOR_VARIABLE_NAME_ALREADY_EXISTS_AS_LABEL_IN_SCOPE")
+    assert(e.getMessage.contains("Found for variable name "))
+    assert(e.getMessage.contains(" that already exists as a label name in scope."))
+  }
+
   test("for statement") {
     val sqlScriptText =
       """

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -2380,15 +2380,12 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
         |  END L1;
         |END""".stripMargin
 
-    val e = intercept[SqlScriptingException] {
-      parsePlan(sqlScriptText).asInstanceOf[CompoundBody]
-    }
-    assert(e.getCondition === "FOR_VARIABLE_NAME_FORBIDDEN.NAME_ALREADY_IN_USE")
-    assert(e.getMessage.contains("An error regarding the naming of an iterator" +
-      " variable inside a for loop occurred. Variable name "))
-    assert(e.getMessage.contains(" used in FOR statement is already used in another " +
-      "parenting FOR loop or as a label in parenting scope. This is forbidden " +
-      "to avoid issues with referencing variables/columns."))
+    checkError(
+      exception = intercept[SqlScriptingException] {
+        parsePlan(sqlScriptText)
+      },
+      condition = "LABEL_ALREADY_EXISTS",
+      parameters = Map("label" -> "`L2`"))
   }
 
   test("for variable name is the same as the label of the for loop - should fail") {
@@ -2400,15 +2397,12 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
         |  END FOR L1;
         |END""".stripMargin
 
-    val e = intercept[SqlScriptingException] {
-      parsePlan(sqlScriptText).asInstanceOf[CompoundBody]
-    }
-    assert(e.getCondition === "FOR_VARIABLE_NAME_FORBIDDEN.NAME_ALREADY_IN_USE")
-    assert(e.getMessage.contains("An error regarding the naming of an iterator" +
-      " variable inside a for loop occurred. Variable name "))
-    assert(e.getMessage.contains(" used in FOR statement is already used in another " +
-      "parenting FOR loop or as a label in parenting scope. This is forbidden " +
-      "to avoid issues with referencing variables/columns."))
+    checkError(
+      exception = intercept[SqlScriptingException] {
+        parsePlan(sqlScriptText)
+      },
+      condition = "LABEL_ALREADY_EXISTS",
+      parameters = Map("label" -> "`L1`"))
   }
 
   test("label name is the same as the for loop variable name - should fail") {
@@ -2421,33 +2415,13 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
         |    END L1;
         |  END FOR;
         |END""".stripMargin
-    val e = intercept[SqlScriptingException] {
-      parsePlan(sqlScriptText).asInstanceOf[CompoundBody]
-    }
-    assert(e.getCondition === "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS")
-    assert(e.getMessage.contains("The label or for variable "))
-    assert(e.getMessage.contains(" already exists. Choose another " +
-      "name or rename the existing label."))
-  }
 
-  test("label name is the same as the for loop variable - should fail") {
-    val sqlScriptText =
-      """
-        |BEGIN
-        |  FOR L1 AS SELECT 1 DO
-        |    L1: BEGIN
-        |      SELECT 2;
-        |    END L1;
-        |  END FOR;
-        |END""".stripMargin
-
-    val e = intercept[SqlScriptingException] {
-      parsePlan(sqlScriptText).asInstanceOf[CompoundBody]
-    }
-    assert(e.getCondition === "LABEL_OR_FOR_VARIABLE_ALREADY_EXISTS")
-    assert(e.getMessage.contains("The label or for variable `"))
-    assert(e.getMessage.contains(" already exists. Choose " +
-      "another name or rename the existing label."))
+    checkError(
+      exception = intercept[SqlScriptingException] {
+        parsePlan(sqlScriptText)
+      },
+      condition = "LABEL_ALREADY_EXISTS",
+      parameters = Map("label" -> "`l1`"))
   }
 
   test("for statement") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Proposed change is to explicitly prohibit the interaction of iterator variable hiding the scoped variable if the label of scope and the iterator variable names are the same.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

For iterator variable hides scoped variables if the label of the scope and iterator variable name are the same.

This interaction leads to undesirable behavior:

- Column of the iterator variable and a variable in scope having the same name will result in the column of the iterator variable hiding the variable in scope;
- Trying to access the variable in scope that does not clash with the column of the iterator variable will result in the compiler not being able to resolve the variable in scope.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, it does. Changes are:

- Error LABEL_ALREADY_DEFINED was renamed to LABEL_OR_FOR_VARIABLE_ALREADY_DEFINED;
- Error LABEL_NAME_FORBIDDEN was renamed to LABEL_OR_FOR_VARIABLE_NAME_FORBIDDEN.

Old behavior:
![2C77E459-18FA-4B0E-8BDF-AA5D3E9B412F](https://github.com/user-attachments/assets/007ec190-e27f-4d70-b5a8-fb0272e05057)

<img width="1198" height="214" alt="image" src="https://github.com/user-attachments/assets/b2586697-49e9-4cbc-b57e-53b6c91700bc" />

New behavior:

<img width="1618" height="162" alt="image" src="https://github.com/user-attachments/assets/d023715c-08a1-47a2-9db1-3a19758140d6" />

<img width="1393" height="110" alt="image" src="https://github.com/user-attachments/assets/855d80c1-3fbd-42a6-ab1e-f664c4b4b47e" />

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

New tests in SqlScriptingExecutionSuite and existing tests.

Instead of printing a variable resolution exception, exception printed is stating the prohibition of such interactions.

Old behavior:
<img width="1335" height="380" alt="467960247-895da398-3ace-4334-b597-1be4a400acf4" src="https://github.com/user-attachments/assets/2d9412e1-5896-4286-b230-b728315a0fc6" />

New behavior:
<img width="1651" height="263" alt="467961070-92a0cbb7-bb93-410a-8266-3ef2591350f8" src="https://github.com/user-attachments/assets/5a44b505-6be2-4c1a-9f05-7fa563eab441" />

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.