### PR TITLE
[SPARK-53109][SQL] Support TIME in the make_timestamp_ntz and try_make_timestamp_ntz functions in Scala

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -8599,8 +8599,7 @@ object functions {
     Column.fn("make_timestamp_ntz", years, months, days, hours, mins, secs)
 
   /**
-   * Create a local date-time from date and time fields. The function throws an error on invalid
-   * inputs.
+   * Create a local date-time from date and time fields.
    *
    * @group datetime_funcs
    * @since 4.1.0
@@ -8625,8 +8624,7 @@ object functions {
     Column.fn("try_make_timestamp_ntz", years, months, days, hours, mins, secs)
 
   /**
-   * Try to create a local date-time from date and time fields. The function returns NULL on
-   * invalid inputs.
+   * Try to create a local date-time from date and time fields.
    *
    * @group datetime_funcs
    * @since 4.1.0

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -8599,6 +8599,16 @@ object functions {
     Column.fn("make_timestamp_ntz", years, months, days, hours, mins, secs)
 
   /**
+   * Create a local date-time from date and time fields. The function throws an error on invalid
+   * inputs.
+   *
+   * @group datetime_funcs
+   * @since 4.1.0
+   */
+  def make_timestamp_ntz(date: Column, time: Column): Column =
+    Column.fn("make_timestamp_ntz", date, time)
+
+  /**
    * Try to create a local date-time from years, months, days, hours, mins, secs fields. The
    * function returns NULL on invalid inputs.
    *
@@ -8613,6 +8623,16 @@ object functions {
       mins: Column,
       secs: Column): Column =
     Column.fn("try_make_timestamp_ntz", years, months, days, hours, mins, secs)
+
+  /**
+   * Try to create a local date-time from date and time fields. The function returns NULL on
+   * invalid inputs.
+   *
+   * @group datetime_funcs
+   * @since 4.1.0
+   */
+  def try_make_timestamp_ntz(date: Column, time: Column): Column =
+    Column.fn("try_make_timestamp_ntz", date, time)
 
   /**
    * Make year-month interval from years, months.

--- a/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuiteBase.scala
@@ -175,6 +175,20 @@ abstract class TimeFunctionsSuiteBase extends QueryTest with SharedSparkSession 
     // Check that the results match the expected output.
     checkAnswer(result1, expected)
     checkAnswer(result2, expected)
+
+    // NULL result is returned for any NULL input.
+    val nullInputDF = Seq(
+      (null, LocalTime.parse("00:00:00")),
+      (LocalDate.parse("2020-01-01"), null),
+      (null, null)
+    ).toDF("date", "time")
+    val nullResult = Seq[Integer](
+      null, null, null
+    ).toDF("ts").select(col("ts"))
+    checkAnswer(
+      nullInputDF.select(make_timestamp_ntz(col("date"), col("time"))),
+      nullResult
+    )
   }
 
   test("SPARK-52885: hour function") {
@@ -395,6 +409,20 @@ abstract class TimeFunctionsSuiteBase extends QueryTest with SharedSparkSession 
     // Check that the results match the expected output.
     checkAnswer(result1, expected)
     checkAnswer(result2, expected)
+
+    // NULL result is returned for any NULL input.
+    val nullInputDF = Seq(
+      (null, LocalTime.parse("00:00:00")),
+      (LocalDate.parse("2020-01-01"), null),
+      (null, null)
+    ).toDF("date", "time")
+    val nullResult = Seq[Integer](
+      null, null, null
+    ).toDF("ts").select(col("ts"))
+    checkAnswer(
+      nullInputDF.select(try_make_timestamp_ntz(col("date"), col("time"))),
+      nullResult
+    )
   }
 
   test("SPARK-52884: try_to_time function without format") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuiteBase.scala
@@ -143,7 +143,7 @@ abstract class TimeFunctionsSuiteBase extends QueryTest with SharedSparkSession 
     checkAnswer(result2, expected)
   }
 
-  test("SPARK-5XXXX: make_timestamp_ntz function") {
+  test("SPARK-53109: make_timestamp_ntz function") {
     // Input data for the function.
     val schema = StructType(Seq(
       StructField("date", DateType, nullable = false),
@@ -363,7 +363,7 @@ abstract class TimeFunctionsSuiteBase extends QueryTest with SharedSparkSession 
     )
   }
 
-  test("SPARK-5XXXX: try_make_timestamp_ntz function") {
+  test("SPARK-53109: try_make_timestamp_ntz function") {
     // Input data for the function.
     val schema = StructType(Seq(
       StructField("date", DateType, nullable = false),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Implement the `make_timestamp_ntz` and `try_make_timestamp_ntz` functions in Scala API.


### Why are the changes needed?
Expand API support for the `MakeTimestampNTZ` and `TryMakeTimestampNTZ` expressions.

### Does this PR introduce _any_ user-facing change?
Yes, the new functions are now available in Scala API.


### How was this patch tested?
Added appropriate Scala functions tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
