### PR TITLE
[SPARK-51745][SQL][SS] Enforce State Machine for RocksDBStateStore

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5181,6 +5181,18 @@
     ],
     "sqlState" : "42K06"
   },
+  "STATE_STORE_INVALID_STAMP" : {
+    "message" : [
+      "Invalid stamp <providedStamp>, current stamp: <currentStamp>."
+    ],
+    "sqlState" : "XXKST"
+  },
+  "STATE_STORE_INVALID_STATE_MACHINE_TRANSITION" : {
+    "message" : [
+      "Invalid state machine transition detected for state store <storeId>. Old state: <oldState>, New state: <newState>, Operation: <operation>."
+    ],
+    "sqlState" : "XXKST"
+  },
   "STATE_STORE_INVALID_VALUE_SCHEMA_EVOLUTION" : {
     "message" : [
       "Schema evolution is not possible new value_schema=<newValueSchema> and old value_schema=<oldValueSchema>",

--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -581,6 +581,7 @@ private[spark] object LogKeys {
   case object OPEN_COST_IN_BYTES extends LogKey
   case object OPERATION_HANDLE extends LogKey
   case object OPERATION_HANDLE_ID extends LogKey
+  case object OPERATION extends LogKey
   case object OPERATION_ID extends LogKey
   case object OPTIMIZED_PLAN_COLUMNS extends LogKey
   case object OPTIMIZER_CLASS_NAME extends LogKey
@@ -783,6 +784,7 @@ private[spark] object LogKeys {
   case object STAGE_ATTEMPT_ID extends LogKey
   case object STAGE_ID extends LogKey
   case object STAGE_NAME extends LogKey
+  case object STAMP extends LogKey
   case object START_INDEX extends LogKey
   case object START_TIME extends LogKey
   case object STATEMENT_ID extends LogKey
@@ -792,6 +794,7 @@ private[spark] object LogKeys {
   case object STATE_STORE_PROVIDER extends LogKey
   case object STATE_STORE_PROVIDER_ID extends LogKey
   case object STATE_STORE_PROVIDER_IDS extends LogKey
+  case object STATE_STORE_STATE extends LogKey
   case object STATE_STORE_VERSION extends LogKey
   case object STATS extends LogKey
   case object STATUS extends LogKey

--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -579,9 +579,9 @@ private[spark] object LogKeys {
   case object OLD_GENERATION_GC extends LogKey
   case object OLD_VALUE extends LogKey
   case object OPEN_COST_IN_BYTES extends LogKey
+  case object OPERATION extends LogKey
   case object OPERATION_HANDLE extends LogKey
   case object OPERATION_HANDLE_ID extends LogKey
-  case object OPERATION extends LogKey
   case object OPERATION_ID extends LogKey
   case object OPTIMIZED_PLAN_COLUMNS extends LogKey
   case object OPTIMIZER_CLASS_NAME extends LogKey

--- a/core/src/main/scala/org/apache/spark/TaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContext.scala
@@ -50,6 +50,15 @@ object TaskContext {
     }
   }
 
+  def withTaskContext[T](context: TaskContext)(task: => T): T = {
+    try {
+      TaskContext.setTaskContext(context)
+      task
+    } finally {
+      TaskContext.unset()
+    }
+  }
+
   private[this] val taskContext: ThreadLocal[TaskContext] = new ThreadLocal[TaskContext]
 
   // Note: protected[spark] instead of private[spark] to prevent the following two from

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StatePartitionReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StatePartitionReader.scala
@@ -124,6 +124,7 @@ abstract class StatePartitionReaderBase(
         stateStoreColFamilySchema.keyStateEncoderSpec.get,
         useMultipleValuesPerKey = useMultipleValuesPerKey,
         isInternal = isInternal)
+      store.abort()
     }
     provider
   }
@@ -204,6 +205,7 @@ class StatePartitionReader(
   }
 
   override def close(): Unit = {
+    store.release()
     super.close()
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -21,13 +21,11 @@ import java.io.File
 import java.util.Locale
 import java.util.Set
 import java.util.UUID
-import java.util.concurrent.{ConcurrentHashMap, ConcurrentLinkedQueue, TimeUnit}
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentLinkedQueue}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong}
-import javax.annotation.concurrent.GuardedBy
 
 import scala.collection.{mutable, Map}
 import scala.jdk.CollectionConverters.ConcurrentMapHasAsScala
-import scala.ref.WeakReference
 import scala.util.Try
 
 import org.apache.hadoop.conf.Configuration
@@ -158,8 +156,6 @@ class RocksDB(
   private val byteArrayPair = new ByteArrayPair()
   private val commitLatencyMs = new mutable.HashMap[String, Long]()
 
-  private val acquireLock = new Object
-
   @volatile private var db: NativeRocksDB = _
   @volatile private var changelogWriter: Option[StateStoreChangelogWriter] = None
   private val enableChangelogCheckpointing: Boolean = conf.enableChangelogCheckpointing
@@ -195,24 +191,14 @@ class RocksDB(
 
   // SPARK-46249 - Keep track of recorded metrics per version which can be used for querying later
   // Updates and access to recordedMetrics are protected by the DB instance lock
-  @GuardedBy("acquireLock")
   @volatile private var recordedMetrics: Option[RocksDBMetrics] = None
 
-  @GuardedBy("acquireLock")
-  @volatile private var acquiredThreadInfo: AcquiredThreadInfo = _
-
-  // This is accessed and updated only between load and commit
-  // which means it is implicitly guarded by acquireLock
-  @GuardedBy("acquireLock")
   private val colFamilyNameToInfoMap = new ConcurrentHashMap[String, ColumnFamilyInfo]()
 
-  @GuardedBy("acquireLock")
   private val colFamilyIdToNameMap = new ConcurrentHashMap[Short, String]()
 
-  @GuardedBy("acquireLock")
   private val maxColumnFamilyId: AtomicInteger = new AtomicInteger(-1)
 
-  @GuardedBy("acquireLock")
   private val shouldForceSnapshot: AtomicBoolean = new AtomicBoolean(false)
 
   private def getColumnFamilyInfo(cfName: String): ColumnFamilyInfo = {
@@ -300,11 +286,6 @@ class RocksDB(
     colFamilyNameToInfoMap.asScala.values.toSeq.count(_.isInternal == isInternal)
   }
 
-  // Mapping of local SST files to DFS files for file reuse.
-  // This mapping should only be updated using the Task thread - at version load and commit time.
-  // If same mapping instance is updated from different threads,
-  // it will result in undefined behavior (and most likely incorrect mapping state).
-  @GuardedBy("acquireLock")
   private val rocksDBFileMapping: RocksDBFileMapping = new RocksDBFileMapping()
 
   // We send snapshots that needs to be uploaded by the maintenance thread to this queue
@@ -584,7 +565,6 @@ class RocksDB(
       stateStoreCkptId: Option[String] = None,
       readOnly: Boolean = false): RocksDB = {
     assert(version >= 0)
-    acquire(LoadStore)
     recordedMetrics = None
     logInfo(log"Loading ${MDC(LogKeys.VERSION_NUM, version)} with stateStoreCkptId: ${
       MDC(LogKeys.UUID, stateStoreCkptId.getOrElse(""))}")
@@ -609,7 +589,6 @@ class RocksDB(
    */
   def loadFromSnapshot(snapshotVersion: Long, endVersion: Long): RocksDB = {
     assert(snapshotVersion >= 0 && endVersion >= snapshotVersion)
-    acquire(LoadStore)
     recordedMetrics = None
     logInfo(
       log"Loading snapshot at version ${MDC(LogKeys.VERSION_NUM, snapshotVersion)} and apply " +
@@ -1025,11 +1004,7 @@ class RocksDB(
     }
   }
 
-  def release(): Unit = {
-    if (db != null) {
-      release(LoadStore)
-    }
-  }
+  def release(): Unit = {}
 
   /**
    * Commit all the updates made as a version to DFS. The steps it needs to do to commits are:
@@ -1111,10 +1086,6 @@ class RocksDB(
       case t: Throwable =>
         loadedVersion = -1  // invalidate loaded version
         throw t
-    } finally {
-      // reset resources as either 1) we already pushed the changes and it has been committed or
-      // 2) commit has failed and the current version is "invalidated".
-      release(LoadStore)
     }
   }
 
@@ -1198,23 +1169,18 @@ class RocksDB(
    * Drop uncommitted changes, and roll back to previous version.
    */
   def rollback(): Unit = {
-    acquire(RollbackStore)
-    try {
-      numKeysOnWritingVersion = numKeysOnLoadedVersion
-      numInternalKeysOnWritingVersion = numInternalKeysOnLoadedVersion
-      loadedVersion = -1L
-      lastCommitBasedStateStoreCkptId = None
-      lastCommittedStateStoreCkptId = None
-      loadedStateStoreCkptId = None
-      sessionStateStoreCkptId = None
-      lineageManager.clear()
-      changelogWriter.foreach(_.abort())
-      // Make sure changelogWriter gets recreated next time.
-      changelogWriter = None
-      logInfo(log"Rolled back to ${MDC(LogKeys.VERSION_NUM, loadedVersion)}")
-    } finally {
-      release(RollbackStore)
-    }
+    numKeysOnWritingVersion = numKeysOnLoadedVersion
+    numInternalKeysOnWritingVersion = numInternalKeysOnLoadedVersion
+    loadedVersion = -1L
+    lastCommitBasedStateStoreCkptId = None
+    lastCommittedStateStoreCkptId = None
+    loadedStateStoreCkptId = None
+    sessionStateStoreCkptId = None
+    lineageManager.clear()
+    changelogWriter.foreach(_.abort())
+    // Make sure changelogWriter gets recreated next time.
+    changelogWriter = None
+    logInfo(log"Rolled back to ${MDC(LogKeys.VERSION_NUM, loadedVersion)}")
   }
 
   def doMaintenance(): Unit = {
@@ -1246,7 +1212,6 @@ class RocksDB(
   /** Release all resources */
   def close(): Unit = {
     // Acquire DB instance lock and release at the end to allow for synchronized access
-    acquire(CloseStore)
     try {
       closeDB()
 
@@ -1268,8 +1233,6 @@ class RocksDB(
     } catch {
       case e: Exception =>
         logWarning("Error closing RocksDB", e)
-    } finally {
-      release(CloseStore)
     }
   }
 
@@ -1365,96 +1328,13 @@ class RocksDB(
    */
   def metricsOpt: Option[RocksDBMetrics] = {
     var rocksDBMetricsOpt: Option[RocksDBMetrics] = None
-    acquire(ReportStoreMetrics)
     try {
       rocksDBMetricsOpt = recordedMetrics
     } catch {
       case ex: Exception =>
         logInfo(log"Failed to acquire metrics with exception=${MDC(LogKeys.ERROR, ex)}")
-    } finally {
-      release(ReportStoreMetrics)
     }
     rocksDBMetricsOpt
-  }
-
-  /**
-   * Function to acquire RocksDB instance lock that allows for synchronized access to the state
-   * store instance
-   *
-   * @param opType - operation type requesting the lock
-   */
-  private def acquire(opType: RocksDBOpType): Unit = acquireLock.synchronized {
-    val newAcquiredThreadInfo = AcquiredThreadInfo()
-    val waitStartTime = System.nanoTime()
-    def timeWaitedMs = {
-      val elapsedNanos = System.nanoTime() - waitStartTime
-      TimeUnit.MILLISECONDS.convert(elapsedNanos, TimeUnit.NANOSECONDS)
-    }
-    def isAcquiredByDifferentThread = acquiredThreadInfo != null &&
-      acquiredThreadInfo.threadRef.get.isDefined &&
-      newAcquiredThreadInfo.threadRef.get.get.getId != acquiredThreadInfo.threadRef.get.get.getId
-
-    while (isAcquiredByDifferentThread && timeWaitedMs < conf.lockAcquireTimeoutMs) {
-      acquireLock.wait(10)
-    }
-    if (isAcquiredByDifferentThread) {
-      val stackTraceOutput = acquiredThreadInfo.threadRef.get.get.getStackTrace.mkString("\n")
-      throw QueryExecutionErrors.unreleasedThreadError(loggingId, opType.toString,
-        newAcquiredThreadInfo.toString(), acquiredThreadInfo.toString(), timeWaitedMs,
-        stackTraceOutput)
-    } else {
-      acquiredThreadInfo = newAcquiredThreadInfo
-      // Add a listener to always release the lock when the task (if active) completes
-      Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit] {
-        _ => this.release(StoreTaskCompletionListener, Some(newAcquiredThreadInfo))
-      })
-      logInfo(log"RocksDB instance was acquired by " +
-        log"ownerThread=${MDC(LogKeys.THREAD, acquiredThreadInfo)} " +
-        log"for opType=${MDC(LogKeys.OP_TYPE, opType.toString)}")
-    }
-  }
-
-  /**
-   * Function to release RocksDB instance lock that allows for synchronized access to the state
-   * store instance. Optionally provide a thread to check against, and release only if provided
-   * thread is the one that acquired the lock.
-   *
-   * @param opType - operation type releasing the lock
-   * @param releaseForThreadOpt - optional thread to check against acquired thread
-   */
-  private def release(
-      opType: RocksDBOpType,
-      releaseForThreadOpt: Option[AcquiredThreadInfo] = None): Unit = acquireLock.synchronized {
-    if (acquiredThreadInfo != null) {
-      val release = releaseForThreadOpt match {
-        case Some(releaseForThread) if releaseForThread.threadRef.get.isEmpty =>
-          logInfo(log"Thread reference is empty when attempting to release for " +
-            log"opType=${MDC(LogKeys.OP_TYPE, opType.toString)}, ignoring release. " +
-            log"Lock is held by ownerThread=${MDC(LogKeys.THREAD, acquiredThreadInfo)}")
-          false
-        // NOTE: we compare the entire acquiredThreadInfo object to ensure that we are
-        // releasing not only for the right thread but the right task as well. This is
-        // inconsistent with the logic for acquire which uses only the thread ID, consider
-        // updating this in future.
-        case Some(releaseForThread) if acquiredThreadInfo != releaseForThread =>
-          logInfo(log"Thread info for " +
-            log"releaseThread=${MDC(LogKeys.THREAD, releaseForThreadOpt.get)} " +
-            log"does not match the acquired thread when attempting to " +
-            log"release for opType=${MDC(LogKeys.OP_TYPE, opType.toString)}, ignoring release. " +
-            log"Lock is held by ownerThread=${MDC(LogKeys.THREAD, acquiredThreadInfo)}")
-          false
-        case _ => true
-      }
-
-      if (release) {
-        logInfo(log"RocksDB instance was released by " +
-          log"releaseThread=${MDC(LogKeys.THREAD, AcquiredThreadInfo())} " +
-          log"with ownerThread=${MDC(LogKeys.THREAD, acquiredThreadInfo)} " +
-          log"for opType=${MDC(LogKeys.OP_TYPE, opType.toString)}")
-        acquiredThreadInfo = null
-        acquireLock.notifyAll()
-      }
-    }
   }
 
   private def getDBProperty(property: String): Long = db.getProperty(property).toLong
@@ -1478,11 +1358,6 @@ class RocksDB(
       }
       db = null
     }
-  }
-
-  private[state] def getAcquiredThreadInfo(): Option[AcquiredThreadInfo] =
-      acquireLock.synchronized {
-    Option(acquiredThreadInfo).map(_.copy())
   }
 
   /** Upload the snapshot to DFS and remove it from snapshots pending */
@@ -2056,21 +1931,6 @@ object RocksDBNativeHistogram {
       nativeHist.getPercentile95,
       nativeHist.getPercentile99,
       nativeHist.getCount)
-  }
-}
-
-case class AcquiredThreadInfo(
-    threadRef: WeakReference[Thread] = new WeakReference[Thread](Thread.currentThread()),
-    tc: TaskContext = TaskContext.get()) {
-  override def toString(): String = {
-    val taskStr = if (tc != null) {
-      val taskDetails =
-        s"partition ${tc.partitionId()}.${tc.attemptNumber()} in stage " +
-          s"${tc.stageId()}.${tc.stageAttemptNumber()}, TID ${tc.taskAttemptId()}"
-      s", task: $taskDetails"
-    } else ""
-
-    s"[ThreadId: ${threadRef.get.map(_.getId)}$taskStr]"
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateMachine.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateMachine.scala
@@ -1,0 +1,330 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming.state
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import javax.annotation.concurrent.GuardedBy
+
+import scala.ref.WeakReference
+
+import org.apache.spark.TaskContext
+import org.apache.spark.internal.{Logging, LogKeys, MDC}
+import org.apache.spark.sql.errors.QueryExecutionErrors
+
+/**
+ * A state machine that manages the lifecycle of a RocksDB instance
+ *
+ * This class enforces proper state transitions and ensures thread-safety for accessing
+ * RocksDB instances.
+ * It prevents concurrent modifications to the same native RocksDB instance by using
+ * a stamp-based locking mechanism.
+ *
+ * State Lifecycle:
+ * - RELEASED: The RocksDB instance is not being accessed by any thread
+ * - ACQUIRED: The RocksDB instance is currently being accessed by a thread
+ * - CLOSED: The RocksDB instance has been closed and can no longer be used
+ *
+ * Valid Transitions:
+ * - RELEASED -> ACQUIRED: When a thread acquires the RocksDB instance
+ * - ACQUIRED -> RELEASED: When a thread releases the RocksDB instance
+ * - RELEASED -> CLOSED: When the RocksDB instance is shut down
+ * - ACQUIRED -> MAINTENANCE: Maintenance can be performed on an acquired RocksDB instance
+ * - RELEASED -> MAINTENANCE: Maintenance can be performed on a released RocksDB instance
+ *
+ * Stamps:
+ * Each time a RocksDB instance is acquired, a unique stamp is generated. This stamp must be
+ * presented when performing operations on the RocksDB instance and when releasing it. This ensures
+ * that only the stamp owner that acquired the RocksDB instance can release it or perform
+ * operations.
+ */
+class RocksDBStateMachine(
+    stateStoreId: StateStoreId,
+    rocksDBConf: RocksDBConf) extends Logging {
+
+  private sealed trait STATE
+  private case object RELEASED extends STATE
+  private case object ACQUIRED extends STATE
+  private case object CLOSED extends STATE
+
+  private sealed abstract class OPERATION(name: String) {
+    override def toString: String = name
+  }
+  private case object LOAD extends OPERATION("load")
+  private case object RELEASE extends OPERATION("release")
+  private case object CLOSE extends OPERATION("close")
+  private case object MAINTENANCE extends OPERATION("maintenance")
+
+  private val stateMachineLock = new Object()
+  @GuardedBy("stateMachineLock")
+  private var state: STATE = RELEASED
+
+  // This is only maintained for logging purposes
+  @GuardedBy("stateMachineLock")
+  private var acquiredThreadInfo: AcquiredThreadInfo = _
+
+  private val RELEASED_STATE_MACHINE_STAMP: Long = -1L
+
+  /**
+   * Map defining all valid state transitions in the state machine.
+   * Key: (currentState, operation) -> Value: nextState
+   *
+   * Valid transitions:
+   * - (RELEASED, LOAD) -> ACQUIRED: Acquire exclusive access to the RocksDB instance
+   * - (ACQUIRED, RELEASE) -> RELEASED: Release exclusive access
+   * - (RELEASED, CLOSE) -> CLOSED: Permanently close the RocksDB instance
+   * - (CLOSED, CLOSE) -> CLOSED: Close is idempotent
+   * - (RELEASED, MAINTENANCE) -> RELEASED: Maintenance on released RocksDB instance
+   * - (ACQUIRED, MAINTENANCE) -> ACQUIRED: Maintenance on acquired RocksDB instance
+   */
+  private val allowedStateTransitions: Map[(STATE, OPERATION), STATE] = Map(
+    (RELEASED, LOAD) -> ACQUIRED,
+    (ACQUIRED, RELEASE) -> RELEASED,
+    (RELEASED, CLOSE) -> CLOSED,
+    (CLOSED, CLOSE) -> CLOSED,  // Idempotent close operation
+    (RELEASED, MAINTENANCE) -> RELEASED,
+    (ACQUIRED, MAINTENANCE) -> ACQUIRED
+  )
+
+  /**
+   * Returns information about the thread that currently has the RocksDB instance acquired.
+   * This method is exposed for testing purposes only.
+   *
+   * @return Some(AcquiredThreadInfo) if a thread currently has the RocksDB instance acquired,
+   *         None if the RocksDB instance is in RELEASED state
+   */
+  private[spark] def getAcquiredThreadInfo: Option[AcquiredThreadInfo] =
+    stateMachineLock.synchronized {
+      Option(acquiredThreadInfo).map(_.copy())
+    }
+
+  // Can be read without holding any locks, but should only be updated when
+  // stateMachineLock is held.
+  private[state] val currentValidStamp = new AtomicLong(RELEASED_STATE_MACHINE_STAMP)
+  @GuardedBy("stateMachineLock")
+  private var lastValidStamp: Long = 0L
+
+  /**
+   * This method is marked "WithLock" because it MUST only be called when the caller
+   * already holds the stateMachineLock. Calling this method without holding the lock
+   * will result in race conditions and data corruption.
+   *
+   * @return A new unique stamp value
+   */
+  @GuardedBy("stateMachineLock")
+  private def incAndGetStampWithLock: Long = {
+    assert(Thread.holdsLock(stateMachineLock), "Instance lock must be held")
+    lastValidStamp += 1
+    currentValidStamp.set(lastValidStamp)
+    logInfo(log"New stamp: ${MDC(LogKeys.STAMP, currentValidStamp.get())} issued for " +
+      log"${MDC(LogKeys.STATE_STORE_ID, stateStoreId)}")
+    lastValidStamp
+  }
+
+  /**
+   * This method is marked "WithLock" because it MUST only be called when the caller
+   * already holds the stateMachineLock. The method uses stateMachineLock.wait() which
+   * requires the calling stamp owner to own the monitor. Calling this without holding the
+   * lock will throw IllegalMonitorStateException.
+   *
+   * @param operation The operation being attempted (used for error reporting)
+   * @throws QueryExecutionErrors.unreleasedThreadError if timeout occurs
+   */
+  @GuardedBy("stateMachineLock")
+  private def awaitNotAcquiredWithLock(operation: OPERATION): Unit = {
+    assert(Thread.holdsLock(stateMachineLock), "Instance lock must be held")
+    val waitStartTime = System.nanoTime()
+    def timeWaitedMs = {
+      val elapsedNanos = System.nanoTime() - waitStartTime
+      // Convert from nanoseconds to milliseconds
+      TimeUnit.MILLISECONDS.convert(elapsedNanos, TimeUnit.NANOSECONDS)
+    }
+    while (state == ACQUIRED && timeWaitedMs < rocksDBConf.lockAcquireTimeoutMs) {
+      stateMachineLock.wait(10)
+      // log every 30 seconds
+      if (timeWaitedMs % (30 * 1000) == 0) {
+        logInfo(log"Waiting to acquire lock for ${MDC(LogKeys.STATE_STORE_ID, stateStoreId)}")
+      }
+    }
+    if (state == ACQUIRED) {
+      val newAcquiredThreadInfo = AcquiredThreadInfo()
+      val stackTraceOutput = acquiredThreadInfo.threadRef.get.get.getStackTrace.mkString("\n")
+      val loggingId = s"StateStoreId(opId=${stateStoreId.operatorId}," +
+        s"partId=${stateStoreId.partitionId},name=${stateStoreId.storeName})"
+      throw QueryExecutionErrors.unreleasedThreadError(loggingId, operation.toString,
+        newAcquiredThreadInfo.toString(), acquiredThreadInfo.toString(), timeWaitedMs,
+        stackTraceOutput)
+    }
+  }
+
+  /**
+   * Validates a state operation and updates the internal state if the transition is legal.
+   *
+   * This method is the core of the state machine that ensures thread-safe access to RocksDB
+   * instances. It uses a map-based approach to define valid state transitions,
+   * making the state machine logic cleaner and more maintainable.
+   *
+   * Thread Safety Requirements:
+   * - Caller MUST hold the stateMachineLock before calling this method
+   * - This is enforced by the synchronized blocks in all public methods
+   *
+   * Side Effects:
+   * - Updates the internal state variable
+   * - Sets acquiredThreadInfo when transitioning to ACQUIRED state
+   * - Logs state transitions for debugging
+   *
+   * @param operation The requested state operation (LOAD, RELEASE, CLOSE, or MAINTENANCE)
+   * @return A tuple of (oldState, newState) representing the state before and after operation
+   * @throws StateStoreInvalidStateMachineTransition if the requested operation is not allowed
+   *         from the current state
+   */
+  @GuardedBy("stateMachineLock")
+  private def validateAndTransitionState(operation: OPERATION): (STATE, STATE) = {
+    assert(Thread.holdsLock(stateMachineLock), "Instance lock must be held")
+    val oldState = state
+    val newState = allowedStateTransitions.get((oldState, operation)) match {
+      case Some(nextState) => nextState
+      case None =>
+        // Determine expected state for better error message
+        val expectedState = operation match {
+          case LOAD => "ACQUIRED"
+          case RELEASE => "RELEASED"
+          case CLOSE => "CLOSED"
+          case MAINTENANCE => oldState.toString
+        }
+        throw StateStoreErrors.invalidStateMachineTransition(
+          oldState.toString, expectedState, operation.toString, stateStoreId)
+    }
+    state = newState
+    if (newState == ACQUIRED) {
+      acquiredThreadInfo = AcquiredThreadInfo()
+    }
+    logInfo(log"Transitioned state from ${MDC(LogKeys.STATE_STORE_STATE, oldState)} " +
+      log"to ${MDC(LogKeys.STATE_STORE_STATE, newState)} " +
+      log"with operation ${MDC(LogKeys.OPERATION, operation.toString)} " +
+      log"for StateStoreId ${MDC(LogKeys.STATE_STORE_ID, stateStoreId)}")
+    (oldState, newState)
+  }
+
+  /**
+   * Verifies that the provided stamp matches the current valid stamp.
+   * This ensures that operations are performed by the task that acquired the RocksDB instance.
+   *
+   * @param stamp The stamp to verify against the current valid stamp
+   * @throws StateStoreInvalidStamp if the stamp does not match the current valid stamp
+   */
+  def verifyStamp(stamp: Long): Unit = {
+    val currentStamp = currentValidStamp.get()
+    if (stamp != currentStamp) {
+      throw StateStoreErrors.invalidStamp(stamp, currentStamp)
+    }
+  }
+
+  /**
+   * Releases the RocksDB instance, transitioning it from ACQUIRED to RELEASED state.
+   * This can only be called by the stamp owner that acquired the RocksDB instance.
+   *
+   * @param stamp The stamp that was returned when the RocksDB instance was acquired
+   * @param throwEx Whether to throw an exception if the stamp is invalid (default: true)
+   * @return true if the RocksDB instance was successfully released, false if stamp was invalid
+   *         and throwEx=false
+   * @throws StateStoreInvalidStamp if stamp is invalid and throwEx=true
+   * @throws StateStoreInvalidStateMachineTransition if the current state doesn't allow release
+   */
+  def releaseStamp(stamp: Long, throwEx: Boolean = true): Boolean = stateMachineLock.synchronized {
+    currentValidStamp.compareAndSet(stamp, RELEASED_STATE_MACHINE_STAMP) match {
+      case true =>
+        validateAndTransitionState(RELEASE)
+        true
+      case false =>
+        throwEx match {
+          case true =>
+            val actualStamp = currentValidStamp.get()
+            throw StateStoreErrors.invalidStamp(stamp, actualStamp)
+          case false =>
+            false
+        }
+    }
+  }
+
+  /**
+   * Acquires the RocksDB instance for exclusive use by the calling task.
+   * Transitions the state from RELEASED to ACQUIRED.
+   *
+   * This method will block if another task currently has a stamp for the RocksDB instance,
+   * waiting up to the configured timeout before throwing an exception.
+   *
+   * @return A unique stamp that must be used for subsequent operations and release
+   * @throws StateStoreInvalidStateMachineTransition if the RocksDB instance is in CLOSED state
+   * @throws QueryExecutionErrors.unreleasedThreadError if timeout occurs waiting for another thread
+   */
+  def acquireStamp(): Long = stateMachineLock.synchronized {
+    awaitNotAcquiredWithLock(LOAD)
+    validateAndTransitionState(LOAD)
+    incAndGetStampWithLock
+  }
+
+  /**
+   * This verifies that it is in a state that allows maintenance to be performed.
+   * This operation is allowed in both RELEASED and ACQUIRED states.
+   *
+   * @throws StateStoreInvalidStateMachineTransition if the RocksDB instance is in CLOSED state
+   */
+  def verifyForMaintenance(): Unit = stateMachineLock.synchronized {
+    validateAndTransitionState(MAINTENANCE)
+  }
+
+  /**
+   * Closes the RocksDB instance permanently, transitioning it to CLOSED state.
+   * Once closed, the RocksDB instance cannot be used again and all future operations will fail.
+   *
+   * This method will block if another task currently has a stamp for the RocksDB instance,
+   * waiting up to the configured timeout before throwing an exception.
+   *
+   * @throws StateStoreInvalidStateMachineTransition if called multiple times (idempotent)
+   * @throws QueryExecutionErrors.unreleasedThreadError if timeout occurs waiting for another thread
+   */
+  def close(): Boolean = stateMachineLock.synchronized {
+    // return boolean as to whether we need to close or not
+    if (state == CLOSED) {
+      false
+    } else {
+      logInfo(log"Trying to close store ${MDC(LogKeys.STATE_STORE_ID, stateStoreId)}")
+      awaitNotAcquiredWithLock(CLOSE)
+      logInfo(log"Finished waiting to acquire lock," +
+        log" transitioning to close store ${MDC(LogKeys.STATE_STORE_ID, stateStoreId)}")
+      validateAndTransitionState(CLOSE)
+      true
+    }
+  }
+}
+
+case class AcquiredThreadInfo(
+    threadRef: WeakReference[Thread] = new WeakReference[Thread](Thread.currentThread()),
+    tc: TaskContext = TaskContext.get()) {
+  override def toString(): String = {
+    val taskStr = if (tc != null) {
+      val taskDetails =
+        s"partition ${tc.partitionId()}.${tc.attemptNumber()} in stage " +
+          s"${tc.stageId()}.${tc.stageAttemptNumber()}, TID ${tc.taskAttemptId()}"
+      s", task: $taskDetails"
+    } else ""
+
+    s"[ThreadId: ${threadRef.get.map(_.getId)}$taskStr]"
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.{SparkConf, SparkEnv, TaskContext}
-import org.apache.spark.internal.{Logging, MDC}
+import org.apache.spark.internal.{Logging, LogKeys, MDC}
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
@@ -45,7 +45,16 @@ private[sql] class RocksDBStateStoreProvider
 
   class RocksDBStateStore(
       lastVersion: Long,
+      private[RocksDBStateStoreProvider] val stamp: Long,
       private[RocksDBStateStoreProvider] var readOnly: Boolean) extends StateStore {
+
+    private sealed trait OPERATION
+    private case object UPDATE extends OPERATION
+    private case object ABORT extends OPERATION
+    private case object RELEASE extends OPERATION
+    private case object COMMIT extends OPERATION
+    private case object METRICS extends OPERATION
+
     /** Trait and classes representing the internal state of the store */
     trait STATE
     case object UPDATING extends STATE
@@ -56,9 +65,103 @@ private[sql] class RocksDBStateStoreProvider
     @volatile private var state: STATE = UPDATING
     @volatile private var isValidated = false
 
+    /**
+     * Map defining all valid state transitions for the RocksDB state store.
+     * Key: (currentState, operation) -> Value: nextState
+     *
+     * Valid transitions:
+     * - (UPDATING, UPDATE) -> UPDATING: Continue updating
+     * - (UPDATING, ABORT) -> ABORTED: Abort during update
+     * - (UPDATING, RELEASE) -> RELEASED: Release during update
+     * - (UPDATING, COMMIT) -> COMMITTED: Direct commit
+     * - (COMMITTED, METRICS) -> COMMITTED: Allow metrics after commit
+     * - (ABORTED, ABORT) -> ABORTED: Abort is idempotent
+     * - (ABORTED, METRICS) -> ABORTED: Allow metrics after abort
+     * - (RELEASED, RELEASE) -> RELEASED: Release is idempotent
+     * - (RELEASED, METRICS) -> RELEASED: Allow metrics after release
+     */
+    private val allowedStateTransitions: Map[(STATE, OPERATION), STATE] = Map(
+      // From UPDATING state
+      (UPDATING, UPDATE) -> UPDATING,
+      (UPDATING, ABORT) -> ABORTED,
+      (UPDATING, RELEASE) -> RELEASED,
+      (UPDATING, COMMIT) -> COMMITTED,
+      // From COMMITTED state
+      (COMMITTED, METRICS) -> COMMITTED,
+      // From ABORTED state
+      (ABORTED, ABORT) -> ABORTED,  // Idempotent
+      (ABORTED, METRICS) -> ABORTED,
+      // From RELEASED state
+      (RELEASED, RELEASE) -> RELEASED,  // Idempotent
+      (RELEASED, METRICS) -> RELEASED
+    )
+
     override def id: StateStoreId = RocksDBStateStoreProvider.this.stateStoreId
 
     override def version: Long = lastVersion
+
+    /**
+     * Validates the expected state, throws exception if state is not as expected.
+     * Returns the current state
+     *
+     * @param possibleStates Expected possible states
+     * @return current state of StateStore
+     */
+    private def validateState(possibleStates: STATE*): STATE = {
+      if (!possibleStates.contains(state)) {
+        throw StateStoreErrors.stateStoreOperationOutOfOrder(
+          s"Expected possible states ${possibleStates.mkString("(", ", ", ")")} but found $state")
+      }
+      state
+    }
+
+    /**
+     * Throws error if transition is illegal.
+     * MUST be called for every StateStore method.
+     *
+     * @param operation The transition type of the operation.
+     */
+    private def validateAndTransitionState(operation: OPERATION): Unit = {
+      val oldState = state
+
+      // Operations requiring stamp verification
+      val needsStampVerification = operation match {
+        case ABORT if state == ABORTED => false     // ABORT is idempotent
+        case RELEASE if state == RELEASED => false  // RELEASE is idempotent
+        case UPDATE | ABORT | RELEASE | COMMIT => true
+        case METRICS => false
+      }
+
+      if (needsStampVerification) {
+        stateMachine.verifyStamp(stamp)
+      }
+
+      val newState = allowedStateTransitions.get((oldState, operation)) match {
+        case Some(nextState) => nextState
+        case None =>
+          val errorMsg = operation match {
+            case UPDATE => s"Cannot update after ${oldState.toString}"
+            case ABORT => s"Cannot abort after ${oldState.toString}"
+            case RELEASE => s"Cannot release after ${oldState.toString}"
+            case COMMIT => s"Cannot commit after ${oldState.toString}"
+            case METRICS => s"Cannot get metrics in ${oldState} state"
+          }
+          throw StateStoreErrors.stateStoreOperationOutOfOrder(errorMsg)
+      }
+
+      // Special handling for COMMIT operation - release the store
+      if (operation == COMMIT || operation == RELEASE) {
+        stateMachine.releaseStamp(stamp)
+      }
+
+      if (operation != UPDATE) {
+        logInfo(log"Transitioned state from ${MDC(LogKeys.STATE_STORE_STATE, oldState)} " +
+          log"to ${MDC(LogKeys.STATE_STORE_STATE, newState)} " +
+          log"for StateStoreId ${MDC(LogKeys.STATE_STORE_ID, stateStoreId)} " +
+          log"with transition ${MDC(LogKeys.OPERATION, operation.toString)}")
+      }
+      state = newState
+    }
 
     Option(TaskContext.get()).foreach { ctxt =>
       ctxt.addTaskCompletionListener[Unit](ctx => {
@@ -72,8 +175,14 @@ private[sql] class RocksDBStateStoreProvider
           }
         } catch {
           case NonFatal(e) =>
-            logWarning("Failed to abort state store", e)
+            logWarning("Failed to abort or release state store", e)
+        } finally {
+          stateMachine.releaseStamp(stamp, throwEx = false)
         }
+      })
+      // Abort the async commit stores only when the task has failed and store is not committed.
+      ctxt.addTaskFailureListener((_, _) => {
+        if (!hasCommitted) abort()
       })
     }
 
@@ -84,6 +193,7 @@ private[sql] class RocksDBStateStoreProvider
         keyStateEncoderSpec: KeyStateEncoderSpec,
         useMultipleValuesPerKey: Boolean = false,
         isInternal: Boolean = false): Unit = {
+      validateAndTransitionState(UPDATE)
       verifyColFamilyCreationOrDeletion("create_col_family", colFamilyName, isInternal)
       val cfId = rocksDB.createColFamilyIfAbsent(colFamilyName, isInternal)
       val dataEncoderCacheKey = StateRowEncoderCacheKey(
@@ -125,6 +235,7 @@ private[sql] class RocksDBStateStoreProvider
     }
 
     override def get(key: UnsafeRow, colFamilyName: String): UnsafeRow = {
+      validateAndTransitionState(UPDATE)
       verify(key != null, "Key cannot be null")
       verifyColFamilyOperations("get", colFamilyName)
 
@@ -151,6 +262,7 @@ private[sql] class RocksDBStateStoreProvider
      * values per key.
      */
     override def valuesIterator(key: UnsafeRow, colFamilyName: String): Iterator[UnsafeRow] = {
+      validateAndTransitionState(UPDATE)
       verify(key != null, "Key cannot be null")
       verifyColFamilyOperations("valuesIterator", colFamilyName)
 
@@ -167,6 +279,7 @@ private[sql] class RocksDBStateStoreProvider
 
     override def merge(key: UnsafeRow, value: UnsafeRow,
         colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit = {
+      validateAndTransitionState(UPDATE)
       verify(state == UPDATING, "Cannot merge after already committed or aborted")
       verifyColFamilyOperations("merge", colFamilyName)
 
@@ -182,6 +295,7 @@ private[sql] class RocksDBStateStoreProvider
     }
 
     override def put(key: UnsafeRow, value: UnsafeRow, colFamilyName: String): Unit = {
+      validateAndTransitionState(UPDATE)
       verify(state == UPDATING, "Cannot put after already committed or aborted")
       verify(key != null, "Key cannot be null")
       require(value != null, "Cannot put a null value")
@@ -192,6 +306,7 @@ private[sql] class RocksDBStateStoreProvider
     }
 
     override def remove(key: UnsafeRow, colFamilyName: String): Unit = {
+      validateAndTransitionState(UPDATE)
       verify(state == UPDATING, "Cannot remove after already committed or aborted")
       verify(key != null, "Key cannot be null")
       verifyColFamilyOperations("remove", colFamilyName)
@@ -201,6 +316,7 @@ private[sql] class RocksDBStateStoreProvider
     }
 
     override def iterator(colFamilyName: String): Iterator[UnsafeRowPair] = {
+      validateAndTransitionState(UPDATE)
       // Note this verify function only verify on the colFamilyName being valid,
       // we are actually doing prefix when useColumnFamilies,
       // but pass "iterator" to throw correct error message
@@ -235,6 +351,7 @@ private[sql] class RocksDBStateStoreProvider
 
     override def prefixScan(prefixKey: UnsafeRow, colFamilyName: String):
       Iterator[UnsafeRowPair] = {
+      validateAndTransitionState(UPDATE)
       verifyColFamilyOperations("prefixScan", colFamilyName)
 
       val kvEncoder = keyValueEncoderMap.get(colFamilyName)
@@ -251,12 +368,16 @@ private[sql] class RocksDBStateStoreProvider
     }
 
     var checkpointInfo: Option[StateStoreCheckpointInfo] = None
+    private var storedMetrics: Option[RocksDBMetrics] = None
+
     override def commit(): Long = synchronized {
+      validateState(UPDATING)
       try {
-        verify(state == UPDATING, "Cannot commit after already committed or aborted")
+        stateMachine.verifyStamp(stamp)
         val (newVersion, newCheckpointInfo) = rocksDB.commit()
         checkpointInfo = Some(newCheckpointInfo)
-        state = COMMITTED
+        storedMetrics = rocksDB.metricsOpt
+        validateAndTransitionState(COMMIT)
         logInfo(log"Committed ${MDC(VERSION_NUM, newVersion)} " +
           log"for ${MDC(STATE_STORE_ID, id)}")
         newVersion
@@ -272,7 +393,7 @@ private[sql] class RocksDBStateStoreProvider
         logInfo(log"Releasing ${MDC(VERSION_NUM, version + 1)} " +
           log"for ${MDC(STATE_STORE_ID, id)}")
         rocksDB.release()
-        state = RELEASED
+        validateAndTransitionState(RELEASE)
       } else {
         // Optionally log at DEBUG level that it's already released
         logDebug(log"State store already released")
@@ -280,15 +401,24 @@ private[sql] class RocksDBStateStoreProvider
     }
 
     override def abort(): Unit = {
-      verify(state == UPDATING || state == ABORTED, "Cannot abort after already committed")
-      logInfo(log"Aborting ${MDC(VERSION_NUM, version + 1)} " +
-        log"for ${MDC(STATE_STORE_ID, id)}")
-      rocksDB.rollback()
-      state = ABORTED
+      if (validateState(UPDATING, ABORTED) != ABORTED) {
+        try {
+          validateAndTransitionState(ABORT)
+          logInfo(log"Aborting ${MDC(VERSION_NUM, version + 1)} " +
+            log"for ${MDC(STATE_STORE_ID, id)}")
+          rocksDB.rollback()
+        } finally {
+          stateMachine.releaseStamp(stamp)
+        }
+      } else {
+        logInfo(log"Skipping abort for ${MDC(VERSION_NUM, version + 1)} " +
+          log"for ${MDC(STATE_STORE_ID, id)} as we already aborted")
+      }
     }
 
     override def metrics: StateStoreMetrics = {
-      val rocksDBMetricsOpt = rocksDB.metricsOpt
+      validateAndTransitionState(METRICS)
+      val rocksDBMetricsOpt = storedMetrics
 
       if (rocksDBMetricsOpt.isDefined) {
         val rocksDBMetrics = rocksDBMetricsOpt.get
@@ -370,6 +500,7 @@ private[sql] class RocksDBStateStoreProvider
     }
 
     override def getStateStoreCheckpointInfo(): StateStoreCheckpointInfo = {
+      validateAndTransitionState(METRICS)
       checkpointInfo match {
         case Some(info) => info
         case None => throw StateStoreErrors.stateStoreOperationOutOfOrder(
@@ -481,6 +612,9 @@ private[sql] class RocksDBStateStoreProvider
 
   override def stateStoreId: StateStoreId = stateStoreId_
 
+  private lazy val stateMachine: RocksDBStateMachine =
+    new RocksDBStateMachine(stateStoreId, RocksDBConf(storeConf))
+
   override protected def logName: String = s"${super.logName} ${stateStoreProviderId}"
 
   /**
@@ -497,6 +631,8 @@ private[sql] class RocksDBStateStoreProvider
       uniqueId: Option[String] = None,
       readOnly: Boolean,
       existingStore: Option[RocksDBStateStore] = None): StateStore = {
+    var acquiredStamp: Option[Long] = None
+    var storeLoaded = false
     try {
       if (version < 0) {
         throw QueryExecutionErrors.unexpectedStateStoreVersion(version)
@@ -510,28 +646,56 @@ private[sql] class RocksDBStateStoreProvider
         }
       }
 
+      // if the existing store is None, then we need to acquire the stamp before
+      // loading RocksDB
+      val stamp = existingStore match {
+        case None =>
+          val s = stateMachine.acquireStamp()
+          acquiredStamp = Some(s)
+          Some(s)
+        case Some(store: RocksDBStateStore) =>
+          val s = store.stamp
+          stateMachine.verifyStamp(s)
+          Some(s)
+      }
+
       rocksDB.load(
         version,
         stateStoreCkptId = if (storeConf.enableStateStoreCheckpointIds) uniqueId else None,
         readOnly = readOnly)
 
       // Create or reuse store instance
-      existingStore match {
+      val store = existingStore match {
         case Some(store: RocksDBStateStore) =>
           // Mark store as being used for write operations
           store.readOnly = readOnly
           store
         case None =>
-          // Create new store instance
-          new RocksDBStateStore(version, readOnly)
+          // Create new store instance. The stamp should be defined
+          // in this case
+          new RocksDBStateStore(version, stamp.get, readOnly)
       }
+      storeLoaded = true
+      store
     } catch {
       case e: OutOfMemoryError =>
         throw QueryExecutionErrors.notEnoughMemoryToLoadStore(
           stateStoreId.toString,
           "ROCKSDB_STORE_PROVIDER",
           e)
+      case e: StateStoreInvalidStateMachineTransition =>
+        throw e
       case e: Throwable => throw StateStoreErrors.cannotLoadStore(e)
+    } finally {
+      // If we acquired a stamp but failed to load the store, release it.
+      // Note: We cannot rely on the task completion listener to clean up the stamp in this case
+      // because the listener is only registered in the RocksDBStateStore constructor. If the
+      // store fails to load (e.g., rocksDB.load() throws an exception), the RocksDBStateStore
+      // instance is never created, so no completion listener exists to release the stamp.
+      // This finally block ensures proper cleanup even when store creation fails early.
+      if (!storeLoaded && acquiredStamp.isDefined) {
+        acquiredStamp.foreach(stamp => stateMachine.releaseStamp(stamp, throwEx = false))
+      }
     }
   }
 
@@ -561,6 +725,7 @@ private[sql] class RocksDBStateStoreProvider
   }
 
   override def doMaintenance(): Unit = {
+    stateMachine.verifyForMaintenance()
     try {
       rocksDB.doMaintenance()
     } catch {
@@ -656,8 +821,15 @@ private[sql] class RocksDBStateStoreProvider
       if (endVersion < snapshotVersion) {
         throw QueryExecutionErrors.unexpectedStateStoreVersion(endVersion)
       }
-      rocksDB.loadFromSnapshot(snapshotVersion, endVersion)
-      new RocksDBStateStore(endVersion, readOnly)
+      val stamp = stateMachine.acquireStamp()
+      try {
+        rocksDB.loadFromSnapshot(snapshotVersion, endVersion)
+        new RocksDBStateStore(endVersion, stamp, readOnly)
+      } catch {
+        case e: Throwable =>
+          stateMachine.releaseStamp(stamp)
+          throw e
+      }
     }
     catch {
       case e: OutOfMemoryError =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
@@ -92,6 +92,18 @@ object StateStoreErrors {
     new StateStoreIncorrectNumOrderingColsForPrefixScan(numPrefixCols)
   }
 
+  def invalidStateMachineTransition(
+      oldState: String,
+      newState: String,
+      transition: String,
+      storeId: StateStoreId): StateStoreInvalidStateMachineTransition = {
+    new StateStoreInvalidStateMachineTransition(oldState, newState, transition, storeId)
+  }
+
+  def invalidStamp(providedStamp: Long, currentStamp: Long): StateStoreInvalidStamp = {
+    new StateStoreInvalidStamp(providedStamp, currentStamp)
+  }
+
   def incorrectNumOrderingColsForRangeScan(numOrderingCols: String):
     StateStoreIncorrectNumOrderingColsForRangeScan = {
     new StateStoreIncorrectNumOrderingColsForRangeScan(numOrderingCols)
@@ -342,6 +354,30 @@ class StateStoreVariableSizeOrderingColsNotSupported(fieldName: String, index: S
   extends SparkUnsupportedOperationException(
     errorClass = "STATE_STORE_VARIABLE_SIZE_ORDERING_COLS_NOT_SUPPORTED",
     messageParameters = Map("fieldName" -> fieldName, "index" -> index))
+
+class StateStoreInvalidStateMachineTransition(
+    oldState: String,
+    newState: String,
+    operation: String,
+    storeId: StateStoreId)
+  extends SparkRuntimeException(
+    errorClass = "STATE_STORE_INVALID_STATE_MACHINE_TRANSITION",
+    messageParameters = Map(
+      "oldState" -> oldState,
+      "newState" -> newState,
+      "operation" -> operation,
+      "storeId" -> storeId.toString
+    )
+  )
+
+class StateStoreInvalidStamp(providedStamp: Long, currentStamp: Long)
+  extends SparkRuntimeException(
+    errorClass = "STATE_STORE_INVALID_STAMP",
+    messageParameters = Map(
+      "providedStamp" -> providedStamp.toString,
+      "currentStamp" -> currentStamp.toString
+    )
+  )
 
 class StateStoreNullTypeOrderingColsNotSupported(fieldName: String, index: String)
   extends SparkUnsupportedOperationException(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceReadSuite.scala
@@ -1166,6 +1166,7 @@ abstract class StateDataSourceReadSuite extends StateDataSourceTestBase with Ass
       assert(get(result, "a", 2).get == 2)
       assert(get(result, "a", 3).get == 3)
       assert(get(result, "a", 4).isEmpty)
+      result.release()
 
       provider.close()
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreCheckpointFormatV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreCheckpointFormatV2Suite.scala
@@ -180,11 +180,38 @@ class CkptIdCollectingStateStoreProviderWrapper extends StateStoreProvider {
   }
 
   override def getReadStore(version: Long, uniqueId: Option[String] = None): ReadStateStore = {
-    new WrappedReadStateStore(
-      CkptIdCollectingStateStoreWrapper(innerProvider.getReadStore(version, uniqueId)))
+    // Don't wrap the read store with WrappedReadStateStore since it makes upgrading difficult
+    // Just return the wrapped store directly
+    CkptIdCollectingStateStoreWrapper(innerProvider.getReadStore(version, uniqueId))
   }
 
-  override def doMaintenance(): Unit = innerProvider.doMaintenance()
+  override def upgradeReadStoreToWriteStore(
+      readStore: ReadStateStore,
+      version: Long,
+      uniqueId: Option[String] = None): StateStore = {
+    // Following the pattern from RocksDBStateStoreProvider, we verify version and id match
+    assert(version == readStore.version,
+      s"Can only upgrade readStore to writeStore with the same version," +
+        s" readStoreVersion: ${readStore.version}, writeStoreVersion: ${version}")
+    assert(this.stateStoreId == readStore.id, "Can only upgrade readStore to writeStore with" +
+      " the same stateStoreId")
+
+    // Extract the inner store from our wrapper
+    val innerReadStore = readStore match {
+      case wrapper: CkptIdCollectingStateStoreWrapper => wrapper.innerStore
+      case _ =>
+        throw new IllegalStateException(
+          s"Expected CkptIdCollectingStateStoreWrapper" +
+            s" but got ${readStore.getClass}")
+    }
+
+    // Delegate to inner provider to upgrade the store
+    val upgradedStore = innerProvider.upgradeReadStoreToWriteStore(
+      innerReadStore, version, uniqueId)
+
+    // Wrap the upgraded store with CkptIdCollectingStateStoreWrapper
+    CkptIdCollectingStateStoreWrapper(upgradedStore)
+  }
 
   override def supportedCustomMetrics: Seq[StateStoreCustomMetric] =
     innerProvider.supportedCustomMetrics

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreLockHardeningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreLockHardeningSuite.scala
@@ -131,7 +131,7 @@ class RocksDBStateStoreLockHardeningSuite extends RocksDBStateStoreSuite {
         condition = "STATE_STORE_OPERATION_OUT_OF_ORDER",
         parameters = Map("errorMsg" ->
           ("Expected possible states (" +
-            "UPDATING, COMMITTING, ABORTED) but found COMMITTED"))
+            "UPDATING, ABORTED) but found COMMITTED"))
       )
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreLockHardeningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreLockHardeningSuite.scala
@@ -1,0 +1,533 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming.state
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+import org.scalactic.source.Position
+import org.scalatest.Tag
+import org.scalatest.time.SpanSugar._
+
+import org.apache.spark.{SparkException, SparkRuntimeException, TaskContext}
+import org.apache.spark.sql.execution.streaming.state.StateStoreTestsHelper._
+import org.apache.spark.util.ThreadUtils
+import org.apache.spark.util.ThreadUtils.awaitResult
+
+/**
+ * Comprehensive test cases for RocksDB State Store lock hardening implementation.
+ * These tests verify the state machine behavior and prevent problematic concurrent executions.
+ */
+class RocksDBStateStoreLockHardeningSuite extends RocksDBStateStoreSuite {
+
+  override protected def test(testName: String, testTags: Tag*)(testBody: => Any)
+                             (implicit pos: Position): Unit = {
+    super.test(s"$testName", testTags: _*) {
+      withSQLConf("spark.sql.streaming.stateStore.rocksdb.lockAcquireTimeoutMs" -> "2000") {
+        testBody
+      }
+    }
+  }
+
+  // Custom ExecutionContext for concurrent testing
+  implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(
+    ThreadUtils.newDaemonFixedThreadPool(5, "lock-hardening-test-pool"))
+
+  val timeout = 10.seconds
+
+  test("lock hardening: metrics atomicity - prevent cross-thread metric contamination") {
+    import scala.concurrent.ExecutionContext
+
+    // Create separate execution contexts to simulate different threads
+    implicit val ec1: ExecutionContext = ExecutionContext.fromExecutor(
+      ThreadUtils.newDaemonSingleThreadExecutor("thread-1"))
+    implicit val ec2: ExecutionContext = ExecutionContext.fromExecutor(
+      ThreadUtils.newDaemonSingleThreadExecutor("thread-2"))
+
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      @volatile var thread1Metrics: StateStoreMetrics = null
+      @volatile var thread2Metrics: StateStoreMetrics = null
+
+      // Thread 1: Complete transaction and store metrics
+      val future1 = Future {
+        val taskContext = TaskContext.empty()
+        TaskContext.setTaskContext(taskContext)
+
+        val store1 = provider.getStore(0)
+        put(store1, "a", 0, 1, StateStore.DEFAULT_COL_FAMILY_NAME)
+        assert(store1.commit() === 1)
+
+        // Store metrics from thread 1's perspective
+        thread1Metrics = store1.metrics
+        taskContext.markTaskCompleted(None)
+      }(ec1)
+
+      // Wait for thread 1 to complete
+      ThreadUtils.awaitResult(future1, 5.seconds)
+
+      // Thread 2: Start new transaction and access metrics
+      val future2 = Future {
+        val taskContext = TaskContext.empty()
+        TaskContext.setTaskContext(taskContext)
+
+        val store2 = provider.getStore(1)
+        put(store2, "b", 0, 2, StateStore.DEFAULT_COL_FAMILY_NAME)
+        assert(store2.commit() === 2)
+
+        // Store metrics from thread 2's perspective
+        thread2Metrics = store2.metrics
+        taskContext.markTaskCompleted(None)
+      }(ec2)
+
+      ThreadUtils.awaitResult(future2, 5.seconds)
+
+      // Verify each thread gets its own correct metrics
+      // Thread 1 should see metrics reflecting its commit (1 key)
+      assert(thread1Metrics.numKeys === 1,
+        s"Thread 1 should see 1 key, but saw ${thread1Metrics.numKeys}")
+
+      // Thread 2 should see metrics reflecting its commit (2 keys total)
+      assert(thread2Metrics.numKeys === 2,
+        s"Thread 2 should see 2 keys, but saw ${thread2Metrics.numKeys}")
+
+      // This test verifies that:
+      // 1. Metrics are stored locally during commit (no cross-thread contamination)
+      // 2. Each thread gets the correct metrics for its transaction
+      // 3. No thread gets metrics from another thread's transaction
+    }
+  }
+
+  test("lock hardening: abort after commit prevention") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      val store = provider.getStore(0)
+      put(store, "key", 0, 1, StateStore.DEFAULT_COL_FAMILY_NAME)
+
+      // Commit the store
+      store.commit()
+
+      // Attempting to abort after commit should throw StateStoreOperationOutOfOrder
+      val exception = intercept[SparkRuntimeException] {
+        store.abort()
+      }
+
+      checkError(
+        exception,
+        condition = "STATE_STORE_OPERATION_OUT_OF_ORDER",
+        parameters = Map("errorMsg" ->
+          ("Expected possible states (" +
+            "UPDATING, COMMITTING, ABORTED) but found COMMITTED"))
+      )
+    }
+  }
+
+  test("lock hardening: access after close prevention") {
+    val provider = newStoreProvider(useColumnFamilies = false)
+    val store = provider.getStore(0)
+    put(store, "key", 0, 1, StateStore.DEFAULT_COL_FAMILY_NAME)
+    store.commit()
+
+    // Manually trigger state machine close to ensure proper state transition
+    val stateMachine = PrivateMethod[Any](Symbol("stateMachine"))
+    val stateMachineObj = provider invokePrivate stateMachine()
+    stateMachineObj.asInstanceOf[RocksDBStateMachine].close()
+
+    // Attempting to get a new store after close should fail
+    // with StateStoreInvalidStateMachineTransition
+    val exception = intercept[StateStoreInvalidStateMachineTransition] {
+      provider.getStore(1)
+    }
+
+    assert(exception.getMessage.contains("Old state: CLOSED"))
+  }
+
+  test("lock hardening: state machine operation ordering after commit") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      val store = provider.getStore(0)
+      put(store, "key", 0, 1, StateStore.DEFAULT_COL_FAMILY_NAME)
+      store.commit()
+
+      // All update operations should fail after commit due to invalid stamp
+      val putException = intercept[StateStoreInvalidStamp] {
+        put(store, "key2", 0, 2, StateStore.DEFAULT_COL_FAMILY_NAME)
+      }
+      assert(putException.getMessage.contains("Invalid stamp"))
+
+      val removeException = intercept[StateStoreInvalidStamp] {
+        remove(store, { case (key, _) => key == "key" }, StateStore.DEFAULT_COL_FAMILY_NAME)
+      }
+      assert(removeException.getMessage.contains("Invalid stamp"))
+
+      // Get operations should also fail with invalid stamp
+      val getException = intercept[StateStoreInvalidStamp] {
+        get(store, "key", 0, StateStore.DEFAULT_COL_FAMILY_NAME)
+      }
+      assert(getException.getMessage.contains("Invalid stamp"))
+    }
+  }
+
+  test("lock hardening: state machine operation ordering after abort") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      val store = provider.getStore(0)
+      put(store, "key", 0, 1, StateStore.DEFAULT_COL_FAMILY_NAME)
+      store.abort()
+
+      // All operations should fail after abort due to invalid stamp
+      val putException = intercept[StateStoreInvalidStamp] {
+        put(store, "key2", 0, 2, StateStore.DEFAULT_COL_FAMILY_NAME)
+      }
+      assert(putException.getMessage.contains("Invalid stamp"))
+
+      val getException = intercept[StateStoreInvalidStamp] {
+        get(store, "key", 0, StateStore.DEFAULT_COL_FAMILY_NAME)
+      }
+      assert(getException.getMessage.contains("Invalid stamp"))
+    }
+  }
+
+  test("lock hardening: concurrent state store instances prevention") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      val store1 = provider.getStore(0)
+      assertAcquiredThreadIsCurrentThread(provider)
+
+      // Latches to coordinate timing between threads
+      val threadStarted = new CountDownLatch(1)
+      val proceedToAcquire = new CountDownLatch(1)
+      val lockAttempted = new CountDownLatch(1)
+
+      // Start concurrent thread that will timeout waiting
+      val concurrentFuture = Future {
+        val taskContext = TaskContext.empty()
+        TaskContext.setTaskContext(taskContext)
+
+        try {
+          threadStarted.countDown()
+
+          // Wait for signal to proceed with lock acquisition
+          proceedToAcquire.await(5, TimeUnit.SECONDS)
+
+          lockAttempted.countDown()
+
+          // This should block and eventually timeout/fail
+          provider.getStore(0)
+          false // Should not reach here
+        } catch {
+          case ex: Exception if ex.getMessage.contains("could not be acquired") => true
+          case ex: Exception if ex.getMessage.contains("not released") => true
+          case ex: Exception if ex.getMessage.contains("Waiting to acquire lock") => true
+          case ex: Exception =>
+            // Log the actual exception for debugging
+            logInfo(s"Unexpected exception: ${ex.getClass.getName}: ${ex.getMessage}")
+            false
+        }
+      }
+
+      // Wait for concurrent thread to start
+      assert(threadStarted.await(5, TimeUnit.SECONDS), "Concurrent thread should start")
+
+      // Signal the concurrent thread to proceed with lock acquisition
+      proceedToAcquire.countDown()
+
+      // Wait for the concurrent thread to attempt lock acquisition
+      assert(lockAttempted.await(5, TimeUnit.SECONDS), "Concurrent thread should attempt lock")
+
+      // Give the concurrent thread time to hit the blocking code and timeout
+      Thread.sleep(2500) // Wait longer than the 2 second timeout in awaitNotLocked
+
+      // The concurrent thread should have timed out by now, so commit to release lock
+      store1.commit()
+
+      // Now the concurrent future should return with the expected error
+      val result = awaitResult(concurrentFuture, 5.seconds)
+      assert(result, "Concurrent access should be prevented with proper error")
+
+      // After commit, new access should work
+      val secondStore = provider.getStore(1)
+      assertAcquiredThreadIsCurrentThread(provider)
+      secondStore.abort()
+    }
+  }
+
+  test("lock hardening: task completion listener releases ownership") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      var taskCompleted = false
+      var storeStamp: Long = -1
+
+      val taskFuture = Future {
+        val taskContext = TaskContext.empty()
+        TaskContext.setTaskContext(taskContext)
+
+        val store = provider.getStore(0)
+        val stateMachine = PrivateMethod[Any](Symbol("stateMachine"))
+        val stateMachineObj = provider invokePrivate stateMachine()
+        storeStamp = stateMachineObj.asInstanceOf[RocksDBStateMachine].currentValidStamp.get()
+        put(store, "key", 0, 1, StateStore.DEFAULT_COL_FAMILY_NAME)
+
+        // Simulate task failure without explicit abort
+        taskContext.markTaskCompleted(Some(new SparkException("Task failure injection")))
+        taskCompleted = true
+
+        // Don't explicitly abort - let TaskCompletionListener handle it
+      }
+
+      awaitResult(taskFuture, timeout)
+      assert(taskCompleted)
+
+      // Wait a bit for TaskCompletionListener to execute
+      Thread.sleep(100)
+
+      // Verify that ownership was released by the TaskCompletionListener
+      val stateMachine = PrivateMethod[Any](Symbol("stateMachine"))
+      val stateMachineObj = provider invokePrivate stateMachine()
+      val currentStamp = stateMachineObj.asInstanceOf[RocksDBStateMachine].currentValidStamp.get()
+      assert(currentStamp == -1,
+        s"State machine should be unlocked (stamp = -1) but was $currentStamp")
+    }
+  }
+
+  test("lock hardening: concurrent access serialization without deadlocks") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      val numThreads = 3
+      val latch = new CountDownLatch(numThreads)
+      var completedThreads = 0
+      val results = new Array[Boolean](numThreads)
+      var exceptions = List.empty[Throwable]
+
+      val futures = (0 until numThreads).map { threadId =>
+        Future {
+          val taskContext = TaskContext.empty()
+          TaskContext.setTaskContext(taskContext)
+
+          try {
+            latch.countDown()
+            latch.await(5, TimeUnit.SECONDS) // Wait for all threads to be ready
+
+            val store = provider.getStore(0)
+            put(store, s"key$threadId",
+              threadId, threadId * 100, StateStore.DEFAULT_COL_FAMILY_NAME)
+
+            // Verify this thread has ownership
+            assertAcquiredThreadIsCurrentThread(provider)
+
+            store.commit()
+
+            synchronized {
+              completedThreads += 1
+              results(threadId) = true
+            }
+            true
+
+          } catch {
+            case ex: Throwable =>
+              synchronized {
+                exceptions = ex :: exceptions
+              }
+              false
+          }
+        }
+      }
+
+      // Wait for all futures to complete
+      futures.foreach(f => awaitResult(f, timeout))
+
+      // Verify results
+      assert(exceptions.isEmpty, s"Unexpected exceptions: ${exceptions.mkString(", ")}")
+      assert(completedThreads == numThreads,
+        s"Expected $numThreads threads to complete, got $completedThreads")
+      assert(results.forall(identity), "All threads should have completed successfully")
+    }
+  }
+
+  test("lock hardening: read-to-write store upgrade stamp consistency") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      // Get a read-only store first
+      val readStore = provider.getReadStore(0)
+
+      // Upgrade to write store
+      val writeStore = provider.upgradeReadStoreToWriteStore(readStore, 0)
+
+      // Verify the upgrade maintains stamp consistency
+      assertAcquiredThreadIsCurrentThread(provider)
+
+      // Should be able to perform write operations
+      put(writeStore, "key", 0, 1, StateStore.DEFAULT_COL_FAMILY_NAME)
+      writeStore.commit()
+
+      // Verify read store operations now fail with invalid stamp
+      val exception = intercept[StateStoreInvalidStamp] {
+        readStore.get(dataToKeyRow("key", 0), StateStore.DEFAULT_COL_FAMILY_NAME)
+      }
+      assert(exception.getMessage.contains("Invalid stamp"))
+    }
+  }
+
+  test("lock hardening: provider state machine transitions") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      // Initially should be in RELEASED state (no acquired thread info)
+      val stateMachine = PrivateMethod[Any](Symbol("stateMachine"))
+      val stateMachineObj = provider invokePrivate stateMachine()
+      val initialThreadInfo =
+        stateMachineObj.asInstanceOf[RocksDBStateMachine].getAcquiredThreadInfo
+      assert(initialThreadInfo.isEmpty, "Initial state should have no acquired thread info")
+
+      // Acquire a store - should transition to ACQUIRED
+      val store = provider.getStore(0)
+      assertAcquiredThreadIsCurrentThread(provider)
+
+      // Verify stamp is valid
+      val stateMachine2 = PrivateMethod[Any](Symbol("stateMachine"))
+      val stateMachineObj2 = provider invokePrivate stateMachine2()
+      val stamp = stateMachineObj2.asInstanceOf[RocksDBStateMachine].currentValidStamp.get()
+      assert(stamp != -1, "Valid stamp should not be -1")
+
+      // Commit and verify transition back to RELEASED
+      store.commit()
+
+      val stateMachine3 = PrivateMethod[Any](Symbol("stateMachine"))
+      val stateMachineObj3 = provider invokePrivate stateMachine3()
+      val finalStamp = stateMachineObj3.asInstanceOf[RocksDBStateMachine].currentValidStamp.get()
+      assert(finalStamp == -1, "After commit, stamp should be -1 (released)")
+
+      // Note: Thread info may still be present after commit as it's only cleared when
+      // the provider is accessed again or explicitly released
+    }
+  }
+
+  test("lock hardening: metrics access control during UPDATING state") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      val store = provider.getStore(0)
+      put(store, "key", 0, 1, StateStore.DEFAULT_COL_FAMILY_NAME)
+
+      // Metrics should not be accessible during UPDATING state
+      val exception = intercept[SparkRuntimeException] {
+        store.metrics
+      }
+
+      checkError(
+        exception,
+        condition = "STATE_STORE_OPERATION_OUT_OF_ORDER",
+        parameters = Map("errorMsg" ->
+          "Cannot get metrics in UPDATING state")
+      )
+
+      // After commit, metrics should be accessible
+      store.commit()
+      val metrics = store.metrics
+      assert(metrics.numKeys == 1)
+    }
+  }
+
+  test("lock hardening: checkpoint info access control during UPDATING state") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      val store = provider.getStore(0)
+      put(store, "key", 0, 1, StateStore.DEFAULT_COL_FAMILY_NAME)
+
+      // Checkpoint info should not be accessible during UPDATING state
+      val exception = intercept[SparkRuntimeException] {
+        store.getStateStoreCheckpointInfo()
+      }
+
+      checkError(
+        exception,
+        condition = "STATE_STORE_OPERATION_OUT_OF_ORDER",
+        parameters = Map("errorMsg" ->
+          "Cannot get metrics in UPDATING state")
+      )
+
+      // After commit, checkpoint info should be accessible
+      store.commit()
+      val checkpointInfo = store.getStateStoreCheckpointInfo()
+      assert(checkpointInfo != null)
+    }
+  }
+
+  test("lock hardening: multiple instance prevention with detailed error") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      val store1 = provider.getStore(0)
+
+      // Try to get another instance from a different thread
+      val concurrentFuture = Future {
+        val taskContext = TaskContext.empty()
+        TaskContext.setTaskContext(taskContext)
+
+        val startTime = System.currentTimeMillis()
+        val exception = intercept[SparkException] {
+          provider.getStore(0)
+        }
+        val endTime = System.currentTimeMillis()
+
+        // Verify error message contains expected details
+        val message = exception.getMessage
+        (message.contains("UNRELEASED_THREAD_ERROR"),
+          endTime - startTime)
+      }
+
+      val (hasCorrectError, duration) = awaitResult(concurrentFuture, timeout)
+      assert(hasCorrectError, "Should get unreleased thread error or timeout waiting for lock")
+
+      // Verify it actually waited (didn't fail immediately)
+      assert(duration >= 2000,
+        s"Should have waited at least 2 seconds but only waited $duration ms")
+
+      store1.commit()
+    }
+  }
+
+  test("lock hardening: stamp verification prevents unauthorized access") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      val store = provider.getStore(0)
+      val stateMachine = PrivateMethod[Any](Symbol("stateMachine"))
+      val stateMachineObj = provider invokePrivate stateMachine()
+      val validStamp = stateMachineObj.asInstanceOf[RocksDBStateMachine].currentValidStamp.get()
+
+      // Simulate stamp verification with correct stamp
+      stateMachineObj.asInstanceOf[RocksDBStateMachine].verifyStamp(validStamp) // Should not throw
+
+      // Simulate stamp verification with incorrect stamp
+      val incorrectStamp = validStamp + 1
+      val exception = intercept[StateStoreInvalidStamp] {
+        stateMachineObj.asInstanceOf[RocksDBStateMachine].verifyStamp(incorrectStamp)
+      }
+      assert(exception.getMessage.contains("Invalid stamp"))
+
+      store.abort()
+
+      // After abort, even the originally valid stamp should be invalid
+      val postAbortException = intercept[StateStoreInvalidStamp] {
+        val stateMachine2 = PrivateMethod[Any](Symbol("stateMachine"))
+        val stateMachineObj2 = provider invokePrivate stateMachine2()
+        stateMachineObj2.asInstanceOf[RocksDBStateMachine].verifyStamp(validStamp)
+      }
+      assert(postAbortException.getMessage.contains("Invalid stamp"))
+    }
+  }
+
+  // Helper method to assert current thread has ownership
+  override def assertAcquiredThreadIsCurrentThread(provider: RocksDBStateStoreProvider): Unit = {
+    val stateMachine = PrivateMethod[Any](Symbol("stateMachine"))
+    val stateMachineObj = provider invokePrivate stateMachine()
+    val threadInfo = stateMachineObj.asInstanceOf[RocksDBStateMachine].getAcquiredThreadInfo
+    assert(threadInfo.isDefined,
+      "acquired thread info should not be null after load")
+    val threadId = threadInfo.get.threadRef.get.get.getId
+    assert(
+      threadId == Thread.currentThread().getId,
+      s"acquired thread should be current thread ${Thread.currentThread().getId} " +
+        s"after load but was $threadId")
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -20,13 +20,17 @@ package org.apache.spark.sql.execution.streaming.state
 import java.util.UUID
 
 import scala.collection.immutable
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Random
 
 import org.apache.avro.AvroTypeException
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.BeforeAndAfter
+import org.scalatest.PrivateMethodTester
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.SpanSugar._
 
-import org.apache.spark.{SparkConf, SparkUnsupportedOperationException}
+import org.apache.spark.{SparkConf, SparkException, SparkRuntimeException, SparkUnsupportedOperationException, TaskContext}
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.sql.LocalSparkSession.withSparkSession
 import org.apache.spark.sql.SparkSession
@@ -40,14 +44,27 @@ import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.types.UTF8String
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{ThreadUtils, Utils}
 
 @ExtendedSQLTest
 class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvider]
   with AlsoTestWithEncodingTypes
   with AlsoTestWithRocksDBFeatures
