### PR TITLE
[SPARK-53101][CORE][SQL][MLLIB] Support `(left|right)Pad` in `SparkStringUtils`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkStringUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkStringUtils.scala
@@ -72,6 +72,20 @@ private[spark] trait SparkStringUtils {
   /** Try to strip prefix and suffix with the given string 's' */
   def strip(str: String, s: String): String =
     if (str == null || s == null) str else str.stripPrefix(s).stripSuffix(s)
+
+  def leftPad(str: String, width: Int): String =
+    if (str == null || str.length >= width) str else String.format(s"%${width}s", str)
+
+  def rightPad(str: String, width: Int): String =
+    if (str == null || str.length >= width) str else String.format(s"%-${width}s", str)
+
+  def rightPad(str: String, width: Int, s: String): String =
+    if (str == null || str.length >= width) {
+      str
+    } else {
+      val tmp = str + s.repeat((width - str.length)/s.length)
+      tmp + s.substring(0, width - tmp.length)
+    }
 }
 
 private[spark] object SparkStringUtils extends SparkStringUtils with Logging {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -22,7 +22,6 @@ import java.util.Locale
 
 import breeze.stats.{distributions => dist}
 import breeze.stats.distributions.Rand.FixedSeed.randBasis
-import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkException
@@ -42,6 +41,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{DataType, DoubleType, StructType}
+import org.apache.spark.util.Utils
 
 /**
  * Params for Generalized Linear Regression.
@@ -1636,12 +1636,12 @@ class GeneralizedLinearRegressionTrainingSummary private[regression] (
       // Output coefficients with statistics
       sb.append("Coefficients:\n")
       colNames.zipWithIndex.map { case (colName: String, i: Int) =>
-        StringUtils.leftPad(colName, colWidths(i))
+        Utils.leftPad(colName, colWidths(i))
       }.addString(sb, "", " ", "\n")
 
       data.foreach { case strRow: Array[String] =>
         strRow.zipWithIndex.map { case (cell: String, i: Int) =>
-          StringUtils.leftPad(cell, colWidths(i))
+          Utils.leftPad(cell, colWidths(i))
         }.addString(sb, "", " ", "\n")
       }
 
@@ -1654,9 +1654,9 @@ class GeneralizedLinearRegressionTrainingSummary private[regression] (
       val rd = s"Residual deviance: ${round(deviance)} on $residualDegreeOfFreedom degrees of " +
         "freedom"
       val l = math.max(nd.length, rd.length)
-      sb.append(StringUtils.leftPad(nd, l))
+      sb.append(Utils.leftPad(nd, l))
       sb.append("\n")
-      sb.append(StringUtils.leftPad(rd, l))
+      sb.append(Utils.leftPad(rd, l))
 
       if (family.name != "tweedie") {
         sb.append("\n")

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -379,6 +379,11 @@ This file is divided into 3 sections:
     <customMessage>Use String concatenation instead</customMessage>
   </check>
 
+  <check customId="commonslang3pad" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bStringUtils\.(left|right)Pad\b</parameter></parameters>
+    <customMessage>Use (left|right)Pad of SparkStringUtils or Utils instead</customMessage>
+  </check>
+
   <check customId="commonslang3split" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">\bStringUtils\.split\b</parameter></parameters>
     <customMessage>Use Utils.stringToSeq instead</customMessage>

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
@@ -26,7 +26,6 @@ import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.control.NonFatal
 
-import org.apache.commons.lang3.StringUtils
 import org.apache.commons.text.StringEscapeUtils
 
 import org.apache.spark.{sql, TaskContext}
@@ -396,9 +395,9 @@ class Dataset[T] private[sql](
       val paddedRows = rows.map { row =>
         row.zipWithIndex.map { case (cell, i) =>
           if (truncate > 0) {
-            StringUtils.leftPad(cell, colWidths(i) - Utils.stringHalfWidth(cell) + cell.length)
+            Utils.leftPad(cell, colWidths(i) - Utils.stringHalfWidth(cell) + cell.length)
           } else {
-            StringUtils.rightPad(cell, colWidths(i) - Utils.stringHalfWidth(cell) + cell.length)
+            Utils.rightPad(cell, colWidths(i) - Utils.stringHalfWidth(cell) + cell.length)
           }
         }
       }
@@ -428,13 +427,13 @@ class Dataset[T] private[sql](
 
       dataRows.zipWithIndex.foreach { case (row, i) =>
         // "+ 5" in size means a character length except for padded names and data
-        val rowHeader = StringUtils.rightPad(
+        val rowHeader = Utils.rightPad(
           s"-RECORD $i", fieldNameColWidth + dataColWidth + 5, "-")
         sb.append(rowHeader).append("\n")
         row.zipWithIndex.map { case (cell, j) =>
-          val fieldName = StringUtils.rightPad(fieldNames(j),
+          val fieldName = Utils.rightPad(fieldNames(j),
             fieldNameColWidth - Utils.stringHalfWidth(fieldNames(j)) + fieldNames(j).length)
-          val data = StringUtils.rightPad(cell,
+          val data = Utils.rightPad(cell,
             dataColWidth - Utils.stringHalfWidth(cell) + cell.length)
           s" $fieldName | $data "
         }.addString(sb, "", "\n", "\n")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `(left|right)Pad` in `SparkStringUtils`.

### Why are the changes needed?

To improve Spark's string utility functions.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.