### PR TITLE
[SPARK-52945][SQL][TESTS] Split `CastSuiteBase#checkInvalidCastFromNumericType` into three methods and guarantee assertions are valid

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -568,7 +568,6 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
     } else {
       Map("functionNames" -> "`DATE_FROM_UNIX_DATE`")
     }
-    // All numeric types: `CAST_WITHOUT_SUGGESTION`
     Seq(1.toByte, 1.toShort, 1, 1L, 1.0.toFloat, 1.0).foreach { testValue =>
       val expectedError =
         createCastMismatch(Literal(testValue).dataType, DateType, errorSubClass, funcParams)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -26,7 +26,6 @@ import org.apache.spark.{SparkFunSuite, SparkIllegalArgumentException}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
-import org.apache.spark.sql.catalyst.expressions.Cast._
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
@@ -545,62 +544,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
     checkCast("0", false)
   }
 
-  protected def checkInvalidCastFromNumericType(to: DataType): Unit = {
-    cast(1.toByte, to).checkInputDataTypes() ==
-      DataTypeMismatch(
-        errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-        messageParameters = Map(
-          "srcType" -> toSQLType(Literal(1.toByte).dataType),
-          "targetType" -> toSQLType(to),
-          "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-        )
-      )
-    cast(1.toShort, to).checkInputDataTypes() ==
-      DataTypeMismatch(
-        errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-        messageParameters = Map(
-          "srcType" -> toSQLType(Literal(1.toShort).dataType),
-          "targetType" -> toSQLType(to),
-          "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-        )
-      )
-    cast(1, to).checkInputDataTypes() ==
-      DataTypeMismatch(
-        errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-        messageParameters = Map(
-          "srcType" -> toSQLType(Literal(1).dataType),
-          "targetType" -> toSQLType(to),
-          "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-        )
-      )
-    cast(1L, to).checkInputDataTypes() ==
-      DataTypeMismatch(
-        errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-        messageParameters = Map(
-          "srcType" -> toSQLType(Literal(1L).dataType),
-          "targetType" -> toSQLType(to),
-          "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-        )
-      )
-    cast(1.0.toFloat, to).checkInputDataTypes() ==
-      DataTypeMismatch(
-        errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-        messageParameters = Map(
-          "srcType" -> toSQLType(Literal(1.0.toFloat).dataType),
-          "targetType" -> toSQLType(to),
-          "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-        )
-      )
-    cast(1.0, to).checkInputDataTypes() ==
-      DataTypeMismatch(
-        errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-        messageParameters = Map(
-          "srcType" -> toSQLType(Literal(1.0).dataType),
-          "targetType" -> toSQLType(to),
-          "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-        )
-      )
-  }
+  protected def checkInvalidCastFromNumericType(to: DataType): Unit
 
   test("SPARK-16729 type checking for casting to date type") {
     assert(cast("1234", DateType).checkInputDataTypes().isSuccess)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
@@ -40,23 +40,6 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
 
   override def evalMode: EvalMode.Value = EvalMode.LEGACY
 
-  private def checkInvalidCastFromNumericType(to: DataType): Unit = {
-    // All numeric types: `CAST_WITHOUT_SUGGESTION`
-    Seq(1.toByte, 1.toShort, 1, 1L, 1.0.toFloat, 1.0).foreach { testValue =>
-      val expectedError =
-        createCastMismatch(Literal(testValue).dataType, to, "CAST_WITHOUT_SUGGESTION")
-      assert(cast(testValue, to).checkInputDataTypes() == expectedError)
-    }
-  }
-
-  override protected def checkInvalidCastFromNumericTypeToDateType(): Unit = {
-    checkInvalidCastFromNumericType(DateType)
-  }
-
-  override protected def checkInvalidCastFromNumericTypeToTimestampNTZType(): Unit = {
-    checkInvalidCastFromNumericType(TimestampNTZType)
-  }
-
   test("null cast #2") {
     import DataTypeTestUtils._
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
@@ -23,10 +23,12 @@ import java.time.temporal.ChronoUnit
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
 import org.apache.spark.sql.catalyst.analysis.TypeCoercionSuite
 import org.apache.spark.sql.catalyst.expressions.aggregate.{CollectList, CollectSet}
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
+import org.apache.spark.sql.errors.DataTypeErrors.toSQLType
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.DayTimeIntervalType.{DAY, HOUR, MINUTE, SECOND}
@@ -39,6 +41,63 @@ import org.apache.spark.unsafe.types.UTF8String
 class CastWithAnsiOffSuite extends CastSuiteBase {
 
   override def evalMode: EvalMode.Value = EvalMode.LEGACY
+
+  override protected def checkInvalidCastFromNumericType(to: DataType): Unit = {
+    assert(cast(1.toByte, to).checkInputDataTypes() ==
+      DataTypeMismatch(
+        errorSubClass = "CAST_WITHOUT_SUGGESTION",
+        messageParameters = Map(
+          "srcType" -> toSQLType(Literal(1.toByte).dataType),
+          "targetType" -> toSQLType(to)
+        )
+      )
+    )
+    assert(cast(1.toShort, to).checkInputDataTypes() ==
+      DataTypeMismatch(
+        errorSubClass = "CAST_WITHOUT_SUGGESTION",
+        messageParameters = Map(
+          "srcType" -> toSQLType(Literal(1.toShort).dataType),
+          "targetType" -> toSQLType(to)
+        )
+      )
+    )
+    assert(cast(1, to).checkInputDataTypes() ==
+      DataTypeMismatch(
+        errorSubClass = "CAST_WITHOUT_SUGGESTION",
+        messageParameters = Map(
+          "srcType" -> toSQLType(Literal(1).dataType),
+          "targetType" -> toSQLType(to)
+        )
+      )
+    )
+    assert(cast(1L, to).checkInputDataTypes() ==
+      DataTypeMismatch(
+        errorSubClass = "CAST_WITHOUT_SUGGESTION",
+        messageParameters = Map(
+          "srcType" -> toSQLType(Literal(1L).dataType),
+          "targetType" -> toSQLType(to)
+        )
+      )
+    )
+    assert(cast(1.0.toFloat, to).checkInputDataTypes() ==
+      DataTypeMismatch(
+        errorSubClass = "CAST_WITHOUT_SUGGESTION",
+        messageParameters = Map(
+          "srcType" -> toSQLType(Literal(1.0.toFloat).dataType),
+          "targetType" -> toSQLType(to)
+        )
+      )
+    )
+    assert(cast(1.0, to).checkInputDataTypes() ==
+      DataTypeMismatch(
+        errorSubClass = "CAST_WITHOUT_SUGGESTION",
+        messageParameters = Map(
+          "srcType" -> toSQLType(Literal(1.0).dataType),
+          "targetType" -> toSQLType(to)
+        )
+      )
+    )
+  }
 
   test("null cast #2") {
     import DataTypeTestUtils._

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
@@ -39,186 +39,48 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
 
   override def evalMode: EvalMode.Value = EvalMode.ANSI
 
-  override protected def checkInvalidCastFromNumericType(to: DataType): Unit = to match {
-    case BinaryType =>
-      assert(cast(1.toByte, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITH_CONF_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.toByte).dataType),
-            "targetType" -> toSQLType(to),
-            "config" -> "\"spark.sql.ansi.enabled\"",
-            "configVal" -> "'false'"
-          )
-        )
-      )
-      assert(cast(1.toShort, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITH_CONF_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.toShort).dataType),
-            "targetType" -> toSQLType(to),
-            "config" -> "\"spark.sql.ansi.enabled\"",
-            "configVal" -> "'false'"
-          )
-        )
-      )
-      assert(cast(1, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITH_CONF_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1).dataType),
-            "targetType" -> toSQLType(to),
-            "config" -> "\"spark.sql.ansi.enabled\"",
-            "configVal" -> "'false'"
-          )
-        )
-      )
-      assert(cast(1L, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITH_CONF_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1L).dataType),
-            "targetType" -> toSQLType(to),
-            "config" -> "\"spark.sql.ansi.enabled\"",
-            "configVal" -> "'false'"
-          )
-        )
-      )
-      assert(cast(1.0.toFloat, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.0.toFloat).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-      assert(cast(1.0, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.0).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-    case TimestampNTZType =>
-      assert(cast(1.toByte, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.toByte).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-      assert(cast(1.toShort, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.toShort).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-      assert(cast(1, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-      assert(cast(1L, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1L).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-      assert(cast(1.0.toFloat, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.0.toFloat).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-      assert(cast(1.0, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.0).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-    case _ =>
-      assert(cast(1.toByte, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.toByte).dataType),
-            "targetType" -> toSQLType(to),
-            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-          )
-        )
-      )
-      assert(cast(1.toShort, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.toShort).dataType),
-            "targetType" -> toSQLType(to),
-            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-          )
-        )
-      )
-      assert(cast(1, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1).dataType),
-            "targetType" -> toSQLType(to),
-            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-          )
-        )
-      )
-      assert(cast(1L, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1L).dataType),
-            "targetType" -> toSQLType(to),
-            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-          )
-        )
-      )
-      assert(cast(1.0.toFloat, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.0.toFloat).dataType),
-            "targetType" -> toSQLType(to),
-            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-          )
-        )
-      )
-      assert(cast(1.0, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.0).dataType),
-            "targetType" -> toSQLType(to),
-            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-          )
-        )
-      )
+  override protected def checkInvalidCastFromNumericTypeToDateType(): Unit = {
+    // All numeric types: `CAST_WITH_FUNC_SUGGESTION`
+    val funcParams = Map("functionNames" -> "`DATE_FROM_UNIX_DATE`")
+    Seq(1.toByte, 1.toShort, 1, 1L, 1.0.toFloat, 1.0).foreach { testValue =>
+      checkNumericTypeCast(
+        testValue, Literal(testValue).dataType, DateType, "CAST_WITH_FUNC_SUGGESTION", funcParams)
+    }
+  }
+
+  override protected def checkInvalidCastFromNumericTypeToTimestampNTZType(): Unit = {
+    // All numeric types: `CAST_WITHOUT_SUGGESTION`
+    Seq(1.toByte, 1.toShort, 1, 1L, 1.0.toFloat, 1.0).foreach { testValue =>
+      checkNumericTypeCast(
+        testValue, Literal(testValue).dataType, TimestampNTZType, "CAST_WITHOUT_SUGGESTION")
+    }
+  }
+
+  protected def checkInvalidCastFromNumericTypeToBinaryType(): Unit = {
+    // Integer types: suggest config change
+    val configParams = Map(
+      "config" -> "\"spark.sql.ansi.enabled\"",
+      "configVal" -> "'false'"
+    )
+    checkNumericTypeCast(1.toByte, ByteType, BinaryType, "CAST_WITH_CONF_SUGGESTION", configParams)
+    checkNumericTypeCast(
+      1.toShort, ShortType, BinaryType, "CAST_WITH_CONF_SUGGESTION", configParams)
+    checkNumericTypeCast(1, IntegerType, BinaryType, "CAST_WITH_CONF_SUGGESTION", configParams)
+    checkNumericTypeCast(1L, LongType, BinaryType, "CAST_WITH_CONF_SUGGESTION", configParams)
+
+    // Floating types: no suggestion
+    checkNumericTypeCast(1.0.toFloat, FloatType, BinaryType, "CAST_WITHOUT_SUGGESTION")
+    checkNumericTypeCast(1.0, DoubleType, BinaryType, "CAST_WITHOUT_SUGGESTION")
+  }
+
+  protected def checkNumericTypeCast(
+      testValue: Any,
+      srcType: DataType,
+      to: DataType,
+      expectedErrorClass: String,
+      extraParams: Map[String, String] = Map.empty): Unit = {
+    val expectedError = createCastMismatch(srcType, to, expectedErrorClass, extraParams)
+    assert(cast(testValue, to).checkInputDataTypes() == expectedError)
   }
 
   private def isTryCast = evalMode == EvalMode.TRY
