### PR TITLE
[SPARK-52910][BUILD][INFRA] Standardize Java version configuration by replacing `java.version` with `maven.compiler.release`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1378,3 +1378,9 @@ jobs:
           cd ui-test
           npm install --save-dev
           node --experimental-vm-modules node_modules/.bin/jest
+
+  maven-test:
+    name: "Run Maven Test"
+    permissions:
+      packages: write
+    uses: ./.github/workflows/maven_test.yml

--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -194,7 +194,7 @@ jobs:
           export ENABLE_KINESIS_TESTS=0
           # Replace with the real module name, for example, connector#kafka-0-10 -> connector/kafka-0-10
           export TEST_MODULES=`echo "$MODULES_TO_TEST" | sed -e "s%#%/%g"`
-          ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pjvm-profiler -Pspark-ganglia-lgpl -Pkinesis-asl -Djava.version=${JAVA_VERSION/-ea} clean install
+          ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pjvm-profiler -Pspark-ganglia-lgpl -Pkinesis-asl -Dmaven.compiler.release=${JAVA_VERSION/-ea} clean install
           
           if [ "$MODULES_TO_TEST" != "connect" ]; then
             echo "Clean up the assembly module before maven testing"
@@ -202,20 +202,20 @@ jobs:
           fi
           
           if [[ "$INCLUDED_TAGS" != "" ]]; then
-            ./build/mvn $MAVEN_CLI_OPTS -pl "$TEST_MODULES" -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pjvm-profiler -Pspark-ganglia-lgpl -Pkinesis-asl -Djava.version=${JAVA_VERSION/-ea} -Dtest.include.tags="$INCLUDED_TAGS" test -fae
+            ./build/mvn $MAVEN_CLI_OPTS -pl "$TEST_MODULES" -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pjvm-profiler -Pspark-ganglia-lgpl -Pkinesis-asl -Dmaven.compiler.release=${JAVA_VERSION/-ea} -Dtest.include.tags="$INCLUDED_TAGS" test -fae
           elif [[ "$MODULES_TO_TEST" == "connect" ]]; then
-            ./build/mvn $MAVEN_CLI_OPTS -Dtest.exclude.tags="$EXCLUDED_TAGS" -Djava.version=${JAVA_VERSION/-ea} -pl sql/connect/client/jvm,sql/connect/common,sql/connect/server test -fae
+            ./build/mvn $MAVEN_CLI_OPTS -Dtest.exclude.tags="$EXCLUDED_TAGS" -Dmaven.compiler.release=${JAVA_VERSION/-ea} -pl sql/connect/client/jvm,sql/connect/common,sql/connect/server test -fae
           elif [[ "$EXCLUDED_TAGS" != "" ]]; then
-            ./build/mvn $MAVEN_CLI_OPTS -pl "$TEST_MODULES" -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pjvm-profiler -Pspark-ganglia-lgpl -Pkinesis-asl -Djava.version=${JAVA_VERSION/-ea} -Dtest.exclude.tags="$EXCLUDED_TAGS" test -fae
+            ./build/mvn $MAVEN_CLI_OPTS -pl "$TEST_MODULES" -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pjvm-profiler -Pspark-ganglia-lgpl -Pkinesis-asl -Dmaven.compiler.release=${JAVA_VERSION/-ea} -Dtest.exclude.tags="$EXCLUDED_TAGS" test -fae
           elif [[ "$MODULES_TO_TEST" == *"sql#hive-thriftserver"* ]]; then
             # To avoid a compilation loop, for the `sql/hive-thriftserver` module, run `clean install` instead
-            ./build/mvn $MAVEN_CLI_OPTS -pl "$TEST_MODULES" -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pjvm-profiler -Pspark-ganglia-lgpl -Pkinesis-asl -Djava.version=${JAVA_VERSION/-ea} clean install -fae
+            ./build/mvn $MAVEN_CLI_OPTS -pl "$TEST_MODULES" -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pjvm-profiler -Pspark-ganglia-lgpl -Pkinesis-asl -Dmaven.compiler.release=${JAVA_VERSION/-ea} clean install -fae
           elif [[ "$MODULES_TO_TEST" == *"sql#pipelines"* && "$INPUT_BRANCH" == "branch-4.0" ]]; then
             # SPARK-52441: Remove sql/pipelines from TEST_MODULES for branch-4.0, this branch can be deleted after the EOL of branch-4.0.
             TEST_MODULES=${TEST_MODULES/,sql\/pipelines/}
-            ./build/mvn $MAVEN_CLI_OPTS -pl "$TEST_MODULES" -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Pspark-ganglia-lgpl -Phadoop-cloud -Pjvm-profiler -Pkinesis-asl -Djava.version=${JAVA_VERSION/-ea} test -fae
+            ./build/mvn $MAVEN_CLI_OPTS -pl "$TEST_MODULES" -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Pspark-ganglia-lgpl -Phadoop-cloud -Pjvm-profiler -Pkinesis-asl -Dmaven.compiler.release=${JAVA_VERSION/-ea} test -fae
           else
