### PR TITLE
[SPARK-53051][CORE][TESTS] Ban `org.apache.hadoop.io.IOUtils`

### DIFF
--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -185,6 +185,7 @@
             <property name="illegalPkgs" value="org.apache.commons.lang" />
             <property name="illegalPkgs" value="org.apache.commons.lang3.tuple" />
             <property name="illegalClasses" value="org.apache.commons.lang3.JavaVersion" />
+            <property name="illegalClasses" value="org.apache.hadoop.io.IOUtils" />
             <property name="illegalClasses" value="com.google.common.base.Strings" />
         </module>
         <module name="RegexpSinglelineJava">

--- a/hadoop-cloud/src/test/scala/org/apache/spark/internal/io/cloud/CommitterBindingSuite.scala
+++ b/hadoop-cloud/src/test/scala/org/apache/spark/internal/io/cloud/CommitterBindingSuite.scala
@@ -21,7 +21,6 @@ import java.io.{File, FileInputStream, FileOutputStream, IOException, ObjectInpu
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{Path, StreamCapabilities}
-import org.apache.hadoop.io.IOUtils
 import org.apache.hadoop.mapreduce.{Job, JobStatus, MRJobConfig, TaskAttemptContext, TaskAttemptID}
 import org.apache.hadoop.mapreduce.lib.output.{BindingPathOutputCommitter, FileOutputFormat}
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
@@ -29,6 +28,7 @@ import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.io.{FileCommitProtocol, FileNameSpec}
 import org.apache.spark.internal.io.cloud.PathOutputCommitProtocol.{CAPABILITY_DYNAMIC_PARTITIONING, OUTPUTCOMMITTER_FACTORY_SCHEME}
+import org.apache.spark.network.util.JavaUtils
 
 class CommitterBindingSuite extends SparkFunSuite {
 
@@ -130,7 +130,8 @@ class CommitterBindingSuite extends SparkFunSuite {
       assert(committer.destPath === committer2.destPath,
         "destPath mismatch on round trip")
     } finally {
-      IOUtils.closeStreams(out, in)
+      JavaUtils.closeQuietly(out)
+      JavaUtils.closeQuietly(in)
       serData.delete()
     }
   }

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -542,6 +542,11 @@ This file is divided into 3 sections:
     <customMessage>Use Java built-in methods or SparkStringUtils instead</customMessage>
   </check>
 
+  <check customId="hadoopioutils" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.hadoop\.io\.IOUtils</parameter></parameters>
+    <customMessage>Use org.apache.spark.util.Utils instead.</customMessage>
+  </check>
+
   <check customId="defaultCharset" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">Charset\.defaultCharset</parameter></parameters>
     <customMessage>Use StandardCharsets.UTF_8 instead.</customMessage>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ban `org.apache.hadoop.io.IOUtils` in favor of Spark's built-in utility functions. In addition, new Scalastyle and Checkstyle rules are added.

### Why are the changes needed?

To simplify Spark code base.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.