### PR TITLE
[SPARK-53058][SQL][DOCS] Clean up old comments related to HashClusteredDistribution

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -172,7 +172,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
    * guarantees that the outputs of these children will have same number of partitions, so that the
    * operator can safely zip partitions of these children's result RDDs. Some operators can leverage
    * this guarantee to satisfy some interesting requirement, e.g., non-broadcast joins can specify
-   * HashClusteredDistribution(a,b) for its left child, and specify HashClusteredDistribution(c,d)
+   * ClusteredDistribution(a,b) for its left child, and specify ClusteredDistribution(c,d)
    * for its right child, then it's guaranteed that left and right child are co-partitioned by
    * a,b/c,d, which means tuples of same value are in the partitions of same index, e.g.,
    * (a=1,b=2) and (c=1,d=2) are both in the second partition of left and right child.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
@@ -37,7 +37,7 @@ trait ShuffledJoin extends JoinCodegenSupport {
   override def requiredChildDistribution: Seq[Distribution] = {
     if (isSkewJoin) {
       // We re-arrange the shuffle partitions to deal with skew join, and the new children
-      // partitioning doesn't satisfy `HashClusteredDistribution`.
+      // partitioning doesn't satisfy `ClusteredDistribution`.
       UnspecifiedDistribution :: UnspecifiedDistribution :: Nil
     } else {
       ClusteredDistribution(leftKeys) :: ClusteredDistribution(rightKeys) :: Nil


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to clean up old comments related to `HashClusteredDistribution`.


### Why are the changes needed?
After https://github.com/apache/spark/commit/d8920ae13346670bac3f1a7e49dfc2ba85c93b03#diff-a9579f7eb596428f9d71e2c83ef0c393716ebc6aed5c907b33beab31665647aa, `HashClusteredDistribution` should not exists in the code comments.


### Does this PR introduce _any_ user-facing change?
'No'.
Just update comments.


### How was this patch tested?
NA


### Was this patch authored or co-authored using generative AI tooling?
'No'.