+  with PrivateMethodTester
   with SharedSparkSession
-  with BeforeAndAfter {
+  with BeforeAndAfter
+  with Matchers {
+
+  // Helper method to get RocksDBStateStore using PrivateMethodTester
+  private def getRocksDBStateStore(
+      provider: RocksDBStateStoreProvider, version: Long): provider.RocksDBStateStore = {
+    val getRocksDBStateStoreMethod =
+      PrivateMethod[provider.RocksDBStateStore](Symbol("getRocksDBStateStore"))
+    provider invokePrivate getRocksDBStateStoreMethod(version)
+  }
+
+  override def beforeEach(): Unit = {}
+  override def afterEach(): Unit = {}
 
   before {
     StateStore.stop()
@@ -68,30 +85,35 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
 
     tryWithProviderResource(newStoreProvider(colFamiliesEnabled)) { provider =>
       val store = provider.getStore(0)
-      val keyRow = dataToKeyRow("a", 0)
-      val valueRow = dataToValueRow(1)
-      store.put(keyRow, valueRow)
-      val iter = provider.rocksDB.iterator()
-      assert(iter.hasNext)
-      val kv = iter.next()
+      try {
+        val keyRow = dataToKeyRow("a", 0)
+        val valueRow = dataToValueRow(1)
+        store.put(keyRow, valueRow)
+        val iter = provider.rocksDB.iterator()
+        assert(iter.hasNext)
+        val kv = iter.next()
 
-      // Verify the version encoded in first byte of the key and value byte arrays
-      assert(Platform.getByte(kv.key, Platform.BYTE_ARRAY_OFFSET) === STATE_ENCODING_VERSION)
-      assert(Platform.getByte(kv.value, Platform.BYTE_ARRAY_OFFSET) === STATE_ENCODING_VERSION)
+        // Verify the version encoded in first byte of the key and value byte arrays
+        assert(Platform.getByte(kv.key, Platform.BYTE_ARRAY_OFFSET) === STATE_ENCODING_VERSION)
+        assert(Platform.getByte(kv.value, Platform.BYTE_ARRAY_OFFSET) === STATE_ENCODING_VERSION)
 
-      // The test verifies that the actual key-value pair (kv) matches these expected byte patterns
-      // exactly using sameElements, which ensures the serialization format remains consistent and
-      // backward compatible. This is particularly important for state storage where the format
-      // needs to be stable across Spark versions.
-      val (expectedKey, expectedValue) = if (conf.stateStoreEncodingFormat == "avro") {
-        (Array(0, 0, 0, 2, 2, 97, 2, 0), Array(0, 0, 0, 2, 2))
-      } else {
-        (Array(0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 24, 0, 0,
-          0, 0, 0, 0, 0, 0, 0, 0, 0, 97, 0, 0, 0, 0, 0, 0, 0),
-          Array(0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0))
+        // The test verifies that the actual key-value pair (kv) matches these expected
+        // byte patterns
+        // exactly using sameElements, which ensures the serialization format remains consistent and
+        // backward compatible. This is particularly important for state storage where the format
+        // needs to be stable across Spark versions.
+        val (expectedKey, expectedValue) = if (conf.stateStoreEncodingFormat == "avro") {
+          (Array(0, 0, 0, 2, 2, 97, 2, 0), Array(0, 0, 0, 2, 2))
+        } else {
+          (Array(0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 24, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 97, 0, 0, 0, 0, 0, 0, 0),
+            Array(0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0))
+        }
+        assert(kv.key.sameElements(expectedKey))
+        assert(kv.value.sameElements(expectedValue))
+      } finally {
+        if (!store.hasCommitted) store.abort()
       }
-      assert(kv.key.sameElements(expectedKey))
-      assert(kv.value.sameElements(expectedValue))
     }
   }
 
@@ -355,6 +377,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         key._1
       }.toSeq
       assert(result1 === (timerTimestamps ++ timerTimestamps1).sorted)
+      store1.commit()
     }
   }
 
