### PR TITLE
[SPARK-53088][BUILD] Remove `scala-collection-compat` dependency

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -398,7 +398,6 @@ org.rocksdb:rocksdbjni
 org.scala-lang:scala-compiler
 org.scala-lang:scala-library
 org.scala-lang:scala-reflect
-org.scala-lang.modules:scala-collection-compat_2.13
 org.scala-lang.modules:scala-parallel-collections_2.13
 org.scala-lang.modules:scala-parser-combinators_2.13
 org.scala-lang.modules:scala-xml_2.13

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -249,7 +249,6 @@ pickle/1.5//pickle-1.5.jar
 py4j/0.10.9.9//py4j-0.10.9.9.jar
 remotetea-oncrpc/1.1.2//remotetea-oncrpc-1.1.2.jar
 rocksdbjni/9.8.4//rocksdbjni-9.8.4.jar
-scala-collection-compat_2.13/2.7.0//scala-collection-compat_2.13-2.7.0.jar
 scala-compiler/2.13.16//scala-compiler-2.13.16.jar
 scala-library/2.13.16//scala-library-2.13.16.jar
 scala-parallel-collections_2.13/1.2.0//scala-parallel-collections_2.13-1.2.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -1150,6 +1150,10 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-collection-compat_${scala.binary.version}</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `scala-collection-compat` dependency at Apache Spark 4.1.0.

### Why are the changes needed?

This is designed to be an empty package for Scala 2.13. Apache Spark 4+ uses Scala 2.13 only. We can remove this safely.
- https://github.com/scala/scala-collection-compat

> The Scala 2.13 and Scala 3 versions consist only of an empty scala.collection.compat package object, so import scala.collection.compat._ won't cause an error in cross-compiled code.

### Does this PR introduce _any_ user-facing change?

No behavior changes.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.