@@ -324,7 +186,7 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
 
   test("ANSI mode: disallow type conversions between Numeric types and Date type") {
     import DataTypeTestUtils.numericTypes
-    checkInvalidCastFromNumericType(DateType)
+    checkInvalidCastFromNumericTypeToDateType()
     verifyCastFailure(
       cast(Literal(0L), DateType),
       DataTypeMismatch(
@@ -350,7 +212,7 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
 
   test("ANSI mode: disallow type conversions between Numeric types and Binary type") {
     import DataTypeTestUtils.numericTypes
-    checkInvalidCastFromNumericType(BinaryType)
+    checkInvalidCastFromNumericTypeToBinaryType()
     val binaryLiteral = Literal(new Array[Byte](1.toByte), BinaryType)
     numericTypes.foreach { numericType =>
       assert(cast(binaryLiteral, numericType).checkInputDataTypes() ==

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeConstants.MILLIS_PER_SECOND
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, UTC}
 import org.apache.spark.sql.errors.QueryErrorsBase
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.{UTF8String, VariantVal}
 
@@ -52,8 +53,8 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
 
     // Integer types: suggest config change
     val configParams = Map(
-      "config" -> "\"spark.sql.ansi.enabled\"",
-      "configVal" -> "'false'"
+      "config" -> toSQLConf(SQLConf.ANSI_ENABLED.key),
+      "configVal" -> toSQLValue("false", StringType)
     )
     checkNumericTypeCast(1.toByte, ByteType, BinaryType, "CAST_WITH_CONF_SUGGESTION", configParams)
     checkNumericTypeCast(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
@@ -39,6 +39,188 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
 
   override def evalMode: EvalMode.Value = EvalMode.ANSI
 
+  override protected def checkInvalidCastFromNumericType(to: DataType): Unit = to match {
+    case BinaryType =>
+      assert(cast(1.toByte, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITH_CONF_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.toByte).dataType),
+            "targetType" -> toSQLType(to),
+            "config" -> "\"spark.sql.ansi.enabled\"",
+            "configVal" -> "'false'"
+          )
+        )
+      )
+      assert(cast(1.toShort, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITH_CONF_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.toShort).dataType),
+            "targetType" -> toSQLType(to),
+            "config" -> "\"spark.sql.ansi.enabled\"",
+            "configVal" -> "'false'"
+          )
+        )
+      )
+      assert(cast(1, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITH_CONF_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1).dataType),
+            "targetType" -> toSQLType(to),
+            "config" -> "\"spark.sql.ansi.enabled\"",
+            "configVal" -> "'false'"
+          )
+        )
+      )
+      assert(cast(1L, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITH_CONF_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1L).dataType),
+            "targetType" -> toSQLType(to),
+            "config" -> "\"spark.sql.ansi.enabled\"",
+            "configVal" -> "'false'"
+          )
+        )
+      )
+      assert(cast(1.0.toFloat, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.0.toFloat).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+      assert(cast(1.0, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.0).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+    case TimestampNTZType =>
+      assert(cast(1.toByte, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.toByte).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+      assert(cast(1.toShort, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.toShort).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+      assert(cast(1, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+      assert(cast(1L, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1L).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+      assert(cast(1.0.toFloat, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.0.toFloat).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+      assert(cast(1.0, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.0).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+    case _ =>
+      assert(cast(1.toByte, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.toByte).dataType),
+            "targetType" -> toSQLType(to),
+            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
+          )
+        )
+      )
+      assert(cast(1.toShort, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.toShort).dataType),
+            "targetType" -> toSQLType(to),
+            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
+          )
+        )
+      )
+      assert(cast(1, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1).dataType),
+            "targetType" -> toSQLType(to),
+            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
+          )
+        )
+      )
+      assert(cast(1L, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1L).dataType),
+            "targetType" -> toSQLType(to),
+            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
+          )
+        )
+      )
+      assert(cast(1.0.toFloat, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.0.toFloat).dataType),
+            "targetType" -> toSQLType(to),
+            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
+          )
+        )
+      )
+      assert(cast(1.0, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.0).dataType),
+            "targetType" -> toSQLType(to),
+            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
+          )
+        )
+      )
+  }
+
   private def isTryCast = evalMode == EvalMode.TRY
 
   private def testIntMaxAndMin(dt: DataType): Unit = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
