### PR TITLE
[SPARK-52917][SQL] Read support to enable round-trip for binary in xml format

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkStringUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkStringUtils.scala
@@ -34,6 +34,10 @@ private[spark] trait SparkStringUtils {
     s"[${SPACE_DELIMITED_UPPERCASE_HEX.formatHex(bytes)}]"
   }
 
+  def fromHexString(hex: String): Array[Byte] = {
+    SPACE_DELIMITED_UPPERCASE_HEX.parseHex(hex.stripPrefix("[").stripSuffix("]"))
+  }
+
   def sideBySide(left: String, right: String): Seq[String] = {
     sideBySide(left.split("\n").toImmutableArraySeq, right.split("\n").toImmutableArraySeq)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
@@ -40,7 +40,7 @@ import org.apache.hadoop.security.AccessControlException
 import org.apache.spark.{SparkIllegalArgumentException, SparkUpgradeException}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{ExprUtils, GenericInternalRow}
+import org.apache.spark.sql.catalyst.expressions.{ExprUtils, GenericInternalRow, ToStringBase}
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, BadRecordException, DateFormatter, DropMalformedMode, FailureSafeParser, GenericArrayData, MapData, ParseMode, PartialResultArrayException, PartialResultException, PermissiveMode, TimestampFormatter}
 import org.apache.spark.sql.catalyst.util.LegacyDateFormats.FAST_DATE_FORMAT
 import org.apache.spark.sql.catalyst.xml.StaxXmlParser.convertStream
@@ -75,6 +75,8 @@ class StaxXmlParser(
     options.locale,
     legacyFormat = FAST_DATE_FORMAT,
     isParsing = true)
+
+  private lazy val binaryParser = ToStringBase.getBinaryParser
 
   private val decimalParser = ExprUtils.getDecimalParser(options.locale)
 
