### PR TITLE
[SPARK-52944][CORE][SQL][YARN] Fix invalid assertions in tests

### DIFF
--- a/core/src/test/scala/org/apache/spark/SortShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SortShuffleSuite.scala
@@ -69,8 +69,8 @@ class SortShuffleSuite extends ShuffleSuite with BeforeAndAfterAll {
     shuffledRdd.count()
     // Ensure that the shuffle actually created files that will need to be cleaned up
     val filesCreatedByShuffle = getAllFiles -- filesBeforeShuffle
-    filesCreatedByShuffle.map(_.getName) should be
-    Set("shuffle_0_0_0.data", "shuffle_0_0_0.index")
+    filesCreatedByShuffle.map(_.getName) should be(
+      Set("shuffle_0_0_0.data", "shuffle_0_0_0.checksum.ADLER32", "shuffle_0_0_0.index"))
     // Check that the cleanup actually removes the files
     sc.env.blockManager.master.removeShuffle(0, blocking = true)
     for (file <- filesCreatedByShuffle) {

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -1189,14 +1189,14 @@ class SparkSubmitSuite
 
             val appArgs = new SparkSubmitArguments(args)
             val (_, _, conf, _) = submit.prepareSubmitEnvironment(appArgs)
-            conf.get("spark.yarn.dist.jars").split(",").toSet should be
-            (Set(jar1.toURI.toString, jar2.toURI.toString))
-            conf.get("spark.yarn.dist.files").split(",").toSet should be
-            (Set(file1.toURI.toString, file2.toURI.toString))
-            conf.get("spark.yarn.dist.pyFiles").split(",").toSet should be
-            (Set(pyFile1.getAbsolutePath, pyFile2.getAbsolutePath))
-            conf.get("spark.yarn.dist.archives").split(",").toSet should be
-            (Set(archive1.toURI.toString, archive2.toURI.toString))
+            conf.get("spark.yarn.dist.jars").split(",").toSet should be(
+              Set(jar1.toURI.toString, jar2.toURI.toString))
+            conf.get("spark.yarn.dist.files").split(",").toSet should be(
+              Set(file1.toURI.toString, file2.toURI.toString))
+            conf.get("spark.yarn.dist.pyFiles").split(",").toSet should be(
+              Set(pyFile1.toURI.toString, pyFile2.toURI.toString))
+            conf.get("spark.yarn.dist.archives").split(",").toSet should be(
+              Set(archive1.toURI.toString, archive2.toURI.toString))
           }
         }
       }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
@@ -616,35 +616,35 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
     val mergeManager1DB = ShuffleTestAccessor.mergeManagerDB(mergeManager1)
     ShuffleTestAccessor.recoveryFile(mergeManager1) should be (mergeMgrFile)
 
-    ShuffleTestAccessor.getAppsShuffleInfo(mergeManager1).size() equals 0
-    ShuffleTestAccessor.reloadAppShuffleInfo(
-      mergeManager1, mergeManager1DB).size() equals 0
+    assert(ShuffleTestAccessor.getAppsShuffleInfo(mergeManager1).size() equals 0)
+    assert(ShuffleTestAccessor.reloadAppShuffleInfo(
+      mergeManager1, mergeManager1DB).size() equals 0)
 
     mergeManager1.registerExecutor(app1Id.toString, mergedShuffleInfo1)
     var appShuffleInfo = ShuffleTestAccessor.getAppsShuffleInfo(mergeManager1)
-    appShuffleInfo.size() equals 1
+    assert(appShuffleInfo.size() equals 1)
     appShuffleInfo.get(app1Id.toString).getAppPathsInfo should be (appPathsInfo1)
     var appShuffleInfoAfterReload =
       ShuffleTestAccessor.reloadAppShuffleInfo(mergeManager1, mergeManager1DB)
-    appShuffleInfoAfterReload.size() equals 1
+    assert(appShuffleInfoAfterReload.size() equals 1)
     appShuffleInfoAfterReload.get(app1Id.toString).getAppPathsInfo should be (appPathsInfo1)
 
     mergeManager1.registerExecutor(app2Attempt1Id.toString, mergedShuffleInfo2Attempt1)
     appShuffleInfo = ShuffleTestAccessor.getAppsShuffleInfo(mergeManager1)
