### PR TITLE
[SPARK-52947][SDP] Fix image path in declarative pipelines programming guide

### DIFF
--- a/docs/declarative-pipelines-programming-guide.md
+++ b/docs/declarative-pipelines-programming-guide.md
@@ -33,7 +33,7 @@ SDP is designed for both batch and streaming data processing, supporting common 
 
 The key advantage of SDP is its declarative approach - you define what tables should exist and what their contents should be, and SDP handles the orchestration, compute management, and error handling automatically.
 
-![Dataflow Graph](../img/declarative-pipelines-dataflow-graph.png)
+![Dataflow Graph](img/declarative-pipelines-dataflow-graph.png)
 
 ## Key Concepts
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Fixes the path of the diagram in the declarative pipelines programming guide to point to the right image file.

### Why are the changes needed?

The image is not rendering correctly.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Manual inspection: https://github.com/sryza/spark/blob/declarative-pipelines-img/docs/declarative-pipelines-programming-guide.md

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
