### PR TITLE
[SPARK-53106][SS] Add schema evolution tests for TWS Scala spark connect suites

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/streaming/TransformWithStateConnectSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/streaming/TransformWithStateConnectSuite.scala
@@ -489,6 +489,10 @@ class TransformWithStateConnectSuite
     }
   }
 
+  test("transformWithState - schema evolution") {
+
+  }
+
   /* Utils functions for tests */
   def prepareInputData(inputPath: String, col1: Seq[String], col2: Seq[Int]): File = {
     // Ensure the parent directory exists

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/streaming/TransformWithStateConnectSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/streaming/TransformWithStateConnectSuite.scala
@@ -37,13 +37,9 @@ import org.apache.spark.util.SparkFileUtils
 
 case class InputRowForConnectTest(key: String, value: String)
 case class OutputRowForConnectTest(key: String, value: String)
-
 case class StateRowForConnectTestWithIntType(count: Int)
-
 case class StateRowForConnectTest(count: Long)
-
 case class StateRowForConnectTestWithTwoLongs(count: Long, count2: Long)
-
 case class StateRowForConnectTestWithReorder(count2: Long, count: Long)
 
 // A basic stateful processor which will return the occurrences of key

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/streaming/TransformWithStateConnectSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/streaming/TransformWithStateConnectSuite.scala
@@ -75,7 +75,7 @@ class BasicCountStatefulProcessor
 // A basic stateful processor which will return the occurrences of key.
 // Count State is a Int type.
 class CountStatefulProcessorWithInt
-  extends StatefulProcessor[String, InputRowForConnectTest, OutputRowForConnectTest]
+    extends StatefulProcessor[String, InputRowForConnectTest, OutputRowForConnectTest]
     with Logging {
   @transient protected var _countState: ValueState[StateRowForConnectTestWithIntType] = _
 
@@ -105,7 +105,7 @@ class CountStatefulProcessorWithInt
 // A stateful processor with Two Longs as state
 // which will return the occurrences of key to test TWS schema evolution
 class CountStatefulProcessorTwoLongs
-  extends StatefulProcessor[String, InputRowForConnectTest, OutputRowForConnectTest]
+    extends StatefulProcessor[String, InputRowForConnectTest, OutputRowForConnectTest]
     with Logging {
   @transient protected var _countState: ValueState[StateRowForConnectTestWithTwoLongs] = _
 
@@ -136,7 +136,7 @@ class CountStatefulProcessorTwoLongs
 // Reorder the field Sequence inside StateRowForConnectTestWithTwoLongs.
 // which will return the occurrences of key to test TWS schema evolution
 class CountStatefulProcessorWithReorder
-  extends StatefulProcessor[String, InputRowForConnectTest, OutputRowForConnectTest]
+    extends StatefulProcessor[String, InputRowForConnectTest, OutputRowForConnectTest]
     with Logging {
   @transient protected var _countState: ValueState[StateRowForConnectTestWithReorder] = _
 
@@ -587,9 +587,10 @@ class TransformWithStateConnectSuite
   private def runSchemaEvolutionTest(
       firstProcessor: StatefulProcessor[String, InputRowForConnectTest, OutputRowForConnectTest],
       secondProcessor: StatefulProcessor[String, InputRowForConnectTest, OutputRowForConnectTest])
-  : Unit = {
-    withSQLConf((twsAdditionalSQLConf ++
-      Seq("spark.sql.streaming.stateStore.encodingFormat" -> "avro")): _*) {
+      : Unit = {
+    withSQLConf(
+      (twsAdditionalSQLConf ++
+        Seq("spark.sql.streaming.stateStore.encodingFormat" -> "avro")): _*) {
       val session: SparkSession = spark
       import session.implicits._
 
@@ -692,7 +693,8 @@ class TransformWithStateConnectSuite
 
   test("transformWithState - reorder fields schema evolution") {
     runSchemaEvolutionTest(
-      new CountStatefulProcessorTwoLongs, new CountStatefulProcessorWithReorder)
+      new CountStatefulProcessorTwoLongs,
+      new CountStatefulProcessorWithReorder)
   }
 
   test("transformWithState - upcast fields schema evolution") {
@@ -703,8 +705,10 @@ class TransformWithStateConnectSuite
     val e = intercept[StreamingQueryException] {
       runSchemaEvolutionTest(new BasicCountStatefulProcessor, new CountStatefulProcessorWithInt)
     }
-    assert(e.getCause.asInstanceOf[SparkUnsupportedOperationException]
-      .getCondition == "STATE_STORE_INVALID_VALUE_SCHEMA_EVOLUTION")
+    assert(
+      e.getCause
+        .asInstanceOf[SparkUnsupportedOperationException]
+        .getCondition == "STATE_STORE_INVALID_VALUE_SCHEMA_EVOLUTION")
   }
 
   /* Utils functions for tests */


### PR DESCRIPTION
### What changes were proposed in this pull request?
It's a test only change to get more coverage on schema evolution for TWS.


### Why are the changes needed?
More test coverage for TWS


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT


### Was this patch authored or co-authored using generative AI tooling?
No
