### PR TITLE
[SPARK-52503][SQL][CONNECT][TESTS][FOLLOW-UP] Add more unit tests for `df.drop` on semantic equality

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/DataFrameSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/DataFrameSuite.scala
@@ -57,13 +57,13 @@ class DataFrameSuite extends QueryTest with RemoteSparkSession {
 
     val df3 = df2.select(col("*"), lit(1).as("v1"))
     assert(df3.drop(df3.col("id")).columns === Array("v0", "v1"))
-    // drop df2.col("id") from df2, which is semantically equal to df3.col("id")
+    // drop df2.col("id") from df3, which is semantically equal to df3.col("id")
     assert(df3.drop(df2.col("id")).columns === Array("v0", "v1"))
-    // drop df1.col("id") from df2, which is semantically equal to df3.col("id")
+    // drop df1.col("id") from df3, which is semantically equal to df3.col("id")
     assert(df3.drop(df1.col("id")).columns === Array("v0", "v1"))
 
     assert(df3.drop(df3.col("v0")).columns === Array("id", "v1"))
-    // drop df2.col("v0") from df2, which is semantically equal to df3.col("v0")
+    // drop df2.col("v0") from df3, which is semantically equal to df3.col("v0")
     assert(df3.drop(df2.col("v0")).columns === Array("id", "v1"))
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add more unit tests for `df.drop` on semantic equality

### Why are the changes needed?
to improve test coverage

### Does this PR introduce _any_ user-facing change?
No, test-only


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No
