### PR TITLE
[SPARK-53054][CONNECT] Fix the connect.DataFrameReader default format behavior

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
@@ -1677,7 +1677,7 @@ class ClientE2ETestSuite
     checkAnswer(df, Row(LocalTime.of(12, 13, 14)))
   }
 
-  test("ES-1538905: DataFrameReader defaults to spark.sql.sources.default") {
+  test("SPARK-53054: DataFrameReader defaults to spark.sql.sources.default") {
     withTempPath { file =>
       val path = file.getAbsoluteFile.toURI.toString
       spark.range(100).write.parquet(file.toPath.toAbsolutePath.toString)

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
@@ -1676,6 +1676,18 @@ class ClientE2ETestSuite
 
     checkAnswer(df, Row(LocalTime.of(12, 13, 14)))
   }
+
+  test("ES-1538905: DataFrameReader defaults to spark.sql.sources.default") {
+    withTempPath { file =>
+      val path = file.getAbsoluteFile.toURI.toString
+      spark.range(100).write.parquet(file.toPath.toAbsolutePath.toString)
+
+      spark.conf.set("spark.sql.sources.default", "parquet")
+
+      val df = spark.read.load(path)
+      assert(df.count() == 100)
+    }
+  }
 }
 
 private[sql] case class ClassData(a: String, b: Int)

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/DataFrameReader.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/DataFrameReader.scala
@@ -79,8 +79,7 @@ class DataFrameReader private[sql] (sparkSession: SparkSession) extends sql.Data
   def load(paths: String*): DataFrame = {
     sparkSession.newDataFrame { builder =>
       val dataSourceBuilder = builder.getReadBuilder.getDataSourceBuilder
-      assertSourceFormatSpecified()
-      dataSourceBuilder.setFormat(source)
+      Option(source).foreach(dataSourceBuilder.setFormat)
       userSpecifiedSchema.foreach(schema => dataSourceBuilder.setSchema(schema.toDDL))
       extraOptions.foreach { case (k, v) =>
         dataSourceBuilder.putOptions(k, v)
@@ -210,12 +209,6 @@ class DataFrameReader private[sql] (sparkSession: SparkSession) extends sql.Data
   /** @inheritdoc */
   @scala.annotation.varargs
   override def textFile(paths: String*): Dataset[String] = super.textFile(paths: _*)
-
-  private def assertSourceFormatSpecified(): Unit = {
-    if (source == null) {
-      throw new IllegalArgumentException("The source format must be specified.")
-    }
-  }
 
   private def parse(ds: Dataset[String], format: ParseFormat): DataFrame = {
     sparkSession.newDataFrame { builder =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
See title.

### Why are the changes needed?
Scala Spark Connect does not adhere to the [documented](https://spark.apache.org/docs/3.5.6/sql-data-sources-load-save-functions.html) behavior.

### Does this PR introduce _any_ user-facing change?
As documented in [Generic Load/Save Functions - Spark 3.5.6 Documentation](https://spark.apache.org/docs/3.5.6/sql-data-sources-load-save-functions.html), and similar to Spark Classic and the Python Spark Connect, Scala Spark Connect's `DataFrameReader` will now also default to the format set via the `spark.sql.sources.default` SQL configuration.

**Before**: `spark.read.load("..."`) throws

```
java.lang.IllegalArgumentException: The source format must be specified.
```
**Now**: `spark.read.load("...")` uses the format specified via `spark.sql.sources.default`

### How was this patch tested?
Test case added to ClientE2ETestSuite.

### Was this patch authored or co-authored using generative AI tooling?
No.