### PR TITLE
[SPARK-53094][SQL] Fix CUBE with aggregate containing HAVING clauses

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -792,27 +792,33 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
       } else {
         colResolved.havingCondition
       }
-      // Try resolving the condition of the filter as though it is in the aggregate clause
-      val (extraAggExprs, Seq(resolvedHavingCond)) =
-        ResolveAggregateFunctions.resolveExprsWithAggregate(Seq(cond), aggForResolving)
-
-      // Push the aggregate expressions into the aggregate (if any).
-      val newChild = constructAggregate(h, selectedGroupByExprs, groupByExprs,
-        aggregate.aggregateExpressions ++ extraAggExprs, aggregate.child)
-
-      // Since the output exprId will be changed in the constructed aggregate, here we build an
-      // attrMap to resolve the condition again.
-      val attrMap = AttributeMap((aggForResolving.output ++ extraAggExprs.map(_.toAttribute))
-        .zip(newChild.output))
-      val newCond = resolvedHavingCond.transform {
-        case a: AttributeReference => attrMap.getOrElse(a, a)
-      }
-
-      if (extraAggExprs.isEmpty) {
-        Filter(newCond, newChild)
+      // `cond` might contain unresolved aggregate functions so defer its resolution to
+      // `ResolveAggregateFunctions` rule if needed.
+      if (!cond.resolved) {
+        colResolved
       } else {
-        Project(newChild.output.dropRight(extraAggExprs.length),
-          Filter(newCond, newChild))
+        // Try resolving the condition of the filter as though it is in the aggregate clause
+        val (extraAggExprs, Seq(resolvedHavingCond)) =
+          ResolveAggregateFunctions.resolveExprsWithAggregate(Seq(cond), aggForResolving)
+
+        // Push the aggregate expressions into the aggregate (if any).
+        val newChild = constructAggregate(h, selectedGroupByExprs, groupByExprs,
+          aggregate.aggregateExpressions ++ extraAggExprs, aggregate.child)
+
+        // Since the output exprId will be changed in the constructed aggregate, here we build an
+        // attrMap to resolve the condition again.
+        val attrMap = AttributeMap((aggForResolving.output ++ extraAggExprs.map(_.toAttribute))
+          .zip(newChild.output))
+        val newCond = resolvedHavingCond.transform {
+          case a: AttributeReference => attrMap.getOrElse(a, a)
+        }
+
+        if (extraAggExprs.isEmpty) {
+          Filter(newCond, newChild)
+        } else {
+          Project(newChild.output.dropRight(extraAggExprs.length),
+            Filter(newCond, newChild))
+        }
       }
     }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/grouping_set.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/grouping_set.sql.out
@@ -116,7 +116,7 @@ FROM   (VALUES ('x', 'a', 10), ('y', 'b', 20) ) AS t (c1, c2, c3)
 GROUP  BY GROUPING SETS ( ( c1 ), ( c2 ) )
 HAVING GROUPING__ID > 1
 -- !query analysis
