### PR TITLE
[SPARK-53059][PYTHON] Arrow UDF no need to depend on pandas

### DIFF
--- a/python/pyspark/sql/pandas/functions.py
+++ b/python/pyspark/sql/pandas/functions.py
@@ -322,6 +322,8 @@ def arrow_udf(f=None, returnType=None, functionType=None):
     pyspark.sql.PandasCogroupedOps.applyInArrow
     pyspark.sql.UDFRegistration.register
     """
+    require_minimum_pyarrow_version()
+
     return vectorized_udf(f, returnType, functionType, "arrow")
 
 
@@ -658,6 +660,9 @@ def pandas_udf(f=None, returnType=None, functionType=None):
     # Note: Python 3.11.9, Pandas 2.2.3 and PyArrow 17.0.0 are used.
     # Note: Timezone is KST.
     # Note: 'X' means it throws an exception during the conversion.
+    require_minimum_pandas_version()
+    require_minimum_pyarrow_version()
+
     return vectorized_udf(f, returnType, functionType, "pandas")
 
 
@@ -667,9 +672,6 @@ def vectorized_udf(
     functionType=None,
     kind: str = "pandas",
 ):
-    require_minimum_pandas_version()
-    require_minimum_pyarrow_version()
-
     assert kind in ["pandas", "arrow"], "kind should be either 'pandas' or 'arrow'"
 
     # decorator @pandas_udf(returnType, functionType)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Arrow UDF no need to depend on pandas


### Why are the changes needed?
Arrow UDF doesn't have to `require_minimum_pandas_version`

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no