### PR TITLE
[SPARK-52992][PYTHON][DOCS] Restore API reference of `pandas_udf`

### DIFF
--- a/python/pyspark/sql/pandas/functions.py
+++ b/python/pyspark/sql/pandas/functions.py
@@ -56,20 +56,11 @@ def arrow_udf(f=None, returnType=None, functionType=None):
 
 
 def pandas_udf(f=None, returnType=None, functionType=None):
-    return vectorized_udf(f, returnType, functionType, "pandas")
-
-
-def vectorized_udf(
-    f=None,
-    returnType=None,
-    functionType=None,
-    kind: str = "pandas",
-):
     """
-    Creates a vectorized user defined function.
+    Creates a pandas user defined function.
 
     Pandas UDFs are user defined functions that are executed by Spark using Arrow to transfer
-    data and Pandas to work with the data, which allows vectorized operations. A Pandas UDF
+    data and Pandas to work with the data, which allows pandas operations. A Pandas UDF
     is defined using the `pandas_udf` as a decorator or to wrap the function, and no
     additional configuration is required. A Pandas UDF behaves as a regular PySpark function
     API in general.
@@ -392,6 +383,15 @@ def vectorized_udf(
     # Note: Python 3.11.9, Pandas 2.2.3 and PyArrow 17.0.0 are used.
     # Note: Timezone is KST.
     # Note: 'X' means it throws an exception during the conversion.
+    return vectorized_udf(f, returnType, functionType, "pandas")
+
+
+def vectorized_udf(
+    f=None,
+    returnType=None,
+    functionType=None,
+    kind: str = "pandas",
+):
     require_minimum_pandas_version()
     require_minimum_pyarrow_version()
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Restore API reference of `pandas_udf`


### Why are the changes needed?
it was mistakenly deleted in 4.1, see 

- 4.1: https://apache.github.io/spark/api/python/reference/pyspark.sql/api/pyspark.sql.functions.pandas_udf.html?highlight=pandas_udf#pyspark.sql.functions.pandas_udf
- 4.0: https://spark.apache.org/docs/4.0.0/api/python/reference/pyspark.sql/api/pyspark.sql.functions.pandas_udf.html

### Does this PR introduce _any_ user-facing change?
No, 4.1 is not released yet


### How was this patch tested?
CI, and will double check the generated documents

### Was this patch authored or co-authored using generative AI tooling?
no
