### PR TITLE
[SPARK-52853][TESTS][FOLLOW-UP] Import SDP module when connect dependencies are available

### DIFF
--- a/python/pyspark/pipelines/tests/test_block_session_mutations.py
+++ b/python/pyspark/pipelines/tests/test_block_session_mutations.py
@@ -25,11 +25,12 @@ from pyspark.testing.connectutils import (
     connect_requirement_message,
 )
 
-from pyspark.pipelines.block_session_mutations import (
-    block_session_mutations,
-    BLOCKED_METHODS,
-    ERROR_CLASS,
-)
+if should_test_connect:
+    from pyspark.pipelines.block_session_mutations import (
+        block_session_mutations,
+        BLOCKED_METHODS,
+        ERROR_CLASS,
+    )
 
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message or "Connect not available")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/51590 that imports SDP module when connect dependencies are available

### Why are the changes needed?

To make the builds without Spark Connect dependencies work, e.g., https://github.com/apache/spark/actions/runs/16552497456/job/46809414074

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.
