### PR TITLE
[SPARK-52875][SQL][TESTS][FOLLOWUP] Override the `sparkConf` for `DataSourceV2StrategySuite` to ensure that `ANSI_ENABLED` is set to true.

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
@@ -773,47 +773,46 @@ class DataSourceV2StrategySuite extends PlanTest with SharedSparkSession {
   }
 
   test("Partial constant folding of math functions") {
-    withSQLConf(SQLConf.ANSI_ENABLED.key -> true.toString) {
-      checkV2Conversion(
-        catalystExpr = Log10(Literal(100.0)) + $"cint".int,
-        v2Expr = new GeneralScalarExpression("+", Array(
-          LiteralValue(2.0, DoubleType),
-          FieldReference("cint"))))
+    assume(SQLConf.get.ansiEnabled)
+    checkV2Conversion(
+      catalystExpr = Log10(Literal(100.0)) + $"cint".int,
+      v2Expr = new GeneralScalarExpression("+", Array(
+        LiteralValue(2.0, DoubleType),
+        FieldReference("cint"))))
 
-      checkV2Conversion(
-        catalystExpr = Abs(Literal(-10), failOnError = true) * $"cdouble".double,
-        v2Expr = new GeneralScalarExpression("*", Array(
-          LiteralValue(10, IntegerType),
-          FieldReference("cdouble"))))
+    checkV2Conversion(
+      catalystExpr = Abs(Literal(-10), failOnError = true) * $"cdouble".double,
+      v2Expr = new GeneralScalarExpression("*", Array(
+        LiteralValue(10, IntegerType),
+        FieldReference("cdouble"))))
 
-      checkV2Conversion(
-        catalystExpr = Sqrt(Literal(16.0)) - $"cint".int,
-        v2Expr = new GeneralScalarExpression("-", Array(
-          LiteralValue(4.0, DoubleType),
-          FieldReference("cint"))))
+    checkV2Conversion(
+      catalystExpr = Sqrt(Literal(16.0)) - $"cint".int,
+      v2Expr = new GeneralScalarExpression("-", Array(
+        LiteralValue(4.0, DoubleType),
+        FieldReference("cint"))))
 
-      checkV2Conversion(
-        catalystExpr = $"cdouble".double / Log2(Literal(32.0)),
-        v2Expr = new GeneralScalarExpression("/", Array(
-          FieldReference("cdouble"),
-          LiteralValue(5.0, DoubleType))))
+    checkV2Conversion(
+      catalystExpr = $"cdouble".double / Log2(Literal(32.0)),
+      v2Expr = new GeneralScalarExpression("/", Array(
+        FieldReference("cdouble"),
+        LiteralValue(5.0, DoubleType))))
 
-      checkV2Conversion(
-        catalystExpr = Floor(Literal(7.9)) + Ceil(Literal(2.1)),
-        v2Expr = LiteralValue(10L, LongType))
+    checkV2Conversion(
+      catalystExpr = Floor(Literal(7.9)) + Ceil(Literal(2.1)),
+      v2Expr = LiteralValue(10L, LongType))
 
-      checkV2Conversion(
-        catalystExpr = $"cint".int % Abs(Literal(-3), failOnError = true),
-        v2Expr = new GeneralScalarExpression("%", Array(
-          FieldReference("cint"),
-          LiteralValue(3, IntegerType))))
+    checkV2Conversion(
+      catalystExpr = $"cint".int % Abs(Literal(-3), failOnError = true),
+      v2Expr = new GeneralScalarExpression("%", Array(
+        FieldReference("cint"),
+        LiteralValue(3, IntegerType))))
 
-      checkV2Conversion(
-        catalystExpr = Exp(Literal(0.0)) * $"cdouble".double,
-        v2Expr = new GeneralScalarExpression("*", Array(
-          LiteralValue(1.0, DoubleType),
-          FieldReference("cdouble"))))
-    }
+    checkV2Conversion(
+      catalystExpr = Exp(Literal(0.0)) * $"cdouble".double,
+      v2Expr = new GeneralScalarExpression("*", Array(
+        LiteralValue(1.0, DoubleType),
+        FieldReference("cdouble"))))
   }
 
   test("Current Like functions are not supported") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
@@ -22,8 +22,8 @@ import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.util.V2ExpressionBuilder
-import org.apache.spark.sql.connector.expressions.{FieldReference, GeneralScalarExpression, LiteralValue, Expression => V2Expression}
-import org.apache.spark.sql.connector.expressions.filter.{AlwaysFalse, AlwaysTrue, Predicate, And => V2And, Not => V2Not, Or => V2Or}
+import org.apache.spark.sql.connector.expressions.{Expression => V2Expression, FieldReference, GeneralScalarExpression, LiteralValue}
+import org.apache.spark.sql.connector.expressions.filter.{AlwaysFalse, AlwaysTrue, And => V2And, Not => V2Not, Or => V2Or, Predicate}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{BooleanType, DoubleType, IntegerType, LongType, StringType, StructField, StructType}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
@@ -30,6 +31,9 @@ import org.apache.spark.sql.types.{BooleanType, DoubleType, IntegerType, LongTyp
 import org.apache.spark.unsafe.types.UTF8String
 
 class DataSourceV2StrategySuite extends PlanTest with SharedSparkSession {
+
+  override def sparkConf: SparkConf = super.sparkConf.set(SQLConf.ANSI_ENABLED, true)
+
   val attrInts = Seq(
     $"cint".int,
     $"`c.int`".int,
@@ -773,7 +777,6 @@ class DataSourceV2StrategySuite extends PlanTest with SharedSparkSession {
   }
 
   test("Partial constant folding of math functions") {
-    assume(SQLConf.get.ansiEnabled)
     checkV2Conversion(
       catalystExpr = Log10(Literal(100.0)) + $"cint".int,
       v2Expr = new GeneralScalarExpression("+", Array(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr ensures that the test case `Partial constant folding of math functions` in `DataSourceV2StrategySuite` is only run when `ansiEnabled` is set to `true`.

### Why are the changes needed?
Restore Non-Ansi daily test:
- https://github.com/apache/spark/actions/runs/16485653304/job/46609769023

<img width="966" height="380" alt="image" src="https://github.com/user-attachments/assets/506f6a3a-f54c-4405-ac6e-d149c4918a8b" />


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

```
SPARK_ANSI_SQL_MODE=false build/sbt "sql/testOnly org.apache.spark.sql.execution.datasources.v2.DataSourceV2StrategySuite"
[info] Run completed in 1 second, 939 milliseconds.
[info] Total number of tests run: 11
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 11, failed 0, canceled 1, ignored 0, pending 0
[info] All tests passed.
```


### Was this patch authored or co-authored using generative AI tooling?
No
