### PR TITLE
[SPARK-53046][CORE][SQL] Use Java `readAllBytes` instead of `IOUtils.toByteArray`

### DIFF
--- a/core/src/main/scala/org/apache/spark/serializer/GenericAvroSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/GenericAvroSerializer.scala
@@ -28,7 +28,6 @@ import com.esotericsoftware.kryo.io.{Input => KryoInput, Output => KryoOutput}
 import org.apache.avro.{Schema, SchemaNormalization}
 import org.apache.avro.generic.{GenericContainer, GenericData}
 import org.apache.avro.io._
-import org.apache.commons.io.IOUtils
 
 import org.apache.spark.{SparkEnv, SparkException}
 import org.apache.spark.io.CompressionCodec
@@ -93,7 +92,7 @@ private[serializer] class GenericAvroSerializer[D <: GenericContainer]
       schemaBytes.remaining())
     val in = codec.compressedInputStream(bis)
     val bytes = Utils.tryWithSafeFinally {
-      IOUtils.toByteArray(in)
+      in.readAllBytes()
     } {
       in.close()
     }

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -547,6 +547,11 @@ This file is divided into 3 sections:
     <customMessage>Use StandardCharsets.UTF_8 instead.</customMessage>
   </check>
 
+  <check customId="ioutilstobytearray" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">IOUtils\.toByteArray</parameter></parameters>
+    <customMessage>Use Java readAllBytes instead.</customMessage>
+  </check>
+
   <check customId="ioutilsclosequietly" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">IOUtils\.closeQuietly</parameter></parameters>
     <customMessage>Use closeQuietly of SparkErrorUtils or Utils instead.</customMessage>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -24,7 +24,7 @@ import java.util
 
 import scala.util.Try
 
-import org.apache.commons.io.{FileUtils, IOUtils}
+import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hive.shims.ShimLoader
 
@@ -258,7 +258,7 @@ private[hive] class IsolatedClientLoader(
             if (isBarrierClass(name)) {
               // For barrier classes, we construct a new copy of the class.
               val bytes = Utils.tryWithResource(
-                baseClassLoader.getResourceAsStream(classToPath(name)))(IOUtils.toByteArray)
+                baseClassLoader.getResourceAsStream(classToPath(name)))(_.readAllBytes)
               logDebug(s"custom defining: $name - ${util.Arrays.hashCode(bytes)}")
               defineClass(name, bytes, 0, bytes.length)
             } else if (!isSharedClass(name)) {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/security/HiveHadoopDelegationTokenManagerSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/security/HiveHadoopDelegationTokenManagerSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.hive.security
 
-import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.Assertions._
 
@@ -65,7 +64,7 @@ class HiveHadoopDelegationTokenManagerSuite extends SparkFunSuite {
         val classFileName = name.replaceAll("\\.", "/") + ".class"
         val in = currentLoader.getResourceAsStream(classFileName)
         if (in != null) {
-          val bytes = IOUtils.toByteArray(in)
+          val bytes = in.readAllBytes()
           return defineClass(name, bytes, 0, bytes.length)
         }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java `readAllBytes` instead of `IOUtils.toByteArray` to simply and improve the performance.

### Why are the changes needed?

Since Java 9+, we can use `readAllBytes` which is **roughly `2x` faster** than `IOUtils.toByteArray`.

```scala
scala> spark.time(new java.io.FileInputStream("/tmp/1G.bin").readAllBytes().length)
Time taken: 226 ms
val res0: Int = 1073741824
```

```scala
scala> spark.time(org.apache.commons.io.IOUtils.toByteArray(new java.io.FileInputStream("/tmp/1G.bin")).length)
Time taken: 414 ms
val res0: Int = 1073741824
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.