### PR TITLE
[SPARK-53081][CORE][SQL][CONNECT] Support `contentEquals` in `SparkFileUtils`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
@@ -184,7 +184,7 @@ private[spark] trait SparkFileUtils extends Logging {
     } else {
       val path1 = file1.toPath
       val path2 = file2.toPath
-      Files.isSameFile(file1.toPath, file2.toPath) || Files.mismatch(path1, path2) == -1L
+      Files.isSameFile(path1, path2) || Files.mismatch(path1, path2) == -1L
     }
   }
 }

--- a/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
@@ -168,6 +168,25 @@ private[spark] trait SparkFileUtils extends Logging {
     }
     Files.copy(src.toPath(), dst.toPath(), StandardCopyOption.REPLACE_EXISTING)
   }
+
+  /** Return true if the content of the files are equal or they both don't exist */
+  def contentEquals(file1: File, file2: File): Boolean = {
+    if (file1 == null && file2 != null || file1 != null && file2 == null) {
+      false
+    } else if (file1 == null && file2 == null || !file1.exists() && !file2.exists()) {
+      true
+    } else if (!file1.exists() || !file2.exists()) {
+      false
+    } else if (file1.isDirectory() || file2.isDirectory()) {
+      throw new IllegalArgumentException(s"Input is not a file: $file1 or $file2")
+    } else if (file1.length != file2.length) {
+      false
+    } else {
+      val path1 = file1.toPath
+      val path2 = file2.toPath
+      Files.isSameFile(file1.toPath, file2.toPath) || Files.mismatch(path1, path2) == -1L
+    }
+  }
 }
 
 private[spark] object SparkFileUtils extends SparkFileUtils

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -327,6 +327,11 @@ This file is divided into 3 sections:
     <customMessage>Use copyDirectory of JavaUtils/SparkFileUtils/Utils instead.</customMessage>
   </check>
 
+  <check customId="contentEquals" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">[^k]FileUtils\.contentEquals</parameter></parameters>
+    <customMessage>Use contentEquals of SparkFileUtils or Utils instead.</customMessage>
+  </check>
+
   <check customId="commonslang2" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">org\.apache\.commons\.lang\.</parameter></parameters>
     <customMessage>Use Commons Lang 3 classes (package org.apache.commons.lang3.*) instead

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
@@ -26,7 +26,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.jdk.CollectionConverters._
 
-import org.apache.commons.io.FileUtils
 import org.apache.commons.io.output.TeeOutputStream
 import org.scalactic.TolerantNumerics
 import org.scalatest.PrivateMethodTester
@@ -46,7 +45,7 @@ import org.apache.spark.sql.connect.test.SparkConnectServerUtils.port
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SqlApiConf
 import org.apache.spark.sql.types._
-import org.apache.spark.util.SparkThreadUtils
+import org.apache.spark.util.{SparkFileUtils, SparkThreadUtils}
 
 class ClientE2ETestSuite
     extends QueryTest
@@ -346,7 +345,7 @@ class ClientE2ETestSuite
       .listFiles()
       .filter(file => file.getPath.endsWith(".csv"))(0)
 
-    assert(FileUtils.contentEquals(testDataPath.toFile, outputFile))
+    assert(SparkFileUtils.contentEquals(testDataPath.toFile, outputFile))
   }
 
   test("read path collision") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/artifact/ArtifactManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/artifact/ArtifactManager.scala
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
-import org.apache.commons.io.{FilenameUtils, FileUtils}
+import org.apache.commons.io.FilenameUtils
 import org.apache.hadoop.fs.{LocalFileSystem, Path => FSPath}
 
 import org.apache.spark.{JobArtifactSet, JobArtifactState, SparkContext, SparkEnv, SparkException, SparkRuntimeException, SparkUnsupportedOperationException}
@@ -213,7 +213,7 @@ class ArtifactManager(session: SparkSession) extends AutoCloseable with Logging 
       // Disallow overwriting with modified version
       if (Files.exists(target)) {
         // makes the query idempotent
-        if (FileUtils.contentEquals(target.toFile, serverLocalStagingPath.toFile)) {
+        if (Utils.contentEquals(target.toFile, serverLocalStagingPath.toFile)) {
           return
         }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `contentEquals` in `SparkFileUtils`.

### Why are the changes needed?

To improve Spark's file utility features.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.