### PR TITLE
[SPARK-52953][SQL] Incorrect parameter order in some ExpressionEvalHelper.checkResult() method invocations

### DIFF
--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
@@ -297,7 +297,7 @@ class AvroCatalystDataConversionSuite extends SparkFunSuite
     expected match {
       case None => assert(deserialized == None)
       case Some(d) =>
-        assert(checkResult(d, deserialized.get, dataType, exprNullable = false))
+        assert(checkResult(deserialized.get, d, dataType, exprNullable = false))
     }
   }
 

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufCatalystDataConversionSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufCatalystDataConversionSuite.scala
@@ -171,7 +171,7 @@ class ProtobufCatalystDataConversionSuite
     expected match {
       case None => assert(deserialized.isEmpty)
       case Some(d) =>
-        assert(checkResult(d, deserialized.get, dataType, exprNullable = false))
+        assert(checkResult(deserialized.get, d, dataType, exprNullable = false))
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/UnsafeRowConverterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/UnsafeRowConverterSuite.scala
@@ -676,7 +676,7 @@ class UnsafeRowConverterSuite extends SparkFunSuite with Matchers with Expressio
 
     val mapResultRow = convertBackToInternalRow(mapRow, fields4)
     val mapExpectedRow = mapRow
-    checkResult(mapExpectedRow, mapResultRow,
+    checkResult(mapResultRow, mapExpectedRow,
       exprDataType = StructType(fields4.zipWithIndex.map(f => StructField(s"c${f._2}", f._1))),
       exprNullable = false)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The method signature ExpressionEvalHelper.checkResult(result: Any, expected: Any, ...) specifies an order where _result_ comes before _expected_. However, some invocations mistakenly pass _expected_ first. This PR will correct them.


### Why are the changes needed?
To make sure we won't get incorrect comparison results or misleading error messages.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
