### PR TITLE
[SPARK-53071][CORE][SQL][CONNECT] Support `copyFile` in `SparkFileUtils`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
@@ -156,6 +156,13 @@ private[spark] trait SparkFileUtils extends Logging {
     val newFile = new File(dir, file.getName())
     Files.copy(file.toPath(), newFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
   }
+
+  def copyFile(src: File, dst: File): Unit = {
+    if (src == null || dst == null || !src.exists() || (dst.exists() && dst.isDirectory())) {
+      throw new IllegalArgumentException(s"Invalid input file $src or directory $dst")
+    }
+    Files.copy(src.toPath(), dst.toPath(), StandardCopyOption.REPLACE_EXISTING)
+  }
 }
 
 private[spark] object SparkFileUtils extends SparkFileUtils

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -302,8 +302,13 @@ This file is divided into 3 sections:
     <customMessage>Use sizeOf of JavaUtils or Utils instead.</customMessage>
   </check>
 
+  <check customId="copyFile" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex"> FileUtils\.copyFile\(</parameter></parameters>
+    <customMessage>Use copyFile of SparkFileUtils or Utils instead.</customMessage>
+  </check>
+
   <check customId="copyFileToDirectory" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
-    <parameters><parameter name="regex">FileUtils\.copyFileToDirectory</parameter></parameters>
+    <parameters><parameter name="regex"> FileUtils\.copyFileToDirectory</parameter></parameters>
     <customMessage>Use copyFileToDirectory of SparkFileUtils or Utils instead.</customMessage>
   </check>
 

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/ClassFinderSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/ClassFinderSuite.scala
@@ -50,7 +50,7 @@ class ClassFinderSuite extends ConnectFunSuite {
     val subDir = SparkFileUtils.createTempDir(copyDir.toAbsolutePath.toString)
     val classToCopy = copyDir.resolve("Hello.class")
     val copyLocation = subDir.toPath.resolve("HelloDup.class")
-    FileUtils.copyFile(classToCopy.toFile, copyLocation.toFile)
+    SparkFileUtils.copyFile(classToCopy.toFile, copyLocation.toFile)
 
     checkClasses(monitor, Seq(s"${subDir.getName}/HelloDup.class"))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetInteroperabilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetInteroperabilitySuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.execution.datasources.parquet
 import java.io.File
 import java.time.ZoneOffset
 
-import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.{Path, PathFilter}
 import org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
@@ -30,6 +29,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{ArrayType, IntegerType, StructField, StructType}
+import org.apache.spark.util.Utils
 
 class ParquetInteroperabilitySuite extends ParquetCompatibilityTest with SharedSparkSession {
   test("parquet files with different physical schemas but share the same logical schema") {
@@ -177,7 +177,7 @@ class ParquetInteroperabilitySuite extends ParquetCompatibilityTest with SharedS
       // match the column names of the file from impala
       val df = spark.createDataset(ts).toDF().repartition(1).withColumnRenamed("value", "ts")
       df.write.parquet(tableDir.getAbsolutePath)
-      FileUtils.copyFile(new File(impalaPath), new File(tableDir, "part-00001.parq"))
+      Utils.copyFile(new File(impalaPath), new File(tableDir, "part-00001.parq"))
 
       Seq(false, true).foreach { int96TimestampConversion =>
         withAllParquetReaders {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `copyFile` in `SparkFileUtils`.

In addition, a new Scalastyle rule to ban `FileUtils.copyFile` is added.

### Why are the changes needed?

To improve Spark's file utility functions.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.