### PR TITLE
[SPARK-53037][CORE][SQL][K8S] Support `closeQuietly` in `SparkErrorUtils`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkErrorUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkErrorUtils.scala
@@ -105,6 +105,17 @@ private[spark] trait SparkErrorUtils extends Logging {
     }
     new String(out.toByteArray, UTF_8)
   }
+
+  /** Try to close by ignoring all exceptions. This is different from JavaUtils.closeQuietly. */
+  def closeQuietly(closeable: Closeable): Unit = {
+    if (closeable != null) {
+      try {
+        closeable.close()
+      } catch {
+        case _: Exception =>
+      }
+    }
+  }
 }
 
 private[spark] object SparkErrorUtils extends SparkErrorUtils

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
@@ -27,7 +27,6 @@ import java.util.Queue;
 import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.io.IOUtils;
 
 import org.apache.spark.TaskContext;
 import org.apache.spark.executor.ShuffleWriteMetrics;
@@ -886,7 +885,7 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
 
     private void closeIfPossible(UnsafeSorterIterator iterator) {
       if (iterator instanceof Closeable closeable) {
-        IOUtils.closeQuietly((closeable));
+        Utils.closeQuietly((closeable));
       }
     }
   }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -36,7 +36,6 @@ import scala.util.control.NonFatal
 import com.codahale.metrics.{MetricRegistry, MetricSet}
 import com.esotericsoftware.kryo.KryoException
 import com.google.common.cache.CacheBuilder
-import org.apache.commons.io.IOUtils
 
 import org.apache.spark._
 import org.apache.spark.errors.SparkCoreErrors
@@ -373,7 +372,7 @@ private[spark] class BlockManager(
           logInfo(extendMessageWithBlockDetails(ex.getMessage, blockId))
           throw ex
       } finally {
-        IOUtils.closeQuietly(inputStream)
+        Utils.closeQuietly(inputStream)
       }
     }
 

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -30,7 +30,6 @@ import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, Queue}
 import scala.util.{Failure, Success}
 
 import io.netty.util.internal.OutOfDirectMemoryError
-import org.apache.commons.io.IOUtils
 import org.roaringbitmap.RoaringBitmap
 
 import org.apache.spark.{MapOutputTracker, SparkException, TaskContext}
@@ -1408,7 +1407,7 @@ private class BufferReleasingInputStream(
         val diagnosisResponse = checkedInOpt.map { checkedIn =>
           iterator.diagnoseCorruption(checkedIn, address, blockId)
         }
-        IOUtils.closeQuietly(this)
+        Utils.closeQuietly(this)
         // We'd never retry the block whatever the cause is since the block has been
         // partially consumed by downstream RDDs.
         iterator.throwFetchFailedException(blockId, mapIndex, address, e, diagnosisResponse)

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -3084,8 +3084,8 @@ private[spark] object Utils
       logDebug(log"Unzipped from ${MDC(PATH, dfsZipFile)}\n\t${MDC(PATHS, files.mkString("\n\t"))}")
     } finally {
       // Close everything no matter what happened
-      IOUtils.closeQuietly(in)
-      IOUtils.closeQuietly(out)
+      Utils.closeQuietly(in)
+      Utils.closeQuietly(out)
     }
     files.toSeq
   }

