### PR TITLE
[SPARK-51555][SQL][FOLLOWUP] Fix the error message for invalid unit in the time_diff() function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -719,7 +719,7 @@ object DateTimeUtils extends SparkDateTimeUtils {
   // Helper method to get the number of nanoseconds per the given time unit, used for calculating
   // the difference between two time values (timediff function). Supported units are: MICROSECOND,
   // MILLISECOND, SECOND, MINUTE, HOUR.
-  private def getNanosPerTimeUnit(unit: UTF8String): Long = {
+  private def getNanosPerTimeUnit(unit: UTF8String, functionName: String): Long = {
     val unitStr = unit.toString
     unitStr.toUpperCase(Locale.ROOT) match {
       case "MICROSECOND" =>
@@ -733,7 +733,7 @@ object DateTimeUtils extends SparkDateTimeUtils {
       case "HOUR" =>
         NANOS_PER_SECOND * SECONDS_PER_MINUTE * MINUTES_PER_HOUR
       case _ =>
-        throw QueryExecutionErrors.invalidTimeUnitError("timediff", unitStr)
+        throw QueryExecutionErrors.invalidTimeUnitError(functionName, unitStr)
     }
   }
 
@@ -750,7 +750,7 @@ object DateTimeUtils extends SparkDateTimeUtils {
    * @return The time span between two time values, in the units specified.
    */
   def timeDiff(unit: UTF8String, startNanos: Long, endNanos: Long): Long = {
-    (endNanos - startNanos) / getNanosPerTimeUnit(unit)
+    (endNanos - startNanos) / getNanosPerTimeUnit(unit, "time_diff")
   }
 
   /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -423,7 +423,7 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
         TimeDiff(Literal(unit), startTimeLit, endTimeLit),
         condition = "INVALID_PARAMETER_VALUE.TIME_UNIT",
         parameters = Map(
-          "functionName" -> "`timediff`",
+          "functionName" -> "`time_diff`",
           "parameter" -> "`unit`",
           "invalidValue" -> s"'$unit'"
         )

--- a/sql/core/src/test/resources/sql-tests/results/time.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/time.sql.out
@@ -1623,7 +1623,7 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INVALID_PARAMETER_VALUE.TIME_UNIT",
   "sqlState" : "22023",
   "messageParameters" : {
-    "functionName" : "`timediff`",
+    "functionName" : "`time_diff`",
     "invalidValue" : "''",
     "parameter" : "`unit`"
   }
@@ -1640,7 +1640,7 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INVALID_PARAMETER_VALUE.TIME_UNIT",
   "sqlState" : "22023",
   "messageParameters" : {
-    "functionName" : "`timediff`",
+    "functionName" : "`time_diff`",
     "invalidValue" : "' '",
     "parameter" : "`unit`"
   }
@@ -1657,7 +1657,7 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INVALID_PARAMETER_VALUE.TIME_UNIT",
   "sqlState" : "22023",
   "messageParameters" : {
-    "functionName" : "`timediff`",
+    "functionName" : "`time_diff`",
     "invalidValue" : "'MS'",
     "parameter" : "`unit`"
   }
@@ -1674,7 +1674,7 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INVALID_PARAMETER_VALUE.TIME_UNIT",
   "sqlState" : "22023",
   "messageParameters" : {
-    "functionName" : "`timediff`",
+    "functionName" : "`time_diff`",
     "invalidValue" : "'DAY'",
     "parameter" : "`unit`"
   }
@@ -1691,7 +1691,7 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INVALID_PARAMETER_VALUE.TIME_UNIT",
   "sqlState" : "22023",
   "messageParameters" : {
-    "functionName" : "`timediff`",
+    "functionName" : "`time_diff`",
     "invalidValue" : "'WEEK'",
     "parameter" : "`unit`"
   }
@@ -1708,7 +1708,7 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INVALID_PARAMETER_VALUE.TIME_UNIT",
   "sqlState" : "22023",
   "messageParameters" : {
-    "functionName" : "`timediff`",
+    "functionName" : "`time_diff`",
     "invalidValue" : "'ABCD'",
     "parameter" : "`unit`"
   }
@@ -1725,7 +1725,7 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INVALID_PARAMETER_VALUE.TIME_UNIT",
   "sqlState" : "22023",
   "messageParameters" : {
-    "functionName" : "`timediff`",
+    "functionName" : "`time_diff`",
     "invalidValue" : "'QUARTER'",
     "parameter" : "`unit`"
   }
@@ -1742,7 +1742,7 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INVALID_PARAMETER_VALUE.TIME_UNIT",
   "sqlState" : "22023",
   "messageParameters" : {
-    "functionName" : "`timediff`",
+    "functionName" : "`time_diff`",
     "invalidValue" : "'INVALID'",
     "parameter" : "`unit`"
   }
@@ -1759,7 +1759,7 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INVALID_PARAMETER_VALUE.TIME_UNIT",
   "sqlState" : "22023",
   "messageParameters" : {
-    "functionName" : "`timediff`",
+    "functionName" : "`time_diff`",
     "invalidValue" : "'INVALID_UNIT'",
     "parameter" : "`unit`"
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Following up on the original PR that introduces the `time_diff` function (https://github.com/apache/spark/pull/51715), this PR fixes the error message to include the correct SQL function name.

### Why are the changes needed?
Fix error messages for the `time_diff` function.


### Does this PR introduce _any_ user-facing change?
Changes the error message for the new SQL function.


### How was this patch tested?
Updated relevant scala tests and golden files.


### Was this patch authored or co-authored using generative AI tooling?
No.
