### PR TITLE
[SPARK-53091][SQL] Ban `org.apache.commons.lang3.Strings`

### DIFF
--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -185,6 +185,7 @@
             <property name="illegalPkgs" value="org.apache.commons.lang" />
             <property name="illegalPkgs" value="org.apache.commons.lang3.tuple" />
             <property name="illegalClasses" value="org.apache.commons.lang3.JavaVersion" />
+            <property name="illegalClasses" value="org.apache.commons.lang3.Strings" />
             <property name="illegalClasses" value="org.apache.hadoop.io.IOUtils" />
             <property name="illegalClasses" value="com.google.common.base.Strings" />
         </module>

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
@@ -26,7 +26,6 @@ import javax.naming.NamingException;
 import javax.naming.directory.InitialDirContext;
 import javax.security.sasl.AuthenticationException;
 
-import org.apache.commons.lang3.Strings;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hive.service.ServiceUtils;
 
@@ -72,7 +71,7 @@ public class LdapAuthenticationProviderImpl implements PasswdAuthenticationProvi
     } else {
       String[] patterns = userDNPattern.split(":");
       for (String pattern : patterns) {
-        if (Strings.CS.contains(pattern, ",") && Strings.CS.contains(pattern, "=")) {
+        if (pattern.contains(",") && pattern.contains("=")) {
           candidatePrincipals.add(pattern.replaceAll("%s", user));
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ban `org.apache.commons.lang3.Strings` in Java code. Since we already replaces all usage in Scala code, this is the only instance to remove.

https://github.com/apache/spark/blob/a8e98340be5189d4be7f3dfe1863faddc3e574bc/scalastyle-config.xml#L393

### Why are the changes needed?

To use built-in simple Java String APIs consistently.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.