### PR TITLE
[SQL][TESTS][SPARK-52918] Batch JDBC database statements in JDBC suites

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -105,10 +105,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     conn.prepareStatement("create schema test").executeUpdate()
     conn.prepareStatement(
       "create table test.people (name TEXT(32) NOT NULL, theid INTEGER NOT NULL)").executeUpdate()
-
-    conn.prepareStatement("insert into test.people values " +
-      "('fred', 1), ('mary', 2), ('joe ''foo'' \"bar\"', 3)").executeUpdate()
-
+    
     sql(
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW foobar
@@ -143,10 +140,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
 
     conn.prepareStatement("create table test.inttypes (a INT, b BOOLEAN, c TINYINT, "
       + "d SMALLINT, e BIGINT)").executeUpdate()
-
-    conn.prepareStatement("insert into test.inttypes values " +
-      "(1, false, 3, 4, 1234567890123), (null, null, null, null, null)").executeUpdate()
-
+    
     sql(
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW inttypes
@@ -173,11 +167,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
 
     conn.prepareStatement("create table test.timetypes (a TIME, b DATE, c TIMESTAMP(7))"
         ).executeUpdate()
-
-    conn.prepareStatement("insert into test.timetypes values " +
-      "('12:34:56', '1996-01-01', '2002-02-20 11:22:33.543543543'), " +
-      "('12:34:56', null, '2002-02-20 11:22:33.543543543')").executeUpdate()
-
+    
     sql(
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW timetypes
@@ -199,7 +189,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       + "1.0000000000000002220446049250313080847263336181640625, "
       + "1.00000011920928955078125, "
       + "123456789012345.543215432154321)").executeUpdate()
-
+    
     sql(
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW flttypes
@@ -216,7 +206,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     conn.prepareStatement("insert into test.nulltypes values ("
       + "null, null, null, null, null, null, null, null, null, "
       + "null, null, null, null, null, null)").executeUpdate()
-
+    
     sql(
       s"""
          |CREATE OR REPLACE TEMPORARY VIEW nulltypes
@@ -228,16 +218,8 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       "create table test.emp(name TEXT(32) NOT NULL," +
         " theid INTEGER, \"Dept\" INTEGER)").executeUpdate()
 
-    conn
-      .prepareStatement("insert into test.emp values " +
-        "('fred', 1, 10), ('mary', 2, null), ('joe ''foo'' \"bar\"', 3, 30), ('kathy', null, null)")
-      .executeUpdate()
-
     conn.prepareStatement(
       "create table test.seq(id INTEGER)").executeUpdate()
-
-    val seqValues = (0 to 6).map(value => s"($value)").mkString(", ") + ", (null)"
-    conn.prepareStatement(s"insert into test.seq values $seqValues").executeUpdate()
 
     sql(
       s"""
@@ -250,9 +232,6 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     conn.prepareStatement(
       """create table test."mixedCaseCols" ("Name" TEXT(32), "Id" INTEGER NOT NULL)""")
       .executeUpdate()
-
-    conn.prepareStatement("""insert into test."mixedCaseCols" values """ +
-      """('fred', 1), ('mary', 2), (null, 3)""").executeUpdate()
 
     sql(
       s"""
@@ -267,18 +246,47 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
 
     conn.prepareStatement("CREATE TABLE test.datetime (d DATE, t TIMESTAMP)").executeUpdate()
 
-    conn.prepareStatement("INSERT INTO test.datetime VALUES " +
-      "('2018-07-06', '2018-07-06 05:50:00.0'), " +
-      "('2018-07-06', '2018-07-06 08:10:08.0'), " +
-      "('2018-07-08', '2018-07-08 13:32:01.0'), " +
-      "('2018-07-12', '2018-07-12 09:51:15.0')").executeUpdate()
-
     conn.prepareStatement(
       "CREATE TABLE test.composite_name (`last name` TEXT(32) NOT NULL, id INTEGER NOT NULL)")
       .executeUpdate()
 
-    conn.prepareStatement("INSERT INTO test.composite_name VALUES " +
-      "('smith', 1), ('jones', 2)").executeUpdate()
+    val batchStmt = conn.createStatement()
+
+    batchStmt.addBatch("insert into test.people values ('fred', 1)")
+    batchStmt.addBatch("insert into test.people values ('mary', 2)")
+    batchStmt.addBatch("insert into test.people values ('joe ''foo'' \"bar\"', 3)")
+
+    batchStmt.addBatch("insert into test.inttypes values (1, false, 3, 4, 1234567890123)")
+    batchStmt.addBatch("insert into test.inttypes values (null, null, null, null, null)")
+
+    batchStmt.addBatch("insert into test.timetypes values " +
+      "('12:34:56', '1996-01-01', '2002-02-20 11:22:33.543543543')")
+    batchStmt.addBatch("insert into test.timetypes values " +
+      "('12:34:56', null, '2002-02-20 11:22:33.543543543')")
+
+    batchStmt.addBatch("insert into test.emp values ('fred', 1, 10)")
+    batchStmt.addBatch("insert into test.emp values ('mary', 2, null)")
+    batchStmt.addBatch("insert into test.emp values ('joe ''foo'' \"bar\"', 3, 30)")
+    batchStmt.addBatch("insert into test.emp values ('kathy', null, null)")
+
+    (0 to 6).foreach { value =>
+      batchStmt.addBatch(s"insert into test.seq values ($value)")
+    }
+    batchStmt.addBatch("insert into test.seq values (null)")
+
+    batchStmt.addBatch("""insert into test."mixedCaseCols" values ('fred', 1)""")
+    batchStmt.addBatch("""insert into test."mixedCaseCols" values ('mary', 2)""")
+    batchStmt.addBatch("""insert into test."mixedCaseCols" values (null, 3)""")
+
+    batchStmt.addBatch("INSERT INTO test.datetime VALUES ('2018-07-06', '2018-07-06 05:50:00.0')")
+    batchStmt.addBatch("INSERT INTO test.datetime VALUES ('2018-07-06', '2018-07-06 08:10:08.0')")
+    batchStmt.addBatch("INSERT INTO test.datetime VALUES ('2018-07-08', '2018-07-08 13:32:01.0')")
+    batchStmt.addBatch("INSERT INTO test.datetime VALUES ('2018-07-12', '2018-07-12 09:51:15.0')")
+
+    batchStmt.addBatch("INSERT INTO test.composite_name VALUES ('smith', 1)")
+    batchStmt.addBatch("INSERT INTO test.composite_name VALUES ('jones', 2)")
+
+    batchStmt.executeBatch()
 
     sql(
       s"""

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -102,21 +102,26 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     properties.setProperty("password", "testPass")
 
     conn = DriverManager.getConnection(url, properties)
-    // JDBC table creation and data insertion
     val batchStmt = conn.createStatement()
 
     batchStmt.addBatch("create schema test")
 
     batchStmt.addBatch("create table test.people (name TEXT(32) NOT NULL, " +
       "theid INTEGER NOT NULL)")
+    batchStmt.addBatch("insert into test.people values ('fred', 1)")
+    batchStmt.addBatch("insert into test.people values ('mary', 2)")
+    batchStmt.addBatch("insert into test.people values ('joe ''foo'' \"bar\"', 3)")
 
     batchStmt.addBatch("create table test.inttypes (a INT, b BOOLEAN, c TINYINT, " +
       "d SMALLINT, e BIGINT)")
-
-    batchStmt.addBatch("create table test.strtypes (a BINARY(20), b VARCHAR(20), " +
-      "c VARCHAR_IGNORECASE(20), d CHAR(20), e BLOB, f CLOB)")
+    batchStmt.addBatch("insert into test.inttypes values (1, false, 3, 4, 1234567890123)")
+    batchStmt.addBatch("insert into test.inttypes values (null, null, null, null, null)")
 
     batchStmt.addBatch("create table test.timetypes (a TIME, b DATE, c TIMESTAMP(7))")
+    batchStmt.addBatch("insert into test.timetypes values " +
+      "('12:34:56', '1996-01-01', '2002-02-20 11:22:33.543543543')")
+    batchStmt.addBatch("insert into test.timetypes values " +
+      "('12:34:56', null, '2002-02-20 11:22:33.543543543')")
 
     batchStmt.addBatch("CREATE TABLE test.timezone (tz TIMESTAMP WITH TIME ZONE) " +
       "AS SELECT '1999-01-08 04:05:06.543543543-08:00'")
@@ -125,60 +130,39 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       "AS SELECT ARRAY[1, 2, 3]")
 
     batchStmt.addBatch("create table test.flttypes (a DOUBLE, b REAL, c DECIMAL(38, 18))")
-
-    batchStmt.addBatch("create table test.nulltypes (a INT, b BOOLEAN, c TINYINT, " +
-      "d BINARY(20), e VARCHAR(20), f VARCHAR_IGNORECASE(20), g CHAR(20), h BLOB, i CLOB, " +
-      "j TIME, k DATE, l TIMESTAMP, m DOUBLE, n REAL, o DECIMAL(38, 18))")
-
-    batchStmt.addBatch("create table test.emp(name TEXT(32) NOT NULL, theid INTEGER, " +
-      "\"Dept\" INTEGER)")
-
-    batchStmt.addBatch("create table test.seq(id INTEGER)")
-
-    batchStmt.addBatch("create table test.\"mixedCaseCols\" (\"Name\" TEXT(32), " +
-      "\"Id\" INTEGER NOT NULL)")
-
-    batchStmt.addBatch("CREATE TABLE test.partition (THEID INTEGER, `THE ID` INTEGER) " +
-      "AS SELECT 1, 1")
-
-    batchStmt.addBatch("CREATE TABLE test.datetime (d DATE, t TIMESTAMP)")
-
-    batchStmt.addBatch("CREATE TABLE test.composite_name (`last name` TEXT(32) NOT NULL, " +
-      "id INTEGER NOT NULL)")
-
-    batchStmt.addBatch("insert into test.people values ('fred', 1)")
-    batchStmt.addBatch("insert into test.people values ('mary', 2)")
-    batchStmt.addBatch("insert into test.people values ('joe ''foo'' \"bar\"', 3)")
-
-    batchStmt.addBatch("insert into test.inttypes values (1, false, 3, 4, 1234567890123)")
-    batchStmt.addBatch("insert into test.inttypes values (null, null, null, null, null)")
-
-    batchStmt.addBatch("insert into test.timetypes values " +
-      "('12:34:56', '1996-01-01', '2002-02-20 11:22:33.543543543')")
-    batchStmt.addBatch("insert into test.timetypes values " +
-      "('12:34:56', null, '2002-02-20 11:22:33.543543543')")
-
     batchStmt.addBatch("insert into test.flttypes values " +
       "(1.0000000000000002220446049250313080847263336181640625, " +
       "1.00000011920928955078125, 123456789012345.543215432154321)")
 
+    batchStmt.addBatch("create table test.nulltypes (a INT, b BOOLEAN, c TINYINT, " +
+      "d BINARY(20), e VARCHAR(20), f VARCHAR_IGNORECASE(20), g CHAR(20), h BLOB, i CLOB, " +
+      "j TIME, k DATE, l TIMESTAMP, m DOUBLE, n REAL, o DECIMAL(38, 18))")
     batchStmt.addBatch("insert into test.nulltypes values " +
       "(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null)")
 
+    batchStmt.addBatch("create table test.emp(name TEXT(32) NOT NULL, theid INTEGER, " +
+      "\"Dept\" INTEGER)")
     batchStmt.addBatch("insert into test.emp values ('fred', 1, 10)")
     batchStmt.addBatch("insert into test.emp values ('mary', 2, null)")
     batchStmt.addBatch("insert into test.emp values ('joe ''foo'' \"bar\"', 3, 30)")
     batchStmt.addBatch("insert into test.emp values ('kathy', null, null)")
 
+    batchStmt.addBatch("create table test.seq(id INTEGER)")
     (0 to 6).foreach { value =>
       batchStmt.addBatch(s"insert into test.seq values ($value)")
     }
     batchStmt.addBatch("insert into test.seq values (null)")
 
+    batchStmt.addBatch("create table test.\"mixedCaseCols\" (\"Name\" TEXT(32), " +
+      "\"Id\" INTEGER NOT NULL)")
     batchStmt.addBatch("""insert into test."mixedCaseCols" values ('fred', 1)""")
     batchStmt.addBatch("""insert into test."mixedCaseCols" values ('mary', 2)""")
     batchStmt.addBatch("""insert into test."mixedCaseCols" values (null, 3)""")
 
+    batchStmt.addBatch("CREATE TABLE test.partition (THEID INTEGER, `THE ID` INTEGER) " +
+      "AS SELECT 1, 1")
+
+    batchStmt.addBatch("CREATE TABLE test.datetime (d DATE, t TIMESTAMP)")
     batchStmt.addBatch("INSERT INTO test.datetime VALUES " +
       "('2018-07-06', '2018-07-06 05:50:00.0')")
     batchStmt.addBatch("INSERT INTO test.datetime VALUES " +
@@ -188,11 +172,17 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     batchStmt.addBatch("INSERT INTO test.datetime VALUES " +
       "('2018-07-12', '2018-07-12 09:51:15.0')")
 
+    batchStmt.addBatch("CREATE TABLE test.composite_name (`last name` TEXT(32) NOT NULL, " +
+      "id INTEGER NOT NULL)")
     batchStmt.addBatch("INSERT INTO test.composite_name VALUES ('smith', 1)")
     batchStmt.addBatch("INSERT INTO test.composite_name VALUES ('jones', 2)")
 
     batchStmt.executeBatch()
 
+    conn
+      .prepareStatement("create table test.strtypes" +
+        "(a BINARY(20), b VARCHAR(20), c VARCHAR_IGNORECASE(20), d CHAR(20), e BLOB, f CLOB)")
+      .executeUpdate()
     val strtypesStmt = conn.prepareStatement("insert into test.strtypes values (?, ?, ?, ?, ?, ?)")
     strtypesStmt.setBytes(1, testBytes)
     strtypesStmt.setString(2, "Sensitive")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -102,10 +102,80 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     properties.setProperty("password", "testPass")
 
     conn = DriverManager.getConnection(url, properties)
-    conn.prepareStatement("create schema test").executeUpdate()
-    conn.prepareStatement(
-      "create table test.people (name TEXT(32) NOT NULL, theid INTEGER NOT NULL)").executeUpdate()
 
+    // Batch 1: Create schema and all tables
+    val tableCreationStmt = conn.createStatement()
+    
+    tableCreationStmt.addBatch("create schema test")
+    tableCreationStmt.addBatch("create table test.people (name TEXT(32) NOT NULL, theid INTEGER NOT NULL)")
+    tableCreationStmt.addBatch("create table test.inttypes (a INT, b BOOLEAN, c TINYINT, d SMALLINT, e BIGINT)")
+    tableCreationStmt.addBatch("create table test.strtypes (a BINARY(20), b VARCHAR(20), c VARCHAR_IGNORECASE(20), d CHAR(20), e BLOB, f CLOB)")
+    tableCreationStmt.addBatch("create table test.timetypes (a TIME, b DATE, c TIMESTAMP(7))")
+    tableCreationStmt.addBatch("CREATE TABLE test.timezone (tz TIMESTAMP WITH TIME ZONE) AS SELECT '1999-01-08 04:05:06.543543543-08:00'")
+    tableCreationStmt.addBatch("CREATE TABLE test.array_table (ar Integer ARRAY) AS SELECT ARRAY[1, 2, 3]")
+    tableCreationStmt.addBatch("create table test.flttypes (a DOUBLE, b REAL, c DECIMAL(38, 18))")
+    tableCreationStmt.addBatch("create table test.nulltypes (a INT, b BOOLEAN, c TINYINT, d BINARY(20), e VARCHAR(20), f VARCHAR_IGNORECASE(20), g CHAR(20), h BLOB, i CLOB, j TIME, k DATE, l TIMESTAMP, m DOUBLE, n REAL, o DECIMAL(38, 18))")
+    tableCreationStmt.addBatch("create table test.emp(name TEXT(32) NOT NULL, theid INTEGER, \"Dept\" INTEGER)")
+    tableCreationStmt.addBatch("create table test.seq(id INTEGER)")
+    tableCreationStmt.addBatch("create table test.\"mixedCaseCols\" (\"Name\" TEXT(32), \"Id\" INTEGER NOT NULL)")
+    tableCreationStmt.addBatch("CREATE TABLE test.partition (THEID INTEGER, `THE ID` INTEGER) AS SELECT 1, 1")
+    tableCreationStmt.addBatch("CREATE TABLE test.datetime (d DATE, t TIMESTAMP)")
+    tableCreationStmt.addBatch("CREATE TABLE test.composite_name (`last name` TEXT(32) NOT NULL, id INTEGER NOT NULL)")
+    
+    tableCreationStmt.executeBatch()
+
+    // Handle special cases that require prepared statements
+    val strtypesStmt = conn.prepareStatement("insert into test.strtypes values (?, ?, ?, ?, ?, ?)")
+    strtypesStmt.setBytes(1, testBytes)
+    strtypesStmt.setString(2, "Sensitive")
+    strtypesStmt.setString(3, "Insensitive")
+    strtypesStmt.setString(4, "Twenty-byte CHAR")
+    strtypesStmt.setBytes(5, testBytes)
+    strtypesStmt.setString(6, "I am a clob!")
+    strtypesStmt.executeUpdate()
+
+    // Batch 2: All data insertion
+    val dataInsertionStmt = conn.createStatement()
+
+    dataInsertionStmt.addBatch("insert into test.people values ('fred', 1)")
+    dataInsertionStmt.addBatch("insert into test.people values ('mary', 2)")
+    dataInsertionStmt.addBatch("insert into test.people values ('joe ''foo'' \"bar\"', 3)")
+
+    dataInsertionStmt.addBatch("insert into test.inttypes values (1, false, 3, 4, 1234567890123)")
+    dataInsertionStmt.addBatch("insert into test.inttypes values (null, null, null, null, null)")
+
+    dataInsertionStmt.addBatch("insert into test.timetypes values ('12:34:56', '1996-01-01', '2002-02-20 11:22:33.543543543')")
+    dataInsertionStmt.addBatch("insert into test.timetypes values ('12:34:56', null, '2002-02-20 11:22:33.543543543')")
+
+    dataInsertionStmt.addBatch("insert into test.flttypes values (1.0000000000000002220446049250313080847263336181640625, 1.00000011920928955078125, 123456789012345.543215432154321)")
+
+    dataInsertionStmt.addBatch("insert into test.nulltypes values (null, null, null, null, null, null, null, null, null, null, null, null, null, null, null)")
+
+    dataInsertionStmt.addBatch("insert into test.emp values ('fred', 1, 10)")
+    dataInsertionStmt.addBatch("insert into test.emp values ('mary', 2, null)")
+    dataInsertionStmt.addBatch("insert into test.emp values ('joe ''foo'' \"bar\"', 3, 30)")
+    dataInsertionStmt.addBatch("insert into test.emp values ('kathy', null, null)")
+
+    (0 to 6).foreach { value =>
+      dataInsertionStmt.addBatch(s"insert into test.seq values ($value)")
+    }
+    dataInsertionStmt.addBatch("insert into test.seq values (null)")
+
+    dataInsertionStmt.addBatch("""insert into test."mixedCaseCols" values ('fred', 1)""")
+    dataInsertionStmt.addBatch("""insert into test."mixedCaseCols" values ('mary', 2)""")
+    dataInsertionStmt.addBatch("""insert into test."mixedCaseCols" values (null, 3)""")
+
+    dataInsertionStmt.addBatch("INSERT INTO test.datetime VALUES ('2018-07-06', '2018-07-06 05:50:00.0')")
+    dataInsertionStmt.addBatch("INSERT INTO test.datetime VALUES ('2018-07-06', '2018-07-06 08:10:08.0')")
+    dataInsertionStmt.addBatch("INSERT INTO test.datetime VALUES ('2018-07-08', '2018-07-08 13:32:01.0')")
+    dataInsertionStmt.addBatch("INSERT INTO test.datetime VALUES ('2018-07-12', '2018-07-12 09:51:15.0')")
+
+    dataInsertionStmt.addBatch("INSERT INTO test.composite_name VALUES ('smith', 1)")
+    dataInsertionStmt.addBatch("INSERT INTO test.composite_name VALUES ('jones', 2)")
+
+    dataInsertionStmt.executeBatch()
+
+    // Finally: All SQL view creation
     sql(
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW foobar
@@ -138,9 +208,6 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
         |         upperBound '9223372036854775807', numPartitions '3')
        """.stripMargin.replaceAll("\n", " "))
 
-    conn.prepareStatement("create table test.inttypes (a INT, b BOOLEAN, c TINYINT, "
-      + "d SMALLINT, e BIGINT)").executeUpdate()
-
     sql(
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW inttypes
@@ -148,25 +215,12 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
         |OPTIONS (url '$url', dbtable 'TEST.INTTYPES', user 'testUser', password 'testPass')
        """.stripMargin.replaceAll("\n", " "))
 
-    conn.prepareStatement("create table test.strtypes (a BINARY(20), b VARCHAR(20), "
-      + "c VARCHAR_IGNORECASE(20), d CHAR(20), e BLOB, f CLOB)").executeUpdate()
-    val stmt = conn.prepareStatement("insert into test.strtypes values (?, ?, ?, ?, ?, ?)")
-    stmt.setBytes(1, testBytes)
-    stmt.setString(2, "Sensitive")
-    stmt.setString(3, "Insensitive")
-    stmt.setString(4, "Twenty-byte CHAR")
-    stmt.setBytes(5, testBytes)
-    stmt.setString(6, "I am a clob!")
-    stmt.executeUpdate()
     sql(
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW strtypes
         |USING org.apache.spark.sql.jdbc
         |OPTIONS (url '$url', dbtable 'TEST.STRTYPES', user 'testUser', password 'testPass')
        """.stripMargin.replaceAll("\n", " "))
-
-    conn.prepareStatement("create table test.timetypes (a TIME, b DATE, c TIMESTAMP(7))"
-        ).executeUpdate()
 
     sql(
       s"""
@@ -175,21 +229,6 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
         |OPTIONS (url '$url', dbtable 'TEST.TIMETYPES', user 'testUser', password 'testPass')
        """.stripMargin.replaceAll("\n", " "))
 
-    conn.prepareStatement("CREATE TABLE test.timezone (tz TIMESTAMP WITH TIME ZONE) " +
-      "AS SELECT '1999-01-08 04:05:06.543543543-08:00'")
-      .executeUpdate()
-
-    conn.prepareStatement("CREATE TABLE test.array_table (ar Integer ARRAY) " +
-      "AS SELECT ARRAY[1, 2, 3]")
-      .executeUpdate()
-
-    conn.prepareStatement("create table test.flttypes (a DOUBLE, b REAL, c DECIMAL(38, 18))"
-        ).executeUpdate()
-    conn.prepareStatement("insert into test.flttypes values ("
-      + "1.0000000000000002220446049250313080847263336181640625, "
-      + "1.00000011920928955078125, "
-      + "123456789012345.543215432154321)").executeUpdate()
-
     sql(
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW flttypes
@@ -197,29 +236,12 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
         |OPTIONS (url '$url', dbtable 'TEST.FLTTYPES', user 'testUser', password 'testPass')
        """.stripMargin.replaceAll("\n", " "))
 
-    conn.prepareStatement(
-      s"""
-        |create table test.nulltypes (a INT, b BOOLEAN, c TINYINT, d BINARY(20), e VARCHAR(20),
-        |f VARCHAR_IGNORECASE(20), g CHAR(20), h BLOB, i CLOB, j TIME, k DATE, l TIMESTAMP,
-        |m DOUBLE, n REAL, o DECIMAL(38, 18))
-       """.stripMargin.replaceAll("\n", " ")).executeUpdate()
-    conn.prepareStatement("insert into test.nulltypes values ("
-      + "null, null, null, null, null, null, null, null, null, "
-      + "null, null, null, null, null, null)").executeUpdate()
-
     sql(
       s"""
          |CREATE OR REPLACE TEMPORARY VIEW nulltypes
          |USING org.apache.spark.sql.jdbc
          |OPTIONS (url '$url', dbtable 'TEST.NULLTYPES', user 'testUser', password 'testPass')
        """.stripMargin.replaceAll("\n", " "))
-
-    conn.prepareStatement(
-      "create table test.emp(name TEXT(32) NOT NULL," +
-        " theid INTEGER, \"Dept\" INTEGER)").executeUpdate()
-
-    conn.prepareStatement(
-      "create table test.seq(id INTEGER)").executeUpdate()
 
     sql(
       s"""
@@ -229,64 +251,12 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
         |partitionColumn '"Dept"', lowerBound '1', upperBound '4', numPartitions '3')
        """.stripMargin.replaceAll("\n", " "))
 
-    conn.prepareStatement(
-      """create table test."mixedCaseCols" ("Name" TEXT(32), "Id" INTEGER NOT NULL)""")
-      .executeUpdate()
-
     sql(
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW mixedCaseCols
         |USING org.apache.spark.sql.jdbc
         |OPTIONS (url '$url', dbtable 'TEST."mixedCaseCols"', user 'testUser', password 'testPass')
        """.stripMargin.replaceAll("\n", " "))
-
-    conn.prepareStatement("CREATE TABLE test.partition (THEID INTEGER, `THE ID` INTEGER) " +
-      "AS SELECT 1, 1")
-      .executeUpdate()
-
-    conn.prepareStatement("CREATE TABLE test.datetime (d DATE, t TIMESTAMP)").executeUpdate()
-
-    conn.prepareStatement(
-      "CREATE TABLE test.composite_name (`last name` TEXT(32) NOT NULL, id INTEGER NOT NULL)")
-      .executeUpdate()
-
-    val batchStmt = conn.createStatement()
-
-    batchStmt.addBatch("insert into test.people values ('fred', 1)")
-    batchStmt.addBatch("insert into test.people values ('mary', 2)")
-    batchStmt.addBatch("insert into test.people values ('joe ''foo'' \"bar\"', 3)")
-
-    batchStmt.addBatch("insert into test.inttypes values (1, false, 3, 4, 1234567890123)")
-    batchStmt.addBatch("insert into test.inttypes values (null, null, null, null, null)")
-
-    batchStmt.addBatch("insert into test.timetypes values " +
-      "('12:34:56', '1996-01-01', '2002-02-20 11:22:33.543543543')")
-    batchStmt.addBatch("insert into test.timetypes values " +
-      "('12:34:56', null, '2002-02-20 11:22:33.543543543')")
-
-    batchStmt.addBatch("insert into test.emp values ('fred', 1, 10)")
-    batchStmt.addBatch("insert into test.emp values ('mary', 2, null)")
-    batchStmt.addBatch("insert into test.emp values ('joe ''foo'' \"bar\"', 3, 30)")
-    batchStmt.addBatch("insert into test.emp values ('kathy', null, null)")
-
-    (0 to 6).foreach { value =>
-      batchStmt.addBatch(s"insert into test.seq values ($value)")
-    }
-    batchStmt.addBatch("insert into test.seq values (null)")
-
-    batchStmt.addBatch("""insert into test."mixedCaseCols" values ('fred', 1)""")
-    batchStmt.addBatch("""insert into test."mixedCaseCols" values ('mary', 2)""")
-    batchStmt.addBatch("""insert into test."mixedCaseCols" values (null, 3)""")
-
-    batchStmt.addBatch("INSERT INTO test.datetime VALUES ('2018-07-06', '2018-07-06 05:50:00.0')")
-    batchStmt.addBatch("INSERT INTO test.datetime VALUES ('2018-07-06', '2018-07-06 08:10:08.0')")
-    batchStmt.addBatch("INSERT INTO test.datetime VALUES ('2018-07-08', '2018-07-08 13:32:01.0')")
-    batchStmt.addBatch("INSERT INTO test.datetime VALUES ('2018-07-12', '2018-07-12 09:51:15.0')")
-
-    batchStmt.addBatch("INSERT INTO test.composite_name VALUES ('smith', 1)")
-    batchStmt.addBatch("INSERT INTO test.composite_name VALUES ('jones', 2)")
-
-    batchStmt.executeBatch()
 
     sql(
       s"""

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -107,29 +107,43 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     val tableCreationStmt = conn.createStatement()
 
     tableCreationStmt.addBatch("create schema test")
+
     tableCreationStmt.addBatch("create table test.people (name TEXT(32) NOT NULL, " +
       "theid INTEGER NOT NULL)")
+
     tableCreationStmt.addBatch("create table test.inttypes (a INT, b BOOLEAN, c TINYINT, " +
       "d SMALLINT, e BIGINT)")
+
     tableCreationStmt.addBatch("create table test.strtypes (a BINARY(20), b VARCHAR(20), " +
       "c VARCHAR_IGNORECASE(20), d CHAR(20), e BLOB, f CLOB)")
+
     tableCreationStmt.addBatch("create table test.timetypes (a TIME, b DATE, c TIMESTAMP(7))")
+
     tableCreationStmt.addBatch("CREATE TABLE test.timezone (tz TIMESTAMP WITH TIME ZONE) " +
       "AS SELECT '1999-01-08 04:05:06.543543543-08:00'")
+
     tableCreationStmt.addBatch("CREATE TABLE test.array_table (ar Integer ARRAY) " +
       "AS SELECT ARRAY[1, 2, 3]")
+
     tableCreationStmt.addBatch("create table test.flttypes (a DOUBLE, b REAL, c DECIMAL(38, 18))")
+
     tableCreationStmt.addBatch("create table test.nulltypes (a INT, b BOOLEAN, c TINYINT, " +
       "d BINARY(20), e VARCHAR(20), f VARCHAR_IGNORECASE(20), g CHAR(20), h BLOB, i CLOB, " +
       "j TIME, k DATE, l TIMESTAMP, m DOUBLE, n REAL, o DECIMAL(38, 18))")
+
     tableCreationStmt.addBatch("create table test.emp(name TEXT(32) NOT NULL, theid INTEGER, " +
       "\"Dept\" INTEGER)")
+
     tableCreationStmt.addBatch("create table test.seq(id INTEGER)")
+
     tableCreationStmt.addBatch("create table test.\"mixedCaseCols\" (\"Name\" TEXT(32), " +
       "\"Id\" INTEGER NOT NULL)")
+
     tableCreationStmt.addBatch("CREATE TABLE test.partition (THEID INTEGER, `THE ID` INTEGER) " +
       "AS SELECT 1, 1")
+
     tableCreationStmt.addBatch("CREATE TABLE test.datetime (d DATE, t TIMESTAMP)")
+
     tableCreationStmt.addBatch("CREATE TABLE test.composite_name (`last name` TEXT(32) NOT NULL, " +
       "id INTEGER NOT NULL)")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -102,54 +102,97 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     properties.setProperty("password", "testPass")
 
     conn = DriverManager.getConnection(url, properties)
+    // JDBC table creation and data insertion
+    val batchStmt = conn.createStatement()
 
-    // Batch 1: Create schema and all tables
-    val tableCreationStmt = conn.createStatement()
+    batchStmt.addBatch("create schema test")
 
-    tableCreationStmt.addBatch("create schema test")
-
-    tableCreationStmt.addBatch("create table test.people (name TEXT(32) NOT NULL, " +
+    batchStmt.addBatch("create table test.people (name TEXT(32) NOT NULL, " +
       "theid INTEGER NOT NULL)")
 
-    tableCreationStmt.addBatch("create table test.inttypes (a INT, b BOOLEAN, c TINYINT, " +
+    batchStmt.addBatch("create table test.inttypes (a INT, b BOOLEAN, c TINYINT, " +
       "d SMALLINT, e BIGINT)")
 
-    tableCreationStmt.addBatch("create table test.strtypes (a BINARY(20), b VARCHAR(20), " +
+    batchStmt.addBatch("create table test.strtypes (a BINARY(20), b VARCHAR(20), " +
       "c VARCHAR_IGNORECASE(20), d CHAR(20), e BLOB, f CLOB)")
 
-    tableCreationStmt.addBatch("create table test.timetypes (a TIME, b DATE, c TIMESTAMP(7))")
+    batchStmt.addBatch("create table test.timetypes (a TIME, b DATE, c TIMESTAMP(7))")
 
-    tableCreationStmt.addBatch("CREATE TABLE test.timezone (tz TIMESTAMP WITH TIME ZONE) " +
+    batchStmt.addBatch("CREATE TABLE test.timezone (tz TIMESTAMP WITH TIME ZONE) " +
       "AS SELECT '1999-01-08 04:05:06.543543543-08:00'")
 
-    tableCreationStmt.addBatch("CREATE TABLE test.array_table (ar Integer ARRAY) " +
+    batchStmt.addBatch("CREATE TABLE test.array_table (ar Integer ARRAY) " +
       "AS SELECT ARRAY[1, 2, 3]")
 
-    tableCreationStmt.addBatch("create table test.flttypes (a DOUBLE, b REAL, c DECIMAL(38, 18))")
+    batchStmt.addBatch("create table test.flttypes (a DOUBLE, b REAL, c DECIMAL(38, 18))")
 
-    tableCreationStmt.addBatch("create table test.nulltypes (a INT, b BOOLEAN, c TINYINT, " +
+    batchStmt.addBatch("create table test.nulltypes (a INT, b BOOLEAN, c TINYINT, " +
       "d BINARY(20), e VARCHAR(20), f VARCHAR_IGNORECASE(20), g CHAR(20), h BLOB, i CLOB, " +
       "j TIME, k DATE, l TIMESTAMP, m DOUBLE, n REAL, o DECIMAL(38, 18))")
 
-    tableCreationStmt.addBatch("create table test.emp(name TEXT(32) NOT NULL, theid INTEGER, " +
+    batchStmt.addBatch("create table test.emp(name TEXT(32) NOT NULL, theid INTEGER, " +
       "\"Dept\" INTEGER)")
 
-    tableCreationStmt.addBatch("create table test.seq(id INTEGER)")
+    batchStmt.addBatch("create table test.seq(id INTEGER)")
 
-    tableCreationStmt.addBatch("create table test.\"mixedCaseCols\" (\"Name\" TEXT(32), " +
+    batchStmt.addBatch("create table test.\"mixedCaseCols\" (\"Name\" TEXT(32), " +
       "\"Id\" INTEGER NOT NULL)")
 
-    tableCreationStmt.addBatch("CREATE TABLE test.partition (THEID INTEGER, `THE ID` INTEGER) " +
+    batchStmt.addBatch("CREATE TABLE test.partition (THEID INTEGER, `THE ID` INTEGER) " +
       "AS SELECT 1, 1")
 
-    tableCreationStmt.addBatch("CREATE TABLE test.datetime (d DATE, t TIMESTAMP)")
+    batchStmt.addBatch("CREATE TABLE test.datetime (d DATE, t TIMESTAMP)")
 
-    tableCreationStmt.addBatch("CREATE TABLE test.composite_name (`last name` TEXT(32) NOT NULL, " +
+    batchStmt.addBatch("CREATE TABLE test.composite_name (`last name` TEXT(32) NOT NULL, " +
       "id INTEGER NOT NULL)")
 
-    tableCreationStmt.executeBatch()
+    batchStmt.addBatch("insert into test.people values ('fred', 1)")
+    batchStmt.addBatch("insert into test.people values ('mary', 2)")
+    batchStmt.addBatch("insert into test.people values ('joe ''foo'' \"bar\"', 3)")
 
-    // Handle special cases that require prepared statements
+    batchStmt.addBatch("insert into test.inttypes values (1, false, 3, 4, 1234567890123)")
+    batchStmt.addBatch("insert into test.inttypes values (null, null, null, null, null)")
+
+    batchStmt.addBatch("insert into test.timetypes values " +
+      "('12:34:56', '1996-01-01', '2002-02-20 11:22:33.543543543')")
+    batchStmt.addBatch("insert into test.timetypes values " +
+      "('12:34:56', null, '2002-02-20 11:22:33.543543543')")
+
+    batchStmt.addBatch("insert into test.flttypes values " +
+      "(1.0000000000000002220446049250313080847263336181640625, " +
+      "1.00000011920928955078125, 123456789012345.543215432154321)")
+
+    batchStmt.addBatch("insert into test.nulltypes values " +
+      "(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null)")
+
+    batchStmt.addBatch("insert into test.emp values ('fred', 1, 10)")
+    batchStmt.addBatch("insert into test.emp values ('mary', 2, null)")
+    batchStmt.addBatch("insert into test.emp values ('joe ''foo'' \"bar\"', 3, 30)")
+    batchStmt.addBatch("insert into test.emp values ('kathy', null, null)")
+
+    (0 to 6).foreach { value =>
+      batchStmt.addBatch(s"insert into test.seq values ($value)")
+    }
+    batchStmt.addBatch("insert into test.seq values (null)")
+
+    batchStmt.addBatch("""insert into test."mixedCaseCols" values ('fred', 1)""")
+    batchStmt.addBatch("""insert into test."mixedCaseCols" values ('mary', 2)""")
+    batchStmt.addBatch("""insert into test."mixedCaseCols" values (null, 3)""")
+
+    batchStmt.addBatch("INSERT INTO test.datetime VALUES " +
+      "('2018-07-06', '2018-07-06 05:50:00.0')")
+    batchStmt.addBatch("INSERT INTO test.datetime VALUES " +
+      "('2018-07-06', '2018-07-06 08:10:08.0')")
+    batchStmt.addBatch("INSERT INTO test.datetime VALUES " +
+      "('2018-07-08', '2018-07-08 13:32:01.0')")
+    batchStmt.addBatch("INSERT INTO test.datetime VALUES " +
+      "('2018-07-12', '2018-07-12 09:51:15.0')")
+
+    batchStmt.addBatch("INSERT INTO test.composite_name VALUES ('smith', 1)")
+    batchStmt.addBatch("INSERT INTO test.composite_name VALUES ('jones', 2)")
+
+    batchStmt.executeBatch()
+
     val strtypesStmt = conn.prepareStatement("insert into test.strtypes values (?, ?, ?, ?, ?, ?)")
     strtypesStmt.setBytes(1, testBytes)
     strtypesStmt.setString(2, "Sensitive")
@@ -159,57 +202,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     strtypesStmt.setString(6, "I am a clob!")
     strtypesStmt.executeUpdate()
 
-    // Batch 2: All data insertion
-    val dataInsertionStmt = conn.createStatement()
-
-    dataInsertionStmt.addBatch("insert into test.people values ('fred', 1)")
-    dataInsertionStmt.addBatch("insert into test.people values ('mary', 2)")
-    dataInsertionStmt.addBatch("insert into test.people values ('joe ''foo'' \"bar\"', 3)")
-
-    dataInsertionStmt.addBatch("insert into test.inttypes values (1, false, 3, 4, 1234567890123)")
-    dataInsertionStmt.addBatch("insert into test.inttypes values (null, null, null, null, null)")
-
-    dataInsertionStmt.addBatch("insert into test.timetypes values " +
-      "('12:34:56', '1996-01-01', '2002-02-20 11:22:33.543543543')")
-    dataInsertionStmt.addBatch("insert into test.timetypes values " +
-      "('12:34:56', null, '2002-02-20 11:22:33.543543543')")
-
-    dataInsertionStmt.addBatch("insert into test.flttypes values " +
-      "(1.0000000000000002220446049250313080847263336181640625, " +
-      "1.00000011920928955078125, 123456789012345.543215432154321)")
-
-    dataInsertionStmt.addBatch("insert into test.nulltypes values " +
-      "(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null)")
-
-    dataInsertionStmt.addBatch("insert into test.emp values ('fred', 1, 10)")
-    dataInsertionStmt.addBatch("insert into test.emp values ('mary', 2, null)")
-    dataInsertionStmt.addBatch("insert into test.emp values ('joe ''foo'' \"bar\"', 3, 30)")
-    dataInsertionStmt.addBatch("insert into test.emp values ('kathy', null, null)")
-
-    (0 to 6).foreach { value =>
-      dataInsertionStmt.addBatch(s"insert into test.seq values ($value)")
-    }
-    dataInsertionStmt.addBatch("insert into test.seq values (null)")
-
-    dataInsertionStmt.addBatch("""insert into test."mixedCaseCols" values ('fred', 1)""")
-    dataInsertionStmt.addBatch("""insert into test."mixedCaseCols" values ('mary', 2)""")
-    dataInsertionStmt.addBatch("""insert into test."mixedCaseCols" values (null, 3)""")
-
-    dataInsertionStmt.addBatch("INSERT INTO test.datetime VALUES " +
-      "('2018-07-06', '2018-07-06 05:50:00.0')")
-    dataInsertionStmt.addBatch("INSERT INTO test.datetime VALUES " +
-      "('2018-07-06', '2018-07-06 08:10:08.0')")
-    dataInsertionStmt.addBatch("INSERT INTO test.datetime VALUES " +
-      "('2018-07-08', '2018-07-08 13:32:01.0')")
-    dataInsertionStmt.addBatch("INSERT INTO test.datetime VALUES " +
-      "('2018-07-12', '2018-07-12 09:51:15.0')")
-
-    dataInsertionStmt.addBatch("INSERT INTO test.composite_name VALUES ('smith', 1)")
-    dataInsertionStmt.addBatch("INSERT INTO test.composite_name VALUES ('jones', 2)")
-
-    dataInsertionStmt.executeBatch()
-
-    // Finally: All SQL view creation
+    // Spark SQL views creation
     sql(
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW foobar

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -105,23 +105,34 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
 
     // Batch 1: Create schema and all tables
     val tableCreationStmt = conn.createStatement()
-    
+
     tableCreationStmt.addBatch("create schema test")
-    tableCreationStmt.addBatch("create table test.people (name TEXT(32) NOT NULL, theid INTEGER NOT NULL)")
-    tableCreationStmt.addBatch("create table test.inttypes (a INT, b BOOLEAN, c TINYINT, d SMALLINT, e BIGINT)")
-    tableCreationStmt.addBatch("create table test.strtypes (a BINARY(20), b VARCHAR(20), c VARCHAR_IGNORECASE(20), d CHAR(20), e BLOB, f CLOB)")
+    tableCreationStmt.addBatch("create table test.people (name TEXT(32) NOT NULL, " +
+      "theid INTEGER NOT NULL)")
+    tableCreationStmt.addBatch("create table test.inttypes (a INT, b BOOLEAN, c TINYINT, " +
+      "d SMALLINT, e BIGINT)")
+    tableCreationStmt.addBatch("create table test.strtypes (a BINARY(20), b VARCHAR(20), " +
+      "c VARCHAR_IGNORECASE(20), d CHAR(20), e BLOB, f CLOB)")
     tableCreationStmt.addBatch("create table test.timetypes (a TIME, b DATE, c TIMESTAMP(7))")
-    tableCreationStmt.addBatch("CREATE TABLE test.timezone (tz TIMESTAMP WITH TIME ZONE) AS SELECT '1999-01-08 04:05:06.543543543-08:00'")
-    tableCreationStmt.addBatch("CREATE TABLE test.array_table (ar Integer ARRAY) AS SELECT ARRAY[1, 2, 3]")
+    tableCreationStmt.addBatch("CREATE TABLE test.timezone (tz TIMESTAMP WITH TIME ZONE) " +
+      "AS SELECT '1999-01-08 04:05:06.543543543-08:00'")
+    tableCreationStmt.addBatch("CREATE TABLE test.array_table (ar Integer ARRAY) " +
+      "AS SELECT ARRAY[1, 2, 3]")
     tableCreationStmt.addBatch("create table test.flttypes (a DOUBLE, b REAL, c DECIMAL(38, 18))")
-    tableCreationStmt.addBatch("create table test.nulltypes (a INT, b BOOLEAN, c TINYINT, d BINARY(20), e VARCHAR(20), f VARCHAR_IGNORECASE(20), g CHAR(20), h BLOB, i CLOB, j TIME, k DATE, l TIMESTAMP, m DOUBLE, n REAL, o DECIMAL(38, 18))")
-    tableCreationStmt.addBatch("create table test.emp(name TEXT(32) NOT NULL, theid INTEGER, \"Dept\" INTEGER)")
+    tableCreationStmt.addBatch("create table test.nulltypes (a INT, b BOOLEAN, c TINYINT, " +
+      "d BINARY(20), e VARCHAR(20), f VARCHAR_IGNORECASE(20), g CHAR(20), h BLOB, i CLOB, " +
+      "j TIME, k DATE, l TIMESTAMP, m DOUBLE, n REAL, o DECIMAL(38, 18))")
+    tableCreationStmt.addBatch("create table test.emp(name TEXT(32) NOT NULL, theid INTEGER, " +
+      "\"Dept\" INTEGER)")
     tableCreationStmt.addBatch("create table test.seq(id INTEGER)")
-    tableCreationStmt.addBatch("create table test.\"mixedCaseCols\" (\"Name\" TEXT(32), \"Id\" INTEGER NOT NULL)")
-    tableCreationStmt.addBatch("CREATE TABLE test.partition (THEID INTEGER, `THE ID` INTEGER) AS SELECT 1, 1")
+    tableCreationStmt.addBatch("create table test.\"mixedCaseCols\" (\"Name\" TEXT(32), " +
+      "\"Id\" INTEGER NOT NULL)")
+    tableCreationStmt.addBatch("CREATE TABLE test.partition (THEID INTEGER, `THE ID` INTEGER) " +
+      "AS SELECT 1, 1")
     tableCreationStmt.addBatch("CREATE TABLE test.datetime (d DATE, t TIMESTAMP)")
-    tableCreationStmt.addBatch("CREATE TABLE test.composite_name (`last name` TEXT(32) NOT NULL, id INTEGER NOT NULL)")
-    
+    tableCreationStmt.addBatch("CREATE TABLE test.composite_name (`last name` TEXT(32) NOT NULL, " +
+      "id INTEGER NOT NULL)")
+
     tableCreationStmt.executeBatch()
 
     // Handle special cases that require prepared statements
@@ -144,12 +155,17 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     dataInsertionStmt.addBatch("insert into test.inttypes values (1, false, 3, 4, 1234567890123)")
     dataInsertionStmt.addBatch("insert into test.inttypes values (null, null, null, null, null)")
 
-    dataInsertionStmt.addBatch("insert into test.timetypes values ('12:34:56', '1996-01-01', '2002-02-20 11:22:33.543543543')")
-    dataInsertionStmt.addBatch("insert into test.timetypes values ('12:34:56', null, '2002-02-20 11:22:33.543543543')")
+    dataInsertionStmt.addBatch("insert into test.timetypes values " +
+      "('12:34:56', '1996-01-01', '2002-02-20 11:22:33.543543543')")
+    dataInsertionStmt.addBatch("insert into test.timetypes values " +
+      "('12:34:56', null, '2002-02-20 11:22:33.543543543')")
 
-    dataInsertionStmt.addBatch("insert into test.flttypes values (1.0000000000000002220446049250313080847263336181640625, 1.00000011920928955078125, 123456789012345.543215432154321)")
+    dataInsertionStmt.addBatch("insert into test.flttypes values " +
+      "(1.0000000000000002220446049250313080847263336181640625, " +
+      "1.00000011920928955078125, 123456789012345.543215432154321)")
 
-    dataInsertionStmt.addBatch("insert into test.nulltypes values (null, null, null, null, null, null, null, null, null, null, null, null, null, null, null)")
+    dataInsertionStmt.addBatch("insert into test.nulltypes values " +
+      "(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null)")
 
     dataInsertionStmt.addBatch("insert into test.emp values ('fred', 1, 10)")
     dataInsertionStmt.addBatch("insert into test.emp values ('mary', 2, null)")
@@ -165,10 +181,14 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     dataInsertionStmt.addBatch("""insert into test."mixedCaseCols" values ('mary', 2)""")
     dataInsertionStmt.addBatch("""insert into test."mixedCaseCols" values (null, 3)""")
 
-    dataInsertionStmt.addBatch("INSERT INTO test.datetime VALUES ('2018-07-06', '2018-07-06 05:50:00.0')")
-    dataInsertionStmt.addBatch("INSERT INTO test.datetime VALUES ('2018-07-06', '2018-07-06 08:10:08.0')")
-    dataInsertionStmt.addBatch("INSERT INTO test.datetime VALUES ('2018-07-08', '2018-07-08 13:32:01.0')")
-    dataInsertionStmt.addBatch("INSERT INTO test.datetime VALUES ('2018-07-12', '2018-07-12 09:51:15.0')")
+    dataInsertionStmt.addBatch("INSERT INTO test.datetime VALUES " +
+      "('2018-07-06', '2018-07-06 05:50:00.0')")
+    dataInsertionStmt.addBatch("INSERT INTO test.datetime VALUES " +
+      "('2018-07-06', '2018-07-06 08:10:08.0')")
+    dataInsertionStmt.addBatch("INSERT INTO test.datetime VALUES " +
+      "('2018-07-08', '2018-07-08 13:32:01.0')")
+    dataInsertionStmt.addBatch("INSERT INTO test.datetime VALUES " +
+      "('2018-07-12', '2018-07-12 09:51:15.0')")
 
     dataInsertionStmt.addBatch("INSERT INTO test.composite_name VALUES ('smith', 1)")
     dataInsertionStmt.addBatch("INSERT INTO test.composite_name VALUES ('jones', 2)")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -105,11 +105,9 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     conn.prepareStatement("create schema test").executeUpdate()
     conn.prepareStatement(
       "create table test.people (name TEXT(32) NOT NULL, theid INTEGER NOT NULL)").executeUpdate()
-    conn.prepareStatement("insert into test.people values ('fred', 1)").executeUpdate()
-    conn.prepareStatement("insert into test.people values ('mary', 2)").executeUpdate()
-    conn.prepareStatement(
-      "insert into test.people values ('joe ''foo'' \"bar\"', 3)").executeUpdate()
-    conn.commit()
+
+    conn.prepareStatement("insert into test.people values " +
+      "('fred', 1), ('mary', 2), ('joe ''foo'' \"bar\"', 3)").executeUpdate()
 
     sql(
       s"""
@@ -145,11 +143,10 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
 
     conn.prepareStatement("create table test.inttypes (a INT, b BOOLEAN, c TINYINT, "
       + "d SMALLINT, e BIGINT)").executeUpdate()
-    conn.prepareStatement("insert into test.inttypes values (1, false, 3, 4, 1234567890123)"
-        ).executeUpdate()
-    conn.prepareStatement("insert into test.inttypes values (null, null, null, null, null)"
-        ).executeUpdate()
-    conn.commit()
+
+    conn.prepareStatement("insert into test.inttypes values " +
+      "(1, false, 3, 4, 1234567890123), (null, null, null, null, null)").executeUpdate()
+
     sql(
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW inttypes
@@ -176,11 +173,11 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
 
     conn.prepareStatement("create table test.timetypes (a TIME, b DATE, c TIMESTAMP(7))"
         ).executeUpdate()
-    conn.prepareStatement("insert into test.timetypes values ('12:34:56', "
-      + "'1996-01-01', '2002-02-20 11:22:33.543543543')").executeUpdate()
-    conn.prepareStatement("insert into test.timetypes values ('12:34:56', "
-      + "null, '2002-02-20 11:22:33.543543543')").executeUpdate()
-    conn.commit()
+
+    conn.prepareStatement("insert into test.timetypes values " +
+      "('12:34:56', '1996-01-01', '2002-02-20 11:22:33.543543543'), " +
+      "('12:34:56', null, '2002-02-20 11:22:33.543543543')").executeUpdate()
+
     sql(
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW timetypes
@@ -191,12 +188,10 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     conn.prepareStatement("CREATE TABLE test.timezone (tz TIMESTAMP WITH TIME ZONE) " +
       "AS SELECT '1999-01-08 04:05:06.543543543-08:00'")
       .executeUpdate()
-    conn.commit()
 
     conn.prepareStatement("CREATE TABLE test.array_table (ar Integer ARRAY) " +
       "AS SELECT ARRAY[1, 2, 3]")
       .executeUpdate()
-    conn.commit()
 
     conn.prepareStatement("create table test.flttypes (a DOUBLE, b REAL, c DECIMAL(38, 18))"
         ).executeUpdate()
@@ -204,7 +199,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       + "1.0000000000000002220446049250313080847263336181640625, "
       + "1.00000011920928955078125, "
       + "123456789012345.543215432154321)").executeUpdate()
-    conn.commit()
+
     sql(
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW flttypes
@@ -221,7 +216,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     conn.prepareStatement("insert into test.nulltypes values ("
       + "null, null, null, null, null, null, null, null, null, "
       + "null, null, null, null, null, null)").executeUpdate()
-    conn.commit()
+
     sql(
       s"""
          |CREATE OR REPLACE TEMPORARY VIEW nulltypes
@@ -232,25 +227,15 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     conn.prepareStatement(
       "create table test.emp(name TEXT(32) NOT NULL," +
         " theid INTEGER, \"Dept\" INTEGER)").executeUpdate()
-    conn.prepareStatement(
-      "insert into test.emp values ('fred', 1, 10)").executeUpdate()
-    conn.prepareStatement(
-      "insert into test.emp values ('mary', 2, null)").executeUpdate()
-    conn.prepareStatement(
-      "insert into test.emp values ('joe ''foo'' \"bar\"', 3, 30)").executeUpdate()
-    conn.prepareStatement(
-      "insert into test.emp values ('kathy', null, null)").executeUpdate()
-    conn.commit()
+
+    conn.prepareStatement("insert into test.emp values " +
+      "('fred', 1, 10), ('mary', 2, null), ('joe ''foo'' \"bar\"', 3, 30), ('kathy', null, null)").executeUpdate()
 
     conn.prepareStatement(
       "create table test.seq(id INTEGER)").executeUpdate()
-    (0 to 6).foreach { value =>
-      conn.prepareStatement(
-        s"insert into test.seq values ($value)").executeUpdate()
-    }
-    conn.prepareStatement(
-      "insert into test.seq values (null)").executeUpdate()
-    conn.commit()
+
+    val seqValues = (0 to 6).map(value => s"($value)").mkString(", ") + ", (null)"
+    conn.prepareStatement(s"insert into test.seq values $seqValues").executeUpdate()
 
     sql(
       s"""
@@ -263,10 +248,9 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     conn.prepareStatement(
       """create table test."mixedCaseCols" ("Name" TEXT(32), "Id" INTEGER NOT NULL)""")
       .executeUpdate()
-    conn.prepareStatement("""insert into test."mixedCaseCols" values ('fred', 1)""").executeUpdate()
-    conn.prepareStatement("""insert into test."mixedCaseCols" values ('mary', 2)""").executeUpdate()
-    conn.prepareStatement("""insert into test."mixedCaseCols" values (null, 3)""").executeUpdate()
-    conn.commit()
+
+    conn.prepareStatement("""insert into test."mixedCaseCols" values """ +
+      """('fred', 1), ('mary', 2), (null, 3)""").executeUpdate()
 
     sql(
       s"""
@@ -278,25 +262,21 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     conn.prepareStatement("CREATE TABLE test.partition (THEID INTEGER, `THE ID` INTEGER) " +
       "AS SELECT 1, 1")
       .executeUpdate()
-    conn.commit()
 
     conn.prepareStatement("CREATE TABLE test.datetime (d DATE, t TIMESTAMP)").executeUpdate()
-    conn.prepareStatement(
-      "INSERT INTO test.datetime VALUES ('2018-07-06', '2018-07-06 05:50:00.0')").executeUpdate()
-    conn.prepareStatement(
-      "INSERT INTO test.datetime VALUES ('2018-07-06', '2018-07-06 08:10:08.0')").executeUpdate()
-    conn.prepareStatement(
-      "INSERT INTO test.datetime VALUES ('2018-07-08', '2018-07-08 13:32:01.0')").executeUpdate()
-    conn.prepareStatement(
-      "INSERT INTO test.datetime VALUES ('2018-07-12', '2018-07-12 09:51:15.0')").executeUpdate()
-    conn.commit()
+
+    conn.prepareStatement("INSERT INTO test.datetime VALUES " +
+      "('2018-07-06', '2018-07-06 05:50:00.0'), " +
+      "('2018-07-06', '2018-07-06 08:10:08.0'), " +
+      "('2018-07-08', '2018-07-08 13:32:01.0'), " +
+      "('2018-07-12', '2018-07-12 09:51:15.0')").executeUpdate()
 
     conn.prepareStatement(
       "CREATE TABLE test.composite_name (`last name` TEXT(32) NOT NULL, id INTEGER NOT NULL)")
       .executeUpdate()
-    conn.prepareStatement("INSERT INTO test.composite_name VALUES ('smith', 1)").executeUpdate()
-    conn.prepareStatement("INSERT INTO test.composite_name VALUES ('jones', 2)").executeUpdate()
-    conn.commit()
+
+    conn.prepareStatement("INSERT INTO test.composite_name VALUES " +
+      "('smith', 1), ('jones', 2)").executeUpdate()
 
     sql(
       s"""

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -228,8 +228,10 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       "create table test.emp(name TEXT(32) NOT NULL," +
         " theid INTEGER, \"Dept\" INTEGER)").executeUpdate()
 
-    conn.prepareStatement("insert into test.emp values " +
-      "('fred', 1, 10), ('mary', 2, null), ('joe ''foo'' \"bar\"', 3, 30), ('kathy', null, null)").executeUpdate()
+    conn
+      .prepareStatement("insert into test.emp values " +
+        "('fred', 1, 10), ('mary', 2, null), ('joe ''foo'' \"bar\"', 3, 30), ('kathy', null, null)")
+      .executeUpdate()
 
     conn.prepareStatement(
       "create table test.seq(id INTEGER)").executeUpdate()

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -105,7 +105,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     conn.prepareStatement("create schema test").executeUpdate()
     conn.prepareStatement(
       "create table test.people (name TEXT(32) NOT NULL, theid INTEGER NOT NULL)").executeUpdate()
-    
+
     sql(
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW foobar
@@ -140,7 +140,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
 
     conn.prepareStatement("create table test.inttypes (a INT, b BOOLEAN, c TINYINT, "
       + "d SMALLINT, e BIGINT)").executeUpdate()
-    
+
     sql(
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW inttypes
@@ -167,7 +167,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
 
     conn.prepareStatement("create table test.timetypes (a TIME, b DATE, c TIMESTAMP(7))"
         ).executeUpdate()
-    
+
     sql(
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW timetypes
@@ -189,7 +189,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       + "1.0000000000000002220446049250313080847263336181640625, "
       + "1.00000011920928955078125, "
       + "123456789012345.543215432154321)").executeUpdate()
-    
+
     sql(
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW flttypes
@@ -206,7 +206,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     conn.prepareStatement("insert into test.nulltypes values ("
       + "null, null, null, null, null, null, null, null, null, "
       + "null, null, null, null, null, null)").executeUpdate()
-    
+
     sql(
       s"""
          |CREATE OR REPLACE TEMPORARY VIEW nulltypes

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -186,9 +186,11 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       conn.prepareStatement("INSERT INTO \"test\".\"dept\" VALUES " +
         "(1, 1), (2, 1)").executeUpdate()
 
+      // scalastyle:off
       conn
         .prepareStatement("CREATE TABLE \"test\".\"person\" (\"名\" INTEGER NOT NULL)")
         .executeUpdate()
+      // scalastyle:on
 
       conn.prepareStatement("INSERT INTO \"test\".\"person\" VALUES (1), (2)").executeUpdate()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -166,17 +166,28 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
 
       batchStmt.addBatch(
         "CREATE TABLE \"test\".\"people\" (name TEXT(32) NOT NULL, id INTEGER NOT NULL)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"people\" VALUES ('fred', 1)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"people\" VALUES ('mary', 2)")
 
       batchStmt.addBatch(
         "CREATE TABLE \"test\".\"employee\" (dept INTEGER, name TEXT(32), salary NUMERIC(20, 2)," +
           " bonus DOUBLE, is_manager BOOLEAN)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"employee\" VALUES (1, 'amy', 10000, 1000, true)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"employee\" VALUES (2, 'alex', 12000, 1200, false)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"employee\" VALUES (1, 'cathy', 9000, 1200, false)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"employee\" VALUES (2, 'david', 10000, 1300, true)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"employee\" VALUES (6, 'jen', 12000, 1200, true)")
 
       batchStmt.addBatch(
         "CREATE TABLE \"test\".\"dept\" (\"dept id\" INTEGER NOT NULL, \"dept.id\" INTEGER)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"dept\" VALUES (1, 1)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"dept\" VALUES (2, 1)")
 
       // scalastyle:off
       batchStmt.addBatch("CREATE TABLE \"test\".\"person\" (\"名\" INTEGER NOT NULL)")
       // scalastyle:on
+      batchStmt.addBatch("INSERT INTO \"test\".\"person\" VALUES (1)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"person\" VALUES (2)")
 
       batchStmt.addBatch(
         """CREATE TABLE "test"."view1" ("|col1" INTEGER, "|col2" INTEGER)""")
@@ -185,52 +196,28 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
 
       batchStmt.addBatch(
         "CREATE TABLE \"test\".\"item\" (id INTEGER, name TEXT(32), price NUMERIC(23, 3))")
-
-      batchStmt.addBatch(
-        "CREATE TABLE \"test\".\"datetime\" (name TEXT(32), date1 DATE, time1 TIMESTAMP)")
-
-      batchStmt.addBatch(
-        "CREATE TABLE \"test\".\"address\" (email TEXT(32) NOT NULL)")
-
-      batchStmt.addBatch("CREATE TABLE \"test\".\"binary_tab\" (name TEXT(32),b BINARY(20))")
-
-      batchStmt.addBatch("CREATE TABLE \"test\".\"employee_bonus\" " +
-        "(name TEXT(32), salary NUMERIC(20, 2), bonus DOUBLE, factor DOUBLE)")
-
-      batchStmt.addBatch(
-        "CREATE TABLE \"test\".\"strings_with_nulls\" (str TEXT(32))")
-
-      batchStmt.addBatch("INSERT INTO \"test\".\"people\" VALUES ('fred', 1)")
-      batchStmt.addBatch("INSERT INTO \"test\".\"people\" VALUES ('mary', 2)")
-
-      batchStmt.addBatch("INSERT INTO \"test\".\"employee\" VALUES (1, 'amy', 10000, 1000, true)")
-      batchStmt.addBatch("INSERT INTO \"test\".\"employee\" VALUES (2, 'alex', 12000, 1200, false)")
-      batchStmt.addBatch("INSERT INTO \"test\".\"employee\" VALUES (1, 'cathy', 9000, 1200, false)")
-      batchStmt.addBatch("INSERT INTO \"test\".\"employee\" VALUES (2, 'david', 10000, 1300, true)")
-      batchStmt.addBatch("INSERT INTO \"test\".\"employee\" VALUES (6, 'jen', 12000, 1200, true)")
-
-      batchStmt.addBatch("INSERT INTO \"test\".\"dept\" VALUES (1, 1)")
-      batchStmt.addBatch("INSERT INTO \"test\".\"dept\" VALUES (2, 1)")
-
-      batchStmt.addBatch("INSERT INTO \"test\".\"person\" VALUES (1)")
-      batchStmt.addBatch("INSERT INTO \"test\".\"person\" VALUES (2)")
-
       batchStmt.addBatch("INSERT INTO \"test\".\"item\"" +
         "VALUES (1, 'bottle', 11111111111111111111.123)")
       batchStmt.addBatch("INSERT INTO \"test\".\"item\"" +
         "VALUES (1, 'bottle', 99999999999999999999.123)")
 
+      batchStmt.addBatch(
+        "CREATE TABLE \"test\".\"datetime\" (name TEXT(32), date1 DATE, time1 TIMESTAMP)")
       batchStmt.addBatch("INSERT INTO \"test\".\"datetime\"" +
         "VALUES ('amy', '2022-05-19', '2022-05-19 00:00:00')")
       batchStmt.addBatch("INSERT INTO \"test\".\"datetime\"" +
         "VALUES ('alex', '2022-05-18', '2022-05-18 00:00:00')")
 
+      batchStmt.addBatch(
+        "CREATE TABLE \"test\".\"address\" (email TEXT(32) NOT NULL)")
       batchStmt.addBatch("INSERT INTO \"test\".\"address\" VALUES ('abc_def@gmail.com')")
       batchStmt.addBatch("INSERT INTO \"test\".\"address\" VALUES ('abc%def@gmail.com')")
       batchStmt.addBatch("INSERT INTO \"test\".\"address\" VALUES ('abc%_def@gmail.com')")
       batchStmt.addBatch("INSERT INTO \"test\".\"address\" VALUES ('abc_%def@gmail.com')")
       batchStmt.addBatch("INSERT INTO \"test\".\"address\" VALUES ('abc_''%def@gmail.com')")
 
+      batchStmt.addBatch("CREATE TABLE \"test\".\"employee_bonus\" " +
+        "(name TEXT(32), salary NUMERIC(20, 2), bonus DOUBLE, factor DOUBLE)")
       batchStmt.addBatch("INSERT INTO \"test\".\"employee_bonus\"" +
         "VALUES ('amy', 10000, 1000, 0.1)")
       batchStmt.addBatch("INSERT INTO \"test\".\"employee_bonus\"" +
@@ -242,12 +229,17 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       batchStmt.addBatch("INSERT INTO \"test\".\"employee_bonus\"" +
         "VALUES ('jen', 12000, 2400, 0.2)")
 
+      batchStmt.addBatch(
+        "CREATE TABLE \"test\".\"strings_with_nulls\" (str TEXT(32))")
       batchStmt.addBatch("INSERT INTO \"test\".\"strings_with_nulls\" VALUES ('abc')")
       batchStmt.addBatch("INSERT INTO \"test\".\"strings_with_nulls\" VALUES ('a a a')")
       batchStmt.addBatch("INSERT INTO \"test\".\"strings_with_nulls\" VALUES (null)")
 
       batchStmt.executeBatch()
 
+      conn
+        .prepareStatement("CREATE TABLE \"test\".\"binary_tab\" (name TEXT(32),b BINARY(20))")
+        .executeUpdate()
       val stmt = conn.prepareStatement("INSERT INTO \"test\".\"binary_tab\" VALUES (?, ?)")
       stmt.setString(1, "jen")
       stmt.setBytes(2, testBytes)

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -190,7 +190,6 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
         .prepareStatement("CREATE TABLE \"test\".\"person\" (\"名\" INTEGER NOT NULL)")
         .executeUpdate()
 
-      // Optimized: Batch insert for person table (was 2 separate INSERTs)
       conn.prepareStatement("INSERT INTO \"test\".\"person\" VALUES (1), (2)").executeUpdate()
 
       conn.prepareStatement(

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -157,54 +157,48 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     super.beforeAll()
     Utils.classForName("org.h2.Driver")
     withConnection { conn =>
-      conn.prepareStatement("CREATE SCHEMA \"test\"").executeUpdate()
-      conn.prepareStatement(
-        "CREATE TABLE \"test\".\"empty_table\" (name TEXT(32) NOT NULL, id INTEGER NOT NULL)")
-        .executeUpdate()
-      conn.prepareStatement(
-        "CREATE TABLE \"test\".\"people\" (name TEXT(32) NOT NULL, id INTEGER NOT NULL)")
-        .executeUpdate()
-
-      conn.prepareStatement(
-        "CREATE TABLE \"test\".\"employee\" (dept INTEGER, name TEXT(32), salary NUMERIC(20, 2)," +
-          " bonus DOUBLE, is_manager BOOLEAN)").executeUpdate()
-
-      conn.prepareStatement(
-        "CREATE TABLE \"test\".\"dept\" (\"dept id\" INTEGER NOT NULL, \"dept.id\" INTEGER)")
-        .executeUpdate()
-
-      // scalastyle:off
-      conn
-        .prepareStatement("CREATE TABLE \"test\".\"person\" (\"名\" INTEGER NOT NULL)")
-        .executeUpdate()
-      // scalastyle:on
-
-      conn.prepareStatement(
-        """CREATE TABLE "test"."view1" ("|col1" INTEGER, "|col2" INTEGER)""").executeUpdate()
-      conn.prepareStatement(
-        """CREATE TABLE "test"."view2" ("|col1" INTEGER, "|col3" INTEGER)""").executeUpdate()
-
-      conn.prepareStatement(
-        "CREATE TABLE \"test\".\"item\" (id INTEGER, name TEXT(32), price NUMERIC(23, 3))")
-        .executeUpdate()
-
-      conn.prepareStatement(
-        "CREATE TABLE \"test\".\"datetime\" (name TEXT(32), date1 DATE, time1 TIMESTAMP)")
-        .executeUpdate()
-
-      conn.prepareStatement(
-        "CREATE TABLE \"test\".\"address\" (email TEXT(32) NOT NULL)").executeUpdate()
-
-      conn.prepareStatement("CREATE TABLE \"test\".\"binary_tab\" (name TEXT(32),b BINARY(20))")
-        .executeUpdate()
-
-      conn.prepareStatement("CREATE TABLE \"test\".\"employee_bonus\" " +
-        "(name TEXT(32), salary NUMERIC(20, 2), bonus DOUBLE, factor DOUBLE)").executeUpdate()
-
-      conn.prepareStatement(
-        "CREATE TABLE \"test\".\"strings_with_nulls\" (str TEXT(32))").executeUpdate()
 
       val batchStmt = conn.createStatement()
+      batchStmt.addBatch("CREATE SCHEMA \"test\"")
+
+      batchStmt.addBatch(
+        "CREATE TABLE \"test\".\"empty_table\" (name TEXT(32) NOT NULL, id INTEGER NOT NULL)")
+
+      batchStmt.addBatch(
+        "CREATE TABLE \"test\".\"people\" (name TEXT(32) NOT NULL, id INTEGER NOT NULL)")
+
+      batchStmt.addBatch(
+        "CREATE TABLE \"test\".\"employee\" (dept INTEGER, name TEXT(32), salary NUMERIC(20, 2)," +
+          " bonus DOUBLE, is_manager BOOLEAN)")
+
+      batchStmt.addBatch(
+        "CREATE TABLE \"test\".\"dept\" (\"dept id\" INTEGER NOT NULL, \"dept.id\" INTEGER)")
+
+      // scalastyle:off
+      batchStmt.addBatch("CREATE TABLE \"test\".\"person\" (\"名\" INTEGER NOT NULL)")
+      // scalastyle:on
+
+      batchStmt.addBatch(
+        """CREATE TABLE "test"."view1" ("|col1" INTEGER, "|col2" INTEGER)""")
+      batchStmt.addBatch(
+        """CREATE TABLE "test"."view2" ("|col1" INTEGER, "|col3" INTEGER)""")
+
+      batchStmt.addBatch(
+        "CREATE TABLE \"test\".\"item\" (id INTEGER, name TEXT(32), price NUMERIC(23, 3))")
+
+      batchStmt.addBatch(
+        "CREATE TABLE \"test\".\"datetime\" (name TEXT(32), date1 DATE, time1 TIMESTAMP)")
+
+      batchStmt.addBatch(
+        "CREATE TABLE \"test\".\"address\" (email TEXT(32) NOT NULL)")
+
+      batchStmt.addBatch("CREATE TABLE \"test\".\"binary_tab\" (name TEXT(32),b BINARY(20))")
+
+      batchStmt.addBatch("CREATE TABLE \"test\".\"employee_bonus\" " +
+        "(name TEXT(32), salary NUMERIC(20, 2), bonus DOUBLE, factor DOUBLE)")
+
+      batchStmt.addBatch(
+        "CREATE TABLE \"test\".\"strings_with_nulls\" (str TEXT(32))")
 
       batchStmt.addBatch("INSERT INTO \"test\".\"people\" VALUES ('fred', 1)")
       batchStmt.addBatch("INSERT INTO \"test\".\"people\" VALUES ('mary', 2)")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -206,43 +206,51 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
 
       val batchStmt = conn.createStatement()
 
-      batchStmt.addBatch("INSERT INTO \"test\".\"people\" VALUES ('fred', 1), ('mary', 2)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"people\" VALUES ('fred', 1)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"people\" VALUES ('mary', 2)")
 
-      batchStmt.addBatch("INSERT INTO \"test\".\"employee\" VALUES " +
-        "(1, 'amy', 10000, 1000, true), " +
-        "(2, 'alex', 12000, 1200, false), " +
-        "(1, 'cathy', 9000, 1200, false), " +
-        "(2, 'david', 10000, 1300, true), " +
-        "(6, 'jen', 12000, 1200, true)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"employee\" VALUES (1, 'amy', 10000, 1000, true)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"employee\" VALUES (2, 'alex', 12000, 1200, false)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"employee\" VALUES (1, 'cathy', 9000, 1200, false)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"employee\" VALUES (2, 'david', 10000, 1300, true)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"employee\" VALUES (6, 'jen', 12000, 1200, true)")
 
-      batchStmt.addBatch("INSERT INTO \"test\".\"dept\" VALUES (1, 1), (2, 1)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"dept\" VALUES (1, 1)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"dept\" VALUES (2, 1)")
 
-      batchStmt.addBatch("INSERT INTO \"test\".\"person\" VALUES (1), (2)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"person\" VALUES (1)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"person\" VALUES (2)")
 
-      batchStmt.addBatch("INSERT INTO \"test\".\"item\" VALUES " +
-        "(1, 'bottle', 11111111111111111111.123), " +
-        "(1, 'bottle', 99999999999999999999.123)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"item\"" +
+        "VALUES (1, 'bottle', 11111111111111111111.123)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"item\"" +
+        "VALUES (1, 'bottle', 99999999999999999999.123)")
 
-      batchStmt.addBatch("INSERT INTO \"test\".\"datetime\" VALUES " +
-        "('amy', '2022-05-19', '2022-05-19 00:00:00'), " +
-        "('alex', '2022-05-18', '2022-05-18 00:00:00')")
+      batchStmt.addBatch("INSERT INTO \"test\".\"datetime\"" +
+        "VALUES ('amy', '2022-05-19', '2022-05-19 00:00:00')")
+      batchStmt.addBatch("INSERT INTO \"test\".\"datetime\"" +
+        "VALUES ('alex', '2022-05-18', '2022-05-18 00:00:00')")
 
-      batchStmt.addBatch("INSERT INTO \"test\".\"address\" VALUES " +
-        "('abc_def@gmail.com'), " +
-        "('abc%def@gmail.com'), " +
-        "('abc%_def@gmail.com'), " +
-        "('abc_%def@gmail.com'), " +
-        "('abc_''%def@gmail.com')")
+      batchStmt.addBatch("INSERT INTO \"test\".\"address\" VALUES ('abc_def@gmail.com')")
+      batchStmt.addBatch("INSERT INTO \"test\".\"address\" VALUES ('abc%def@gmail.com')")
+      batchStmt.addBatch("INSERT INTO \"test\".\"address\" VALUES ('abc%_def@gmail.com')")
+      batchStmt.addBatch("INSERT INTO \"test\".\"address\" VALUES ('abc_%def@gmail.com')")
+      batchStmt.addBatch("INSERT INTO \"test\".\"address\" VALUES ('abc_''%def@gmail.com')")
 
-      batchStmt.addBatch("INSERT INTO \"test\".\"employee_bonus\" VALUES " +
-        "('amy', 10000, 1000, 0.1), " +
-        "('alex', 12000, 1200, 0.1), " +
-        "('cathy', 8000, 1200, 0.15), " +
-        "('david', 10000, 1300, 0.13), " +
-        "('jen', 12000, 2400, 0.2)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"employee_bonus\"" +
+        "VALUES ('amy', 10000, 1000, 0.1)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"employee_bonus\"" +
+        "VALUES ('alex', 12000, 1200, 0.1)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"employee_bonus\"" +
+        "VALUES ('cathy', 8000, 1200, 0.15)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"employee_bonus\"" +
+        "VALUES ('david', 10000, 1300, 0.13)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"employee_bonus\"" +
+        "VALUES ('jen', 12000, 2400, 0.2)")
 
-      batchStmt.addBatch("INSERT INTO \"test\".\"strings_with_nulls\" VALUES " +
-        "('abc'), ('a a a'), (null)")
+      batchStmt.addBatch("INSERT INTO \"test\".\"strings_with_nulls\" VALUES ('abc')")
+      batchStmt.addBatch("INSERT INTO \"test\".\"strings_with_nulls\" VALUES ('a a a')")
+      batchStmt.addBatch("INSERT INTO \"test\".\"strings_with_nulls\" VALUES (null)")
 
       batchStmt.executeBatch()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -164,33 +164,35 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       conn.prepareStatement(
         "CREATE TABLE \"test\".\"people\" (name TEXT(32) NOT NULL, id INTEGER NOT NULL)")
         .executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"people\" VALUES ('fred', 1)").executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"people\" VALUES ('mary', 2)").executeUpdate()
+
+      conn.prepareStatement("INSERT INTO \"test\".\"people\" VALUES " +
+        "('fred', 1), ('mary', 2)").executeUpdate()
+
       conn.prepareStatement(
         "CREATE TABLE \"test\".\"employee\" (dept INTEGER, name TEXT(32), salary NUMERIC(20, 2)," +
           " bonus DOUBLE, is_manager BOOLEAN)").executeUpdate()
-      conn.prepareStatement(
-        "INSERT INTO \"test\".\"employee\" VALUES (1, 'amy', 10000, 1000, true)").executeUpdate()
-      conn.prepareStatement(
-        "INSERT INTO \"test\".\"employee\" VALUES (2, 'alex', 12000, 1200, false)").executeUpdate()
-      conn.prepareStatement(
-        "INSERT INTO \"test\".\"employee\" VALUES (1, 'cathy', 9000, 1200, false)").executeUpdate()
-      conn.prepareStatement(
-        "INSERT INTO \"test\".\"employee\" VALUES (2, 'david', 10000, 1300, true)").executeUpdate()
-      conn.prepareStatement(
-        "INSERT INTO \"test\".\"employee\" VALUES (6, 'jen', 12000, 1200, true)").executeUpdate()
+
+      conn.prepareStatement("INSERT INTO \"test\".\"employee\" VALUES " +
+        "(1, 'amy', 10000, 1000, true), " +
+        "(2, 'alex', 12000, 1200, false), " +
+        "(1, 'cathy', 9000, 1200, false), " +
+        "(2, 'david', 10000, 1300, true), " +
+        "(6, 'jen', 12000, 1200, true)").executeUpdate()
+
       conn.prepareStatement(
         "CREATE TABLE \"test\".\"dept\" (\"dept id\" INTEGER NOT NULL, \"dept.id\" INTEGER)")
         .executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"dept\" VALUES (1, 1)").executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"dept\" VALUES (2, 1)").executeUpdate()
 
-      // scalastyle:off
-      conn.prepareStatement(
-        "CREATE TABLE \"test\".\"person\" (\"名\" INTEGER NOT NULL)").executeUpdate()
-      // scalastyle:on
-      conn.prepareStatement("INSERT INTO \"test\".\"person\" VALUES (1)").executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"person\" VALUES (2)").executeUpdate()
+      conn.prepareStatement("INSERT INTO \"test\".\"dept\" VALUES " +
+        "(1, 1), (2, 1)").executeUpdate()
+
+      conn
+        .prepareStatement("CREATE TABLE \"test\".\"person\" (\"名\" INTEGER NOT NULL)")
+        .executeUpdate()
+
+      // Optimized: Batch insert for person table (was 2 separate INSERTs)
+      conn.prepareStatement("INSERT INTO \"test\".\"person\" VALUES (1), (2)").executeUpdate()
+
       conn.prepareStatement(
         """CREATE TABLE "test"."view1" ("|col1" INTEGER, "|col2" INTEGER)""").executeUpdate()
       conn.prepareStatement(
@@ -199,30 +201,27 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       conn.prepareStatement(
         "CREATE TABLE \"test\".\"item\" (id INTEGER, name TEXT(32), price NUMERIC(23, 3))")
         .executeUpdate()
+
       conn.prepareStatement("INSERT INTO \"test\".\"item\" VALUES " +
-        "(1, 'bottle', 11111111111111111111.123)").executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"item\" VALUES " +
+        "(1, 'bottle', 11111111111111111111.123), " +
         "(1, 'bottle', 99999999999999999999.123)").executeUpdate()
 
       conn.prepareStatement(
         "CREATE TABLE \"test\".\"datetime\" (name TEXT(32), date1 DATE, time1 TIMESTAMP)")
         .executeUpdate()
+
       conn.prepareStatement("INSERT INTO \"test\".\"datetime\" VALUES " +
-        "('amy', '2022-05-19', '2022-05-19 00:00:00')").executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"datetime\" VALUES " +
+        "('amy', '2022-05-19', '2022-05-19 00:00:00'), " +
         "('alex', '2022-05-18', '2022-05-18 00:00:00')").executeUpdate()
 
       conn.prepareStatement(
         "CREATE TABLE \"test\".\"address\" (email TEXT(32) NOT NULL)").executeUpdate()
+
       conn.prepareStatement("INSERT INTO \"test\".\"address\" VALUES " +
-        "('abc_def@gmail.com')").executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"address\" VALUES " +
-        "('abc%def@gmail.com')").executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"address\" VALUES " +
-        "('abc%_def@gmail.com')").executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"address\" VALUES " +
-        "('abc_%def@gmail.com')").executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"address\" VALUES " +
+        "('abc_def@gmail.com'), " +
+        "('abc%def@gmail.com'), " +
+        "('abc%_def@gmail.com'), " +
+        "('abc_%def@gmail.com'), " +
         "('abc_''%def@gmail.com')").executeUpdate()
 
       conn.prepareStatement("CREATE TABLE \"test\".\"binary_tab\" (name TEXT(32),b BINARY(20))")
@@ -234,25 +233,18 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
 
       conn.prepareStatement("CREATE TABLE \"test\".\"employee_bonus\" " +
         "(name TEXT(32), salary NUMERIC(20, 2), bonus DOUBLE, factor DOUBLE)").executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"employee_bonus\" " +
-        "VALUES ('amy', 10000, 1000, 0.1)").executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"employee_bonus\" " +
-        "VALUES ('alex', 12000, 1200, 0.1)").executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"employee_bonus\" " +
-        "VALUES ('cathy', 8000, 1200, 0.15)").executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"employee_bonus\" " +
-        "VALUES ('david', 10000, 1300, 0.13)").executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"employee_bonus\" " +
-        "VALUES ('jen', 12000, 2400, 0.2)").executeUpdate()
+
+      conn.prepareStatement("INSERT INTO \"test\".\"employee_bonus\" VALUES " +
+        "('amy', 10000, 1000, 0.1), " +
+        "('alex', 12000, 1200, 0.1), " +
+        "('cathy', 8000, 1200, 0.15), " +
+        "('david', 10000, 1300, 0.13), " +
+        "('jen', 12000, 2400, 0.2)").executeUpdate()
 
       conn.prepareStatement(
         "CREATE TABLE \"test\".\"strings_with_nulls\" (str TEXT(32))").executeUpdate()
       conn.prepareStatement("INSERT INTO \"test\".\"strings_with_nulls\" VALUES " +
-        "('abc')").executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"strings_with_nulls\" VALUES " +
-        "('a a a')").executeUpdate()
-      conn.prepareStatement("INSERT INTO \"test\".\"strings_with_nulls\" VALUES " +
-        "(null)").executeUpdate()
+        "('abc'), ('a a a'), (null)").executeUpdate()
     }
     h2Dialect.registerFunction("my_avg", IntegralAverage)
     h2Dialect.registerFunction("my_strlen", StrLen(CharLength))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
To modify the before all to reduce the amount of roundtrips with the database. Per my benchmarks this led to decreased time in `beforeAll` from ~850ms to ~690ms in `JDBCV2Suite` and 3s to 1.8s in `JDBCSuite`.  It also clears tech debt where people in the future won't unknowingly add more roundtrips than needed.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improve test performance, it is not drastic improvement when running whole suite but is great when running just a single test.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Test-only change.
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claiude Sonnet