### PR TITLE
[SPARK-53028][SQL][K8S][EXAMPLE] Use `StandardCharsets.UTF_8` instead of `Charset.defaultCharset`

### DIFF
--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -188,6 +188,10 @@
             <property name="illegalClasses" value="com.google.common.base.Strings" />
         </module>
         <module name="RegexpSinglelineJava">
+            <property name="format" value="Charset\.defaultCharset"/>
+            <property name="message" value="Use StandardCharsets.UTF_8 instead." />
+        </module>
+        <module name="RegexpSinglelineJava">
             <property name="format" value="new URL\("/>
             <property name="message" value="Use URI.toURL or URL.of instead of URL constructors." />
         </module>

--- a/examples/src/main/java/org/apache/spark/examples/streaming/JavaRecoverableNetworkWordCount.java
+++ b/examples/src/main/java/org/apache/spark/examples/streaming/JavaRecoverableNetworkWordCount.java
@@ -18,7 +18,7 @@
 package org.apache.spark.examples.streaming;
 
 import java.io.File;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -153,7 +153,7 @@ public final class JavaRecoverableNetworkWordCount {
       System.out.println(output);
       System.out.println("Dropped " + droppedWordsCounter.value() + " word(s) totally");
       System.out.println("Appending to " + outputFile.getAbsolutePath());
-      Files.asCharSink(outputFile, Charset.defaultCharset(), FileWriteMode.APPEND)
+      Files.asCharSink(outputFile, StandardCharsets.UTF_8, FileWriteMode.APPEND)
         .write(output + "\n");
     });
 

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/RecoverableNetworkWordCount.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/RecoverableNetworkWordCount.scala
@@ -19,7 +19,7 @@
 package org.apache.spark.examples.streaming
 
 import java.io.File
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 import com.google.common.io.{Files, FileWriteMode}
 
@@ -134,7 +134,7 @@ object RecoverableNetworkWordCount {
       println(output)
       println(s"Dropped ${droppedWordsCounter.value} word(s) totally")
       println(s"Appending to ${outputFile.getAbsolutePath}")
-      Files.asCharSink(outputFile, Charset.defaultCharset(), FileWriteMode.APPEND)
+      Files.asCharSink(outputFile, StandardCharsets.UTF_8, FileWriteMode.APPEND)
         .write(output + "\n")
     }
     ssc

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.deploy.k8s.integrationtest
 
 import java.io.{Closeable, File, FileInputStream, FileOutputStream, PrintWriter}
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 import java.util.concurrent.CountDownLatch
 import java.util.zip.{ZipEntry, ZipOutputStream}
@@ -96,7 +96,7 @@ object Utils extends Logging {
     listener.waitForClose()
     watch.close()
     out.flush()
-    val result = out.toString(Charset.defaultCharset())
+    val result = out.toString(StandardCharsets.UTF_8)
     result
   }
 

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -526,4 +526,9 @@ This file is divided into 3 sections:
     <parameters><parameter name="regex">com\.google\.common\.base\.Strings</parameter></parameters>
     <customMessage>Use Java built-in methods or SparkStringUtils instead</customMessage>
   </check>
+
+  <check customId="defaultCharset" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">Charset\.defaultCharset</parameter></parameters>
+    <customMessage>Use StandardCharsets.UTF_8 instead.</customMessage>
+  </check>
 </scalastyle>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.streaming.state
 
 import java.io._
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 import java.util.concurrent.Executors
 
@@ -2176,7 +2176,7 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
     withTempDir { dir =>
       val file2 = new File(dir, "json")
       val json2 = """{"sstFiles":[],"numKeys":0}"""
-      FileUtils.write(file2, s"v2\n$json2", Charset.defaultCharset)
+      FileUtils.write(file2, s"v2\n$json2", StandardCharsets.UTF_8)
       val e = intercept[SparkException] {
         RocksDBCheckpointMetadata.readFromFile(file2)
       }
@@ -2194,7 +2194,7 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
       assert(metadata.json == json)
       withTempDir { dir =>
         val file = new File(dir, "json")
-        FileUtils.write(file, s"v1\n$json", Charset.defaultCharset)
+        FileUtils.write(file, s"v1\n$json", StandardCharsets.UTF_8)
         assert(metadata == RocksDBCheckpointMetadata.readFromFile(file))
       }
     }
@@ -3485,7 +3485,7 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
   def generateFiles(dir: String, fileToLengths: Seq[(String, Int)]): Unit = {
     fileToLengths.foreach { case (fileName, length) =>
       val file = new File(dir, fileName)
-      FileUtils.write(file, "a" * length, Charset.defaultCharset)
+      FileUtils.write(file, "a" * length, StandardCharsets.UTF_8)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `StandardCharsets.UTF_8` instead of `Charset.defaultCharset`.

### Why are the changes needed?

Since `Charset.defaultCharset` is determined at JVM starting time, it's random to us. We had better use `UTF_8`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.