@@ -522,6 +545,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         key._1
       }.toSeq
       assert(result1 === (timerTimestamps ++ timerTimestamps1).sorted)
+      store1.commit()
     }
   }
 
@@ -1320,89 +1344,95 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
     tryWithProviderResource(newStoreProvider(testSchema,
       RangeKeyScanStateEncoderSpec(testSchema, Seq(0, 1)), colFamiliesEnabled)) { provider =>
       val store = provider.getStore(0)
+      try {
+        val cfName = if (colFamiliesEnabled) "testColFamily" else "default"
+        if (colFamiliesEnabled) {
+          store.createColFamilyIfAbsent(cfName,
+            testSchema, valueSchema,
+            RangeKeyScanStateEncoderSpec(testSchema, Seq(0, 1)))
+        }
 
-      val cfName = if (colFamiliesEnabled) "testColFamily" else "default"
-      if (colFamiliesEnabled) {
-        store.createColFamilyIfAbsent(cfName,
-          testSchema, valueSchema,
-          RangeKeyScanStateEncoderSpec(testSchema, Seq(0, 1)))
+        val timerTimestamps = Seq((931L, 10), (null, 40), (452300L, 1),
+          (4200L, 68), (90L, 2000), (1L, 27), (1L, 394), (1L, 5), (3L, 980), (35L, 2112),
+          (6L, 90118), (9L, 95118), (6L, 87210), (null, 113), (null, 28),
+          (null, -23), (null, -5534), (-67450L, 2434), (-803L, 3422))
+        timerTimestamps.foreach { ts =>
+          // order by long col first and then by int col
+          val keyRow = schemaProj.apply(new GenericInternalRow(Array[Any](ts._1, ts._2,
+            UTF8String.fromString(Random.alphanumeric.take(Random.nextInt(20) + 1).mkString))))
+          val valueRow = dataToValueRow(1)
+          store.put(keyRow, valueRow, cfName)
+          assert(valueRowToData(store.get(keyRow, cfName)) === 1)
+        }
+
+        // verify that the expected null cols are seen
+        val nullRows = store.iterator(cfName).filter { kv =>
+          val keyRow = kv.key
+          keyRow.isNullAt(0)
+        }
+        assert(nullRows.size === 5)
+
+        // filter out the null rows and verify the rest
+        val result: Seq[(Long, Int)] = store.iterator(cfName).filter { kv =>
+          val keyRow = kv.key
+          !keyRow.isNullAt(0)
+        }.map { kv =>
+          val keyRow = kv.key
+          val key = (keyRow.getLong(0), keyRow.getInt(1), keyRow.getString(2))
+          (key._1, key._2)
+        }.toSeq
+
+        val timerTimestampsWithoutNulls = Seq((931L, 10), (452300L, 1),
+          (4200L, 68), (90L, 2000), (1L, 27), (1L, 394), (1L, 5), (3L, 980), (35L, 2112),
+          (6L, 90118), (9L, 95118), (6L, 87210), (-67450L, 2434), (-803L, 3422))
+
+        assert(result === timerTimestampsWithoutNulls.sorted)
+
+        // verify that the null cols are seen in the correct order filtering for nulls
+        val nullRowsWithOrder = store.iterator(cfName).filter { kv =>
+          val keyRow = kv.key
+          keyRow.isNullAt(0)
+        }.map { kv =>
+          val keyRow = kv.key
+          keyRow.getInt(1)
+        }.toSeq
+
+        assert(nullRowsWithOrder === Seq(-5534, -23, 28, 40, 113))
+      } finally {
+        if (!store.hasCommitted) store.abort()
       }
-
-      val timerTimestamps = Seq((931L, 10), (null, 40), (452300L, 1),
-        (4200L, 68), (90L, 2000), (1L, 27), (1L, 394), (1L, 5), (3L, 980), (35L, 2112),
-        (6L, 90118), (9L, 95118), (6L, 87210), (null, 113), (null, 28), (null, -23), (null, -5534),
-        (-67450L, 2434), (-803L, 3422))
-      timerTimestamps.foreach { ts =>
-        // order by long col first and then by int col
-        val keyRow = schemaProj.apply(new GenericInternalRow(Array[Any](ts._1, ts._2,
-          UTF8String.fromString(Random.alphanumeric.take(Random.nextInt(20) + 1).mkString))))
-        val valueRow = dataToValueRow(1)
-        store.put(keyRow, valueRow, cfName)
-        assert(valueRowToData(store.get(keyRow, cfName)) === 1)
-      }
-
-      // verify that the expected null cols are seen
-      val nullRows = store.iterator(cfName).filter { kv =>
-        val keyRow = kv.key
-        keyRow.isNullAt(0)
-      }
-      assert(nullRows.size === 5)
-
-      // filter out the null rows and verify the rest
-      val result: Seq[(Long, Int)] = store.iterator(cfName).filter { kv =>
-        val keyRow = kv.key
-        !keyRow.isNullAt(0)
-      }.map { kv =>
-        val keyRow = kv.key
-        val key = (keyRow.getLong(0), keyRow.getInt(1), keyRow.getString(2))
-        (key._1, key._2)
-      }.toSeq
-
-      val timerTimestampsWithoutNulls = Seq((931L, 10), (452300L, 1),
-        (4200L, 68), (90L, 2000), (1L, 27), (1L, 394), (1L, 5), (3L, 980), (35L, 2112),
-        (6L, 90118), (9L, 95118), (6L, 87210), (-67450L, 2434), (-803L, 3422))
-
-      assert(result === timerTimestampsWithoutNulls.sorted)
-
-      // verify that the null cols are seen in the correct order filtering for nulls
-      val nullRowsWithOrder = store.iterator(cfName).filter { kv =>
-        val keyRow = kv.key
-        keyRow.isNullAt(0)
-      }.map { kv =>
-        val keyRow = kv.key
-        keyRow.getInt(1)
-      }.toSeq
-
-      assert(nullRowsWithOrder === Seq(-5534, -23, 28, 40, 113))
-
-      store.abort()
 
       val store1 = provider.getStore(0)
-      if (colFamiliesEnabled) {
-        store1.createColFamilyIfAbsent(cfName,
-          testSchema, valueSchema,
-          RangeKeyScanStateEncoderSpec(testSchema, Seq(0, 1)))
+      try {
+        val cfName = if (colFamiliesEnabled) "testColFamily" else "default"
+        if (colFamiliesEnabled) {
+          store1.createColFamilyIfAbsent(cfName,
+            testSchema, valueSchema,
+            RangeKeyScanStateEncoderSpec(testSchema, Seq(0, 1)))
+        }
+
+        val timerTimestamps1 = Seq((null, 3), (null, 1), (null, 32),
+          (null, 113), (null, 40872), (null, -675456), (null, -924), (null, -666),
+          (null, 66))
+        timerTimestamps1.foreach { ts =>
+          // order by long col first and then by int col
+          val keyRow = schemaProj.apply(new GenericInternalRow(Array[Any](ts._1, ts._2,
+            UTF8String.fromString(Random.alphanumeric.take(Random.nextInt(20) + 1).mkString))))
+          val valueRow = dataToValueRow(1)
+          store1.put(keyRow, valueRow, cfName)
+          assert(valueRowToData(store1.get(keyRow, cfName)) === 1)
+        }
+
+        // verify that ordering for non-null columns on the right in still maintained
+        val result1: Seq[Int] = store1.iterator(cfName).map { kv =>
+          val keyRow = kv.key
+          keyRow.getInt(1)
+        }.toSeq
+
+        assert(result1 === timerTimestamps1.map(_._2).sorted)
+      } finally {
+        if (!store1.hasCommitted) store1.abort()
       }
-
-      val timerTimestamps1 = Seq((null, 3), (null, 1), (null, 32),
-        (null, 113), (null, 40872), (null, -675456), (null, -924), (null, -666),
-        (null, 66))
-      timerTimestamps1.foreach { ts =>
-        // order by long col first and then by int col
-        val keyRow = schemaProj.apply(new GenericInternalRow(Array[Any](ts._1, ts._2,
-          UTF8String.fromString(Random.alphanumeric.take(Random.nextInt(20) + 1).mkString))))
-        val valueRow = dataToValueRow(1)
-        store1.put(keyRow, valueRow, cfName)
-        assert(valueRowToData(store1.get(keyRow, cfName)) === 1)
-      }
-
-      // verify that ordering for non-null columns on the right in still maintained
-      val result1: Seq[Int] = store.iterator(cfName).map { kv =>
-        val keyRow = kv.key
-        keyRow.getInt(1)
-      }.toSeq
-
-      assert(result1 === timerTimestamps1.map(_._2).sorted)
     }
   }
 
@@ -1513,37 +1543,42 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
     tryWithProviderResource(newStoreProvider(valueSchema,
       RangeKeyScanStateEncoderSpec(valueSchema, Seq(0)), colFamiliesEnabled)) { provider =>
       val store = provider.getStore(0)
-      val cfName = if (colFamiliesEnabled) "testColFamily" else "default"
-      if (colFamiliesEnabled) {
-        store.createColFamilyIfAbsent(cfName,
-          valueSchema, valueSchema,
-          RangeKeyScanStateEncoderSpec(valueSchema, Seq(0)))
-      }
+      try {
+        val cfName = if (colFamiliesEnabled) "testColFamily" else "default"
+        if (colFamiliesEnabled) {
+          store.createColFamilyIfAbsent(cfName,
+            valueSchema, valueSchema,
+            RangeKeyScanStateEncoderSpec(valueSchema, Seq(0)))
+        }
 
-      val timerTimestamps = Seq(931, 8000, 452300, 4200,
-        -3545, -343, 133, -90, -8014490, -79247,
-        90, 1, 2, 8, 3, 35, 6, 9, 5, -233)
-      timerTimestamps.foreach { ts =>
-        // non-timestamp col is of variable size
-        val keyRow = dataToValueRow(ts)
-        val valueRow = dataToValueRow(1)
-        store.put(keyRow, valueRow, cfName)
-        assert(valueRowToData(store.get(keyRow, cfName)) === 1)
-      }
+        val timerTimestamps = Seq(931, 8000, 452300, 4200,
+          -3545, -343, 133, -90, -8014490, -79247,
+          90, 1, 2, 8, 3, 35, 6, 9, 5, -233)
+        timerTimestamps.foreach { ts =>
+          // non-timestamp col is of variable size
+          val keyRow = dataToValueRow(ts)
+          val valueRow = dataToValueRow(1)
+          store.put(keyRow, valueRow, cfName)
+          assert(valueRowToData(store.get(keyRow, cfName)) === 1)
+        }
 
-      val result = store.iterator(cfName).map { kv =>
-        valueRowToData(kv.key)
-      }.toSeq
-      assert(result === timerTimestamps.sorted)
-
-      // also check for prefix scan
-      timerTimestamps.foreach { ts =>
-        val prefix = dataToValueRow(ts)
-        val result = store.prefixScan(prefix, cfName).map { kv =>
-          assert(valueRowToData(kv.value) === 1)
+        val result = store.iterator(cfName).map { kv =>
           valueRowToData(kv.key)
         }.toSeq
-        assert(result.size === 1)
+        assert(result === timerTimestamps.sorted)
+
+        // also check for prefix scan
+        timerTimestamps.foreach { ts =>
+          val prefix = dataToValueRow(ts)
+          val result = store.prefixScan(prefix, cfName).map { kv =>
+            assert(valueRowToData(kv.value) === 1)
+            valueRowToData(kv.key)
+          }.toSeq
+          assert(result.size === 1)
+        }
+        store.commit()
+      } finally {
+        if (!store.hasCommitted) store.abort()
       }
     }
   }
@@ -1555,32 +1590,36 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
       RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
       colFamiliesEnabled)) { provider =>
       val store = provider.getStore(0)
-
-      val cfName = if (colFamiliesEnabled) "testColFamily" else "default"
-      if (colFamiliesEnabled) {
-        store.createColFamilyIfAbsent(cfName,
-          keySchemaWithRangeScan, valueSchema,
-          RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)))
-      }
-
-      val timerTimestamps = Seq(931L, -1331L, 8000L, 1L, -244L, -8350L, -55L)
-      timerTimestamps.zipWithIndex.foreach { case (ts, idx) =>
-        (1 to idx + 1).foreach { keyVal =>
-          val keyRow = dataToKeyRowWithRangeScan(ts, keyVal.toString)
-          val valueRow = dataToValueRow(1)
-          store.put(keyRow, valueRow, cfName)
-          assert(valueRowToData(store.get(keyRow, cfName)) === 1)
+      try {
+        val cfName = if (colFamiliesEnabled) "testColFamily" else "default"
+        if (colFamiliesEnabled) {
+          store.createColFamilyIfAbsent(cfName,
+            keySchemaWithRangeScan, valueSchema,
+            RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)))
         }
-      }
 
