### PR TITLE
[SPARK-52829][PYTHON][FOLLOWUP] Remove unnecessary special handling

### DIFF
--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -1668,12 +1668,9 @@ def read_udtf(pickleSer, infile, eval_type):
                         pa.RecordBatch.from_pylist(data, schema=pa.schema(list(arrow_return_type)))
                     ]
                 try:
-                    ret = LocalDataToArrowConversion.convert(
+                    return LocalDataToArrowConversion.convert(
                         data, return_type, prefers_large_var_types
                     ).to_batches()
-                    if len(return_type.fields) == 0:
-                        return [pa.RecordBatch.from_struct_array(pa.array([{}] * len(data)))]
-                    return ret
                 except Exception as e:
                     raise PySparkRuntimeError(
                         errorClass="UDTF_ARROW_TYPE_CONVERSION_ERROR",


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removes unnecessary special handling for empty schema in UDTF with Arrow path.

### Why are the changes needed?

`LocalDataToArrowConversion.convert` handles the empty schema properly after https://github.com/apache/spark/pull/51523.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.