### PR TITLE
[SPARK-53082][CORE][SQL][TESTS] Use Java `Files.readString` instead of `FileUtils.readFileToString`

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -205,7 +205,7 @@ abstract class SparkFunSuite
         logInfo("\n\n===== EXTRA LOGS FOR THE FAILED TEST\n")
         workerLogfiles.foreach { logFile =>
           logInfo(s"\n----- Logfile: ${logFile.getAbsolutePath()}")
-          logInfo(FileUtils.readFileToString(logFile, "UTF-8"))
+          logInfo(Files.readString(logFile.toPath))
         }
       }
     }

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -21,6 +21,7 @@ import java.io._
 import java.net.{URI, URL}
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
+import java.nio.file.{Path => JPath}
 
 import scala.collection.mutable.ArrayBuffer
 import scala.io.{Codec, Source}
@@ -1293,8 +1294,7 @@ class SparkSubmitSuite
 
     // The path and filename are preserved.
     assert(outputUri.getPath.endsWith(new Path(sourceUri).getName))
-    assert(FileUtils.readFileToString(new File(outputUri.getPath), StandardCharsets.UTF_8) ===
-      FileUtils.readFileToString(new File(sourceUri.getPath), StandardCharsets.UTF_8))
+    assert(Files.readString(JPath.of(outputUri)) === Files.readString(JPath.of(sourceUri)))
   }
 
   private def deleteTempOutputFile(outputPath: String): Unit = {

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -21,7 +21,6 @@ import java.io._
 import java.net.{URI, URL}
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
-import java.nio.file.{Path => JPath}
 
 import scala.collection.mutable.ArrayBuffer
 import scala.io.{Codec, Source}
@@ -1294,7 +1293,8 @@ class SparkSubmitSuite
 
     // The path and filename are preserved.
     assert(outputUri.getPath.endsWith(new Path(sourceUri).getName))
-    assert(Files.readString(JPath.of(outputUri)) === Files.readString(JPath.of(sourceUri)))
+    assert(Files.readString(new File(outputUri.getPath).toPath) ===
+      Files.readString(new File(sourceUri.getPath).toPath))
   }
 
   private def deleteTempOutputFile(outputPath: String): Unit = {

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -287,6 +287,11 @@ This file is divided into 3 sections:
     <customMessage>Use Files.readAllLines instead.</customMessage>
   </check>
 
+  <check customId="readLines" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">FileUtils\.readFileToString</parameter></parameters>
+    <customMessage>Use Files.readString instead.</customMessage>
+  </check>
+
   <check customId="writeLines" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">FileUtils\.writeLines</parameter></parameters>
     <customMessage>Use Files.write instead.</customMessage>

--- a/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
@@ -104,9 +104,9 @@ trait PlanStabilitySuite extends DisableAdaptiveExecutionSuite {
   private def isApproved(
       dir: File, actualSimplifiedPlan: String, actualExplain: String): Boolean = {
     val simplifiedFile = new File(dir, "simplified.txt")
-    val expectedSimplified = FileUtils.readFileToString(simplifiedFile, StandardCharsets.UTF_8)
+    val expectedSimplified = Files.readString(simplifiedFile.toPath)
     lazy val explainFile = new File(dir, "explain.txt")
-    lazy val expectedExplain = FileUtils.readFileToString(explainFile, StandardCharsets.UTF_8)
+    lazy val expectedExplain = Files.readString(explainFile.toPath)
     expectedSimplified == actualSimplifiedPlan && expectedExplain == actualExplain
   }
 
@@ -150,8 +150,7 @@ trait PlanStabilitySuite extends DisableAdaptiveExecutionSuite {
       val actualSimplifiedFile = new File(tempDir, s"$name.actual.simplified.txt")
       val actualExplainFile = new File(tempDir, s"$name.actual.explain.txt")
 
-      val approvedSimplified = FileUtils.readFileToString(
-        approvedSimplifiedFile, StandardCharsets.UTF_8)
+      val approvedSimplified = Files.readString(approvedSimplifiedFile.toPath)
       // write out for debugging
       Files.writeString(actualSimplifiedFile.toPath(), actualSimplified, StandardCharsets.UTF_8)
       Files.writeString(actualExplainFile.toPath(), explain, StandardCharsets.UTF_8)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.streaming
 
 import java.io.File
 import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Files
 import java.util.Collections
 import java.util.concurrent.CountDownLatch
 
@@ -1109,7 +1110,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
     // Ideally we should copy "_spark_metadata" directly like what the user is supposed to do to
     // migrate to new version. However, in our test, "tempDir" will be different in each run and
     // we need to fix the absolute path in the metadata to match "tempDir".
-    val sparkMetadata = FileUtils.readFileToString(new File(legacySparkMetadataDir, "0"), UTF_8)
+    val sparkMetadata = Files.readString(new File(legacySparkMetadataDir, "0").toPath)
     FileUtils.write(
       new File(legacySparkMetadataDir, "0"),
       sparkMetadata.replaceAll("TEMPDIR", dir.getCanonicalPath), UTF_8)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java `Files.readString` instead of `FileUtils.readFileToString`.

### Why are the changes needed?

`Files.readString` is roughly 3 times faster.

**BEFORE**

```scala
scala> spark.time(org.apache.commons.io.FileUtils.readFileToString(new java.io.File("/tmp/500000000_byte")).length)
Time taken: 347 ms
```

**AFTER**

```scala
scala> spark.time(java.nio.file.Files.readString(java.nio.file.Path.of("/tmp/500000000_byte")).length)
Time taken: 144 ms
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.