### PR TITLE
[SPARK-53102][BUILD] Upgrade `commons-cli` to 1.10.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -35,7 +35,7 @@ cats-kernel_2.13/2.8.0//cats-kernel_2.13-2.8.0.jar
 checker-qual/3.43.0//checker-qual-3.43.0.jar
 chill-java/0.10.0//chill-java-0.10.0.jar
 chill_2.13/0.10.0//chill_2.13-0.10.0.jar
-commons-cli/1.9.0//commons-cli-1.9.0.jar
+commons-cli/1.10.0//commons-cli-1.10.0.jar
 commons-codec/1.18.0//commons-codec-1.18.0.jar
 commons-collections/3.2.2//commons-collections-3.2.2.jar
 commons-collections4/4.5.0//commons-collections4-4.5.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
     <htmlunit3-driver.version>4.21.0</htmlunit3-driver.version>
     <maven-antrun.version>3.1.0</maven-antrun.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
-    <commons-cli.version>1.9.0</commons-cli.version>
+    <commons-cli.version>1.10.0</commons-cli.version>
     <bouncycastle.version>1.80</bouncycastle.version>
     <tink.version>1.16.0</tink.version>
     <datasketches.version>6.2.0</datasketches.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `commons-cli` to 1.10.0 which is the first release tested with **Java 25-ea**.

### Why are the changes needed?

To bring the latest improvements and bug fixes.
- https://commons.apache.org/proper/commons-cli/changes.html#a1.10.0 (2025-07-30)
  - [Run Java 24 and 25-ea](https://github.com/apache/commons-cli/commit/e6a611f80f8cca0128b9a0579ae2937caca8fc7a)
  - [[CLI-333] org.apache.commons.cli.Option.Builder implements](https://github.com/apache/commons-cli/commit/c9698e622f3e0d2fe1d304056b28c24ff7d02e81)
  - https://github.com/apache/commons-cli/pull/314
  - https://github.com/apache/commons-cli/pull/334
  - [[CLI-341] HelpFormatter infinite loop with 0 width input](https://github.com/apache/commons-cli/commit/bce0f6a9899830eaa5161ea6fd2af04d5679257b)
  - [[CLI-343] OptionFormatter.getBothOpt() lacks validation for Options](https://github.com/apache/commons-cli/commit/859d5e5e749c1ec6a4c7f7ead88a587f316d8065)
  - [[CLI-344] Option.processValue() throws NullPointerException when passed](https://github.com/apache/commons-cli/commit/4e0cdd0f96762df26e6335be8a1ab1afd55234f1)
  - [[CLI-347] Options.addOptionGroup(OptionGroup) does not remove required](https://github.com/apache/commons-cli/commit/42be7926be5599342a812c170b03ab73f8cbb35c)
  - [[CLI-349] DefaultParser.parse() throws NullPointerException when options](https://github.com/apache/commons-cli/commit/ff678b0ac3019e621d23b2eb2230096206baae78)

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.