### PR TITLE
[SPARK-53072][TESTS] Only run Lock Hardening tests in RocksDBStateStoreLockHardeningSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreLockHardeningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreLockHardeningSuite.scala
@@ -17,16 +17,26 @@
 
 package org.apache.spark.sql.execution.streaming.state
 
+import java.util.UUID
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Random, Success}
 
+import org.apache.hadoop.conf.Configuration
 import org.scalactic.source.Position
-import org.scalatest.Tag
+import org.scalatest.{BeforeAndAfter, PrivateMethodTester, Tag}
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.SpanSugar._
 
-import org.apache.spark.{SparkException, SparkRuntimeException, TaskContext}
+import org.apache.spark.{SparkException, SparkFunSuite, SparkRuntimeException, TaskContext}
+import org.apache.spark.TaskContext.withTaskContext
+import org.apache.spark.sql.catalyst.plans.PlanTestBase
+import org.apache.spark.sql.execution.streaming.{StatefulOperatorStateInfo, StreamExecution}
 import org.apache.spark.sql.execution.streaming.state.StateStoreTestsHelper._
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.ThreadUtils
 import org.apache.spark.util.ThreadUtils.awaitResult
 
@@ -34,7 +44,101 @@ import org.apache.spark.util.ThreadUtils.awaitResult
  * Comprehensive test cases for RocksDB State Store lock hardening implementation.
  * These tests verify the state machine behavior and prevent problematic concurrent executions.
  */
-class RocksDBStateStoreLockHardeningSuite extends RocksDBStateStoreSuite {
+class RocksDBStateStoreLockHardeningSuite extends SparkFunSuite
+    with PlanTestBase
+    with AlsoTestWithRocksDBFeatures
+    with PrivateMethodTester
+    with SharedSparkSession
+    with BeforeAndAfter
+    with Matchers {
+
+  before {
+    StateStore.stop()
+    require(!StateStore.isMaintenanceRunning)
+    spark.streams.stateStoreCoordinator // initialize the lazy coordinator
+  }
+
+  after {
+    StateStore.stop()
+    require(!StateStore.isMaintenanceRunning)
+  }
+
+  protected def tryWithProviderResource[T](
+      provider: RocksDBStateStoreProvider)(f: RocksDBStateStoreProvider => T): T = {
+    try {
+      f(provider)
+    } finally {
+      provider.close()
+    }
+  }
+
+  def newStoreProvider(): RocksDBStateStoreProvider = {
+    newStoreProvider(StateStoreId(newDir(), Random.nextInt(), 0))
+  }
+
+  def newStoreProvider(storeId: StateStoreId): RocksDBStateStoreProvider = {
+    newStoreProvider(storeId, NoPrefixKeyStateEncoderSpec(keySchema))
+  }
+
+  def newStoreProvider(storeId: StateStoreId, useColumnFamilies: Boolean):
+  RocksDBStateStoreProvider = {
+    newStoreProvider(storeId, NoPrefixKeyStateEncoderSpec(keySchema),
+      useColumnFamilies = useColumnFamilies)
+  }
+
+  def newStoreProvider(useColumnFamilies: Boolean): RocksDBStateStoreProvider = {
+    newStoreProvider(StateStoreId(newDir(), Random.nextInt(), 0),
+      NoPrefixKeyStateEncoderSpec(keySchema),
+      useColumnFamilies = useColumnFamilies)
+  }
+
+  def newStoreProvider(
+      useColumnFamilies: Boolean,
+      useMultipleValuesPerKey: Boolean): RocksDBStateStoreProvider = {
+    newStoreProvider(StateStoreId(newDir(), Random.nextInt(), 0),
+      NoPrefixKeyStateEncoderSpec(keySchema),
+      useColumnFamilies = useColumnFamilies,
+      useMultipleValuesPerKey = useMultipleValuesPerKey
+    )
+  }
+
+  def newStoreProvider(storeId: StateStoreId, conf: Configuration): RocksDBStateStoreProvider = {
+    newStoreProvider(storeId, NoPrefixKeyStateEncoderSpec(keySchema), conf = conf)
+  }
+
+  def newStoreProvider(
+      keySchema: StructType,
+      keyStateEncoderSpec: KeyStateEncoderSpec,
+      useColumnFamilies: Boolean): RocksDBStateStoreProvider = {
+    newStoreProvider(StateStoreId(newDir(), Random.nextInt(), 0),
+      keyStateEncoderSpec = keyStateEncoderSpec,
+      keySchema = keySchema,
+      useColumnFamilies = useColumnFamilies)
+  }
+
+  def newStoreProvider(
+      storeId: StateStoreId,
+      keyStateEncoderSpec: KeyStateEncoderSpec,
+      keySchema: StructType = keySchema,
+      sqlConf: Option[SQLConf] = None,
+      conf: Configuration = new Configuration,
+      useColumnFamilies: Boolean = false,
+      useMultipleValuesPerKey: Boolean = false): RocksDBStateStoreProvider = {
+    val provider = new RocksDBStateStoreProvider()
+    val testStateSchemaProvider = new TestStateSchemaProvider
+    conf.set(StreamExecution.RUN_ID_KEY, UUID.randomUUID().toString)
+    provider.init(
+      storeId,
+      keySchema,
+      valueSchema,
+      keyStateEncoderSpec,
+      useColumnFamilies,
+      new StateStoreConf(sqlConf.getOrElse(SQLConf.get)),
+      conf,
+      useMultipleValuesPerKey,
+      stateSchemaProvider = Some(testStateSchemaProvider))
+    provider
+  }
 
   override protected def test(testName: String, testTags: Tag*)(testBody: => Any)
                              (implicit pos: Position): Unit = {
@@ -518,7 +622,7 @@ class RocksDBStateStoreLockHardeningSuite extends RocksDBStateStoreSuite {
   }
 
   // Helper method to assert current thread has ownership
-  override def assertAcquiredThreadIsCurrentThread(provider: RocksDBStateStoreProvider): Unit = {
+  def assertAcquiredThreadIsCurrentThread(provider: RocksDBStateStoreProvider): Unit = {
     val stateMachine = PrivateMethod[Any](Symbol("stateMachine"))
     val stateMachineObj = provider invokePrivate stateMachine()
     val threadInfo = stateMachineObj.asInstanceOf[RocksDBStateMachine].getAcquiredThreadInfo

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreLockHardeningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreLockHardeningSuite.scala
@@ -21,7 +21,7 @@ import java.util.UUID
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Random, Success}
+import scala.util.Random
 
 import org.apache.hadoop.conf.Configuration
 import org.scalactic.source.Position
@@ -30,9 +30,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.{SparkException, SparkFunSuite, SparkRuntimeException, TaskContext}
-import org.apache.spark.TaskContext.withTaskContext
 import org.apache.spark.sql.catalyst.plans.PlanTestBase
-import org.apache.spark.sql.execution.streaming.{StatefulOperatorStateInfo, StreamExecution}
+import org.apache.spark.sql.execution.streaming.StreamExecution
 import org.apache.spark.sql.execution.streaming.state.StateStoreTestsHelper._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Adding all the necessary methods that we would usually get from RocksDBStateStoreSuite to the Lock Hardening Suite so we no longer have to extend it.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, we run all RocksDBStateStoreSuite tests in the Lock Hardening Suite since we extend from that suite, increasing the runtime of the CI. This is undesirable and can significantly increase job runtime.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
It is only a test refactor, as long as the test passes, this is successful.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No