### PR TITLE
Revert "[SPARK-52610][BUILD] Upgrade rocksdbjni to 10.2.1"

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -248,7 +248,7 @@ parquet-jackson/1.15.2//parquet-jackson-1.15.2.jar
 pickle/1.5//pickle-1.5.jar
 py4j/0.10.9.9//py4j-0.10.9.9.jar
 remotetea-oncrpc/1.1.2//remotetea-oncrpc-1.1.2.jar
-rocksdbjni/10.2.1//rocksdbjni-10.2.1.jar
+rocksdbjni/9.8.4//rocksdbjni-9.8.4.jar
 scala-collection-compat_2.13/2.7.0//scala-collection-compat_2.13-2.7.0.jar
 scala-compiler/2.13.16//scala-compiler-2.13.16.jar
 scala-library/2.13.16//scala-library-2.13.16.jar

--- a/pom.xml
+++ b/pom.xml
@@ -762,7 +762,7 @@
       <dependency>
         <groupId>org.rocksdb</groupId>
         <artifactId>rocksdbjni</artifactId>
-        <version>10.2.1</version>
+        <version>9.8.4</version>
       </dependency>
       <dependency>
         <groupId>${leveldbjni.group}</groupId>

--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk21-results.txt
@@ -2,143 +2,143 @@
 put rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                            8              8           0          1.3         781.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                              43             44           1          0.2        4285.7       0.2X
-RocksDB (trackTotalNumberOfRows: false)                             16             16           1          0.6        1583.2       0.5X
+In-memory                                                            8              9           1          1.2         815.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              46             47           2          0.2        4559.1       0.2X
+RocksDB (trackTotalNumberOfRows: false)                             17             18           1          0.6        1678.7       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              8           0          1.3         790.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            45             46           1          0.2        4462.0       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           16             16           1          0.6        1554.9       0.5X
+In-memory                                                          8              9           1          1.3         798.1       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            47             48           2          0.2        4659.8       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           17             17           1          0.6        1663.4       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              8           0          1.3         776.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            45             46           1          0.2        4451.2       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           15             16           1          0.7        1537.2       0.5X
+In-memory                                                          8              9           1          1.3         794.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            46             48           1          0.2        4625.7       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           17             17           1          0.6        1660.7       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                      8              8           0          1.3         769.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                        44             45           1          0.2        4420.2       0.2X
-RocksDB (trackTotalNumberOfRows: false)                       15             16           0          0.7        1537.6       0.5X
+In-memory                                                      8              8           1          1.3         788.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        46             47           1          0.2        4557.0       0.2X
+RocksDB (trackTotalNumberOfRows: false)                       17             17           1          0.6        1650.3       0.5X
 
 
 ================================================================================================
 merge rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                    547            558           5          0.0       54682.0       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                   177            182           2          0.1       17735.0       3.1X
+RocksDB (trackTotalNumberOfRows: true)                                                    574            585           6          0.0       57387.8       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                   181            186           3          0.1       18065.2       3.2X
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                  486            496           4          0.0       48620.6       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                 177            181           2          0.1       17699.5       2.7X
+RocksDB (trackTotalNumberOfRows: true)                                                  504            515           5          0.0       50382.4       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                 179            185           3          0.1       17882.2       2.8X
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                  432            441           4          0.0       43172.3       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                 177            181           2          0.1       17658.4       2.4X
+RocksDB (trackTotalNumberOfRows: true)                                                  442            455           6          0.0       44235.2       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                 180            185           3          0.1       17971.5       2.5X
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                              415            424           5          0.0       41475.2       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                             176            181           2          0.1       17613.7       2.4X
+RocksDB (trackTotalNumberOfRows: true)                                              424            436           5          0.0       42391.9       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                             179            185           4          0.1       17923.5       2.4X
 
 
 ================================================================================================
 delete rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                        0              1           0         26.9          37.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                          44             45           1          0.2        4428.4       0.0X