-      timerTimestamps.zipWithIndex.foreach { case (ts, idx) =>
-        val prefix = dataToPrefixKeyRowWithRangeScan(ts)
-        val result = store.prefixScan(prefix, cfName).map { kv =>
-          assert(valueRowToData(kv.value) === 1)
-          val key = keyRowWithRangeScanToData(kv.key)
-          key._2
-        }.toSeq
-        assert(result.size === idx + 1)
+        val timerTimestamps = Seq(931L, -1331L, 8000L, 1L, -244L, -8350L, -55L)
+        timerTimestamps.zipWithIndex.foreach { case (ts, idx) =>
+          (1 to idx + 1).foreach { keyVal =>
+            val keyRow = dataToKeyRowWithRangeScan(ts, keyVal.toString)
+            val valueRow = dataToValueRow(1)
+            store.put(keyRow, valueRow, cfName)
+            assert(valueRowToData(store.get(keyRow, cfName)) === 1)
+          }
+        }
+
+        timerTimestamps.zipWithIndex.foreach { case (ts, idx) =>
+          val prefix = dataToPrefixKeyRowWithRangeScan(ts)
+          val result = store.prefixScan(prefix, cfName).map { kv =>
+            assert(valueRowToData(kv.value) === 1)
+            val key = keyRowWithRangeScanToData(kv.key)
+            key._2
+          }.toSeq
+          assert(result.size === idx + 1)
+        }
+        store.commit()
+      } finally {
+        if (!store.hasCommitted) store.abort()
       }
     }
   }
