### PR TITLE
[SPARK-52933][K8S] Verify if the executor cpu request exceeds limit

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -227,8 +227,8 @@ private[spark] class BasicExecutorFeatureStep(
       executorLimitCores.map { limitCores =>
         val executorCpuLimitQuantity = new Quantity(limitCores)
         if (executorCpuLimitQuantity.compareTo(executorCpuQuantity) < 0) {
-          throw new SparkException(
-              "The executor cpu request should be less than or equal to cpu limit")
+          throw new SparkException(s"The executor cpu request ($executorCpuQuantity) should be " +
+            s"less than or equal to cpu limit ($executorCpuLimitQuantity)")
         }
         new ContainerBuilder(executorContainerWithConfVolume)
           .editResources()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -226,6 +226,10 @@ private[spark] class BasicExecutorFeatureStep(
     val containerWithLimitCores = if (isDefaultProfile) {
       executorLimitCores.map { limitCores =>
         val executorCpuLimitQuantity = new Quantity(limitCores)
+        if (executorCpuLimitQuantity.compareTo(executorCpuQuantity) < 0) {
+          throw new SparkException(
+              "The executor cpu request should be less than or equal to cpu limit")
+        }
         new ContainerBuilder(executorContainerWithConfVolume)
           .editResources()
           .addToLimits("cpu", executorCpuLimitQuantity)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -129,7 +129,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
         defaultProfile)
       val executor = step.configurePod(SparkPod.initialPod())
     }.getMessage()
-    assert(error.contains("The executor cpu request should be less than or equal to cpu limit"))
+    assert(error.contains("cpu request (2) should be less than or equal to cpu limit (1)"))
   }
 
   test("basic executor pod with resources") {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -126,7 +126,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     val error = intercept[SparkException] {
       initDefaultProfile(baseConf)
       val step = new BasicExecutorFeatureStep(newExecutorConf(), new SecurityManager(baseConf),
-      defaultProfile)
+        defaultProfile)
       val executor = step.configurePod(SparkPod.initialPod())
     }.getMessage()
     assert(error.contains("The executor cpu request should be less than or equal to cpu limit"))

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -120,6 +120,18 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(error.contains("You must specify an amount for gpu"))
   }
 
+  test("SPARK-52933: Verify if the executor cpu request exceeds limit") {
+    baseConf.set(KUBERNETES_EXECUTOR_REQUEST_CORES, "2")
+    baseConf.set(KUBERNETES_EXECUTOR_LIMIT_CORES, "1")
+    val error = intercept[SparkException] {
+      initDefaultProfile(baseConf)
+      val step = new BasicExecutorFeatureStep(newExecutorConf(), new SecurityManager(baseConf),
+      defaultProfile)
+      val executor = step.configurePod(SparkPod.initialPod())
+    }.getMessage()
+    assert(error.contains("The executor cpu request should be less than or equal to cpu limit"))
+  }
+
   test("basic executor pod with resources") {
     val fpgaResourceID = new ResourceID(SPARK_EXECUTOR_PREFIX, FPGA)
     val gpuExecutorResourceID = new ResourceID(SPARK_EXECUTOR_PREFIX, GPU)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to verify if the executor pod's cpu request exceeds cpu limit or not in order to make it fail-fast.

### Why are the changes needed?

Since Spark creates many executor pods, we had better do fail-fast on the invalid settings before submitting invalid pod spec to K8s cluster. It wastes lots of K8s resources.

Note that newly added validation check only happens when `spark.kubernetes.executor.limit.cores` is given explicitly.

### Does this PR introduce _any_ user-facing change?

No behavior change eventually because the existing misconfigured `spark.kubernetes.executor.limit.cores` means Spark driver cannot get any executor pods and the job will hang or fail eventually.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.