-    appShuffleInfo.size() equals 2
+    assert(appShuffleInfo.size() equals 2)
     appShuffleInfo.get(app1Id.toString).getAppPathsInfo should be (appPathsInfo1)
     appShuffleInfo.get(
       app2Attempt1Id.toString).getAppPathsInfo should be (appPathsInfo2Attempt1)
     appShuffleInfoAfterReload =
       ShuffleTestAccessor.reloadAppShuffleInfo(mergeManager1, mergeManager1DB)
-    appShuffleInfoAfterReload.size() equals 2
+    assert(appShuffleInfoAfterReload.size() equals 2)
     appShuffleInfoAfterReload.get(app1Id.toString).getAppPathsInfo should be (appPathsInfo1)
     appShuffleInfoAfterReload.get(
       app2Attempt1Id.toString).getAppPathsInfo should be (appPathsInfo2Attempt1)
 
     mergeManager1.registerExecutor(app3IdNoAttemptId.toString, mergedShuffleInfo3NoAttemptId)
     appShuffleInfo = ShuffleTestAccessor.getAppsShuffleInfo(mergeManager1)
-    appShuffleInfo.size() equals 3
+    assert(appShuffleInfo.size() equals 3)
     appShuffleInfo.get(app1Id.toString).getAppPathsInfo should be (appPathsInfo1)
     appShuffleInfo.get(
       app2Attempt1Id.toString).getAppPathsInfo should be (appPathsInfo2Attempt1)
@@ -652,7 +652,7 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
       app3IdNoAttemptId.toString).getAppPathsInfo should be (appPathsInfo3NoAttempt)
     appShuffleInfoAfterReload =
       ShuffleTestAccessor.reloadAppShuffleInfo(mergeManager1, mergeManager1DB)
-    appShuffleInfoAfterReload.size() equals 3
+    assert(appShuffleInfoAfterReload.size() equals 3)
     appShuffleInfoAfterReload.get(app1Id.toString).getAppPathsInfo should be (appPathsInfo1)
     appShuffleInfoAfterReload.get(
       app2Attempt1Id.toString).getAppPathsInfo should be (appPathsInfo2Attempt1)
@@ -661,7 +661,7 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
 
     mergeManager1.registerExecutor(app2Attempt2Id.toString, mergedShuffleInfo2Attempt2)
     appShuffleInfo = ShuffleTestAccessor.getAppsShuffleInfo(mergeManager1)
-    appShuffleInfo.size() equals 3
+    assert(appShuffleInfo.size() equals 3)
     appShuffleInfo.get(app1Id.toString).getAppPathsInfo should be (appPathsInfo1)
     appShuffleInfo.get(
       app2Attempt2Id.toString).getAppPathsInfo should be (appPathsInfo2Attempt2)
@@ -669,7 +669,7 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
       app3IdNoAttemptId.toString).getAppPathsInfo should be (appPathsInfo3NoAttempt)
     appShuffleInfoAfterReload =
       ShuffleTestAccessor.reloadAppShuffleInfo(mergeManager1, mergeManager1DB)
-    appShuffleInfoAfterReload.size() equals 3
+    assert(appShuffleInfoAfterReload.size() equals 3)
     appShuffleInfoAfterReload.get(app1Id.toString).getAppPathsInfo should be (appPathsInfo1)
     appShuffleInfoAfterReload.get(
       app2Attempt2Id.toString).getAppPathsInfo should be (appPathsInfo2Attempt2)
@@ -678,14 +678,14 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
 
     mergeManager1.applicationRemoved(app2Attempt2Id.toString, true)
     appShuffleInfo = ShuffleTestAccessor.getAppsShuffleInfo(mergeManager1)
-    appShuffleInfo.size() equals 2
+    assert(appShuffleInfo.size() equals 2)
     appShuffleInfo.get(app1Id.toString).getAppPathsInfo should be (appPathsInfo1)
     assert(!appShuffleInfo.containsKey(app2Attempt2Id.toString))
     appShuffleInfo.get(
       app3IdNoAttemptId.toString).getAppPathsInfo should be (appPathsInfo3NoAttempt)
     appShuffleInfoAfterReload =
       ShuffleTestAccessor.reloadAppShuffleInfo(mergeManager1, mergeManager1DB)