@@ -1726,30 +1765,34 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
       newStoreProvider(useColumnFamilies = colFamiliesEnabled)) { provider =>
       val store = provider.getStore(0)
 
-      val colFamilyName = "test"
+      try {
+        val colFamilyName = "test"
 
-      verifyStoreOperationUnsupported("put", colFamiliesEnabled, colFamilyName) {
-        store.put(dataToKeyRow("a", 1), dataToValueRow(1), colFamilyName)
-      }
+        verifyStoreOperationUnsupported("put", colFamiliesEnabled, colFamilyName) {
+          store.put(dataToKeyRow("a", 1), dataToValueRow(1), colFamilyName)
+        }
 
-      verifyStoreOperationUnsupported("remove", colFamiliesEnabled, colFamilyName) {
-        store.remove(dataToKeyRow("a", 1), colFamilyName)
-      }
+        verifyStoreOperationUnsupported("remove", colFamiliesEnabled, colFamilyName) {
+          store.remove(dataToKeyRow("a", 1), colFamilyName)
+        }
 
-      verifyStoreOperationUnsupported("get", colFamiliesEnabled, colFamilyName) {
-        store.get(dataToKeyRow("a", 1), colFamilyName)
-      }
+        verifyStoreOperationUnsupported("get", colFamiliesEnabled, colFamilyName) {
+          store.get(dataToKeyRow("a", 1), colFamilyName)
+        }
 
-      verifyStoreOperationUnsupported("iterator", colFamiliesEnabled, colFamilyName) {
-        store.iterator(colFamilyName)
-      }
+        verifyStoreOperationUnsupported("iterator", colFamiliesEnabled, colFamilyName) {
+          store.iterator(colFamilyName)
+        }
 
-      verifyStoreOperationUnsupported("merge", colFamiliesEnabled, colFamilyName) {
-        store.merge(dataToKeyRow("a", 1), dataToValueRow(1), colFamilyName)
-      }
+        verifyStoreOperationUnsupported("merge", colFamiliesEnabled, colFamilyName) {
+          store.merge(dataToKeyRow("a", 1), dataToValueRow(1), colFamilyName)
+        }
 
-      verifyStoreOperationUnsupported("prefixScan", colFamiliesEnabled, colFamilyName) {
-        store.prefixScan(dataToKeyRow("a", 1), colFamilyName)
+        verifyStoreOperationUnsupported("prefixScan", colFamiliesEnabled, colFamilyName) {
+          store.prefixScan(dataToKeyRow("a", 1), colFamilyName)
+        }
+      } finally {
+        if (!store.hasCommitted) store.abort()
       }
     }
   }
