### PR TITLE
[SPARK-53074][SQL] Avoid partial clustering in SPJ to meet a child's required distribution 

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -505,7 +505,8 @@ case class EnsureRequirements(
           // Similarly, the partially clustered distribution cannot be applied if the
           // partially clustered side must use the scan's key-grouped partitioning to
           // satisfy some required distribution in its plan (for example, for an aggregate
-          // or window function).
+          // or window function), as this will give incorrect results (for example, duplicate
+          // row_number() values).
           // Otherwise, query result could be incorrect.
           val canReplicateLeft = canReplicateLeftSide(joinType) &&
             canApplyPartialClusteredDistribution(right)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -1120,10 +1120,6 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
              |""".stripMargin)
         val shuffles = collectShuffles(df.queryExecution.executedPlan)
         assert(shuffles.isEmpty, "should not contain any shuffle")
-        if (pushDownValues) {
-          val scans = collectScans(df.queryExecution.executedPlan)
-          assert(scans.forall(_.inputRDD.partitions.length === 3))
-        }
         checkAnswer(df, Seq(Row(140.0, 7, 140.0, Timestamp.valueOf("2020-02-01 00:00:00"))))
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -1118,9 +1118,13 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
              |  ON i.id = p.item_id
              |WHERE p.RN = 1
              |""".stripMargin)
+        checkAnswer(df, Seq(Row(140.0, 7, 140.0, Timestamp.valueOf("2020-02-01 00:00:00"))))
         val shuffles = collectShuffles(df.queryExecution.executedPlan)
         assert(shuffles.isEmpty, "should not contain any shuffle")
-        checkAnswer(df, Seq(Row(140.0, 7, 140.0, Timestamp.valueOf("2020-02-01 00:00:00"))))
+        if (pushDownValues) {
+          val scans = collectScans(df.queryExecution.executedPlan)
+          assert(scans.forall(_.inputRDD.partitions.length === 3))
+        }
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, SPJ logic can apply partial clustering (when enabled) to either side of an inner JOIN as long as the nodes between the scan and JOIN preserve partitioning. This doesn't work if one of these nodes is using the scan's key-grouped partitioning to satisfy its required distribution (for example, a grouping agg or window function).

This PR avoids this issue by avoiding applying a partially clustered distribution to a JOIN's child if any node in that child relies on the KeyGroupedPartitioning to satisfy its required distribution (since it's not safe to do so with a partially clustered distribution).


### Why are the changes needed?
Without this fix, using a partially-clustered distribution with SPJ may cause correctness issues.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
See test changes.

### Was this patch authored or co-authored using generative AI tooling?
No.
