### PR TITLE
[SPARK-53062][CORE] Support `deleteQuietly` in `SparkFileUtils` and `JavaUtils`

### DIFF
--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java
@@ -28,7 +28,6 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Slf4jReporter;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +36,9 @@ import org.junit.jupiter.api.Test;
 // checkstyle.off: RegexpSinglelineJava
 import org.slf4j.LoggerFactory;
 // checkstyle.on: RegexpSinglelineJava
+
+import org.apache.spark.network.util.JavaUtils;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -79,7 +81,7 @@ public class LevelDBBenchmark {
       }
     }
     if (dbpath != null) {
-      FileUtils.deleteQuietly(dbpath);
+      JavaUtils.deleteQuietly(dbpath);
     }
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBIteratorSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBIteratorSuite.java
@@ -19,10 +19,10 @@ package org.apache.spark.util.kvstore;
 
 import java.io.File;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterAll;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.util.SparkSystemUtils$;
 
 public class LevelDBIteratorSuite extends DBIteratorSuite {
@@ -36,7 +36,7 @@ public class LevelDBIteratorSuite extends DBIteratorSuite {
       db.close();
     }
     if (dbpath != null) {
-      FileUtils.deleteQuietly(dbpath);
+      JavaUtils.deleteQuietly(dbpath);
     }
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -30,12 +30,12 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import com.google.common.collect.ImmutableSet;
-import org.apache.commons.io.FileUtils;
 import org.iq80.leveldb.DBIterator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.util.SparkSystemUtils$;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -52,7 +52,7 @@ public class LevelDBSuite {
       db.close();
     }
     if (dbpath != null) {
-      FileUtils.deleteQuietly(dbpath);
+      JavaUtils.deleteQuietly(dbpath);
     }
   }
 
@@ -306,7 +306,7 @@ public class LevelDBSuite {
     }
     dbForCloseTest.close();
     assertTrue(dbPathForCloseTest.exists());
-    FileUtils.deleteQuietly(dbPathForCloseTest);
+    JavaUtils.deleteQuietly(dbPathForCloseTest);
     assertTrue(!dbPathForCloseTest.exists());
   }
 
@@ -420,7 +420,7 @@ public class LevelDBSuite {
       assertTrue(resourceCleaner.isCompleted());
     } finally {
       dbForCleanerTest.close();
-      FileUtils.deleteQuietly(dbPathForCleanerTest);
+      JavaUtils.deleteQuietly(dbPathForCleanerTest);
     }
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBIteratorSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBIteratorSuite.java
@@ -19,8 +19,9 @@ package org.apache.spark.util.kvstore;
 
 import java.io.File;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterAll;
+
+import org.apache.spark.network.util.JavaUtils;
 
 public class RocksDBIteratorSuite extends DBIteratorSuite {
 
@@ -33,7 +34,7 @@ public class RocksDBIteratorSuite extends DBIteratorSuite {
       db.close();
     }
     if (dbpath != null) {
-      FileUtils.deleteQuietly(dbpath);
+      JavaUtils.deleteQuietly(dbpath);
     }
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
@@ -30,11 +30,12 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import com.google.common.collect.ImmutableSet;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.rocksdb.RocksIterator;
+
+import org.apache.spark.network.util.JavaUtils;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -49,7 +50,7 @@ public class RocksDBSuite {
       db.close();
     }
     if (dbpath != null) {
-      FileUtils.deleteQuietly(dbpath);
+      JavaUtils.deleteQuietly(dbpath);
     }
   }
 
@@ -302,7 +303,7 @@ public class RocksDBSuite {
     }
     dbForCloseTest.close();
     assertTrue(dbPathForCloseTest.exists());
-    FileUtils.deleteQuietly(dbPathForCloseTest);
+    JavaUtils.deleteQuietly(dbPathForCloseTest);
     assertTrue(!dbPathForCloseTest.exists());
   }
 
@@ -417,7 +418,7 @@ public class RocksDBSuite {
       assertTrue(resourceCleaner.isCompleted());
     } finally {
       dbForCleanerTest.close();
-      FileUtils.deleteQuietly(dbPathForCleanerTest);
+      JavaUtils.deleteQuietly(dbPathForCleanerTest);
     }
   }
 

--- a/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.apache.spark.internal.SparkLogger;
 import org.apache.spark.internal.SparkLoggerFactory;
@@ -60,6 +61,16 @@ public class JavaUtils {
       }
     } catch (IOException e) {
       logger.error("IOException should not have been thrown.", e);
+    }
+  }
+
+  /** Delete a file or directory and its contents recursively without throwing exceptions. */
+  public static void deleteQuietly(File file) {
+    if (file != null && file.exists()) {
+      Path path = file.toPath();
+      try (Stream<Path> walk = Files.walk(path)) {
+        walk.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+      } catch (Exception ignored) { /* No-op */ }
     }
   }
 

--- a/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
@@ -128,6 +128,11 @@ private[spark] trait SparkFileUtils extends Logging {
     JavaUtils.deleteRecursively(file)
   }
 