@@ -1790,12 +1833,10 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
       put(store, ("a", 1), 1, colFamily2)
       assert(valueRowToData(get(store, "a", 1, colFamily2)) === 1)
 
-      // calling commit on this store creates version 1
       store.commit()
 
       // reload version 0
       store = provider.getStore(0)
-
       val e = intercept[Exception]{
         get(store, "a", 1, colFamily1)
       }
@@ -1805,6 +1846,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         sqlState = Some("42802"),
         parameters = Map("operationType" -> "get", "colFamilyName" -> colFamily1)
       )
+      store.abort()
 
       store = provider.getStore(1)
       // version 1 data recovered correctly
@@ -1829,7 +1871,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
 
   test("verify that column family id is assigned correctly after removal") {
     tryWithProviderResource(newStoreProvider(useColumnFamilies = true)) { provider =>
-      var store = provider.getRocksDBStateStore(0)
+      var store = getRocksDBStateStore(provider, 0)
       val colFamily1: String = "abc"
       val colFamily2: String = "def"
       val colFamily3: String = "ghi"
@@ -1842,27 +1884,29 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         NoPrefixKeyStateEncoderSpec(keySchema))
       store.commit()
 
-      store = provider.getRocksDBStateStore(1)
+      store = getRocksDBStateStore(provider, 1)
       store.removeColFamilyIfExists(colFamily2)
       store.commit()
 
-      store = provider.getRocksDBStateStore(2)
+      store = getRocksDBStateStore(provider, 2)
       store.createColFamilyIfAbsent(colFamily3, keySchema, valueSchema,
         NoPrefixKeyStateEncoderSpec(keySchema))
       store.removeColFamilyIfExists(colFamily1)
       store.removeColFamilyIfExists(colFamily3)
       store.commit()
 
-      store = provider.getRocksDBStateStore(1)
+      store = getRocksDBStateStore(provider, 1)
       // this should return the old id, because we didn't remove this colFamily for version 1
       store.createColFamilyIfAbsent(colFamily1, keySchema, valueSchema,
         NoPrefixKeyStateEncoderSpec(keySchema))
+      store.abort()
 
-      store = provider.getRocksDBStateStore(3)
+      store = getRocksDBStateStore(provider, 3)
       store.createColFamilyIfAbsent(colFamily4, keySchema, valueSchema,
         NoPrefixKeyStateEncoderSpec(keySchema))
       store.createColFamilyIfAbsent(colFamily5, keySchema, valueSchema,
         NoPrefixKeyStateEncoderSpec(keySchema))
+      store.abort()
     }
   }
 
@@ -1963,10 +2007,12 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         val metricPairUpdated = reloadedStore
           .metrics.customMetrics.find(_._1.name == "rocksdbNumInternalColFamiliesKeys")
         assert(metricPairUpdated.isDefined && metricPairUpdated.get._2 === 3)
-        assert(rowPairsToDataSet(reloadedStore.iterator(cfName)) ===
+        val reloadedStore1 = reloadedProvider.getStore(2)
+        assert(rowPairsToDataSet(reloadedStore1.iterator(cfName)) ===
           Set(("a", 0) -> 1, ("c", 0) -> 3, ("d", 0) -> 4, ("e", 0) -> 5))
-        assert(rowPairsToDataSet(reloadedStore.iterator(internalCfName)) ===
+        assert(rowPairsToDataSet(reloadedStore1.iterator(internalCfName)) ===
           Set(("a", 0) -> 1, ("n", 0) -> 3, ("b", 0) -> 4))
+        reloadedStore.commit()
       }
     }
   }
@@ -1980,36 +2026,455 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
       tryWithProviderResource(newStoreProvider(keySchema, keyEncoder, true)) { provider =>
         val store = provider.getStore(0)
 
-        val cfName = "testColFamily"
-        store.createColFamilyIfAbsent(cfName, keySchema, valueSchema, keyEncoder)
+        try {
+          val cfName = "testColFamily"
+          store.createColFamilyIfAbsent(cfName, keySchema, valueSchema, keyEncoder)
 
-        // remove non-exist col family will return false
-        assert(!store.removeColFamilyIfExists("non-existence"))
+          // remove non-exist col family will return false
+          assert(!store.removeColFamilyIfExists("non-existence"))
 
-        // put some test data into state store
-        val timerTimestamps = Seq(931L, 8000L, 452300L, 4200L, -1L, 90L, 1L, 2L, 8L,
-          -230L, -14569L, -92L, -7434253L, 35L, 6L, 9L, -323L, 5L)
-        timerTimestamps.foreach { ts =>
-          val keyRow = dataToKeyRow(ts.toString, ts.toInt)
-          val valueRow = dataToValueRow(1)
-          store.put(keyRow, valueRow, cfName)
+          // put some test data into state store
+          val timerTimestamps = Seq(931L, 8000L, 452300L, 4200L, -1L, 90L, 1L, 2L, 8L,
+            -230L, -14569L, -92L, -7434253L, 35L, 6L, 9L, -323L, 5L)
+          timerTimestamps.foreach { ts =>
+            val keyRow = dataToKeyRow(ts.toString, ts.toInt)
+            val valueRow = dataToValueRow(1)
+            store.put(keyRow, valueRow, cfName)
+          }
+          assert(store.iterator(cfName).toSeq.length == timerTimestamps.length)
+
+          // assert col family existence
+          assert(store.removeColFamilyIfExists(cfName))
+
+          val e = intercept[Exception] {
+            store.iterator(cfName)
+          }
+
+          checkError(
+            exception = e.asInstanceOf[StateStoreUnsupportedOperationOnMissingColumnFamily],
+            condition = "STATE_STORE_UNSUPPORTED_OPERATION_ON_MISSING_COLUMN_FAMILY",
+            sqlState = Some("42802"),
+            parameters = Map("operationType" -> "iterator", "colFamilyName" -> cfName)
+          )
+        } finally {
+          store.abort()
         }
-        assert(store.iterator(cfName).toSeq.length == timerTimestamps.length)
-
-        // assert col family existence
-        assert(store.removeColFamilyIfExists(cfName))
-
-        val e = intercept[Exception] {
-          store.iterator(cfName)
-        }
-
-        checkError(
-          exception = e.asInstanceOf[StateStoreUnsupportedOperationOnMissingColumnFamily],
-          condition = "STATE_STORE_UNSUPPORTED_OPERATION_ON_MISSING_COLUMN_FAMILY",
-          sqlState = Some("42802"),
-          parameters = Map("operationType" -> "iterator", "colFamilyName" -> cfName)
-        )
       }
+    }
+  }
+
+  test("state transitions with commit and illegal operations") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      // Get a store and put some data
+      val store = provider.getStore(0)
+      put(store, "a", 0, 1)
+      put(store, "b", 0, 2)
+
+      // Verify data is accessible before commit
+      assert(get(store, "a", 0) === Some(1))
+      assert(get(store, "b", 0) === Some(2))
+
+      // Commit the changes
+      assert(store.commit() === 1)
+      assert(store.hasCommitted)
+
+      // Operations after commit should fail with IllegalStateException
+      val exception = intercept[StateStoreInvalidStamp] {
+        put(store, "c", 0, 3)
+      }
+      assert(exception.getMessage.contains("Invalid stamp"))
+
+      // Getting a new store for the same version should work
+      val store1 = provider.getStore(1)
+      assert(get(store1, "a", 0) === Some(1))
+      assert(get(store1, "b", 0) === Some(2))
+
+      // Can update the new store instance
+      put(store1, "c", 0, 3)
+      assert(get(store1, "c", 0) === Some(3))
+
+      // Commit the new changes
+      assert(store1.commit() === 2)
+    }
+  }
+
+  test("state transitions with abort and subsequent operations") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      // Get a store and put some data
+      val store = provider.getStore(0)
+      put(store, "a", 0, 1)
+      put(store, "b", 0, 2)
+
+      // Abort the changes
+      store.abort()
+
+      // Operations after abort should fail with IllegalStateException
+      val exception = intercept[StateStoreInvalidStamp] {
+        put(store, "c", 0, 3)
+      }
+      assert(exception.getMessage.contains("Invalid stamp"))
+
+      // Get a new store, should be empty since previous changes were aborted
+      val store1 = provider.getStore(0)
+      assert(store1.iterator().isEmpty)
+
+      // Put data and commit
+      put(store1, "d", 0, 4)
+      assert(store1.commit() === 1)
+
+      // Get a new store and verify data
+      val store2 = provider.getStore(1)
+      assert(get(store2, "d", 0) === Some(4))
+      store2.commit()
+    }
+  }
+
+  test("abort after commit throws StateStoreOperationOutOfOrder") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      val store = provider.getStore(0)
+      put(store, "a", 0, 1)
+      assert(store.commit() === 1)
+
+      // Abort after commit should throw a SparkRuntimeException
+      val exception = intercept[SparkRuntimeException] {
+        store.abort()
+      }
+      checkError(
+        exception,
+        condition = "STATE_STORE_OPERATION_OUT_OF_ORDER",
+        parameters = Map("errorMsg" ->
+          ("Expected possible states " +
+          "(UPDATING, COMMITTING, ABORTED) but found COMMITTED"))
+      )
+
+      // Get a new store and verify data was committed
+      val store1 = provider.getStore(1)
+      assert(get(store1, "a", 0) === Some(1))
+      store1.commit()
+    }
+  }
+
+  test("multiple aborts are idempotent") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      val store = provider.getStore(0)
+      put(store, "a", 0, 1)
+
+      // First abort
+      store.abort()
+
+      // Second abort should not throw
+      store.abort()
+
+      // Operations should still fail
+      val exception = intercept[StateStoreInvalidStamp] {
+        put(store, "b", 0, 2)
+      }
+      assert(exception.getMessage.contains("Invalid stamp"))
+    }
+  }
+
+  test("multiple commits throw exception") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      val store = provider.getStore(0)
+      put(store, "a", 0, 1)
+      assert(store.commit() === 1)
+
+      // Second commit should fail with stamp verification
+      val exception = intercept[SparkRuntimeException] {
+        store.commit()
+      }
+      checkError(
+        exception,
+        condition = "STATE_STORE_OPERATION_OUT_OF_ORDER",
+        parameters = Map("errorMsg" ->
+          "Expected possible states (UPDATING) but found COMMITTED")
+      )
+    }
+  }
+
+  test("get metrics works only after commit") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      val store = provider.getStore(0)
+      put(store, "a", 0, 1)
+
+      // Getting metrics before commit should throw
+      val exception = intercept[SparkRuntimeException] {
+        store.metrics
+      }
+      checkError(
+        exception,
+        condition = "STATE_STORE_OPERATION_OUT_OF_ORDER",
+        parameters = Map("errorMsg" -> "Cannot get metrics in UPDATING state")
+      )
+      // Commit the changes
+      assert(store.commit() === 1)
+
+      // Getting metrics after commit should work
+      val metrics = store.metrics
+      assert(metrics.numKeys === 1)
+    }
+  }
+
+  test("get checkpoint info works only after commit") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      val store = provider.getStore(0)
+      put(store, "a", 0, 1)
+
+      // Getting checkpoint info before commit should throw
+      val exception = intercept[SparkRuntimeException] {
+        store.getStateStoreCheckpointInfo()
+      }
+      checkError(
+        exception,
+        condition = "STATE_STORE_OPERATION_OUT_OF_ORDER",
+        parameters = Map("errorMsg" -> "Cannot get metrics in UPDATING state")
+      )
+
+      // Commit the changes
+      assert(store.commit() === 1)
+
+      // Getting checkpoint info after commit should work
+      val checkpointInfo = store.getStateStoreCheckpointInfo()
+      assert(checkpointInfo != null)
+    }
+  }
+
+  test("read store and write store with common stamp") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      // First prepare some data
+      val initialStore = provider.getStore(0)
+      put(initialStore, "a", 0, 1)
+      assert(initialStore.commit() === 1)
+
+      // Get a read store
+      val readStore = provider.getReadStore(1)
+      assert(get(readStore, "a", 0) === Some(1))
+
+      // Get a write store from the read store
+      val writeStore = provider.upgradeReadStoreToWriteStore(
+        readStore, 1)
+
+      // Verify data access
+      assert(get(writeStore, "a", 0) === Some(1))
+
+      // Update through write store
+      put(writeStore, "b", 0, 2)
+      assert(get(writeStore, "b", 0) === Some(2))
+
+      // Commit the write store
+      assert(writeStore.commit() === 2)
+
+      // Get a new store and verify
+      val newStore = provider.getStore(2)
+      assert(get(newStore, "a", 0) === Some(1))
+      assert(get(newStore, "b", 0) === Some(2))
+      newStore.commit()
+    }
+  }
+
+  test("verify operation validation before and after commit") {
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      val store = provider.getStore(0)
+
+      // Put operations should work in UPDATING state
+      put(store, "a", 0, 1)
+      assert(get(store, "a", 0) === Some(1))
+
+      // Remove operations should work in UPDATING state
+      remove(store, _._1 == "a")
+      assert(get(store, "a", 0) === None)
+
+      // Iterator operations should work in UPDATING state
+      put(store, "b", 0, 2)
+      assert(rowPairsToDataSet(store.iterator()) === Set(("b", 0) -> 2))
+
+      // Commit should work in UPDATING state
+      assert(store.commit() === 1)
+
+      intercept[StateStoreInvalidStamp] {
+        put(store, "c", 0, 3)
+      }
+
+      intercept[StateStoreInvalidStamp] {
+        remove(store, _._1 == "b")
+      }
+
+      intercept[StateStoreInvalidStamp] {
+        store.iterator()
+      }
+
+      // Get a new store for the next version
+      val store1 = provider.getStore(1)
+
+      // Abort the store
+      store1.abort()
+
+      // Operations after abort should fail due to invalid stamp
+      intercept[StateStoreInvalidStamp] {
+        put(store1, "c", 0, 3)
+      }
+    }
+  }
+
+  test("Rocks DB task completion listener does not double unlock acquireThread") {
+    // This test verifies that a thread that locks then unlocks the db and then
+    // fires a completion listener (Thread 1) does not unlock the lock validly
+    // acquired by another thread (Thread 2).
+    //
+    // Timeline of this test (* means thread is active):
+    // STATE | MAIN             | THREAD 1         | THREAD 2         |
+    // ------| ---------------- | ---------------- | ---------------- |
+    // 0.    | wait for s3      | *load, commit    | wait for s1      |
+    //       |                  | *signal s1       |                  |
+    // ------| ---------------- | ---------------- | ---------------- |
+    // 1.    |                  | wait for s2      | *load, signal s2 |
+    // ------| ---------------- | ---------------- | ---------------- |
+    // 2.    |                  | *task complete   | wait for s4      |
+    //       |                  | *signal s3, END  |                  |
+    // ------| ---------------- | ---------------- | ---------------- |
+    // 3.    | *verify locked   |                  |                  |
+    //       | *signal s4       |                  |                  |
+    // ------| ---------------- | ---------------- | ---------------- |
+    // 4.    | wait for s5      |                  | *commit          |
+    //       |                  |                  | *signal s5, END  |
+    // ------| ---------------- | ---------------- | ---------------- |
+    // 5.    | *close db, END   |                  |                  |
+    //
+    // NOTE: state 4 and 5 are only for cleanup
+
+    // Create a custom ExecutionContext with 3 threads
+    implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(
+      ThreadUtils.newDaemonFixedThreadPool(3, "pool-thread-executor"))
+    val stateLock = new Object()
+    var state = 0
+
+    tryWithProviderResource(newStoreProvider()) { provider =>
+      Future { // THREAD 1
+        // Set thread 1's task context so that it is not a clone
+        // of the main thread's taskContext, which will end if the
+        // task is marked as complete
+        val taskContext = TaskContext.empty()
+        TaskContext.setTaskContext(taskContext)
+
+        stateLock.synchronized {
+          // -------------------- STATE 0 --------------------
+          // Simulate a task that loads and commits, db should be unlocked after
+          val store = provider.getStore(0)
+          store.commit()
+          // Signal that we have entered state 1
+          state = 1
+          stateLock.notifyAll()
+
+          // -------------------- STATE 2 --------------------
+          // Wait until we have entered state 2 (thread 2 has loaded db and acquired lock)
+          while (state != 2) {
+            stateLock.wait()
+          }
+
+          // thread 1's task context is marked as complete and signal
+          // that we have entered state 3
+          // At this point, thread 2 should still hold the DB lock.
+          taskContext.markTaskCompleted(None)
+          state = 3
+          stateLock.notifyAll()
+        }
+      }
+
+      Future { // THREAD 2
+        // Set thread 2's task context so that it is not a clone of thread 1's
+        // so it won't be marked as complete
+        val taskContext = TaskContext.empty()
+        TaskContext.setTaskContext(taskContext)
+
+        stateLock.synchronized {
+          // -------------------- STATE 1 --------------------
+          // Wait until we have entered state 1 (thread 1 finished loading and committing)
+          while (state != 1) {
+            stateLock.wait()
+          }
+
+          // Load the db and signal that we have entered state 2
+          val store = provider.getStore(1)
+          assertAcquiredThreadIsCurrentThread(provider)
+          state = 2
+          stateLock.notifyAll()
+
+          // -------------------- STATE 4 --------------------
+          // Wait until we have entered state 4 (thread 1 completed and
+          // main thread confirmed that lock is held)
+          while (state != 4) {
+            stateLock.wait()
+          }
+
+          // Ensure we still have the lock
+          assertAcquiredThreadIsCurrentThread(provider)
+
+          // commit and signal that we have entered state 5
+          store.commit()
+          state = 5
+          stateLock.notifyAll()
+        }
+      }
+
+      // MAIN THREAD
+      stateLock.synchronized {
+        // -------------------- STATE 3 --------------------
+        // Wait until we have entered state 3 (thread 1 is complete)
+        while (state != 3) {
+          stateLock.wait()
+        }
+
+        // Verify that the lock is being held
+        val stateMachine = PrivateMethod[Any](Symbol("stateMachine"))
+        val stateMachineObj = provider invokePrivate stateMachine()
+        val threadInfo = stateMachineObj.asInstanceOf[RocksDBStateMachine].getAcquiredThreadInfo
+        assert(threadInfo.nonEmpty, s"acquiredThreadInfo was None when it should be Some")
+
+        // Signal that we have entered state 4 (thread 2 can now release lock)
+        state = 4
+        stateLock.notifyAll()
+
+        // -------------------- STATE 5 --------------------
+        // Wait until we have entered state 5 (thread 2 has released lock)
+        // so that we can clean up
+        while (state != 5) {
+          stateLock.wait()
+        }
+      }
+    }
+  }
+
+  test("RocksDB task completion listener correctly releases for failed task") {
+    // This test verifies that a thread that locks the DB and then fails
+    // can rely on the completion listener to release the lock.
+
+    // Create a custom ExecutionContext with 1 thread
+    implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(
+      ThreadUtils.newDaemonSingleThreadExecutor("single-thread-executor"))
+    val timeout = 5.seconds
+
+    tryWithProviderResource(newStoreProvider()) { provider =>
+      // New task that will load and then complete with failure
+      val fut = Future {
+        val taskContext = TaskContext.empty()
+        TaskContext.setTaskContext(taskContext)
+
+        provider.getStore(0)
+        assertAcquiredThreadIsCurrentThread(provider)
+
+        // Task completion listener should unlock
+        taskContext.markTaskCompleted(
+          Some(new SparkException("Task failure injection")))
+      }
+
+      ThreadUtils.awaitResult(fut, timeout)
+
+      // Assert that db is not locked
+      val stateMachine = PrivateMethod[Any](Symbol("stateMachine"))
+      val stateMachineObj = provider invokePrivate stateMachine()
+      val stamp = stateMachineObj.asInstanceOf[RocksDBStateMachine].currentValidStamp.get()
+      assert(stamp == -1,
+        s"state machine stamp should be -1 (unlocked) but was $stamp")
     }
   }
 
