### PR TITLE
[SPARK-53034][CORE][SQL][MLLIB][YARN] Use `deleteRecursively` instead of `FileUtils.deleteDirectory`

### DIFF
--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
@@ -41,7 +41,6 @@ import java.util.concurrent.TimeUnit;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,6 +67,7 @@ import org.apache.spark.network.shuffle.protocol.PushBlockStream;
 import org.apache.spark.network.shuffle.protocol.RemoveShuffleMerge;
 import org.apache.spark.network.util.MapConfigProvider;
 import org.apache.spark.network.util.TransportConf;
+import org.apache.spark.util.SparkFileUtils$;
 
 /**
  * Tests for {@link RemoteBlockPushResolver}.
@@ -107,7 +107,7 @@ public class RemoteBlockPushResolverSuite {
   public void after() {
     try {
       for (Path local : localDirs) {
-        FileUtils.deleteDirectory(local.toFile());
+        SparkFileUtils$.MODULE$.deleteRecursively(local.toFile());
       }
       removeApplication(TEST_APP);
     } catch (Exception e) {

--- a/common/utils/src/test/scala/org/apache/spark/util/IvyTestUtils.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/IvyTestUtils.scala
@@ -23,10 +23,10 @@ import java.util.jar.Attributes.Name
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.commons.io.FileUtils
 import org.apache.ivy.core.settings.IvySettings
 
 import org.apache.spark.util.MavenUtils.MavenCoordinate
+import org.apache.spark.util.SparkFileUtils.deleteRecursively
 
 private[spark] object IvyTestUtils {
 
@@ -319,7 +319,7 @@ private[spark] object IvyTestUtils {
       val descriptor = createDescriptor(tempPath, artifact, dependencies, useIvyLayout)
       assert(descriptor.exists(), "Problem creating Pom file")
     } finally {
-      FileUtils.deleteDirectory(root)
+      deleteRecursively(root)
     }
     tempPath
   }
@@ -377,13 +377,13 @@ private[spark] object IvyTestUtils {
       if (repo.toString.contains(".m2") || repo.toString.contains(".ivy2") ||
           repo.toString.contains(".ivy2.5.2")) {
         val groupDir = getBaseGroupDirectory(artifact, useIvyLayout)
-        FileUtils.deleteDirectory(new File(repo, groupDir + File.separator + artifact.artifactId))
+        deleteRecursively(new File(repo, groupDir + File.separator + artifact.artifactId))
         deps.foreach { _.foreach { dep =>
-            FileUtils.deleteDirectory(new File(repo, getBaseGroupDirectory(dep, useIvyLayout)))
+            deleteRecursively(new File(repo, getBaseGroupDirectory(dep, useIvyLayout)))
           }
         }
       } else {
-        FileUtils.deleteDirectory(repo)
+        deleteRecursively(repo)
       }
       purgeLocalIvyCache(artifact, deps, ivySettings)
     }
@@ -395,9 +395,9 @@ private[spark] object IvyTestUtils {
       dependencies: Option[Seq[MavenCoordinate]],
       ivySettings: IvySettings): Unit = {
     // delete the artifact from the cache as well if it already exists
-    FileUtils.deleteDirectory(new File(ivySettings.getDefaultCache, artifact.groupId))
+    deleteRecursively(new File(ivySettings.getDefaultCache, artifact.groupId))
     dependencies.foreach { _.foreach { dep =>
-        FileUtils.deleteDirectory(new File(ivySettings.getDefaultCache, dep.groupId))
+        deleteRecursively(new File(ivySettings.getDefaultCache, dep.groupId))
       }
     }
   }

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServerDiskManager.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServerDiskManager.scala
@@ -214,7 +214,7 @@ private class HistoryServerDiskManager(
   def committed(): Long = committedUsage.get()
 
   private def deleteStore(path: File): Unit = {
-    FileUtils.deleteDirectory(path)
+    Utils.deleteRecursively(path)
     listing.delete(classOf[ApplicationStoreInfo], path.getAbsolutePath())
   }
 
@@ -334,7 +334,7 @@ private class HistoryServerDiskManager(
     /** Deletes the temporary directory created for the lease. */
     def rollback(): Unit = {
       updateUsage(-leased)
-      FileUtils.deleteDirectory(tmpPath)
+      Utils.deleteRecursively(tmpPath)
     }
 
   }

