### PR TITLE
[SPARK-52866][SQL][4.0] Fix error message for `to_date`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -2107,8 +2107,8 @@ case class ParseToDate(
 
   override lazy val replacement: Expression = withOrigin(origin) {
     format.map { f =>
-      Cast(GetTimestamp(left, f, TimestampType, "try_to_date", timeZoneId, ansiEnabled), DateType,
-        timeZoneId, EvalMode.fromBoolean(ansiEnabled))
+      Cast(GetTimestamp(left, f, TimestampType, "try_to_timestamp", timeZoneId, ansiEnabled),
+        DateType, timeZoneId, EvalMode.fromBoolean(ansiEnabled))
     }.getOrElse(Cast(left, DateType, timeZoneId,
       EvalMode.fromBoolean(ansiEnabled))) // backwards compatibility
   }

--- a/sql/connect/common/src/test/resources/query-tests/explain-results/function_to_date_with_format.explain
+++ b/sql/connect/common/src/test/resources/query-tests/explain-results/function_to_date_with_format.explain
@@ -1,2 +1,2 @@
-Project [cast(gettimestamp(s#0, yyyy-MM-dd, TimestampType, try_to_date, Some(America/Los_Angeles), false) as date) AS to_date(s, yyyy-MM-dd)#0]
+Project [cast(gettimestamp(s#0, yyyy-MM-dd, TimestampType, try_to_timestamp, Some(America/Los_Angeles), false) as date) AS to_date(s, yyyy-MM-dd)#0]
 +- LocalRelation <empty>, [d#0, t#0, s#0, x#0L, wt#0]

--- a/sql/connect/common/src/test/resources/query-tests/explain-results/function_unix_date.explain
+++ b/sql/connect/common/src/test/resources/query-tests/explain-results/function_unix_date.explain
@@ -1,2 +1,2 @@
-Project [unix_date(cast(gettimestamp(s#0, yyyy-MM-dd, TimestampType, try_to_date, Some(America/Los_Angeles), false) as date)) AS unix_date(to_date(s, yyyy-MM-dd))#0]
+Project [unix_date(cast(gettimestamp(s#0, yyyy-MM-dd, TimestampType, try_to_timestamp, Some(America/Los_Angeles), false) as date)) AS unix_date(to_date(s, yyyy-MM-dd))#0]
 +- LocalRelation <empty>, [d#0, t#0, s#0, x#0L, wt#0]

--- a/sql/core/src/test/resources/sql-tests/results/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/date.sql.out
@@ -207,7 +207,7 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "CANNOT_PARSE_TIMESTAMP",
   "sqlState" : "22007",
   "messageParameters" : {
-    "func" : "`try_to_date`",
+    "func" : "`try_to_timestamp`",
     "message" : "Invalid date 'February 29' as '1970' is not a leap year"
   }
 }

--- a/sql/core/src/test/resources/sql-tests/results/datetime-legacy.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/datetime-legacy.sql.out
@@ -207,7 +207,7 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "CANNOT_PARSE_TIMESTAMP",
   "sqlState" : "22007",
   "messageParameters" : {
-    "func" : "`try_to_date`",
+    "func" : "`try_to_timestamp`",
     "message" : "Unparseable date: \"02-29\""
   }
 }

--- a/sql/core/src/test/resources/sql-tests/results/datetime-parsing-invalid.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/datetime-parsing-invalid.sql.out
@@ -299,7 +299,7 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "CANNOT_PARSE_TIMESTAMP",
   "sqlState" : "22007",
   "messageParameters" : {
-    "func" : "`try_to_date`",
+    "func" : "`try_to_timestamp`",
     "message" : "Text '2020-01-27T20:06:11.847' could not be parsed at index 10"
   }
 }
@@ -315,7 +315,7 @@ org.apache.spark.SparkDateTimeException
   "errorClass" : "CANNOT_PARSE_TIMESTAMP",
   "sqlState" : "22007",
   "messageParameters" : {
-    "func" : "`try_to_date`",
+    "func" : "`try_to_timestamp`",
     "message" : "Text 'Unparseable' could not be parsed at index 0"
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change of suggestion of method in `to_date`


### Why are the changes needed?
In 4.0 we need to fix the error message for `to_date`. In master we have improved spark with addition of `try_to_date`.


### Does this PR introduce _any_ user-facing change?
Yes, fix of error message.


### How was this patch tested?
Existing tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
