### PR TITLE
[SPARK-52975][SQL] Simplify field names in pushdown join sql

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/join/MySQLJoinPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/join/MySQLJoinPushdownIntegrationSuite.scala
@@ -43,6 +43,8 @@ class MySQLJoinPushdownIntegrationSuite
 
   override def caseConvert(identifier: String): String = identifier.toUpperCase(Locale.ROOT)
 
+  override def remainColumnCase(identifier: String): String = "`" + identifier + "`"
+
   // This method comes from DockerJDBCIntegrationSuite
   override def dataPreparation(connection: Connection): Unit = {
     super.dataPreparation()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
+import java.util.Locale
+
 import scala.collection.mutable
 
 import org.apache.spark.internal.LogKeys.{AGGREGATE_FUNCTIONS, GROUP_BY_EXPRS, POST_SCAN_FILTERS, PUSHED_FILTERS, RELATION_NAME, RELATION_OUTPUT}
@@ -208,7 +210,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
   ): (Array[SupportsPushDownJoin.ColumnWithAlias],
     Array[SupportsPushDownJoin.ColumnWithAlias]) = {
     // Normalize all column names to lowercase for case-insensitive comparison
-    val normalizeCase: String => String = _.toLowerCase()
+    val normalizeCase: String => String = _.toLowerCase(Locale.ROOT)
 
     // Count occurrences of each column name (case-insensitive)
     val allRequiredColumnNames = leftSideRequiredColumnNames ++ rightSideRequiredColumnNames

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -230,7 +230,11 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
         // Update state: next suffix index and mark alias as used
         aliasSuffixIndex(name) = attempt + 1
         allClaimedAliases.add(candidate)
-        new SupportsPushDownJoin.ColumnWithAlias(name, candidate)
+        if (name == candidate) {
+          new SupportsPushDownJoin.ColumnWithAlias(name, null)
+        } else {
+          new SupportsPushDownJoin.ColumnWithAlias(name, candidate)
+        }
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -206,7 +206,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
       allRequiredColumnNames.groupBy(identity).view.mapValues(_.size).toMap
     // Use Set for O(1) lookups when checking existing column names, claim all names
     // that appears only once to ensure they have highest priority.
-    val allClaimedAliases = mutable.HashSet.empty ++ allNameCounts.filter(_._2 == 1).keySet
+    val allClaimedAliases = mutable.Set.from(allNameCounts.filter(_._2 == 1).keys)
 
     // Track the next suffix index for each column name (starts at 0) to avoid extreme worst
     // case of O(n^2) alias generation.

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourcePushdownTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourcePushdownTestUtils.scala
@@ -182,9 +182,7 @@ trait DataSourcePushdownTestUtils extends ExplainSuiteHelper {
 
           assert(dfSchema.length == schema.length)
           dfSchema.fields.zip(schema.fields).foreach { case (f1, f2) =>
-            if (f2.name.nonEmpty) {
-              assert(f1.name == f2.name)
-            }
+            assert(f1.name == f2.name)
             assert(f1.dataType == f2.dataType)
             assert(f1.nullable == f2.nullable)
           }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DSV2JoinPushDownAliasGenerationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DSV2JoinPushDownAliasGenerationSuite.scala
@@ -17,10 +17,12 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
+import java.util.Locale
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.connector.read.SupportsPushDownJoin.ColumnWithAlias
 
-class V2ScanRelationPushDownSuite extends SparkFunSuite {
+class DSV2JoinPushDownAliasGenerationSuite extends SparkFunSuite {
 
   private def assertAliases(
     leftInput: Array[String],
@@ -31,11 +33,11 @@ class V2ScanRelationPushDownSuite extends SparkFunSuite {
     val (actualLeft, actualRight) = V2ScanRelationPushDown
       .generateColumnAliasesForDuplicatedName(leftInput, rightInput)
 
-    val uniqName : ColumnWithAlias => String = col => {
-      if (col.alias() == null) col.colName() else col.alias().toLowerCase()
+    val uniqName: ColumnWithAlias => String = col => {
+      if (col.alias() == null) col.colName() else col.alias().toLowerCase(Locale.ROOT)
     }
     // Ensure no duplicate column names after ignoring capitalization
-    assert((actualLeft++actualRight).map(uniqName).distinct.length
+    assert((actualLeft ++ actualRight).map(uniqName).distinct.length
       == actualLeft.length + actualRight.length)
 
     assert(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDownSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDownSuite.scala
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.connector.read.SupportsPushDownJoin.ColumnWithAlias
+
+class V2ScanRelationPushDownSuite extends SparkFunSuite {
+
+  private def assertAliases(
+                             leftInput: Array[String],
+                             rightInput: Array[String],
+                             expectedLeft: Array[ColumnWithAlias],
+                             expectedRight: Array[ColumnWithAlias]
+                           ): Unit = {
+    val (actualLeft, actualRight) = V2ScanRelationPushDown
+      .generateColumnAliasesForDuplicatedName(leftInput, rightInput)
+
+    assert(
+      actualLeft === expectedLeft,
+      s"""Left side aliases mismatch.
+         |Expected: ${expectedLeft.map(_.alias()).mkString(", ")}
+         |Actual: ${actualLeft.map(_.alias()).mkString(", ")}""".stripMargin
+    )
+
+    assert(
+      actualRight === expectedRight,
+      s"""Right side aliases mismatch.
+         |Expected: ${expectedRight.map(_.alias()).mkString(", ")}
+         |Actual: ${actualRight.map(_.alias()).mkString(", ")}""".stripMargin
+    )
+  }
+
+  test("Basic case with no duplicate column names") {
+    assertAliases(
+      leftInput = Array("id", "name"),
+      rightInput = Array("email", "phone"),
+      expectedLeft = Array(
+        new ColumnWithAlias("id", null),
+        new ColumnWithAlias("name", null)
+      ),
+      expectedRight = Array(
+        new ColumnWithAlias("email", null),
+        new ColumnWithAlias("phone", null)
+      )
+    )
+  }
+
+  test("Extreme duplication scenarios") {
+    assertAliases(
+      leftInput = Array("id", "id", "id"),
+      rightInput = Array("id", "id"),
+      expectedLeft = Array(
+        new ColumnWithAlias("id", null),
+        new ColumnWithAlias("id", "id_1"),
+        new ColumnWithAlias("id", "id_2")
+      ),
+      expectedRight = Array(
+        new ColumnWithAlias("id", "id_3"),
+        new ColumnWithAlias("id", "id_4")
+      )
+    )
+  }
+
+  test("Exact duplicate column names") {
+    assertAliases(
+      leftInput = Array("id", "name"),
+      rightInput = Array("id", "name"),
+      expectedLeft = Array(
+        new ColumnWithAlias("id", null),
+        new ColumnWithAlias("name", null)
+      ),
+      expectedRight = Array(
+        new ColumnWithAlias("id", "id_1"),
+        new ColumnWithAlias("name", "name_1")
+      )
+    )
+  }
+
+  test("Columns with numeric suffixes (id vs id_1)") {
+    assertAliases(
+      leftInput = Array("id", "id_1", "name"),
+      rightInput = Array("id", "name", "value"),
+      expectedLeft = Array(
+        new ColumnWithAlias("id", null),
+        new ColumnWithAlias("id_1", null),
+        new ColumnWithAlias("name", null)
+      ),
+      expectedRight = Array(
+        new ColumnWithAlias("id", "id_2"),
+        new ColumnWithAlias("name", "name_1"),
+        new ColumnWithAlias("value", null)
+      )
+    )
+  }
+
+  test("Case-sensitive conflicts (ID vs id)") {
+    assertAliases(
+      leftInput = Array("ID", "Name"),
+      rightInput = Array("id", "name"),
+      expectedLeft = Array(
+        new ColumnWithAlias("ID", null),
+        new ColumnWithAlias("Name", null)
+      ),
+      expectedRight = Array(
+        new ColumnWithAlias("id", "id_1"),
+        new ColumnWithAlias("name", "name_1")
+      )
+    )
+  }
+
+  test("Mixed case and numeric suffixes") {
+    assertAliases(
+      leftInput = Array("UserID", "user_id", "user_id_1"),
+      rightInput = Array("userId", "USER_ID", "user_id_2"),
+      expectedLeft = Array(
+        new ColumnWithAlias("UserID", null),
+        new ColumnWithAlias("user_id", null),
+        new ColumnWithAlias("user_id_1", null)
+      ),
+      expectedRight = Array(
+        new ColumnWithAlias("userId", "userId_1"),
+        new ColumnWithAlias("USER_ID", "USER_ID_3"),
+        new ColumnWithAlias("user_id_2", null)
+      )
+    )
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDownSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDownSuite.scala
@@ -23,13 +23,20 @@ import org.apache.spark.sql.connector.read.SupportsPushDownJoin.ColumnWithAlias
 class V2ScanRelationPushDownSuite extends SparkFunSuite {
 
   private def assertAliases(
-                             leftInput: Array[String],
-                             rightInput: Array[String],
-                             expectedLeft: Array[ColumnWithAlias],
-                             expectedRight: Array[ColumnWithAlias]
-                           ): Unit = {
+    leftInput: Array[String],
+    rightInput: Array[String],
+    expectedLeft: Array[ColumnWithAlias],
+    expectedRight: Array[ColumnWithAlias]
+  ): Unit = {
     val (actualLeft, actualRight) = V2ScanRelationPushDown
       .generateColumnAliasesForDuplicatedName(leftInput, rightInput)
+
+    val uniqName : ColumnWithAlias => String = col => {
+      if (col.alias() == null) col.colName() else col.alias().toLowerCase()
+    }
+    // Ensure no duplicate column names after ignoring capitalization
+    assert((actualLeft++actualRight).map(uniqName).distinct.length
+      == actualLeft.length + actualRight.length)
 
     assert(
       actualLeft === expectedLeft,

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
@@ -212,9 +212,9 @@ trait JDBCV2JoinPushdownIntegrationSuiteBase
       insertStmt2.close()
 
       conn.createStatement().execute(
-        s"""insert into $fullyQualifiedTableName3 values (0, 1, 2, 3, 4)""")
+        s"""INSERT INTO $fullyQualifiedTableName3 VALUES (0, 1, 2, 3, 4)""")
       conn.createStatement().execute(
-        s"""insert into $fullyQualifiedTableName4 values (0, -1, -2, -3, -4)""")
+        s"""INSERT INTO $fullyQualifiedTableName4 VALUES (0, -1, -2, -3, -4)""")
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
@@ -657,7 +657,7 @@ trait JDBCV2JoinPushdownIntegrationSuiteBase
     withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "true") {
       val df = sql(sqlQuery)
       val row = df.collect()(0)
-      assert(row == Row(0, 1, 2, 3, 0, -1, -2, -3))
+      assert(row.toString == Row(0, 1, 2, 3, 0, -1, -2, -3).toString)
 
       assert(df.schema.fields.map(_.name) sameElements
         Array("id", "id_1", "id_2", "id_1_1", "id", "id_1", "id_2", "id_2_1"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
@@ -668,5 +668,8 @@ trait JDBCV2JoinPushdownIntegrationSuiteBase
 
       checkJoinPushed(df)
     }
+
+    sql(s"drop table $catalogAndNamespace.t1")
+    sql(s"drop table $catalogAndNamespace.t2")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
@@ -145,7 +145,8 @@ trait JDBCV2JoinPushdownIntegrationSuiteBase
            |"id" ${getJDBCTypeString(integerType)},
            |"id_1" ${getJDBCTypeString(integerType)},
            |"id_2" ${getJDBCTypeString(integerType)},
-           |"id_1_1" ${getJDBCTypeString(integerType)}
+           |"id_1_1" ${getJDBCTypeString(integerType)},
+           |"sid" ${getJDBCTypeString(integerType)}
            |)""".stripMargin
       ).executeUpdate()
       conn.prepareStatement(
@@ -153,7 +154,8 @@ trait JDBCV2JoinPushdownIntegrationSuiteBase
            |"id" ${getJDBCTypeString(integerType)},
            |"id_1" ${getJDBCTypeString(integerType)},
            |"id_2" ${getJDBCTypeString(integerType)},
-           |"id_2_1" ${getJDBCTypeString(integerType)}
+           |"id_2_1" ${getJDBCTypeString(integerType)},
+           |"Sid" ${getJDBCTypeString(integerType)}
            |)""".stripMargin
       ).executeUpdate()
     }
@@ -206,9 +208,9 @@ trait JDBCV2JoinPushdownIntegrationSuiteBase
       insertStmt2.close()
 
       conn.createStatement().execute(
-        s"""insert into $fullyQualifiedTableName3 values (0, 1, 2, 3)""")
+        s"""insert into $fullyQualifiedTableName3 values (0, 1, 2, 3, 4)""")
       conn.createStatement().execute(
-        s"""insert into $fullyQualifiedTableName4 values (0, -1, -2, -3)""")
+        s"""insert into $fullyQualifiedTableName4 values (0, -1, -2, -3, -4)""")
     }
   }
 
@@ -680,14 +682,16 @@ trait JDBCV2JoinPushdownIntegrationSuiteBase
     withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "true") {
       val df = sql(sqlQuery)
       val row = df.collect()(0)
-      assert(row.toString == Row(0, 1, 2, 3, 0, -1, -2, -3).toString)
+      assert(row.toString == Row(0, 1, 2, 3, 4, 0, -1, -2, -3, -4).toString)
 
       assert(df.schema.fields.map(_.name) sameElements
-        Array("id", "id_1", "id_2", "id_1_1", "id", "id_1", "id_2", "id_2_1"))
+        Array("id", "id_1", "id_2", "id_1_1", "sid",
+          "id", "id_1", "id_2", "id_2_1", "Sid"))
       assert(df.queryExecution.optimizedPlan.collectFirst {
         case j: DataSourceV2ScanRelation => j
       }.get.schema.fields.map(_.name) sameElements
-        Array("id", "id_1", "id_2", "id_1_1", "id_3", "id_1_2", "id_2_2", "id_2_1"))
+        Array("id", "id_1", "id_2", "id_1_1", "sid",
+          "id_3", "id_1_2", "id_2_2", "id_2_1", "Sid"))
 
       checkJoinPushed(df)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
@@ -305,14 +305,14 @@ trait JDBCV2JoinPushdownIntegrationSuiteBase
     withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "true") {
       val df = sql(sqlQuery)
 
-      val expectedSchemaWithoutNames = StructType(
+      val expectedSchema = StructType(
         Seq(
-          StructField("", integerType), // ID
-          StructField("", integerType), // NEXT_ID
+          StructField(caseConvert("id"), integerType), // ID
+          StructField(caseConvert("id_1"), integerType), // ID
           StructField(caseConvert("amount"), decimalType) // AMOUNT
         )
       )
-      checkPrunedColumnsDataTypeAndNullability(df, expectedSchemaWithoutNames)
+      checkPrunedColumnsDataTypeAndNullability(df, expectedSchema)
       checkJoinPushed(
         df,
         expectedTables = s"$catalogAndNamespace.${caseConvert(joinTableName1)}, " +
@@ -337,13 +337,13 @@ trait JDBCV2JoinPushdownIntegrationSuiteBase
     withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "true") {
       val df = sql(sqlQuery)
 
-      val expectedSchemaWithoutNames = StructType(
+      val expectedSchema = StructType(
         Seq(
           StructField(caseConvert("id"), integerType), // ID
           StructField(caseConvert("next_id"), integerType) // NEXT_ID
         )
       )
-      checkPrunedColumnsDataTypeAndNullability(df, expectedSchemaWithoutNames)
+      checkPrunedColumnsDataTypeAndNullability(df, expectedSchema)
       checkJoinPushed(
         df,
         expectedTables = s"$catalogAndNamespace.${caseConvert(joinTableName1)}",
@@ -372,18 +372,18 @@ trait JDBCV2JoinPushdownIntegrationSuiteBase
     withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "true") {
       val df = sql(sqlQuery)
 
-      val expectedSchemaWithoutNames = StructType(
+      val expectedSchema = StructType(
         Seq(
-          StructField("", integerType), // ID_UUID
-          StructField("", decimalType), // AMOUNT_UUID
-          StructField("", integerType), // ID_UUID
-          StructField("", decimalType), // AMOUNT_UUID
-          StructField(caseConvert("address"), stringType), // ADDRESS
           StructField(caseConvert("id"), integerType), // ID
-          StructField(caseConvert("amount"), decimalType) // AMOUNT
+          StructField(caseConvert("amount"), decimalType), // AMOUNT
+          StructField(caseConvert("id_1"), integerType), // ID
+          StructField(caseConvert("amount_1"), decimalType), // AMOUNT
+          StructField(caseConvert("address"), stringType), // ADDRESS
+          StructField(caseConvert("id_2"), integerType), // ID
+          StructField(caseConvert("amount_2"), decimalType) // AMOUNT
         )
       )
-      checkPrunedColumnsDataTypeAndNullability(df, expectedSchemaWithoutNames)
+      checkPrunedColumnsDataTypeAndNullability(df, expectedSchema)
       checkJoinPushed(
         df,
         expectedTables = s"$catalogAndNamespace.${caseConvert(joinTableName1)}, " +


### PR DESCRIPTION
### What changes were proposed in this pull request?
When pushing down join SQL, we generated aliases for duplicated names, but the aliases are too long to read and nondeterministic.

Before this change:
```
SELECT "ID_bf822dc6_e06d_492c_a489_1e92a6fe84a0","AMOUNT_c9f3fc67_62f8_4ec6_9c3f_b7ee7bafcb5a","ADDRESS_d937a313_3e09_4b97_b91f_b2a47ef5e31d","ID","AMOUNT","ADDRESS" FROM xxxx     

RelationV2[ID_bf822dc6_e06d_492c_a489_1e92a6fe84a0#18, AMOUNT_c9f3fc67_62f8_4ec6_9c3f_b7ee7bafcb5a#19, ADDRESS_d937a313_3e09_4b97_b91f_b2a47ef5e31d#20, ID#21, AMOUNT#22, ADDRESS#23] join_pushdown_catalog.JOIN_SCHEMA.JOIN_TABLE_1
```

After this change.
```
SELECT "ID","AMOUNT","ADDRESS","ID_1","AMOUNT_1","ADDRESS_1" FROM xxx   

RelationV2[ID#18, AMOUNT#19, ADDRESS#20, ID_1#21, AMOUNT_1#22, ADDRESS_1#23] join_pushdown_catalog.JOIN_SCHEMA.JOIN_TABLE_1
```


### Why are the changes needed?
Make code-generated JDBC SQL clearer and deterministic.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests can ensure no side effects are introduced. 


### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Trae.
