### PR TITLE
[SPARK-53078][CORE][TESTS] Remove `commons-(io|lang3)` test dependencies from `kvstore`

### DIFF
--- a/common/kvstore/pom.xml
+++ b/common/kvstore/pom.xml
@@ -72,17 +72,6 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `commons-io` and `commons-lang3` test dependencies from `kvstore` module.

### Why are the changes needed?

These test dependencies are unused as of now since the following changes.
- SPARK-52859 removes `commons-lang3` usage.
- SPARK-53062 removes `commons-io` usage.

### Does this PR introduce _any_ user-facing change?

No, this is a test change.

### How was this patch tested?

Pass the CIs.

**BEFORE**

```
$ mvn dependency:tree --pl common/kvstore --am | grep commons
[INFO] |     |     \- org.apache.commons:commons-exec:jar:1.4.0:test
[INFO] |  |  +- org.junit.platform:junit-platform-commons:jar:1.13.1:test
[INFO] |     |     \- org.apache.commons:commons-exec:jar:1.4.0:test
[INFO] |  |  +- org.junit.platform:junit-platform-commons:jar:1.13.1:test
[INFO] |     |     \- org.apache.commons:commons-exec:jar:1.4.0:test
[INFO] |  |  +- org.junit.platform:junit-platform-commons:jar:1.13.1:test
[INFO] +- commons-io:commons-io:jar:2.20.0:test
[INFO] +- org.apache.commons:commons-lang3:jar:3.18.0:test
[INFO] |     |     \- org.apache.commons:commons-exec:jar:1.4.0:test
[INFO] |  |  +- org.junit.platform:junit-platform-commons:jar:1.13.1:test
```

**AFTER**

```
$ mvn dependency:tree --pl common/kvstore --am | grep commons
[INFO] |     |     \- org.apache.commons:commons-exec:jar:1.4.0:test
[INFO] |  |  +- org.junit.platform:junit-platform-commons:jar:1.13.1:test
[INFO] |     |     \- org.apache.commons:commons-exec:jar:1.4.0:test
[INFO] |  |  +- org.junit.platform:junit-platform-commons:jar:1.13.1:test
[INFO] |     |     \- org.apache.commons:commons-exec:jar:1.4.0:test
[INFO] |  |  +- org.junit.platform:junit-platform-commons:jar:1.13.1:test
[INFO] |     |     \- org.apache.commons:commons-exec:jar:1.4.0:test
[INFO] |  |  +- org.junit.platform:junit-platform-commons:jar:1.13.1:test
```

### Was this patch authored or co-authored using generative AI tooling?

No.