### PR TITLE
[SPARK-52990][CORE] Support `StringSubstitutor`

### DIFF
--- a/common/network-shuffle/pom.xml
+++ b/common/network-shuffle/pom.xml
@@ -43,6 +43,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
     </dependency>

--- a/common/utils/pom.xml
+++ b/common/utils/pom.xml
@@ -52,10 +52,6 @@
       <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-text</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/common/utils/src/main/scala/org/apache/spark/ErrorClassesJSONReader.scala
+++ b/common/utils/src/main/scala/org/apache/spark/ErrorClassesJSONReader.scala
@@ -19,13 +19,10 @@ package org.apache.spark
 
 import java.net.URL
 
-import scala.jdk.CollectionConverters._
-
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import org.apache.commons.text.StringSubstitutor
 
 import org.apache.spark.annotation.DeveloperApi
 
@@ -48,9 +45,7 @@ class ErrorClassesJsonReader(jsonFileURLs: Seq[URL]) {
       case (key, null) => key -> "null"
       case (key, value) => key -> value
     }
-    val sub = new StringSubstitutor(sanitizedParameters.asJava)
-    sub.setEnableUndefinedVariableException(true)
-    sub.setDisableSubstitutionInValues(true)
+    val sub = new StringSubstitutor(sanitizedParameters)
     val errorMessage = try {
       sub.replace(ErrorClassesJsonReader.TEMPLATE_REGEX.replaceAllIn(
         messageTemplate, "\\$\\{$1\\}"))

--- a/common/utils/src/main/scala/org/apache/spark/StringSubstitutor.scala
+++ b/common/utils/src/main/scala/org/apache/spark/StringSubstitutor.scala
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark
+
+import scala.collection.mutable.{ListBuffer, StringBuilder}
+
+class StringSubstitutor(
+    resolver: Map[String, Any],
+    prefix: String = "${",
+    suffix: String = "}",
+    escape: Char = '$',
+    valueDelimiter: String = ":-",
+    preserveEscapes: Boolean = true,
+    enableSubstitutionInVariables: Boolean = false,
+    enableUndefinedVariableException: Boolean = true) {
+
+  private val prefixLen = prefix.length
+  private val suffixLen = suffix.length
+
+  def replace(source: String): String = {
+    if (source == null) return null
+    val buf = new StringBuilder(source)
+    if (!substitute(buf, 0, buf.length, ListBuffer.empty[String])) {
+      source
+    } else {
+      buf.toString
+    }
+  }
+
+  private def substitute(
+      buf: StringBuilder,
+      offset: Int,
+      length: Int,
+      priorVariables: ListBuffer[String]): Boolean = {
+    var altered = false
+    var currentPos = offset
+    val endPos = offset + length
+
+    while (currentPos < endPos) {
+      // Find prefix
+      val prefixPos = buf.indexOf(prefix, currentPos)
+      if (prefixPos < 0 || prefixPos >= endPos) {
+        return altered
+      }
+
+      if (prefixPos > 0 && buf.charAt(prefixPos - 1) == escape) {
+        if (preserveEscapes) {
+          currentPos = prefixPos + prefixLen
+        } else {
+          buf.deleteCharAt(prefixPos - 1)
+          altered = true
+          currentPos = prefixPos - 1 + prefixLen // adjust position
+        }
+      } else {
+        // Find suffix
+        val suffixPos = buf.indexOf(suffix, prefixPos + prefixLen)
+        if (suffixPos < 0) {
+          currentPos = prefixPos + prefixLen
+        } else {
+          // Extract variable name and default
+          val varFull = buf.substring(prefixPos + prefixLen, suffixPos)
+          val index = varFull.indexOf(valueDelimiter)
+          val (varName, defaultValue) = if (index >= 0) {
+            (varFull.substring(0, index), Some(varFull.substring(index + valueDelimiter.length)))
+          } else {
+            (varFull, None)
+          }
+
+          // Check for cycle
+          if (priorVariables.contains(varName)) {
+            throw new IllegalStateException(
+              s"Infinite loop in property interpolation of $varName")
+          }
+
+          resolver.get(varName) match {
+            case Some(value) =>
+              var replacement = value.toString
+              if (enableSubstitutionInVariables) {
+                val newPrior = priorVariables.clone() += varName
+                val tempBuf = new StringBuilder(replacement)
+                if (substitute(tempBuf, 0, tempBuf.length, newPrior)) {
+                  replacement = tempBuf.toString
+                }
+              }
+              buf.replace(prefixPos, suffixPos + suffixLen, replacement)
+              // Adjust positions and recurse on the changed part
+              val changeInLength = replacement.length - (suffixPos + suffixLen - prefixPos)
+              val newLength = length + changeInLength
+              substitute(buf, prefixPos + replacement.length, newLength, priorVariables)
+              return true // restart scan after change
+
+            case None =>
+              defaultValue match {
+                case Some(value) =>
+                  buf.replace(prefixPos, suffixPos + suffixLen, value)
+                  val changeInLength = value.length - (suffixPos + suffixLen - prefixPos)
+                  val newLength = length + changeInLength
+                  substitute(buf, prefixPos + value.length, length, priorVariables)
+                  return true
+                case None =>
+                  if (enableUndefinedVariableException) {
+                    throw new IllegalArgumentException(s"Undefined variable: $varName")
+                  }
+              }
+          }
+          currentPos = suffixPos + suffixLen
+        }
+      }
+    }
+    altered
+  }
+}

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -319,6 +319,11 @@ This file is divided into 3 sections:
     <customMessage>Use Java String methods instead</customMessage>
   </check>
 
+  <check customId="commonstextstringsubstitutor" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.text\.StringSubstitutor</parameter></parameters>
+    <customMessage>Use org.apache.spark.StringSubstitutor instead</customMessage>
+  </check>
+
   <check customId="uribuilder" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">UriBuilder\.fromUri</parameter></parameters>
     <customMessage>Use Utils.getUriBuilder instead.</customMessage>

--- a/sql/api/pom.xml
+++ b/sql/api/pom.xml
@@ -65,6 +65,10 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+           <groupId>org.apache.commons</groupId>
+           <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
         </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `StringSubstitutor` in `common/utils` module. In addition, new Scalastyle rule is added to ban `org.apache.commons.text.StringSubstitutor`.

### Why are the changes needed?

- Improve String utility. New one is faster.

```scala
scala> import scala.jdk.CollectionConverters._
import scala.jdk.CollectionConverters._

scala> val s = "a" * 500_000_000 + "${a}"

scala> spark.time((new org.apache.commons.text.StringSubstitutor(Map("a" -> "b").asJava)).replace(s)).length
Time taken: 706 ms
val res0: Int = 500000001

scala> spark.time((new org.apache.spark.StringSubstitutor(Map("a" -> "b"))).replace(s)).length
Time taken: 312 ms
val res1: Int = 500000001
```

- Removes `commons-text` compile dependency from `common` modules.
  - After this PR, `common/unsafe` module has the only  `commons-text` test dependency under `common` directory.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the existing CIs because this is a replacement.

### Was this patch authored or co-authored using generative AI tooling?

No.