### PR TITLE
[SPARK-53080][CORE][CONNECT] Support `cleanDirectory` in `SparkFileUtils` and `JavaUtils`

### DIFF
--- a/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -145,6 +145,30 @@ public class JavaUtils {
     return size.get();
   }
 
+  public static void cleanDirectory(File dir) throws IOException {
+    if (dir == null || !dir.exists() || !dir.isDirectory()) {
+      throw new IllegalArgumentException("Invald input directory " + dir.getAbsolutePath());
+    }
+    cleanDirectory(dir.toPath());
+  }
+
+  public static void cleanDirectory(Path rootDir) throws IOException {
+    Files.walkFileTree(rootDir, new SimpleFileVisitor<Path>() {
+      @Override
+      public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+      }
+
+      @Override
+      public FileVisitResult postVisitDirectory(Path dir, IOException e) throws IOException {
+        if (e != null) throw e;
+        if (!dir.equals(rootDir)) Files.delete(dir);
+        return FileVisitResult.CONTINUE;
+      }
+    });
+  }
+
   /**
    * Delete a file or directory and its contents recursively.
    * Don't follow directories if they are symlinks.

--- a/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -147,12 +147,12 @@ public class JavaUtils {
 
   public static void cleanDirectory(File dir) throws IOException {
     if (dir == null || !dir.exists() || !dir.isDirectory()) {
-      throw new IllegalArgumentException("Invald input directory " + dir.getAbsolutePath());
+      throw new IllegalArgumentException("Invalid input directory " + dir);
     }
     cleanDirectory(dir.toPath());
   }
 
-  public static void cleanDirectory(Path rootDir) throws IOException {
+  private static void cleanDirectory(Path rootDir) throws IOException {
     Files.walkFileTree(rootDir, new SimpleFileVisitor<Path>() {
       @Override
       public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {

--- a/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
@@ -119,6 +119,11 @@ private[spark] trait SparkFileUtils extends Logging {
     createDirectory(root, namePrefix)
   }
 
+  /** Delete recursively while keeping the given directory itself. */
+  def cleanDirectory(dir: File): Unit = {
+    JavaUtils.cleanDirectory(dir)
+  }
+
   /**
    * Delete a file or directory and its contents recursively.
    * Don't follow directories if they are symlinks.

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -292,13 +292,18 @@ This file is divided into 3 sections:
     <customMessage>Use Files.write instead.</customMessage>
   </check>
 
+  <check customId="cleanDirectory" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex"> FileUtils\.cleanDirectory</parameter></parameters>
+    <customMessage>Use cleanDirectory of JavaUtils/SparkFileUtils/Utils</customMessage>
+  </check>
+
   <check customId="deleteRecursively" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">FileUtils\.deleteDirectory</parameter></parameters>
     <customMessage>Use deleteRecursively of SparkFileUtils or Utils</customMessage>
   </check>
 
   <check customId="deleteQuietly" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
-    <parameters><parameter name="regex">FileUtils\.deleteQuietly</parameter></parameters>
+    <parameters><parameter name="regex"> FileUtils\.deleteQuietly</parameter></parameters>
     <customMessage>Use deleteQuietly of JavaUtils/SparkFileUtils/Utils</customMessage>
   </check>
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicLong
 import scala.collection.mutable
 
 import com.google.common.cache.{CacheBuilder, RemovalNotification}
-import org.apache.commons.io.FileUtils
 
 import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
@@ -243,7 +242,7 @@ private[connect] class MLCache(sessionHolder: SessionHolder) extends Logging {
     val size = cachedModel.size()
     cachedModel.clear()
     if (getMemoryControlEnabled) {
-      FileUtils.cleanDirectory(new File(offloadedModelsDir.toString))
+      SparkFileUtils.cleanDirectory(new File(offloadedModelsDir.toString))
     }
     size
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `cleanDirectory` in `SparkFileUtils` and `JavaUtils`.

### Why are the changes needed?

To provide a better implementation.

**BEFORE**

```scala
scala> spark.time(org.apache.commons.io.FileUtils.cleanDirectory(new java.io.File("/tmp/spark")))
Time taken: 1731 ms
```

**AFTER**

```scala
scala> spark.time(org.apache.spark.network.util.JavaUtils.cleanDirectory(new java.io.File("/tmp/spark")))
Time taken: 1247 ms
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.