### PR TITLE
[SPARK-53114][CORE][SQL] Support `join` in `JavaUtils`

### DIFF
--- a/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -522,4 +522,12 @@ public class JavaUtils {
     }
   }
 
+  public static String join(List<Object> arr, String sep) {
+    if (arr == null) return "";
+    StringJoiner joiner = new StringJoiner(sep == null ? "" : sep);
+    for (Object a : arr) {
+      joiner.add(a == null ? "" : a.toString());
+    }
+    return joiner.toString();
+  }
 }

--- a/sql/hive/src/test/java/org/apache/spark/sql/hive/execution/UDFListString.java
+++ b/sql/hive/src/test/java/org/apache/spark/sql/hive/execution/UDFListString.java
@@ -19,8 +19,9 @@ package org.apache.spark.sql.hive.execution;
 
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.ql.exec.UDF;
+
+import org.apache.spark.network.util.JavaUtils;
 
 public class UDFListString extends UDF {
 
@@ -31,7 +32,7 @@ public class UDFListString extends UDF {
     @SuppressWarnings("unchecked")
     List<Object> s = (List<Object>) a;
 
-    return StringUtils.join(s, ',');
+    return JavaUtils.join(s, ",");
   }
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `join` in `JavaUtils`.

### Why are the changes needed?

By taking advantage of Java `StringJoiner`, we can provide `join` method.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.