### PR TITLE
[SPARK-53090][CORE][SS][TESTS] Use Java `OutputStream.write` instead of `IOUtils.write`

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -32,7 +32,6 @@ import scala.collection.mutable.ListBuffer
 import scala.util.{Random, Try}
 
 import com.google.common.io.Files
-import org.apache.commons.io.IOUtils
 import org.apache.commons.math3.stat.inference.ChiSquareTest
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -343,7 +342,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     } else {
       new FileOutputStream(path)
     }
-    IOUtils.write(content, outputStream)
+    outputStream.write(content)
     outputStream.close()
     content.length
   }

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -627,6 +627,11 @@ This file is divided into 3 sections:
     <customMessage>Use toString of SparkStreamUtils or Utils instead.</customMessage>
   </check>
 
+  <check customId="ioutilswrite" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bIOUtils\.write\b</parameter></parameters>
+    <customMessage>Use Java `write` instead.</customMessage>
+  </check>
+
   <check customId="maputils" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">org\.apache\.commons\.collections4\.MapUtils</parameter></parameters>
     <customMessage>Use org.apache.spark.util.collection.Utils instead.</customMessage>

--- a/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
@@ -27,7 +27,6 @@ import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 import com.google.common.io.Files
-import org.apache.commons.io.IOUtils
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.io.{LongWritable, Text}
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat
@@ -264,7 +263,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
 
         def write(path: Path, text: String): Unit = {
           val out = fs.create(path, true)
-          IOUtils.write(text, out, StandardCharsets.UTF_8)
+          out.write(text.getBytes(StandardCharsets.UTF_8))
           out.close()
         }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java `OutputStream.write` instead of `IOUtils.write`.

### Why are the changes needed?

To use a better implementation for our use cases.

```scala
scala> val s = "a".repeat(400_000_000)

scala> spark.time(new java.io.FileOutputStream("/tmp/a").write(s.getBytes()))
Time taken: 270 ms

scala> spark.time(org.apache.commons.io.IOUtils.write(s, new java.io.FileOutputStream("/tmp/a")))
Time taken: 1070 ms
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.