@@ -493,6 +495,7 @@ class StaxXmlParser(
         case _: TimestampNTZType => timestampNTZFormatter.parseWithoutTimeZone(datum, false)
         case _: DateType => parseXmlDate(datum, options)
         case _: StringType => UTF8String.fromString(datum)
+        case _: BinaryType => binaryParser(UTF8String.fromString(datum))
         case _ => throw new SparkIllegalArgumentException(
           errorClass = "_LEGACY_ERROR_TEMP_3244",
           messageParameters = Map("castType" -> "castType.typeName"))
@@ -536,6 +539,7 @@ class StaxXmlParser(
         case DoubleType => signSafeToDouble(value)
         case BooleanType => castTo(value, BooleanType)
         case StringType => castTo(value, StringType)
+        case BinaryType => castTo(value, BinaryType)
         case DateType => castTo(value, DateType)
         case TimestampType => castTo(value, TimestampType)
         case TimestampNTZType => castTo(value, TimestampNTZType)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/binary.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/binary.sql.out
@@ -39,3 +39,21 @@ select to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary
 -- !query analysis
 Project [to_xml(named_struct(name, cast(Eason as binary), birth, 2018, org, cast(Kindergarten Cop as binary)), Some(America/Los_Angeles)) AS to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop))#x]
 +- OneRowRelation
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name STRING, birth INT, org STRING')
+-- !query analysis
+Project [from_xml(StructField(name,StringType,true), StructField(birth,IntegerType,true), StructField(org,StringType,true), to_xml(named_struct(name, cast(Eason as binary), birth, 2018, org, cast(Kindergarten Cop as binary)), Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name binary, birth INT, org binary')
+-- !query analysis
+Project [from_xml(StructField(name,BinaryType,true), StructField(birth,IntegerType,true), StructField(org,BinaryType,true), to_xml(named_struct(name, cast(Eason as binary), birth, 2018, org, cast(Kindergarten Cop as binary)), Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop)))#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/binary_base64.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/binary_base64.sql.out
@@ -39,3 +39,21 @@ select to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary
 -- !query analysis
 Project [to_xml(named_struct(name, cast(Eason as binary), birth, 2018, org, cast(Kindergarten Cop as binary)), Some(America/Los_Angeles)) AS to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop))#x]
 +- OneRowRelation
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name STRING, birth INT, org STRING')
+-- !query analysis
+Project [from_xml(StructField(name,StringType,true), StructField(birth,IntegerType,true), StructField(org,StringType,true), to_xml(named_struct(name, cast(Eason as binary), birth, 2018, org, cast(Kindergarten Cop as binary)), Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name binary, birth INT, org binary')
+-- !query analysis
+Project [from_xml(StructField(name,BinaryType,true), StructField(birth,IntegerType,true), StructField(org,BinaryType,true), to_xml(named_struct(name, cast(Eason as binary), birth, 2018, org, cast(Kindergarten Cop as binary)), Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop)))#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/binary_basic.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/binary_basic.sql.out
@@ -39,3 +39,21 @@ select to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary
 -- !query analysis
 Project [to_xml(named_struct(name, cast(Eason as binary), birth, 2018, org, cast(Kindergarten Cop as binary)), Some(America/Los_Angeles)) AS to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop))#x]
 +- OneRowRelation
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name STRING, birth INT, org STRING')
+-- !query analysis
+Project [from_xml(StructField(name,StringType,true), StructField(birth,IntegerType,true), StructField(org,StringType,true), to_xml(named_struct(name, cast(Eason as binary), birth, 2018, org, cast(Kindergarten Cop as binary)), Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name binary, birth INT, org binary')
+-- !query analysis
+Project [from_xml(StructField(name,BinaryType,true), StructField(birth,IntegerType,true), StructField(org,BinaryType,true), to_xml(named_struct(name, cast(Eason as binary), birth, 2018, org, cast(Kindergarten Cop as binary)), Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop)))#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/binary_hex.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/binary_hex.sql.out
@@ -39,3 +39,21 @@ select to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary
 -- !query analysis
 Project [to_xml(named_struct(name, cast(Eason as binary), birth, 2018, org, cast(Kindergarten Cop as binary)), Some(America/Los_Angeles)) AS to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop))#x]
 +- OneRowRelation
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name STRING, birth INT, org STRING')
+-- !query analysis
+Project [from_xml(StructField(name,StringType,true), StructField(birth,IntegerType,true), StructField(org,StringType,true), to_xml(named_struct(name, cast(Eason as binary), birth, 2018, org, cast(Kindergarten Cop as binary)), Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name binary, birth INT, org binary')
+-- !query analysis
+Project [from_xml(StructField(name,BinaryType,true), StructField(birth,IntegerType,true), StructField(org,BinaryType,true), to_xml(named_struct(name, cast(Eason as binary), birth, 2018, org, cast(Kindergarten Cop as binary)), Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop)))#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/binary_hex_discrete.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/binary_hex_discrete.sql.out
@@ -39,3 +39,21 @@ select to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary
 -- !query analysis
 Project [to_xml(named_struct(name, cast(Eason as binary), birth, 2018, org, cast(Kindergarten Cop as binary)), Some(America/Los_Angeles)) AS to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop))#x]
 +- OneRowRelation
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name STRING, birth INT, org STRING')
+-- !query analysis
+Project [from_xml(StructField(name,StringType,true), StructField(birth,IntegerType,true), StructField(org,StringType,true), to_xml(named_struct(name, cast(Eason as binary), birth, 2018, org, cast(Kindergarten Cop as binary)), Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name binary, birth INT, org binary')
+-- !query analysis
+Project [from_xml(StructField(name,BinaryType,true), StructField(birth,IntegerType,true), StructField(org,BinaryType,true), to_xml(named_struct(name, cast(Eason as binary), birth, 2018, org, cast(Kindergarten Cop as binary)), Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop)))#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/inputs/binary.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/binary.sql
@@ -6,3 +6,9 @@ SELECT CAST('Spark' as BINARY);
 SELECT array( X'', X'4561736F6E2059616F20323031382D31312D31373A31333A33333A3333', CAST('Spark' as BINARY));
 SELECT to_csv(named_struct('n', 1, 'info', X'4561736F6E2059616F20323031382D31312D31373A31333A33333A3333'));
 select to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop')));
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name STRING, birth INT, org STRING');
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name binary, birth INT, org binary');

--- a/sql/core/src/test/resources/sql-tests/results/binary.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/binary.sql.out
@@ -49,3 +49,23 @@ struct<to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop)):str
     <birth>2018</birth>
     <org>Kindergarten Cop</org>
 </ROW>
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name STRING, birth INT, org STRING')
+-- !query schema
+struct<from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop))):struct<name:string,birth:int,org:string>>
+-- !query output
+{"name":"Eason","birth":2018,"org":"Kindergarten Cop"}
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name binary, birth INT, org binary')
+-- !query schema
+struct<from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop))):struct<name:binary,birth:int,org:binary>>
+-- !query output
+{"name":Eason,"birth":2018,"org":Kindergarten Cop}

--- a/sql/core/src/test/resources/sql-tests/results/binary_base64.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/binary_base64.sql.out
@@ -49,3 +49,23 @@ struct<to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop)):str
     <birth>2018</birth>
     <org>S2luZGVyZ2FydGVuIENvcA</org>
 </ROW>
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name STRING, birth INT, org STRING')
+-- !query schema
+struct<from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop))):struct<name:string,birth:int,org:string>>
+-- !query output
+{"name":"RWFzb24","birth":2018,"org":"S2luZGVyZ2FydGVuIENvcA"}
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name binary, birth INT, org binary')
+-- !query schema
+struct<from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop))):struct<name:binary,birth:int,org:binary>>
+-- !query output
+{"name":RWFzb24,"birth":2018,"org":S2luZGVyZ2FydGVuIENvcA}

