### PR TITLE
[SPARK-52937][SDP] Sinks

### DIFF
--- a/sql/connect/common/src/main/protobuf/spark/connect/pipelines.proto
+++ b/sql/connect/common/src/main/protobuf/spark/connect/pipelines.proto
@@ -90,6 +90,21 @@ message PipelineCommand {
     optional string format = 8;
   }
 
+  // Request to define a sink
+  message DefineSink {
+    // The graph to attach this dataset to.
+    optional string dataflow_graph_id = 1;
+
+    // Name of the sink
+    optional string sink_name = 2;
+
+    // Streaming write options
+    map<string, string> options = 3;
+
+    // Streaming write format
+    optional string format = 4;
+  }
+
   // Request to define a flow targeting a dataset.
   message DefineFlow {
     // The graph to attach this flow to.

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
@@ -246,18 +246,7 @@ private[connect] object PipelinesHandler extends Logging {
     // responseObserver to the pipelines execution code so that the pipelines module does not need
     // to take a dependency on SparkConnect.
     val eventCallback = { event: PipelineEvent =>
-      val message = if (event.error.nonEmpty) {
-        // Returns the message associated with a Throwable and all its causes
-        def getExceptionMessages(throwable: Throwable): Seq[String] = {
-          throwable.getMessage +:
-            Option(throwable.getCause).map(getExceptionMessages).getOrElse(Nil)
-        }
-        val errorMessages = getExceptionMessages(event.error.get)
-        s"""${event.message}
-           |Error: ${errorMessages.mkString("\n")}""".stripMargin
-      } else {
-        event.message
-      }
+      val message = event.messageWithError
       event.details match {
         // Failed runs are recorded in the event log. We do not pass these to the SparkConnect
         // client since the failed run will already result in an unhandled exception that is

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PipelineEventStreamSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PipelineEventStreamSuite.scala
@@ -37,7 +37,7 @@ class PipelineEventStreamSuite extends SparkDeclarativePipelinesServerTest {
           datasetType = proto.DatasetType.TABLE,
           sql = Some("SELECT * FROM STREAM a"))
       }
-      registerPipelineDatasets(pipeline)
+      registerGraphElements(pipeline)
 
       val capturedEvents = new ArrayBuffer[PipelineEvent]()
       withClient { client =>
@@ -86,7 +86,7 @@ class PipelineEventStreamSuite extends SparkDeclarativePipelinesServerTest {
             datasetType = proto.DatasetType.TABLE,
             sql = Some("SELECT * FROM STREAM a"))
         }
-        registerPipelineDatasets(pipeline)
+        registerGraphElements(pipeline)
 
         val capturedEvents = new ArrayBuffer[PipelineEvent]()
         withClient { client =>
@@ -136,7 +136,7 @@ class PipelineEventStreamSuite extends SparkDeclarativePipelinesServerTest {
           datasetType = proto.DatasetType.TABLE,
           sql = Some("SELECT * FROM STREAM a"))
       }
-      registerPipelineDatasets(pipeline)
+      registerGraphElements(pipeline)
 
       val capturedEvents = new ArrayBuffer[PipelineEvent]()
       withClient { client =>

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PipelineRefreshFunctionalSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PipelineRefreshFunctionalSuite.scala
@@ -81,7 +81,7 @@ class PipelineRefreshFunctionalSuite
     withRawBlockingStub { implicit stub =>
       val graphId = createDataflowGraph
       val pipeline = createTestPipeline(graphId)
-      registerPipelineDatasets(pipeline)
+      registerGraphElements(pipeline)
 
       // First run to populate tables
       startPipelineAndWaitForCompletion(graphId)
@@ -226,7 +226,7 @@ class PipelineRefreshFunctionalSuite
     withRawBlockingStub { implicit stub =>
       val graphId = createDataflowGraph
       val pipeline = createTestPipeline(graphId)
-      registerPipelineDatasets(pipeline)
+      registerGraphElements(pipeline)
 
       val startRun = PipelineCommand.StartRun
         .newBuilder()
@@ -248,7 +248,7 @@ class PipelineRefreshFunctionalSuite
     withRawBlockingStub { implicit stub =>
       val graphId = createDataflowGraph
       val pipeline = createTestPipeline(graphId)
-      registerPipelineDatasets(pipeline)
+      registerGraphElements(pipeline)
 
       val startRun = PipelineCommand.StartRun
         .newBuilder()
@@ -270,7 +270,7 @@ class PipelineRefreshFunctionalSuite
     withRawBlockingStub { implicit stub =>
       val graphId = createDataflowGraph
       val pipeline = createTestPipeline(graphId)
-      registerPipelineDatasets(pipeline)
+      registerGraphElements(pipeline)
 
       val startRun = PipelineCommand.StartRun
         .newBuilder()
@@ -293,7 +293,7 @@ class PipelineRefreshFunctionalSuite
     withRawBlockingStub { implicit stub =>
       val graphId = createDataflowGraph
       val pipeline = createTestPipeline(graphId)
-      registerPipelineDatasets(pipeline)
+      registerGraphElements(pipeline)
 
       val startRun = PipelineCommand.StartRun
         .newBuilder()
@@ -317,7 +317,7 @@ class PipelineRefreshFunctionalSuite
     withRawBlockingStub { implicit stub =>
       val graphId = createDataflowGraph
       val pipeline = createTestPipeline(graphId)
-      registerPipelineDatasets(pipeline)
+      registerGraphElements(pipeline)
 
       val startRun = PipelineCommand.StartRun
         .newBuilder()

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
@@ -31,7 +31,10 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.connect.service.SparkConnectService
 import org.apache.spark.sql.pipelines.graph.DataflowGraph
-import org.apache.spark.sql.pipelines.utils.{EventVerificationTestHelpers, TestPipelineUpdateContextMixin}
+import org.apache.spark.sql.pipelines.utils.{
+  EventVerificationTestHelpers,
+  TestPipelineUpdateContextMixin
+}
 
 /**
  * Test suite that starts a Spark Connect server and executes Spark Declarative Pipelines Python
@@ -81,7 +84,8 @@ class PythonPipelineSuite
 
     if (exitCode != 0) {
       throw new RuntimeException(
-        s"Python process failed with exit code $exitCode. Output: ${output.mkString("\n")}")
+        s"Python process failed with exit code $exitCode. Output: ${output.mkString("\n")}"
+      )
     }
     val activeSessions = SparkConnectService.sessionManager.listActiveSessions
 
@@ -155,7 +159,9 @@ class PythonPipelineSuite
     assert(
       graph.flowsTo(graphIdentifier("a")).map(_.identifier).toSet == Set(
         graphIdentifier("a"),
-        graphIdentifier("supplement")))
+        graphIdentifier("supplement")
+      )
+    )
   }
 
   test("referencing internal datasets") {
@@ -174,10 +180,8 @@ class PythonPipelineSuite
       |""".stripMargin).resolve().validate()
 
     assert(
-      graph.table.keySet == Set(
-        graphIdentifier("src"),
-        graphIdentifier("a"),
-        graphIdentifier("b")))
+      graph.table.keySet == Set(graphIdentifier("src"), graphIdentifier("a"), graphIdentifier("b"))
+    )
     Seq("a", "b").foreach { flowName =>
       // dependency is properly tracked
       assert(graph.resolvedFlow(graphIdentifier(flowName)).inputs == Set(graphIdentifier("src")))
@@ -205,10 +209,10 @@ class PythonPipelineSuite
         |""".stripMargin).resolve().validate()
 
     assert(
-      graph.tables.map(_.identifier).toSet == Set(
-        graphIdentifier("a"),
-        graphIdentifier("b"),
-        graphIdentifier("c")))
+      graph.tables
+        .map(_.identifier)
+        .toSet == Set(graphIdentifier("a"), graphIdentifier("b"), graphIdentifier("c"))
+    )
     // dependency is not tracked
     assert(graph.resolvedFlows.forall(_.inputs.isEmpty))
     val (streamingFlows, batchFlows) = graph.resolvedFlows.partition(_.df.isStreaming)
@@ -297,37 +301,49 @@ class PythonPipelineSuite
         TableIdentifier(
           catalog = Option("spark_catalog"),
           database = Option("default"),
-          table = "mv_1"),
+          table = "mv_1"
+        ),
         TableIdentifier(
           catalog = Option("spark_catalog"),
           database = Option("schema_a"),
-          table = "mv_2"),
+          table = "mv_2"
+        ),
         TableIdentifier(
           catalog = Option("spark_catalog"),
           database = Option("default"),
-          table = "st_1"),
+          table = "st_1"
+        ),
         TableIdentifier(
           catalog = Option("spark_catalog"),
           database = Option("schema_b"),
-          table = "st_2")))
+          table = "st_2"
+        )
+      )
+    )
     assert(
       graph.flows.map(_.identifier).toSet == Set(
         TableIdentifier(
           catalog = Option("spark_catalog"),
           database = Option("default"),
-          table = "mv_1"),
+          table = "mv_1"
+        ),
         TableIdentifier(
           catalog = Option("spark_catalog"),
           database = Option("schema_a"),
-          table = "mv_2"),
+          table = "mv_2"
+        ),
         TableIdentifier(
           catalog = Option("spark_catalog"),
           database = Option("default"),
-          table = "st_1"),
+          table = "st_1"
+        ),
         TableIdentifier(
           catalog = Option("spark_catalog"),
           database = Option("schema_b"),
-          table = "st_2")))
+          table = "st_2"
+        )
+      )
+    )
   }
 
   test("create datasets with three part names") {
@@ -346,11 +362,15 @@ class PythonPipelineSuite
     assert(
       graphTry.get.tables.map(_.identifier).toSet == Set(
         TableIdentifier("mv", Some("some_schema"), Some("some_catalog")),
-        TableIdentifier("st", Some("some_schema"), Some("some_catalog"))))
+        TableIdentifier("st", Some("some_schema"), Some("some_catalog"))
+      )
+    )
     assert(
       graphTry.get.flows.map(_.identifier).toSet == Set(
         TableIdentifier("mv", Some("some_schema"), Some("some_catalog")),
-        TableIdentifier("st", Some("some_schema"), Some("some_catalog"))))
+        TableIdentifier("st", Some("some_schema"), Some("some_catalog"))
+      )
+    )
   }
 
   test("temporary views works") {
@@ -373,13 +393,11 @@ class PythonPipelineSuite
          |""".stripMargin).resolve()
     // views are temporary views, so they're not fully qualified.
     assert(
-      Set("view_1", "view_2", "view_3").subsetOf(
-        graph.flows.map(_.identifier.unquotedString).toSet))
+      Set("view_1", "view_2", "view_3").subsetOf(graph.flows.map(_.identifier.unquotedString).toSet)
+    )
     // dependencies are correctly resolved view_2 reading from view_1
-    assert(
-      graph.resolvedFlow(TableIdentifier("view_2")).inputs.contains(TableIdentifier("view_1")))
-    assert(
-      graph.resolvedFlow(TableIdentifier("view_3")).inputs.contains(TableIdentifier("view_1")))
+    assert(graph.resolvedFlow(TableIdentifier("view_2")).inputs.contains(TableIdentifier("view_1")))
+    assert(graph.resolvedFlow(TableIdentifier("view_3")).inputs.contains(TableIdentifier("view_1")))
   }
 
   test("create named flow with multipart name will fail") {
@@ -413,7 +431,8 @@ class PythonPipelineSuite
       graph
         .flowsTo(graphIdentifier("a"))
         .map(_.identifier)
-        .toSet == Set(graphIdentifier("a"), graphIdentifier("supplement")))
+        .toSet == Set(graphIdentifier("a"), graphIdentifier("supplement"))
+    )
   }
 
   test("create named flow with multipart target succeeds") {
@@ -431,7 +450,8 @@ class PythonPipelineSuite
     assert(
       graph
         .flowsTo(graphIdentifier("a"))
-        .map(_.identifier) == Seq(graphIdentifier("a"), graphIdentifier("something")))
+        .map(_.identifier) == Seq(graphIdentifier("a"), graphIdentifier("something"))
+    )
   }
 
   test("create pipeline without table will throw RUN_EMPTY_PIPELINE exception") {
@@ -442,7 +462,8 @@ class PythonPipelineSuite
             |""".stripMargin)
       },
       condition = "RUN_EMPTY_PIPELINE",
-      parameters = Map.empty)
+      parameters = Map.empty
+    )
   }
 
   test("create pipeline with only temp view will throw RUN_EMPTY_PIPELINE exception") {
@@ -455,7 +476,8 @@ class PythonPipelineSuite
             |""".stripMargin)
       },
       condition = "RUN_EMPTY_PIPELINE",
-      parameters = Map.empty)
+      parameters = Map.empty
+    )
   }
 
   test("create pipeline with only flow will throw RUN_EMPTY_PIPELINE exception") {
@@ -468,7 +490,32 @@ class PythonPipelineSuite
             |""".stripMargin)
       },
       condition = "RUN_EMPTY_PIPELINE",
-      parameters = Map.empty)
+      parameters = Map.empty
+    )
+  }
+
+  test("external sink") {
+    val graph = buildGraph("""
+           |sdp.create_sink(
+           |  "myKafkaSink",
+           |  format = "kafka",
+           |  options = {"kafka.bootstrap.servers": "host1:port1,host2:port2"}
+           |)
+           |
+           |@sdp.append_flow(
+           |  target = "myKafkaSink"
+           |)
+           |def mySinkFlow():
+           |  return spark.readStream.format("rate").load()
+           |""".stripMargin)
+
+    assert(graph.sinks.map(_.identifier) == Seq(graphIdentifier("myKafkaSink")))
+    assert(
+      graph
+        .flowsTo(graphIdentifier("myKafkaSink"))
+        .map(_.identifier) == Seq(graphIdentifier("mySinkFlow")
+      )
+    )
   }
 
   /**
@@ -490,7 +537,8 @@ class PythonPipelineSuite
     val pythonPath = PythonUtils.mergePythonPaths(
       sourcePath.toString,
       py4jPath.toString,
-      sys.env.getOrElse("PYTHONPATH", ""))
+      sys.env.getOrElse("PYTHONPATH", "")
+    )
 
     val pb = new ProcessBuilder(pythonExec, "-c", pythonCode)
     pb.redirectErrorStream(true)
@@ -500,7 +548,8 @@ class PythonPipelineSuite
 
     // Read the output
     val reader = new BufferedReader(
-      new InputStreamReader(process.getInputStream, StandardCharsets.UTF_8))
+      new InputStreamReader(process.getInputStream, StandardCharsets.UTF_8)
+    )
     val output = new ArrayBuffer[String]()
     var line: String = null
     while ({ line = reader.readLine(); line != null }) {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerTest.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerTest.scala
@@ -58,10 +58,12 @@ class SparkDeclarativePipelinesServerTest extends SparkConnectServerTest {
       sc.PipelineCommand
         .newBuilder()
         .setCreateDataflowGraph(createDataflowGraph)
-        .build())
+        .build()
+    )
   }
 
-  def createDataflowGraph(implicit
+  def createDataflowGraph(
+      implicit
       stub: sc.SparkConnectServiceGrpc.SparkConnectServiceBlockingStub): String = {
     sendPlan(
       buildCreateDataflowGraphPlan(
@@ -71,8 +73,9 @@ class SparkDeclarativePipelinesServerTest extends SparkConnectServerTest {
           // support streaming.
           .setDefaultCatalog("spark_catalog")
           .setDefaultDatabase("default")
-          .build()))(
-      stub).getPipelineCommandResult.getCreateDataflowGraphResult.getDataflowGraphId
+          .build()
+      )
+    )(stub).getPipelineCommandResult.getCreateDataflowGraphResult.getDataflowGraphId
   }
 
   def buildStartRunPlan(startRun: sc.PipelineCommand.StartRun): sc.Plan = {
@@ -80,12 +83,13 @@ class SparkDeclarativePipelinesServerTest extends SparkConnectServerTest {
       sc.PipelineCommand
         .newBuilder()
         .setStartRun(startRun)
-        .build())
+        .build()
+    )
   }
 
-  def sendPlan(plan: sc.Plan)(implicit
-      stub: sc.SparkConnectServiceGrpc.SparkConnectServiceBlockingStub)
-      : sc.ExecutePlanResponse = {
+  def sendPlan(plan: sc.Plan)(
+      implicit
+      stub: sc.SparkConnectServiceGrpc.SparkConnectServiceBlockingStub): sc.ExecutePlanResponse = {
     val iter = stub.executePlan(buildExecutePlanRequest(plan))
     if (iter.hasNext) {
       iter.next()
@@ -94,7 +98,8 @@ class SparkDeclarativePipelinesServerTest extends SparkConnectServerTest {
     }
   }
 
-  def registerPipelineDatasets(testPipelineDefinition: TestPipelineDefinition)(implicit
+  def registerGraphElements(testPipelineDefinition: TestPipelineDefinition)(
+      implicit
       stub: sc.SparkConnectServiceGrpc.SparkConnectServiceBlockingStub): Unit = {
     (testPipelineDefinition.viewDefs ++ testPipelineDefinition.tableDefs).foreach { tv =>
       sendPlan(
@@ -102,7 +107,9 @@ class SparkDeclarativePipelinesServerTest extends SparkConnectServerTest {
           sc.PipelineCommand
             .newBuilder()
             .setDefineDataset(tv)
-            .build()))
+            .build()
+        )
+      )
     }
 
     testPipelineDefinition.flowDefs.foreach { flow =>
@@ -111,14 +118,14 @@ class SparkDeclarativePipelinesServerTest extends SparkConnectServerTest {
           sc.PipelineCommand
             .newBuilder()
             .setDefineFlow(flow)
-            .build()))
+            .build()
+        )
+      )
     }
   }
 
-  def registerGraphElementsFromSql(
-      graphId: String,
-      sql: String,
-      sqlFileName: String = "table.sql")(implicit
+  def registerGraphElementsFromSql(graphId: String, sql: String, sqlFileName: String = "table.sql")(
+      implicit
       stub: sc.SparkConnectServiceGrpc.SparkConnectServiceBlockingStub): Unit = {
     sendPlan(
       buildPlanFromPipelineCommand(
@@ -129,8 +136,11 @@ class SparkDeclarativePipelinesServerTest extends SparkConnectServerTest {
               .newBuilder()
               .setDataflowGraphId(graphId)
               .setSqlFilePath(sqlFileName)
-              .setSqlText(sql))
-          .build()))
+              .setSqlText(sql)
+          )
+          .build()
+      )
+    )
   }
 
   def createPlanner(): SparkConnectPlanner =

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/TestPipelineDefinition.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/TestPipelineDefinition.scala
@@ -29,6 +29,8 @@ class TestPipelineDefinition(graphId: String) {
     new scala.collection.mutable.ArrayBuffer[sc.PipelineCommand.DefineDataset]()
   private[connect] val viewDefs =
     new scala.collection.mutable.ArrayBuffer[sc.PipelineCommand.DefineDataset]()
+  private[connect] val sinkDefs =
+    new scala.collection.mutable.ArrayBuffer[sc.PipelineCommand.DefineSink]()
   private[connect] val flowDefs =
     new scala.collection.mutable.ArrayBuffer[sc.PipelineCommand.DefineFlow]()
 
@@ -71,11 +73,24 @@ class TestPipelineDefinition(graphId: String) {
     createTable(
       name,
       datasetType,
-      query = sql.map(s =>
-        sc.Relation
-          .newBuilder()
-          .setSql(sc.SQL.newBuilder().setQuery(s).build())
-          .build()))
+      query = sql.map(
+        s =>
+          sc.Relation
+            .newBuilder()
+            .setSql(sc.SQL.newBuilder().setQuery(s).build())
+            .build()
+      )
+    )
+  }
+
+  protected def createSink(name: String, format: String, options: Map[String, String]): Unit = {
+    tableDefs += sc.PipelineCommand.DefineDataset
+      .newBuilder()
+      .setDataflowGraphId(graphId)
+      .setDatasetName(name)
+      .setFormat(format)
+      .putAllOptions(options.asJava)
+      .build()
   }
 
   protected def createView(
@@ -109,7 +124,8 @@ class TestPipelineDefinition(graphId: String) {
       query = sc.Relation
         .newBuilder()
         .setSql(sc.SQL.newBuilder().setQuery(sql).build())
-        .build())
+        .build()
+    )
   }
 
   protected def createFlow(

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/CoreDataflowNodeProcessor.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/CoreDataflowNodeProcessor.scala
@@ -103,6 +103,8 @@ class CoreDataflowNodeProcessor(rawGraph: DataflowGraph) {
               s"${upstreamNodes.getClass}"
             )
         }
+      case sink: Sink =>
+        Seq(sink)
       case _ =>
         throw new IllegalArgumentException(s"Unsupported node type: ${node.getClass}")
     }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DataflowGraphTransformer.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DataflowGraphTransformer.scala
@@ -61,6 +61,8 @@ class DataflowGraphTransformer(graph: DataflowGraph) extends AutoCloseable {
   private var flowsTo: Map[TableIdentifier, Seq[Flow]] = computeFlowsTo()
   private var views: Seq[View] = graph.views
   private var viewMap: Map[TableIdentifier, View] = computeViewMap()
+  private var sinks: Seq[Sink] = graph.sinks
+  private var sinkMap: Map[TableIdentifier, Sink] = computeSinkMap()
 
   // Fail analysis nodes
   // Failed flows are flows that are failed to resolve or its inputs are not available or its
@@ -68,6 +70,8 @@ class DataflowGraphTransformer(graph: DataflowGraph) extends AutoCloseable {
   private var failedFlows: Seq[ResolutionCompletedFlow] = Seq.empty
   // We define a dataset is failed to resolve if it is a destination of a flow that is unresolved.
   private var failedTables: Seq[Table] = Seq.empty
+  private var failedSinks: Seq[Sink] = Seq.empty
+
 
   private val parallelism = 10
 
@@ -90,6 +94,10 @@ class DataflowGraphTransformer(graph: DataflowGraph) extends AutoCloseable {
 
   private def computeViewMap(): Map[TableIdentifier, View] = synchronized {
     views.map(view => view.identifier -> view).toMap
+  }
+
+  private def computeSinkMap(): Map[TableIdentifier, Sink] = synchronized {
+    sinks.map(sink => sink.identifier -> sink).toMap
   }
 
   private def computeFlowsTo(): Map[TableIdentifier, Seq[Flow]] = synchronized {
@@ -128,6 +136,7 @@ class DataflowGraphTransformer(graph: DataflowGraph) extends AutoCloseable {
     val resolvedFlows = new ConcurrentLinkedQueue[ResolutionCompletedFlow]()
     val resolvedTables = new ConcurrentLinkedQueue[Table]()
     val resolvedViews = new ConcurrentLinkedQueue[View]()
+    val resolvedSinks = new ConcurrentLinkedQueue[Sink]()
     // Flow identifier to a list of transformed flows mapping to track resolved flows
     val resolvedFlowsMap = new ConcurrentHashMap[TableIdentifier, Seq[Flow]]()
     val resolvedFlowDestinationsMap = new ConcurrentHashMap[TableIdentifier, Boolean]()
@@ -238,22 +247,32 @@ class DataflowGraphTransformer(graph: DataflowGraph) extends AutoCloseable {
                       resolvedFlows.addAll(
                         transformed.collect { case f: ResolvedFlow => f }.asJava
                       )
-                    } else {
-                      if (viewMap.contains(flow.destinationIdentifier)) {
-                        resolvedViews.addAll {
-                          val transformed =
-                            transformer(
-                              viewMap(flow.destinationIdentifier),
-                              flowsTo(flow.destinationIdentifier)
-                            )
-                          transformed.map(_.asInstanceOf[View]).asJava
-                        }
-                      } else {
-                        throw new IllegalArgumentException(
-                          s"Unsupported destination ${flow.destinationIdentifier.unquotedString}" +
-                          s" in flow: ${flow.displayName} at transformDownNodes"
-                        )
+                    } else if (viewMap.contains(flow.destinationIdentifier)) {
+                      resolvedViews.addAll {
+                        val transformed =
+                          transformer(
+                            viewMap(flow.destinationIdentifier),
+                            flowsTo(flow.destinationIdentifier)
+                          )
+                        transformed.map(_.asInstanceOf[View]).asJava
                       }
+                    } else if (sinkMap.contains(flow.destinationIdentifier)) {
+                      resolvedSinks.addAll {
+                        val transformed =
+                          transformer(
+                            sinkMap(flow.destinationIdentifier), flowsTo(flow.destinationIdentifier)
+                          )
+                        require(
+                          transformed.forall(_.isInstanceOf[Sink]),
+                          "transformer must return a Seq[Sink]"
+                        )
+                        transformed.map(_.asInstanceOf[Sink]).asJava
+                      }
+                    } else {
+                      throw new IllegalArgumentException(
+                        s"Unsupported destination ${flow.destinationIdentifier.unquotedString}" +
+                        s" in flow: ${flow.displayName} at transformDownNodes"
+                      )
                     }
                     // Set flow destination as resolved now.
                     resolvedFlowDestinationsMap.computeIfPresent(
@@ -287,6 +306,11 @@ class DataflowGraphTransformer(graph: DataflowGraph) extends AutoCloseable {
     failedTables = tables.filterNot { table =>
       resolvedFlowDestinationsMap.getOrDefault(table.identifier, false)
     }
+    // A sink is failed to analyze if:
+    // - It does not exist in the resolvedFlowDestinationsMap
+    failedSinks = sinks.filterNot { sink =>
+      resolvedFlowDestinationsMap.getOrDefault(sink.identifier, false)
+    }
 
     // We maintain the topological sort order of successful flows always
     val (resolvedFlowsWithResolvedDest, resolvedFlowsWithFailedDest) =
@@ -313,8 +337,10 @@ class DataflowGraphTransformer(graph: DataflowGraph) extends AutoCloseable {
     flowsTo = computeFlowsTo()
     tables = resolvedTables.asScala.toSeq
     views = resolvedViews.asScala.toSeq
+    sinks = resolvedSinks.asScala.toSeq
     tableMap = computeTableMap()
     viewMap = computeViewMap()
+    sinkMap = computeSinkMap()
     this
   }
 
@@ -326,7 +352,8 @@ class DataflowGraphTransformer(graph: DataflowGraph) extends AutoCloseable {
       // they will be front of the list in failedFlows and thus by definition topologically sorted
       // in the combined sequence too.
       flows = flows ++ failedFlows,
-      tables = tables ++ failedTables
+      tables = tables ++ failedTables,
+      sinks = sinks ++ failedSinks
     )
   }
 

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DatasetManager.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DatasetManager.scala
@@ -24,6 +24,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.internal.{Logging, LogKeys, MDC}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.connector.catalog.{
   CatalogV2Util,
   Identifier,
@@ -32,10 +33,11 @@ import org.apache.spark.sql.connector.catalog.{
   TableInfo
 }
 import org.apache.spark.sql.connector.catalog.CatalogV2Util.v2ColumnsToStructType
-import org.apache.spark.sql.connector.expressions.Expressions
+import org.apache.spark.sql.connector.expressions.{Expressions, Transform}
 import org.apache.spark.sql.pipelines.graph.QueryOrigin.ExceptionHelpers
 import org.apache.spark.sql.pipelines.util.SchemaInferenceUtils.diffSchemas
 import org.apache.spark.sql.pipelines.util.SchemaMergingUtils
+import org.apache.spark.sql.types.StructType
 
 /**
  * `DatasetManager` is responsible for materializing tables in the catalog based on the given
@@ -61,6 +63,40 @@ object DatasetManager extends Logging {
       with NoStackTrace
 
   /**
+   * Creates the table in the catalog if it doesn't already exist.
+   * @return A Table with its `path` attribute filled out.
+   */
+  def ensureTableCreated(
+      spark: SparkSession,
+      table: Table,
+      resolvedDataflowGraph: DataflowGraph): Table = {
+    val catalog = getTableCatalogForTable(spark, table.identifier)
+
+    val identifier = table.catalogV2Identifier
+    val properties = resolveTableProperties(table, identifier)
+
+    // Create the table if we need to
+    if (!catalog.tableExists(identifier)) {
+      catalog.createTable(
+        identifier,
+        new TableInfo.Builder()
+          .withProperties(properties.asJava)
+          .withColumns(
+            CatalogV2Util.structTypeToV2Columns(tableOutputSchema(table, resolvedDataflowGraph))
+          )
+          .withPartitions(tablePartitioning(table).toArray)
+          .build()
+      )
+    }
+
+    table.copy(
+      normalizedPath = Option(
+        catalog.loadTable(identifier).properties().get(TableCatalog.PROP_LOCATION)
+      )
+    )
+  }
+
+  /**
    * Materializes the tables in the given graph. This method will create or update the tables
    * in the catalog based on the given graph and context.
    *
@@ -72,7 +108,7 @@ object DatasetManager extends Logging {
   def materializeDatasets(
       resolvedDataflowGraph: DataflowGraph,
       context: PipelineUpdateContext
-  ): DataflowGraph = {
+  ): Unit = {
     val (_, refreshTableIdentsSet, fullRefreshTableIdentsSet) = {
       DatasetManager.constructFullRefreshSet(resolvedDataflowGraph.tables, context)
     }
@@ -91,44 +127,36 @@ object DatasetManager extends Logging {
       tablesToMatz(resolvedDataflowGraph).map(t => t.table.identifier -> t).toMap
     }
 
-    // materialized [[DataflowGraph]] where each table has been materialized and each table
-    // has metadata (e.g., normalized table storage path) populated
-    val materializedGraph: DataflowGraph = try {
-      DataflowGraphTransformer
-        .withDataflowGraphTransformer(resolvedDataflowGraph) { transformer =>
-          transformer.transformTables { table =>
-            if (tablesToMaterialize.keySet.contains(table.identifier)) {
-              try {
-                materializeTable(
-                  resolvedDataflowGraph = resolvedDataflowGraph,
-                  table = table,
-                  isFullRefresh = tablesToMaterialize(table.identifier).isFullRefresh,
-                  context = context
-                )
-              } catch {
-                case NonFatal(e) =>
-                  throw TableMaterializationException(
-                    table.displayName,
-                    cause = e.addOrigin(table.origin)
-                  )
-              }
-            } else {
-              table
-            }
+    try {
+      resolvedDataflowGraph.tables.foreach { table =>
+        if (tablesToMaterialize.contains(table.identifier)) {
+          try {
+            materializeTable(
+              resolvedDataflowGraph = resolvedDataflowGraph,
+              table = table,
+              isFullRefresh = tablesToMaterialize(table.identifier).isFullRefresh,
+              context = context
+            )
+          } catch {
+            case NonFatal(e) =>
+              throw TableMaterializationException(
+                table.displayName,
+                cause = e.addOrigin(table.origin)
+              )
           }
-        // TODO: Publish persisted views to the metastore.
         }
-        .getDataflowGraph
+      }
     } catch {
       case e: SparkException if e.getCause != null => throw e.getCause
     }
-
-    materializedGraph
   }
 
   /**
-   * Materializes a table in the catalog. This method will create or update the table in the
-   * catalog based on the given table and context.
+   * Materializes metadata for a table in the catalog, i.e. updates the metadata in the catalog to
+   * match the metadata on the table's definition in the graph.
+   *
+   * Expects that the table already exists.
+   *
    * @param resolvedDataflowGraph The resolved [[DataflowGraph]] used to infer the table schema.
    * @param table The table to be materialized.
    * @param isFullRefresh Whether this table should be full refreshed or not.
@@ -140,23 +168,16 @@ object DatasetManager extends Logging {
       table: Table,
       isFullRefresh: Boolean,
       context: PipelineUpdateContext
-  ): Table = {
+  ): Unit = {
     logInfo(log"Materializing metadata for table ${MDC(LogKeys.TABLE_NAME, table.identifier)}.")
-    val catalogManager = context.spark.sessionState.catalogManager
-    val catalog = (table.identifier.catalog match {
-      case Some(catalogName) =>
-        catalogManager.catalog(catalogName)
-      case None =>
-        catalogManager.currentCatalog
-    }).asInstanceOf[TableCatalog]
+    val catalog = getTableCatalogForTable(context.spark, table.identifier)
 
-    val identifier =
-      Identifier.of(Array(table.identifier.database.get), table.identifier.identifier)
+    val identifier = table.catalogV2Identifier
     val outputSchema = table.specifiedSchema.getOrElse(
       resolvedDataflowGraph.inferredSchema(table.identifier).asNullable
     )
     val mergedProperties = resolveTableProperties(table, identifier)
-    val partitioning = table.partitionCols.toSeq.flatten.map(Expressions.identity)
+    val partitioning = tablePartitioning(table)
 
     val existingTableOpt = if (catalog.tableExists(identifier)) {
       Some(catalog.loadTable(identifier))
@@ -179,7 +200,7 @@ object DatasetManager extends Logging {
     }
 
     // Wipe the data if we need to
-    if ((isFullRefresh || !table.isStreamingTable) && existingTableOpt.isDefined) {
+    if (!table.isStreamingTable && existingTableOpt.isDefined) {
       context.spark.sql(s"TRUNCATE TABLE ${table.identifier.quotedString}")
     }
 
@@ -197,24 +218,6 @@ object DatasetManager extends Logging {
       val setProperties = mergedProperties.map { case (k, v) => TableChange.setProperty(k, v) }
       catalog.alterTable(identifier, (columnChanges ++ setProperties).toArray: _*)
     }
-
-    // Create the table if we need to
-    if (existingTableOpt.isEmpty) {
-      catalog.createTable(
-        identifier,
-        new TableInfo.Builder()
-          .withProperties(mergedProperties.asJava)
-          .withColumns(CatalogV2Util.structTypeToV2Columns(outputSchema))
-          .withPartitions(partitioning.toArray)
-          .build()
-      )
-    }
-
-    table.copy(
-      normalizedPath = Option(
-        catalog.loadTable(identifier).properties().get(TableCatalog.PROP_LOCATION)
-      )
-    )
   }
 
   /**
@@ -292,4 +295,26 @@ object DatasetManager extends Logging {
     val fullRefreshTableIdentsSet = fullRefreshTablesSet.map(_.identifier)
     (allRefreshTables, refreshTableIdentsSet, fullRefreshTableIdentsSet)
   }
+
+  def getTableCatalogForTable(
+      spark: SparkSession,
+      tableIdentifier: TableIdentifier): TableCatalog = {
+    val catalogManager = spark.sessionState.catalogManager
+    (tableIdentifier.catalog match {
+      case Some(catalogName) =>
+        catalogManager.catalog(catalogName)
+      case None =>
+        catalogManager.currentCatalog
+    }).asInstanceOf[TableCatalog]
+  }
+
+  private def tablePartitioning(table: Table): Seq[Transform] = {
+    table.partitionCols.toSeq.flatten.map(Expressions.identity)
+  }
+
+  private def tableOutputSchema(table: Table, resolvedDataflowGraph: DataflowGraph): StructType =
+    table.specifiedSchema.getOrElse(
+      resolvedDataflowGraph.inferredSchema(table.identifier).asNullable
+    )
+
 }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/FlowExecution.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/FlowExecution.scala
@@ -191,6 +191,15 @@ trait StreamingFlowExecution extends FlowExecution with Logging {
   /** Starts a stream and returns its streaming query. */
   protected def startStream(): StreamingQuery
 
+  private var _streamingQuery: Option[StreamingQuery] = None
+
+  /** Visible for testing */
+  def getStreamingQuery: StreamingQuery =
+    _streamingQuery.getOrElse(
+      throw new IllegalStateException(s"StreamingPhysicalFlow has not been started")
+    )
+
+
   /**
    * Executes this `StreamingFlowExecution` by starting its stream with the correct scheduling pool
    * and confs.
@@ -201,6 +210,7 @@ trait StreamingFlowExecution extends FlowExecution with Logging {
       log"checkpoint location ${MDC(LogKeys.CHECKPOINT_PATH, checkpointPath)}"
     )
     val streamingQuery = SparkSessionUtils.withSqlConf(spark, sqlConf.toList: _*)(startStream())
+    _streamingQuery = Option(streamingQuery)
     Future(streamingQuery.awaitTermination())
   }
 }
@@ -260,4 +270,31 @@ class BatchTableWrite(
           .saveAsTable(destination.identifier.unquotedString)
       }
     }
+}
+
+/** A `StreamingFlowExecution` that writes a streaming `DataFrame` to a `Table`. */
+class SinkWrite(
+    val identifier: TableIdentifier,
+    val flow: ResolvedFlow,
+    val graph: DataflowGraph,
+    val updateContext: PipelineUpdateContext,
+    val checkpointPath: String,
+    val trigger: Trigger,
+    val destination: Sink,
+    val sqlConf: Map[String, String]
+) extends StreamingFlowExecution {
+
+  override def getOrigin: QueryOrigin = flow.origin
+
+  def startStream(): StreamingQuery = {
+    val data = graph.reanalyzeFlow(flow).df
+    data.writeStream
+      .queryName(displayName)
+      .option("checkpointLocation", checkpointPath)
+      .trigger(trigger)
+      .outputMode(OutputMode.Append())
+      .format(destination.format)
+      .options(destination.options)
+      .start()
+  }
 }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/FlowPlanner.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/FlowPlanner.scala
@@ -50,17 +50,29 @@ class FlowPlanner(
           updateContext = updateContext
         )
       case sf: StreamingFlow =>
+        val flowMetadata = FlowSystemMetadata(updateContext, sf, graph)
         output match {
-          case o: Table =>
+          case t: Table =>
             new StreamingTableWrite(
               graph = graph,
               flow = flow,
               identifier = sf.identifier,
-              destination = o,
+              destination = t,
               updateContext = updateContext,
               sqlConf = sf.sqlConf,
               trigger = triggerFor(sf),
-              checkpointPath = output.path
+              checkpointPath = flowMetadata.latestCheckpointLocation
+            )
+          case s: Sink =>
+            new SinkWrite(
+              graph = graph,
+              flow = flow,
+              identifier = sf.identifier,
+              destination = s,
+              updateContext = updateContext,
+              sqlConf = sf.sqlConf,
+              trigger = triggerFor(sf),
+              checkpointPath = flowMetadata.latestCheckpointLocation
             )
           case _ =>
             throw new UnsupportedOperationException(

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphErrors.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphErrors.scala
@@ -71,6 +71,14 @@ object GraphErrors {
     )
   }
 
+  def unresolvedSinkPath(identifier: TableIdentifier): SparkException = {
+    new SparkException(
+      errorClass = "UNRESOLVED_SINK_PATH",
+      messageParameters = Map("identifier" -> identifier.toString),
+      cause = null
+    )
+  }
+
   /**
    * Throws an error if the user-specified schema and the inferred schema are not compatible.
    *

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphIdentifierManager.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphIdentifierManager.scala
@@ -19,7 +19,11 @@ package org.apache.spark.sql.pipelines.graph
 
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.analysis.{ResolvedIdentifier, UnresolvedIdentifier, UnresolvedRelation}
+import org.apache.spark.sql.catalyst.analysis.{
+  ResolvedIdentifier,
+  UnresolvedIdentifier,
+  UnresolvedRelation
+}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.execution.datasources.DataSource
@@ -149,6 +153,27 @@ object GraphIdentifierManager {
       throw new AnalysisException(
         "MULTIPART_TEMPORARY_VIEW_NAME_NOT_SUPPORTED",
         Map("viewName" -> rawViewIdentifier.unquotedString)
+      )
+    }
+    internalDatasetIdentifier.identifier
+  }
+
+  /**
+   * Parses and validates the sink identifier from the raw sink identifier.
+   *
+   * @param rawSinkIdentifier the raw view identifier
+   * @return the parsed sink identifier
+   */
+  @throws[AnalysisException]
+  def parseAndValidateSinkIdentifier(rawSinkIdentifier: TableIdentifier): TableIdentifier = {
+    val internalDatasetIdentifier = parseAndValidatePipelineDatasetIdentifier(
+      rawDatasetIdentifier = rawSinkIdentifier
+    )
+    // Sinks are not persisted to the catalog in use, therefore should not be qualified.
+    if (!isSinglePartIdentifier(internalDatasetIdentifier.identifier)) {
+      throw new AnalysisException(
+        "MULTIPART_SINK_NAME_NOT_SUPPORTED",
+        Map("viewName" -> rawSinkIdentifier.unquotedString)
       )
     }
     internalDatasetIdentifier.identifier

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/PipelineUpdateContext.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/PipelineUpdateContext.scala
@@ -34,6 +34,11 @@ trait PipelineUpdateContext {
   def resetCheckpointFlows: FlowFilter
 
   /**
+   * The root storage location for pipeline metadata, including checkpoints for some kinds of flows.
+   */
+  def storageRootOpt: Option[String]
+
+  /**
    * Filter for which flows should be refreshed when performing this update. Should be a superset of
    * fullRefreshFlows.
    */

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/PipelineUpdateContextImpl.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/PipelineUpdateContextImpl.scala
@@ -32,7 +32,8 @@ class PipelineUpdateContextImpl(
     override val unresolvedGraph: DataflowGraph,
     override val eventCallback: PipelineEvent => Unit,
     override val refreshTables: TableFilter = AllTables,
-    override val fullRefreshTables: TableFilter = NoTables
+    override val fullRefreshTables: TableFilter = NoTables,
+    override val storageRootOpt: Option[String]
 ) extends PipelineUpdateContext {
 
   override val spark: SparkSession = SparkSession.getActiveSession.getOrElse(

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/State.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/State.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.pipelines.graph
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.internal.{Logging, LogKeys, MDC}
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.connector.catalog.{Identifier, TableChange}
+import org.apache.spark.sql.pipelines.graph.DatasetManager.getTableCatalogForTable
+
+object State extends Logging {
+
+  /**
+   * Find the graph elements to reset given the current update context.
+   * @param graph The graph to reset.
+   * @param env The current update context.
+   */
+  private def findElementsToReset(graph: DataflowGraph, env: PipelineUpdateContext): Seq[Input] = {
+    // If tableFilter is an instance of SomeTables, this is a refresh selection and all tables
+    // to reset should be resettable; Otherwise, this is a full graph update, and we reset all
+    // tables that are resettable.
+    val specifiedTablesToReset = {
+      val specifiedTables = env.fullRefreshTables.filter(graph.tables)
+      env.fullRefreshTables match {
+        case SomeTables(_) =>
+          specifiedTables.foreach { t =>
+            if (!PipelinesTableProperties.resetAllowed.fromMap(t.properties)) {
+              throw new AnalysisException(
+                "TABLE_NOT_RESETTABLE",
+                Map("tableName" -> t.displayName)
+              )
+            }
+          }
+          specifiedTables
+        case AllTables =>
+          specifiedTables.filter(t => PipelinesTableProperties.resetAllowed.fromMap(t.properties))
+        case NoTables => Seq.empty
+      }
+    }
+
+    val specifiedSinksToReset = {
+      env.fullRefreshTables match {
+        case SomeTables(tablesAndSinks) =>
+          graph.sinks.filter(sink => tablesAndSinks.contains(sink.identifier))
+        case AllTables =>
+          graph.sinks
+        case NoTables => Seq.empty
+      }
+    }
+
+    specifiedTablesToReset.flatMap(t => t +: graph.resolvedFlowsTo(t.identifier)) ++
+    specifiedSinksToReset.flatMap(s => graph.resolvedFlowsTo(s.identifier))
+  }
+
+  /**
+   * Performs the following on targets selected for full refresh:
+   * - Clearing checkpoint data
+   * - Truncating table data
+   */
+  def reset(resolvedGraph: DataflowGraph, env: PipelineUpdateContext): Seq[Input] = {
+    val elementsToReset: Seq[Input] = findElementsToReset(resolvedGraph, env)
+
+    elementsToReset.foreach {
+      case t: Table => reset(t, env)
+      case f: ResolvedFlow => reset(f, env, resolvedGraph)
+    }
+
+    elementsToReset
+  }
+
+  /**
+   * Resets the table by:
+   *  - Clearing out all data
+   *  - Removing all columns
+   */
+  private def reset(table: Table, env: PipelineUpdateContext): Unit = {
+    logInfo(log"Clearing out state for table ${MDC(LogKeys.TABLE_NAME, table.displayName)}}")
+    val catalog = getTableCatalogForTable(env.spark, table.identifier)
+    val identifier =
+      Identifier.of(Array(table.identifier.database.get), table.identifier.identifier)
+
+    env.spark.sql(s"TRUNCATE TABLE ${table.identifier.quotedString}")
+
+    val catalogTable = catalog.loadTable(identifier)
+    val deletions = catalogTable.columns().map { c =>
+      TableChange.deleteColumn(Array(c.name), false)
+    }
+    catalog.alterTable(identifier, deletions: _*)
+  }
+
+  /**
+   * Resets the checkpoint for the given flow by creating the next consecutive directory. Also
+   * clears out batch append state if it exists.
+   */
+  private def reset(flow: ResolvedFlow, env: PipelineUpdateContext, graph: DataflowGraph): Unit = {
+    logInfo(log"Clearing out state for flow ${MDC(LogKeys.FLOW_NAME, flow.displayName)}")
+    val flowMetadata = FlowSystemMetadata(env, flow, graph)
+    flow match {
+      case f if flowMetadata.latestCheckpointLocationOpt().isEmpty =>
+        logInfo(
+          s"Skipping resetting flow ${f.identifier} since its destination not been previously" +
+          s"materialized and we can't find the checkpoint location."
+        )
+      case _ =>
+        val hadoopConf = env.spark.sessionState.newHadoopConf()
+
+        // Write a new checkpoint folder if needed
+        val checkpointDir = new Path(flowMetadata.latestCheckpointLocation)
+        val fs1 = checkpointDir.getFileSystem(hadoopConf)
+        if (fs1.exists(checkpointDir)) {
+          val nextVersion = checkpointDir.getName.toInt + 1
+          val nextPath = new Path(checkpointDir.getParent, nextVersion.toString)
+          fs1.mkdirs(nextPath)
+          logInfo(
+            log"Created new checkpoint for stream ${MDC(LogKeys.FLOW_NAME, flow.displayName)} " +
+            log"at ${MDC(LogKeys.CHECKPOINT_PATH, nextPath.toString)}."
+          )
+        }
+    }
+  }
+}

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/SystemMetadata.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/SystemMetadata.scala
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.pipelines.graph
+
+import scala.util.Try
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.classic.SparkSession
+
+sealed trait SystemMetadata {}
+
+/**
+ * Represents the system metadata associated with a [[Flow]].
+ */
+case class FlowSystemMetadata(
+    context: PipelineUpdateContext,
+    flow: Flow,
+    graph: DataflowGraph
+) extends SystemMetadata {
+
+  /**
+   * Returns the checkpoint root directory for a given flow.
+   * @return the checkpoint root directory for `flow`
+   */
+  private def flowCheckpointsDirOpt(): Option[Path] = {
+    Option(if (graph.sink.contains(flow.destinationIdentifier)) {
+      val storageRoot = context.storageRootOpt.getOrElse(
+        // TODO: better error
+        throw new IllegalArgumentException("Storage root must be defined for flow checkpoints")
+      )
+      val storageFlowName = flow.identifier.table
+      new Path(new Path(storageRoot, "checkpoints"), storageFlowName)
+    } else if (graph.table.contains(flow.destinationIdentifier)) {
+      val storageFlowName = flow.identifier.table
+      new Path(
+        new Path(graph.table(flow.destinationIdentifier).path, "checkpoints"),
+        storageFlowName
+      )
+    } else {
+      // TODO: raise an error
+      throw new IllegalArgumentException(
+        s"Flow ${flow.identifier} does not have a valid destination for checkpoints."
+      )
+    })
+  }
+
+  /** Returns the location for the most recent checkpoint of a given flow. */
+  def latestCheckpointLocation: String = {
+    val checkpointsDir = flowCheckpointsDirOpt().get
+    SystemMetadata.getLatestCheckpointDir(checkpointsDir)
+  }
+
+  /**
+   * Same as [[latestCheckpointLocation()]] but returns [[None]] if the flow checkpoints directory
+   * does not exist.
+   */
+  def latestCheckpointLocationOpt(): Option[String] = {
+    flowCheckpointsDirOpt().map { flowCheckpointsDir =>
+      SystemMetadata.getLatestCheckpointDir(flowCheckpointsDir)
+    }
+  }
+}
+
+object SystemMetadata {
+  private def spark = SparkSession.getActiveSession.get
+
+  /**
+   * Finds the largest checkpoint version subdirectory path within a checkpoint directory, or
+   * creates and returns a version 0 subdirectory path if no versions exist.
+   * @param rootDir The root/parent directory where all the numbered checkpoint subdirectories are
+   *                stored
+   * @param createNewCheckpointDir If true, a new latest numbered checkpoint directory should be
+   *                               created and returned
+   * @return The string URI path to the latest checkpoint directory
+   */
+  def getLatestCheckpointDir(
+      rootDir: Path,
+      createNewCheckpointDir: Boolean = false
+  ): String = {
+    val fs = rootDir.getFileSystem(spark.sessionState.newHadoopConf())
+    val defaultDir = new Path(rootDir, "0")
+    val checkpoint = if (fs.exists(rootDir)) {
+      val availableCheckpoints =
+        fs.listStatus(rootDir)
+          .toSeq
+          .sortBy(fs => Try(fs.getPath.getName.toInt).getOrElse(-1))
+      availableCheckpoints.lastOption
+        .filter(fs => Try(fs.getPath.getName.toInt).isSuccess)
+        .map(
+          latestCheckpoint =>
+            if (createNewCheckpointDir) {
+              val incrementedLatestCheckpointDir =
+                new Path(rootDir, Math.max(latestCheckpoint.getPath.getName.toInt + 1, 0).toString)
+              fs.mkdirs(incrementedLatestCheckpointDir)
+              incrementedLatestCheckpointDir
+            } else {
+              latestCheckpoint.getPath
+            }
+        )
+        .getOrElse {
+          fs.mkdirs(defaultDir)
+          defaultDir
+        }
+    } else {
+      defaultDir
+    }
+    checkpoint.toUri.toString
+  }
+}

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/elements.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/elements.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.classic.{DataFrame, SparkSession}
+import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.pipelines.common.DatasetType
 import org.apache.spark.sql.pipelines.util.{
@@ -72,6 +73,10 @@ trait Input extends GraphElement {
    * @return Streaming or batch DataFrame of this Input's data.
    */
   def load(readOptions: InputReadOptions): DataFrame
+
+  /** Returns the DSv2 catalog identifier */
+  def catalogV2Identifier: Identifier =
+    Identifier.of(Array(identifier.database.get), identifier.identifier)
 }
 
 /**
@@ -256,3 +261,33 @@ case class PersistedView(
     comment: Option[String],
     origin: QueryOrigin
 ) extends View {}
+
+trait Sink extends GraphElement with Output {
+
+  /** format of the sink */
+  val format: String
+
+  /** options defined for the sink */
+  val options: Map[String, String]
+
+  /** Is only for storing metadata, e.g. checkpoints. */
+  def normalizedPath: Option[String]
+  val origin: QueryOrigin
+}
+
+case class SinkImpl(
+    identifier: TableIdentifier,
+    format: String,
+    options: Map[String, String],
+    normalizedPath: Option[String],
+    origin: QueryOrigin
+) extends Sink {
+
+  /** Returns the normalized storage location for this [[Sink]]. */
+  override def path: String = {
+    if (!normalized) {
+      throw GraphErrors.unresolvedSinkPath(identifier)
+    }
+    normalizedPath.get
+  }
+}

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/logging/PipelineEvent.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/logging/PipelineEvent.scala
@@ -39,7 +39,22 @@ case class PipelineEvent(
     message: String,
     details: EventDetails,
     error: Option[Throwable]
-)
+) {
+  def messageWithError: String = {
+    if (error.nonEmpty) {
+      // Returns the message associated with a Throwable and all its causes
+      def getExceptionMessages(throwable: Throwable): Seq[String] = {
+        throwable.getMessage +:
+          Option(throwable.getCause).map(getExceptionMessages).getOrElse(Nil)
+      }
+      val errorMessages = getExceptionMessages(error.get)
+      s"""${message}
+         |Error: ${errorMessages.mkString("\n")}""".stripMargin
+    } else {
+      message
+    }
+  }
+}
 
 /**
  * Describes where the event originated from

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
@@ -836,7 +836,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
     import session.implicits._
 
     val graph1 =
-      new DataflowGraph(flows = Seq.empty, tables = Seq.empty, views = Seq.empty)
+      new DataflowGraph(flows = Seq.empty, tables = Seq.empty, sinks = Seq.empty, views = Seq.empty)
     val graph2 = new TestGraphRegistrationContext(spark) {
       registerFlow(
         "a",

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SinkExecutionSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SinkExecutionSuite.scala
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.pipelines.graph
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.classic.DataFrame
+import org.apache.spark.sql.execution.streaming.{MemoryStream, StreamingQueryWrapper}
+import org.apache.spark.sql.pipelines.utils.{ExecutionTest, TestGraphRegistrationContext}
+import org.apache.spark.sql.streaming.StreamingQuery
+import org.apache.spark.sql.test.SharedSparkSession
+
+class SinkExecutionSuite extends ExecutionTest with SharedSparkSession {
+  def createDataflowGraph(
+      inputs: DataFrame,
+      sinkName: String,
+      flowName: String,
+      format: String,
+      sinkOptions: Map[String, String] = Map.empty
+  ): DataflowGraph = {
+    val registrationContext = new TestGraphRegistrationContext(spark) {
+      registerTemporaryView("a", query = dfFlowFunc(inputs))
+      registerSink(sinkName, format, sinkOptions)
+      registerFlow(sinkName, flowName, query = readStreamFlowFunc("a"))
+    }
+    registrationContext.toDataflowGraph
+  }
+
+  test("writing to external sink - memory sink") {
+    val session = spark
+    import session.implicits._
+
+    withTempDir { rootDirectory =>
+      val ints = MemoryStream[Int]
+      ints.addData(1, 2, 3, 4)
+
+      val unresolvedGraph =
+        createDataflowGraph(ints.toDF(), "sink_a", "flow_to_sink_a", "memory")
+      val updateContext = TestPipelineUpdateContext(
+        spark,
+        unresolvedGraph,
+        storageRootOpt = Option(rootDirectory.getPath)
+      )
+      updateContext.pipelineExecution.startPipeline()
+      updateContext.pipelineExecution.awaitCompletion()
+
+      verifyCheckpointLocation(
+        rootDirectory.getPath,
+        updateContext.pipelineExecution.graphExecution.get,
+        TableIdentifier("flow_to_sink_a")
+      )
+
+      checkAnswer(spark.sql("SELECT * FROM flow_to_sink_a"), Seq(1, 2, 3, 4).toDF().collect().toSeq)
+    }
+  }
+
+  test("writing to external sink - parquet sink with path") {
+    val session = spark
+    import session.implicits._
+
+    withTempDir { rootDirectory =>
+      withTempDir { externalDeltaPath =>
+        val ints = MemoryStream[Int]
+        ints.addData(1, 2, 3, 4)
+        val unresolvedGraph = createDataflowGraph(
+          ints.toDF(),
+          "parquet_sink",
+          "flow_to_parquet_sink",
+          "parquet",
+          Map(
+            "path" -> externalDeltaPath.getPath
+          )
+        )
+
+        val updateContext = TestPipelineUpdateContext(
+          spark,
+          unresolvedGraph,
+          storageRootOpt = Option(rootDirectory.getPath)
+        )
+        updateContext.pipelineExecution.startPipeline()
+        updateContext.pipelineExecution.awaitCompletion()
+
+        verifyCheckpointLocation(
+          rootDirectory.getPath,
+          updateContext.pipelineExecution.graphExecution.get,
+          TableIdentifier("flow_to_parquet_sink")
+        )
+
+        checkAnswer(
+          spark.read.format("parquet").load(externalDeltaPath.getPath),
+          Seq(1, 2, 3, 4).toDF().collect().toSeq
+        )
+      }
+    }
+  }
+
+  test("writing to sink, no storage root") {
+    val session = spark
+    import session.implicits._
+
+    val ints = MemoryStream[Int]
+    ints.addData(1, 2, 3, 4)
+
+    val unresolvedGraph =
+      createDataflowGraph(ints.toDF(), "sink_a", "flow_to_sink_a", "memory")
+    val updateContext = TestPipelineUpdateContext(
+      spark,
+      unresolvedGraph,
+      storageRootOpt = None
+    )
+    updateContext.pipelineExecution.startPipeline()
+    updateContext.pipelineExecution.awaitCompletion()
+    // TODO
+  }
+
+  def verifyCheckpointLocation(
+      rootDirectory: String,
+      graphExecution: GraphExecution,
+      flowIdentifier: TableIdentifier): Unit = {
+    val expectedCheckpointLocation = new Path(
+      "file://" + rootDirectory + s"/checkpoints/${flowIdentifier.table}/0"
+    )
+    val streamingQuery = graphExecution
+      .flowExecutions(flowIdentifier)
+      .asInstanceOf[StreamingFlowExecution]
+      .getStreamingQuery
+
+    val actualCheckpointLocation = new Path(getCheckpointPath(streamingQuery))
+
+    assert(actualCheckpointLocation == expectedCheckpointLocation)
+  }
+
+  private def getCheckpointPath(q: StreamingQuery): String =
+    q.asInstanceOf[StreamingQueryWrapper].streamingQuery.resolvedCheckpointRoot
+}

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SystemMetadataSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SystemMetadataSuite.scala
@@ -1,0 +1,540 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.pipelines.graph
+
+import java.nio.file.Files
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.execution.streaming.{MemoryStream, StreamingQueryWrapper}
+import org.apache.spark.sql.pipelines.utils.{ExecutionTest, TestGraphRegistrationContext}
+import org.apache.spark.sql.test.SharedSparkSession
+
+class SystemMetadataSuite
+    extends ExecutionTest
+    with SystemMetadataTestHelpers
+    with SharedSparkSession {
+  test("flow checkpoint for ST wrote to the expected location") {
+    val session = spark
+    import session.implicits._
+
+    // create a pipeline with only a single ST
+    val graph = new TestGraphRegistrationContext(spark) {
+      val mem: MemoryStream[Int] = MemoryStream[Int]
+      mem.addData(1, 2, 3)
+      registerView("a", query = dfFlowFunc(mem.toDF()))
+      registerTable("st")
+      registerFlow("st", "st", query = readStreamFlowFunc("a"))
+    }.toDataflowGraph
+
+    val testStorageRoot = Files.createTempDirectory("TestUpdateContext").normalize.toString
+    val updateContext1 = TestPipelineUpdateContext(
+      unresolvedGraph = graph,
+      spark = spark,
+      storageRootOpt = Option(testStorageRoot)
+    )
+
+    // start an update in continuous mode, checkpoints are only created to streaming query
+    updateContext1.pipelineExecution.startPipeline()
+    updateContext1.pipelineExecution.awaitCompletion()
+
+    val graphExecution1 = updateContext1.pipelineExecution.graphExecution.get
+    val executionGraph1 = graphExecution1.graphForExecution
+
+    val stIdentifier = fullyQualifiedIdentifier("st")
+
+    val expectedStorageSuffix = "st"
+
+    // assert that the checkpoint dir for the ST is created as expected
+    assertFlowCheckpointDirExists(
+      tableOrSinkElement = executionGraph1.table(stIdentifier),
+      flowElement = executionGraph1.flow(stIdentifier),
+      expectedStorageName = expectedStorageSuffix,
+      // the default checkpoint version is 0
+      expectedCheckpointVersion = 0,
+      graphExecution = graphExecution1,
+      updateContext = updateContext1
+    )
+
+    // start another update in full refresh, expected a new checkpoint dir to be created
+    // with version number incremented to 1
+    val updateContext2 = TestPipelineUpdateContext(
+      unresolvedGraph = graph,
+      spark = spark,
+      storageRootOpt = Option(testStorageRoot),
+      fullRefreshTables = AllTables
+    )
+
+    updateContext2.pipelineExecution.startPipeline()
+    updateContext2.pipelineExecution.awaitCompletion()
+    val graphExecution2 = updateContext2.pipelineExecution.graphExecution.get
+    val executionGraph2 = graphExecution2.graphForExecution
+
+    // due to full refresh, assert that new checkpoint dir is created with version number
+    // incremented to 1
+    assertFlowCheckpointDirExists(
+      tableOrSinkElement = executionGraph2.table(stIdentifier),
+      flowElement = executionGraph1.flow(stIdentifier),
+      expectedStorageName = expectedStorageSuffix,
+      // new checkpoint directory is created
+      expectedCheckpointVersion = 1,
+      graphExecution = graphExecution2,
+      updateContext2
+    )
+  }
+
+  test(
+    "flow checkpoint for ST (with flow name different from table name) wrote to the expected " +
+    "location"
+  ) {
+    val session = spark
+    import session.implicits._
+
+    val graph = new TestGraphRegistrationContext(spark) {
+      val mem: MemoryStream[Int] = MemoryStream[Int]
+      mem.addData(1, 2, 3)
+      registerView("a", query = dfFlowFunc(mem.toDF()))
+      registerTable("st")
+      registerFlow("st", "st_flow", query = readStreamFlowFunc("a"))
+    }.toDataflowGraph
+
+    val testStorageRoot = Files.createTempDirectory("TestUpdateContext").normalize.toString
+    val updateContext1 = TestPipelineUpdateContext(
+      unresolvedGraph = graph,
+      spark = spark,
+      storageRootOpt = Option(testStorageRoot)
+    )
+
+    // start an update in continuous mode, checkpoints are only created to streaming query
+    updateContext1.pipelineExecution.startPipeline()
+    updateContext1.pipelineExecution.awaitCompletion()
+
+    val graphExecution1 = updateContext1.pipelineExecution.graphExecution.get
+    val executionGraph1 = graphExecution1.graphForExecution
+
+    val stIdentifier = fullyQualifiedIdentifier("st")
+
+    val expectedStorageSuffix = "st_flow"
+
+    // assert that the checkpoint dir for the ST is created as expected
+    assertFlowCheckpointDirExists(
+      tableOrSinkElement = executionGraph1.table(stIdentifier),
+      flowElement = executionGraph1.flow(stIdentifier),
+      expectedStorageName = expectedStorageSuffix,
+      // the default checkpoint version is 0
+      expectedCheckpointVersion = 0,
+      graphExecution = graphExecution1,
+      updateContext = updateContext1
+    )
+
+    // start another update in full refresh, expected a new checkpoint dir to be created
+    // with version number incremented to 1
+    val updateContext2 = TestPipelineUpdateContext(
+      unresolvedGraph = graph,
+      spark = spark,
+      storageRootOpt = Option(testStorageRoot),
+      fullRefreshTables = AllTables
+    )
+
+    updateContext2.pipelineExecution.startPipeline()
+    updateContext2.pipelineExecution.awaitCompletion()
+    val graphExecution2 = updateContext2.pipelineExecution.graphExecution.get
+    val executionGraph2 = graphExecution2.graphForExecution
+
+    // due to full refresh, assert that new checkpoint dir is created with version number
+    // incremented to 1
+    assertFlowCheckpointDirExists(
+      tableOrSinkElement = executionGraph2.table(stIdentifier),
+      flowElement = executionGraph1.flow(stIdentifier),
+      expectedStorageName = expectedStorageSuffix,
+      // new checkpoint directory is created
+      expectedCheckpointVersion = 1,
+      graphExecution = graphExecution2,
+      updateContext2
+    )
+  }
+
+  test("flow checkpoint for sink wrote to the expected location for full refresh") {
+    val session = spark
+    import session.implicits._
+
+    val graph = new TestGraphRegistrationContext(spark) {
+      val mem: MemoryStream[Int] = MemoryStream[Int]
+      mem.addData(1, 2, 3)
+      registerView("a", query = dfFlowFunc(mem.toDF()))
+      registerSink("sink", format = "console")
+      registerFlow("sink", "sink", query = readStreamFlowFunc("a"))
+    }.toDataflowGraph
+    val sinkIdentifier = fullyQualifiedIdentifier("sink")
+
+    val testStorageRoot = Files.createTempDirectory("TestUpdateContext").normalize.toString
+    val updateContext1 = TestPipelineUpdateContext(
+      unresolvedGraph = graph,
+      spark = spark,
+      storageRootOpt = Option(testStorageRoot)
+    )
+
+    updateContext1.pipelineExecution.startPipeline()
+    updateContext1.pipelineExecution.awaitCompletion()
+    val graphExecution1 = updateContext1.pipelineExecution.graphExecution.get
+    val executionGraph1 = graphExecution1.graphForExecution
+
+    val expectedStorageSuffix = "sink"
+
+    // assert that the checkpoint dir for the sink is created as expected
+    assertFlowCheckpointDirExists(
+      tableOrSinkElement = executionGraph1.sink(sinkIdentifier),
+      flowElement = executionGraph1.flow(sinkIdentifier),
+      expectedStorageName = expectedStorageSuffix,
+      // the default checkpoint version is 0
+      expectedCheckpointVersion = 0,
+      graphExecution = graphExecution1,
+      updateContext = updateContext1
+    )
+
+    // start another update in full refresh, expected a new checkpoint dir to be created
+    // with version number incremented to 1
+    val updateContext2 = TestPipelineUpdateContext(
+      unresolvedGraph = graph,
+      spark = spark,
+      storageRootOpt = Option(testStorageRoot),
+      fullRefreshTables = AllTables
+    )
+
+    updateContext2.pipelineExecution.startPipeline()
+    updateContext2.pipelineExecution.awaitCompletion()
+    val graphExecution2 = updateContext2.pipelineExecution.graphExecution.get
+    val executionGraph2 = graphExecution2.graphForExecution
+
+    // due to full refresh, assert that new checkpoint dir is created with version number
+    // incremented to 1
+    assertFlowCheckpointDirExists(
+      tableOrSinkElement = executionGraph2.sink(sinkIdentifier),
+      flowElement = executionGraph2.flow(sinkIdentifier),
+      expectedStorageName = expectedStorageSuffix,
+      // new checkpoint directory is created with version number incremented to 1
+      expectedCheckpointVersion = 1,
+      graphExecution = graphExecution2,
+      updateContext2
+    )
+
+  }
+
+  // This test creates three sinks, and selectively full-refreshes two of them. We check that
+  // the checkpoints are updated for only the two sinks that are refreshed.
+  test("flow checkpoint for sink wrote to the expected location for selective refresh") {
+    val session = spark
+    import session.implicits._
+
+    val graph = new TestGraphRegistrationContext(spark) {
+      // Create external sink
+      val mem1: MemoryStream[Int] = MemoryStream[Int]
+      mem1.addData(1, 2, 3)
+      registerView("a", query = dfFlowFunc(mem1.toDF()))
+      registerSink("sink", format = "console")
+      registerFlow("sink", "sink", query = readStreamFlowFunc("a"))
+
+      val mem2 = MemoryStream[Int]
+      mem2.addData(1, 2, 3)
+      registerView("b", query = dfFlowFunc(mem2.toDF()))
+      registerSink("sink_1", "memory")
+      registerFlow("sink_1", "sink_1", query = readStreamFlowFunc("b"))
+
+      val mem3 = MemoryStream[Int]
+      mem3.addData(1, 2, 3)
+      registerView("c", query = dfFlowFunc(mem3.toDF()))
+      registerSink("sink_2", "memory")
+      registerFlow("sink_2", "sink_2", query = readStreamFlowFunc("c"))
+    }.toDataflowGraph
+
+    val sinkIdentifier = fullyQualifiedIdentifier("sink")
+    val sinkIdentifier1 = fullyQualifiedIdentifier("sink_1")
+    val sinkIdentifier2 = fullyQualifiedIdentifier("sink_2")
+
+    val testStorageRoot = Files.createTempDirectory("TestUpdateContext").normalize.toString
+    val updateContext1 = TestPipelineUpdateContext(
+      unresolvedGraph = graph,
+      spark = spark,
+      storageRootOpt = Option(testStorageRoot)
+    )
+
+    updateContext1.pipelineExecution.startPipeline()
+    updateContext1.pipelineExecution.awaitCompletion()
+    val graphExecution1 = updateContext1.pipelineExecution.graphExecution.get
+    val executionGraph1 = graphExecution1.graphForExecution
+
+    val expectedSinkStorageSuffix = "sink"
+    val expectedSink1StorageSuffix = "sink_1"
+    val expectedSink2StorageSuffix = "sink_2"
+
+    // Assert that the checkpoint dir for the sinks are created as expected
+    assertFlowCheckpointDirExists(
+      tableOrSinkElement = executionGraph1.sink(sinkIdentifier),
+      flowElement = executionGraph1.flow(sinkIdentifier),
+      expectedStorageName = expectedSinkStorageSuffix,
+      expectedCheckpointVersion = 0, // the default checkpoint version is 0
+      graphExecution = graphExecution1,
+      updateContext = updateContext1
+    )
+    assertFlowCheckpointDirExists(
+      tableOrSinkElement = executionGraph1.sink(sinkIdentifier1),
+      flowElement = executionGraph1.flow(sinkIdentifier1),
+      expectedStorageName = expectedSink1StorageSuffix,
+      expectedCheckpointVersion = 0, // the default checkpoint version is 0
+      graphExecution = graphExecution1,
+      updateContext = updateContext1
+    )
+    assertFlowCheckpointDirExists(
+      tableOrSinkElement = executionGraph1.sink(sinkIdentifier2),
+      flowElement = executionGraph1.flow(sinkIdentifier2),
+      expectedStorageName = expectedSink2StorageSuffix,
+      expectedCheckpointVersion = 0, // the default checkpoint version is 0
+      graphExecution = graphExecution1,
+      updateContext = updateContext1
+    )
+
+    // Start another update with full refresh for selected sinks, expect a new checkpoint dir to be
+    // created for selected sinks with version number incremented to 1
+    val updateContext2 = TestPipelineUpdateContext(
+      unresolvedGraph = graph,
+      spark = spark,
+      storageRootOpt = Option(testStorageRoot),
+      fullRefreshTables = SomeTables(Set(sinkIdentifier, sinkIdentifier2))
+    )
+
+    updateContext2.pipelineExecution.startPipeline()
+    updateContext2.pipelineExecution.awaitCompletion()
+    val graphExecution2 = updateContext2.pipelineExecution.graphExecution.get
+    val executionGraph2 = graphExecution2.graphForExecution
+
+    assertFlowCheckpointDirExists(
+      tableOrSinkElement = executionGraph2.sink(sinkIdentifier),
+      flowElement = executionGraph2.flow(sinkIdentifier),
+      expectedStorageName = expectedSinkStorageSuffix,
+      expectedCheckpointVersion = 1, // version number incremented to 1 due to full refresh
+      graphExecution = graphExecution2,
+      updateContext = updateContext2
+    )
+    assertFlowCheckpointDirExists(
+      tableOrSinkElement = executionGraph2.sink(sinkIdentifier1),
+      flowElement = executionGraph2.flow(sinkIdentifier1),
+      expectedStorageName = expectedSink1StorageSuffix,
+      expectedCheckpointVersion = 0, // version number unchanged
+      graphExecution = graphExecution2,
+      updateContext = updateContext2
+    )
+    assertFlowCheckpointDirExists(
+      tableOrSinkElement = executionGraph2.sink(sinkIdentifier2),
+      flowElement = executionGraph2.flow(sinkIdentifier2),
+      expectedStorageName = expectedSink2StorageSuffix,
+      expectedCheckpointVersion = 1, // version number incremented to 1 due to full refresh
+      graphExecution = graphExecution2,
+      updateContext = updateContext2
+    )
+
+  }
+
+  // This test creates a sink with two incoming flows, and we selectively full-refresh the sink.
+  // We check that for all incoming flows are refreshed.
+  test("all flow checkpoints for a sink are updated in selective refresh") {
+    val session = spark
+    import session.implicits._
+
+    val graph = new TestGraphRegistrationContext(spark) {
+      val (mem1, mem2) = (MemoryStream[Int], MemoryStream[Int])
+      mem1.addData(1, 2, 3)
+      mem2.addData(4, 5, 6)
+      registerView("a", query = dfFlowFunc(mem2.toDF()))
+      registerView("b", query = dfFlowFunc(mem2.toDF()))
+      registerSink(
+        "sink",
+        "memory"
+      )
+      registerFlow("sink", "sink_a", query = readStreamFlowFunc("a"))
+      registerFlow("sink", "sink_a", query = readStreamFlowFunc("b"))
+    }.toDataflowGraph
+
+    val sinkIdentifier = fullyQualifiedIdentifier("sink")
+    val sinkFlowIdentifier1 = fullyQualifiedIdentifier("sink_a")
+    val sinkFlowIdentifier2 = fullyQualifiedIdentifier("sink_b")
+
+    val testStorageRoot = Files.createTempDirectory("TestUpdateContext").normalize.toString
+    val updateContext1 = TestPipelineUpdateContext(
+      unresolvedGraph = graph,
+      spark = spark,
+      storageRootOpt = Option(testStorageRoot)
+    )
+
+    updateContext1.pipelineExecution.startPipeline()
+    updateContext1.pipelineExecution.awaitCompletion()
+    val graphExecution1 = updateContext1.pipelineExecution.graphExecution.get
+    val executionGraph1 = graphExecution1.graphForExecution
+
+    val expectedSinkStorageSuffix1 = "sink_a"
+    val expectedSinkStorageSuffix2 = "sink_b"
+
+    // Assert that the checkpoint dir for the sinks are created as expected
+    assertFlowCheckpointDirExists(
+      tableOrSinkElement = executionGraph1.sink(sinkIdentifier),
+      flowElement = executionGraph1.flow(sinkFlowIdentifier1),
+      expectedStorageName = expectedSinkStorageSuffix1,
+      expectedCheckpointVersion = 0, // the default checkpoint version is 0
+      graphExecution = graphExecution1,
+      updateContext = updateContext1
+    )
+    assertFlowCheckpointDirExists(
+      tableOrSinkElement = executionGraph1.sink(sinkIdentifier),
+      flowElement = executionGraph1.flow(sinkFlowIdentifier2),
+      expectedStorageName = expectedSinkStorageSuffix2,
+      expectedCheckpointVersion = 0, // the default checkpoint version is 0
+      graphExecution = graphExecution1,
+      updateContext = updateContext1
+    )
+
+    // Start another update with full refresh for selected sinks, expect a new checkpoint dir to be
+    // created for the sink's flows with version number incremented to 1
+    val updateContext2 = TestPipelineUpdateContext(
+      unresolvedGraph = graph,
+      spark = spark,
+      storageRootOpt = Option(testStorageRoot),
+      fullRefreshTables = SomeTables(Set(sinkIdentifier))
+    )
+
+    updateContext2.pipelineExecution.startPipeline()
+    updateContext2.pipelineExecution.awaitCompletion()
+    val graphExecution2 = updateContext2.pipelineExecution.graphExecution.get
+    val executionGraph2 = graphExecution2.graphForExecution
+
+    assertFlowCheckpointDirExists(
+      tableOrSinkElement = executionGraph2.sink(sinkIdentifier),
+      flowElement = executionGraph2.flow(sinkFlowIdentifier1),
+      expectedStorageName = expectedSinkStorageSuffix1,
+      expectedCheckpointVersion = 1, // version number incremented to 1 due to full refresh
+      graphExecution = graphExecution2,
+      updateContext2
+    )
+    assertFlowCheckpointDirExists(
+      tableOrSinkElement = executionGraph2.sink(sinkIdentifier),
+      flowElement = executionGraph2.flow(sinkFlowIdentifier2),
+      expectedStorageName = expectedSinkStorageSuffix2,
+      expectedCheckpointVersion = 1, // version number incremented to 1 due to full refresh
+      graphExecution = graphExecution2,
+      updateContext2
+    )
+  }
+}
+
+trait SystemMetadataTestHelpers {
+  this: ExecutionTest =>
+
+  /** Return the expected checkpoint directory location for a table or sink.
+   *  These directories have "<expectedStorageName>/<expectedCheckpointVersion>" as their suffix. */
+  private def getExpectedFlowCheckpointDirForTableOrSink(
+      tableOrSinkElement: GraphElement,
+      expectedStorageName: String,
+      expectedCheckpointVersion: Int,
+      updateContext: PipelineUpdateContext
+  ): Path = {
+    val expectedRawCheckPointDir = tableOrSinkElement match {
+      case t: Table => t.normalizedPath.get + s"/checkpoints/$expectedStorageName"
+      case _: Sink =>
+        new Path(updateContext.storageRootOpt.get)
+          .suffix(s"/checkpoints/$expectedStorageName")
+          .toString
+      case _ =>
+        fail(
+          s"unexpected table element type for assertFlowCheckpointDirForTableOrSink: " +
+          tableOrSinkElement.getClass.getSimpleName
+        )
+    }
+
+    new Path("file://", expectedRawCheckPointDir).suffix(s"/$expectedCheckpointVersion")
+  }
+
+  /** Return the actual checkpoint directory location used by the table or sink.
+   * We use a Flow object as input since the checkpoints for a table or sink are associated with
+   * each of their incoming flows.
+   */
+  private def getActualFlowCheckpointDirForTableOrSink(
+      flowElement: Flow,
+      graphExecution: GraphExecution
+  ): Path = {
+    // spark flow stream takes a while to be created, so we need to poll for it
+    val flowStream = graphExecution
+      .flowExecutions(flowElement.identifier)
+      .asInstanceOf[StreamingFlowExecution]
+      .getStreamingQuery
+
+    // we grab the checkpoint location from the actual spark stream query executed in the update
+    // execution, which is the best source of truth.
+    new Path(
+      flowStream.asInstanceOf[StreamingQueryWrapper].streamingQuery.resolvedCheckpointRoot
+    )
+  }
+
+  /** Assert the flow checkpoint directory exists in the filesystem. */
+  protected def assertFlowCheckpointDirExists(
+      tableOrSinkElement: GraphElement,
+      flowElement: Flow,
+      expectedStorageName: String,
+      expectedCheckpointVersion: Int,
+      graphExecution: GraphExecution,
+      updateContext: PipelineUpdateContext
+  ): Path = {
+    val expectedCheckPointDir = getExpectedFlowCheckpointDirForTableOrSink(
+      tableOrSinkElement = tableOrSinkElement,
+      expectedStorageName = expectedStorageName,
+      expectedCheckpointVersion = expectedCheckpointVersion,
+      updateContext
+    )
+    val actualCheckpointDir = getActualFlowCheckpointDirForTableOrSink(
+      flowElement = flowElement,
+      graphExecution = graphExecution
+    )
+    val fs = expectedCheckPointDir.getFileSystem(spark.sessionState.newHadoopConf())
+    assert(actualCheckpointDir == expectedCheckPointDir)
+    assert(fs.exists(actualCheckpointDir))
+    actualCheckpointDir
+  }
+
+  /** Assert the flow checkpoint directory does not exist in the filesystem. */
+  protected def assertFlowCheckpointDirNotExists(
+      tableOrSinkElement: GraphElement,
+      flowElement: Flow,
+      expectedStorageName: String,
+      expectedCheckpointVersion: Int,
+      graphExecution: GraphExecution,
+      updateContext: PipelineUpdateContext
+  ): Path = {
+    val expectedCheckPointDir = getExpectedFlowCheckpointDirForTableOrSink(
+      tableOrSinkElement = tableOrSinkElement,
+      expectedStorageName = expectedStorageName,
+      expectedCheckpointVersion = expectedCheckpointVersion,
+      updateContext
+    )
+    val actualCheckpointDir = getActualFlowCheckpointDirForTableOrSink(
+      flowElement = flowElement,
+      graphExecution = graphExecution
+    )
+    val fs = expectedCheckPointDir.getFileSystem(spark.sessionState.newHadoopConf())
+    assert(actualCheckpointDir != expectedCheckPointDir)
+    assert(!fs.exists(expectedCheckPointDir))
+    actualCheckpointDir
+  }
+
+}

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/ExecutionTest.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/ExecutionTest.scala
@@ -57,11 +57,18 @@ trait TestPipelineUpdateContextMixin {
       unresolvedGraph: DataflowGraph,
       fullRefreshTables: TableFilter = NoTables,
       refreshTables: TableFilter = AllTables,
-      resetCheckpointFlows: FlowFilter = AllFlows
+      resetCheckpointFlows: FlowFilter = AllFlows,
+      storageRootOpt: Option[String] = None
   ) extends PipelineUpdateContext {
     val eventBuffer = new PipelineRunEventBuffer()
 
-    override val eventCallback: PipelineEvent => Unit = eventBuffer.addEvent
+    override val eventCallback: PipelineEvent => Unit = { event =>
+      eventBuffer.addEvent(event)
+      println(event.messageWithError)
+      event.error.foreach { error =>
+        throw error
+      }
+    }
 
     override def flowProgressEventLogger: FlowProgressEventLogger = {
       new FlowProgressEventLogger(eventCallback = eventCallback)

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/PipelineTest.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/PipelineTest.scala
@@ -35,7 +35,11 @@ import org.apache.spark.sql.{Column, QueryTest, Row, SQLContext, TypedColumn}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.classic.{DataFrame, Dataset, SparkSession}
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.pipelines.graph.{DataflowGraph, PipelineUpdateContextImpl, SqlGraphRegistrationContext}
+import org.apache.spark.sql.pipelines.graph.{
+  DataflowGraph,
+  PipelineUpdateContextImpl,
+  SqlGraphRegistrationContext
+}
 import org.apache.spark.sql.pipelines.utils.PipelineTest.{cleanupMetastore, createTempDir}
 
 abstract class PipelineTest
@@ -56,9 +60,15 @@ abstract class PipelineTest
 
   def sql(text: String): DataFrame = spark.sql(text)
 
-  protected def startPipelineAndWaitForCompletion(unresolvedDataflowGraph: DataflowGraph): Unit = {
-    val updateContext = new PipelineUpdateContextImpl(
-      unresolvedDataflowGraph, eventCallback = _ => ())
+  protected def startPipelineAndWaitForCompletion(
+      unresolvedDataflowGraph: DataflowGraph,
+      storageRootOpt: Option[String] = None): Unit = {
+    val updateContext =
+      new PipelineUpdateContextImpl(
+        unresolvedDataflowGraph,
+        eventCallback = _ => (),
+        storageRootOpt = storageRootOpt
+      )
     updateContext.pipelineExecution.runPipeline()
     updateContext.pipelineExecution.awaitCompletion()
   }
@@ -106,8 +116,7 @@ abstract class PipelineTest
         spark = spark
       )
     }
-    graphRegistrationContext
-      .toDataflowGraph
+    graphRegistrationContext.toDataflowGraph
   }
 
   /** Construct an unresolved DataflowGraph object from a single SQL file, given the file contents
@@ -376,7 +385,7 @@ object PipelineTest extends Logging {
   )
 
   /** Creates a temporary directory. */
-  protected def createTempDir(): String = {
+  def createTempDir(): String = {
     Files.createTempDirectory(getClass.getSimpleName).normalize.toString
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

We were not resetting checkpoint dirs on full refresh.

### What changes were proposed in this pull request?

As proposed in the [Declarative Pipelines SPIP](https://docs.google.com/document/d/1PsSTngFuRVEOvUGzp_25CQL1yfzFHFr02XdMfQ7jOM4/edit?tab=t.0), a sink is a generic target for a flow to send data that is external to the pipeline. Add support for defining them and executing flows that target them.

This PR implements sinks:
- Spark Connect message for registering sink definitions – `DefineSink`
- New `FlowExecution` subtype for executing flows that write to sinks – `SinkWrite`


TODO: explain sink checkpoint locations and pipeline storage root

### Why are the changes needed?

Implement the Declarative Pipelines SPIP.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