-Filter (grouping__id#xL > cast(1 as bigint))
+Filter (GROUPING__ID#xL > cast(1 as bigint))
 +- Aggregate [c1#x, c2#x, spark_grouping_id#xL], [c1#x, c2#x, sum(c3#x) AS sum(c3)#xL, spark_grouping_id#xL AS grouping__id#xL]
    +- Expand [[c1#x, c2#x, c3#x, c1#x, null, 1], [c1#x, c2#x, c3#x, null, c2#x, 2]], [c1#x, c2#x, c3#x, c1#x, c2#x, spark_grouping_id#xL]
       +- Project [c1#x, c2#x, c3#x, c1#x AS c1#x, c2#x AS c2#x]

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -5057,6 +5057,28 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
       }
     }
   }
+
+  test("SPARK-53094: Fix cube-related data quality problem") {
+    withTable("table1") {
+      withSQLConf() {
+        sql(
+          """CREATE TABLE table1(product string, amount bigint,
+            |region string) using csv""".stripMargin)
+
+        sql("INSERT INTO table1 " + "VALUES('a', 100, 'east')")
+        sql("INSERT INTO table1 " + "VALUES('b', 200, 'east')")
+        sql("INSERT INTO table1 " + "VALUES('a', 150, 'west')")
+        sql("INSERT INTO table1 " + "VALUES('b', 250, 'west')")
+        sql("INSERT INTO table1 " + "VALUES('a', 120, 'east')")
+
+        checkAnswer(
+          sql("select product, region, sum(amount) as s " +
+            "from table1 group by product, region with cube having count(product) > 2 " +
+            "order by s desc"),
+          Seq(Row(null, null, 820), Row(null, "east", 420), Row("a", null, 370)))
+      }
+    }
+  }
 }
 
 case class Foo(bar: Option[String])


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is an alternative PR to https://github.com/apache/spark/pull/51810 to fix a regresion introduced in Spark 3.2 with https://github.com/apache/spark/pull/32470.
This PR defers the resolution of not fully resolved `UnresolvedHaving` nodes from `ResolveGroupingAnalytics`:
```
=== Applying Rule org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveGroupingAnalytics ===
 'Sort ['s DESC NULLS LAST], true                                                                                               'Sort ['s DESC NULLS LAST], true
!+- 'UnresolvedHaving ('count('product) > 2)                                                                                    +- 'UnresolvedHaving ('count(tempresolvedcolumn(product#261, product, false)) > 2)
!   +- 'Aggregate [cube(Vector(0), Vector(1), product#261, region#262)], [product#261, region#262, sum(amount#263) AS s#264L]      +- Aggregate [product#269, region#270, spark_grouping_id#268L], [product#269, region#270, sum(amount#263) AS s#264L]
!      +- SubqueryAlias t                                                                                                             +- Expand [[product#261, region#262, amount#263, product#266, region#267, 0], [product#261, region#262, amount#263, product#266, null, 1], [product#261, region#262, amount#263, null, region#267, 2], [product#261, region#262, amount#263, null, null, 3]], [product#261, region#262, amount#263, product#269, region#270, spark_grouping_id#268L]
!         +- LocalRelation [product#261, region#262, amount#263]                                                                         +- Project [product#261, region#262, amount#263, product#261 AS product#266, region#262 AS region#267]
!                                                                                                                                           +- SubqueryAlias t
!                                                                                                                                              +- LocalRelation [product#261, region#262, amount#263]
```
to `ResolveAggregateFunctions` to add the correct aggregate expressions (`count(product#261)`):
```
=== Applying Rule org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveAggregateFunctions ===
 'Sort ['s DESC NULLS LAST], true                                                                                                                                                                                                                                                                                                                             'Sort ['s DESC NULLS LAST], true
!+- 'UnresolvedHaving (count(tempresolvedcolumn(product#261, product, false)) > cast(2 as bigint))                                                                                                                                                                                                                                                            +- Project [product#269, region#270, s#264L]
!   +- Aggregate [product#269, region#270, spark_grouping_id#268L], [product#269, region#270, sum(amount#263) AS s#264L]                                                                                                                                                                                                                                         +- Filter (count(product)#272L > cast(2 as bigint))
!      +- Expand [[product#261, region#262, amount#263, product#266, region#267, 0], [product#261, region#262, amount#263, product#266, null, 1], [product#261, region#262, amount#263, null, region#267, 2], [product#261, region#262, amount#263, null, null, 3]], [product#261, region#262, amount#263, product#269, region#270, spark_grouping_id#268L]         +- Aggregate [product#269, region#270, spark_grouping_id#268L], [product#269, region#270, sum(amount#263) AS s#264L, count(product#261) AS count(product)#272L]
!         +- Project [product#261, region#262, amount#263, product#261 AS product#266, region#262 AS region#267]                                                                                                                                                                                                                                                       +- Expand [[product#261, region#262, amount#263, product#266, region#267, 0], [product#261, region#262, amount#263, product#266, null, 1], [product#261, region#262, amount#263, null, region#267, 2], [product#261, region#262, amount#263, null, null, 3]], [product#261, region#262, amount#263, product#269, region#270, spark_grouping_id#268L]
!            +- SubqueryAlias t                                                                                                                                                                                                                                                                                                                                           +- Project [product#261, region#262, amount#263, product#261 AS product#266, region#262 AS region#267]
!               +- LocalRelation [product#261, region#262, amount#263]                                                                                                                                                                                                                                                                                                       +- SubqueryAlias t
!                                                                                                                                                                                                                                                                                                                                                                               +- LocalRelation [product#261, region#262, amount#263]
```

### Why are the changes needed?

Fix a correctness isue described in https://github.com/apache/spark/pull/51810.

### Does this PR introduce _any_ user-facing change?

Yes, it fixes a correctness issue.

### How was this patch tested?

Added new UT from https://github.com/apache/spark/pull/51810.

### Was this patch authored or co-authored using generative AI tooling?

No.