-RocksDB (trackTotalNumberOfRows: false)                                                         16             16           0          0.6        1575.1       0.0X
+In-memory                                                                                        0              1           0         27.1          36.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          45             46           1          0.2        4470.0       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         16             17           1          0.6        1583.0       0.0X
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      6              7           0          1.6         622.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        45             46           1          0.2        4467.4       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       16             16           0          0.6        1563.6       0.4X
+In-memory                                                                                      7              7           0          1.5         651.4       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        46             47           1          0.2        4580.3       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       16             17           0          0.6        1582.7       0.4X
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              7           0          1.5         665.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        44             45           0          0.2        4390.2       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       16             16           0          0.6        1563.7       0.4X
+In-memory                                                                                      7              8           0          1.4         713.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        45             47           1          0.2        4538.6       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                       16             16           0          0.6        1579.3       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                  7              7           0          1.5         674.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                    43             44           1          0.2        4326.5       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                   16             16           0          0.6        1569.0       0.4X
+In-memory                                                                                  7              8           0          1.4         716.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    45             46           1          0.2        4459.8       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                   16             16           1          0.6        1580.7       0.5X
 
 
 ================================================================================================
 evict rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                            7              7           1          1.5         664.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                              42             44           1          0.2        4249.5       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                             17             17           0          0.6        1701.9       0.4X
+In-memory                                                                            7              7           0          1.5         689.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              44             45           1          0.2        4424.0       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                             18             18           0          0.6        1784.2       0.4X
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           6              6           0          1.6         624.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             23             23           1          0.4        2264.8       0.3X
-RocksDB (trackTotalNumberOfRows: false)                                            10             10           0          1.0         996.1       0.6X
+In-memory                                                                           6              7           0          1.5         650.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             23             24           1          0.4        2347.8       0.3X
+RocksDB (trackTotalNumberOfRows: false)                                            10             11           0          1.0        1037.1       0.6X
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                          6              6           0          1.8         561.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             7              8           0          1.4         734.1       0.8X
-RocksDB (trackTotalNumberOfRows: false)                                            5              5           0          2.1         479.5       1.2X
+In-memory                                                                          6              6           0          1.7         585.4       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             8              8           0          1.3         766.5       0.8X
+RocksDB (trackTotalNumberOfRows: false)                                            5              5           0          2.0         503.2       1.2X
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 21.0.6+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                      0              0           0         24.2          41.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                         3              4           0          2.9         343.7       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                        3              4           0          2.9         344.1       0.1X
+In-memory                                                                      0              0           0         25.0          40.1       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         4              4           0          2.8         359.1       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                        4              4           0          2.8         359.9       0.1X
 
 

--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-results.txt
@@ -2,143 +2,143 @@
 put rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                            8              9           0          1.3         792.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                              45             47           1          0.2        4526.6       0.2X
-RocksDB (trackTotalNumberOfRows: false)                             16             17           1          0.6        1621.6       0.5X
+In-memory                                                            8              9           1          1.2         816.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              45             47           1          0.2        4514.1       0.2X
+RocksDB (trackTotalNumberOfRows: false)                             17             18           1          0.6        1682.7       0.5X
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              8           0          1.3         772.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            46             47           1          0.2        4586.1       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           16             17           1          0.6        1608.3       0.5X
+In-memory                                                          8             10           1          1.2         811.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            47             49           1          0.2        4694.9       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           17             18           1          0.6        1680.2       0.5X
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              8           0          1.3         750.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            46             47           1          0.2        4556.6       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           16             17           1          0.6        1600.9       0.5X
+In-memory                                                          8              9           1          1.3         786.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            47             48           1          0.2        4679.7       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           17             18           1          0.6        1650.0       0.5X
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                      7              8           0          1.3         746.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                        45             46           1          0.2        4529.2       0.2X
-RocksDB (trackTotalNumberOfRows: false)                       16             17           1          0.6        1597.8       0.5X
+In-memory                                                      8              8           1          1.3         778.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        46             48           1          0.2        4629.4       0.2X
+RocksDB (trackTotalNumberOfRows: false)                       17             17           1          0.6        1664.9       0.5X
 
 
 ================================================================================================
 merge rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                    586            599           6          0.0       58566.8       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                   184            190           3          0.1       18360.6       3.2X
