### PR TITLE
[SPARK-52832][SQL][FOLLOWUP] Fix comment in `MySQLDialect::quoteIdentifier`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -201,7 +201,6 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
     // Identifier quote characters can be included within an identifier if you quote the
     // identifier. If the character to be included within the identifier is the same as
     // that used to quote the identifier itself, then you need to double the character.
-    // The following statement creates a table named a`b that contains a column named c"d:
     val escapedColName = colName.replace("`", "``")
     s"`$escapedColName`"
   }


### PR DESCRIPTION
This PR is a follow up for recently closed PR:
https://github.com/apache/spark/pull/51533/files

### What changes were proposed in this pull request?
- Fix MySQL dialect comment in `quoteIdentifier` method

### Why are the changes needed?
It is not clear what the last sentence in comment means without the example from docs:
<img width="2330" height="356" alt="image" src="https://github.com/user-attachments/assets/b3ad2dcc-9877-43fe-b2a4-2fb22325473e" />


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
NA

### Was this patch authored or co-authored using generative AI tooling?
No