-    appShuffleInfoAfterReload.size() equals 2
+    assert(appShuffleInfoAfterReload.size() equals 2)
     appShuffleInfoAfterReload.get(app1Id.toString).getAppPathsInfo should be (appPathsInfo1)
     assert(!appShuffleInfoAfterReload.containsKey(app2Attempt2Id.toString))
     appShuffleInfoAfterReload.get(
@@ -725,9 +725,9 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
     val mergeManager1DB = ShuffleTestAccessor.mergeManagerDB(mergeManager1)
     ShuffleTestAccessor.recoveryFile(mergeManager1) should be (mergeMgrFile)
 
-    ShuffleTestAccessor.getAppsShuffleInfo(mergeManager1).size() equals 0
-    ShuffleTestAccessor.reloadAppShuffleInfo(
-      mergeManager1, mergeManager1DB).size() equals 0
+    assert(ShuffleTestAccessor.getAppsShuffleInfo(mergeManager1).size() equals 0)
+    assert(ShuffleTestAccessor.reloadAppShuffleInfo(
+      mergeManager1, mergeManager1DB).size() equals 0)
 
     mergeManager1.registerExecutor(app1Id.toString, mergedShuffleInfo1)
     mergeManager1.registerExecutor(app2Attempt1Id.toString, mergedShuffleInfo2Attempt1)
@@ -737,7 +737,7 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
     prepareAppShufflePartition(mergeManager1, partitionId2, 2, "4")
 
     var appShuffleInfo = ShuffleTestAccessor.getAppsShuffleInfo(mergeManager1)
-    appShuffleInfo.size() equals 2
+    assert(appShuffleInfo.size() equals 2)
     appShuffleInfo.get(app1Id.toString).getAppPathsInfo should be (appPathsInfo1)
     appShuffleInfo.get(
       app2Attempt1Id.toString).getAppPathsInfo should be (appPathsInfo2Attempt1)
@@ -745,7 +745,7 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
     assert(!appShuffleInfo.get(app2Attempt1Id.toString).getShuffles.get(2).isFinalized)
     var appShuffleInfoAfterReload =
       ShuffleTestAccessor.reloadAppShuffleInfo(mergeManager1, mergeManager1DB)
-    appShuffleInfoAfterReload.size() equals 2
+    assert(appShuffleInfoAfterReload.size() equals 2)
     appShuffleInfoAfterReload.get(app1Id.toString).getAppPathsInfo should be (appPathsInfo1)
     appShuffleInfoAfterReload.get(
       app2Attempt1Id.toString).getAppPathsInfo should be (appPathsInfo2Attempt1)
@@ -765,12 +765,12 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
 
     mergeManager1.applicationRemoved(app1Id.toString, true)
     appShuffleInfo = ShuffleTestAccessor.getAppsShuffleInfo(mergeManager1)
-    appShuffleInfo.size() equals 1
+    assert(appShuffleInfo.size() equals 1)
     assert(!appShuffleInfo.containsKey(app1Id.toString))
     assert(appShuffleInfo.get(app2Attempt1Id.toString).getShuffles.get(2).isFinalized)
     appShuffleInfoAfterReload =
       ShuffleTestAccessor.reloadAppShuffleInfo(mergeManager1, mergeManager1DB)
-    appShuffleInfoAfterReload.size() equals 1
+    assert(appShuffleInfoAfterReload.size() equals 1)
     assert(!appShuffleInfoAfterReload.containsKey(app1Id.toString))
     assert(appShuffleInfoAfterReload.get(app2Attempt1Id.toString).getShuffles.get(2).isFinalized)
 
@@ -844,7 +844,7 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
     prepareAppShufflePartition(mergeManager1, partitionId2, 2, "4")
 
     var appShuffleInfo = ShuffleTestAccessor.getAppsShuffleInfo(mergeManager1)
-    appShuffleInfo.size() equals 2
+    assert(appShuffleInfo.size() equals 2)
     appShuffleInfo.get(app1Id.toString).getAppPathsInfo should be (appPathsInfo1)
     appShuffleInfo.get(
       app2Id.toString).getAppPathsInfo should be (appPathsInfo2Attempt1)
@@ -867,20 +867,20 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
     mergeManager1.applicationRemoved(app1Id.toString, true)
 
     appShuffleInfo = ShuffleTestAccessor.getAppsShuffleInfo(mergeManager1)
-    appShuffleInfo.size() equals 1
+    assert(appShuffleInfo.size() equals 1)
     assert(!appShuffleInfo.containsKey(app1Id.toString))
     assert(appShuffleInfo.get(app2Id.toString).getShuffles.get(2).isFinalized)
     // Clear the AppsShuffleInfo hashmap and reload the hashmap from DB
     appShuffleInfoAfterReload =
       ShuffleTestAccessor.reloadAppShuffleInfo(mergeManager1, mergeManager1DB)
-    appShuffleInfoAfterReload.size() equals 1
+    assert(appShuffleInfoAfterReload.size() equals 1)
     assert(!appShuffleInfoAfterReload.containsKey(app1Id.toString))
     assert(appShuffleInfoAfterReload.get(app2Id.toString).getShuffles.get(2).isFinalized)
 
     // Register application app1Id again and reload the DB again
     mergeManager1.registerExecutor(app1Id.toString, mergedShuffleInfo1)
     appShuffleInfo = ShuffleTestAccessor.getAppsShuffleInfo(mergeManager1)
-    appShuffleInfo.size() equals 2
+    assert(appShuffleInfo.size() equals 2)
     appShuffleInfo.get(app1Id.toString).getAppPathsInfo should be (appPathsInfo1)
     assert(appShuffleInfo.get(app1Id.toString).getShuffles.isEmpty)
     assert(appShuffleInfo.get(app2Id.toString).getShuffles.get(2).isFinalized)
@@ -924,7 +924,7 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
     prepareAppShufflePartition(mergeManager1, partitionId1, 2, "4")
 
     var appShuffleInfo = ShuffleTestAccessor.getAppsShuffleInfo(mergeManager1)
-    appShuffleInfo.size() equals 1
+    assert(appShuffleInfo.size() equals 1)
     appShuffleInfo.get(
       app1Id.toString).getAppPathsInfo should be (appPathsInfo1Attempt1)
     assert(!appShuffleInfo.get(app1Id.toString).getShuffles.get(2).isFinalized)
@@ -938,7 +938,7 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
     prepareAppShufflePartition(mergeManager1, partitionId2, 2, "4")
 
     appShuffleInfo = ShuffleTestAccessor.getAppsShuffleInfo(mergeManager1)
-    appShuffleInfo.size() equals 1
+    assert(appShuffleInfo.size() equals 1)
     appShuffleInfo.get(
       app1Id.toString).getAppPathsInfo should be (appPathsInfo1Attempt2)
     assert(!appShuffleInfo.get(app1Id.toString).getShuffles.get(2).isFinalized)
@@ -973,7 +973,7 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
     val mergeManager3 = s3.shuffleMergeManager.asInstanceOf[RemoteBlockPushResolver]
     val mergeManager3DB = ShuffleTestAccessor.mergeManagerDB(mergeManager3)
     appShuffleInfo = ShuffleTestAccessor.getAppsShuffleInfo(mergeManager3)
-    appShuffleInfo.size() equals 1
+    assert(appShuffleInfo.size() equals 1)
     appShuffleInfo.get(
       app1Id.toString).getAppPathsInfo should be (appPathsInfo1Attempt2)
     assert(appShuffleInfo.get(app1Id.toString).getShuffles.get(2).isFinalized)
@@ -1014,7 +1014,7 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
     mergeManager1.registerExecutor(app1Id.toString, mergedShuffleInfo1Attempt2)
 
     val appShuffleInfo = ShuffleTestAccessor.getAppsShuffleInfo(mergeManager1)
-    appShuffleInfo.size() equals 1
+    assert(appShuffleInfo.size() equals 1)
     appShuffleInfo.get(
       app1Id.toString).getAppPathsInfo should be (appPathsInfo1Attempt2)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -546,7 +546,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   protected def checkInvalidCastFromNumericType(to: DataType): Unit = {
-    cast(1.toByte, to).checkInputDataTypes() ==
+    assert(cast(1.toByte, to).checkInputDataTypes() ==
       DataTypeMismatch(
         errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
         messageParameters = Map(
@@ -554,8 +554,8 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "targetType" -> toSQLType(to),
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
-      )
-    cast(1.toShort, to).checkInputDataTypes() ==
+      ))
+    assert(cast(1.toShort, to).checkInputDataTypes() ==
       DataTypeMismatch(
         errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
         messageParameters = Map(
@@ -563,8 +563,8 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "targetType" -> toSQLType(to),
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
-      )
-    cast(1, to).checkInputDataTypes() ==
+      ))
+    assert(cast(1, to).checkInputDataTypes() ==
       DataTypeMismatch(
         errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
         messageParameters = Map(
@@ -572,8 +572,8 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "targetType" -> toSQLType(to),
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
-      )
-    cast(1L, to).checkInputDataTypes() ==
+      ))
+    assert(cast(1L, to).checkInputDataTypes() ==
       DataTypeMismatch(
         errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
         messageParameters = Map(
@@ -581,8 +581,8 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "targetType" -> toSQLType(to),
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
-      )
-    cast(1.0.toFloat, to).checkInputDataTypes() ==
+      ))
+    assert(cast(1.0.toFloat, to).checkInputDataTypes() ==
       DataTypeMismatch(
         errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
         messageParameters = Map(
@@ -590,8 +590,8 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "targetType" -> toSQLType(to),
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
-      )
-    cast(1.0, to).checkInputDataTypes() ==
+      ))
+    assert(cast(1.0, to).checkInputDataTypes() ==
       DataTypeMismatch(
         errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
         messageParameters = Map(
@@ -599,7 +599,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "targetType" -> toSQLType(to),
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
-      )
+      ))
   }
 
   test("SPARK-16729 type checking for casting to date type") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -546,7 +546,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   protected def checkInvalidCastFromNumericType(to: DataType): Unit = {
-    assert(cast(1.toByte, to).checkInputDataTypes() ==
+    cast(1.toByte, to).checkInputDataTypes() ==
       DataTypeMismatch(
         errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
         messageParameters = Map(
@@ -555,8 +555,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
       )
-    )
-    assert(cast(1.toShort, to).checkInputDataTypes() ==
+    cast(1.toShort, to).checkInputDataTypes() ==
       DataTypeMismatch(
         errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
         messageParameters = Map(
@@ -565,8 +564,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
       )
-    )
-    assert(cast(1, to).checkInputDataTypes() ==
+    cast(1, to).checkInputDataTypes() ==
       DataTypeMismatch(
         errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
         messageParameters = Map(
@@ -575,8 +573,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
       )
-    )
-    assert(cast(1L, to).checkInputDataTypes() ==
+    cast(1L, to).checkInputDataTypes() ==
       DataTypeMismatch(
         errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
         messageParameters = Map(
@@ -585,8 +582,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
       )
-    )
-    assert(cast(1.0.toFloat, to).checkInputDataTypes() ==
+    cast(1.0.toFloat, to).checkInputDataTypes() ==
       DataTypeMismatch(
         errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
         messageParameters = Map(
@@ -595,8 +591,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
       )
-    )
-    assert(cast(1.0, to).checkInputDataTypes() ==
+    cast(1.0, to).checkInputDataTypes() ==
       DataTypeMismatch(
         errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
         messageParameters = Map(
@@ -605,7 +600,6 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
       )
-    )
   }
 
   test("SPARK-16729 type checking for casting to date type") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -554,7 +554,8 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "targetType" -> toSQLType(to),
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
-      ))
+      )
+    )
     assert(cast(1.toShort, to).checkInputDataTypes() ==
       DataTypeMismatch(
         errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
@@ -563,7 +564,8 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "targetType" -> toSQLType(to),
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
-      ))
+      )
+    )
     assert(cast(1, to).checkInputDataTypes() ==
       DataTypeMismatch(
         errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
@@ -572,7 +574,8 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "targetType" -> toSQLType(to),
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
-      ))
+      )
+    )
     assert(cast(1L, to).checkInputDataTypes() ==
       DataTypeMismatch(
         errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
@@ -581,7 +584,8 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "targetType" -> toSQLType(to),
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
-      ))
+      )
+    )
     assert(cast(1.0.toFloat, to).checkInputDataTypes() ==
       DataTypeMismatch(
         errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
@@ -590,7 +594,8 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "targetType" -> toSQLType(to),
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
-      ))
+      )
+    )
     assert(cast(1.0, to).checkInputDataTypes() ==
       DataTypeMismatch(
         errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
@@ -599,7 +604,8 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "targetType" -> toSQLType(to),
           "functionNames" -> "`DATE_FROM_UNIX_DATE`"
         )
-      ))
+      )
+    )
   }
 
   test("SPARK-16729 type checking for casting to date type") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/UnsafeRowConverterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/UnsafeRowConverterSuite.scala
