### PR TITLE
[SPARK-52903][SQL][FOLLOWUP] Fix query failure with LCAs on structs

### DIFF
--- a/sql/core/src/test/resources/sql-tests/analyzer-results/struct.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/struct.sql.out
@@ -104,12 +104,29 @@ Project [b#x, b#x AS c#x]
 
 
 -- !query
+SELECT STRUCT(col1 AS a) AS b, b AS c FROM VALUES(1)
+-- !query analysis
+Project [b#x, b#x AS c#x]
++- Project [col1#x, struct(a, col1#x) AS b#x]
+   +- LocalRelation [col1#x]
+
+
+-- !query
 SELECT STRUCT(1 AS a) AS b, b AS c GROUP BY b
 -- !query analysis
 Project [b#x, b#x AS c#x]
 +- Project [struct(1)#x, struct(1)#x AS b#x]
    +- Aggregate [struct(a, 1)], [struct(a, 1) AS struct(1)#x]
       +- OneRowRelation
+
+
+-- !query
+SELECT STRUCT(col1 AS a) AS b, b AS c FROM VALUES(1) GROUP BY b
+-- !query analysis
+Project [b#x, b#x AS c#x]
++- Project [struct(col1)#x, struct(col1)#x AS b#x]
+   +- Aggregate [struct(a, col1#x)], [struct(a, col1#x) AS struct(col1)#x]
+      +- LocalRelation [col1#x]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/inputs/struct.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/struct.sql
@@ -28,5 +28,7 @@ SELECT ID, STRUCT(ST.C as STC, ST.D as STD).STD FROM tbl_x;
 
 -- LCAs with struct columns
 SELECT STRUCT(1 AS a) AS b, b AS c;
+SELECT STRUCT(col1 AS a) AS b, b AS c FROM VALUES(1);
 SELECT STRUCT(1 AS a) AS b, b AS c GROUP BY b;
+SELECT STRUCT(col1 AS a) AS b, b AS c FROM VALUES(1) GROUP BY b;
 SELECT MAX(STRUCT(1 AS a)), 2 AS b, b AS c GROUP BY b;

--- a/sql/core/src/test/resources/sql-tests/results/struct.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/struct.sql.out
@@ -96,7 +96,23 @@ struct<b:struct<a:int>,c:struct<a:int>>
 
 
 -- !query
+SELECT STRUCT(col1 AS a) AS b, b AS c FROM VALUES(1)
+-- !query schema
+struct<b:struct<a:int>,c:struct<a:int>>
+-- !query output
+{"a":1}	{"a":1}
+
+
+-- !query
 SELECT STRUCT(1 AS a) AS b, b AS c GROUP BY b
+-- !query schema
+struct<b:struct<a:int>,c:struct<a:int>>
+-- !query output
+{"a":1}	{"a":1}
+
+
+-- !query
+SELECT STRUCT(col1 AS a) AS b, b AS c FROM VALUES(1) GROUP BY b
 -- !query schema
 struct<b:struct<a:int>,c:struct<a:int>>
 -- !query output


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR is a followup to https://github.com/apache/spark/pull/51591. In that PR I proposed that we trim inner aliases before LCA resolution. This PR is improvement on that and trims alias immediately on rule entry.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
This is necessary in order to fix a long-standing bug in LCA resolution in fixed-point analyzer.

For a query like:
```
SELECT STRUCT(col1 AS a) AS b, b AS c FROM VALUES(1) GROUP BY b
```

LCA resolution never triggers because `eligibleToLiftUp` method always returns false. This is because at the moment of resolution, aggregate node looks like:
```
Aggregate [struct(a, col1#3)], [struct(a, col1#3 AS a#4) AS b#5, lateralAliasReference(b) AS c#6]
```
Because inner aliases are trimmed in grouping expressions but not in aggregate expressions, we never match aggregate expression to a grouping one so the LCA resolution never happens.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Query pattern no longer fails with `INTERNAL_ERROR`.
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Added a test case to golden files.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
