### PR TITLE
[SPARK-52948][PS] Enable test_np_spark_compat_frame under ANSI

### DIFF
--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -23,7 +23,6 @@ from pyspark import pandas as ps
 from pyspark.pandas import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
-from pyspark.testing.utils import is_ansi_mode_test, ansi_mode_not_supported_message
 
 
 class NumPyCompatTestsMixin:

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -132,7 +132,6 @@ class NumPyCompatTestsMixin:
         finally:
             reset_option("compute.ops_on_diff_frames")
 
-    @unittest.skipIf(is_ansi_mode_test, ansi_mode_not_supported_message)
     def test_np_spark_compat_frame(self):
         from pyspark.pandas.numpy_compat import unary_np_spark_mappings, binary_np_spark_mappings
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable "pyspark.pandas.tests.test_numpy_compat NumPyCompatTests.test_np_spark_compat_frame" under ANSI

### Why are the changes needed?
Enable pandas on Spark testing with ANSI mode on.
Part of https://issues.apache.org/jira/browse/SPARK-52169.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Test change only.

```py
SPARK_ANSI_SQL_MODE=true ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.test_numpy_compat NumPyCompatTests.test_np_spark_compat_frame"

SPARK_ANSI_SQL_MODE=false ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.test_numpy_compat NumPyCompatTests.test_np_spark_compat_frame"
```

### Was this patch authored or co-authored using generative AI tooling?
No.