### PR TITLE
[SPARK-53018][PYTHON] ArrowStreamArrowUDFSerializer should respect argument arrow_cast

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -703,8 +703,13 @@ class ArrowStreamArrowUDFSerializer(ArrowStreamSerializer):
 
         if arr.type == arrow_type:
             return arr
-        else:
+        elif arrow_cast:
             return arr.cast(target_type=arrow_type, safe=self._safecheck)
+        else:
+            raise PySparkTypeError(
+                "Arrow UDFs require the return type to match the expected Arrow type. "
+                f"Expected: {arrow_type}, but got: {arr.type}."
+            )
 
     def dump_stream(self, iterator, stream):
         """


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
ArrowStreamArrowUDFSerializer should respect argument arrow_cast

### Why are the changes needed?
the arrow_cast took no effect before


### Does this PR introduce _any_ user-facing change?
no, this is only used in arrow udf which are not released yet


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no