### PR TITLE
[SPARK-52919][SQL] Fix DSv2 Join pushdown to use previously aliased column

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -179,8 +179,12 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
         node.output
           .zip(leftSideRequiredColumnsWithAliases ++ rightSideRequiredColumnsWithAliases)
           .collect {
-            case (attr, columnWithAlias) if columnWithAlias.alias() != null =>
-              (attr, attr.withName(columnWithAlias.alias()))
+            case (attr, columnWithAlias) =>
+              if (columnWithAlias.alias() != null) {
+                (attr, attr.withName(columnWithAlias.alias()))
+              } else {
+                (attr, attr.withName(columnWithAlias.colName()))
+              }
           }
           .toMap
       )

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
@@ -600,4 +600,44 @@ trait JDBCV2JoinPushdownIntegrationSuiteBase
       checkAnswer(df, rows)
     }
   }
+
+  test("Test condition with aliased column") {
+    // After the first join, columns will be aliased because we are doing self join in CTE.
+    // Second join, is joining on aliased column, so the aliased value should be used in generated
+    // SQL query.
+    val sqlQuery = s"""
+      |WITH ws_wh AS (
+      |    SELECT
+      |        ws1.ID,
+      |        ws1.AMOUNT wh1,
+      |        ws2.AMOUNT wh2
+      |    FROM
+      |        $catalogAndNamespace.$casedJoinTableName1 ws1,
+      |        $catalogAndNamespace.$casedJoinTableName1 ws2
+      |    WHERE
+      |        ws1.ID = ws2.ID
+      |        AND ws1.AMOUNT <> ws2.AMOUNT
+      |)
+      |SELECT
+      |   NEXT_ID
+      |FROM
+      |   $catalogAndNamespace.$casedJoinTableName2,
+      |   ws_wh
+      |WHERE
+      |   NEXT_ID = ws_wh.ID
+      |""".stripMargin
+
+    val rows = withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "false") {
+      sql(sqlQuery).collect().toSeq
+    }
+
+    assert(!rows.isEmpty)
+
+    withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "true") {
+      val df = sql(sqlQuery)
+
+      checkJoinPushed(df)
+      checkAnswer(df, rows)
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
There is a bug in join pushdown for DSv2 where we populate the `AttributeMap` with aliased names. If alias is null, we wouldn't populate the map for such attribute and the original column name would be used.

This was wrong, because the column could've been aliased previously, so no new alias is needed in new join. Therefore, instead of using `colName` (which has the information of up to date column name) we had empty map, and would return the original column name (before join pushdown even happened; the column name from scan).
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Bug in DSv2 join pushdown.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No, it is a bug fix.
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Added new test in base suite.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No.
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
