### PR TITLE
[SPARK-53025][CORE][SQL][TESTS] Use Java `Files.writeString` instead of `FileUtils.writeStringToFile`

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.core.util.{DefaultIndenter, DefaultPrettyPrinter}
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import org.apache.commons.io.{FileUtils, IOUtils}
+import org.apache.commons.io.IOUtils
 
 import org.apache.spark.SparkThrowableHelper._
 import org.apache.spark.util.Utils
@@ -97,8 +97,8 @@ class SparkThrowableSuite extends SparkFunSuite {
         val errorConditionsFile = errorJsonFilePath.toFile
         logInfo(s"Regenerating error conditions file $errorConditionsFile")
         Files.delete(errorConditionsFile.toPath)
-        FileUtils.writeStringToFile(
-          errorConditionsFile,
+        Files.writeString(
+          errorJsonFilePath,
           rewrittenString + lineSeparator,
           StandardCharsets.UTF_8)
       }
@@ -421,7 +421,7 @@ class SparkThrowableSuite extends SparkFunSuite {
   test("overwrite error classes") {
     withTempDir { dir =>
       val json = new File(dir, "errors.json")
-      FileUtils.writeStringToFile(json,
+      Files.writeString(json.toPath(),
         """
           |{
           |  "DIVIDE_BY_ZERO" : {
@@ -439,7 +439,7 @@ class SparkThrowableSuite extends SparkFunSuite {
   test("prohibit dots in error class names") {
     withTempDir { dir =>
       val json = new File(dir, "errors.json")
-      FileUtils.writeStringToFile(json,
+      Files.writeString(json.toPath(),
         """
           |{
           |  "DIVIDE.BY_ZERO" : {
@@ -458,7 +458,7 @@ class SparkThrowableSuite extends SparkFunSuite {
 
     withTempDir { dir =>
       val json = new File(dir, "errors.json")
-      FileUtils.writeStringToFile(json,
+      Files.writeString(json.toPath(),
         """
           |{
           |  "DIVIDE" : {
@@ -486,7 +486,7 @@ class SparkThrowableSuite extends SparkFunSuite {
   test("handle null values in message parameters") {
     withTempDir { dir =>
       val json = new File(dir, "errors.json")
-      FileUtils.writeStringToFile(json,
+      Files.writeString(json.toPath(),
         """
           |{
           |  "MISSING_PARAMETER" : {

--- a/core/src/test/scala/org/apache/spark/ui/DriverLogPageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/DriverLogPageSuite.scala
@@ -19,9 +19,9 @@ package org.apache.spark.ui
 
 import java.io.File
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 
 import jakarta.servlet.http.HttpServletRequest
-import org.apache.commons.io.FileUtils
 import org.mockito.Mockito.{mock, when}
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
@@ -54,7 +54,7 @@ class DriverLogPageSuite extends SparkFunSuite {
     withTempDir { dir =>
       val page = new DriverLogPage(null, conf.set(DRIVER_LOG_LOCAL_DIR, dir.getCanonicalPath))
       val file = new File(dir, "driver.log")
-      FileUtils.writeStringToFile(file, "driver log content", StandardCharsets.UTF_8)
+      Files.writeString(file.toPath(), "driver log content", StandardCharsets.UTF_8)
       val request = mock(classOf[HttpServletRequest])
       val log = page.renderLog(request)
       assert(log.startsWith("==== Bytes 0-18 of 18 of"))

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -195,6 +195,10 @@
             <property name="format" value="new ToStringBuilder\("/>
             <property name="message" value="Use String concatenation instead." />
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="FileUtils.writeStringToFile"/>
+            <property name="message" value="Use java.nio.file.Files.writeString instead." />
+        </module>
         <!-- support structured logging -->
         <module name="RegexpSinglelineJava">
             <property name="format" value="org\.slf4j\.(Logger|LoggerFactory)" />

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -288,6 +288,11 @@ This file is divided into 3 sections:
     of Commons Lang 2 (package org.apache.commons.lang.*)</customMessage>
   </check>
 
+  <check customId="writeStringToFile" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">FileUtils\.writeStringToFile</parameter></parameters>
+    <customMessage>Use java.nio.file.Files.writeString instead.</customMessage>
+  </check>
+
   <check customId="commonslang3javaversion" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">org\.apache\.commons\.lang3\..*JavaVersion</parameter></parameters>
     <customMessage>Use JEP 223 API (java.lang.Runtime.Version) instead of

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/xml/UDFXPathUtilSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/xml/UDFXPathUtilSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions.xml
 
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import javax.xml.xpath.XPathConstants.STRING
 
 import org.w3c.dom.Node
@@ -79,14 +80,13 @@ class UDFXPathUtilSuite extends SparkFunSuite {
   }
 
   test("embedFailure") {
-    import org.apache.commons.io.FileUtils
     import java.io.File
     val secretValue = String.valueOf(Math.random)
     val tempFile = File.createTempFile("verifyembed", ".tmp")
     tempFile.deleteOnExit()
     val fname = tempFile.getAbsolutePath
 
-    FileUtils.writeStringToFile(tempFile, secretValue, StandardCharsets.UTF_8)
+    Files.writeString(tempFile.toPath(), secretValue, StandardCharsets.UTF_8)
 
     val xml =
       s"""<?xml version="1.0" encoding="utf-8"?>

--- a/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql
 
 import java.io.File
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 
 import scala.collection.mutable
 
@@ -128,9 +129,9 @@ trait PlanStabilitySuite extends DisableAdaptiveExecutionSuite {
       assert(Utils.createDirectory(dir))
 
       val file = new File(dir, "simplified.txt")
-      FileUtils.writeStringToFile(file, simplified, StandardCharsets.UTF_8)
+      Files.writeString(file.toPath(), simplified, StandardCharsets.UTF_8)
       val fileOriginalPlan = new File(dir, "explain.txt")
-      FileUtils.writeStringToFile(fileOriginalPlan, explain, StandardCharsets.UTF_8)
+      Files.writeString(fileOriginalPlan.toPath(), explain, StandardCharsets.UTF_8)
       logDebug(s"APPROVED: $file $fileOriginalPlan")
     }
   }
@@ -152,8 +153,8 @@ trait PlanStabilitySuite extends DisableAdaptiveExecutionSuite {
       val approvedSimplified = FileUtils.readFileToString(
         approvedSimplifiedFile, StandardCharsets.UTF_8)
       // write out for debugging
-      FileUtils.writeStringToFile(actualSimplifiedFile, actualSimplified, StandardCharsets.UTF_8)
-      FileUtils.writeStringToFile(actualExplainFile, explain, StandardCharsets.UTF_8)
+      Files.writeString(actualSimplifiedFile.toPath(), actualSimplified, StandardCharsets.UTF_8)
+      Files.writeString(actualExplainFile.toPath(), explain, StandardCharsets.UTF_8)
 
       fail(
         s"""


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java `Files.writeString` instead of `FileUtils.writeStringToFile` to improve Apache Spark CIs because we runs CI many times heavily.

```scala
- FileUtils.writeStringToFile(file, simplified, StandardCharsets.UTF_8)
+ Files.writeString(file.toPath(), simplified, StandardCharsets.UTF_8)
```

To prevent future regressions, new Scalastyle and Checkstyle rules are added to enforce this.

### Why are the changes needed?

Since Java 11, `Files.writeString` is supported and about **5x faster** than `commons-io` library.

```scala
scala> val s = "a".repeat(100_000_000)

scala> spark.time(org.apache.commons.io.FileUtils.writeStringToFile(new java.io.File("/tmp/a"), s, java.nio.charset.StandardCharsets.UTF_8))
Time taken: 269 ms

scala> spark.time(java.nio.file.Files.writeString(new java.io.File("/tmp/a").toPath(), s, java.nio.charset.StandardCharsets.UTF_8))
Time taken: 44 ms
val res3: java.nio.file.Path = /tmp/a
```

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a test-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.