+  /** Delete a file or directory and its contents recursively without throwing exceptions. */
+  def deleteQuietly(file: File): Unit = {
+    JavaUtils.deleteQuietly(file)
+  }
+
   def getFile(names: String*): File = {
     require(names != null && names.forall(_ != null))
     names.tail.foldLeft(Path.of(names.head)) { (path, part) =>

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServerDiskManager.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServerDiskManager.scala
@@ -22,8 +22,6 @@ import java.util.concurrent.atomic.AtomicLong
 
 import scala.collection.mutable.{HashMap, ListBuffer}
 
-import org.apache.commons.io.FileUtils
-
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys._
@@ -76,7 +74,7 @@ private class HistoryServerDiskManager(
 
     // Clean up any temporary stores during start up. This assumes that they're leftover from other
     // instances and are not useful.
-    tmpStoreDir.listFiles().foreach(FileUtils.deleteQuietly)
+    tmpStoreDir.listFiles().foreach(Utils.deleteQuietly)
 
     // Go through the recorded store directories and remove any that may have been removed by
     // external code.

--- a/core/src/test/scala/org/apache/spark/deploy/history/HybridStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HybridStoreSuite.scala
@@ -21,7 +21,6 @@ import java.io.File
 import java.util.NoSuchElementException
 import java.util.concurrent.LinkedBlockingQueue
 
-import org.apache.commons.io.FileUtils
 import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.TimeLimits
 import org.scalatest.time.SpanSugar._
@@ -42,7 +41,7 @@ abstract class HybridStoreSuite extends SparkFunSuite with BeforeAndAfter with T
       db.close()
     }
     if (dbpath != null) {
-      FileUtils.deleteQuietly(dbpath)
+      Utils.deleteQuietly(dbpath)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -25,7 +25,6 @@ import java.util.HashMap
 import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import jnr.posix.{POSIX, POSIXFactory}
-import org.apache.commons.io.FileUtils
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.internal.config
@@ -116,14 +115,14 @@ class DiskBlockManagerSuite extends SparkFunSuite {
 
   test("Test dir creation with permission 770") {
     val testDir = new File("target/testDir");
-    FileUtils.deleteQuietly(testDir)
+    Utils.deleteQuietly(testDir)
     diskBlockManager = new DiskBlockManager(testConf, deleteFilesOnStop = true, isDriver = false)
     diskBlockManager.createDirWithPermission770(testDir)
     assert(testDir.exists && testDir.isDirectory)
     val permission = PosixFilePermissions.toString(
       Files.getPosixFilePermissions(Paths.get("target/testDir")))
     assert(permission.equals("rwxrwx---"))
-    FileUtils.deleteQuietly(testDir)
+    Utils.deleteQuietly(testDir)
   }
 
   test("Encode merged directory name and attemptId in shuffleManager field") {

--- a/core/src/test/scala/org/apache/spark/util/kvstore/RocksDBBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/util/kvstore/RocksDBBenchmark.scala
@@ -24,9 +24,8 @@ import scala.beans.BeanProperty
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
-import org.apache.commons.io.FileUtils
-
 import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
+import org.apache.spark.util.Utils
 
 
 /**
@@ -459,7 +458,7 @@ object RocksDBBenchmark extends BenchmarkBase {
       db = null
     }
     if (dbpath != null) {
-      FileUtils.deleteQuietly(dbpath)
+      Utils.deleteQuietly(dbpath)
       dbpath = null
     }
   }

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -208,6 +208,10 @@
             <property name="format" value="FileUtils\.deleteDirectory"/>
             <property name="message" value="Use deleteRecursively of SparkFileUtils or Utils instead." />
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="FileUtils\.deleteQuietly"/>
+            <property name="message" value="Use deleteQuietly of JavaUtils/SparkFileUtils/Utils instead." />
+        </module>
         <!-- support structured logging -->
         <module name="RegexpSinglelineJava">
             <property name="format" value="org\.slf4j\.(Logger|LoggerFactory)" />

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -287,6 +287,11 @@ This file is divided into 3 sections:
     <customMessage>Use deleteRecursively of SparkFileUtils or Utils</customMessage>
   </check>
 
+  <check customId="deleteQuietly" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">FileUtils\.deleteQuietly</parameter></parameters>
+    <customMessage>Use deleteQuietly of JavaUtils/SparkFileUtils/Utils</customMessage>
+  </check>
+
   <check customId="readFileToByteArray" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">FileUtils\.readFileToByteArray</parameter></parameters>
     <customMessage>Use java.nio.file.Files.readAllBytes</customMessage>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `deleteQuietly` in `SparkFileUtils` and `JavaUtils`.

### Why are the changes needed?

To provide a better implementation.

```scala
scala> spark.time(org.apache.commons.io.FileUtils.deleteQuietly(new java.io.File("/tmp/spark")))
Time taken: 1624 ms
val res0: Boolean = true
```

```scala
scala> spark.time(org.apache.spark.network.util.JavaUtils.deleteQuietly(new java.io.File("/tmp/spark")))
Time taken: 1184 ms
```

### Does this PR introduce _any_ user-facing change?

No user-facing behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.