### PR TITLE
[SPARK-53003][CORE] Support `strip` in `SparkStringUtils`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkStringUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkStringUtils.scala
@@ -56,6 +56,9 @@ private[spark] trait SparkStringUtils {
     import org.apache.spark.util.ArrayImplicits._
     str.split(",").map(_.trim()).filter(_.nonEmpty).toImmutableArraySeq
   }
+
+  /** Try to strip prefix and suffix with the given string 's' */
+  def strip(str: String, s: String): String = str.stripPrefix(s).stripSuffix(s)
 }
 
 private[spark] object SparkStringUtils extends SparkStringUtils with Logging {

--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -38,7 +38,6 @@ import scala.sys.process.Process
 import scala.util.Try
 
 import com.google.common.io.{ByteStreams, Files}
-import org.apache.commons.lang3.StringUtils
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.core.LoggerContext
 import org.apache.logging.log4j.core.appender.ConsoleAppender
@@ -234,7 +233,7 @@ private[spark] object TestUtils extends SparkTestUtils {
       Some(Paths.get(command).toAbsolutePath.toString)
     } else {
       sys.env("PATH").split(Pattern.quote(File.pathSeparator))
-        .map(path => Paths.get(s"${StringUtils.strip(path, "\"")}${File.separator}$command"))
+        .map(path => Paths.get(s"${Utils.strip(path, "\"")}${File.separator}$command"))
         .find(p => JavaFiles.isRegularFile(p) && JavaFiles.isExecutable(p))
         .map(_.toString)
     }

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -319,6 +319,11 @@ This file is divided into 3 sections:
     <customMessage>Use Java String methods instead</customMessage>
   </check>
 
+  <check customId="commonslang3strip" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">StringUtils\.strip\(</parameter></parameters>
+    <customMessage>Use Utils.strip method instead</customMessage>
+  </check>
+
   <check customId="commonstextstringsubstitutor" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">org\.apache\.commons\.text\.StringSubstitutor</parameter></parameters>
     <customMessage>Use org.apache.spark.StringSubstitutor instead</customMessage>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `strip` in `SparkStringUtils`. Note that this new method aims to invoke Scala's `stripPrefix` and `stripSuffix`. So, it serves the existing usage whose removal target is a single-length string.

In addition, this PR adds a new Scalastyle rule to ban `StringUtils.strip(...)` in favor of the built-in implementation.

### Why are the changes needed?

To improve String utility.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.