### PR TITLE
[SPARK-52959][PYTHON] Support UDT in Arrow-optimized Python UDTF

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -841,7 +841,7 @@ class ArrowStreamPandasUDTFSerializer(ArrowStreamPandasUDFSerializer):
     Serializer used by Python worker to evaluate Arrow-optimized Python UDTFs.
     """
 
-    def __init__(self, timezone, safecheck, int_to_decimal_coercion_enabled):
+    def __init__(self, timezone, safecheck, input_types, int_to_decimal_coercion_enabled):
         super(ArrowStreamPandasUDTFSerializer, self).__init__(
             timezone=timezone,
             safecheck=safecheck,
@@ -861,6 +861,7 @@ class ArrowStreamPandasUDTFSerializer(ArrowStreamPandasUDFSerializer):
             ndarray_as_list=True,
             # Enables explicit casting for mismatched return types of Arrow Python UDTFs.
             arrow_cast=True,
+            input_types=input_types,
             # Enable additional coercions for UDTF serialization
             int_to_decimal_coercion_enabled=int_to_decimal_coercion_enabled,
         )
@@ -885,35 +886,44 @@ class ArrowStreamPandasUDTFSerializer(ArrowStreamPandasUDFSerializer):
         import pandas as pd
         import pyarrow as pa
 
-        # Make input conform to [(series1, type1), (series2, type2), ...]
-        if not isinstance(series, (list, tuple)) or (
-            len(series) == 2 and isinstance(series[1], pa.DataType)
+        # Make input conform to
+        # [(series1, arrow_type1, spark_type1), (series2, arrow_type2, spark_type2), ...]
+        if (
+            not isinstance(series, (list, tuple))
+            or (len(series) == 2 and isinstance(series[1], pa.DataType))
+            or (
+                len(series) == 3
+                and isinstance(series[1], pa.DataType)
+                and isinstance(series[2], DataType)
+            )
         ):
             series = [series]
         series = ((s, None) if not isinstance(s, (list, tuple)) else s for s in series)
+        series = ((s[0], s[1], None) if len(s) == 2 else s for s in series)
 
         arrs = []
-        for s, t in series:
+        for s, arrow_type, spark_type in series:
             if not isinstance(s, pd.DataFrame):
                 raise PySparkValueError(
                     "Output of an arrow-optimized Python UDTFs expects "
                     f"a pandas.DataFrame but got: {type(s)}"
                 )
 
-            arrs.append(self._create_struct_array(s, t))
+            arrs.append(self._create_struct_array(s, arrow_type, spark_type))
 
         return pa.RecordBatch.from_arrays(arrs, ["_%d" % i for i in range(len(arrs))])
 
     def _get_or_create_converter_from_pandas(self, dt):
-        if dt not in self._converter_map:
+        key = dt.json()
+        if key not in self._converter_map:
             conv = _create_converter_from_pandas(
                 dt,
                 timezone=self._timezone,
                 error_on_duplicated_field_names=False,
                 ignore_unexpected_complex_type_values=True,
             )
-            self._converter_map[dt] = conv
-        return self._converter_map[dt]
+            self._converter_map[key] = conv
+        return self._converter_map[key]
 
     def _create_array(self, series, arrow_type, spark_type=None, arrow_cast=False):
         """

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -63,6 +63,7 @@ from pyspark.sql.types import (
     VariantVal,
 )
 from pyspark.testing import assertDataFrameEqual, assertSchemaEqual