--- a/core/src/test/scala/org/apache/spark/deploy/RPackageUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/RPackageUtilsSuite.scala
@@ -26,7 +26,6 @@ import java.util.zip.ZipFile
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 
-import org.apache.commons.io.FileUtils
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkFunSuite
@@ -170,7 +169,7 @@ class RPackageUtilsSuite
         zipFile.close()
       }
     } {
-      FileUtils.deleteDirectory(tempDir)
+      Utils.deleteRecursively(tempDir)
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -27,7 +27,7 @@ import scala.jdk.CollectionConverters._
 import com.google.common.io.{ByteStreams, Files}
 import jakarta.servlet._
 import jakarta.servlet.http.{HttpServletRequest, HttpServletRequestWrapper, HttpServletResponse}
-import org.apache.commons.io.{FileUtils, IOUtils}
+import org.apache.commons.io.IOUtils
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.json4s.JsonAST._
 import org.json4s.jackson.JsonMethods
@@ -219,7 +219,7 @@ abstract class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with
   )
 
   if (regenerateGoldenFiles) {
-    FileUtils.deleteDirectory(expRoot)
+    Utils.deleteRecursively(expRoot)
     Utils.createDirectory(expRoot)
   }
 

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -203,6 +203,10 @@
             <property name="format" value="FileUtils.writeStringToFile"/>
             <property name="message" value="Use java.nio.file.Files.writeString instead." />
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="FileUtils\.deleteDirectory"/>
+            <property name="message" value="Use deleteRecursively of SparkFileUtils or Utils instead." />
+        </module>
         <!-- support structured logging -->
         <module name="RegexpSinglelineJava">
             <property name="format" value="org\.slf4j\.(Logger|LoggerFactory)" />

--- a/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
@@ -30,7 +30,6 @@ import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.{Failure, Success, Try, Using}
 
-import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.Path
 import org.json4s._
 import org.json4s.{DefaultFormats, JObject}