@@ -2172,6 +2637,19 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         }
       }
     }
+  }
+
+  def assertAcquiredThreadIsCurrentThread(provider: RocksDBStateStoreProvider): Unit = {
+    val stateMachine = PrivateMethod[Any](Symbol("stateMachine"))
+    val stateMachineObj = provider invokePrivate stateMachine()
+    val threadInfo = stateMachineObj.asInstanceOf[RocksDBStateMachine].getAcquiredThreadInfo
+    assert(threadInfo.isDefined,
+      "acquired thread info should not be null after load")
+    val threadId = threadInfo.get.threadRef.get.get.getId
+    assert(
+      threadId == Thread.currentThread().getId,
+      s"acquired thread should be curent thread ${Thread.currentThread().getId} " +
+        s"after load but was $threadId")
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -1987,10 +1987,12 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         val metricPair = store
           .metrics.customMetrics.find(_._1.name == "rocksdbNumInternalColFamiliesKeys")
         assert(metricPair.isDefined && metricPair.get._2 === 4)
-        assert(rowPairsToDataSet(store.iterator(cfName)) ===
+        val store1 = provider.getStore(1)
+        assert(rowPairsToDataSet(store1.iterator(cfName)) ===
           Set(("a", 0) -> 1, ("b", 0) -> 2, ("c", 0) -> 3, ("d", 0) -> 4, ("e", 0) -> 5))
-        assert(rowPairsToDataSet(store.iterator(internalCfName)) ===
+        assert(rowPairsToDataSet(store1.iterator(internalCfName)) ===
           Set(("a", 0) -> 1, ("m", 0) -> 2, ("n", 0) -> 3, ("b", 0) -> 4))
+        store1.abort()
 
         // Reload the store and remove some keys
         val reloadedProvider = newStoreProvider(store.id, colFamiliesEnabled)
@@ -2012,7 +2014,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
           Set(("a", 0) -> 1, ("c", 0) -> 3, ("d", 0) -> 4, ("e", 0) -> 5))
         assert(rowPairsToDataSet(reloadedStore1.iterator(internalCfName)) ===
           Set(("a", 0) -> 1, ("n", 0) -> 3, ("b", 0) -> 4))
-        reloadedStore.commit()
+        reloadedStore1.commit()
       }
     }
   }
@@ -2144,7 +2146,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         condition = "STATE_STORE_OPERATION_OUT_OF_ORDER",
         parameters = Map("errorMsg" ->
           ("Expected possible states " +
-          "(UPDATING, COMMITTING, ABORTED) but found COMMITTED"))
+          "(UPDATING, ABORTED) but found COMMITTED"))
       )
 
       // Get a new store and verify data was committed

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -2152,81 +2152,6 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
     }
   }
 
-  testWithStateStoreCheckpointIdsAndColumnFamilies("disallow concurrent updates to the same " +
-    "RocksDB instance",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled) {
-    case (enableStateStoreCheckpointIds, colFamiliesEnabled) =>
-    quietly {
-      val versionToUniqueId = new mutable.HashMap[Long, String]()
-      withDB(
-        Utils.createTempDir().toString,
-        conf = dbConf.copy(lockAcquireTimeoutMs = 20),
-        useColumnFamilies = colFamiliesEnabled,
-        enableStateStoreCheckpointIds = enableStateStoreCheckpointIds,
-        versionToUniqueId = versionToUniqueId) { db =>
-        // DB has been loaded so current thread has already
-        // acquired the lock on the RocksDB instance
-
-        db.load(0, versionToUniqueId.get(0)) // Current thread should be able to load again
-
-        // Another thread should not be able to load while current thread is using it
-        var ex = intercept[SparkException] {
-          ThreadUtils.runInNewThread("concurrent-test-thread-1") {
-            db.load(0, versionToUniqueId.get(0))
-          }
-        }
-        checkError(
-          ex,
-          condition = "CANNOT_LOAD_STATE_STORE.UNRELEASED_THREAD_ERROR",
-          parameters = Map(
-            "loggingId" -> "\\[Thread-\\d+\\]",
-            "operationType" -> "load_store",
-            "newAcquiredThreadInfo" -> "\\[ThreadId: Some\\(\\d+\\)\\]",
-            "acquiredThreadInfo" -> "\\[ThreadId: Some\\(\\d+\\)\\]",
-            "timeWaitedMs" -> "\\d+",
-            "stackTraceOutput" -> "(?s).*"
-          ),
-          matchPVals = true
-        )
-
-        // Commit should release the instance allowing other threads to load new version
-        db.commit()
-        ThreadUtils.runInNewThread("concurrent-test-thread-2") {
-          db.load(1, versionToUniqueId.get(1))
-          db.commit()
-        }
-
-        // Another thread should not be able to load while current thread is using it
-        db.load(2, versionToUniqueId.get(2))
-        ex = intercept[SparkException] {
-          ThreadUtils.runInNewThread("concurrent-test-thread-2") {
-            db.load(2, versionToUniqueId.get(2))
-          }
-        }
-        checkError(
-          ex,
-          condition = "CANNOT_LOAD_STATE_STORE.UNRELEASED_THREAD_ERROR",
-          parameters = Map(
-            "loggingId" -> "\\[Thread-\\d+\\]",
-            "operationType" -> "load_store",
-            "newAcquiredThreadInfo" -> "\\[ThreadId: Some\\(\\d+\\)\\]",
-            "acquiredThreadInfo" -> "\\[ThreadId: Some\\(\\d+\\)\\]",
-            "timeWaitedMs" -> "\\d+",
-            "stackTraceOutput" -> "(?s).*"
-          ),
-          matchPVals = true
-        )
-
-        // Rollback should release the instance allowing other threads to load new version
-        db.rollback()
-        ThreadUtils.runInNewThread("concurrent-test-thread-3") {
-          db.load(1, versionToUniqueId.get(1))
-          db.commit()
-        }
-      }
-    }
-  }
-
   testWithColumnFamilies("ensure concurrent access lock is released after Spark task completes",
     TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
     RocksDBSuite.withSingletonDB {
@@ -3339,146 +3264,6 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
     }
   }
 
-  test("Rocks DB task completion listener does not double unlock acquireThread") {
-    // This test verifies that a thread that locks then unlocks the db and then
-    // fires a completion listener (Thread 1) does not unlock the lock validly
-    // acquired by another thread (Thread 2).
-    //
-    // Timeline of this test (* means thread is active):
-    // STATE | MAIN             | THREAD 1         | THREAD 2         |
-    // ------| ---------------- | ---------------- | ---------------- |
-    // 0.    | wait for s3      | *load, commit    | wait for s1      |
-    //       |                  | *signal s1       |                  |
-    // ------| ---------------- | ---------------- | ---------------- |
-    // 1.    |                  | wait for s2      | *load, signal s2 |
-    // ------| ---------------- | ---------------- | ---------------- |
-    // 2.    |                  | *task complete   | wait for s4      |
-    //       |                  | *signal s3, END  |                  |
-    // ------| ---------------- | ---------------- | ---------------- |
-    // 3.    | *verify locked   |                  |                  |
-    //       | *signal s4       |                  |                  |
-    // ------| ---------------- | ---------------- | ---------------- |
-    // 4.    | wait for s5      |                  | *commit          |
-    //       |                  |                  | *signal s5, END  |
-    // ------| ---------------- | ---------------- | ---------------- |
-    // 5.    | *close db, END   |                  |                  |
-    //
-    // NOTE: state 4 and 5 are only for cleanup
-
-    // Create a custom ExecutionContext with 3 threads
-    implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(
-      ThreadUtils.newDaemonFixedThreadPool(3, "pool-thread-executor"))
-    val stateLock = new Object()
-    var state = 0
-
-    withTempDir { dir =>
-      val remoteDir = dir.getCanonicalPath
-      val db = new RocksDB(
-        remoteDir,
-        conf = dbConf,
-        localRootDir = Utils.createTempDir(),
-        hadoopConf = new Configuration(),
-        loggingId = s"[Thread-${Thread.currentThread.getId}]",
-        useColumnFamilies = false
-      )
-      try {
-        Future { // THREAD 1
-          // Set thread 1's task context so that it is not a clone
-          // of the main thread's taskContext, which will end if the
-          // task is marked as complete
-          val taskContext = TaskContext.empty()
-          TaskContext.setTaskContext(taskContext)
-
-          stateLock.synchronized {
-            // -------------------- STATE 0 --------------------
-            // Simulate a task that loads and commits, db should be unlocked after
-            db.load(0)
-            db.put("a", "1")
-            db.commit()
-            // Signal that we have entered state 1
-            state = 1
-            stateLock.notifyAll()
-
-            // -------------------- STATE 2 --------------------
-            // Wait until we have entered state 2 (thread 2 has loaded db and acquired lock)
-            while (state != 2) {
-              stateLock.wait()
-            }
-
-            // thread 1's task context is marked as complete and signal
-            // that we have entered state 3
-            // At this point, thread 2 should still hold the DB lock.
-            taskContext.markTaskCompleted(None)
-            state = 3
-            stateLock.notifyAll()
-          }
-        }
-
-        Future { // THREAD 2
-          // Set thread 2's task context so that it is not a clone of thread 1's
-          // so it won't be marked as complete
-          val taskContext = TaskContext.empty()
-          TaskContext.setTaskContext(taskContext)
-
-          stateLock.synchronized {
-            // -------------------- STATE 1 --------------------
-            // Wait until we have entered state 1 (thread 1 finished loading and committing)
-            while (state != 1) {
-              stateLock.wait()
-            }
-
-            // Load the db and signal that we have entered state 2
-            db.load(1)
-            assertAcquiredThreadIsCurrentThread(db)
-            state = 2
-            stateLock.notifyAll()
-
-            // -------------------- STATE 4 --------------------
-            // Wait until we have entered state 4 (thread 1 completed and
-            // main thread confirmed that lock is held)
-            while (state != 4) {
-              stateLock.wait()
-            }
-
-            // Ensure we still have the lock
-            assertAcquiredThreadIsCurrentThread(db)
-
-            // commit and signal that we have entered state 5
-            db.commit()
-            state = 5
-            stateLock.notifyAll()
-          }
-        }
-
-        // MAIN THREAD
-        stateLock.synchronized {
-          // -------------------- STATE 3 --------------------
-          // Wait until we have entered state 3 (thread 1 is complete)
-          while (state != 3) {
-            stateLock.wait()
-          }
-
-          // Verify that the lock is being held
-          val threadInfo = db.getAcquiredThreadInfo()
-          assert(threadInfo.nonEmpty, s"acquiredThreadInfo was None when it should be Some")
-
-          // Signal that we have entered state 4 (thread 2 can now release lock)
-          state = 4
-          stateLock.notifyAll()
-
-          // -------------------- STATE 5 --------------------
-          // Wait until we have entered state 5 (thread 2 has released lock)
-          // so that we can clean up
-          while (state != 5) {
-            stateLock.wait()
-          }
-        }
-      } finally {
-        db.close()
-      }
-    }
-  }
-
   test("RocksDB task completion listener correctly releases for failed task") {
     // This test verifies that a thread that locks the DB and then fails
     // can rely on the completion listener to release the lock.
@@ -3500,7 +3285,6 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
           TaskContext.setTaskContext(taskContext)
 
           db.load(0)
-          assertAcquiredThreadIsCurrentThread(db)
 
           // Task completion listener should unlock
           taskContext.markTaskCompleted(
@@ -3508,10 +3292,6 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
         }
 
         ThreadUtils.awaitResult(fut, timeout)
-
-        // Assert that db is not locked
-        val threadInfo = db.getAcquiredThreadInfo()
-        assert(threadInfo.isEmpty, s"acquiredThreadInfo should be None but was $threadInfo")
       }
     }
   }
@@ -3613,17 +3393,6 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
         })
       }
     }}
-  }
-
-  private def assertAcquiredThreadIsCurrentThread(db: RocksDB): Unit = {
-    val threadInfo = db.getAcquiredThreadInfo()
-    assert(threadInfo != None,
-      "acquired thread info should not be null after load")
-    val threadId = threadInfo.get.threadRef.get.get.getId
-    assert(
-      threadId == Thread.currentThread().getId,
-      s"acquired thread should be curent thread ${Thread.currentThread().getId} " +
-        s"after load but was $threadId")
   }
 
   private def dbConf = RocksDBConf(StateStoreConf(SQLConf.get.clone()))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -1787,6 +1787,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
 
       checkInvalidVersion(-1, provider.isInstanceOf[HDFSBackedStateStoreProvider])
       checkInvalidVersion(2, provider.isInstanceOf[HDFSBackedStateStoreProvider])
+      store1_.abort()
 
       // Update store version with some data
       val store1 = provider.getStore(1)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -1759,7 +1759,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
           checkError(
             e,
             condition = "CANNOT_LOAD_STATE_STORE.CANNOT_READ_STREAMING_STATE_FILE",
-            parameters = Map("fileToRead" -> ".*", "clazz" -> ".*"),
+            parameters = Map("fileToRead" -> ".*"),
             matchPVals = true
           )
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -1745,7 +1745,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
 
   testWithAllCodec(s"getStore with invalid versions") { colFamiliesEnabled =>
     tryWithProviderResource(newStoreProvider(colFamiliesEnabled)) { provider =>
-      def checkInvalidVersion(version: Int): Unit = {
+      def checkInvalidVersion(version: Int, isHDFSBackedStoreProvider: Boolean): Unit = {
         val e = intercept[SparkException] {
           provider.getStore(version)
         }
@@ -1756,17 +1756,26 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
             parameters = Map("version" -> version.toString)
           )
         } else {
-          checkError(
-            e,
-            condition = "CANNOT_LOAD_STATE_STORE.CANNOT_READ_STREAMING_STATE_FILE",
-            parameters = Map("fileToRead" -> ".*"),
-            matchPVals = true
-          )
+          if (isHDFSBackedStoreProvider) {
+            checkError(
+              e,
+              condition = "CANNOT_LOAD_STATE_STORE.CANNOT_READ_DELTA_FILE_NOT_EXISTS",
+              parameters = Map("fileToRead" -> ".*", "clazz" -> ".*"),
+              matchPVals = true
+            )
+          } else {
+            checkError(
+              e,
+              condition = "CANNOT_LOAD_STATE_STORE.CANNOT_READ_STREAMING_STATE_FILE",
+              parameters = Map("fileToRead" -> ".*"),
+              matchPVals = true
+            )
+          }
         }
       }
 
-      checkInvalidVersion(-1)
-      checkInvalidVersion(1)
+      checkInvalidVersion(-1, provider.isInstanceOf[HDFSBackedStateStoreProvider])
+      checkInvalidVersion(1, provider.isInstanceOf[HDFSBackedStateStoreProvider])
 
       val store = provider.getStore(0)
       put(store, "a", 0, 1)
@@ -1775,10 +1784,9 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
 
       val store1_ = provider.getStore(1)
       assert(rowPairsToDataSet(store1_.iterator()) === Set(("a", 0) -> 1))
-      store1_.abort()
 
-      checkInvalidVersion(-1)
-      checkInvalidVersion(2)
+      checkInvalidVersion(-1, provider.isInstanceOf[HDFSBackedStateStoreProvider])
+      checkInvalidVersion(2, provider.isInstanceOf[HDFSBackedStateStoreProvider])
 
       // Update store version with some data
       val store1 = provider.getStore(1)
@@ -1787,8 +1795,8 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
       assert(rowPairsToDataSet(store1.iterator()) === Set(("a", 0) -> 1, ("b", 0) -> 1))
       assert(store1.commit() === 2)
 
-      checkInvalidVersion(-1)
-      checkInvalidVersion(3)
+      checkInvalidVersion(-1, provider.isInstanceOf[HDFSBackedStateStoreProvider])
+      checkInvalidVersion(3, provider.isInstanceOf[HDFSBackedStateStoreProvider])
     }
   }
 
