### PR TITLE
[SPARK-52944][CORE][TESTS][FOLLOWUP] Avoid hard-coding the checksum algorithm name

### DIFF
--- a/core/src/test/scala/org/apache/spark/SortShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SortShuffleSuite.scala
@@ -26,7 +26,7 @@ import org.apache.commons.io.filefilter.TrueFileFilter
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers._
 
-import org.apache.spark.internal.config.SHUFFLE_MANAGER
+import org.apache.spark.internal.config.{SHUFFLE_CHECKSUM_ALGORITHM, SHUFFLE_MANAGER}
 import org.apache.spark.rdd.ShuffledRDD
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
 import org.apache.spark.shuffle.sort.SortShuffleManager
@@ -70,7 +70,8 @@ class SortShuffleSuite extends ShuffleSuite with BeforeAndAfterAll {
     // Ensure that the shuffle actually created files that will need to be cleaned up
     val filesCreatedByShuffle = getAllFiles -- filesBeforeShuffle
     filesCreatedByShuffle.map(_.getName) should be(
-      Set("shuffle_0_0_0.data", "shuffle_0_0_0.checksum.ADLER32", "shuffle_0_0_0.index"))
+      Set("shuffle_0_0_0.data", s"shuffle_0_0_0.checksum.${conf.get(SHUFFLE_CHECKSUM_ALGORITHM)}",
+        "shuffle_0_0_0.index"))
     // Check that the cleanup actually removes the files
     sc.env.blockManager.master.removeShuffle(0, blocking = true)
     for (file <- filesCreatedByShuffle) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR retrieves the shuffle checksum algorithm name via `conf.get(SHUFFLE_CHECKSUM_ALGORITHM)` to eliminate hard-coding.

### Why are the changes needed?
Address https://github.com/apache/spark/pull/51654#discussion_r2231775664


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No