+RocksDB (trackTotalNumberOfRows: true)                                                    570            585           6          0.0       56996.2       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                   184            190           3          0.1       18411.4       3.1X
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                  512            521           4          0.0       51196.5       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                 185            189           3          0.1       18466.2       2.8X
+RocksDB (trackTotalNumberOfRows: true)                                                  493            505           5          0.0       49327.2       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                 181            188           3          0.1       18140.8       2.7X
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                  448            458           5          0.0       44781.9       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                 183            188           3          0.1       18283.7       2.4X
+RocksDB (trackTotalNumberOfRows: true)                                                  435            448           5          0.0       43484.3       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                 183            188           3          0.1       18289.1       2.4X
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                              430            441           4          0.0       43011.1       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                             182            188           2          0.1       18248.3       2.4X
+RocksDB (trackTotalNumberOfRows: true)                                              416            432           5          0.0       41606.2       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                             183            189           3          0.1       18282.2       2.3X
 
 
 ================================================================================================
 delete rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                        0              0           0         26.4          37.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                          45             46           1          0.2        4530.3       0.0X
-RocksDB (trackTotalNumberOfRows: false)                                                         16             17           0          0.6        1585.2       0.0X
+In-memory                                                                                        0              1           0         26.6          37.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          45             47           1          0.2        4514.1       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         16             17           0          0.6        1587.8       0.0X
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      6              7           0          1.6         630.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        46             47           1          0.2        4573.8       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       16             17           0          0.6        1592.2       0.4X
+In-memory                                                                                      6              7           1          1.6         644.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        45             47           1          0.2        4524.6       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       16             17           1          0.6        1579.1       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              7           0          1.5         672.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        45             46           2          0.2        4510.6       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       16             17           0          0.6        1603.7       0.4X
+In-memory                                                                                      7              8           1          1.4         698.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        45             46           1          0.2        4481.1       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                       16             17           1          0.6        1585.3       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                  7              7           0          1.5         686.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                    45             46           1          0.2        4486.3       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                   16             17           0          0.6        1591.1       0.4X
+In-memory                                                                                  7              8           1          1.4         707.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    43             45           1          0.2        4326.6       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                   16             17           1          0.6        1560.6       0.5X
 
 
 ================================================================================================
 evict rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                            7              7           0          1.5         662.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                              44             45           1          0.2        4446.8       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                             18             18           1          0.6        1753.6       0.4X
+In-memory                                                                            7              7           0          1.4         693.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              43             44           1          0.2        4285.3       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                             17             18           0          0.6        1726.3       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           6              7           0          1.6         625.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             24             25           0          0.4        2412.9       0.3X
-RocksDB (trackTotalNumberOfRows: false)                                            11             11           0          0.9        1087.3       0.6X
+In-memory                                                                           6              7           0          1.5         646.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             24             24           0          0.4        2351.2       0.3X
+RocksDB (trackTotalNumberOfRows: false)                                            11             11           0          0.9        1062.9       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                          6              6           0          1.8         570.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             8              8           0          1.2         805.2       0.7X
-RocksDB (trackTotalNumberOfRows: false)                                            5              6           0          1.9         538.5       1.1X
+In-memory                                                                          6              6           0          1.7         587.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             8              8           0          1.3         784.7       0.7X
+RocksDB (trackTotalNumberOfRows: false)                                            5              6           0          1.9         529.1       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1015-azure
+OpenJDK 64-Bit Server VM 17.0.14+7-LTS on Linux 6.8.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                      0              0           0         23.1          43.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                         4              4           0          2.5         394.8       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                        4              4           0          2.5         394.7       0.1X
+In-memory                                                                      0              0           0         23.2          43.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         4              4           0          2.6         387.5       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                        4              4           0          2.6         389.4       0.1X
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr reverts commit 2d4ff6eeeffd74ba6126936849cf6d3a71de7f70 to downgrade rocksdbjni from 10.2.1 to 9.8.4.


