### PR TITLE
[SPARK-52931][Core] Restrict declare variable naming

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3874,6 +3874,11 @@
       "Invalid variable declaration."
     ],
     "subClass" : {
+      "FORBIDDEN_NAME" : {
+        "message" : [
+          "The variable name <varName> is forbidden."
+        ]
+      },
       "NOT_ALLOWED_IN_SCOPE" : {
         "message" : [
           "Declaration of the variable <varName> is not allowed in this scope."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3874,7 +3874,7 @@
       "Invalid variable declaration."
     ],
     "subClass" : {
-      "FORBIDDEN_NAME" : {
+      "NAME_FORBIDDEN" : {
         "message" : [
           "The variable name <varName> is forbidden."
         ]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -20,11 +20,9 @@ package org.apache.spark.sql.catalyst.parser
 import java.util.{List, Locale}
 import java.util.concurrent.TimeUnit
 
-import scala.collection.immutable
 import scala.collection.mutable.{ArrayBuffer, HashMap, ListBuffer, Set}
 import scala.jdk.CollectionConverters._
 import scala.util.{Left, Right}
-import scala.util.matching.Regex
 
 import org.antlr.v4.runtime.{ParserRuleContext, RuleContext, Token}
 import org.antlr.v4.runtime.tree.{ParseTree, RuleNode, TerminalNode}
@@ -415,9 +413,6 @@ class AstBuilder extends DataTypeAstBuilder
                 visitDeclareHandlerStatementImpl(declareHandlerContext, parsingCtx)
               case declareConditionContext: DeclareConditionStatementContext =>
                 visitDeclareConditionStatementImpl(declareConditionContext)
-              case createVariableContext: CreateVariableContext =>
-                visitCreateVariableImpl(createVariableContext, isSqlScript = true)
-                  .asInstanceOf[CompoundPlanStatement]
               case stmt => visit(stmt).asInstanceOf[CompoundPlanStatement]
             }
           } else {
@@ -6379,15 +6374,6 @@ class AstBuilder extends DataTypeAstBuilder
   override def visitPosParameterLiteral(
       ctx: PosParameterLiteralContext): Expression = withOrigin(ctx) {
     PosParameter(ctx.QUESTION().getSymbol.getStartIndex)
-  }
-
-  private object SqlScriptingVariableContext {
-    private val forbiddenVariableNames: immutable.Set[Regex] =
-      immutable.Set("system".r, "session".r)
-
-    def isForbiddenVariableName(variableName: String): Boolean = {
-      forbiddenVariableNames.exists(_.matches(variableName.toLowerCase(Locale.ROOT)))
-    }
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -18,17 +18,14 @@ package org.apache.spark.sql.catalyst.parser
 
 import java.util
 import java.util.Locale
-
 import scala.collection.{immutable, mutable}
 import scala.util.matching.Regex
-
 import org.antlr.v4.runtime.{ParserRuleContext, Token}
 import org.antlr.v4.runtime.misc.Interval
 import org.antlr.v4.runtime.tree.{ParseTree, TerminalNodeImpl}
-
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.analysis.UnresolvedIdentifier
-import org.apache.spark.sql.catalyst.parser.SqlBaseParser.{BeginLabelContext, EndLabelContext}
+import org.apache.spark.sql.catalyst.parser.SqlBaseParser.{BeginLabelContext, EndLabelContext, IdentifierReferenceContext}
 import org.apache.spark.sql.catalyst.plans.logical.{CreateVariable, ErrorCondition}
 import org.apache.spark.sql.catalyst.trees.CurrentOrigin
 import org.apache.spark.sql.catalyst.util.SparkParserUtils
@@ -367,6 +364,15 @@ object SqlScriptingLabelContext {
 
   def isForbiddenLabelName(labelName: String): Boolean = {
     forbiddenLabelNames.exists(_.matches(labelName.toLowerCase(Locale.ROOT)))
+  }
+}
+
+object SqlScriptingVariableContext {
+  private val forbiddenVariableNames: immutable.Set[String] =
+    immutable.Set("system", "session")
+
+  def isForbiddenVariableName(variableName: String): Boolean = {
+    forbiddenVariableNames.contains(variableName.toLowerCase(Locale.ROOT))
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -66,7 +66,7 @@ private[sql] object SqlScriptingErrors {
   def variableNameForbidden(origin: Origin, varName: String): Throwable = {
     new SqlScriptingException(
       origin = origin,
-      errorClass = "VARIABLE_NAME_FORBIDDEN",
+      errorClass = "INVALID_VARIABLE_DECLARATION.NAME_FORBIDDEN",
       cause = null,
       messageParameters = Map("varName" -> toSQLId(varName))
     )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -63,6 +63,15 @@ private[sql] object SqlScriptingErrors {
     )
   }
 
+  def variableNameForbidden(origin: Origin, varName: String): Throwable = {
+    new SqlScriptingException(
+      origin = origin,
+      errorClass = "VARIABLE_NAME_FORBIDDEN",
+      cause = null,
+      messageParameters = Map("varName" -> toSQLId(varName))
+    )
+  }
+
   def variableDeclarationNotAllowedInScope(
       origin: Origin,
       varName: Seq[String]): Throwable = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -533,6 +533,34 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     assert(exception.origin.line.contains(4))
   }
 
+  test("declare with variable name \"system\"") {
+    val sqlScriptText =
+      """
+        |BEGIN
+        |  DECLARE system VARCHAR(50);
+        |END""".stripMargin
+    checkError(
+      exception = intercept[SqlScriptingException] {
+        parsePlan(sqlScriptText)
+      },
+      condition = "INVALID_VARIABLE_DECLARATION.NAME_FORBIDDEN",
+      parameters = Map("varName" -> "`system`"))
+  }
+
+  test("declare with variable name \"session\"") {
+    val sqlScriptText =
+      """
+        |BEGIN
+        |  DECLARE session VARCHAR(50);
+        |END""".stripMargin
+    checkError(
+      exception = intercept[SqlScriptingException] {
+        parsePlan(sqlScriptText)
+      },
+      condition = "INVALID_VARIABLE_DECLARATION.NAME_FORBIDDEN",
+      parameters = Map("varName" -> "`session`"))
+  }
+
   test("declare variable in wrong scope") {
     val sqlScriptText =
       """

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -533,7 +533,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     assert(exception.origin.line.contains(4))
   }
 
-  test("declare with variable name \"system\"") {
+  test("declare with variable name \"system\" inside the sql script - should fail") {
     val sqlScriptText =
       """
         |BEGIN
@@ -547,7 +547,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
       parameters = Map("varName" -> "`system`"))
   }
 
-  test("declare with variable name \"session\"") {
+  test("declare with variable name \"session\" inside the sql script - should fail") {
     val sqlScriptText =
       """
         |BEGIN
@@ -559,6 +559,18 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
       },
       condition = "INVALID_VARIABLE_DECLARATION.NAME_FORBIDDEN",
       parameters = Map("varName" -> "`session`"))
+  }
+
+  test("declare with variable name \"system\" outside the sql script") {
+    val sqlScriptText =
+      "DECLARE system VARCHAR(50);"
+    parsePlan(sqlScriptText).asInstanceOf[CreateVariable]
+  }
+
+  test("declare with variable name \"session\" outside the sql script") {
+    val sqlScriptText =
+      "DECLARE session VARCHAR(50);"
+    parsePlan(sqlScriptText).asInstanceOf[CreateVariable]
   }
 
   test("declare variable in wrong scope") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Restrict DECLARE variable names to any name except "system" or "session".

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Names "system" and "session" are reserved, hence the restriction.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Written tests to catch these cases.

Single statements:

<img width="407" height="49" alt="image" src="https://github.com/user-attachments/assets/4d32e954-10d1-4316-9690-e082206f82b3" />

<img width="375" height="44" alt="image" src="https://github.com/user-attachments/assets/d626fda5-3ce7-4981-a26d-bd5dc00005e4" />


SQL Scripts:

<img width="1580" height="99" alt="image" src="https://github.com/user-attachments/assets/f9c648d3-95cd-46a7-9955-3276c2a8cccb" />

<img width="1589" height="96" alt="image" src="https://github.com/user-attachments/assets/f420762a-5d1f-46cb-b745-24bf35d80311" />

<img width="383" height="101" alt="image" src="https://github.com/user-attachments/assets/db970f45-f837-44aa-acd5-60539c3723c1" />


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.
