### PR TITLE
[SPARK-53010][MLLIB][YARN] Ban `com.google.common.base.Strings`

### DIFF
--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -185,6 +185,7 @@
             <property name="illegalPkgs" value="org.apache.commons.lang" />
             <property name="illegalPkgs" value="org.apache.commons.lang3.tuple" />
             <property name="illegalClasses" value="org.apache.commons.lang3.JavaVersion" />
+            <property name="illegalClasses" value="com.google.common.base.Strings" />
         </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="new URL\("/>

--- a/mllib/src/test/java/org/apache/spark/mllib/feature/JavaWord2VecSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/feature/JavaWord2VecSuite.java
@@ -20,8 +20,6 @@ package org.apache.spark.mllib.feature;
 import java.util.Arrays;
 import java.util.List;
 
-import com.google.common.base.Strings;
-
 import scala.Tuple2;
 
 import org.junit.jupiter.api.Assertions;
@@ -35,7 +33,7 @@ public class JavaWord2VecSuite extends SharedSparkSession {
   @Test
   public void word2Vec() {
     // The tests are to check Java compatibility.
-    String sentence = Strings.repeat("a b ", 100) + Strings.repeat("a c ", 10);
+    String sentence = "a b ".repeat(100) + "a c ".repeat(10);
     List<String> words = Arrays.asList(sentence.split(" "));
     List<List<String>> localDoc = Arrays.asList(words, words);
     JavaRDD<List<String>> doc = jsc.parallelize(localDoc);

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/SparkRackResolver.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/SparkRackResolver.scala
@@ -20,11 +20,10 @@ package org.apache.spark.deploy.yarn
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 
-import com.google.common.base.Strings
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic
 import org.apache.hadoop.net._
-import org.apache.hadoop.util.ReflectionUtils
+import org.apache.hadoop.util.{ReflectionUtils, SparkStringUtils}
 
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys.NODE_LOCATION
@@ -73,7 +72,7 @@ private[spark] class SparkRackResolver(conf: Configuration) extends Logging {
         log"Falling back to ${MDC(NODE_LOCATION, NetworkTopology.DEFAULT_RACK)} for all")
     } else {
       for ((hostName, rName) <- hostNames.zip(rNameList)) {
-        if (Strings.isNullOrEmpty(rName)) {
+        if (Utils.isEmpty(rName)) {
           nodes += new NodeBase(hostName, NetworkTopology.DEFAULT_RACK)
           logDebug(s"Could not resolve $hostName. " +
             s"Falling back to ${NetworkTopology.DEFAULT_RACK}")

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/SparkRackResolver.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/SparkRackResolver.scala
@@ -23,10 +23,11 @@ import scala.jdk.CollectionConverters._
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic
 import org.apache.hadoop.net._
-import org.apache.hadoop.util.{ReflectionUtils, SparkStringUtils}
+import org.apache.hadoop.util.ReflectionUtils
 
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys.NODE_LOCATION
+import org.apache.spark.util.SparkStringUtils
 
 /**
  * Re-implement YARN's [[RackResolver]] for hadoop releases without YARN-9332.
@@ -72,7 +73,7 @@ private[spark] class SparkRackResolver(conf: Configuration) extends Logging {
         log"Falling back to ${MDC(NODE_LOCATION, NetworkTopology.DEFAULT_RACK)} for all")
     } else {
       for ((hostName, rName) <- hostNames.zip(rNameList)) {
-        if (Utils.isEmpty(rName)) {
+        if (SparkStringUtils.isEmpty(rName)) {
           nodes += new NodeBase(hostName, NetworkTopology.DEFAULT_RACK)
           logDebug(s"Could not resolve $hostName. " +
             s"Falling back to ${NetworkTopology.DEFAULT_RACK}")

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -506,4 +506,9 @@ This file is divided into 3 sections:
     <parameters><parameter name="regex">buildConf\("spark.databricks.</parameter></parameters>
     <customMessage>Use Apache Spark config namespace.</customMessage>
   </check>
+
+  <check customId="googleStrings" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">com\.google\.common\.base\.Strings</parameter></parameters>
+    <customMessage>Use Java built-in methods or SparkStringUtils instead</customMessage>
+  </check>
 </scalastyle>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ban `com.google.common.base.Strings` in favor of Java's built-in method and `SparkStringUtils`.

### Why are the changes needed?

- `Strings.repeat`: Java 11+ supports **faster** `String.repeat` natively.

```scala
scala> spark.time("a".repeat(1_000_000_000).length)
Time taken: 83 ms
val res0: Int = 1000000000

scala> spark.time(com.google.common.base.Strings.repeat("a", 1_000_000_000).length)
Time taken: 397 ms
val res1: Int = 1000000000
```

- `Strings.isNullOrEmpty`: `SparkStringUtils` supports `isEmpty` already.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.