### PR TITLE
[SPARK-52922][PS] Avoid CAST_INVALID_INPUT of "astype" in ANSI mode

### DIFF
--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -52,6 +52,7 @@ from pyspark.pandas.typedef.typehints import (
     extension_object_dtypes_available,
     spark_type_to_pandas_dtype,
 )
+from pyspark.pandas.utils import is_ansi_mode_enabled
 
 if extension_dtypes_available:
     from pandas import Int8Dtype, Int16Dtype, Int32Dtype, Int64Dtype
@@ -189,7 +190,10 @@ def _as_other_type(index_ops: IndexOpsLike, dtype: Dtype, spark_type: DataType) 
     )
     assert not need_pre_process, "Pre-processing is needed before the type casting."
 
-    scol = index_ops.spark.column.cast(spark_type)
+    if is_ansi_mode_enabled(index_ops._internal.spark_frame.sparkSession):
+        scol = index_ops.spark.column.try_cast(spark_type)
+    else:
+        scol = index_ops.spark.column.cast(spark_type)
     return index_ops._with_new_scol(scol, field=InternalField(dtype=dtype))
 
 

--- a/python/pyspark/pandas/tests/series/test_as_type.py
+++ b/python/pyspark/pandas/tests/series/test_as_type.py
@@ -53,7 +53,7 @@ class SeriesAsTypeMixin:
         self.assert_eq(psser.astype(bool), pser.astype(bool))
         self.assert_eq(psser.astype(str), pser.astype(str))
         self.assert_eq(psser.str.strip().astype(bool), pser.str.strip().astype(bool))
-        self.assert_eq(ps.Series(["abc"]).astype(int), pd.Series([float('nan')]))
+        self.assert_eq(ps.Series(["abc"]).astype(int), pd.Series([float("nan")]))
 
         if extension_object_dtypes_available:
             from pandas import StringDtype

--- a/python/pyspark/pandas/tests/series/test_as_type.py
+++ b/python/pyspark/pandas/tests/series/test_as_type.py
@@ -53,6 +53,7 @@ class SeriesAsTypeMixin:
         self.assert_eq(psser.astype(bool), pser.astype(bool))
         self.assert_eq(psser.astype(str), pser.astype(str))
         self.assert_eq(psser.str.strip().astype(bool), pser.str.strip().astype(bool))
+        self.assert_eq(ps.Series(["abc"]).astype(int), pd.Series([float('nan')]))
 
         if extension_object_dtypes_available:
             from pandas import StringDtype


### PR DESCRIPTION
### What changes were proposed in this pull request?
Avoid CAST_INVALID_INPUT of "astype" in ANSI mode


### Why are the changes needed?
Ensure pandas on Spark works well with ANSI mode on.
Part of https://issues.apache.org/jira/browse/SPARK-52556.


### Does this PR introduce _any_ user-facing change?
```py
>>> import pandas as pd
>>> import numpy as np
>>> 
>>> ps.set_option("compute.fail_on_ansi_mode", False)
>>> ps.set_option("compute.ansi_mode_support", True)

BEFORE
```py
>>> ps.Series(["abc"]).astype(int)
...
org.apache.spark.SparkNumberFormatException: [CAST_INVALID_INPUT] The value 'abc' of the type "STRING" cannot be cast to "BIGINT" because it is malformed. Correct the value as per the syntax, or change its target type. Use `try_cast` to tolerate malformed input and return NULL instead. SQLSTATE: 22018
...
```

AFTER
```py
>>> ps.Series(["abc"]).astype(int)
0   NaN                                                                         
dtype: float64
```

Following non ANSI:
```py
>>> spark.conf.set("spark.sql.ansi.enabled", False)
>>> ps.Series(["abc"]).astype(int)
0   NaN
dtype: float64
```


### How was this patch tested?
Existing tests.


### Was this patch authored or co-authored using generative AI tooling?
No.