--- a/core/src/main/scala/org/apache/spark/util/logging/RollingFileAppender.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/RollingFileAppender.scala
@@ -27,6 +27,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.internal.{config, MDC}
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.util.ArrayImplicits._
+import org.apache.spark.util.Utils
 
 /**
  * Continuously appends data from input stream into the given file, and rolls
@@ -96,8 +97,8 @@ private[spark] class RollingFileAppender(
         gzOutputStream.close()
         activeFile.delete()
       } finally {
-        IOUtils.closeQuietly(inputStream)
-        IOUtils.closeQuietly(gzOutputStream)
+        Utils.closeQuietly(inputStream)
+        Utils.closeQuietly(gzOutputStream)
       }
     } else {
       Files.move(activeFile, rolloverFile)

--- a/core/src/test/scala/org/apache/spark/JobArtifactSetSuite.scala
+++ b/core/src/test/scala/org/apache/spark/JobArtifactSetSuite.scala
@@ -22,6 +22,7 @@ import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import org.apache.commons.io.IOUtils
 
+import org.apache.spark.util.Utils
 
 class JobArtifactSetSuite extends SparkFunSuite with LocalSparkContext {
 
@@ -33,8 +34,8 @@ class JobArtifactSetSuite extends SparkFunSuite with LocalSparkContext {
     val zipEntry = new ZipEntry(fileToZip.getName)
     zipOut.putNextEntry(zipEntry)
     IOUtils.copy(fis, zipOut)
-    IOUtils.closeQuietly(fis)
-    IOUtils.closeQuietly(zipOut)
+    Utils.closeQuietly(fis)
+    Utils.closeQuietly(zipOut)
   }
 
   test("JobArtifactSet uses resources from SparkContext") {

--- a/core/src/test/scala/org/apache/spark/util/FileAppenderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/FileAppenderSuite.scala
@@ -35,6 +35,7 @@ import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.internal.config
+import org.apache.spark.util.Utils
 import org.apache.spark.util.logging.{FileAppender, RollingFileAppender, SizeBasedRollingPolicy, TimeBasedRollingPolicy}
 
 class FileAppenderSuite extends SparkFunSuite with BeforeAndAfter {
@@ -389,7 +390,7 @@ class FileAppenderSuite extends SparkFunSuite with BeforeAndAfter {
         try {
           IOUtils.toString(inputStream, StandardCharsets.UTF_8)
         } finally {
-          IOUtils.closeQuietly(inputStream)
+          Utils.closeQuietly(inputStream)
         }
       } else {
         Files.asCharSource(file, StandardCharsets.UTF_8).read()

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -248,8 +248,8 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
         assert(mergedStream.read() === -1)
         assert(byteBufferInputStream.chunkedByteBuffer === null)
       } finally {
-        IOUtils.closeQuietly(mergedStream)
-        IOUtils.closeQuietly(in)
+        Utils.closeQuietly(mergedStream)
+        Utils.closeQuietly(in)
       }
     }
   }

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
@@ -33,6 +33,7 @@ import org.apache.commons.io.output.ByteArrayOutputStream
 
 import org.apache.spark.{SPARK_VERSION, SparkException}
 import org.apache.spark.internal.Logging
+import org.apache.spark.util.SparkErrorUtils
 
 object Utils extends Logging {
 
@@ -146,8 +147,8 @@ object Utils extends Logging {
     val zipEntry = new ZipEntry(fileToZip.getName)
     zipOut.putNextEntry(zipEntry)
     IOUtils.copy(fis, zipOut)
-    IOUtils.closeQuietly(fis)
-    IOUtils.closeQuietly(zipOut)
+    SparkErrorUtils.closeQuietly(fis)
+    SparkErrorUtils.closeQuietly(zipOut)
   }
 
   def createTarGzFile(inFile: String, outFile: String): Unit = {

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -541,4 +541,9 @@ This file is divided into 3 sections:
     <parameters><parameter name="regex">Charset\.defaultCharset</parameter></parameters>
     <customMessage>Use StandardCharsets.UTF_8 instead.</customMessage>
   </check>
+
+  <check customId="ioutilsclosequietly" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">IOUtils\.closeQuietly</parameter></parameters>
+    <customMessage>Use closeQuietly of SparkErrorUtils or Utils instead.</customMessage>
+  </check>
 </scalastyle>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/HDFSMetadataLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/HDFSMetadataLog.scala
@@ -24,7 +24,6 @@ import java.util.{Collections, LinkedHashMap => JLinkedHashMap}
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
-import org.apache.commons.io.IOUtils
 import org.apache.hadoop.fs._
 import org.json4s.{Formats, NoTypeHints}
 import org.json4s.jackson.Serialization
@@ -35,6 +34,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.ArrayImplicits._
+import org.apache.spark.util.Utils
 
 
 /**
@@ -191,7 +191,7 @@ class HDFSMetadataLog[T <: AnyRef : ClassTag](sparkSession: SparkSession, path: 
           throw new IllegalStateException(
             s"Failed to read log file $batchMetadataFile. ${ise.getMessage}", ise)
       } finally {
-        IOUtils.closeQuietly(input)
+        Utils.closeQuietly(input)
       }
     } else {
       throw QueryExecutionErrors.batchMetadataFileNotFoundError(batchMetadataFile)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamMetadata.scala
@@ -22,7 +22,6 @@ import java.nio.charset.StandardCharsets
 
 import scala.util.control.NonFatal
 
-import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileAlreadyExistsException, FSDataInputStream, Path}
 import org.json4s.{Formats, NoTypeHints}
@@ -31,6 +30,7 @@ import org.json4s.jackson.Serialization
 import org.apache.spark.internal.{Logging, LogKeys, MDC}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.streaming.CheckpointFileManager.CancellableFSDataOutputStream
+import org.apache.spark.util.Utils
 
 /**
  * Contains metadata associated with a [[org.apache.spark.sql.streaming.StreamingQuery]].
@@ -63,7 +63,7 @@ object StreamMetadata extends Logging {
           logError(log"Error reading stream metadata from ${MDC(LogKeys.PATH, metadataFile)}", e)
           throw e
       } finally {
-        IOUtils.closeQuietly(input)
+        Utils.closeQuietly(input)
       }
     } else None
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -27,7 +27,6 @@ import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
 import com.google.common.io.ByteStreams
-import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
 
@@ -737,7 +736,7 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
       rawStream: CancellableFSDataOutputStream): Unit = {
     try {
       if (rawStream != null) rawStream.cancel()
-      IOUtils.closeQuietly(compressedStream)
+      Utils.closeQuietly(compressedStream)
     } catch {
       // Closing the compressedStream causes the stream to write/flush flush data into the
       // rawStream. Since the rawStream is already closed, there may be errors.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -880,8 +880,8 @@ class RocksDBFileManager(
         throw e
     } finally {
       // Close everything no matter what happened
-      IOUtils.closeQuietly(in)
-      IOUtils.closeQuietly(zout)
+      Utils.closeQuietly(in)
+      Utils.closeQuietly(zout)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreChangelog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreChangelog.scala
@@ -22,7 +22,6 @@ import java.io.{DataInputStream, DataOutputStream, FileNotFoundException, IOExce
 import scala.util.control.NonFatal
 
 import com.google.common.io.ByteStreams
-import org.apache.commons.io.IOUtils
 import org.apache.hadoop.fs.{FSError, Path}
 import org.json4s._
 import org.json4s.jackson.Serialization
@@ -36,6 +35,7 @@ import org.apache.spark.sql.execution.streaming.CheckpointFileManager
 import org.apache.spark.sql.execution.streaming.CheckpointFileManager.CancellableFSDataOutputStream
 import org.apache.spark.sql.execution.streaming.state.RecordType.RecordType
 import org.apache.spark.util.NextIterator
+import org.apache.spark.util.Utils
 
 /**
  * Enum used to write record types to changelog files used with RocksDBStateStoreProvider.
@@ -132,7 +132,7 @@ abstract class StateStoreChangelogWriter(
   def abort(): Unit = {
     try {
       if (backingFileStream != null) backingFileStream.cancel()
-      if (compressedStream != null) IOUtils.closeQuietly(compressedStream)
+      if (compressedStream != null) Utils.closeQuietly(compressedStream)
     } catch {
       // Closing the compressedStream causes the stream to write/flush data into the
       // rawStream. Since the rawStream is already closed, there may be errors.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `closeQuietly` in `SparkErrorUtils`.

### Why are the changes needed?

To provide a way to close a closable object without any exceptions and logs.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.