### PR TITLE
[SPARK-53017][SQL][FOLLOWUP] Add logs in DSv2 Join pushdown rule

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -149,6 +149,7 @@ private[spark] object LogKeys {
   case object COLUMN_DATA_TYPE_TARGET extends LogKey
   case object COLUMN_DEFAULT_VALUE extends LogKey
   case object COLUMN_NAME extends LogKey
+  case object COLUMN_NAMES extends LogKey
   case object COMMAND extends LogKey
   case object COMMAND_OUTPUT extends LogKey
   case object COMMITTED_VERSION extends LogKey

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownJoin.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownJoin.java
@@ -69,5 +69,10 @@ public interface SupportsPushDownJoin extends ScanBuilder {
    *  <br>
    *  Holds information of original output name and the alias of the new output.
    */
-  record ColumnWithAlias(String colName, String alias) {}
+  record ColumnWithAlias(String colName, String alias) {
+    public String prettyString() {
+      if (alias == null) return colName;
+      else return colName + " AS " + alias;
+    }
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -245,7 +245,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
 
         leftHolder
       } else {
-        logInfo(log"DSV2 Join pushdown - failed to push down join.")
+        logInfo(log"DSv2 Join pushdown - failed to push down join.")
         node
       }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources.v2
 
 import scala.collection.mutable
 
-import org.apache.spark.internal.LogKeys.{AGGREGATE_FUNCTIONS, GROUP_BY_EXPRS, POST_SCAN_FILTERS, PUSHED_FILTERS, RELATION_NAME, RELATION_OUTPUT}
+import org.apache.spark.internal.LogKeys.{AGGREGATE_FUNCTIONS, COLUMN_NAMES, GROUP_BY_EXPRS, JOIN_CONDITION, JOIN_TYPE, POST_SCAN_FILTERS, PUSHED_FILTERS, RELATION_NAME, RELATION_OUTPUT}
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.catalyst.expressions.{aggregate, Alias, And, Attribute, AttributeMap, AttributeReference, AttributeSet, Cast, Expression, IntegerLiteral, Literal, NamedExpression, PredicateHelper, ProjectionOverSchema, SortOrder, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
@@ -204,6 +204,36 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
         normalizedCondition.flatMap(DataSourceV2Strategy.translateFilterV2(_))
       val translatedJoinType = DataSourceStrategy.translateJoinType(joinType)
 
+      logInfo(log"DSv2 Join pushdown - translated join condition " +
+        log"${MDC(JOIN_CONDITION, translatedCondition)}")
+      logInfo(log"DSv2 Join pushdown - translated join type " +
+        log"${MDC(JOIN_TYPE, translatedJoinType)}")
+
+      val prettyLeftSideRequiredColumnsWithAliases = leftSideRequiredColumnsWithAliases
+        .map(e => s"(${e.colName()}, ${e.alias()})")
+        .mkString(", ")
+      val prettyRightSideRequiredColumnsWithAliases = rightSideRequiredColumnsWithAliases
+        .map(e => s"(${e.colName()}, ${e.alias()})")
+        .mkString(", ")
+
+      def columnsWithAliasesPrettyString(
+          cols: Seq[SupportsPushDownJoin.ColumnWithAlias]): String = {
+        cols
+          .map(e => s"(${e.colName()}, ${e.alias()})")
+          .mkString(", ")
+      }
+
+      logInfo(log"DSv2 Join pushdown - left side required columns with aliases: " +
+        log"${MDC(
+          COLUMN_NAMES,
+          columnsWithAliasesPrettyString(leftSideRequiredColumnsWithAliases)
+        )}")
+      logInfo(log"DSv2 Join pushdown - right side required columns with aliases: " +
+        log"${MDC(
+          COLUMN_NAMES,
+          columnsWithAliasesPrettyString(rightSideRequiredColumnsWithAliases)
+        )}")
+
       if (translatedJoinType.isDefined &&
         translatedCondition.isDefined &&
         lBuilder.pushDownJoin(
@@ -220,8 +250,16 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
         leftHolder.output = node.output.asInstanceOf[Seq[AttributeReference]]
         leftHolder.pushedJoinOutputMap = pushedJoinOutputMap
 
+        // TODO: for cascade joins, already joined relations will still have the name of the
+        // original(leaf) relation. It should be thought of if we want to change the name of the
+        // relation when join is pushed down.
+        logInfo(log"DSv2 Join pushdown - successfully pushed down join between relations " +
+          log"${MDC(RELATION_NAME, leftHolder.relation.name)} and " +
+          log"${MDC(RELATION_NAME, rightHolder.relation.name)}.")
+
         leftHolder
       } else {
+        logInfo(log"DSV2 Join pushdown - failed to push down join.")
         node
       }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -209,29 +209,15 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
       logInfo(log"DSv2 Join pushdown - translated join type " +
         log"${MDC(JOIN_TYPE, translatedJoinType)}")
 
-      val prettyLeftSideRequiredColumnsWithAliases = leftSideRequiredColumnsWithAliases
-        .map(e => s"(${e.colName()}, ${e.alias()})")
-        .mkString(", ")
-      val prettyRightSideRequiredColumnsWithAliases = rightSideRequiredColumnsWithAliases
-        .map(e => s"(${e.colName()}, ${e.alias()})")
-        .mkString(", ")
-
-      def columnsWithAliasesPrettyString(
-          cols: Seq[SupportsPushDownJoin.ColumnWithAlias]): String = {
-        cols
-          .map(e => s"(${e.colName()}, ${e.alias()})")
-          .mkString(", ")
-      }
-
       logInfo(log"DSv2 Join pushdown - left side required columns with aliases: " +
         log"${MDC(
           COLUMN_NAMES,
-          columnsWithAliasesPrettyString(leftSideRequiredColumnsWithAliases)
+          leftSideRequiredColumnsWithAliases.map(_.prettyString()).mkString(", ")
         )}")
       logInfo(log"DSv2 Join pushdown - right side required columns with aliases: " +
         log"${MDC(
           COLUMN_NAMES,
-          columnsWithAliasesPrettyString(rightSideRequiredColumnsWithAliases)
+          rightSideRequiredColumnsWithAliases.map(_.prettyString()).mkString(", ")
         )}")
 
       if (translatedJoinType.isDefined &&

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -240,7 +240,7 @@ case class JDBCScanBuilder(
     jdbcOptions = new JDBCOptions(newJdbcOptionsMap)
     finalSchema = requiredSchema
     logInfo(log"Updated JDBC schema due to join pushdown. " +
-      log"New schema: ${MDC(SCHEMA, finalSchema.simpleString)}")
+      log"New schema: ${MDC(SCHEMA, finalSchema.toDDL)}")
 
     // We need to reset the pushedPredicate because it has already been consumed in previously
     // crafted SQL query.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -18,7 +18,8 @@ package org.apache.spark.sql.execution.datasources.v2.jdbc
 
 import scala.util.control.NonFatal
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.{Logging, MDC}
+import org.apache.spark.internal.LogKeys.{JOIN_CONDITION, JOIN_TYPE, SCHEMA}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.expressions.{FieldReference, SortOrder}
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation
@@ -187,11 +188,15 @@ case class JDBCScanBuilder(
       case _ => None
     }
     if (!joinTypeStringOption.isDefined) {
+      logError(log"Failed to push down join to JDBC due to unsupported join type " +
+        log"${MDC(JOIN_TYPE, joinType)}")
       return false
     }
 
     val compiledCondition = dialect.compileExpression(condition)
     if (!compiledCondition.isDefined) {
+      logError(log"Failed to push down join to JDBC due to unsupported join condition " +
+        log"${MDC(JOIN_CONDITION, condition)}")
       return false
     }
 
@@ -234,6 +239,8 @@ case class JDBCScanBuilder(
 
     jdbcOptions = new JDBCOptions(newJdbcOptionsMap)
     finalSchema = requiredSchema
+    logInfo(log"Updated JDBC schema due to join pushdown. " +
+      log"New schema: ${MDC(SCHEMA, finalSchema.simpleString)}")
 
     // We need to reset the pushedPredicate because it has already been consumed in previously
     // crafted SQL query.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Added logs in DSv2 Join pushdown to improve debugability.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
If the join pushdown fails, it should be easier for user to see what entry points have been touched and where it failed.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No.
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
No need for tests as it is logging only change.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No.
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
