### PR TITLE
[SPARK-52961][PYTHON] Fix Arrow-optimized Python UDTF with 0-arg eval on lateral join

### DIFF
--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -1706,18 +1706,19 @@ def read_udtf(pickleSer, infile, eval_type):
                     else:
                         yield from res
 
-            def evaluate(*args: pd.Series):
+            def evaluate(*args: pd.Series, num_rows=1):
                 if len(args) == 0:
-                    res = func()
-                    yield verify_result(pd.DataFrame(check_return_value(res))), arrow_return_type
+                    for _ in range(num_rows):
+                        yield verify_result(
+                            pd.DataFrame(check_return_value(func()))
+                        ), arrow_return_type
                 else:
                     # Create tuples from the input pandas Series, each tuple
                     # represents a row across all Series.
                     row_tuples = zip(*args)
                     for row in row_tuples:
-                        res = func(*row)
                         yield verify_result(
-                            pd.DataFrame(check_return_value(res))
+                            pd.DataFrame(check_return_value(func(*row)))
                         ), arrow_return_type
 
             return evaluate
@@ -1739,7 +1740,7 @@ def read_udtf(pickleSer, infile, eval_type):
                 for a in it:
                     # The eval function yields an iterator. Each element produced by this
                     # iterator is a tuple in the form of (pandas.DataFrame, arrow_return_type).
-                    yield from eval(*[a[o] for o in args_kwargs_offsets])
+                    yield from eval(*[a[o] for o in args_kwargs_offsets], num_rows=len(a[0]))
                 if terminate is not None:
                     yield from terminate()
             except SkipRestOfInputTableException:
@@ -1867,10 +1868,11 @@ def read_udtf(pickleSer, infile, eval_type):
                 except Exception as e:
                     raise_conversion_error(e)
 
-            def evaluate(*args: pa.ChunkedArray):
+            def evaluate(*args: pa.ChunkedArray, num_rows=1):
                 if len(args) == 0:
-                    for batch in verify_result(convert_to_arrow(func())).to_batches():
-                        yield batch, arrow_return_type
+                    for _ in range(num_rows):
+                        for batch in verify_result(convert_to_arrow(func())).to_batches():
+                            yield batch, arrow_return_type
 
                 else:
                     list_args = list(args)
@@ -1903,7 +1905,7 @@ def read_udtf(pickleSer, infile, eval_type):
                 for a in it:
                     # The eval function yields an iterator. Each element produced by this
                     # iterator is a tuple in the form of (pyarrow.RecordBatch, arrow_return_type).
-                    yield from eval(*[a[o] for o in args_kwargs_offsets])
+                    yield from eval(*[a[o] for o in args_kwargs_offsets], num_rows=a.num_rows)
                 if terminate is not None:
                     yield from terminate()
             except SkipRestOfInputTableException:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes Arrow-optimized Python UDTF with 0-arg eval on lateral join.

### Why are the changes needed?

The Arrow-optimized Python UDTF with 0-arg returns less rows than expected.
Both legacy and non-legacy code paths are affected.

```py
>>> @udtf(returnType="i: int", useArrow=True)
... class TestUDTF:
...     def eval(self):
...         yield 0,
...
>>> spark.range(3, numPartitions=1).lateralJoin(TestUDTF()).show()
+---+---+
| id|  i|
+---+---+
|  0|  0|
+---+---+
```

It should be:

```py
+---+---+
| id|  i|
+---+---+
|  0|  0|
|  1|  0|
|  2|  0|
+---+---+
```

### Does this PR introduce _any_ user-facing change?

Yes, Arrow-optimized Python UDTF with 0-arg eval will work well with lateral join.

### How was this patch tested?

Added the related test.

### Was this patch authored or co-authored using generative AI tooling?

No.
