### PR TITLE
[SPARK-52987][SQL][K8S] Use Java `String.(equals|replace)` method instead of `commons-lang3`

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/cloud/KubeConfigBackend.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/cloud/KubeConfigBackend.scala
@@ -18,7 +18,6 @@ package org.apache.spark.deploy.k8s.integrationtest.backend.cloud
 
 import io.fabric8.kubernetes.client.{Config, KubernetesClient, KubernetesClientBuilder}
 import io.fabric8.kubernetes.client.utils.Utils
-import org.apache.commons.lang3.Strings
 
 import org.apache.spark.deploy.k8s.integrationtest.TestConstants
 import org.apache.spark.deploy.k8s.integrationtest.backend.IntegrationTestBackend
@@ -49,7 +48,7 @@ private[spark] class KubeConfigBackend(var context: String)
       // Clean up master URL which would have been specified in Spark format into a normal
       // K8S master URL
       masterUrl = checkAndGetK8sMasterUrl(masterUrl).replaceFirst("k8s://", "")
-      if (!Strings.CS.equals(config.getMasterUrl, masterUrl)) {
+      if (!config.getMasterUrl.equals(masterUrl)) {
         logInfo(s"Overriding K8S master URL ${config.getMasterUrl} from K8S config file " +
           s"with user specified master URL ${masterUrl}")
         config.setMasterUrl(masterUrl)

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -314,6 +314,11 @@ This file is divided into 3 sections:
     <customMessage>Use Utils.is(Not)?(Blank|Empty) instead</customMessage>
   </check>
 
+  <check customId="commonslang3strings" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.lang3\.Strings</parameter></parameters>
+    <customMessage>Use Java String methods instead</customMessage>
+  </check>
+
   <check customId="uribuilder" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">UriBuilder\.fromUri</parameter></parameters>
     <customMessage>Use Utils.getUriBuilder instead.</customMessage>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.connector.expressions
 
 import org.apache.commons.codec.binary.Hex
-import org.apache.commons.lang3.Strings
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst
@@ -390,7 +389,7 @@ private[sql] object HoursTransform {
 
 private[sql] final case class LiteralValue[T](value: T, dataType: DataType) extends Literal[T] {
   override def toString: String = dataType match {
-    case StringType => s"'${Strings.CS.replace(s"$value", "'", "''")}'"
+    case StringType => s"'${s"$value".replace("'", "''")}'"
     case BinaryType =>
       assert(value.isInstanceOf[Array[Byte]])
       val bytes = value.asInstanceOf[Array[Byte]]

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -26,8 +26,6 @@ import java.util.concurrent.TimeUnit
 import scala.collection.mutable.ArrayBuilder
 import scala.util.control.NonFatal
 
-import org.apache.commons.lang3.Strings
-
 import org.apache.spark.{SparkRuntimeException, SparkThrowable, SparkUnsupportedOperationException}
 import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.internal.Logging
@@ -354,7 +352,7 @@ abstract class JdbcDialect extends Serializable with Logging {
    */
   @Since("2.3.0")
   protected[jdbc] def escapeSql(value: String): String =
-    if (value == null) null else Strings.CS.replace(value, "'", "''")
+    if (value == null) null else value.replace("'", "''")
 
   /**
    * Converts value to SQL expression.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java's built-in `String.(equals|replace)` methods instead of `commons-lang3`.

In addition, new Scalastyle rule is added to ban `org.apache.commons.lang3.Strings` usage in order to prevent a future regression.

### Why are the changes needed?

Java's built-in one is faster than `commons-lang3` for our usage.

```scala
scala> val s = "'" * 400_000_000
val s: String = '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''...

scala> spark.time(s.replace("'", "''")).length
Time taken: 3545 ms
val res0: Int = 800000000

scala> spark.time(org.apache.commons.lang3.Strings.CS.replace(s, "'", "''")).length
Time taken: 5322 ms
val res1: Int = 800000000
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.