### PR TITLE
[SPARK-53002][SS] Show accurate memory usage statistics when bounded memory is enabled for RocksDB

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBMemoryManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBMemoryManager.scala
@@ -97,7 +97,6 @@ object RocksDBMemoryManager extends Logging with UnmanagedMemoryConsumer {
     logDebug(s"Unregistered instance $uniqueId")
   }
 
-
   def getNumRocksDBInstances(boundedMemory: Boolean): Long = {
     instanceMemoryMap.values().asScala.count(_.isBoundedMemory == boundedMemory)
   }
@@ -120,7 +119,6 @@ object RocksDBMemoryManager extends Logging with UnmanagedMemoryConsumer {
       totalMemoryUsage
     }
   }
-
 
   def getOrCreateRocksDBMemoryManagerAndCache(conf: RocksDBConf): (WriteBufferManager, Cache)
     = synchronized {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -787,7 +787,7 @@ private[sql] class RocksDBStateStoreProvider
       enableStateStoreCheckpointIds: Boolean,
       partitionId: Int = 0,
       eventForwarder: Option[RocksDBEventForwarder] = None,
-      uniqueId: String = ""): RocksDB = {
+      uniqueId: Option[String] = None): RocksDB = {
     new RocksDB(
       dfsRootDir,
       conf,
@@ -810,7 +810,7 @@ private[sql] class RocksDBStateStoreProvider
     val localRootDir = Utils.createTempDir(Utils.getLocalDir(sparkConf), storeIdStr)
     createRocksDB(dfsRootDir, RocksDBConf(storeConf), localRootDir, hadoopConf, loggingId,
       useColumnFamilies, storeConf.enableStateStoreCheckpointIds, stateStoreId.partitionId,
-      rocksDBEventForwarder, stateStoreProviderId.toString)
+      rocksDBEventForwarder, Some(stateStoreProviderId))
   }
 
   private val keyValueEncoderMap = new java.util.concurrent.ConcurrentHashMap[String,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -810,7 +810,7 @@ private[sql] class RocksDBStateStoreProvider
     val localRootDir = Utils.createTempDir(Utils.getLocalDir(sparkConf), storeIdStr)
     createRocksDB(dfsRootDir, RocksDBConf(storeConf), localRootDir, hadoopConf, loggingId,
       useColumnFamilies, storeConf.enableStateStoreCheckpointIds, stateStoreId.partitionId,
-      rocksDBEventForwarder, Some(stateStoreProviderId))
+      rocksDBEventForwarder, Some(stateStoreProviderId.toString))
   }
 
   private val keyValueEncoderMap = new java.util.concurrent.ConcurrentHashMap[String,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/FailureInjectionCheckpointFileManager.scala
@@ -259,7 +259,7 @@ class FailureInjectionRocksDBStateStoreProvider extends RocksDBStateStoreProvide
       enableStateStoreCheckpointIds: Boolean,
       partitionId: Int,
       eventForwarder: Option[RocksDBEventForwarder] = None,
-      uniqueId: String): RocksDB = {
+      uniqueId: Option[String]): RocksDB = {
     FailureInjectionRocksDBStateStoreProvider.createRocksDBWithFaultInjection(
       dfsRootDir,
       conf,
@@ -289,7 +289,7 @@ object FailureInjectionRocksDBStateStoreProvider {
       enableStateStoreCheckpointIds: Boolean,
       partitionId: Int,
       eventForwarder: Option[RocksDBEventForwarder],
-      uniqueId: String): RocksDB = {
+      uniqueId: Option[String]): RocksDB = {
     new RocksDB(
       dfsRootDir,
       conf = conf,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBCheckpointFailureInjectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBCheckpointFailureInjectionSuite.scala
@@ -603,7 +603,7 @@ class RocksDBCheckpointFailureInjectionSuite extends StreamTest
         enableStateStoreCheckpointIds = enableStateStoreCheckpointIds,
         partitionId = 0,
         eventForwarder = None,
-        uniqueId = "")
+        uniqueId = None)
       db.load(version, checkpointId)
       func(db)
     } finally {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -2598,11 +2598,7 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
               db.load(0)
               db.put("a", "1")
               db.commit()
-              if (boundedMemoryUsage == "true") {
-                assert(db.metricsOpt.get.totalMemUsageBytes === 0)
-              } else {
-                assert(db.metricsOpt.get.totalMemUsageBytes > 0)
-              }
+              assert(db.metricsOpt.get.totalMemUsageBytes > 0)
               db.getWriteBufferManagerAndCache()
             }
 
@@ -2613,11 +2609,7 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
               db.load(0)
               db.put("a", "1")
               db.commit()
-              if (boundedMemoryUsage == "true") {
-                assert(db.metricsOpt.get.totalMemUsageBytes === 0)
-              } else {
-                assert(db.metricsOpt.get.totalMemUsageBytes > 0)
-              }
+              assert(db.metricsOpt.get.totalMemUsageBytes > 0)
               db.getWriteBufferManagerAndCache()
             }
 
@@ -2667,7 +2659,7 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
             db.remove("a")
             db.put("c", "3")
             db.commit()
-            assert(db.metricsOpt.get.totalMemUsageBytes === 0)
+            assert(db.metricsOpt.get.totalMemUsageBytes > 0)
           }
         } finally {
           RocksDBMemoryManager.resetWriteBufferManagerAndCache


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently, RocksDB metrics show 0 bytes used if bounded memory is enabled. This PR will provide an approximation of memory used by fetching the memory used by RocksDB per executor, then dividing it by the open RocksDB instances per executor.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To show more accurate memory usage for when bounded memory is enabled. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No