@@ -64,8 +64,9 @@ class TryCastSuite extends CastWithAnsiOnSuite {
   override protected def checkInvalidCastFromNumericTypeToBinaryType(): Unit = {
     // All numeric types: `CAST_WITHOUT_SUGGESTION`
     Seq(1.toByte, 1.toShort, 1, 1L, 1.0.toFloat, 1.0).foreach { testValue =>
-      checkNumericTypeCast(
-        testValue, Literal(testValue).dataType, BinaryType, "CAST_WITHOUT_SUGGESTION")
+      val expectedError =
+        createCastMismatch(Literal(testValue).dataType, BinaryType, "CAST_WITHOUT_SUGGESTION")
+      assert(cast(testValue, BinaryType).checkInputDataTypes() == expectedError)
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
@@ -21,7 +21,6 @@ import scala.reflect.ClassTag
 
 import org.apache.spark.{SparkFunSuite, SparkThrowable}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.UTC_OPT
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
@@ -62,178 +61,12 @@ class TryCastSuite extends CastWithAnsiOnSuite {
     checkEvaluation(cast(l, to), tryCastResult, InternalRow(l.value))
   }
 
-  override protected def checkInvalidCastFromNumericType(to: DataType): Unit = to match {
-    case BinaryType =>
-      assert(cast(1.toByte, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.toByte).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-      assert(cast(1.toShort, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.toShort).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-      assert(cast(1, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-      assert(cast(1L, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1L).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-      assert(cast(1.0.toFloat, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.0.toFloat).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-      assert(cast(1.0, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.0).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-    case TimestampNTZType =>
-      assert(cast(1.toByte, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.toByte).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-      assert(cast(1.toShort, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.toShort).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-      assert(cast(1, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-      assert(cast(1L, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1L).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-      assert(cast(1.0.toFloat, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.0.toFloat).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-      assert(cast(1.0, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITHOUT_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.0).dataType),
-            "targetType" -> toSQLType(to)
-          )
-        )
-      )
-    case _ =>
-      assert(cast(1.toByte, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.toByte).dataType),
-            "targetType" -> toSQLType(to),
-            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-          )
-        )
-      )
-      assert(cast(1.toShort, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.toShort).dataType),
-            "targetType" -> toSQLType(to),
-            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-          )
-        )
-      )
-      assert(cast(1, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1).dataType),
-            "targetType" -> toSQLType(to),
-            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-          )
-        )
-      )
-      assert(cast(1L, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1L).dataType),
-            "targetType" -> toSQLType(to),
-            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-          )
-        )
-      )
-      assert(cast(1.0.toFloat, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.0.toFloat).dataType),
-            "targetType" -> toSQLType(to),
-            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-          )
-        )
-      )
-      assert(cast(1.0, to).checkInputDataTypes() ==
-        DataTypeMismatch(
-          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
-          messageParameters = Map(
-            "srcType" -> toSQLType(Literal(1.0).dataType),
-            "targetType" -> toSQLType(to),
-            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
-          )
-        )
-      )
+  override protected def checkInvalidCastFromNumericTypeToBinaryType(): Unit = {
+    // All numeric types: `CAST_WITHOUT_SUGGESTION`
+    Seq(1.toByte, 1.toShort, 1, 1L, 1.0.toFloat, 1.0).foreach { testValue =>
+      checkNumericTypeCast(
+        testValue, Literal(testValue).dataType, BinaryType, "CAST_WITHOUT_SUGGESTION")
+    }
   }
 
   test("print string") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
