### PR TITLE
[SPARK-53038][SQL][HIVE] Call initialize only once per GenericUDF instance

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
@@ -29,6 +29,7 @@ import org.apache.hadoop.hive.ql.exec.UDF
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFMacro
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils
 import org.apache.hadoop.hive.serde2.avro.{AvroGenericRecordWritable, AvroSerdeUtils}
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveDecimalObjectInspector
 import org.apache.hadoop.io.Writable
 
@@ -209,6 +210,17 @@ private[hive] object HiveShim {
         }
         func
       }
+    }
+
+    private var returnInspector: ObjectInspector = null
+
+    def getReturnInspector(build: => ObjectInspector): ObjectInspector = {
+      if (returnInspector != null) {
+        return returnInspector
+      }
+
+      returnInspector = build
+      returnInspector
     }
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFEvaluators.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFEvaluators.scala
@@ -119,7 +119,7 @@ class HiveGenericUDFEvaluator(
   private lazy val argumentInspectors = children.map(toInspector).toArray
 
   @transient
-  lazy val returnInspector = {
+  lazy val returnInspector = funcWrapper.getReturnInspector {
     // Inline o.a.h.hive.ql.udf.generic.GenericUDF#initializeAndFoldConstants, but
     // eliminate calls o.a.h.hive.ql.exec.FunctionRegistry to avoid initializing Hive
     // built-in UDFs.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -25,7 +25,7 @@ import scala.jdk.CollectionConverters._
 import org.apache.hadoop.hive.ql.exec._
 import org.apache.hadoop.hive.ql.udf.generic._
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator.AggregationBuffer
-import org.apache.hadoop.hive.serde2.objectinspector.{ConstantObjectInspector, ObjectInspector, ObjectInspectorFactory}
+import org.apache.hadoop.hive.serde2.objectinspector.{ConstantObjectInspector, ObjectInspector, ObjectInspectorFactory, StructObjectInspector}
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -224,7 +224,9 @@ private[hive] case class HiveGenericUDTF(
   }
 
   @transient
-  protected lazy val outputInspector = function.initialize(inputInspector)
+  protected lazy val outputInspector = funcWrapper.getReturnInspector {
+    function.initialize(inputInspector)
+  }.asInstanceOf[StructObjectInspector]
 
   @transient
   protected lazy val udtInput = new Array[AnyRef](children.length)


### PR DESCRIPTION
### What changes were proposed in this pull request?

In DeduplicateRelations rule, HiveGenericUDF will create many new HiveGenericUDFEvaluator, and each HiveGenericUDFEvaluator will call GenericUDF initialize method once.

We could cached the returnInspector to avoid the unnecessary initialization of HiveGenericUDFEvaluator.

```java
private[hive] case class HiveGenericUDF(
    name: String, funcWrapper: HiveFunctionWrapper, children: Seq[Expression]) {
  @transient
  private lazy val evaluator = new HiveGenericUDFEvaluator(funcWrapper, children)
}
```

Stack for DeduplicateRelations rule:
```
	at org.apache.spark.sql.hive.HiveGenericUDF.evaluator(hiveUDFs.scala:138)
	at org.apache.spark.sql.hive.HiveGenericUDF.dataType$lzycompute(hiveUDFs.scala:135)
	at org.apache.spark.sql.hive.HiveGenericUDF.dataType(hiveUDFs.scala:135)
	at org.apache.spark.sql.catalyst.expressions.ExpectsInputTypes$$anonfun$1.applyOrElse(ExpectsInputTypes.scala:56)
	at org.apache.spark.sql.catalyst.expressions.ExpectsInputTypes$$anonfun$1.applyOrElse(ExpectsInputTypes.scala:55)
	at scala.collection.IterableOnceOps.collectFirst(IterableOnce.scala:1256)
	at scala.collection.IterableOnceOps.collectFirst$(IterableOnce.scala:1248)
	at scala.collection.AbstractIterable.collectFirst(Iterable.scala:935)
	at org.apache.spark.sql.catalyst.expressions.ExpectsInputTypes$.checkInputDataTypes(ExpectsInputTypes.scala:55)
	at org.apache.spark.sql.catalyst.expressions.ExpectsInputTypes.checkInputDataTypes(ExpectsInputTypes.scala:46)
	at org.apache.spark.sql.catalyst.expressions.ExpectsInputTypes.checkInputDataTypes$(ExpectsInputTypes.scala:45)
	at org.apache.spark.sql.catalyst.expressions.GetJsonObject.checkInputDataTypes(jsonExpressions.scala:137)
	at org.apache.spark.sql.catalyst.expressions.Expression.resolved$lzycompute(Expression.scala:267)
	at org.apache.spark.sql.catalyst.expressions.Expression.resolved(Expression.scala:267)
	at org.apache.spark.sql.catalyst.expressions.Expression.$anonfun$childrenResolved$1(Expression.scala:279)
	at org.apache.spark.sql.catalyst.expressions.Expression.$anonfun$childrenResolved$1$adapted(Expression.scala:279)
	at scala.collection.IterableOnceOps.forall(IterableOnce.scala:633)
	at scala.collection.IterableOnceOps.forall$(IterableOnce.scala:630)
	at scala.collection.AbstractIterable.forall(Iterable.scala:935)
	at org.apache.spark.sql.catalyst.expressions.Expression.childrenResolved(Expression.scala:279)
	at org.apache.spark.sql.catalyst.expressions.Expression.resolved$lzycompute(Expression.scala:267)
	at org.apache.spark.sql.catalyst.expressions.Expression.resolved(Expression.scala:267)
	at org.apache.spark.sql.catalyst.expressions.Expression.$anonfun$childrenResolved$1(Expression.scala:279)
	at org.apache.spark.sql.catalyst.expressions.Expression.$anonfun$childrenResolved$1$adapted(Expression.scala:279)
	at scala.collection.IterableOnceOps.forall(IterableOnce.scala:633)
	at scala.collection.IterableOnceOps.forall$(IterableOnce.scala:630)
	at scala.collection.AbstractIterable.forall(Iterable.scala:935)
	at org.apache.spark.sql.catalyst.expressions.Expression.childrenResolved(Expression.scala:279)
	at org.apache.spark.sql.catalyst.expressions.Expression.resolved$lzycompute(Expression.scala:267)
	at org.apache.spark.sql.catalyst.expressions.Expression.resolved(Expression.scala:267)
	at org.apache.spark.sql.catalyst.expressions.Expression.$anonfun$childrenResolved$1(Expression.scala:279)
	at org.apache.spark.sql.catalyst.expressions.Expression.$anonfun$childrenResolved$1$adapted(Expression.scala:279)
	at scala.collection.IterableOnceOps.forall(IterableOnce.scala:633)
	at scala.collection.IterableOnceOps.forall$(IterableOnce.scala:630)
	at scala.collection.AbstractIterable.forall(Iterable.scala:935)
	at org.apache.spark.sql.catalyst.expressions.Expression.childrenResolved(Expression.scala:279)
	at org.apache.spark.sql.catalyst.expressions.Expression.resolved$lzycompute(Expression.scala:267)
	at org.apache.spark.sql.catalyst.expressions.Expression.resolved(Expression.scala:267)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.$anonfun$resolved$1(LogicalPlan.scala:104)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.$anonfun$resolved$1$adapted(LogicalPlan.scala:104)
	at scala.collection.immutable.List.forall(List.scala:387)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.resolved$lzycompute(LogicalPlan.scala:104)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.resolved(LogicalPlan.scala:104)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.$anonfun$childrenResolved$1(LogicalPlan.scala:111)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.$anonfun$childrenResolved$1$adapted(LogicalPlan.scala:111)
	at scala.collection.IterableOnceOps.forall(IterableOnce.scala:633)
	at scala.collection.IterableOnceOps.forall$(IterableOnce.scala:630)
	at scala.collection.AbstractIterable.forall(Iterable.scala:935)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.childrenResolved(LogicalPlan.scala:111)
	at org.apache.spark.sql.catalyst.plans.logical.Project.resolved$lzycompute(basicLogicalOperators.scala:89)
	at org.apache.spark.sql.catalyst.plans.logical.Project.resolved(basicLogicalOperators.scala:81)
	at org.apache.spark.sql.catalyst.analysis.DeduplicateRelations$.deduplicateAndRenew(DeduplicateRelations.scala:288)
	at org.apache.spark.sql.catalyst.analysis.DeduplicateRelations$.org$apache$spark$sql$catalyst$analysis$DeduplicateRelations$$renewDuplicatedRelations(DeduplicateRelations.scala:119)
	at org.apache.spark.sql.catalyst.analysis.DeduplicateRelations$.$anonfun$deduplicate$1(DeduplicateRelations.scala:212)
	at org.apache.spark.sql.catalyst.analysis.DeduplicateRelations$.$anonfun$deduplicate$1$adapted(DeduplicateRelations.scala:211)
	at scala.collection.immutable.Vector.foreach(Vector.scala:2124)
	at org.apache.spark.sql.catalyst.analysis.DeduplicateRelations$.deduplicate(DeduplicateRelations.scala:211)
	at org.apache.spark.sql.catalyst.analysis.DeduplicateRelations$.org$apache$spark$sql$catalyst$analysis$DeduplicateRelations$$renewDuplicatedRelations(DeduplicateRelations.scala:202)
	at org.apache.spark.sql.catalyst.analysis.DeduplicateRelations$.$anonfun$deduplicate$1(DeduplicateRelations.scala:212)
	at org.apache.spark.sql.catalyst.analysis.DeduplicateRelations$.$anonfun$deduplicate$1$adapted(DeduplicateRelations.scala:211)
	at scala.collection.immutable.Vector.foreach(Vector.scala:2124)
	at org.apache.spark.sql.catalyst.analysis.DeduplicateRelations$.deduplicate(DeduplicateRelations.scala:211)
	at org.apache.spark.sql.catalyst.analysis.DeduplicateRelations$.org$apache$spark$sql$catalyst$analysis$DeduplicateRelations$$renewDuplicatedRelations(DeduplicateRelations.scala:202)
	at org.apache.spark.sql.catalyst.analysis.DeduplicateRelations$.apply(DeduplicateRelations.scala:40)
	at org.apache.spark.sql.catalyst.optimizer.InlineCTE.org$apache$spark$sql$catalyst$optimizer$InlineCTE$$inlineCTE(InlineCTE.scala:171)
	at org.apache.spark.sql.catalyst.optimizer.InlineCTE.$anonfun$inlineCTE$3(InlineCTE.scala:187)
	at scala.collection.immutable.Vector1.map(Vector.scala:2140)
	at scala.collection.immutable.Vector1.map(Vector.scala:385)
	at org.apache.spark.sql.catalyst.optimizer.InlineCTE.org$apache$spark$sql$catalyst$optimizer$InlineCTE$$inlineCTE(InlineCTE.scala:187)
	at org.apache.spark.sql.catalyst.optimizer.InlineCTE.$anonfun$inlineCTE$3(InlineCTE.scala:187)
	at scala.collection.immutable.Vector1.map(Vector.scala:2140)
	at scala.collection.immutable.Vector1.map(Vector.scala:385)
	at org.apache.spark.sql.catalyst.optimizer.InlineCTE.org$apache$spark$sql$catalyst$optimizer$InlineCTE$$inlineCTE(InlineCTE.scala:187)
	at org.apache.spark.sql.catalyst.optimizer.InlineCTE.$anonfun$inlineCTE$3(InlineCTE.scala:187)
	at scala.collection.immutable.Vector1.map(Vector.scala:2140)
	at scala.collection.immutable.Vector1.map(Vector.scala:385)
	at org.apache.spark.sql.catalyst.optimizer.InlineCTE.org$apache$spark$sql$catalyst$optimizer$InlineCTE$$inlineCTE(InlineCTE.scala:187)
	at org.apache.spark.sql.catalyst.optimizer.InlineCTE.$anonfun$inlineCTE$3(InlineCTE.scala:187)
	at scala.collection.immutable.Vector1.map(Vector.scala:2140)
	at scala.collection.immutable.Vector1.map(Vector.scala:385)
	at org.apache.spark.sql.catalyst.optimizer.InlineCTE.org$apache$spark$sql$catalyst$optimizer$InlineCTE$$inlineCTE(InlineCTE.scala:187)
	at org.apache.spark.sql.catalyst.optimizer.InlineCTE.$anonfun$inlineCTE$1(InlineCTE.scala:155)
	at scala.collection.immutable.Vector.foreach(Vector.scala:2124)
	at org.apache.spark.sql.catalyst.optimizer.InlineCTE.org$apache$spark$sql$catalyst$optimizer$InlineCTE$$inlineCTE(InlineCTE.scala:152)
	at org.apache.spark.sql.catalyst.optimizer.InlineCTE.apply(InlineCTE.scala:49)
	at org.apache.spark.sql.catalyst.analysis.CheckAnalysis.checkAnalysis(CheckAnalysis.scala:181)
	at org.apache.spark.sql.catalyst.analysis.CheckAnalysis.checkAnalysis$(CheckAnalysis.scala:161)
	at org.apache.spark.sql.catalyst.analysis.Analyzer.checkAnalysis(Analyzer.scala:191)
	at org.apache.spark.sql.catalyst.analysis.Analyzer.$anonfun$executeAndCheck$1(Analyzer.scala:213)
	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$.markInAnalyzer(AnalysisHelper.scala:393)
	at org.apache.spark.sql.catalyst.analysis.Analyzer.executeAndCheck(Analyzer.scala:211)
```


### Why are the changes needed?

Bug fix for Hive UDF codegen.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Local test


### Was this patch authored or co-authored using generative AI tooling?

No
