### PR TITLE
[SPARK-53100][SQL] Use Java `String.substring` instead of `StringUtils.substring`

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -414,6 +414,11 @@ This file is divided into 3 sections:
     <customMessage>Use Utils.abbreviate method instead</customMessage>
   </check>
 
+  <check customId="commonslang3substring" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bStringUtils\.substring\b</parameter></parameters>
+    <customMessage>Use Java String.substring instead.</customMessage>
+  </check>
+
   <check customId="uribuilder" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">\bUriBuilder\.fromUri\b</parameter></parameters>
     <customMessage>Use Utils.getUriBuilder instead.</customMessage>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.catalyst.csv
 
-import org.apache.commons.lang3.StringUtils
-
 import org.apache.spark.SparkIllegalArgumentException
 
 object CSVExprUtils {
@@ -134,7 +132,7 @@ object CSVExprUtils {
       // in order to use existing escape logic
       val readAhead = if (str(idx) == '\\') 2 else 1
       // get the chunk of 1 or 2 input characters to convert to a single delimiter char
-      val chunk = StringUtils.substring(str, idx, idx + readAhead)
+      val chunk = str.substring(idx, idx + readAhead)
       delimiter += toChar(chunk)
       // advance the counter by the length of input chunk processed
       idx += chunk.length()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java `String.substring` instead of `StringUtils.substring`.

### Why are the changes needed?

We had better use Java's built-in method for code simplification if there is no benefit of 3rd party libraries.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.