### PR TITLE
[SPARK-52804][BUILD][FOLLOWUP] Revert Java minimum version check for Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2630,8 +2630,7 @@
                     <version>${maven.version}</version>
                   </requireMavenVersion>
                   <requireJavaVersion>
-                    <version>[${java.minimum.version},)</version>
-                    <message>The Java version used to build the project is outdated. Please use ${java.minimum.version} or later.</message>
+                    <version>${java.version}</version>
                   </requireJavaVersion>
                   <bannedDependencies>
                     <excludes>


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this pr, the Java minimum version check on the Maven side is temporarily revert because it leads to incorrect judgments when `-Djava.version=17` is specified:

Running `build/mvn clean install -DskipTests -Djava.version=17` results in an error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.6.0:enforce (enforce-versions) on project spark-parent_2.13: 
[ERROR] Rule 1: org.apache.maven.enforcer.rules.version.RequireJavaVersion failed with message:
[ERROR] The Java version used to build the project is outdated. Please use 17.0.11 or later.
[ERROR] -> [Help 1]
```

This occurs because when `-Djava.version=17` is specified, both the Detected Java Version and the Normalized Java Version are set to 17 instead of the actual Java version.

### Why are the changes needed?
These changes are necessary to temporarily restore Maven daily tests. Further fixes will be implemented once a reasonable solution is found. This issue does not affect sbt.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Passed GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No