@@ -21,6 +21,7 @@ import scala.reflect.ClassTag
 
 import org.apache.spark.{SparkFunSuite, SparkThrowable}
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.UTC_OPT
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
@@ -59,6 +60,180 @@ class TryCastSuite extends CastWithAnsiOnSuite {
   override def checkCastToNumericError(l: Literal, to: DataType,
       expectedDataTypeInErrorMsg: DataType, tryCastResult: Any): Unit = {
     checkEvaluation(cast(l, to), tryCastResult, InternalRow(l.value))
+  }
+
+  override protected def checkInvalidCastFromNumericType(to: DataType): Unit = to match {
+    case BinaryType =>
+      assert(cast(1.toByte, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.toByte).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+      assert(cast(1.toShort, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.toShort).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+      assert(cast(1, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+      assert(cast(1L, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1L).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+      assert(cast(1.0.toFloat, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.0.toFloat).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+      assert(cast(1.0, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.0).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+    case TimestampNTZType =>
+      assert(cast(1.toByte, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.toByte).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+      assert(cast(1.toShort, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.toShort).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+      assert(cast(1, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+      assert(cast(1L, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1L).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+      assert(cast(1.0.toFloat, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.0.toFloat).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+      assert(cast(1.0, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITHOUT_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.0).dataType),
+            "targetType" -> toSQLType(to)
+          )
+        )
+      )
+    case _ =>
+      assert(cast(1.toByte, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.toByte).dataType),
+            "targetType" -> toSQLType(to),
+            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
+          )
+        )
+      )
+      assert(cast(1.toShort, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.toShort).dataType),
+            "targetType" -> toSQLType(to),
+            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
+          )
+        )
+      )
+      assert(cast(1, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1).dataType),
+            "targetType" -> toSQLType(to),
+            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
+          )
+        )
+      )
+      assert(cast(1L, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1L).dataType),
+            "targetType" -> toSQLType(to),
+            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
+          )
+        )
+      )
+      assert(cast(1.0.toFloat, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.0.toFloat).dataType),
+            "targetType" -> toSQLType(to),
+            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
+          )
+        )
+      )
+      assert(cast(1.0, to).checkInputDataTypes() ==
+        DataTypeMismatch(
+          errorSubClass = "CAST_WITH_FUNC_SUGGESTION",
+          messageParameters = Map(
+            "srcType" -> toSQLType(Literal(1.0).dataType),
+            "targetType" -> toSQLType(to),
+            "functionNames" -> "`DATE_FROM_UNIX_DATE`"
+          )
+        )
+      )
   }
 
   test("print string") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Due to the absence of `assert` statements, the `CastSuiteBase#checkInvalidCastFromNumericType` method previously performed no assertion checks. 

Additionally, since `checkInvalidCastFromNumericType` had significant variations in target type validation logic across different `EvalMode` contexts, this pr refactors the method into three specialized methods to ensure robust assertion enforcement:  

- `checkInvalidCastFromNumericTypeToDateType`  
- `checkInvalidCastFromNumericTypeToTimestampNTZType`  
- `checkInvalidCastFromNumericTypeToBinaryType` 

### Why are the changes needed?
To address the missing assertion validation in `CastSuiteBase`.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No