### PR TITLE
[SPARK-52904][PYTHON] Enable convertToArrowArraySafely by default

### DIFF
--- a/python/docs/source/migration_guide/pyspark_upgrade.rst
+++ b/python/docs/source/migration_guide/pyspark_upgrade.rst
@@ -28,6 +28,8 @@ Upgrading from PySpark 4.0 to 4.1
 
 * In Spark 4.1, unnecessary conversion to pandas instances is removed when ``spark.sql.execution.pythonUDTF.arrow.enabled`` is enabled. As a result, the type coercion changes when the produced output has a schema different from the specified schema. To restore the previous behavior, enable ``spark.sql.legacy.execution.pythonUDTF.pandas.conversion.enabled``.
 
+* In Spark 4.1, the ``spark.sql.execution.pandas.convertToArrowArraySafely`` configuration is enabled by default. When this setting is enabled, PyArrow raises errors for unsafe conversions such as integer overflows, floating point truncation, and loss of precision. This change affects the return data serialization of arrow-enabled UDFs/pandas_udfs, and the creation of PySpark DataFrames. To restore the previous behavior, set the configuration to ``false``.
+
 Upgrading from PySpark 3.5 to 4.0
 ---------------------------------
 

--- a/python/pyspark/pandas/tests/computation/test_describe.py
+++ b/python/pyspark/pandas/tests/computation/test_describe.py
@@ -135,7 +135,7 @@ class FrameDescribeMixin:
         psdf = ps.DataFrame(
             {
                 "a": [1, 2, 3],
-                "b": [pd.Timestamp(1000), pd.Timestamp(1000), pd.Timestamp(1000)],
+                "b": [pd.Timestamp(1), pd.Timestamp(1), pd.Timestamp(1)],
                 "c": [None, None, None],
             }
         )
@@ -184,8 +184,8 @@ class FrameDescribeMixin:
         # Explicit empty DataFrame timestamp only
         psdf = ps.DataFrame(
             {
-                "a": [pd.Timestamp(1000), pd.Timestamp(1000), pd.Timestamp(1000)],
-                "b": [pd.Timestamp(1000), pd.Timestamp(1000), pd.Timestamp(1000)],
+                "a": [pd.Timestamp(1), pd.Timestamp(1), pd.Timestamp(1)],
+                "b": [pd.Timestamp(1), pd.Timestamp(1), pd.Timestamp(1)],
             }
         )
         pdf = psdf._to_pandas()
@@ -199,7 +199,7 @@ class FrameDescribeMixin:
 
         # Explicit empty DataFrame numeric & timestamp
         psdf = ps.DataFrame(
-            {"a": [1, 2, 3], "b": [pd.Timestamp(1000), pd.Timestamp(1000), pd.Timestamp(1000)]}
+            {"a": [1, 2, 3], "b": [pd.Timestamp(1), pd.Timestamp(1), pd.Timestamp(1)]}
         )
         pdf = psdf._to_pandas()
         pdf_result = pdf[pdf.a != pdf.a].describe()
@@ -219,10 +219,7 @@ class FrameDescribeMixin:
 
         # Explicit empty DataFrame string & timestamp
         psdf = ps.DataFrame(
-            {
-                "a": ["a", "b", "c"],
-                "b": [pd.Timestamp(1000), pd.Timestamp(1000), pd.Timestamp(1000)],
-            }
+            {"a": ["a", "b", "c"], "b": [pd.Timestamp(1), pd.Timestamp(1), pd.Timestamp(1)]}
         )
         pdf = psdf._to_pandas()
         pdf_result = pdf[pdf.a != pdf.a].describe()

