### PR TITLE
[SPARK-53054][CONNECT][3.5] Fix the connect.DataFrameReader default format behavior

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -1326,7 +1326,7 @@ class ClientE2ETestSuite extends RemoteSparkSession with SQLHelper with PrivateM
     testAndVerify(result2)
   }
 
-  test("ES-1538905: DataFrameReader defaults to spark.sql.sources.default") {
+  test("SPARK-53054: DataFrameReader defaults to spark.sql.sources.default") {
     withTempPath { file =>
       val path = file.getAbsoluteFile.toURI.toString
       spark.range(100).write.parquet(file.toPath.toAbsolutePath.toString)

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -1325,6 +1325,18 @@ class ClientE2ETestSuite extends RemoteSparkSession with SQLHelper with PrivateM
       .dropDuplicatesWithinWatermark("newcol")
     testAndVerify(result2)
   }
+
+  test("ES-1538905: DataFrameReader defaults to spark.sql.sources.default") {
+    withTempPath { file =>
+      val path = file.getAbsoluteFile.toURI.toString
+      spark.range(100).write.parquet(file.toPath.toAbsolutePath.toString)
+
+      spark.conf.set("spark.sql.sources.default", "parquet")
+
+      val df = spark.read.load(path)
+      assert(df.count == 100)
+    }
+  }
 }
 
 private[sql] case class ClassData(a: String, b: Int)


### PR DESCRIPTION
### What changes were proposed in this pull request?
See title.


### Why are the changes needed?
Scala Spark Connect does not adhere to the [documented](https://spark.apache.org/docs/3.5.6/sql-data-sources-load-save-functions.html) behavior.


### Does this PR introduce _any_ user-facing change?
As documented in [Generic Load/Save Functions - Spark 3.5.6 Documentation](https://spark.apache.org/docs/3.5.6/sql-data-sources-load-save-functions.html), and similar to Spark Classic and the Python Spark Connect, Scala Spark Connect's `DataFrameReader` will now also default to the format set via the `spark.sql.sources.default` SQL configuration.

**Before**: `spark.read.load("..."`) throws

```
java.lang.IllegalArgumentException: The source format must be specified.
```
**Now**: `spark.read.load("...")` uses the format specified via `spark.sql.sources.default`


### How was this patch tested?
Test case added to ClientE2ETestSuite.


### Was this patch authored or co-authored using generative AI tooling?
No.