### PR TITLE
[SPARK-52877][PYTHON][FOLLOW-UP] Use columns instead of itercolumns in RecordBatch

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -793,7 +793,7 @@ class ArrowBatchUDFSerializer(ArrowStreamArrowUDFSerializer):
         for batch in super().load_stream(stream):
             columns = [
                 [conv(v) for v in column.to_pylist()] if conv is not None else column.to_pylist()
-                for column, conv in zip(batch.itercolumns(), converters)
+                for column, conv in zip(batch.columns, converters)
             ]
             if len(columns) == 0:
                 yield [[pyspark._NoValue] * batch.num_rows]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to use `columns` instead of `itercolumns` in RecordBatch, which does not exist in the old version of PyArrow.

### Why are the changes needed?

To recover the build https://github.com/apache/spark/actions/runs/16507806777/job/46682838114
This is just a temporary workaround.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No,
