### PR TITLE
[SPARK-53093][K8S][DOCS] Drop K8s v1.31 Support

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -44,7 +44,7 @@ Cluster administrators should use [Pod Security Policies](https://kubernetes.io/
 
 # Prerequisites
 
-* A running Kubernetes cluster at version >= 1.31 with access configured to it using
+* A running Kubernetes cluster at version >= 1.32 with access configured to it using
 [kubectl](https://kubernetes.io/docs/reference/kubectl/).  If you do not already have a working Kubernetes cluster,
 you may set up a test cluster on your local machine using
 [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/).


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update K8s docs to recommend K8s v1.32+ at Apache Spark 4.1.0 to utilize more stable features like the following example features graduated to `Stable` at K8s v1.32.
- [KEP-1847: Auto remove PVCs created by StatefulSet](https://github.com/kubernetes/enhancements/issues/1847)
- [KEP-1967: Support to size memory backed volumes](https://github.com/kubernetes/enhancements/issues/1967)
- [KEP-4358: Custom Resource field selectors](https://github.com/kubernetes/enhancements/issues/4358)

### Why are the changes needed?

**1. K8s v1.31 will enter the maintenance soon (2025-08-28) and will reach the end of support on 2025-10-28**
- https://kubernetes.io/releases/patch-releases/#1-31

**2. Default K8s Versions in Public Cloud environments**

The default K8s versions of public cloud providers are already moving to K8s 1.32+ like the following.

- EKS: v1.32 (Default), v1.33 (Available)
- AKS: v1.32 (Default), v1.33 (GA)
- GKE: v1.32 (Stable), v1.32 (Regular), v1.33 (Rapid)

**3. End Of Support**

In addition, K8s 1.31 will reach the end of standard support around Apache Spark 4.1.0 release. 

| K8s  |   EKS   |  AKE  |  GKE  |
| ---- | ------- | ------- | ------- |
| 1.31 | 2025-11 | 2025-11 | 2026-01 |

- [EKS EOL Schedule](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar)
- [AKS EOL Schedule](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)
- [GKE EOL Schedule](https://cloud.google.com/kubernetes-engine/docs/release-schedule)

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only change about K8s versions.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.