### PR TITLE
[SPARK-52996][TESTS] Update brace-expansion to 1.1.12

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -4,9 +4,9 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "dev",
       "devDependencies": {
         "ansi-regex": "^5.0.1",
+        "brace-expansion": "^1.1.12",
         "eslint": "^7.25.0",
         "minimatch": "^3.1.2"
       }

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -237,10 +237,11 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1407,9 +1408,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -2,7 +2,8 @@
   "devDependencies": {
     "eslint": "^7.25.0",
     "ansi-regex": "^5.0.1",
-    "minimatch": "^3.1.2"
+    "minimatch": "^3.1.2",
+    "brace-expansion": "^1.1.12"
   },
   "resolutions": {
     "optionator": "^0.9.3"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update brace-expansion to 1.1.12


### Why are the changes needed?
brace-expansion 1.1.11 contains CVE-2025-5889. Updating to 1.1.12 removes it


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Passed all CI tests


### Was this patch authored or co-authored using generative AI tooling?
No
