### PR TITLE
[SPARK-52920][DOCS] Improve memory profiler doc to clarify generator UDFs are unsupported

### DIFF
--- a/python/docs/source/development/debugging.rst
+++ b/python/docs/source/development/debugging.rst
@@ -215,7 +215,7 @@ Python/Pandas UDF
 ~~~~~~~~~~~~~~~~~
 
 PySpark provides remote `memory_profiler <https://github.com/pythonprofilers/memory_profiler>`_ for
-Python/Pandas UDFs. That can be used on editors with line numbers such as Jupyter notebooks. UDFs with iterators as inputs/outputs are not supported.
+Python/Pandas UDFs. That can be used on editors with line numbers such as Jupyter notebooks. UDFs that are generator functions are not supported.
 
 SparkSession-based memory profiler can be enabled by setting the `Runtime SQL configuration <https://spark.apache.org/docs/latest/configuration.html#runtime-sql-configuration>`_
 ``spark.sql.pyspark.udf.profiler`` to ``memory``. An example on a Jupyter notebook is as shown below.
@@ -320,7 +320,7 @@ Python/Pandas UDF
 ~~~~~~~~~~~~~~~~~
 
 PySpark provides remote `Python Profilers <https://docs.python.org/3/library/profile.html>`_ for
-Python/Pandas UDFs. UDFs with iterators as inputs/outputs are not supported.
+Python/Pandas UDFs. UDFs that are generator functions are not supported.
 
 SparkSession-based performance profiler can be enabled by setting the `Runtime SQL configuration <https://spark.apache.org/docs/latest/configuration.html#runtime-sql-configuration>`_
 ``spark.sql.pyspark.udf.profiler`` to ``perf``. An example is as shown below.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve the memory profiler documentation by stating "generator UDFs" are not supported, instead of "UDFs with iterator inputs/outputs", due to limitations of memory-profiler.

### Why are the changes needed?
More accurate documentation.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
N/A.

### Was this patch authored or co-authored using generative AI tooling?
No.
