### PR TITLE
[SPARK-53104][PS] Introduce ansi_mode_context to avoid multiple config checks per API call

### DIFF
--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -322,7 +322,8 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
     # arithmetic operators
     def __neg__(self: IndexOpsLike) -> IndexOpsLike:
-        return self._dtype_op.neg(self)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.neg(self)
 
     def __add__(self, other: Any) -> SeriesOrIndex:
         with ansi_mode_context(self._internal.spark_frame.sparkSession):

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -42,6 +42,7 @@ from pyspark.pandas.internal import (
 from pyspark.pandas.spark.accessors import SparkIndexOpsMethods
 from pyspark.pandas.typedef import extension_dtypes
 from pyspark.pandas.utils import (
+    ansi_mode_context,
     combine_frames,
     same_anchor,
     scol_for,
@@ -324,13 +325,16 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         return self._dtype_op.neg(self)
 
     def __add__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.add(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.add(self, other)
 
     def __sub__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.sub(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.sub(self, other)
 
     def __mul__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.mul(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.mul(self, other)
 
     def __truediv__(self, other: Any) -> SeriesOrIndex:
         """
@@ -350,22 +354,28 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         |          -10          |   null  | -np.inf |
         +-----------------------|---------|---------+
         """
-        return self._dtype_op.truediv(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.truediv(self, other)
 
     def __mod__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.mod(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.mod(self, other)
 
     def __radd__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.radd(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.radd(self, other)
 
     def __rsub__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.rsub(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.rsub(self, other)
 
     def __rmul__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.rmul(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.rmul(self, other)
 
     def __rtruediv__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.rtruediv(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.rtruediv(self, other)
 
     def __floordiv__(self, other: Any) -> SeriesOrIndex:
         """
@@ -385,74 +395,93 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         |          -10          |   null  | -np.inf |
         +-----------------------|---------|---------+
         """
-        return self._dtype_op.floordiv(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.floordiv(self, other)
 
     def __rfloordiv__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.rfloordiv(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.rfloordiv(self, other)
 
     def __rmod__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.rmod(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.rmod(self, other)
 
     def __pow__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.pow(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.pow(self, other)
 
     def __rpow__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.rpow(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.rpow(self, other)
 
     def __abs__(self: IndexOpsLike) -> IndexOpsLike:
-        return self._dtype_op.abs(self)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.abs(self)
 
     # comparison operators
     def __eq__(self, other: Any) -> SeriesOrIndex:  # type: ignore[override]
         # pandas always returns False for all items with dict and set.
-        _exclude_pd_np_operand(other)
-        if isinstance(other, (dict, set)):
-            return self != self
-        else:
-            return self._dtype_op.eq(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            _exclude_pd_np_operand(other)
+            if isinstance(other, (dict, set)):
+                return self != self
+            else:
+                return self._dtype_op.eq(self, other)
 
     def __ne__(self, other: Any) -> SeriesOrIndex:  # type: ignore[override]
-        _exclude_pd_np_operand(other)
-        return self._dtype_op.ne(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            _exclude_pd_np_operand(other)
+            return self._dtype_op.ne(self, other)
 
     def __lt__(self, other: Any) -> SeriesOrIndex:
-        _exclude_pd_np_operand(other)
-        return self._dtype_op.lt(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            _exclude_pd_np_operand(other)
+            return self._dtype_op.lt(self, other)
 
     def __le__(self, other: Any) -> SeriesOrIndex:
-        _exclude_pd_np_operand(other)
-        return self._dtype_op.le(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            _exclude_pd_np_operand(other)
+            return self._dtype_op.le(self, other)
 
     def __ge__(self, other: Any) -> SeriesOrIndex:
-        _exclude_pd_np_operand(other)
-        return self._dtype_op.ge(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            _exclude_pd_np_operand(other)
+            return self._dtype_op.ge(self, other)
 
     def __gt__(self, other: Any) -> SeriesOrIndex:
-        _exclude_pd_np_operand(other)
-        return self._dtype_op.gt(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            _exclude_pd_np_operand(other)
+            return self._dtype_op.gt(self, other)
 
     def __invert__(self: IndexOpsLike) -> IndexOpsLike:
-        return self._dtype_op.invert(self)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.invert(self)
 
     # `and`, `or`, `not` cannot be overloaded in Python,
     # so use bitwise operators as boolean operators
     def __and__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.__and__(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.__and__(self, other)
 
     def __or__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.__or__(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.__or__(self, other)
 
     def __rand__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.rand(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.rand(self, other)
 
     def __ror__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.ror(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.ror(self, other)
 
     def __xor__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.xor(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.xor(self, other)
 
     def __rxor__(self, other: Any) -> SeriesOrIndex:
-        return self._dtype_op.rxor(self, other)
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return self._dtype_op.rxor(self, other)
 
     def __len__(self) -> int:
         return len(self._psdf)

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -25,7 +25,7 @@ import warnings
 import inspect
 import json
 import types
-from functools import partial, reduce
+from functools import partial, reduce, wraps
 import sys
 from itertools import zip_longest, chain
 from types import TracebackType
@@ -42,6 +42,7 @@ from typing import (
     Sequence,
     Tuple,
     Type,
+    TypeVar,
     Union,
     cast,
     no_type_check,
@@ -109,6 +110,7 @@ from pyspark.pandas.correlation import (
 from pyspark.pandas.spark.accessors import SparkFrameMethods, CachedSparkFrameMethods
 from pyspark.pandas.utils import (
     align_diff_frames,
+    ansi_mode_context,
     column_labels_level,
     combine_frames,
     default_session,
@@ -167,6 +169,18 @@ REPR_PATTERN = re.compile(r"\n\n\[(?P<rows>[0-9]+) rows x (?P<columns>[0-9]+) co
 REPR_HTML_PATTERN = re.compile(
     r"\n\<p\>(?P<rows>[0-9]+) rows × (?P<columns>[0-9]+) columns\<\/p\>\n\<\/div\>$"
 )
+
+
+FuncT = TypeVar("FuncT", bound=Callable[..., Any])
+
+
+def with_ansi_mode_context(f: FuncT) -> FuncT:
+    @wraps(f)
+    def _with_ansi_mode_context(self: "DataFrame", *args: Any, **kwargs: Any) -> Any:
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return f(self, *args, **kwargs)
+
+    return cast(FuncT, _with_ansi_mode_context)
 
 
 _flex_doc_FRAME = """
@@ -740,6 +754,7 @@ class DataFrame(Frame, Generic[T]):
         """
         return [self.index, self.columns]
 
+    @with_ansi_mode_context
     def _reduce_for_stat_function(
         self,
         sfun: Callable[["Series"], PySparkColumn],
@@ -870,6 +885,7 @@ class DataFrame(Frame, Generic[T]):
         """
         return self._pssers[label]
 
+    @with_ansi_mode_context
     def _apply_series_op(
         self,
         op: Callable[["Series"], Union["Series", PySparkColumn]],
@@ -884,6 +900,7 @@ class DataFrame(Frame, Generic[T]):
         return DataFrame(internal)
 
     # Arithmetic Operators
+    @with_ansi_mode_context
     def _map_series_op(self, op: str, other: Any) -> "DataFrame":
         from pyspark.pandas.base import IndexOpsMixin
 
@@ -1507,6 +1524,7 @@ class DataFrame(Frame, Generic[T]):
 
     agg = aggregate
 
+    @with_ansi_mode_context
     def corr(self, method: str = "pearson", min_periods: Optional[int] = None) -> "DataFrame":
         """
         Compute pairwise correlation of columns, excluding NA/null values.
@@ -1726,6 +1744,7 @@ class DataFrame(Frame, Generic[T]):
             )
         )
 
+    @with_ansi_mode_context
     def corrwith(
         self, other: DataFrameOrSeries, axis: Axis = 0, drop: bool = False, method: str = "pearson"
     ) -> "Series":
@@ -8384,6 +8403,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         by_scols = self._prepare_sort_by_scols(columns)
         return self._sort(by=by_scols, ascending=True, na_position="last", keep=keep).head(n=n)
 
+    @with_ansi_mode_context
     def isin(self, values: Union[List, Dict]) -> "DataFrame":
         """
         Whether each element in the DataFrame is contained in values.
@@ -10432,6 +10452,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         else:
             raise TypeError("other must be a pandas-on-Spark DataFrame")
 
+    @with_ansi_mode_context
     def melt(
         self,
         id_vars: Optional[Union[Name, List[Name]]] = None,

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -21,7 +21,7 @@ A wrapper for GroupedData to behave like pandas GroupBy.
 from abc import ABCMeta, abstractmethod
 import inspect
 from collections import defaultdict, namedtuple
-from functools import partial
+from functools import partial, wraps
 from itertools import product
 from typing import (
     Any,
@@ -36,6 +36,7 @@ from typing import (
     Set,
     Tuple,
     Type,
+    TypeVar,
     Union,
     cast,
     TYPE_CHECKING,
@@ -85,6 +86,7 @@ from pyspark.pandas.correlation import (
 )
 from pyspark.pandas.utils import (
     align_diff_frames,
+    ansi_mode_context,
     is_name_like_tuple,
     is_name_like_value,
     name_like_string,
@@ -98,6 +100,18 @@ from pyspark.pandas.exceptions import DataError
 
 if TYPE_CHECKING:
     from pyspark.pandas.window import RollingGroupby, ExpandingGroupby, ExponentialMovingGroupby
+
+
+FuncT = TypeVar("FuncT", bound=Callable[..., Any])
+
+
+def with_ansi_mode_context(f: FuncT) -> FuncT:
+    @wraps(f)
+    def _with_ansi_mode_context(self: "GroupBy", *args: Any, **kwargs: Any) -> Any:
+        with ansi_mode_context(self._psdf._internal.spark_frame.sparkSession):
+            return f(self, *args, **kwargs)
+
+    return cast(FuncT, _with_ansi_mode_context)
 
 
 # to keep it the same as pandas
@@ -3940,6 +3954,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         # Cast columns to ``"float64"`` to match `pandas.DataFrame.groupby`.
         return DataFrame(internal).astype("float64")
 
+    @with_ansi_mode_context
     def corr(
         self,
         method: str = "pearson",

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -23,7 +23,7 @@ import re
 import inspect
 import warnings
 from collections.abc import Mapping
-from functools import partial, reduce
+from functools import partial, reduce, wraps
 from typing import (
     Any,
     Callable,
@@ -36,6 +36,7 @@ from typing import (
     Sequence,
     Tuple,
     Type,
+    TypeVar,
     Union,
     cast,
     no_type_check,
@@ -103,6 +104,7 @@ from pyspark.pandas.internal import (
 from pyspark.pandas.missing.series import MissingPandasLikeSeries
 from pyspark.pandas.plot import PandasOnSparkPlotAccessor
 from pyspark.pandas.utils import (
+    ansi_mode_context,
     combine_frames,
     is_ansi_mode_enabled,
     is_name_like_tuple,
@@ -142,6 +144,18 @@ if TYPE_CHECKING:
 # pattern every time it is used in _repr_ in Series.
 # This pattern basically seeks the footer string from pandas'
 REPR_PATTERN = re.compile(r"Length: (?P<length>[0-9]+)")
+
+FuncT = TypeVar("FuncT", bound=Callable[..., Any])
+
+
+def with_ansi_mode_context(f: FuncT) -> FuncT:
+    @wraps(f)
+    def _with_ansi_mode_context(self: "Series", *args: Any, **kwargs: Any) -> Any:
+        with ansi_mode_context(self._internal.spark_frame.sparkSession):
+            return f(self, *args, **kwargs)
+
+    return cast(FuncT, _with_ansi_mode_context)
+
 
 _flex_doc_SERIES = """
 Return {desc} of series and other, element-wise (binary operator `{op_name}`).
@@ -3403,6 +3417,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             )
         return np.nan if corr is None else corr
 
+    @with_ansi_mode_context
     def corr(
         self, other: "Series", method: str = "pearson", min_periods: Optional[int] = None
     ) -> float:
@@ -4882,6 +4897,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         return self.index
 
     # TODO: introduce 'in_place'; fully support 'regex'
+    @with_ansi_mode_context
     def replace(
         self,
         to_replace: Optional[Union[Any, List, Tuple, Dict]] = None,

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -22,6 +22,7 @@ import functools
 from contextlib import contextmanager
 import json
 import os
+import threading
 from typing import (
     Any,
     Callable,
@@ -1071,29 +1072,101 @@ def xor(df1: PySparkDataFrame, df2: PySparkDataFrame) -> PySparkDataFrame:
     )
 
 
-def is_ansi_mode_enabled(spark: SparkSession) -> bool:
+_ansi_mode_enabled = threading.local()
+
+
+def _is_in_ansi_mode_context(spark: SparkSession) -> bool:
     if is_remote():
         from pyspark.sql.connect.session import SparkSession as ConnectSession
-        from pyspark.pandas.config import _key_format, _options_dict
 
-        client = cast(ConnectSession, spark).client
-        (ansi_mode_support, ansi_enabled) = client.get_config_with_defaults(
-            (
-                _key_format("compute.ansi_mode_support"),
-                json.dumps(_options_dict["compute.ansi_mode_support"].default),
-            ),
-            ("spark.sql.ansi.enabled", None),
-        )
-        if ansi_enabled is None:
-            ansi_enabled = spark.conf.get("spark.sql.ansi.enabled")
-            # Explicitly set the default value to reduce the roundtrip for the next time.
-            spark.conf.set("spark.sql.ansi.enabled", ansi_enabled)
-        return json.loads(ansi_mode_support) and ansi_enabled.lower() == "true"
+        session_id = cast(ConnectSession, spark).session_id
+        return hasattr(_ansi_mode_enabled, session_id)
     else:
-        return (
-            ps.get_option("compute.ansi_mode_support", spark_session=spark)
-            and spark.conf.get("spark.sql.ansi.enabled").lower() == "true"
-        )
+        return hasattr(_ansi_mode_enabled, "enabled")
+
+
+def _set_ansi_mode_enabled_in_context(spark: SparkSession, enabled: Optional[bool] = None) -> None:
+    if enabled is not None:
+        assert _is_in_ansi_mode_context(spark)
+
+    if is_remote():
+        from pyspark.sql.connect.session import SparkSession as ConnectSession
+
+        session_id = cast(ConnectSession, spark).session_id
+        setattr(_ansi_mode_enabled, session_id, enabled)
+    else:
+        _ansi_mode_enabled.enabled = enabled
+
+
+def _get_ansi_mode_enabled_in_context(spark: SparkSession) -> Optional[bool]:
+    assert _is_in_ansi_mode_context(spark)
+
+    if is_remote():
+        from pyspark.sql.connect.session import SparkSession as ConnectSession
+
+        session_id = cast(ConnectSession, spark).session_id
+        return getattr(_ansi_mode_enabled, session_id)
+    else:
+        return _ansi_mode_enabled.enabled
+
+
+def _unset_ansi_mode_enabled_in_context(spark: SparkSession) -> None:
+    assert _is_in_ansi_mode_context(spark)
+
+    if is_remote():
+        from pyspark.sql.connect.session import SparkSession as ConnectSession
+
+        session_id = cast(ConnectSession, spark).session_id
+        delattr(_ansi_mode_enabled, session_id)
+    else:
+        del _ansi_mode_enabled.enabled
+
+
+@contextmanager
+def ansi_mode_context(spark: SparkSession) -> Iterator[None]:
+    if _is_in_ansi_mode_context(spark):
+        yield
+    else:
+        _set_ansi_mode_enabled_in_context(spark)
+        try:
+            yield
+        finally:
+            _unset_ansi_mode_enabled_in_context(spark)
+
+
+def is_ansi_mode_enabled(spark: SparkSession) -> bool:
+    def _is_ansi_mode_enabled() -> bool:
+        if is_remote():
+            from pyspark.sql.connect.session import SparkSession as ConnectSession
+            from pyspark.pandas.config import _key_format, _options_dict
+
+            client = cast(ConnectSession, spark).client
+            (ansi_mode_support, ansi_enabled) = client.get_config_with_defaults(
+                (
+                    _key_format("compute.ansi_mode_support"),
+                    json.dumps(_options_dict["compute.ansi_mode_support"].default),
+                ),
+                ("spark.sql.ansi.enabled", None),
+            )
+            if ansi_enabled is None:
+                ansi_enabled = spark.conf.get("spark.sql.ansi.enabled")
+                # Explicitly set the default value to reduce the roundtrip for the next time.
+                spark.conf.set("spark.sql.ansi.enabled", ansi_enabled)
+            return json.loads(ansi_mode_support) and ansi_enabled.lower() == "true"
+        else:
+            return (
+                ps.get_option("compute.ansi_mode_support", spark_session=spark)
+                and spark.conf.get("spark.sql.ansi.enabled").lower() == "true"
+            )
+
+    if _is_in_ansi_mode_context(spark):
+        enabled = _get_ansi_mode_enabled_in_context(spark)
+        if enabled is None:
+            enabled = _is_ansi_mode_enabled()
+            _set_ansi_mode_enabled_in_context(spark, enabled)
+        return enabled
+    else:
+        return _is_ansi_mode_enabled()
 
 
 def _test() -> None:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduces `ansi_mode_context` to avoid multiple config checks per API call.

### Why are the changes needed?

Currently `is_ansi_mode_enabled` is called many times, which could cause a performance issue as it retrieves the related config every time it's called.

For example:

```py
many_columns = ps.DataFrame({f"col_{i}": [i] for i in range(500)})
many_columns + 1
```

will cause the roundtrip between the client and the server 500 times. To be exact, classic needs two roundtrips to check configs, so the number is 1000 times.

We should reduce the number of retrievals to at most once (or twice in classic) per API call.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing tests should pass, also manually checked the number of config retrivals.

### Was this patch authored or co-authored using generative AI tooling?

No.