--- a/sql/core/src/test/resources/sql-tests/results/binary_basic.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/binary_basic.sql.out
@@ -49,3 +49,23 @@ struct<to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop)):str
     <birth>2018</birth>
     <org>[75, 105, 110, 100, 101, 114, 103, 97, 114, 116, 101, 110, 32, 67, 111, 112]</org>
 </ROW>
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name STRING, birth INT, org STRING')
+-- !query schema
+struct<from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop))):struct<name:string,birth:int,org:string>>
+-- !query output
+{"name":"[69, 97, 115, 111, 110]","birth":2018,"org":"[75, 105, 110, 100, 101, 114, 103, 97, 114, 116, 101, 110, 32, 67, 111, 112]"}
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name binary, birth INT, org binary')
+-- !query schema
+struct<from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop))):struct<name:binary,birth:int,org:binary>>
+-- !query output
+{"name":[69, 97, 115, 111, 110],"birth":2018,"org":[75, 105, 110, 100, 101, 114, 103, 97, 114, 116, 101, 110, 32, 67, 111, 112]}

--- a/sql/core/src/test/resources/sql-tests/results/binary_hex.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/binary_hex.sql.out
@@ -49,3 +49,23 @@ struct<to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop)):str
     <birth>2018</birth>
     <org>4B696E64657267617274656E20436F70</org>
 </ROW>
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name STRING, birth INT, org STRING')
+-- !query schema
+struct<from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop))):struct<name:string,birth:int,org:string>>
+-- !query output
+{"name":"4561736F6E","birth":2018,"org":"4B696E64657267617274656E20436F70"}
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name binary, birth INT, org binary')
+-- !query schema
+struct<from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop))):struct<name:binary,birth:int,org:binary>>
+-- !query output
+{"name":4561736F6E,"birth":2018,"org":4B696E64657267617274656E20436F70}

--- a/sql/core/src/test/resources/sql-tests/results/binary_hex_discrete.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/binary_hex_discrete.sql.out
@@ -49,3 +49,23 @@ struct<to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop)):str
     <birth>2018</birth>
     <org>[4B 69 6E 64 65 72 67 61 72 74 65 6E 20 43 6F 70]</org>
 </ROW>
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name STRING, birth INT, org STRING')
+-- !query schema
+struct<from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop))):struct<name:string,birth:int,org:string>>
+-- !query output
+{"name":"[45 61 73 6F 6E]","birth":2018,"org":"[4B 69 6E 64 65 72 67 61 72 74 65 6E 20 43 6F 70]"}
+
+
+-- !query
+SELECT from_xml(
+         to_xml(named_struct('name', binary('Eason'), 'birth', 2018, 'org', binary('Kindergarten Cop'))),
+         'name binary, birth INT, org binary')
+-- !query schema
+struct<from_xml(to_xml(named_struct(name, Eason, birth, 2018, org, Kindergarten Cop))):struct<name:binary,birth:int,org:binary>>
+-- !query output
+{"name":[45 61 73 6F 6E],"birth":2018,"org":[4B 69 6E 64 65 72 67 61 72 74 65 6E 20 43 6F 70]}


### PR DESCRIPTION
### What changes were proposed in this pull request?

After SPARK-52788 fixed binary write for XML format, we need to add the functionality to support reading it back instead of producing null constantly.


### Why are the changes needed?

XML improvement


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
new tests


### Was this patch authored or co-authored using generative AI tooling?
no
