### PR TITLE
[SPARK-53070][CORE] Support `is(Not)?Empty` in `SparkCollectionUtils`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkCollectionUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkCollectionUtils.scala
@@ -32,6 +32,12 @@ private[spark] trait SparkCollectionUtils {
     }
     builder.result()
   }
+
+  def isEmpty[K, V](map: java.util.Map[K, V]): Boolean = {
+    map == null || map.isEmpty()
+  }
+
+  def isNotEmpty[K, V](map: java.util.Map[K, V]): Boolean = !isEmpty(map)
 }
 
 private[spark] object SparkCollectionUtils extends SparkCollectionUtils

--- a/core/src/main/scala/org/apache/spark/status/protobuf/StageDataWrapperSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/StageDataWrapperSerializer.scala
@@ -21,12 +21,11 @@ import java.util.Date
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.commons.collections4.MapUtils
-
 import org.apache.spark.status.StageDataWrapper
 import org.apache.spark.status.api.v1.{ExecutorMetricsDistributions, ExecutorPeakMetricsDistributions, InputMetricDistributions, InputMetrics, OutputMetricDistributions, OutputMetrics, ShufflePushReadMetricDistributions, ShufflePushReadMetrics, ShuffleReadMetricDistributions, ShuffleReadMetrics, ShuffleWriteMetricDistributions, ShuffleWriteMetrics, SpeculationStageSummary, StageData, TaskData, TaskMetricDistributions, TaskMetrics}
 import org.apache.spark.status.protobuf.Utils._
 import org.apache.spark.util.Utils.weakIntern
+import org.apache.spark.util.collection.Utils.isNotEmpty
 
 private[protobuf] class StageDataWrapperSerializer extends ProtobufSerDe[StageDataWrapper] {
 
@@ -397,11 +396,11 @@ private[protobuf] class StageDataWrapperSerializer extends ProtobufSerDe[StageDa
     val failureReason = getOptional(binary.hasFailureReason, binary.getFailureReason)
     val description = getOptional(binary.hasDescription, binary.getDescription)
     val accumulatorUpdates = AccumulableInfoSerializer.deserialize(binary.getAccumulatorUpdatesList)
-    val tasks = if (MapUtils.isNotEmpty(binary.getTasksMap)) {
+    val tasks = if (isNotEmpty(binary.getTasksMap)) {
       Some(binary.getTasksMap.asScala.map(
         entry => (entry._1.toLong, deserializeTaskData(entry._2))).toMap)
     } else None
-    val executorSummary = if (MapUtils.isNotEmpty(binary.getExecutorSummaryMap)) {
+    val executorSummary = if (isNotEmpty(binary.getExecutorSummaryMap)) {
       Some(binary.getExecutorSummaryMap.asScala.toMap
         .transform((_, v) => ExecutorStageSummarySerializer.deserialize(v)))
     } else None

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -586,4 +586,9 @@ This file is divided into 3 sections:
     <parameters><parameter name="regex">IOUtils\.toString\(</parameter></parameters>
     <customMessage>Use toString of SparkStreamUtils or Utils instead.</customMessage>
   </check>
+
+  <check customId="ioutilstostring" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.collections4\.MapUtils</parameter></parameters>
+    <customMessage>Use org.apache.spark.util.collection.Utils instead.</customMessage>
+  </check>
 </scalastyle>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -587,7 +587,7 @@ This file is divided into 3 sections:
     <customMessage>Use toString of SparkStreamUtils or Utils instead.</customMessage>
   </check>
 
-  <check customId="ioutilstostring" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+  <check customId="maputils" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">org\.apache\.commons\.collections4\.MapUtils</parameter></parameters>
     <customMessage>Use org.apache.spark.util.collection.Utils instead.</customMessage>
   </check>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `isEmpty` and `isNotEmpty` in `SparkCollectionUtils`.

In addition, a new Scalastyle is added to ban `org.apache.commons.collections4.MapUtils`.

### Why are the changes needed?

To improve Spark's collection utility.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.