### PR TITLE
[SPARK-52940][PYTHON][TESTS][FOLLOW-UP] Correct the return type in test UDFs 

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_grouped_agg.py
@@ -688,7 +688,7 @@ class GroupedAggArrowUDFTestsMixin:
         df = self.spark.createDataFrame([(1, 1), (1, 2), (2, 3), (2, 5), (2, 1)], ("id", "v"))
 
         @arrow_udf("array<int>")
-        def arrow_collect_set(v: pa.Array) -> list[int]:
+        def arrow_collect_set(v: pa.Array) -> pa.Scalar:
             assert isinstance(v, pa.Array), str(type(v))
             s = sorted([x.as_py() for x in pa.compute.unique(v)])
             t = pa.list_(pa.int32())
@@ -712,7 +712,7 @@ class GroupedAggArrowUDFTestsMixin:
         df = self.spark.createDataFrame([(1, 1), (1, 2), (2, 3), (2, 5), (2, 1)], ("id", "v"))
 
         @arrow_udf("array<int>")
-        def arrow_collect_list(v: pa.Array) -> list[int]:
+        def arrow_collect_list(v: pa.Array) -> pa.Scalar:
             assert isinstance(v, pa.Array), str(type(v))
             s = sorted([x.as_py() for x in v])
             t = pa.list_(pa.int32())
@@ -736,7 +736,7 @@ class GroupedAggArrowUDFTestsMixin:
         df = self.spark.createDataFrame([(1, 1), (2, 2), (3, 5)], ("id", "v"))
 
         @arrow_udf("map<int, int>")
-        def arrow_collect_as_map(id: pa.Array, v: pa.Array) -> dict[int, int]:
+        def arrow_collect_as_map(id: pa.Array, v: pa.Array) -> pa.Scalar:
             assert isinstance(id, pa.Array), str(type(id))
             assert isinstance(v, pa.Array), str(type(v))
             d = {i: j for i, j in zip(id.to_pylist(), v.to_pylist())}
@@ -759,7 +759,7 @@ class GroupedAggArrowUDFTestsMixin:
         df = self.spark.createDataFrame([(1, 1), (2, 2), (3, 5)], ("id", "v"))
 
         @arrow_udf("struct<m1: int, m2:int>")
-        def arrow_collect_min_max(id: pa.Array, v: pa.Array) -> dict[int, int]:
+        def arrow_collect_min_max(id: pa.Array, v: pa.Array) -> pa.Scalar:
             assert isinstance(id, pa.Array), str(type(id))
             assert isinstance(v, pa.Array), str(type(v))
             m1 = pa.compute.min(id)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Correct the return type in test UDFs 


### Why are the changes needed?
the return type in these tests should be `pa.Scalar`

### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no