### PR TITLE
[SPARK-53117][CORE][SQL] Support `moveDirectory` in `SparkFileUtils` and `JavaUtils`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
@@ -152,6 +152,11 @@ private[spark] trait SparkFileUtils extends Logging {
     }.toFile
   }
 
+  /** Move src to dst simply. File attribute times are not copied. */
+  def moveDirectory(src: File, dst: File): Unit = {
+    JavaUtils.moveDirectory(src, dst)
+  }
+
   /** Copy src to the target directory simply. File attribute times are not copied. */
   def copyDirectory(src: File, dir: File): Unit = {
     JavaUtils.copyDirectory(src, dir)

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -342,6 +342,11 @@ This file is divided into 3 sections:
     <customMessage>Use copyDirectory of JavaUtils/SparkFileUtils/Utils instead.</customMessage>
   </check>
 
+  <check customId="moveDirectory" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.moveDirectory\b</parameter></parameters>
+    <customMessage>Use copyDirectory of SparkFileUtils or Utils instead.</customMessage>
+  </check>
+
   <check customId="contentEquals" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">\bFileUtils\.contentEquals\b</parameter></parameters>
     <customMessage>Use contentEquals of SparkFileUtils or Utils instead.</customMessage>

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -25,7 +25,6 @@ import java.util.concurrent.CountDownLatch
 import scala.collection.mutable
 import scala.util.{Success, Try}
 
-import org.apache.commons.io.FileUtils
 import org.apache.commons.lang3.RandomStringUtils
 import org.apache.hadoop.fs.Path
 import org.mockito.Mockito.when
@@ -1163,7 +1162,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
       assertMigrationError(e2.getMessage, sparkMetadataDir, legacySparkMetadataDir)
 
       // Move "_spark_metadata" to fix the file sink and test the checkpoint path.
-      FileUtils.moveDirectory(legacySparkMetadataDir, sparkMetadataDir)
+      Utils.moveDirectory(legacySparkMetadataDir, sparkMetadataDir)
 
       // Restarting the streaming query should detect the legacy
       // checkpoint path and throw an error.
@@ -1177,7 +1176,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
       assertMigrationError(e3.getMessage, checkpointDir, legacyCheckpointDir)
 
       // Fix the checkpoint path and verify that the user can migrate the issue by moving files.
-      FileUtils.moveDirectory(legacyCheckpointDir, checkpointDir)
+      Utils.moveDirectory(legacyCheckpointDir, checkpointDir)
 
       val q = inputData.toDF()
         .writeStream


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `moveDirectory` in `SparkFileUtils` and `JavaUtils`.

### Why are the changes needed?

To improve Spark file utility functions.

### Does this PR introduce _any_ user-facing change?

No behavior changes.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.