### PR TITLE
[SPARK-53055][PS][TESTS] Remove sort_values from pyspark.pandas.tests.indexes.test_insert

### DIFF
--- a/python/pyspark/pandas/tests/indexes/test_insert.py
+++ b/python/pyspark/pandas/tests/indexes/test_insert.py
@@ -27,14 +27,8 @@ class IndexesInsertMixin:
         # Integer
         pidx = pd.Index([1, 2, 3], name="Koalas")
         psidx = ps.from_pandas(pidx)
-        self.assert_eq(
-            pidx.insert(1, 100).sort_values(),
-            psidx.insert(1, 100).sort_values(),
-        )
-        self.assert_eq(
-            pidx.insert(-1, 100).sort_values(),
-            psidx.insert(-1, 100).sort_values(),
-        )
+        self.assert_eq(pidx.insert(1, 100), psidx.insert(1, 100))
+        self.assert_eq(pidx.insert(-1, 100), psidx.insert(-1, 100))
         err_msg = "index 100 is out of bounds for axis 0 with size 3"
         with self.assertRaisesRegex(IndexError, err_msg):
             psidx.insert(100, 100)
@@ -45,14 +39,8 @@ class IndexesInsertMixin:
         # Floating
         pidx = pd.Index([1.0, 2.0, 3.0], name="Koalas")
         psidx = ps.from_pandas(pidx)
-        self.assert_eq(
-            pidx.insert(1, 100.0).sort_values(),
-            psidx.insert(1, 100.0).sort_values(),
-        )
-        self.assert_eq(
-            pidx.insert(-1, 100.0).sort_values(),
-            psidx.insert(-1, 100.0).sort_values(),
-        )
+        self.assert_eq(pidx.insert(1, 100.0), psidx.insert(1, 100.0))
+        self.assert_eq(pidx.insert(-1, 100.0), psidx.insert(-1, 100.0))
         err_msg = "index 100 is out of bounds for axis 0 with size 3"
         with self.assertRaisesRegex(IndexError, err_msg):
             psidx.insert(100, 100)
@@ -63,14 +51,8 @@ class IndexesInsertMixin:
         # String
         pidx = pd.Index(["a", "b", "c"], name="Koalas")
         psidx = ps.from_pandas(pidx)
-        self.assert_eq(
-            pidx.insert(1, "x").sort_values(),
-            psidx.insert(1, "x").sort_values(),
-        )
-        self.assert_eq(
-            pidx.insert(-1, "x").sort_values(),
-            psidx.insert(-1, "x").sort_values(),
-        )
+        self.assert_eq(pidx.insert(1, "x"), psidx.insert(1, "x"))
+        self.assert_eq(pidx.insert(-1, "x"), psidx.insert(-1, "x"))
         err_msg = "index 100 is out of bounds for axis 0 with size 3"
         with self.assertRaisesRegex(IndexError, err_msg):
             psidx.insert(100, "x")
@@ -81,14 +63,8 @@ class IndexesInsertMixin:
         # Boolean
         pidx = pd.Index([True, False, True, False], name="Koalas")
         psidx = ps.from_pandas(pidx)
-        self.assert_eq(
-            pidx.insert(1, True).sort_values(),
-            psidx.insert(1, True).sort_values(),
-        )
-        self.assert_eq(
-            pidx.insert(-1, True).sort_values(),
-            psidx.insert(-1, True).sort_values(),
-        )
+        self.assert_eq(pidx.insert(1, True), psidx.insert(1, True))
+        self.assert_eq(pidx.insert(-1, True), psidx.insert(-1, True))
         err_msg = "index 100 is out of bounds for axis 0 with size 4"
         with self.assertRaisesRegex(IndexError, err_msg):
             psidx.insert(100, True)
@@ -101,14 +77,8 @@ class IndexesInsertMixin:
             [("a", "x"), ("b", "y"), ("c", "z")], names=["Hello", "Koalas"]
         )
         psmidx = ps.from_pandas(pmidx)
-        self.assert_eq(
-            pmidx.insert(2, ("h", "j")).sort_values(),
-            psmidx.insert(2, ("h", "j")).sort_values(),
-        )
-        self.assert_eq(
-            pmidx.insert(-1, ("h", "j")).sort_values(),
-            psmidx.insert(-1, ("h", "j")).sort_values(),
-        )
+        self.assert_eq(pmidx.insert(2, ("h", "j")), psmidx.insert(2, ("h", "j")))
+        self.assert_eq(pmidx.insert(-1, ("h", "j")), psmidx.insert(-1, ("h", "j")))
 
         err_msg = "index 4 is out of bounds for axis 0 with size 3"
         with self.assertRaisesRegex(IndexError, err_msg):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removes `sort_values` from `pyspark.pandas.tests.indexes.test_insert`.

### Why are the changes needed?

The tests shouldn't ignore the value order as where the value is inserted is important for the tests.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Updated the tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
