### PR TITLE
[SPARK-52999][K8S][TESTS] Clean up the deprecated APIs usage in `kubernetes-integration-tests` module

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/ClientModeTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/ClientModeTestsSuite.scala
@@ -34,7 +34,7 @@ private[spark] trait ClientModeTestsSuite { k8sSuite: KubernetesSuite =>
       .getKubernetesClient
       .services()
       .inNamespace(kubernetesTestComponents.namespace)
-      .create(new ServiceBuilder()
+      .resource(new ServiceBuilder()
         .withNewMetadata()
           .withName(s"$driverPodName-svc")
           .endMetadata()
@@ -53,11 +53,12 @@ private[spark] trait ClientModeTestsSuite { k8sSuite: KubernetesSuite =>
             .endPort()
           .endSpec()
         .build())
+      .create()
     try {
       val driverPod = testBackend.getKubernetesClient
         .pods()
         .inNamespace(kubernetesTestComponents.namespace)
-        .create(new PodBuilder()
+        .resource(new PodBuilder()
           .withNewMetadata()
           .withName(driverPodName)
           .withLabels(labels.asJava)
@@ -95,6 +96,7 @@ private[spark] trait ClientModeTestsSuite { k8sSuite: KubernetesSuite =>
             .endContainer()
           .endSpec()
         .build())
+        .create()
       Eventually.eventually(TIMEOUT, INTERVAL) {
         assert(kubernetesTestComponents.kubernetesClient
           .pods()

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
@@ -135,7 +135,7 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
       .kubernetesClient
       .services()
       .inNamespace(kubernetesTestComponents.namespace)
-      .create(minioService))
+      .resource(minioService).create())
 
     // try until the stateful set of a previous test is deleted
     Eventually.eventually(TIMEOUT, INTERVAL) (kubernetesTestComponents
@@ -143,7 +143,7 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
       .apps()
       .statefulSets()
       .inNamespace(kubernetesTestComponents.namespace)
-      .create(minioStatefulSet))
+      .resource(minioStatefulSet).create())
   }
 
   private def deleteMinioStorage(): Unit = {

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesTestComponents.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesTestComponents.scala
@@ -45,11 +45,12 @@ private[spark] class KubernetesTestComponents(val kubernetesClient: KubernetesCl
   val clientConfig = kubernetesClient.getConfiguration
 
   def createNamespace(): Unit = {
-    kubernetesClient.namespaces.create(new NamespaceBuilder()
+    kubernetesClient.namespaces.resource(new NamespaceBuilder()
       .withNewMetadata()
       .withName(namespace)
       .endMetadata()
       .build())
+      .create()
   }
 
   def deleteNamespace(): Unit = {

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PVTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PVTestsSuite.scala
@@ -71,13 +71,15 @@ private[spark] trait PVTestsSuite { k8sSuite: KubernetesSuite =>
     kubernetesTestComponents
       .kubernetesClient
       .persistentVolumes()
-      .create(pvBuilder.build())
+      .resource(pvBuilder.build())
+      .create()
 
     kubernetesTestComponents
       .kubernetesClient
       .persistentVolumeClaims()
       .inNamespace(kubernetesTestComponents.namespace)
-      .create(pvcBuilder.build())
+      .resource(pvcBuilder.build())
+      .create()
   }
 
   private def deleteLocalStorage(): Unit = {

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SecretsTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SecretsTestsSuite.scala
@@ -45,7 +45,8 @@ private[spark] trait SecretsTestsSuite { k8sSuite: KubernetesSuite =>
       .kubernetesClient
       .secrets()
       .inNamespace(kubernetesTestComponents.namespace)
-      .createOrReplace(envSecret)
+      .resource(envSecret)
+      .serverSideApply()
   }
 
   private def deleteTestSecret(): Unit = {

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.deploy.k8s.integrationtest
 
 import java.io.{Closeable, File, FileInputStream, FileOutputStream, PrintWriter}
-import java.nio.charset.StandardCharsets
+import java.nio.charset.Charset
 import java.nio.file.{Files, Path}
 import java.util.concurrent.{CompletableFuture, CountDownLatch}
 import java.util.zip.{ZipEntry, ZipOutputStream}
@@ -119,7 +119,7 @@ object Utils extends Logging {
     listener.waitForClose()
     watch.close()
     out.flush()
-    val result = out.toString(StandardCharsets.UTF_8)
+    val result = out.toString(Charset.defaultCharset())
     result
   }
 

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
@@ -107,8 +107,9 @@ object Utils extends Logging {
     listener.waitForInputStreamToConnect()
     val inputTransferFuture = CompletableFuture.runAsync(() => {
       try {
-        val inputStream = watch.getInput
-        if (inputStream != null) System.in.transferTo(inputStream)
+        // The return type of `watch.getInput` is `OutputStream`.
+        val outputStream = watch.getInput
+        if (outputStream != null) System.in.transferTo(outputStream)
       } catch {
         case _: InterruptedException =>
         case e: Exception =>

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
@@ -90,9 +90,9 @@ object Utils extends Logging {
       .withTTY()
       .usingListener(listener)
       .exec(cmd.toArray: _*)
-    System.in.transferTo(watch.getInput)
     // under load sometimes the stdout isn't connected by the time we try to read from it.
     listener.waitForInputStreamToConnect()
+    System.in.transferTo(watch.getInput)
     listener.waitForClose()
     watch.close()
     out.flush()

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
@@ -19,7 +19,7 @@ package org.apache.spark.deploy.k8s.integrationtest
 import java.io.{Closeable, File, FileInputStream, FileOutputStream, PrintWriter}
 import java.nio.charset.Charset
 import java.nio.file.{Files, Path}
-import java.util.concurrent.{CompletableFuture, CountDownLatch}
+import java.util.concurrent.CountDownLatch
 import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import scala.jdk.CollectionConverters._
@@ -62,23 +62,16 @@ object Utils extends Logging {
     class ReadyListener extends ExecListener {
       val openLatch: CountDownLatch = new CountDownLatch(1)
       val closeLatch: CountDownLatch = new CountDownLatch(1)
-      @volatile var inputStreamTransferFuture: CompletableFuture[Void] = _
 
       override def onOpen(): Unit = {
         openLatch.countDown()
       }
 
       override def onClose(a: Int, b: String): Unit = {
-        if (inputStreamTransferFuture != null && !inputStreamTransferFuture.isDone) {
-          inputStreamTransferFuture.cancel(true)
-        }
         closeLatch.countDown()
       }
 
       override def onFailure(e: Throwable, r: Response): Unit = {
-        if (inputStreamTransferFuture != null && !inputStreamTransferFuture.isDone) {
-          inputStreamTransferFuture.cancel(true)
-        }
       }
 
       def waitForInputStreamToConnect(): Unit = {
@@ -88,16 +81,10 @@ object Utils extends Logging {
       def waitForClose(): Unit = {
         closeLatch.await()
       }
-
-      def setInputStreamTransferFuture(future: CompletableFuture[Void]): Unit = {
-        this.inputStreamTransferFuture = future
-      }
     }
-
     val listener = new ReadyListener()
-
     val watch = pod
-      .redirectingInput()
+      .readingInput(System.in)
       .writingOutput(out)
       .writingError(System.err)
       .withTTY()
@@ -105,17 +92,6 @@ object Utils extends Logging {
       .exec(cmd.toArray: _*)
     // under load sometimes the stdout isn't connected by the time we try to read from it.
     listener.waitForInputStreamToConnect()
-    val inputTransferFuture = CompletableFuture.runAsync(() => {
-      try {
-        val inputStream = watch.getInput
-        if (inputStream != null) System.in.transferTo(inputStream)
-      } catch {
-        case _: InterruptedException =>
-        case e: Exception =>
-          logError(s"Error transferring input: ${e.getMessage}")
-      }
-    })
-    listener.setInputStreamTransferFuture(inputTransferFuture)
     listener.waitForClose()
     watch.close()
     out.flush()

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
@@ -19,7 +19,7 @@ package org.apache.spark.deploy.k8s.integrationtest
 import java.io.{Closeable, File, FileInputStream, FileOutputStream, PrintWriter}
 import java.nio.charset.Charset
 import java.nio.file.{Files, Path}
-import java.util.concurrent.{CompletableFuture, CountDownLatch}
+import java.util.concurrent.CountDownLatch
 import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import scala.jdk.CollectionConverters._
@@ -62,23 +62,16 @@ object Utils extends Logging {
     class ReadyListener extends ExecListener {
       val openLatch: CountDownLatch = new CountDownLatch(1)
       val closeLatch: CountDownLatch = new CountDownLatch(1)
-      @volatile var inputStreamTransferFuture: CompletableFuture[Void] = _
 
       override def onOpen(): Unit = {
         openLatch.countDown()
       }
 
       override def onClose(a: Int, b: String): Unit = {
-        if (inputStreamTransferFuture != null && !inputStreamTransferFuture.isDone) {
-          inputStreamTransferFuture.cancel(true)
-        }
         closeLatch.countDown()
       }
 
       override def onFailure(e: Throwable, r: Response): Unit = {
-        if (inputStreamTransferFuture != null && !inputStreamTransferFuture.isDone) {
-          inputStreamTransferFuture.cancel(true)
-        }
       }
 
       def waitForInputStreamToConnect(): Unit = {
@@ -88,14 +81,8 @@ object Utils extends Logging {
       def waitForClose(): Unit = {
         closeLatch.await()
       }
-
-      def setInputStreamTransferFuture(future: CompletableFuture[Void]): Unit = {
-        this.inputStreamTransferFuture = future
-      }
     }
-
     val listener = new ReadyListener()
-
     val watch = pod
       .redirectingInput()
       .writingOutput(out)
@@ -103,20 +90,9 @@ object Utils extends Logging {
       .withTTY()
       .usingListener(listener)
       .exec(cmd.toArray: _*)
+    System.in.transferTo(watch.getInput)
     // under load sometimes the stdout isn't connected by the time we try to read from it.
     listener.waitForInputStreamToConnect()
-    val inputTransferFuture = CompletableFuture.runAsync(() => {
-      try {
-        // The return type of `watch.getInput` is `OutputStream`.
-        val outputStream = watch.getInput
-        if (outputStream != null) System.in.transferTo(outputStream)
-      } catch {
-        case _: InterruptedException =>
-        case e: Exception =>
-          logError(s"Error transferring input: ${e.getMessage}")
-      }
-    })
-    listener.setInputStreamTransferFuture(inputTransferFuture)
     listener.waitForClose()
     watch.close()
     out.flush()


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR cleans up the usage of deprecated APIs in `kubernetes-integration-tests`:

1. For kubernetes-client:

- Replaced `ItemWritableOperation#create` with `AnyNamespaceOperation#resource(item).create()`

https://github.com/fabric8io/kubernetes-client/blob/40e5b2d12646ced86dfeb256be236bbe6b6b6cfe/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ItemWritableOperation.java#L35-L45

![image](https://github.com/user-attachments/assets/374ab565-17cf-4124-b53b-e98b9742eff7)


- Replaced `ItemWritableOperation#createOrReplace` with `AnyNamespaceOperation#resource(item).serverSideApply()`

https://github.com/fabric8io/kubernetes-client/blob/40e5b2d12646ced86dfeb256be236bbe6b6b6cfe/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ItemWritableOperation.java#L24-L33

![image](https://github.com/user-attachments/assets/bc936678-5fdd-4f06-8e2f-164be7118474)


https://github.com/fabric8io/kubernetes-client/blob/40e5b2d12646ced86dfeb256be236bbe6b6b6cfe/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java#L20-L33

![image](https://github.com/user-attachments/assets/353f99d2-ff92-4a79-b1a5-b6440b5ee5f9)


- Replaced `ContainerResource#readingInput(in)` with `ContainerResource#redirectingInput()` and the resulting `ExecWatch#getOutput()` combined with `InputStream#transferTo(java.io.OutputStream)`

https://github.com/fabric8io/kubernetes-client/blob/40e5b2d12646ced86dfeb256be236bbe6b6b6cfe/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ContainerResource.java#L27-L37

![image](https://github.com/user-attachments/assets/960f51f3-2c99-42fb-97ab-5a1be50cfb09)


2. For commons-compress:
- Replaced `org.apache.commons.compress.utils.IOUtils#copy(InputStream, OutputStream)` with `org.apache.commons.io.IOUtils#copy(InputStream, OutputStream)`

https://github.com/apache/commons-compress/blob/8de4d85b09a5d60e03191c0d362797de253a3516/src/main/java/org/apache/commons/compress/utils/IOUtils.java#L75-L87

![image](https://github.com/user-attachments/assets/1d2a6897-53b3-422e-a2c2-1c84a9065a26)


- Replaced `org.apache.commons.compress.utils.IOUtils#closeQuietly(Closeable)` with `org.apache.commons.io.IOUtils#closeQuietly(Closeable)`

https://github.com/apache/commons-compress/blob/8de4d85b09a5d60e03191c0d362797de253a3516/src/main/java/org/apache/commons/compress/utils/IOUtils.java#L49-L59

![image](https://github.com/user-attachments/assets/2e84bbd1-a034-4069-b8ce-90ffa244d2e0)


3. For commons-io:

- Replaced `AbstractByteArrayOutputStream#toString()` with `AbstractByteArrayOutputStream#toString(Charset)`

https://github.com/apache/commons-io/blob/d5f5b24aa58cc09e959e71f74b944622b42ff2e2/src/main/java/org/apache/commons/io/output/AbstractByteArrayOutputStream.java#L278-L291

![image](https://github.com/user-attachments/assets/f0ae232e-538c-49a3-b445-5b4af429e56f)


### Why are the changes needed?
Clean up the usage of deprecated APIs


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
