### PR TITLE
[SPARK-53030][PYTHON] Support Arrow writer for streaming Python data sources

### DIFF
--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -300,7 +300,7 @@ class Filter(ABC):
 
     +---------------------+--------------------------------------------+
     | SQL filter          | Representation                             |
-    +---------------------+---------------------------------------------+
+    +---------------------+--------------------------------------------+
     | `a.b.c = 1`         | `EqualTo(("a", "b", "c"), 1)`              |
     | `a = 1`             | `EqualTo(("a",), 1)`                       |
     | `a = 'hi'`          | `EqualTo(("a",), "hi")`                    |
@@ -1103,8 +1103,9 @@ class DataSourceStreamArrowWriter(DataSourceStreamWriter):
     A base class for data stream writers that process data using PyArrow's `RecordBatch`.
 
     Unlike :class:`DataSourceStreamWriter`, which works with an iterator of Spark Rows, this class
-    is optimized for using the Arrow format when writing streaming data. It can offer better performance
-    when interfacing with systems or libraries that natively support Arrow for streaming use cases.
+    is optimized for using the Arrow format when writing streaming data. It can offer better
+    performance when interfacing with systems or libraries that natively support Arrow for
+    streaming use cases.
 
     .. versionadded: 4.1.0
     """
@@ -1115,13 +1116,13 @@ class DataSourceStreamArrowWriter(DataSourceStreamWriter):
         Writes an iterator of PyArrow `RecordBatch` objects to the streaming sink.
 
         This method is called on executors to write data to the streaming data sink in
-        each microbatch. It accepts an iterator of PyArrow `RecordBatch` objects and returns a single row
-        representing a commit message, or None if there is no commit message.
+        each microbatch. It accepts an iterator of PyArrow `RecordBatch` objects and
+        returns a single row representing a commit message, or None if there is no commit message.
 
         The driver collects commit messages, if any, from all executors and passes them
-        to the :class:`DataSourceStreamArrowWriter.commit` method if all tasks run successfully. If any
-        task fails, the :class:`DataSourceStreamArrowWriter.abort` method will be called with the
-        collected commit messages.
+        to the :class:`DataSourceStreamArrowWriter.commit` method if all tasks run
+        successfully. If any task fails, the :class:`DataSourceStreamArrowWriter.abort` method
+        will be called with the collected commit messages.
 
         Parameters
         ----------

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -399,8 +399,8 @@ class BasePythonStreamingDataSourceTestsMixin:
                 .start()
             )
 
-            while not query.recentProgress:
-                time.sleep(0.2)
+            # Wait a bit for data to be processed, then stop
+            time.sleep(6)  # Allow a few batches to run
             query.stop()
             query.awaitTermination()
 

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -399,8 +399,8 @@ class BasePythonStreamingDataSourceTestsMixin:
                 .start()
             )
 
-            # Wait a bit for data to be processed, then stop
-            time.sleep(6)  # Allow a few batches to run
+            while not query.recentProgress:
+                time.sleep(0.2)
             query.stop()
             query.awaitTermination()
 

--- a/python/pyspark/sql/worker/write_into_data_source.py
+++ b/python/pyspark/sql/worker/write_into_data_source.py
@@ -177,7 +177,7 @@ def main(infile: IO, outfile: IO) -> None:
 
         if is_streaming:
             # Instantiate the streaming data source writer.
-            writer = data_source.streamWriter(schema, overwrite)
+            writer = data_source.streamWriter(schema, overwrite)  # type: ignore[assignment]
             if not isinstance(writer, (DataSourceStreamWriter, DataSourceStreamArrowWriter)):
                 raise PySparkAssertionError(
                     errorClass="DATA_SOURCE_TYPE_MISMATCH",
@@ -222,7 +222,7 @@ def main(infile: IO, outfile: IO) -> None:
             if isinstance(writer, DataSourceArrowWriter):
                 res = writer.write(iterator)
             elif isinstance(writer, DataSourceStreamArrowWriter):
-                res = writer.write(iter(iterator))
+                res = writer.write(iterator)  # type: ignore[arg-type]
             else:
                 res = writer.write(batch_to_rows())
 

--- a/python/pyspark/sql/worker/write_into_data_source.py
+++ b/python/pyspark/sql/worker/write_into_data_source.py
@@ -222,7 +222,7 @@ def main(infile: IO, outfile: IO) -> None:
             if isinstance(writer, DataSourceArrowWriter):
                 res = writer.write(iterator)
             elif isinstance(writer, DataSourceStreamArrowWriter):
-                res = writer.write(iterator)
+                res = writer.write(iter(iterator))
             else:
                 res = writer.write(batch_to_rows())
 

--- a/python/pyspark/sql/worker/write_into_data_source.py
+++ b/python/pyspark/sql/worker/write_into_data_source.py
@@ -182,7 +182,8 @@ def main(infile: IO, outfile: IO) -> None:
                 raise PySparkAssertionError(
                     errorClass="DATA_SOURCE_TYPE_MISMATCH",
                     messageParameters={
-                        "expected": "an instance of DataSourceStreamWriter or DataSourceStreamArrowWriter",
+                        "expected": ("an instance of DataSourceStreamWriter or "
+                                     "DataSourceStreamArrowWriter"),
                         "actual": f"'{type(writer).__name__}'",
                     },
                 )

--- a/python/pyspark/sql/worker/write_into_data_source.py
+++ b/python/pyspark/sql/worker/write_into_data_source.py
@@ -182,8 +182,10 @@ def main(infile: IO, outfile: IO) -> None:
                 raise PySparkAssertionError(
                     errorClass="DATA_SOURCE_TYPE_MISMATCH",
                     messageParameters={
-                        "expected": ("an instance of DataSourceStreamWriter or "
-                                     "DataSourceStreamArrowWriter"),
+                        "expected": (
+                            "an instance of DataSourceStreamWriter or "
+                            "DataSourceStreamArrowWriter"
+                        ),
                         "actual": f"'{type(writer).__name__}'",
                     },
                 )

--- a/python/pyspark/sql/worker/write_into_data_source.py
+++ b/python/pyspark/sql/worker/write_into_data_source.py
@@ -177,7 +177,7 @@ def main(infile: IO, outfile: IO) -> None:
 
         if is_streaming:
             # Instantiate the streaming data source writer.
-            writer = data_source.streamWriter(schema, overwrite)  # type: ignore[assignment]
+            writer = data_source.streamWriter(schema, overwrite)
             if not isinstance(writer, (DataSourceStreamWriter, DataSourceStreamArrowWriter)):
                 raise PySparkAssertionError(
                     errorClass="DATA_SOURCE_TYPE_MISMATCH",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds a new streaming Python data source arrow writer to support directly writing data from arrow record batches.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To make it consistent with batch python arrow writer.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, this PR adds a new user-facing API: PythonArrowStreamWriter.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No