### PR TITLE
[SPARK-53049][CORE][SQL][SS] Support `toString` in `SparkStreamUtils`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkStreamUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkStreamUtils.scala
@@ -18,6 +18,7 @@ package org.apache.spark.util
 
 import java.io.{FileInputStream, FileOutputStream, InputStream, OutputStream}
 import java.nio.channels.{FileChannel, WritableByteChannel}
+import java.nio.charset.StandardCharsets
 
 import org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally
 
@@ -103,6 +104,10 @@ private[spark] trait SparkStreamUtils {
            |You can set spark.file.transferTo = false to disable this NIO feature.
          """.stripMargin)
     }
+  }
+
+  def toString(in: InputStream): String = {
+    new String(in.readAllBytes(), StandardCharsets.UTF_8)
   }
 }
 

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceInitialOffsetWriter.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceInitialOffsetWriter.scala
@@ -20,10 +20,9 @@ package org.apache.spark.sql.kafka010
 import java.io._
 import java.nio.charset.StandardCharsets
 
-import org.apache.commons.io.IOUtils
-
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.{HDFSMetadataLog, SerializedOffset}
+import org.apache.spark.util.Utils
 
 /** A version of [[HDFSMetadataLog]] specialized for saving the initial offsets. */
 private[kafka010] class KafkaSourceInitialOffsetWriter(
@@ -43,7 +42,7 @@ private[kafka010] class KafkaSourceInitialOffsetWriter(
 
   override def deserialize(in: InputStream): KafkaSourceOffset = {
     in.read() // A zero byte is read to support Spark 2.1.0 (SPARK-19517)
-    val content = IOUtils.toString(new InputStreamReader(in, StandardCharsets.UTF_8))
+    val content = Utils.toString(in)
     // HDFSMetadataLog guarantees that it never creates a partial file.
     require(content.nonEmpty)
     if (content(0) == 'v') {

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.core.util.{DefaultIndenter, DefaultPrettyPrinter}
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import org.apache.commons.io.IOUtils
 
 import org.apache.spark.SparkThrowableHelper._
 import org.apache.spark.util.Utils
@@ -80,7 +79,7 @@ class SparkThrowableSuite extends SparkFunSuite {
 
   test("Error conditions are correctly formatted") {
     val errorConditionFileContents =
-      IOUtils.toString(errorJsonFilePath.toUri.toURL.openStream(), StandardCharsets.UTF_8)
+      Utils.toString(errorJsonFilePath.toUri.toURL.openStream())
     val mapper = JsonMapper.builder()
       .addModule(DefaultScalaModule)
       .enable(SerializationFeature.INDENT_OUTPUT)

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -27,7 +27,6 @@ import scala.jdk.CollectionConverters._
 import com.google.common.io.{ByteStreams, Files}
 import jakarta.servlet._
 import jakarta.servlet.http.{HttpServletRequest, HttpServletRequestWrapper, HttpServletResponse}
-import org.apache.commons.io.IOUtils
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.json4s.JsonAST._
 import org.json4s.jackson.JsonMethods
@@ -246,7 +245,7 @@ abstract class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with
         }
       }
 
-      val exp = IOUtils.toString(new FileInputStream(goldenFile), StandardCharsets.UTF_8)
+      val exp = Utils.toString(new FileInputStream(goldenFile))
       // compare the ASTs so formatting differences don't cause failures
       val expAst = parse(exp)
       assertValidDataInJson(jsonAst, expAst)
@@ -750,7 +749,7 @@ object HistoryServerSuite {
 
   def getContentAndCode(url: URL): (Int, Option[String], Option[String]) = {
     val (code, in, errString) = connectAndGetInputStream(url)
-    val inString = in.map(IOUtils.toString(_, StandardCharsets.UTF_8))
+    val inString = in.map(Utils.toString)
     (code, inString, errString)
   }
 
@@ -766,7 +765,7 @@ object HistoryServerSuite {
     }
     val errString = try {
       val err = Option(connection.getErrorStream())
-      err.map(IOUtils.toString(_, StandardCharsets.UTF_8))
+      err.map(Utils.toString)
     } catch {
       case io: IOException => None
     }

--- a/core/src/test/scala/org/apache/spark/util/FileAppenderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/FileAppenderSuite.scala
@@ -26,7 +26,6 @@ import scala.collection.mutable.HashSet
 import scala.reflect._
 
 import com.google.common.io.Files
-import org.apache.commons.io.IOUtils
 import org.apache.logging.log4j._
 import org.apache.logging.log4j.core.{Appender, LogEvent, Logger}
 import org.mockito.ArgumentCaptor
@@ -388,7 +387,7 @@ class FileAppenderSuite extends SparkFunSuite with BeforeAndAfter {
       if (file.getName.endsWith(RollingFileAppender.GZIP_LOG_SUFFIX)) {
         val inputStream = new GZIPInputStream(new FileInputStream(file))
         try {
-          IOUtils.toString(inputStream, StandardCharsets.UTF_8)
+          Utils.toString(inputStream)
         } finally {
           Utils.closeQuietly(inputStream)
         }

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -556,4 +556,9 @@ This file is divided into 3 sections:
     <parameters><parameter name="regex">IOUtils\.copy\(</parameter></parameters>
     <customMessage>Use Java transferTo instead.</customMessage>
   </check>
+
+  <check customId="ioutilstostring" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">IOUtils\.toString\(</parameter></parameters>
+    <customMessage>Use toString of SparkStreamUtils or Utils instead.</customMessage>
+  </check>
 </scalastyle>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamMicroBatchStream.scala
@@ -21,8 +21,6 @@ import java.io._
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
 
-import org.apache.commons.io.IOUtils
-
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.sql.SparkSession
@@ -33,7 +31,7 @@ import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, Offset}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import org.apache.spark.util.{ManualClock, SystemClock}
+import org.apache.spark.util.{ManualClock, SystemClock, Utils}
 
 class RateStreamMicroBatchStream(
     rowsPerSecond: Long,
@@ -71,7 +69,7 @@ class RateStreamMicroBatchStream(
         }
 
         override def deserialize(in: InputStream): LongOffset = {
-          val content = IOUtils.toString(new InputStreamReader(in, StandardCharsets.UTF_8))
+          val content = Utils.toString(in)
           // HDFSMetadataLog guarantees that it never creates a partial file.
           assert(content.length != 0)
           if (content(0) == 'v') {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `toString` in `SparkStreamUtils` to simplify the existing usage and improve the performance.

**NEW**
```scala
+ def toString(in: InputStream): String = {
+   new String(in.readAllBytes(), StandardCharsets.UTF_8)
+ }
```

**REPLACEMENT**
```scala
- IOUtils.toString(new InputStreamReader(in, StandardCharsets.UTF_8))
+ Utils.toString(in)
```

### Why are the changes needed?

Since Java 9+, we can implement this method efficiently. Roughly, 2x faster.

```scala
scala> spark.time(new String(new java.io.FileInputStream("/tmp/1G.bin").readAllBytes(), java.nio.charset.StandardCharsets.UTF_8).length)
Time taken: 321 ms
val res0: Int = 1073741824

scala> spark.time(org.apache.commons.io.IOUtils.toString(new java.io.FileInputStream("/tmp/1G.bin")).length)
Time taken: 635 ms
val res1: Int = 1073741824
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.