### PR TITLE
[SPARK-53079][K8S][DOCS] Update `YuniKorn` docs with `1.7.0`

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1991,10 +1991,10 @@ Install Apache YuniKorn:
 ```bash
 helm repo add yunikorn https://apache.github.io/yunikorn-release
 helm repo update
-helm install yunikorn yunikorn/yunikorn --namespace yunikorn --version 1.6.3 --create-namespace --set embedAdmissionController=false
+helm install yunikorn yunikorn/yunikorn --namespace yunikorn --version 1.7.0 --create-namespace --set embedAdmissionController=false
 ```
 
-The above steps will install YuniKorn v1.6.3 on an existing Kubernetes cluster.
+The above steps will install YuniKorn v1.7.0 on an existing Kubernetes cluster.
 
 ##### Get started
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to recommend `YuniKorn` v1.7.0 for Apache Spark 4.1.0 documentation.

### Why are the changes needed?

Apache YuniKorn v1.7.0 is a new feature release with 169 patches.
- https://issues.apache.org/jira/projects/YUNIKORN/versions/12354201

I installed YuniKorn v1.7.0 on K8s 1.32 and tested manually.

**K8s v1.32**

```
$ kubectl version
Client Version: v1.33.3
Kustomize Version: v5.6.0
Server Version: v1.32.2
```

**YuniKorn v1.7.0**
```
$ helm list -n yunikorn
NAME    	NAMESPACE	REVISION	UPDATED                             	STATUS  	CHART         	APP VERSION
yunikorn	yunikorn 	1       	2025-08-02 14:01:37.266418 -0700 PDT	deployed	yunikorn-1.7.0
```

```
$ build/sbt -Pkubernetes -Pkubernetes-integration-tests -Dspark.kubernetes.test.deployMode=docker-desktop "kubernetes-integration-tests/testOnly *.YuniKornSuite" -Dtest.exclude.tags=minikube,local,decom,r -Dtest.default.exclude.tags=
...
[info] YuniKornSuite:
[info] - SPARK-42190: Run SparkPi with local[*] (7 seconds, 20 milliseconds)
[info] - Run SparkPi with no resources (9 seconds, 991 milliseconds)
[info] - Run SparkPi with no resources & statefulset allocation (10 seconds, 178 milliseconds)
[info] - Run SparkPi with a very long application name. (10 seconds, 38 milliseconds)
[info] - Use SparkLauncher.NO_RESOURCE (9 seconds, 941 milliseconds)
...
[info] All tests passed.
[success] Total time: 432 s (07:12), completed Aug 2, 2025, 2:20:12 PM
```

```
Normal  Scheduling         2s    yunikorn  spark-*-driver is queued and waiting for allocation
Normal  Scheduled          2s    yunikorn  Successfully assigned spark-*-driver to node docker-desktop
Normal  PodBindSuccessful  2s    yunikorn  Pod spark-*-driver is successfully bound to node docker-desktop
```