+from pyspark.testing.objects import ExamplePoint, ExamplePointUDT
 from pyspark.testing.sqlutils import (
     have_pandas,
     have_pyarrow,
@@ -230,6 +231,14 @@ class BaseUDTFTestsMixin:
         with self.assertRaisesRegex(PythonException, "UDTF_INVALID_OUTPUT_ROW_TYPE"):
             TestUDTF(lit(1)).collect()
 
+        @udtf(returnType=StructType().add("point", ExamplePointUDT()))
+        class TestUDTF:
+            def eval(self, x: float, y: float):
+                yield ExamplePoint(x=x * 10, y=y * 10)
+
+        with self.assertRaisesRegex(PythonException, "UDTF_INVALID_OUTPUT_ROW_TYPE"):
+            TestUDTF(lit(1.0), lit(2.0)).collect()
+
     def test_udtf_eval_returning_tuple_with_struct_type(self):
         @udtf(returnType="a: struct<b: int, c: int>")
         class TestUDTF:
@@ -245,6 +254,30 @@ class BaseUDTFTestsMixin:
 
         with self.assertRaisesRegex(PythonException, "UDTF_RETURN_SCHEMA_MISMATCH"):
             TestUDTF(lit(1)).collect()
+
+    def test_udtf_eval_returning_udt(self):
+        @udtf(returnType=StructType().add("point", ExamplePointUDT()))
+        class TestUDTF:
+            def eval(self, x: float, y: float):
+                yield ExamplePoint(x=x * 10, y=y * 10),
+
+        assertDataFrameEqual(
+            TestUDTF(lit(1.0), lit(2.0)), [Row(point=ExamplePoint(x=10.0, y=20.0))]
+        )
+
+    def test_udtf_eval_taking_udt(self):
+        @udtf(returnType="x: double, y: double")
+        class TestUDTF:
+            def eval(self, point: ExamplePoint):
+                yield point.x * 10, point.y * 10
+
+        df = self.spark.createDataFrame(
+            [(ExamplePoint(x=1.0, y=2.0),)], schema=StructType().add("point", ExamplePointUDT())
+        )
+        assertDataFrameEqual(
+            df.lateralJoin(TestUDTF(col("point").outer())),
+            [Row(point=ExamplePoint(x=1.0, y=2.0), x=10.0, y=20.0)],
+        )
 
     def test_udtf_with_invalid_return_value(self):
         @udtf(returnType="x: int")
@@ -2954,6 +2987,13 @@ class LegacyUDTFArrowTestsMixin(BaseUDTFTestsMixin):
                 return [a]
 
         assertDataFrameEqual(TestUDTF(lit(1)), [Row(a=1)])
+
+        @udtf(returnType=StructType().add("udt", ExamplePointUDT()))
+        class TestUDTF:
+            def eval(self, x: float, y: float):
+                yield ExamplePoint(x=x * 10, y=y * 10)
+
+        assertDataFrameEqual(TestUDTF(lit(1.0), lit(2.0)), [Row(udt=ExamplePoint(x=10.0, y=20.0))])
 
     def test_udtf_use_large_var_types(self):
         for use_large_var_types in [True, False]:

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowPythonUDTFRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowPythonUDTFRunner.scala
@@ -48,6 +48,7 @@ class ArrowPythonUDTFRunner(
   with BasicPythonArrowOutput {
 
   override protected def writeUDF(dataOut: DataOutputStream): Unit = {
+    PythonWorkerUtils.writeUTF(schema.json, dataOut)
     PythonUDTFRunner.writeUDTF(dataOut, udtf, argMetas)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Supports UDT in Arrow-optimized Python UDTF.

### Why are the changes needed?

Arrow-optimized Python UDTF doesn't work with UDTs.

```py
>>> @udtf(returnType=StructType().add("point", ExamplePointUDT()), useArrow=True)
... class TestUDTFReturningUDT:
...   def eval(self, x: float, y: float):
...     yield ExamplePoint(x=x, y=y)
...
>>> df = spark.createDataFrame([(ExamplePoint(x=1.0, y=2.0),)], schema=StructType().add("point", ExamplePointUDT()))
>>> df.lateralJoin(TestUDTFTakingUDT(col("point").outer())).show()
...
AttributeError: 'list' object has no attribute 'x'

>>> @udtf(returnType=StructType().add("point", ExamplePointUDT()), useArrow=True)
... class TestUDTFReturningUDT:
...   def eval(self, x: float, y: float):
...     yield ExamplePoint(x=x, y=y),
...
>>> df = spark.range(2).select((col("id") + 10.0).alias("x"), (col("id") * 10.0).alias("y"))
>>> df.lateralJoin(TestUDTFReturningUDT(col("x").outer(), col("y").outer())).show()
...
org.apache.spark.SparkException: [ARROW_TYPE_MISMATCH] Invalid schema from Python UDTF: expected org.apache.spark.sql.test.ExamplePointUDT@7f511308, got ArrayType(DoubleType,false). SQLSTATE: 42K0G
```

### Does this PR introduce _any_ user-facing change?

Yes, UDTs are available as input / output for Arrow-optimized Python UDTF.

### How was this patch tested?

Added the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
