### PR TITLE
[MINOR][CORE][TESTS] Rename `TestMemoryManager.(markconsequentOOM -> markConsequentOOM)`

### DIFF
--- a/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
+++ b/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
@@ -591,7 +591,7 @@ public class UnsafeExternalSorterSuite {
     }
 
     // Check that spilling still succeeds when the task is starved for memory.
-    memoryManager.markconsequentOOM(Integer.MAX_VALUE);
+    memoryManager.markConsequentOOM(Integer.MAX_VALUE);
     sorter.spill();
     memoryManager.resetConsequentOOM();
 

--- a/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeInMemorySorterSuite.java
+++ b/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeInMemorySorterSuite.java
@@ -172,7 +172,7 @@ public class UnsafeInMemorySorterSuite {
             recordComparator, prefixComparator, 100, shouldUseRadixSort());
 
     // Ensure that the sorter does not OOM while freeing its memory.
-    testMemoryManager.markconsequentOOM(Integer.MAX_VALUE);
+    testMemoryManager.markConsequentOOM(Integer.MAX_VALUE);
     sorter.freeMemory();
     testMemoryManager.resetConsequentOOM();
     Assertions.assertFalse(sorter.hasSpaceForAnotherRecord());
@@ -182,7 +182,7 @@ public class UnsafeInMemorySorterSuite {
     sorter.expandPointerArray(array);
 
     // Ensure that it is safe to call freeMemory() multiple times.
-    testMemoryManager.markconsequentOOM(Integer.MAX_VALUE);
+    testMemoryManager.markConsequentOOM(Integer.MAX_VALUE);
     sorter.freeMemory();
     sorter.freeMemory();
     testMemoryManager.resetConsequentOOM();

--- a/core/src/test/scala/org/apache/spark/memory/TestMemoryManager.scala
+++ b/core/src/test/scala/org/apache/spark/memory/TestMemoryManager.scala
@@ -108,19 +108,19 @@ class TestMemoryManager(conf: SparkConf)
    * memory (returning `0`), simulating low-on-memory / out-of-memory conditions.
    */
   def markExecutionAsOutOfMemoryOnce(): Unit = {
-    markconsequentOOM(1)
+    markConsequentOOM(1)
   }
 
   /**
    * Causes the next `n` calls to [[acquireExecutionMemory()]] to fail to allocate
    * memory (returning `0`), simulating low-on-memory / out-of-memory conditions.
    */
-  def markconsequentOOM(n: Int): Unit = synchronized {
+  def markConsequentOOM(n: Int): Unit = synchronized {
     consequentOOM += n
   }
 
   /**
-   * Undos the effects of [[markExecutionAsOutOfMemoryOnce]] and [[markconsequentOOM]] and lets
+   * Undos the effects of [[markExecutionAsOutOfMemoryOnce]] and [[markConsequentOOM]] and lets
    * calls to [[acquireExecutionMemory()]] (if there is enough memory available).
    */
   def resetConsequentOOM(): Unit = synchronized {

--- a/core/src/test/scala/org/apache/spark/memory/TestMemoryManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/memory/TestMemoryManagerSuite.scala
@@ -47,7 +47,7 @@ class TestMemoryManagerSuite extends SparkFunSuite {
   test("markconsequentOOM") {
     val testMemoryManager = new TestMemoryManager(new SparkConf())
     assert(testMemoryManager.acquireExecutionMemory(1, 0, MemoryMode.ON_HEAP) == 1)
-    testMemoryManager.markconsequentOOM(2)
+    testMemoryManager.markConsequentOOM(2)
     assert(testMemoryManager.acquireExecutionMemory(1, 0, MemoryMode.ON_HEAP) == 0)
     assert(testMemoryManager.acquireExecutionMemory(1, 0, MemoryMode.ON_HEAP) == 0)
     assert(testMemoryManager.acquireExecutionMemory(1, 0, MemoryMode.ON_HEAP) == 1)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix a typo: `s/markconsequentOOM/markConsequentOOM`

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

 No.