### PR TITLE
[SPARK-53067][BUILD] Increase GCLockerRetryAllocationCount for SBT

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,4 @@
+-XX:+IgnoreUnrecognizedVMOptions
+-XX:+UnlockDiagnosticVMOptions
+-XX:GCLockerRetryAllocationCount=100
 --enable-native-access=ALL-UNNAMED

--- a/build/sbt
+++ b/build/sbt
@@ -36,7 +36,7 @@ fi
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
 declare -r sbt_opts_file=".sbtopts"
 declare -r etc_sbt_opts_file="/etc/sbt/sbtopts"
-declare -r default_sbt_opts="-Xss64m"
+declare -r default_sbt_opts="-Xss64m -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:GCLockerRetryAllocationCount=100"
 
 usage() {
  cat <<EOM


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add `-XX:GCLockerRetryAllocationCount=100` to default SBT opts.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
I frequently see SBT OOM in GHA during the compilation phase, for example, https://github.com/pan3793/spark/actions/runs/16675016817/job/47203747786
```
Warning: [733.825s][warning][gc,alloc] pool-6-thread-491: Retried waiting for GCLocker too often allocating 104623 words
Warning: [734.881s][warning][gc,alloc] pool-6-thread-493: Retried waiting for GCLocker too often allocating 27154 words
Warning: [734.882s][warning][gc,alloc] pool-6-thread-494: Retried waiting for GCLocker too often allocating 27847 words
Warning: [734.943s][warning][gc,alloc] pool-6-thread-481: Retried waiting for GCLocker too often allocating 52200 words
Warning: [734.944s][warning][gc,alloc] pool-6-thread-495: Retried waiting for GCLocker too often allocating 29120 words
Warning: [734.979s][warning][gc,alloc] pool-6-thread-493: Retried waiting for GCLocker too often allocating 3 words
[error] ## Exception when compiling 42 sources to /__w/spark/spark/sql/connect/server/target/scala-2.13/test-classes
[error] java.lang.OutOfMemoryError: Java heap space
[error] java.base/java.lang.StringLatin1.newString(StringLatin1.java:769)
[error] java.base/java.lang.String.substring(String.java:2714)
[error] java.base/java.lang.String.substring(String.java:2682)
[error] java.base/java.io.File.getName(File.java:458)
[error] scala.tools.nsc.classpath.FileUtils$FileOps$.isClass$extension(FileUtils.scala:43)
...
```

The `Retried waiting for GCLocker too often allocating N words` **might**(I'm not sure) be related to [JDK-8192647](https://bugs.openjdk.org/browse/JDK-8192647), and this [article](https://tech.clevertap.com/demystifying-g1-gc-gclocker-jni-critical-and-fake-oom-exceptions/) explains how it works.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unfortunately, I'm not able to reproduce the issue locally, so it must be verified by monitoring CI stability after merging.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.