### PR TITLE
[SPARK-53023][SQL] Remove `commons-io` dependency from `sql/api` module

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -282,6 +282,11 @@ This file is divided into 3 sections:
       scala.jdk.CollectionConverters._ and use .asScala / .asJava methods</customMessage>
   </check>
 
+  <check customId="readFileToByteArray" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">FileUtils\.readFileToByteArray</parameter></parameters>
+    <customMessage>Use java.nio.file.Files.readAllBytes</customMessage>
+  </check>
+
   <check customId="commonslang2" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">org\.apache\.commons\.lang\.</parameter></parameters>
     <customMessage>Use Commons Lang 3 classes (package org.apache.commons.lang3.*) instead

--- a/sql/api/pom.xml
+++ b/sql/api/pom.xml
@@ -65,10 +65,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
            <groupId>org.apache.commons</groupId>
            <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ProtobufUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ProtobufUtils.scala
@@ -18,18 +18,16 @@
 package org.apache.spark.sql.util
 
 import java.io.{File, FileNotFoundException}
-import java.nio.file.NoSuchFileException
+import java.nio.file.{Files, NoSuchFileException}
 
 import scala.util.control.NonFatal
-
-import org.apache.commons.io.FileUtils
 
 import org.apache.spark.sql.errors.CompilationErrors
 
 object ProtobufUtils {
   def readDescriptorFileContent(filePath: String): Array[Byte] = {
     try {
-      FileUtils.readFileToByteArray(new File(filePath))
+      Files.readAllBytes(new File(filePath).toPath())
     } catch {
       case ex: FileNotFoundException =>
         throw CompilationErrors.cannotFindDescriptorFileError(filePath, ex)

--- a/sql/connect/client/jvm/pom.xml
+++ b/sql/connect/client/jvm/pom.xml
@@ -108,6 +108,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `commons-io` dependency from `sql/api` module.

In addition, this PR adds a new Scalastyle to ban `org.apache.commons.io.FileUtils.readFileToByteArray` in favor of Java's native `Files.readAllBytes` API.

```scala
- FileUtils.readFileToByteArray(new File(filePath))
+ Files.readAllBytes(new File(filePath).toPath())
```

### Why are the changes needed?

To reduce `sql/api` module dependency burden.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.