### PR TITLE
[SPARK-52911][SQL] Remove `StringUtils.(split|chop)` usage

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -304,6 +304,11 @@ This file is divided into 3 sections:
     <customMessage>Use String concatenation instead</customMessage>
   </check>
 
+  <check customId="commonslang3split" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">StringUtils.split</parameter></parameters>
+    <customMessage>Use Utils.stringToSeq instead</customMessage>
+  </check>
+
   <check customId="uribuilder" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">UriBuilder\.fromUri</parameter></parameters>
     <customMessage>Use Utils.getUriBuilder instead.</customMessage>

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -169,7 +169,7 @@ private[hive] object SparkSQLCLIDriver extends Logging {
     val auxJars = HiveConf.getVar(conf, HiveConf.getConfVars("hive.aux.jars.path"))
     if (StringUtils.isNotBlank(auxJars)) {
       val resourceLoader = SparkSQLEnv.sparkSession.sessionState.resourceLoader
-      StringUtils.split(auxJars, ",").foreach(resourceLoader.addJar(_))
+      Utils.stringToSeq(auxJars).foreach(resourceLoader.addJar(_))
     }
 
     // The class loader of CliSessionState's conf is current main thread's class loader
@@ -574,7 +574,7 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
       var command: String = ""
       for (oneCmd <- commands) {
         if (Strings.CS.endsWith(oneCmd, "\\")) {
-          command += StringUtils.chop(oneCmd) + ";"
+          command += oneCmd.substring(0, oneCmd.length - 1) + ";"
         } else {
           command += oneCmd
           if (!StringUtils.isBlank(command)) {

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -574,7 +574,7 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
       var command: String = ""
       for (oneCmd <- commands) {
         if (Strings.CS.endsWith(oneCmd, "\\")) {
-          command += oneCmd.substring(0, oneCmd.length - 1) + ";"
+          command += oneCmd.dropRight(1) + ";"
         } else {
           command += oneCmd
           if (!StringUtils.isBlank(command)) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `StringUtils.(split|chop)` usage.

### Why are the changes needed?

To use the better Spark's or Java methods

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

After this PR,
```
$ git grep 'StringUtils.chop(' | wc -l
       0
$ git grep 'StringUtils.split(' | wc -l
       0
```

### Was this patch authored or co-authored using generative AI tooling?

No.