### PR TITLE
[SPARK-53075][CORE][TESTS] Use Java `Files.readAllLines/write` instead of `FileUtils.(read|write)Lines`

### DIFF
--- a/common/utils/pom.xml
+++ b/common/utils/pom.xml
@@ -52,11 +52,6 @@
       <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.ivy</groupId>
       <artifactId>ivy</artifactId>
     </dependency>

--- a/common/utils/src/test/scala/org/apache/spark/util/LogKeySuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/LogKeySuite.scala
@@ -17,14 +17,12 @@
 
 package org.apache.spark.util
 
-import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 import java.util.{ArrayList => JList}
 
 import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.universe._
 
-import org.apache.commons.io.FileUtils
 import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
 
 import org.apache.spark.internal.{Logging, LogKeys}
@@ -61,9 +59,8 @@ class LogKeySuite
   private def regenerateLogKeyFile(
       originalKeys: Seq[String], sortedKeys: Seq[String]): Unit = {
     if (originalKeys != sortedKeys) {
-      val logKeyFile = logKeyFilePath.toFile
-      logInfo(s"Regenerating the file $logKeyFile")
-      val originalContents = FileUtils.readLines(logKeyFile, StandardCharsets.UTF_8)
+      logInfo(s"Regenerating the file $logKeyFilePath")
+      val originalContents = Files.readAllLines(logKeyFilePath)
       val sortedContents = new JList[String]()
       var firstMatch = false
       originalContents.asScala.foreach { line =>
@@ -78,8 +75,8 @@ class LogKeySuite
           sortedContents.add(line)
         }
       }
-      Files.delete(logKeyFile.toPath)
-      FileUtils.writeLines(logKeyFile, StandardCharsets.UTF_8.name(), sortedContents)
+      Files.delete(logKeyFilePath)
+      Files.write(logKeyFilePath, sortedContents)
     }
   }
 

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -282,6 +282,16 @@ This file is divided into 3 sections:
       scala.jdk.CollectionConverters._ and use .asScala / .asJava methods</customMessage>
   </check>
 
+  <check customId="readLines" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">FileUtils\.readLines</parameter></parameters>
+    <customMessage>Use Files.readAllLines instead.</customMessage>
+  </check>
+
+  <check customId="writeLines" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">FileUtils\.writeLines</parameter></parameters>
+    <customMessage>Use Files.write instead.</customMessage>
+  </check>
+
   <check customId="deleteRecursively" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">FileUtils\.deleteDirectory</parameter></parameters>
     <customMessage>Use deleteRecursively of SparkFileUtils or Utils</customMessage>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java `Files.readAllLines/write` instead of `FileUtils.(read|write)Lines`.

In addition,
- `commons-io` test dependency is removed from `commons-utils` module
- Two Scalastyle rules are added to prevent a future regression.

### Why are the changes needed?

Java implementations are faster.

**SAMPLE DATA**

```scala
scala> val array = new java.util.ArrayList[String]()
val array: java.util.ArrayList[String] = []

scala> (1 to 100_000_000).foreach { _ => array.add("a") }
```

**BEFORE (WRITE)**

```scala
scala> spark.time(org.apache.commons.io.FileUtils.writeLines(new java.io.File("/tmp/text"), array))
Time taken: 5013 ms
```

**AFTER (WRITE)**

```scala
scala> spark.time(java.nio.file.Files.write(java.nio.file.Paths.get("/tmp/text"), array))
Time taken: 1191 ms
```

**BEFORE(READ)**

```scala
scala> spark.time(org.apache.commons.io.FileUtils.readLines(new java.io.File("/tmp/text")))
Time taken: 2377 ms
```

**AFTER(READ)**

```scala
scala> spark.time(java.nio.file.Files.readAllLines(java.nio.file.Paths.get("/tmp/text")))
Time taken: 2279 ms
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.