@@ -114,14 +114,14 @@ class UnsafeRowConverterSuite extends SparkFunSuite with Matchers with Expressio
     // Date is represented as Int in unsafeRow
     assert(DateTimeUtils.toJavaDate(unsafeRow.getInt(2)) === Date.valueOf("1970-01-01"))
     // Timestamp is represented as Long in unsafeRow
-    DateTimeUtils.toJavaTimestamp(unsafeRow.getLong(3)) should be
-    (Timestamp.valueOf("2015-05-08 08:10:25"))
+    DateTimeUtils.toJavaTimestamp(unsafeRow.getLong(3)) should be(
+      Timestamp.valueOf("2015-05-08 08:10:25"))
 
     unsafeRow.setInt(2, DateTimeUtils.fromJavaDate(Date.valueOf("2015-06-22")))
     assert(DateTimeUtils.toJavaDate(unsafeRow.getInt(2)) === Date.valueOf("2015-06-22"))
     unsafeRow.setLong(3, DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf("2015-06-22 08:10:25")))
-    DateTimeUtils.toJavaTimestamp(unsafeRow.getLong(3)) should be
-    (Timestamp.valueOf("2015-06-22 08:10:25"))
+    DateTimeUtils.toJavaTimestamp(unsafeRow.getLong(3)) should be(
+      Timestamp.valueOf("2015-06-22 08:10:25"))
   }
 
   testBothCodegenAndInterpreted(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -339,11 +339,11 @@ class DataTypeSuite extends SparkFunSuite {
         |""".stripMargin
     val dt = DataType.fromJson(schema)
 
-    dt.simpleString equals "struct<c1:string>"
-    dt.json equals
+    assert(dt.simpleString equals "struct<c1:string>")
+    assert(dt.json equals
       """
         |{"type":"struct","fields":[{"name":"c1","type":"string","nullable":false,"metadata":{}}]}
-        |""".stripMargin
+        |""".stripMargin)
   }
 
   def checkDefaultSize(dataType: DataType, expectedDefaultSize: Int): Unit = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -342,8 +342,8 @@ class DataTypeSuite extends SparkFunSuite {
     assert(dt.simpleString equals "struct<c1:string>")
     assert(dt.json equals
       """
-        |{"type":"struct","fields":[{"name":"c1","type":"string","nullable":false,"metadata":{}}]}
-        |""".stripMargin)
+        |{"type":"struct","fields":[{"name":"c1","type":"string","nullable":true,"metadata":{}}]}
+        |""".stripMargin.trim)
   }
 
   def checkDefaultSize(dataType: DataType, expectedDefaultSize: Int): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationSuite.scala
@@ -321,7 +321,7 @@ class StreamingDeduplicationSuite extends StateStoreMetricsTest {
         },
         AssertOnQuery { q =>
           eventually(timeout(streamingTimeout)) {
-            q.lastProgress.sink.numOutputRows == 0L
+            assert(q.lastProgress.sink.numOutputRows == 0L)
             true
           }
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr fixes some invalid assertions in the test code, mainly addressing two types of issues:

1. Forgetting to use `assert`. For example:

https://github.com/apache/spark/blob/5a9929c32ef8aafd275a3cf4797bb0ba9a6e61e2/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala#L342

Here, it is clearly intended to assert that `dt.simpleString equals "struct<c1:string>"`, but the use of `assert` was forgotten, rendering it an invalid expression.

2. Incorrect line breaks in `should be` statements, causing one line of code to be mistakenly treated as two unrelated lines. For example:

https://github.com/apache/spark/blob/5a9929c32ef8aafd275a3cf4797bb0ba9a6e61e2/core/src/test/scala/org/apache/spark/SortShuffleSuite.scala#L72-L73

Here, it is clearly intended to make an assertion similar to the following:

```
filesCreatedByShuffle.map(_.getName) should be Set("shuffle_0_0_0.data", "shuffle_0_0_0.index") 
```

However, due to the incorrect line break, it actually fails to function as an assertion.

Meanwhile, after implementing the aforementioned fixes, this pr also addresses and repairs the failing test cases within it.

### Why are the changes needed?
Fix invalid assertions in tests 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No