### PR TITLE
[SPARK-53060] Test to showcase Aggregate followed by ORDER BY doesn't preserve orders

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/HashAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/HashAggregationSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
+import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
+import org.apache.spark.sql.test.SharedSparkSession
+
+abstract class HashAggregationSuiteBase
+    extends QueryTest
+    with SharedSparkSession
+    with AdaptiveSparkPlanHelper {
+
+  private def checkNumAggs(df: DataFrame, hashAggCount: Int, sortAggCount: Int): Unit = {
+    val plan = df.queryExecution.executedPlan
+    assert(collectWithSubqueries(plan) {
+      case s @ (_: HashAggregateExec | _: ObjectHashAggregateExec) => s
+    }.length == hashAggCount)
+    assert(collectWithSubqueries(plan) { case s: SortAggregateExec => s }.length == sortAggCount)
+  }
+
+  private def checkAggs(
+      query: String,
+      enabledHashAggCount: Int,
+      enabledSortAggCount: Int): Unit = {
+    val df = sql(query)
+    checkNumAggs(df, enabledHashAggCount, enabledSortAggCount)
+  }
+
+  test("should use SortAgg to preserve order") {
+    withTempView("t") {
+      spark.range(100).selectExpr("id as key").createOrReplaceTempView("t")
+      Seq("FIRST", "LAST", "FIRST_VALUE", "LAST_VALUE").foreach { aggExpr =>
+        val query =
+          s"""
+             |SELECT $aggExpr(key)
+             |FROM
+             |(
+             |   SELECT key
+             |   FROM t
+             |   ORDER BY key
+             |)
+           """.stripMargin
+        checkAggs(query, 0, 2)
+      }
+    }
+  }
+}
+
+class HashAggregationSuite extends HashAggregationSuiteBase
+  with DisableAdaptiveExecutionSuite
+
+class HashAggregationSuiteAE extends HashAggregationSuiteBase
+  with EnableAdaptiveExecutionSuite


### PR DESCRIPTION
This is a demo of a potential Spark planner bug: it chooses HashAggregate over SortAggregate for a SQL query that requires ordering. I didn't find any official documentation that says "HashAggregate" is order-preserving, so Spark seems to choose a wrong plan (as shown below)

```
[info]   List(HashAggregate(keys=[], functions=[first(key#1L, false)], output=[first(key)#3L])
[info]   +- Exchange SinglePartition, ENSURE_REQUIREMENTS, [plan_id=33]
[info]      +- *(2) HashAggregate(keys=[], functions=[partial_first(key#1L, false)], output=[first#6L, valueSet#7])
[info]         +- *(2) Sort [key#1L ASC NULLS FIRST], true, 0
[info]            +- Exchange rangepartitioning(key#1L ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=28]
[info]               +- *(1) Project [id#0L AS key#1L]
[info]                  +- *(1) Range (0, 100, step=1, splits=2)
```

for a simple query

```sql
SELECT FIRST(val) FROM (SELECT val FROM t ORDER BY val)
```

or

```sql
SELECT FIRST_VALUE(val) FROM (SELECT val FROM t ORDER BY val)
```

NOTE: This PR does NOT contain a fix. I'd like to hear if Spark people think this is by design.