### PR TITLE
[SPARK-53056][BUILD] Upgrade `objenesis` to 3.4

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -225,7 +225,7 @@ netty-transport-native-kqueue/4.1.123.Final/osx-aarch_64/netty-transport-native-
 netty-transport-native-kqueue/4.1.123.Final/osx-x86_64/netty-transport-native-kqueue-4.1.123.Final-osx-x86_64.jar
 netty-transport-native-unix-common/4.1.123.Final//netty-transport-native-unix-common-4.1.123.Final.jar
 netty-transport/4.1.123.Final//netty-transport-4.1.123.Final.jar
-objenesis/3.3//objenesis-3.3.jar
+objenesis/3.4//objenesis-3.4.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.17.6//okio-1.17.6.jar
 opencsv/2.3//opencsv-2.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -516,12 +516,12 @@
       </dependency>
       <!--
         SPARK-51806: Kryo 4.0.x depends on objenesis 2.5.1, while Spark currently
-        depends on objenesis 3.3. Here, it is uniformly defined as version 3.3.
+        depends on objenesis 3.4. Here, it is uniformly defined as version 3.4.
         -->
       <dependency>
         <groupId>org.objenesis</groupId>
         <artifactId>objenesis</artifactId>
-        <version>3.3</version>
+        <version>3.4</version>
       </dependency>
       <dependency>
         <groupId>com.github.jnr</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `objenesis` to 3.4.

### Why are the changes needed?

This is the first version which is tested with Java 21 and 22.

- https://github.com/easymock/objenesis/commit/b7ff694a57e2e5af4d8a461ff1d38db04654f826 (Java 21)
- https://github.com/easymock/objenesis/commit/5f6b7989bc81a196745ce7eb35e961ad994cf1cf (Java 22)

Here is the full release note.
- https://github.com/easymock/objenesis/releases/tag/3.4

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.