### PR TITLE
[SPARK-52960][SQL] Show subtree string in LogicalQueryStage toString

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/LogicalQueryStage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/LogicalQueryStage.scala
@@ -82,4 +82,32 @@ case class LogicalQueryStage(
     case _: QueryStageExec => true
     case _ => false
   }
+
+  override def generateTreeString(
+    depth: Int,
+    lastChildren: java.util.ArrayList[Boolean],
+    append: String => Unit,
+    verbose: Boolean,
+    prefix: String = "",
+    addSuffix: Boolean = false,
+    maxFields: Int,
+    printNodeId: Boolean,
+    printOutputColumns: Boolean,
+    indent: Int = 0): Unit = {
+    super.generateTreeString(depth,
+      lastChildren,
+      append,
+      verbose,
+      prefix,
+      addSuffix,
+      maxFields,
+      printNodeId,
+      printOutputColumns,
+      indent)
+    lastChildren.add(true)
+    logicalPlan.generateTreeString(
+      depth + 1, lastChildren, append, verbose, "", false, maxFields, printNodeId,
+      printOutputColumns, indent)
+    lastChildren.remove(lastChildren.size() - 1)
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/LogicalQueryStage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/LogicalQueryStage.scala
@@ -84,16 +84,16 @@ case class LogicalQueryStage(
   }
 
   override def generateTreeString(
-    depth: Int,
-    lastChildren: java.util.ArrayList[Boolean],
-    append: String => Unit,
-    verbose: Boolean,
-    prefix: String = "",
-    addSuffix: Boolean = false,
-    maxFields: Int,
-    printNodeId: Boolean,
-    printOutputColumns: Boolean,
-    indent: Int = 0): Unit = {
+      depth: Int,
+      lastChildren: java.util.ArrayList[Boolean],
+      append: String => Unit,
+      verbose: Boolean,
+      prefix: String = "",
+      addSuffix: Boolean = false,
+      maxFields: Int,
+      printNodeId: Boolean,
+      printOutputColumns: Boolean,
+      indent: Int = 0): Unit = {
     super.generateTreeString(depth,
       lastChildren,
       append,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Show subtree string in LogicalQueryStage toString, just like how we did with physical `QueryStageExec`

before:
```
RepartitionByExpression [key1#262L]
+- Project [key1#262L]
   +- Join Inner, (key1#262L = key2#265L), rightHint=(strategy=no_broadcast_hash)
      :- LogicalQueryStage Project [(id#261L % 3) AS key1#262L], ShuffleQueryStage 0
      +- LogicalQueryStage Project [(id#264L % 1) AS key2#265L], ShuffleQueryStage 1
```

after:
```
RepartitionByExpression [key1#262L]
+- Project [key1#262L]
   +- Join Inner, (key1#262L = key2#265L), rightHint=(strategy=no_broadcast_hash)
      :- LogicalQueryStage Project [(id#261L % 3) AS key1#262L], ShuffleQueryStage 0
      :  +- Project [(id#261L % 3) AS key1#262L]
      :     +- Filter isnotnull((id#261L % 3))
      :        +- Range (0, 1000, step=1, splits=Some(10))
      +- LogicalQueryStage Project [(id#264L % 1) AS key2#265L], ShuffleQueryStage 1
         +- Project [(id#264L % 1) AS key2#265L]
            +- Filter isnotnull((id#264L % 1))
               +- Range (0, 1000, step=1, splits=Some(10))
```

This is especially useful when query plan is complicated where we have deeply nested logical query stage.

### Why are the changes needed?
Better debugging.

### Does this PR introduce _any_ user-facing change?

NO


### How was this patch tested?

N/A

### Was this patch authored or co-authored using generative AI tooling?
NO