--- a/python/pyspark/pandas/tests/computation/test_describe.py
+++ b/python/pyspark/pandas/tests/computation/test_describe.py
@@ -26,6 +26,11 @@ from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class FrameDescribeMixin:
+    @classmethod
+    def setUpClass(cls):
+        super(FrameDescribeMixin, cls).setUpClass()
+        cls.spark.conf.set("spark.sql.execution.pandas.convertToArrowArraySafely", "false")
+
     @property
     def pdf(self):
         return pd.DataFrame(

--- a/python/pyspark/pandas/tests/computation/test_describe.py
+++ b/python/pyspark/pandas/tests/computation/test_describe.py
@@ -135,7 +135,7 @@ class FrameDescribeMixin:
         psdf = ps.DataFrame(
             {
                 "a": [1, 2, 3],
-                "b": [pd.Timestamp(1), pd.Timestamp(1), pd.Timestamp(1)],
+                "b": [pd.Timestamp(1000), pd.Timestamp(1000), pd.Timestamp(1000)],
                 "c": [None, None, None],
             }
         )
@@ -184,8 +184,8 @@ class FrameDescribeMixin:
         # Explicit empty DataFrame timestamp only
         psdf = ps.DataFrame(
             {
-                "a": [pd.Timestamp(1), pd.Timestamp(1), pd.Timestamp(1)],
-                "b": [pd.Timestamp(1), pd.Timestamp(1), pd.Timestamp(1)],
+                "a": [pd.Timestamp(1000), pd.Timestamp(1000), pd.Timestamp(1000)],
+                "b": [pd.Timestamp(1000), pd.Timestamp(1000), pd.Timestamp(1000)],
             }
         )
         pdf = psdf._to_pandas()
@@ -199,7 +199,7 @@ class FrameDescribeMixin:
 
         # Explicit empty DataFrame numeric & timestamp
         psdf = ps.DataFrame(
-            {"a": [1, 2, 3], "b": [pd.Timestamp(1), pd.Timestamp(1), pd.Timestamp(1)]}
+            {"a": [1, 2, 3], "b": [pd.Timestamp(1000), pd.Timestamp(1000), pd.Timestamp(1000)]}
         )
         pdf = psdf._to_pandas()
         pdf_result = pdf[pdf.a != pdf.a].describe()
@@ -219,7 +219,10 @@ class FrameDescribeMixin:
 
         # Explicit empty DataFrame string & timestamp
         psdf = ps.DataFrame(
-            {"a": ["a", "b", "c"], "b": [pd.Timestamp(1), pd.Timestamp(1), pd.Timestamp(1)]}
+            {
+                "a": ["a", "b", "c"],
+                "b": [pd.Timestamp(1000), pd.Timestamp(1000), pd.Timestamp(1000)],
+            }
         )
         pdf = psdf._to_pandas()
         pdf_result = pdf[pdf.a != pdf.a].describe()

--- a/python/pyspark/pandas/tests/computation/test_describe.py
+++ b/python/pyspark/pandas/tests/computation/test_describe.py
@@ -29,6 +29,7 @@ class FrameDescribeMixin:
     @classmethod
     def setUpClass(cls):
         super(FrameDescribeMixin, cls).setUpClass()
+        # Some nanosecond->microsecond conversions throw loss of precision errors
         cls.spark.conf.set("spark.sql.execution.pandas.convertToArrowArraySafely", "false")
 
     @property

--- a/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
@@ -41,6 +41,11 @@ if extension_object_dtypes_available:
 class OpsTestBase:
     """The test base for arithmetic operations of different data types."""
 
+    @classmethod
+    def setUpClass(cls):
+        super(OpsTestBase, cls).setUpClass()
+        cls.spark.conf.set("spark.sql.execution.pandas.convertToArrowArraySafely", "false")
+
     @property
     def numeric_pdf(self):
         dtypes = [np.int32, int, np.float32, float]

--- a/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
@@ -41,7 +41,6 @@ if extension_object_dtypes_available:
 class OpsTestBase:
     """The test base for arithmetic operations of different data types."""
 
-
     @classmethod
     def setUpClass(cls):
         super(OpsTestBase, cls).setUpClass()

--- a/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
@@ -80,7 +80,7 @@ class OpsTestBase:
             "date": pd.Series(
                 [datetime.date(1994, 1, 1), datetime.date(1994, 1, 2), datetime.date(1994, 1, 3)]
             ),
-            "datetime": pd.to_datetime(pd.Series([1, 2, 3]), unit="s"),
+            "datetime": pd.to_datetime(pd.Series([1, 2, 3])),
             "timedelta": pd.Series(
                 [datetime.timedelta(1), datetime.timedelta(hours=2), datetime.timedelta(weeks=3)]
             ),
@@ -127,7 +127,7 @@ class OpsTestBase:
     def non_numeric_psers(self):
         psers = {
             "string": pd.Series(["x", "y", "z"]),
-            "datetime": pd.to_datetime(pd.Series([1, 2, 3]), unit="s"),
+            "datetime": pd.to_datetime(pd.Series([1, 2, 3])),
             "bool": pd.Series([True, True, False]),
             "date": pd.Series(
                 [datetime.date(1994, 1, 1), datetime.date(1994, 1, 2), datetime.date(1994, 1, 3)]

--- a/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
@@ -41,9 +41,11 @@ if extension_object_dtypes_available:
 class OpsTestBase:
     """The test base for arithmetic operations of different data types."""
 
+
     @classmethod
     def setUpClass(cls):
         super(OpsTestBase, cls).setUpClass()
+        # Some nanosecond->microsecond conversions throw loss of precision errors
         cls.spark.conf.set("spark.sql.execution.pandas.convertToArrowArraySafely", "false")
 
     @property

--- a/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
@@ -80,7 +80,7 @@ class OpsTestBase:
             "date": pd.Series(
                 [datetime.date(1994, 1, 1), datetime.date(1994, 1, 2), datetime.date(1994, 1, 3)]
             ),
-            "datetime": pd.to_datetime(pd.Series([1, 2, 3])),
+            "datetime": pd.to_datetime(pd.Series([1, 2, 3]), unit="s"),
             "timedelta": pd.Series(
                 [datetime.timedelta(1), datetime.timedelta(hours=2), datetime.timedelta(weeks=3)]
             ),
@@ -127,7 +127,7 @@ class OpsTestBase:
     def non_numeric_psers(self):
         psers = {
             "string": pd.Series(["x", "y", "z"]),
-            "datetime": pd.to_datetime(pd.Series([1, 2, 3])),
+            "datetime": pd.to_datetime(pd.Series([1, 2, 3]), unit="s"),
             "bool": pd.Series([True, True, False]),
             "date": pd.Series(
                 [datetime.date(1994, 1, 1), datetime.date(1994, 1, 2), datetime.date(1994, 1, 3)]

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -27,6 +27,11 @@ from pyspark.testing.utils import is_ansi_mode_test, ansi_mode_not_supported_mes
 
 
 class NumPyCompatTestsMixin:
+    @classmethod
+    def setUpClass(cls):
+        super(NumPyCompatTestsMixin, cls).setUpClass()
+        cls.spark.conf.set("spark.sql.execution.pandas.convertToArrowArraySafely", "false")
+
     blacklist = [
         # Pandas-on-Spark does not currently support
         "conj",

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -85,56 +85,52 @@ class NumPyCompatTestsMixin:
     def test_np_spark_compat_series(self):
         from pyspark.pandas.numpy_compat import unary_np_spark_mappings, binary_np_spark_mappings
 
-        # Disable arrow errors, some numpy functions produce results that exceed value ranges
-        with self.sql_conf({"spark.sql.execution.pandas.convertToArrowArraySafely": False}):
-            # Use randomly generated dataFrame
-            pdf = pd.DataFrame(
-                np.random.randint(-100, 100, size=(np.random.randint(100), 2)), columns=["a", "b"]
-            )
-            pdf2 = pd.DataFrame(
-                np.random.randint(-100, 100, size=(len(pdf), len(pdf.columns))), columns=["a", "b"]
-            )
-            psdf = ps.from_pandas(pdf)
-            psdf2 = ps.from_pandas(pdf2)
+        # Use randomly generated dataFrame
+        pdf = pd.DataFrame(
+            np.random.randint(-100, 100, size=(np.random.randint(100), 2)), columns=["a", "b"]
+        )
+        pdf2 = pd.DataFrame(
+            np.random.randint(-100, 100, size=(len(pdf), len(pdf.columns))), columns=["a", "b"]
+        )
+        psdf = ps.from_pandas(pdf)
+        psdf2 = ps.from_pandas(pdf2)
 
-            for np_name, spark_func in unary_np_spark_mappings.items():
-                np_func = getattr(np, np_name)
-                if np_name not in self.blacklist:
-                    try:
-                        # unary ufunc
-                        self.assert_eq(np_func(pdf.a), np_func(psdf.a), almost=True)
-                    except Exception as e:
-                        raise AssertionError("Test in '%s' function was failed." % np_name) from e
+        for np_name, spark_func in unary_np_spark_mappings.items():
+            np_func = getattr(np, np_name)
+            if np_name not in self.blacklist:
+                try:
+                    # unary ufunc
+                    self.assert_eq(np_func(pdf.a), np_func(psdf.a), almost=True)
+                except Exception as e:
+                    raise AssertionError("Test in '%s' function was failed." % np_name) from e
 
-            for np_name, spark_func in binary_np_spark_mappings.items():
+        for np_name, spark_func in binary_np_spark_mappings.items():
+            np_func = getattr(np, np_name)
+            if np_name not in self.blacklist:
+                try:
+                    # binary ufunc
+                    self.assert_eq(np_func(pdf.a, pdf.b), np_func(psdf.a, psdf.b), almost=True)
+                    self.assert_eq(np_func(pdf.a, 1), np_func(psdf.a, 1), almost=True)
+                except Exception as e:
+                    raise AssertionError("Test in '%s' function was failed." % np_name) from e
+
+        # Test only top 5 for now. 'compute.ops_on_diff_frames' option increases too much time.
+        try:
+            set_option("compute.ops_on_diff_frames", True)
+            for np_name, spark_func in list(binary_np_spark_mappings.items())[:5]:
                 np_func = getattr(np, np_name)
                 if np_name not in self.blacklist:
                     try:
                         # binary ufunc
-                        self.assert_eq(np_func(pdf.a, pdf.b), np_func(psdf.a, psdf.b), almost=True)
-                        self.assert_eq(np_func(pdf.a, 1), np_func(psdf.a, 1), almost=True)
+                        self.assert_eq(
+                            np_func(pdf.a, pdf2.b).sort_index(),
+                            np_func(psdf.a, psdf2.b).sort_index(),
+                            almost=True,
+                        )
                     except Exception as e:
                         raise AssertionError("Test in '%s' function was failed." % np_name) from e
-
-            # Test only top 5 for now. 'compute.ops_on_diff_frames' option increases too much time.
-            try:
-                set_option("compute.ops_on_diff_frames", True)
-                for np_name, spark_func in list(binary_np_spark_mappings.items())[:5]:
-                    np_func = getattr(np, np_name)
-                    if np_name not in self.blacklist:
-                        try:
-                            # binary ufunc
-                            self.assert_eq(
-                                np_func(pdf.a, pdf2.b).sort_index(),
-                                np_func(psdf.a, psdf2.b).sort_index(),
-                                almost=True,
-                            )
-                        except Exception as e:
-                            raise AssertionError(
-                                "Test in '%s' function was failed." % np_name
-                            ) from e
-            finally:
-                reset_option("compute.ops_on_diff_frames")
+        finally:
+            reset_option("compute.ops_on_diff_frames")
 
     @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_np_spark_compat_frame(self):

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -30,6 +30,7 @@ class NumPyCompatTestsMixin:
     @classmethod
     def setUpClass(cls):
         super(NumPyCompatTestsMixin, cls).setUpClass()
+        # Some nanosecond->microsecond conversions throw loss of precision errors
         cls.spark.conf.set("spark.sql.execution.pandas.convertToArrowArraySafely", "false")
 
     blacklist = [

--- a/python/pyspark/sql/tests/arrow/test_arrow.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow.py
@@ -707,8 +707,8 @@ class ArrowTestsMixin:
     def test_createDataFrame_does_not_modify_input(self):
         # Some series get converted for Spark to consume, this makes sure input is unchanged
         pdf = self.create_pandas_data_frame()
-        # Use a nanosecond value to make sure it is not truncated
-        pdf.iloc[0, 7] = pd.Timestamp(1)
+        # Use a nanosecond value that converts to microseconds without precision loss
+        pdf.iloc[0, 7] = pd.Timestamp(1000)
         # Integers with nulls will get NaNs filled with 0 and will be casted
         pdf.iloc[1, 1] = None
         pdf_copy = pdf.copy(deep=True)

--- a/python/pyspark/sql/tests/connect/test_connect_creation.py
+++ b/python/pyspark/sql/tests/connect/test_connect_creation.py
@@ -530,12 +530,15 @@ class SparkConnectCreationTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
         from pandas import Timestamp
         import pandas as pd
 
+        # Nanoseconds are truncated to microseconds in the serializer
+        # Arrow will throw an error if precision is lost
+        # (i.e., nanoseconds cannot be represented in microseconds)
         pdf = pd.DataFrame(
             {
                 "naive": [datetime(2019, 1, 1, 0)],
                 "aware": [
                     Timestamp(
-                        year=2019, month=1, day=1, nanosecond=500, tz=timezone(timedelta(hours=-8))
+                        year=2019, month=1, day=1, nanosecond=0, tz=timezone(timedelta(hours=-8))
                     )
                 ],
             }

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -517,7 +517,10 @@ class ScalarPandasUDFTestsMixin:
 
         def _scalar_f(id):
             return pd.DataFrame(
-                {"ts": id.apply(lambda i: pd.Timestamp(i)), "arr": id.apply(lambda i: [i, i + 1])}
+                {
+                    "ts": id.apply(lambda i: pd.Timestamp(i, unit="s")),
+                    "arr": id.apply(lambda i: [i, i + 1]),
+                }
             )
 
         scalar_f = pandas_udf(_scalar_f, returnType=return_type)
@@ -532,7 +535,7 @@ class ScalarPandasUDFTestsMixin:
             for i, row in enumerate(actual):
                 id, f = row
                 self.assertEqual(i, id)
-                self.assertEqual(pd.Timestamp(i).to_pydatetime(), f[0])
+                self.assertEqual(pd.Timestamp(i, unit="s").to_pydatetime(), f[0])
                 self.assertListEqual([i, i + 1], f[1])
 
     def test_vectorized_udf_struct_empty(self):

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -167,7 +167,7 @@ class MemoryProfilerTests(PySparkTestCase):
     def exec_pandas_udf_ser_to_scalar(self):
         import pandas as pd
 
-        @pandas_udf("int")
+        @pandas_udf("double")
         def ser_to_scalar(ser: pd.Series) -> float:
             return ser.median()
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3990,7 +3990,7 @@ object SQLConf {
         "check and do type conversions anyway. This config only works for Arrow 0.11.0+.")
       .version("3.0.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val PYSPARK_WORKER_PYTHON_EXECUTABLE =
     buildConf("spark.sql.execution.pyspark.python")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
- this enables `spark.sql.execution.pandas.convertToArrowArraySafely` by default
- I am also adjusting unit tests that previously relied on implicit conversions (truncating nanosecond timestamps to microseconds / loss of precision, int overflows) and now start to fail with the new default. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- This change aligns pyspark UDF behavior to ANSI SQL behavior in the rest of Spark. On integer overflow, the standard behavior is to throw an error. Users can and should handle such overflow or truncation cases explicitly.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
- Yes. This throws errors on int overflow, float truncation, and loss of precision when truncating timestamps. Citing PySpark's upgrade docs:
```
    =======================================  ================  =========================
    PyArrow version                          Integer overflow  Floating point truncation
    =======================================  ================  =========================
    0.11.0 and below                         Raise error       Silently allows
    > 0.11.0, arrowSafeTypeConversion=false  Silent overflow (returns 0)   Silently allows
    > 0.11.0, arrowSafeTypeConversion=true   Raise error       Raise error
    =======================================  ================  =========================
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
- adjusted unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No