-            ./build/mvn $MAVEN_CLI_OPTS -pl "$TEST_MODULES" -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Pspark-ganglia-lgpl -Phadoop-cloud -Pjvm-profiler -Pkinesis-asl -Djava.version=${JAVA_VERSION/-ea} test -fae
+            ./build/mvn $MAVEN_CLI_OPTS -pl "$TEST_MODULES" -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Pspark-ganglia-lgpl -Phadoop-cloud -Pjvm-profiler -Pkinesis-asl -Dmaven.compiler.release=${JAVA_VERSION/-ea} test -fae
           fi
       - name: Clean up local Maven repository
         run: |  

--- a/pom.xml
+++ b/pom.xml
@@ -2754,7 +2754,7 @@
               <arg>-feature</arg>
               <arg>-explaintypes</arg>
               <arg>-release</arg>
-              <arg>${maven.compiler.release}</arg>
+              <arg>17</arg>
               <arg>-Wconf:any:e</arg>
               <arg>-Wconf:cat=deprecation:wv</arg>
               <arg>-Wunused:imports</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -2630,7 +2630,6 @@
                     <version>${maven.version}</version>
                   </requireMavenVersion>
                   <requireJavaVersion>
-                    <display>true</display>
                     <version>[${java.minimum.version},)</version>
                     <message>The Java version used to build the project is outdated. Please use ${java.minimum.version} or later.</message>
                   </requireJavaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -2630,6 +2630,7 @@
                     <version>${maven.version}</version>
                   </requireMavenVersion>
                   <requireJavaVersion>
+                    <display>true</display>
                     <version>[${java.minimum.version},)</version>
                     <message>The Java version used to build the project is outdated. Please use ${java.minimum.version} or later.</message>
                   </requireJavaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -2649,7 +2649,7 @@
                     <searchTransitive>true</searchTransitive>
                   </bannedDependencies>
                   <enforceBytecodeVersion>
-                    <maxJdkVersion>${java.version}</maxJdkVersion>
+                    <maxJdkVersion>${maven.compiler.release}</maxJdkVersion>
                     <ignoredScopes>test</ignoredScopes>
                     <ignoredScopes>provided</ignoredScopes>
                   </enforceBytecodeVersion>
@@ -2754,7 +2754,7 @@
               <arg>-feature</arg>
               <arg>-explaintypes</arg>
               <arg>-release</arg>
-              <arg>17</arg>
+              <arg>${maven.compiler.release}</arg>
               <arg>-Wconf:any:e</arg>
               <arg>-Wconf:cat=deprecation:wv</arg>
               <arg>-Wunused:imports</arg>
@@ -2793,7 +2793,7 @@
             </jvmArgs>
             <javacArgs>
               <javacArg>--release</javacArg>
-              <javacArg>${java.version}</javacArg>
+              <javacArg>${maven.compiler.release}</javacArg>
               <javacArg>-Xlint:all,-serial,-path,-try</javacArg>
               <javacArg>-proc:full</javacArg>
             </javacArgs>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -334,7 +334,7 @@ object SparkBuild extends PomBuild {
       Seq("-Xdoclint:all", "-Xdoclint:-missing")
     },
 
-    javaVersion := SbtPomKeys.effectivePom.value.getProperties.get("maven.compiler.release").asInstanceOf[String],
+    javaVersion := SbtPomKeys.effectivePom.value.getProperties.get("java.version").asInstanceOf[String],
 
     (Compile / javacOptions) ++= Seq(
       "-encoding", UTF_8.name(),

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -334,7 +334,7 @@ object SparkBuild extends PomBuild {
       Seq("-Xdoclint:all", "-Xdoclint:-missing")
     },
 
-    javaVersion := SbtPomKeys.effectivePom.value.getProperties.get("java.version").asInstanceOf[String],
+    javaVersion := SbtPomKeys.effectivePom.value.getProperties.get("maven.compiler.release").asInstanceOf[String],
 
     (Compile / javacOptions) ++= Seq(
       "-encoding", UTF_8.name(),


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR standardizes Java version configuration across the project by replacing `java.version` with `maven.compiler.release` in the following areas:

1. Updated all Maven build commands in `maven_test.yml` to use `-Dmaven.compiler.release=${JAVA_VERSION/-ea}` instead of `-Djava.version=${JAVA_VERSION/-ea}`

2. **Maven POM configuration**: 
   - Updated the Maven Enforcer plugin's `enforceBytecodeVersion` rule to use `${maven.compiler.release}` instead of `${java.version}`
   - Updated Maven Scala plugin's `javacArgs` to use `${maven.compiler.release}` instead of `${java.version}`

### Why are the changes needed?
Using `-Djava.version` overrides Maven's internal understanding of the current Java version, potentially causing Maven to incorrectly assume that a different Java version is being used at runtime. In contrast, `-Dmaven.compiler.release` is a property specifically designed to specify the target compilation version and does not interfere with Maven's judgment of the runtime Java version. Therefore, switching to use `maven.compiler.release` will not affect the `maven-enforcer-plugin`'s `requireJavaVersion` check.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Test with Maven: https://github.com/LuciferYang/spark/runs/46412841487


### Was this patch authored or co-authored using generative AI tooling?
No
