### PR TITLE
[SPARK-53021][BUILD] Switch `common/utils` module to have `commons-io` test dependency

### DIFF
--- a/common/utils/pom.xml
+++ b/common/utils/pom.xml
@@ -54,6 +54,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.ivy</groupId>

--- a/sql/api/pom.xml
+++ b/sql/api/pom.xml
@@ -65,6 +65,10 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
            <groupId>org.apache.commons</groupId>
            <artifactId>commons-lang3</artifactId>
         </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to switch the `commons-io` dependency of  `common/utils` to `test` from `compile`.

### Why are the changes needed?

- `commons/utils` module uses `commons-io` in `test` only.
- Since it turns out that `sql/api` modules uses `commons-io` actually via the above transitive dependency, this PR makes it clear.

```
$ git grep 'org.apache.commons.io' sql/api
sql/api/src/main/scala/org/apache/spark/sql/util/ProtobufUtils.scala:import org.apache.commons.io.FileUtils
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.