### PR TITLE
[SPARK-52954][PYTHON] Arrow UDF support return type coercion

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -762,7 +762,6 @@ class ArrowBatchUDFSerializer(ArrowStreamArrowUDFSerializer):
             timezone=timezone,
             safecheck=safecheck,
             assign_cols_by_name=False,
-            arrow_cast=True,
         )
         self._input_types = input_types
 

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -24,7 +24,6 @@ from itertools import groupby
 from typing import TYPE_CHECKING, Optional
 
 import pyspark
-from fontTools.misc.cython import returns
 from pyspark.errors import PySparkRuntimeError, PySparkTypeError, PySparkValueError
 from pyspark.loose_version import LooseVersion
 from pyspark.serializers import (

--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_window.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_window.py
@@ -549,6 +549,41 @@ class WindowArrowUDFTestsMixin:
                             )
                         ).show()
 
+    def test_return_type_coercion(self):
+        import pyarrow as pa
+
+        df = self.spark.range(10).withColumn("v", sf.lit(1))
+        w = Window.partitionBy("id").orderBy("v")
+
+        @arrow_udf("long", ArrowUDFType.GROUPED_AGG)
+        def agg_long(id: pa.Array) -> int:
+            assert isinstance(id, pa.Array), str(type(id))
+            return pa.scalar(value=len(id), type=pa.int64())
+
+        result1 = df.select(agg_long("v").over(w).alias("res"))
+        self.assertEqual(10, len(result1.collect()))
+
+        # long -> int coercion
+        @arrow_udf("int", ArrowUDFType.GROUPED_AGG)
+        def agg_int1(id: pa.Array) -> int:
+            assert isinstance(id, pa.Array), str(type(id))
+            return pa.scalar(value=len(id), type=pa.int64())
+
+        result2 = df.select(agg_int1("v").over(w).alias("res"))
+        self.assertEqual(10, len(result2.collect()))
+
+        # long -> int coercion, overflow
+        @arrow_udf("int", ArrowUDFType.GROUPED_AGG)
+        def agg_int2(id: pa.Array) -> int:
+            assert isinstance(id, pa.Array), str(type(id))
+            return pa.scalar(value=len(id) + 2147483647, type=pa.int64())
+
+        result3 = df.select(agg_int2("id").alias("res"))
+        with self.assertRaises(Exception):
+            # pyarrow.lib.ArrowInvalid:
+            # Integer value 2147483657 not in range: -2147483648 to 2147483647
+            result3.collect()
+
 
 class WindowArrowUDFTests(WindowArrowUDFTestsMixin, ReusedSQLTestCase):
     pass

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2146,8 +2146,8 @@ def read_udfs(pickleSer, infile, eval_type):
             PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF,
             PythonEvalType.SQL_WINDOW_AGG_ARROW_UDF,
         ):
-            # Arrow cast for type coercion is disabled by default
-            ser = ArrowStreamArrowUDFSerializer(timezone, safecheck, _assign_cols_by_name)
+            # Arrow cast for type coercion is enabled by default
+            ser = ArrowStreamArrowUDFSerializer(timezone, safecheck, _assign_cols_by_name, True)
         elif (
             eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF
             and not use_legacy_pandas_udf_conversion(runner_conf)

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2147,7 +2147,7 @@ def read_udfs(pickleSer, infile, eval_type):
             PythonEvalType.SQL_WINDOW_AGG_ARROW_UDF,
         ):
             # Arrow cast for type coercion is disabled by default
-            ser = ArrowStreamArrowUDFSerializer(timezone, safecheck, _assign_cols_by_name, False)
+            ser = ArrowStreamArrowUDFSerializer(timezone, safecheck, _assign_cols_by_name)
         elif (
             eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF
             and not use_legacy_pandas_udf_conversion(runner_conf)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Arrow UDF support return type coercion


### Why are the changes needed?
To make arrow udf support data coercion


### Does this PR introduce _any_ user-facing change?
not yet

### How was this patch tested?
added tests


### Was this patch authored or co-authored using generative AI tooling?
no