### PR TITLE
[SPARK-53006][BUILD][TESTS] Upgrade `bytebuddy` to 1.17.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1238,13 +1238,13 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.6</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.6</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade a test dependency, `bytebuddy` to 1.17.6 to test Java 25 better.

### Why are the changes needed?

Previously, we upgrade `bytebuddy` to `1.17.0` to support Java 25.
- https://github.com/apache/spark/pull/49940

This PR aims to bring the latest bug fixes.

**Release Note**
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.6
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.5
  - Update ASM to version 9.8 to support Java 25 using ASM reader and writer.
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.4
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.3
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.2
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.1

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.