### PR TITLE
[SPARK-53045][SQL] DESCRIBE EXTENDED should be resilient to corrupt metadata

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -22,6 +22,7 @@ import java.time.{ZoneId, ZoneOffset}
 import java.util.Date
 
 import scala.collection.mutable
+import scala.util.Try
 import scala.util.control.NonFatal
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include
@@ -629,16 +630,6 @@ case class CatalogTable(
       if (lastAccessTime <= 0) JString("UNKNOWN")
       else JLong(lastAccessTime)
 
-    val viewQueryOutputColumns: JValue = {
-      if (viewSchemaMode == SchemaEvolution) {
-        JArray(schema.map(_.name).map(JString).toList)
-      } else if (viewQueryColumnNames.nonEmpty) {
-        JArray(viewQueryColumnNames.map(JString).toList)
-      } else {
-        JNull
-      }
-    }
-
     val map = mutable.LinkedHashMap[String, JValue]()
 
     if (identifier.catalog.isDefined) map += "Catalog" -> JString(identifier.catalog.get)
@@ -655,21 +646,35 @@ case class CatalogTable(
     }
     if (comment.isDefined) map += "Comment" -> JString(comment.get)
     if (collation.isDefined) map += "Collation" -> JString(collation.get)
-    if (tableType == CatalogTableType.VIEW && viewText.isDefined) {
-      map += "View Text" -> JString(viewText.get)
-    }
-    if (tableType == CatalogTableType.VIEW && viewOriginalText.isDefined) {
-      map += "View Original Text" -> JString(viewOriginalText.get)
-    }
-    if (SQLConf.get.viewSchemaBindingEnabled && tableType == CatalogTableType.VIEW) {
-      map += "View Schema Mode" -> JString(viewSchemaMode.toString)
-    }
-    if (viewCatalogAndNamespace.nonEmpty && tableType == CatalogTableType.VIEW) {
-      import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
-      map += "View Catalog and Namespace" -> JString(viewCatalogAndNamespace.quoted)
-    }
-    if (viewQueryOutputColumns != JNull) {
-      map += "View Query Output Columns" -> viewQueryOutputColumns
+
+    if (tableType == CatalogTableType.VIEW) {
+      if (viewText.isDefined) {
+        map += "View Text" -> JString(viewText.get)
+      }
+      if (viewOriginalText.isDefined) {
+        map += "View Original Text" -> JString(viewOriginalText.get)
+      }
+      if (SQLConf.get.viewSchemaBindingEnabled) {
+        val viewSchemaModeInfo = Try(viewSchemaMode.toString).getOrElse("UNKNOWN")
+        map += "View Schema Mode" -> JString(viewSchemaModeInfo)
+      }
+      val viewCatalogAndNamespaceInfos = Try(viewCatalogAndNamespace).getOrElse(Seq.empty)
+      if (viewCatalogAndNamespaceInfos.nonEmpty) {
+        import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+        map += "View Catalog and Namespace" -> JString(viewCatalogAndNamespaceInfos.quoted)
+      }
+      val viewQueryOutputColumns: JValue = Try {
+        if (viewSchemaMode == SchemaEvolution) {
+          JArray(schema.map(_.name).map(JString).toList)
+        } else if (viewQueryColumnNames.nonEmpty) {
+          JArray(viewQueryColumnNames.map(JString).toList)
+        } else {
+          JNull
+        }
+      }.getOrElse(JNull)
+      if (viewQueryOutputColumns != JNull) {
+        map += "View Query Output Columns" -> viewQueryOutputColumns
+      }
     }
     if (tableProperties != JNull) map += "Table Properties" -> tableProperties
     stats.foreach { s =>


### PR DESCRIPTION


### What changes were proposed in this pull request?
A lot of methods called by DESCRIBE EXTENDED can throw exception if the CatalotTable metadata is not a certain way, in particular in the case of view which has strict requirements.

This proposes to make DESCRIBE EXTENDED and CatalogTable.toString still able to return successfully in this case.


### Why are the changes needed?
We see some issue where somehow there is some leftover View metadata on a table, and DESC EXTENDED and jobs attempting to call toString on the table both crash, even if the table is not a view


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing unit test


### Was this patch authored or co-authored using generative AI tooling?
No