### PR TITLE
[SPARK-53019][SQL] Fix job attempt path conflicts in o.a.hadoop..FileOutputCommitter

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/io/FileCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/FileCommitProtocol.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.internal.io
 
-import java.util.concurrent.atomic.AtomicInteger
-
 import org.apache.hadoop.fs._
 import org.apache.hadoop.mapreduce._
 
@@ -231,14 +229,15 @@ object FileCommitProtocol extends Logging {
     }
   }
 
-  def getStagingDir(path: String, jobId: String): Path = {
+  def getStagingDir(path: Path, jobId: String): Path = {
     new Path(path, ".spark-staging-" + jobId)
   }
 
-  private val NEXT_JOB_ATTEMPT_ID = new AtomicInteger(0)
-  def nextJobAttemptId(): Int = {
-    NEXT_JOB_ATTEMPT_ID.getAndIncrement()
+  def getStagingDir(path: String, jobId: String): Path = {
+    getStagingDir(new Path(path), jobId)
   }
+
+  val SPARK_WRITE_JOB_ID: String = "spark.write.job.id"
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/internal/io/FileCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/FileCommitProtocol.scala
@@ -237,7 +237,7 @@ object FileCommitProtocol extends Logging {
     getStagingDir(new Path(path), jobId)
   }
 
-  val SPARK_WRITE_JOB_ID: String = "spark.write.job.id"
+  val SPARK_WRITE_JOB_ID: String = "spark.sql.sources.writeJobUUID"
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/internal/io/FileCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/FileCommitProtocol.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.internal.io
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import org.apache.hadoop.fs._
 import org.apache.hadoop.mapreduce._
 
@@ -231,6 +233,11 @@ object FileCommitProtocol extends Logging {
 
   def getStagingDir(path: String, jobId: String): Path = {
     new Path(path, ".spark-staging-" + jobId)
+  }
+
+  private val NEXT_JOB_ATTEMPT_ID = new AtomicInteger(0)
+  def nextJobAttemptId(): Int = {
+    NEXT_JOB_ATTEMPT_ID.getAndIncrement()
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
@@ -174,14 +174,13 @@ class HadoopMapReduceCommitProtocol(
 
   override def setupJob(jobContext: JobContext): Unit = {
     // Setup IDs
-    val jobAttemptId = nextJobAttemptId()
-    val jobId = SparkHadoopWriterUtils.createJobID(new Date, jobAttemptId)
+    val jobId = SparkHadoopWriterUtils.createJobID(new Date, 0)
     val taskId = new TaskID(jobId, TaskType.MAP, 0)
     val taskAttemptId = new TaskAttemptID(taskId, 0)
 
     // Set up the configuration object
     jobContext.getConfiguration.set("mapreduce.job.id", jobId.toString)
-    jobContext.getConfiguration.setInt("mapreduce.job.application.attempt.id", jobAttemptId)
+    jobContext.getConfiguration.set(SPARK_WRITE_JOB_ID, this.jobId)
     jobContext.getConfiguration.set("mapreduce.task.id", taskAttemptId.getTaskID.toString)
     jobContext.getConfiguration.set("mapreduce.task.attempt.id", taskAttemptId.toString)
     jobContext.getConfiguration.setBoolean("mapreduce.task.ismap", true)

--- a/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
@@ -127,14 +127,13 @@ class HadoopMapReduceCommitProtocol(
     val filename = getFilename(taskContext, spec)
 
     val stagingDir: Path = committer match {
-      // For FileOutputCommitter it has its own staging path called "work path".
       case f: FileOutputCommitter =>
         if (dynamicPartitionOverwrite) {
           assert(dir.isDefined,
             "The dataset to be written must be partitioned when dynamicPartitionOverwrite is true.")
           partitionPaths += dir.get
         }
-        new Path(Option(f.getWorkPath).map(_.toString).getOrElse(path))
+        f.getTaskAttemptPath(taskContext)
       case _ => new Path(path)
     }
 
@@ -180,7 +179,6 @@ class HadoopMapReduceCommitProtocol(
 
     // Set up the configuration object
     jobContext.getConfiguration.set("mapreduce.job.id", jobId.toString)
-    jobContext.getConfiguration.set(SPARK_WRITE_JOB_ID, this.jobId)
     jobContext.getConfiguration.set("mapreduce.task.id", taskAttemptId.getTaskID.toString)
     jobContext.getConfiguration.set("mapreduce.task.attempt.id", taskAttemptId.toString)
     jobContext.getConfiguration.setBoolean("mapreduce.task.ismap", true)

--- a/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
@@ -174,12 +174,14 @@ class HadoopMapReduceCommitProtocol(
 
   override def setupJob(jobContext: JobContext): Unit = {
     // Setup IDs
-    val jobId = SparkHadoopWriterUtils.createJobID(new Date, 0)
+    val jobAttemptId = nextJobAttemptId()
+    val jobId = SparkHadoopWriterUtils.createJobID(new Date, jobAttemptId)
     val taskId = new TaskID(jobId, TaskType.MAP, 0)
     val taskAttemptId = new TaskAttemptID(taskId, 0)
 
     // Set up the configuration object
     jobContext.getConfiguration.set("mapreduce.job.id", jobId.toString)
+    jobContext.getConfiguration.setInt("mapreduce.job.application.attempt.id", jobAttemptId)
     jobContext.getConfiguration.set("mapreduce.task.id", taskAttemptId.getTaskID.toString)
     jobContext.getConfiguration.set("mapreduce.task.attempt.id", taskAttemptId.toString)
     jobContext.getConfiguration.setBoolean("mapreduce.task.ismap", true)

--- a/core/src/main/scala/org/apache/spark/internal/io/SparkHadoopWriter.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/SparkHadoopWriter.scala
@@ -25,16 +25,14 @@ import scala.reflect.ClassTag
 import org.apache.hadoop.conf.{Configurable, Configuration}
 import org.apache.hadoop.fs.FileSystem
 import org.apache.hadoop.mapred._
-import org.apache.hadoop.mapreduce.{JobContext => NewJobContext,
-OutputFormat => NewOutputFormat, RecordWriter => NewRecordWriter,
-TaskAttemptContext => NewTaskAttemptContext, TaskAttemptID => NewTaskAttemptID, TaskType}
+import org.apache.hadoop.mapreduce.{JobContext => NewJobContext, OutputFormat => NewOutputFormat, RecordWriter => NewRecordWriter, TaskAttemptContext => NewTaskAttemptContext, TaskAttemptID => NewTaskAttemptID, TaskType}
 import org.apache.hadoop.mapreduce.task.{TaskAttemptContextImpl => NewTaskAttemptContextImpl}
 
 import org.apache.spark.{SerializableWritable, SparkConf, SparkException, TaskContext}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys.{DURATION, JOB_ID, TASK_ATTEMPT_ID}
-import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
+import org.apache.spark.internal.io.FileCommitProtocol.{SPARK_WRITE_JOB_ID, TaskCommitMessage}
 import org.apache.spark.rdd.{HadoopRDD, RDD}
 import org.apache.spark.util.{SerializableConfiguration, SerializableJobConf, Utils}
 import org.apache.spark.util.ArrayImplicits._
@@ -74,8 +72,7 @@ object SparkHadoopWriter extends Logging {
 
     // propagate the description UUID into the jobs, so that committers
     // get an ID guaranteed to be unique.
-    jobContext.getConfiguration.set("spark.sql.sources.writeJobUUID",
-      UUID.randomUUID.toString)
+    jobContext.getConfiguration.set(SPARK_WRITE_JOB_ID, UUID.randomUUID.toString)
 
     val committer = config.createCommitter(commitJobId)
     committer.setupJob(jobContext)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -29,6 +29,7 @@ import org.apache.spark._
 import org.apache.spark.internal.{Logging, LogKeys, MDC}
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.internal.io.{FileCommitProtocol, SparkHadoopWriterUtils}
+import org.apache.spark.internal.io.FileCommitProtocol.SPARK_WRITE_JOB_ID
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
@@ -163,7 +164,7 @@ object FileFormatWriter extends Logging {
 
     // propagate the description UUID into the jobs, so that committers
     // get an ID guaranteed to be unique.
-    job.getConfiguration.set("spark.sql.sources.writeJobUUID", description.uuid)
+    job.getConfiguration.set(SPARK_WRITE_JOB_ID, description.uuid)
 
     // When `PLANNED_WRITE_ENABLED` is true, the optimizer rule V1Writes will add logical sort
     // operator based on the required ordering of the V1 write command. So the output
@@ -377,7 +378,7 @@ object FileFormatWriter extends Logging {
       hadoopConf.set("mapreduce.task.attempt.id", taskAttemptId.toString)
       hadoopConf.setBoolean("mapreduce.task.ismap", true)
       hadoopConf.setInt("mapreduce.task.partition", 0)
-
+      hadoopConf.set(SPARK_WRITE_JOB_ID, description.uuid)
       new TaskAttemptContextImpl(hadoopConf, taskAttemptId)
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SQLHadoopMapReduceCommitProtocol.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SQLHadoopMapReduceCommitProtocol.scala
@@ -68,7 +68,10 @@ class SQLHadoopMapReduceCommitProtocol(
         val ctor = clazz.getDeclaredConstructor()
         committer = ctor.newInstance()
       }
-    } else if (clazz == classOf[FileOutputCommitter]) {
+    } else if (committer.getClass == classOf[FileOutputCommitter]) {
+      // If both OUTPUT_COMMITTER_CLASS is not specified by user and FileOutputCommitter is not
+      // overridden by the data source, we will use the default UniqueJobPathOutputCommitter to
+      // make the job temporary output path unique.
       committer = new UniqueJobPathOutputCommitter(new Path(path), context)
     }
     logInfo(log"Using output committer class " +
@@ -81,6 +84,7 @@ class SQLHadoopMapReduceCommitProtocol(
  * An implementation of [[FileOutputCommitter]] that uses the Spark write ID to create
  * a staging directory for job attempts instead of static `_temporary` as root.
  *
+ * This class can be set to spark.sql.sources.outputCommitterClass for direct use.
  */
 class UniqueJobPathOutputCommitter(outputPath: Path, context: TaskAttemptContext)
   extends FileOutputCommitter(outputPath, context)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SQLHadoopMapReduceCommitProtocol.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SQLHadoopMapReduceCommitProtocol.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.execution.datasources
 
 import java.io.FileNotFoundException
-import java.lang.invoke.MethodHandles
 
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.{JobContext, OutputCommitter, TaskAttemptContext}
@@ -86,10 +85,6 @@ class SQLHadoopMapReduceCommitProtocol(
 class UniqueJobPathOutputCommitter(outputPath: Path, context: TaskAttemptContext)
   extends FileOutputCommitter(outputPath, context)
   with Logging {
-
-  MethodHandles.lookup()
-    .findVarHandle(classOf[FileOutputCommitter], "workPath", classOf[Path])
-    .set(this, getTaskAttemptPath(context))
 
   private def getSparkWriteId: String = {
     context.getConfiguration.get(SPARK_WRITE_JOB_ID, FileOutputCommitter.PENDING_DIR_NAME)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, `mapreduce.job.application.attempt.id` is not set while setting up write jobs. This leads `FileOutputCommitter` to use `0` by default.

```java:FileOutputCommitter.java
  private static int getAppAttemptId(JobContext context) {
    return context.getConfiguration().getInt("mapreduce.job.application.attempt.id", 0);
  }

  public Path getJobAttemptPath(JobContext context) {
    return getJobAttemptPath(context, this.getOutputPath());
  }

  public static Path getJobAttemptPath(JobContext context, Path out) {
    return getJobAttemptPath(getAppAttemptId(context), out);
  }
```
While two or more write jobs run at the same time, the early completed ones will remove the job temp path, which still contains the pending job's task outputs. We shall make a unique ID for `mapreduce.job.application.attempt.id` for each write job


### Why are the changes needed?
Fix a race for write

### Does this PR introduce _any_ user-facing change?

no
### How was this patch tested?
new tests


### Was this patch authored or co-authored using generative AI tooling?
no