@@ -1812,7 +1820,8 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
       store.commit()
       val store1 = provider0.getStore(1)
       assert(rowPairsToDataSet(store1.iterator()) === Set((key1, key2) -> 1))
-      store1.abort()    }
+      store1.abort()
+    }
 
     // two state stores
     tryWithProviderResource(newStoreProvider(storeId, colFamiliesEnabled)) { provider1 =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -590,31 +590,35 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
     tryWithProviderResource(newStoreProvider(opId = Random.nextInt(), partition = 0,
       minDeltasForSnapshot = 5)) { provider =>
       val store = provider.getStore(0)
-      val keyRow = dataToKeyRow("a", 0)
-      val valueRow = dataToValueRow(1)
-      val colFamilyName = "test"
-      verifyStoreOperationUnsupported("put") {
-        store.put(keyRow, valueRow, colFamilyName)
-      }
+      try {
+        val keyRow = dataToKeyRow("a", 0)
+        val valueRow = dataToValueRow(1)
+        val colFamilyName = "test"
+        verifyStoreOperationUnsupported("put") {
+          store.put(keyRow, valueRow, colFamilyName)
+        }
 
-      verifyStoreOperationUnsupported("remove") {
-        store.remove(keyRow, colFamilyName)
-      }
+        verifyStoreOperationUnsupported("remove") {
+          store.remove(keyRow, colFamilyName)
+        }
 
-      verifyStoreOperationUnsupported("get") {
-        store.get(keyRow, colFamilyName)
-      }
+        verifyStoreOperationUnsupported("get") {
+          store.get(keyRow, colFamilyName)
+        }
 
-      verifyStoreOperationUnsupported("merge") {
-        store.merge(keyRow, valueRow, colFamilyName)
-      }
+        verifyStoreOperationUnsupported("merge") {
+          store.merge(keyRow, valueRow, colFamilyName)
+        }
 
-      verifyStoreOperationUnsupported("iterator") {
-        store.iterator(colFamilyName)
-      }
+        verifyStoreOperationUnsupported("iterator") {
+          store.iterator(colFamilyName)
+        }
 
-      verifyStoreOperationUnsupported("prefixScan") {
-        store.prefixScan(keyRow, colFamilyName)
+        verifyStoreOperationUnsupported("prefixScan") {
+          store.prefixScan(keyRow, colFamilyName)
+        }
+      } finally {
+        if (!store.hasCommitted) store.abort()
       }
     }
   }
@@ -1457,7 +1461,12 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
       if (version < 0) {
         reloadedProvider.latestIterator().map(rowPairToDataPair).toSet
       } else {
-        reloadedProvider.getStore(version).iterator().map(rowPairToDataPair).toSet
+        val store = reloadedProvider.getStore(version)
+        try {
+          store.iterator().map(rowPairToDataPair).toSet
+        } finally {
+          if (!store.hasCommitted) store.abort()
+        }
       }
     }
   }
@@ -1562,7 +1571,6 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
       assert(!store.hasCommitted)
       assert(get(store, "a", 0) === None)
       assert(store.iterator().isEmpty)
-      assert(store.metrics.numKeys === 0)
 
       // Verify state after updating
       put(store, "a", 0, 1)
@@ -1578,9 +1586,9 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
       assert(store.commit() === 1)
 
       assert(store.hasCommitted)
-      assert(rowPairsToDataSet(store.iterator()) === Set(("b", 0) -> 2))
-      assert(getLatestData(provider,
-        useColumnFamilies = colFamiliesEnabled) === Set(("b", 0) -> 2))
+      val store1 = provider.getStore(1)
+      assert(rowPairsToDataSet(store1.iterator()) === Set(("b", 0) -> 2))
+      store1.abort()
 
       // Trying to get newer versions should fail
       var e = intercept[SparkException] {
@@ -1598,11 +1606,9 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
         val reloadedStore = reloadedProvider.getStore(1)
         put(reloadedStore, "c", 0, 4)
         assert(reloadedStore.commit() === 2)
-        assert(rowPairsToDataSet(reloadedStore.iterator()) === Set(("b", 0) -> 2, ("c", 0) -> 4))
-        assert(getLatestData(provider, useColumnFamilies = colFamiliesEnabled)
-          === Set(("b", 0) -> 2, ("c", 0) -> 4))
-        assert(getData(provider, version = 1, useColumnFamilies = colFamiliesEnabled)
-          === Set(("b", 0) -> 2))
+        val reloadedStore1 = reloadedProvider.getStore(2)
+        assert(rowPairsToDataSet(reloadedStore1.iterator()) === Set(("b", 0) -> 2, ("c", 0) -> 4))
+        reloadedStore1.commit()
       }
     }
   }
@@ -1664,6 +1670,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
       // prefix scan should not reflect the uncommitted changes
       verifyScan(key1AtVersion0, key2AtVersion0)
       verifyScan(Seq("d"), Seq.empty)
+      store.abort()
     }
   }
 
@@ -1680,16 +1687,19 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
       put(store, "e", 0, 5)
       assert(store.commit() === 1)
       assert(store.metrics.numKeys === 5)
-      assert(rowPairsToDataSet(store.iterator()) ===
+      val store1 = provider.getStore(1)
+      assert(rowPairsToDataSet(store1.iterator()) ===
         Set(("a", 0) -> 1, ("b", 0) -> 2, ("c", 0) -> 3, ("d", 0) -> 4, ("e", 0) -> 5))
+      store1.abort()
 
-      val reloadedProvider = newStoreProvider(store.id, colFamiliesEnabled)
-      val reloadedStore = reloadedProvider.getStore(1)
-      remove(reloadedStore, _._1 == "b")
-      assert(reloadedStore.commit() === 2)
-      assert(reloadedStore.metrics.numKeys === 4)
-      assert(rowPairsToDataSet(reloadedStore.iterator()) ===
-        Set(("a", 0) -> 1, ("c", 0) -> 3, ("d", 0) -> 4, ("e", 0) -> 5))
+      tryWithProviderResource(newStoreProvider(store.id, colFamiliesEnabled)) { reloadedProvider =>
+        val reloadedStore = reloadedProvider.getStore(1)
+        remove(reloadedStore, _._1 == "b")
+        assert(rowPairsToDataSet(reloadedStore.iterator()) ===
+          Set(("a", 0) -> 1, ("c", 0) -> 3, ("d", 0) -> 4, ("e", 0) -> 5))
+        assert(reloadedStore.commit() === 2)
+        assert(reloadedStore.metrics.numKeys === 4)
+      }
     }
   }
 
@@ -1698,20 +1708,24 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
       // Verify state before starting a new set of updates
       assert(getLatestData(provider, useColumnFamilies = colFamiliesEnabled).isEmpty)
       val store = provider.getStore(0)
-      put(store, "a", 0, 1)
-      put(store, "b", 0, 2)
+      try {
+        put(store, "a", 0, 1)
+        put(store, "b", 0, 2)
 
-      // Updates should work while iterating of filtered entries
-      val filtered = store.iterator().filter { tuple => keyRowToData(tuple.key) == ("a", 0) }
-      filtered.foreach { tuple =>
-        store.put(tuple.key, dataToValueRow(valueRowToData(tuple.value) + 1))
+        // Updates should work while iterating of filtered entries
+        val filtered = store.iterator().filter { tuple => keyRowToData(tuple.key) == ("a", 0) }
+        filtered.foreach { tuple =>
+          store.put(tuple.key, dataToValueRow(valueRowToData(tuple.value) + 1))
+        }
+        assert(get(store, "a", 0) === Some(2))
+
+        // Removes should work while iterating of filtered entries
+        val filtered2 = store.iterator().filter { tuple => keyRowToData(tuple.key) == ("b", 0) }
+        filtered2.foreach { tuple => store.remove(tuple.key) }
+        assert(get(store, "b", 0) === None)
+      } finally {
+        if (!store.hasCommitted) store.abort()
       }
-      assert(get(store, "a", 0) === Some(2))
-
-      // Removes should work while iterating of filtered entries
-      val filtered2 = store.iterator().filter { tuple => keyRowToData(tuple.key) == ("b", 0) }
-      filtered2.foreach { tuple => store.remove(tuple.key) }
-      assert(get(store, "b", 0) === None)
     }
   }
 
@@ -1719,8 +1733,8 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
     tryWithProviderResource(newStoreProvider(colFamiliesEnabled)) { provider =>
       val store = provider.getStore(0)
       put(store, "a", 0, 1)
-      store.commit()
       assert(rowPairsToDataSet(store.iterator()) === Set(("a", 0) -> 1))
+      store.commit()
 
       // cancelUpdates should not change the data in the files
       val store1 = provider.getStore(1)
@@ -1731,7 +1745,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
 
   testWithAllCodec(s"getStore with invalid versions") { colFamiliesEnabled =>
     tryWithProviderResource(newStoreProvider(colFamiliesEnabled)) { provider =>
-      def checkInvalidVersion(version: Int, isHDFSBackedStoreProvider: Boolean): Unit = {
+      def checkInvalidVersion(version: Int): Unit = {
         val e = intercept[SparkException] {
           provider.getStore(version)
         }
@@ -1742,47 +1756,39 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
             parameters = Map("version" -> version.toString)
           )
         } else {
-          if (isHDFSBackedStoreProvider) {
-            checkError(
-              e,
-              condition = "CANNOT_LOAD_STATE_STORE.CANNOT_READ_DELTA_FILE_NOT_EXISTS",
-              parameters = Map("fileToRead" -> ".*", "clazz" -> ".*"),
-              matchPVals = true
-            )
-          } else {
-            checkError(
-              e,
-              condition = "CANNOT_LOAD_STATE_STORE.CANNOT_READ_STREAMING_STATE_FILE",
-              parameters = Map("fileToRead" -> ".*"),
-              matchPVals = true
-            )
-          }
+          checkError(
+            e,
+            condition = "CANNOT_LOAD_STATE_STORE.CANNOT_READ_STREAMING_STATE_FILE",
+            parameters = Map("fileToRead" -> ".*", "clazz" -> ".*"),
+            matchPVals = true
+          )
         }
       }
 
-      checkInvalidVersion(-1, provider.isInstanceOf[HDFSBackedStateStoreProvider])
-      checkInvalidVersion(1, provider.isInstanceOf[HDFSBackedStateStoreProvider])
+      checkInvalidVersion(-1)
+      checkInvalidVersion(1)
 
       val store = provider.getStore(0)
       put(store, "a", 0, 1)
-      assert(store.commit() === 1)
       assert(rowPairsToDataSet(store.iterator()) === Set(("a", 0) -> 1))
+      assert(store.commit() === 1)
 
       val store1_ = provider.getStore(1)
       assert(rowPairsToDataSet(store1_.iterator()) === Set(("a", 0) -> 1))
+      store1_.abort()
 
-      checkInvalidVersion(-1, provider.isInstanceOf[HDFSBackedStateStoreProvider])
-      checkInvalidVersion(2, provider.isInstanceOf[HDFSBackedStateStoreProvider])
+      checkInvalidVersion(-1)
+      checkInvalidVersion(2)
 
       // Update store version with some data
       val store1 = provider.getStore(1)
       assert(rowPairsToDataSet(store1.iterator()) === Set(("a", 0) -> 1))
       put(store1, "b", 0, 1)
-      assert(store1.commit() === 2)
       assert(rowPairsToDataSet(store1.iterator()) === Set(("a", 0) -> 1, ("b", 0) -> 1))
+      assert(store1.commit() === 2)
 
-      checkInvalidVersion(-1, provider.isInstanceOf[HDFSBackedStateStoreProvider])
-      checkInvalidVersion(3, provider.isInstanceOf[HDFSBackedStateStoreProvider])
+      checkInvalidVersion(-1)
+      checkInvalidVersion(3)
     }
   }
 
@@ -1804,13 +1810,14 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
 
       put(store, key1, key2, 1)
       store.commit()
-      assert(rowPairsToDataSet(store.iterator()) === Set((key1, key2) -> 1))
-    }
+      val store1 = provider0.getStore(1)
+      assert(rowPairsToDataSet(store1.iterator()) === Set((key1, key2) -> 1))
+      store1.abort()    }
 
     // two state stores
     tryWithProviderResource(newStoreProvider(storeId, colFamiliesEnabled)) { provider1 =>
       val restoreStore = provider1.getReadStore(1)
-      val saveStore = provider1.getStore(1)
+      val saveStore = provider1.upgradeReadStoreToWriteStore(restoreStore, 1)
 
       put(saveStore, key1, key2, get(restoreStore, key1, key2).get + 1)
       saveStore.commit()
@@ -1820,6 +1827,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
     tryWithProviderResource(newStoreProvider(storeId, colFamiliesEnabled)) { provider2 =>
       val finalStore = provider2.getStore(2)
       assert(rowPairsToDataSet(finalStore.iterator()) === Set((key1, key2) -> 2))
+      finalStore.abort()
     }
   }
 
@@ -1834,19 +1842,25 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
     val storeId = StateStoreId(dir, operatorId = 0, partitionId = 0)
     tryWithProviderResource(newStoreProvider(storeId, conf)) { provider =>
       val store = provider.getStore(0)
-      put(store, "a", 0, 0)
-      val e = intercept[SparkException](quietly { store.commit() } )
+      try {
+        put(store, "a", 0, 0)
+        val e = intercept[SparkException](quietly {
+          store.commit()
+        })
 
-      assert(e.getCondition == "CANNOT_WRITE_STATE_STORE.CANNOT_COMMIT")
-      if (store.getClass.getName contains ROCKSDB_STATE_STORE) {
-        assert(e.getMessage contains "RocksDBStateStore")
-      } else {
-        assert(e.getMessage contains "HDFSStateStore")
+        assert(e.getCondition == "CANNOT_WRITE_STATE_STORE.CANNOT_COMMIT")
+        if (store.getClass.getName contains ROCKSDB_STATE_STORE) {
+          assert(e.getMessage contains "RocksDBStateStore")
+        } else {
+          assert(e.getMessage contains "HDFSStateStore")
+        }
+        assert(e.getMessage contains "operatorId=0")
+        assert(e.getMessage contains "partitionId=0")
+        assert(e.getMessage contains "Error writing state store files")
+        assert(e.getCause.getMessage.contains("Failed to rename"))
+      } finally {
+        if (!store.hasCommitted) store.abort()
       }
-      assert(e.getMessage contains "operatorId=0")
-      assert(e.getMessage contains "partitionId=0")
-      assert(e.getMessage contains "Error writing state store files")
-      assert(e.getCause.getMessage.contains("Failed to rename"))
     }
   }
 
@@ -2121,10 +2135,9 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
     tryWithProviderResource(newStoreProvider(minDeltasForSnapshot = 1,
       numOfVersToRetainInMemory = 1)) { provider =>
       val store = provider.getStore(0)
-      val noDataMemoryUsed = store.metrics.memoryUsedBytes
       put(store, "a", 0, 1)
       store.commit()
-      assert(store.metrics.memoryUsedBytes > noDataMemoryUsed)
+      assert(store.metrics.memoryUsedBytes > 0)
     }
   }
 
@@ -2156,10 +2169,14 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
       assert(getLatestData(provider, useColumnFamilies = false).isEmpty)
 
       val store = provider.getStore(0)
-      val err = intercept[IllegalArgumentException] {
-        store.put(dataToKeyRow("key", 0), null)
+      try {
+        val err = intercept[IllegalArgumentException] {
+          store.put(dataToKeyRow("key", 0), null)
+        }
+        assert(err.getMessage.contains("Cannot put a null value"))
+      } finally {
+        if (!store.hasCommitted) store.abort()
       }
-      assert(err.getMessage.contains("Cannot put a null value"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -1784,10 +1784,10 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
 
       val store1_ = provider.getStore(1)
       assert(rowPairsToDataSet(store1_.iterator()) === Set(("a", 0) -> 1))
+      store1_.abort()
 
       checkInvalidVersion(-1, provider.isInstanceOf[HDFSBackedStateStoreProvider])
       checkInvalidVersion(2, provider.isInstanceOf[HDFSBackedStateStoreProvider])
-      store1_.abort()
 
       // Update store version with some data
       val store1 = provider.getStore(1)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/ValueStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/ValueStateSuite.scala
@@ -25,7 +25,8 @@ import scala.util.Random
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.{SparkException, SparkUnsupportedOperationException}
+import org.apache.spark.{SparkException, SparkUnsupportedOperationException, TaskContext}
+import org.apache.spark.TaskContext.withTaskContext
 import org.apache.spark.sql.Encoders
 import org.apache.spark.sql.catalyst.encoders.{encoderFor, ExpressionEncoder}
 import org.apache.spark.sql.execution.streaming.{ImplicitGroupingKeyTracker, StatefulProcessorHandleImpl, StreamExecution, ValueStateImplWithTTL}
@@ -476,7 +477,14 @@ abstract class StateVariableSuiteBase extends SharedSparkSession
   protected def tryWithProviderResource[T](
       provider: StateStoreProvider)(f: StateStoreProvider => T): T = {
     try {
-      f(provider)
+      val tc = TaskContext.empty()
+      try {
+        withTaskContext(tc) {
+          f(provider)
+        }
+      } finally {
+        tc.markTaskCompleted(None)
+      }
     } finally {
       provider.close()
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR introduces state machine validation to RocksDBStateStore to enforce proper usage patterns. It adds:

1. Explicit state machine transitions between UPDATING, COMMITTED, and ABORTED states
2. Validation logic to ensure operations are only executed in appropriate states
3. Automatic cleanup via task completion listeners
4. Error handling improvements for state store maintenance
5. Refactoring of unload operation to ensure it runs only on maintenance threads

The implementation ensures that:
- No updates can be made after a store has been committed or aborted
- Metrics can only be accessed after commit/abort
- All operations validate the state before execution
- Task thread cleanup properly triggers maintenance for unloaded providers

### Why are the changes needed?

RocksDBStateStore has implicit usage requirements that weren't being enforced. This could lead to incorrect usage patterns, potential data corruption, and hard-to-debug issues.

### Does this PR introduce *any* user-facing change?

No

### How was this patch tested?

Unit tests have been added and existing tests modified to validate state transitions and error cases. The PR includes a new test case specifically for SPARK-51596 (unloading only occurs on maintenance thread but occurs promptly).

### Was this patch authored or co-authored using generative AI tooling?

No