### Why are the changes needed?
Rocksdbjni 10.2.1 crashed during testing:

- https://github.com/apache/spark/actions/runs/16638741674/job/47084788641

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
03:55:47.848 WARN org.apache.spark.scheduler.DAGScheduler: Failed to cancel job group 2d75e504-d47d-4eb3-ac5b-1ce066ae486b. Cannot find active jobs for it.

#  SIGSEGV (0xb) at pc=0x00007f8d46c7eed9, pid=25508, tid=653254
#
# JRE version: OpenJDK Runtime Environment Zulu17.60+17-CRaC-CA (17.0.16+8) (build 17.0.16+8-LTS)
# Java VM: OpenJDK 64-Bit Server VM Zulu17.60+17-CRaC-CA (17.0.16+8-LTS, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# C03:55:47.850 ERROR org.apache.spark.util.Utils: Aborting task
org.apache.spark.SparkException: [CANNOT_WRITE_STATE_STORE.CANNOT_COMMIT] Error writing state store files for provider RocksDBStateStore[stateStoreId=StateStoreId[ operatorId=0, partitionId=2, storeName=default ], version=18]. Cannot perform commit during state checkpoint. SQLSTATE: 58030
	at org.apache.spark.sql.errors.QueryExecutionErrors$.failedToCommitStateFileError(QueryExecutionErrors.scala:2249)
	at org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider$RocksDBStateStore.commit(RocksDBStateStoreProvider.scala:392)
	at org.apache.spark.sql.execution.streaming.TransformWithStateExec.$anonfun$processDataWithPartition$5(TransformWithStateExec.scala:341)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at org.apache.spark.util.Utils$.timeTakenMs(Utils.scala:482)
	at org.apache.spark.sql.execution.streaming.StateStoreWriter.timeTakenMs(statefulOperators.scala:406)
	at org.apache.spark.sql.execution.streaming.StateStoreWriter.timeTakenMs$(statefulOperators.scala:406)
  [librocksdbjni3950065922734541121.so+0x47eed9]03:55:47.851 ERROR org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask: Aborting commit for partition 2 (task 465, attempt 0, stage 161.0)

03:55:47.851 ERROR org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask: Aborted commit for partition 2 (task 465, attempt 0, stage 161.0)

  rocksdb::DBImpl::FailIfCfHasTs(rocksdb::ColumnFamilyHandle const*) const+0x29
#
# Core dump will be written. Default location: Core dumps may be processed with "/usr/lib/systemd/systemd-coredump %P %u %g %s %t 9223372036854775808 %h %d" (or dumping to /home/runner/work/spark/spark/sql/core/core.25508)
#
# An error report file with more information is saved as:
# /home/runner/work/spark/spark/sql/core/hs_err_pid25508.log
03:55:47.852 WARN org.apache.spark.scheduler.TaskSetManager: Lost task 2.0 in stage 161.0 (TID 465) (localhost executor driver): TaskKilled (Stage cancelled: [SPARK_JOB_CANCELLED] Job 89 cancelled Query [id = a4a0ad54-035d-4049-961c-a36ee70e3d7c, runId = 2d75e504-d47d-4eb3-ac5b-1ce066ae486b] was stopped SQLSTATE: XXKDA)

#
# If you would like to submit a bug report, please visit:
#   http://www.azul.com/support/
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions

### Was this patch authored or co-authored using generative AI tooling?
No