### PR TITLE
[SPARK-53084][CORE] Supplement default GC options in SparkContext initialization

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -3442,8 +3442,8 @@ object SparkContext extends Logging {
     // They're specific policy options that modify GC behavior rather than representing
     // complete GC implementations, so we exclude them when detecting available GC algorithms.
     val nonGCAlgorithmFlags: Set[String] = Set(
-      "-XX:UseAdaptiveSizePolicyWithSystemGC",
-      "-XX:UseMaximumCompactionOnSystemGC")
+      "-XX:+UseAdaptiveSizePolicyWithSystemGC",
+      "-XX:+UseMaximumCompactionOnSystemGC")
 
     def supplement(key: OptionalConfigEntry[String]): Unit = {
       conf.get(key).foreach { opts =>

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -3438,21 +3438,11 @@ object SparkContext extends Logging {
   }
 
   private def supplementJavaGCOptions(conf: SparkConf): Unit = {
-    // These flags contain "GC" in their names but aren't standalone garbage collection algorithms.
-    // They're specific policy options that modify GC behavior rather than representing
-    // complete GC implementations, so we exclude them when detecting available GC algorithms.
-    val nonGCAlgorithmFlags: Set[String] = Set(
-      "-XX:+UseAdaptiveSizePolicyWithSystemGC",
-      "-XX:+UseMaximumCompactionOnSystemGC")
-
     def supplement(key: OptionalConfigEntry[String]): Unit = {
       conf.get(key).foreach { opts =>
         val hasGCAlgorithm = opts.split("\\s+").exists { option =>
-          option.startsWith("-XX:+Use") &&
-            option.endsWith("GC") &&
-            !nonGCAlgorithmFlags.contains(option)
+          option.startsWith("-XX:+Use") && option.endsWith("GC")
         }
-
         if (!hasGCAlgorithm) {
           conf.set(key.key, s"-XX:+UseParallelGC $opts")
         }

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -3465,7 +3465,7 @@ object SparkContext extends Logging {
     def supplement(key: OptionalConfigEntry[String]): Unit = {
       conf.get(key).foreach { opts =>
         val splitOpts = opts.split("\\s+")
-        if (!splitOpts.exists(gcAlgorithms)) {
+        if (!splitOpts.exists(gcAlgorithms.contains)) {
           conf.set(key.key, s"-XX:+UseParallelGC $opts")
         }
       }

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1482,12 +1482,13 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
   test("SPARK-53084: Do not supplement UseParallelGC when GC algorithm is specified") {
     val conf = new SparkConf().setAppName("test").setMaster("local")
       .set(SparkLauncher.DRIVER_DEFAULT_JAVA_OPTIONS, "-XX:+UseG1GC")
-      .set(SparkLauncher.EXECUTOR_DEFAULT_JAVA_OPTIONS, "-XX:+UseZGC")
+      .set(SparkLauncher.EXECUTOR_DEFAULT_JAVA_OPTIONS, "-XX:+UseMaximumCompactionOnSystemGC")
     sc = new SparkContext(conf)
     val driverJavaOptions = sc.conf.get(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS)
     assert(driverJavaOptions.contains("-XX:+UseG1GC"))
+    assert(!driverJavaOptions.contains("-XX:+UseParallelGC"))
     val executorJavaOptions = sc.getConf.get(EXECUTOR_JAVA_OPTIONS).get
-    assert(executorJavaOptions.contains("-XX:+UseZGC"))
+    assert(executorJavaOptions.contains("-XX:+UseParallelGC"))
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1482,13 +1482,14 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
   test("SPARK-53084: Do not supplement UseParallelGC when GC algorithm is specified") {
     val conf = new SparkConf().setAppName("test").setMaster("local")
       .set(SparkLauncher.DRIVER_DEFAULT_JAVA_OPTIONS, "-XX:+UseG1GC")
-      .set(SparkLauncher.EXECUTOR_DEFAULT_JAVA_OPTIONS, "-XX:+UseMaximumCompactionOnSystemGC")
+      .set(SparkLauncher.EXECUTOR_DEFAULT_JAVA_OPTIONS, "-XX:+UseC4GC")
     sc = new SparkContext(conf)
     val driverJavaOptions = sc.conf.get(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS)
     assert(driverJavaOptions.contains("-XX:+UseG1GC"))
     assert(!driverJavaOptions.contains("-XX:+UseParallelGC"))
     val executorJavaOptions = sc.getConf.get(EXECUTOR_JAVA_OPTIONS).get
-    assert(executorJavaOptions.contains("-XX:+UseParallelGC"))
+    assert(executorJavaOptions.contains("-XX:+UseC4GC"))
+    assert(!driverJavaOptions.contains("-XX:+UseParallelGC"))
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -42,6 +42,7 @@ import org.apache.spark.executor.ExecutorExitCode
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Tests._
 import org.apache.spark.internal.config.UI._
+import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.resource.ResourceAllocation
 import org.apache.spark.resource.ResourceUtils._
 import org.apache.spark.resource.TestResourceIDs._
@@ -1469,6 +1470,25 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
     sc.stop()
   }
 
+  test("Supplement UseParallelGC when GC algorithm is not specified") {
+    val conf = new SparkConf().setAppName("test").setMaster("local")
+    sc = new SparkContext(conf)
+    val driverJavaOptions = sc.conf.get(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS)
+    assert(driverJavaOptions.contains("-XX:+UseParallelGC"))
+    val executorJavaOptions = sc.getConf.get(EXECUTOR_JAVA_OPTIONS).get
+    assert(executorJavaOptions.contains("-XX:+UseParallelGC"))
+  }
+
+  test("Do not supplement UseParallelGC when GC algorithm is specified") {
+    val conf = new SparkConf().setAppName("test").setMaster("local")
+      .set(SparkLauncher.DRIVER_DEFAULT_JAVA_OPTIONS, "-XX:+UseG1GC")
+      .set(SparkLauncher.EXECUTOR_DEFAULT_JAVA_OPTIONS, "-XX:+UseZGC")
+    sc = new SparkContext(conf)
+    val driverJavaOptions = sc.conf.get(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS)
+    assert(driverJavaOptions.contains("-XX:+UseG1GC"))
+    val executorJavaOptions = sc.getConf.get(EXECUTOR_JAVA_OPTIONS).get
+    assert(executorJavaOptions.contains("-XX:+UseZGC"))
+  }
 }
 
 object SparkContextSuite {

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1470,7 +1470,7 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
     sc.stop()
   }
 
-  test("Supplement UseParallelGC when GC algorithm is not specified") {
+  test("SPARK-53084: Supplement UseParallelGC when GC algorithm is not specified") {
     val conf = new SparkConf().setAppName("test").setMaster("local")
     sc = new SparkContext(conf)
     val driverJavaOptions = sc.conf.get(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS)
@@ -1479,7 +1479,7 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
     assert(executorJavaOptions.contains("-XX:+UseParallelGC"))
   }
 
-  test("Do not supplement UseParallelGC when GC algorithm is specified") {
+  test("SPARK-53084: Do not supplement UseParallelGC when GC algorithm is specified") {
     val conf = new SparkConf().setAppName("test").setMaster("local")
       .set(SparkLauncher.DRIVER_DEFAULT_JAVA_OPTIONS, "-XX:+UseG1GC")
       .set(SparkLauncher.EXECUTOR_DEFAULT_JAVA_OPTIONS, "-XX:+UseZGC")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR introduces a method `supplementJavaGCOptions` in `SparkContext` to ensure that a default garbage collection (GC) algorithm (`UseParallelGC`) is supplemented when no GC algorithm is explicitly specified in the JVM options for the driver or executor.

This method checks `DRIVER_JAVA_OPTIONS` and `EXECUTOR_JAVA_OPTIONS` in the Spark configuration. If neither contains an explicit GC algorithm flag (excluding certain policy flags like `-XX:UseAdaptiveSizePolicyWithSystemGC`), `-XX:+UseParallelGC` is prepended to the options.

### Why are the changes needed?

- Since Java 9+, the default GC algorithm has changed from `UseParallelGC` to `UseG1GC`(more details: https://blog.gceasy.io/what-is-javas-default-gc-algorithm). This change cause hundreds of jobs to fail due to OOM errors in our cluster.
- Smooth upgrade from Spark 3.5 to 4.0
- Smooth upgrade from Java 8 to 17.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

- Added unit tests to verify that `UseParallelGC` is supplemented when no GC algorithm is specified.
- Verified that existing GC options are not overridden if already present.


### Was this patch authored or co-authored using generative AI tooling?

No.