@@ -822,7 +821,7 @@ private[spark] class FileSystemOverwrite extends Logging {
       val filePath = new File(path)
       if (filePath.exists()) {
         if (shouldOverwrite) {
-          FileUtils.deleteDirectory(filePath)
+          Utils.deleteRecursively(filePath)
         } else {
           throw new IOException(errMsg)
         }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnShuffleIntegrationSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnShuffleIntegrationSuite.scala
@@ -34,6 +34,7 @@ import org.apache.spark.network.shuffle.ShuffleTestAccessor
 import org.apache.spark.network.shuffledb.DBBackend
 import org.apache.spark.network.yarn.{YarnShuffleService, YarnTestAccessor}
 import org.apache.spark.tags.{ExtendedLevelDBTest, ExtendedYarnTest}
+import org.apache.spark.util.Utils
 
 /**
  * Integration test for the external shuffle service with a yarn mini-cluster
@@ -179,7 +180,7 @@ private object YarnExternalShuffleDriver extends Logging with Matchers {
     } finally {
       sc.stop()
       if (execStateCopy != null) {
-        FileUtils.deleteDirectory(execStateCopy)
+        Utils.deleteRecursively(execStateCopy)
       }
       Files.asCharSink(status, StandardCharsets.UTF_8).write(result)
     }

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -282,6 +282,11 @@ This file is divided into 3 sections:
       scala.jdk.CollectionConverters._ and use .asScala / .asJava methods</customMessage>
   </check>
 
+  <check customId="deleteRecursively" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">FileUtils\.deleteDirectory</parameter></parameters>
+    <customMessage>Use deleteRecursively of SparkFileUtils or Utils</customMessage>
+  </check>
+
   <check customId="readFileToByteArray" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">FileUtils\.readFileToByteArray</parameter></parameters>
     <customMessage>Use java.nio.file.Files.readAllBytes</customMessage>

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/CatalogSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/CatalogSuite.scala
@@ -19,13 +19,12 @@ package org.apache.spark.sql.connect
 
 import java.io.{File, FilenameFilter}
 
-import org.apache.commons.io.FileUtils
-
 import org.apache.spark.SparkException
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.connect.test.{ConnectFunSuite, RemoteSparkSession, SQLHelper}
 import org.apache.spark.sql.types.{DoubleType, LongType, StructType}
 import org.apache.spark.storage.StorageLevel
+import org.apache.spark.util.SparkFileUtils
 
 class CatalogSuite extends ConnectFunSuite with RemoteSparkSession with SQLHelper {
 
@@ -258,7 +257,7 @@ class CatalogSuite extends ConnectFunSuite with RemoteSparkSession with SQLHelpe
           spark.catalog.cacheTable(tableName)
           assert(spark.table(tableName).collect().length == 1)
 
-          FileUtils.deleteDirectory(dir)
+          SparkFileUtils.deleteRecursively(dir)
           assert(spark.table(tableName).collect().length == 1)
 
           spark.catalog.refreshTable(tableName)

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
@@ -33,6 +33,7 @@ import org.apache.spark.ml.Model
 import org.apache.spark.ml.util.{ConnectHelper, HasTrainingSummary, MLWritable, Summary}
 import org.apache.spark.sql.connect.config.Connect
 import org.apache.spark.sql.connect.service.SessionHolder
+import org.apache.spark.util.SparkFileUtils
 
 /**
  * MLCache is for caching ML objects, typically for models and summaries evaluated by a model.
@@ -213,7 +214,7 @@ private[connect] class MLCache(sessionHolder: SessionHolder) extends Logging {
       val removePath = getModelOffloadingPath(refId)
       val offloadingPath = new File(removePath.toString)
       if (offloadingPath.exists()) {
-        FileUtils.deleteDirectory(offloadingPath)
+        SparkFileUtils.deleteRecursively(offloadingPath)
         true
       } else {
         false

--- a/sql/core/src/main/scala/org/apache/spark/sql/artifact/ArtifactManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/artifact/ArtifactManager.scala
@@ -524,7 +524,7 @@ object ArtifactManager extends Logging {
 
     // Clean up artifacts folder
     try {
-      FileUtils.deleteDirectory(artifactPath.toFile)
+      Utils.deleteRecursively(artifactPath.toFile)
     } catch {
       case e: IOException =>
         logWarning(log"Failed to delete directory ${MDC(LogKeys.PATH, artifactPath.toFile)}: " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
@@ -125,7 +125,7 @@ trait PlanStabilitySuite extends DisableAdaptiveExecutionSuite {
     val foundMatch = dir.exists() && isApproved(dir, simplified, explain)
 
     if (!foundMatch) {
-      FileUtils.deleteDirectory(dir)
+      Utils.deleteRecursively(dir)
       assert(Utils.createDirectory(dir))
 
       val file = new File(dir, "simplified.txt")

--- a/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
@@ -230,7 +230,7 @@ class ArtifactManagerSuite extends SharedSparkSession {
           case _: SparkException =>
           case throwable: Throwable => throw throwable
         } finally {
-          FileUtils.deleteDirectory(copyDir.toFile)
+          Utils.deleteRecursively(copyDir.toFile)
           blockManager.removeCache(spark.sessionUUID)
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/MsckRepairTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/MsckRepairTableSuite.scala
@@ -19,10 +19,9 @@ package org.apache.spark.sql.execution.command.v1
 
 import java.io.File
 
-import org.apache.commons.io.FileUtils
-
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.command
+import org.apache.spark.util.Utils
 
 /**
  * This base suite contains unified tests for the `MSCK REPAIR TABLE` command that
@@ -37,7 +36,7 @@ import org.apache.spark.sql.execution.command
 trait MsckRepairTableSuiteBase extends command.MsckRepairTableSuiteBase {
   def deletePartitionDir(tableName: String, part: String): Unit = {
     val partLoc = getPartitionLocation(tableName, part)
-    FileUtils.deleteDirectory(new File(partLoc))
+    Utils.deleteRecursively(new File(partLoc))
   }
 
   test("drop partitions") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.internal
 
 import java.io.File
 
-import org.apache.commons.io.FileUtils
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.sql.{AnalysisException, DataFrame}
@@ -39,6 +38,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.util.Utils
 
 
 /**
@@ -999,7 +999,7 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
       spark.catalog.cacheTable(tableName)
       assert(spark.table(tableName).collect().length == 1)
 
-      FileUtils.deleteDirectory(dir)
+      Utils.deleteRecursively(dir)
       assert(spark.table(tableName).collect().length == 1)
 
       spark.catalog.refreshTable(tableName)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `deleteRecursively` instead of `FileUtils.deleteDirectory`.

```scala
- FileUtils.deleteDirectory(dir)
+ Utils.deleteRecursively(dir)
```

```scala
- FileUtils.deleteDirectory(dir)
+ SparkFileUtils.deleteRecursively(dir)
```

### Why are the changes needed?

Apache Spark provides `Utils.deleteRecursively` which contains two versions, `deleteRecursivelyUsingUnixNative` and `deleteRecursivelyUsingJavaIO`. We had better take advantage of Spark's built-in optimized one because it's more optimized than `commons-io`.

https://github.com/apache/spark/blob/7c6693ddec00c32d50d254817a7f09a993d71017/core/src/main/scala/org/apache/spark/util/Utils.scala#L1047-L1052

https://github.com/apache/spark/blob/7c6693ddec00c32d50d254817a7f09a993d71017/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala#L120-L122

https://github.com/apache/spark/blob/7c6693ddec00c32d50d254817a7f09a993d71017/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java#L105-L125

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.