### PR TITLE
[SPARK-53118][CORE][TESTS] Use `Files.write` in `GenericFileInputStreamSuite`

### DIFF
--- a/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
+++ b/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.io;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,7 +44,7 @@ public abstract class GenericFileInputStreamSuite {
   public void setUp() throws IOException {
     ThreadLocalRandom.current().nextBytes(randomBytes);
     inputFile = File.createTempFile("temp-file", ".tmp");
-    FileUtils.writeByteArrayToFile(inputFile, randomBytes);
+    Files.write(inputFile.toPath(), randomBytes);
   }
 
   @AfterEach


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `Files.write` instead of `FileUtils.writeByteArrayToFile` in the abstract test suite `GenericFileInputStreamSuite`. This will be used in the following two test cases.

- org.apache.spark.io.GenericFileInputStreamSuite
  - org.apache.spark.io.NioBufferedInputStreamSuite
  - org.apache.spark.io.ReadAheadInputStreamSuite

### Why are the changes needed?

This is the only place to use `FileUtils.writeByteArrayToFile` to write **2MB** byte array to generate a test input file. We had better use Java's native method for small test data usage.

https://github.com/apache/spark/blob/50882d2d88866ef0747ab7b542ac8ebaab4418ae/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java#L37

### Does this PR introduce _any_ user-facing change?

This is a test only change.

### How was this patch tested?

Pass the CIs.

**BEFORE**
```
$ git grep FileUtils.writeByteArrayToFile
core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java:    FileUtils.writeByteArrayToFile(inputFile, randomBytes);
```

**AFTER**
```
$ git grep FileUtils.writeByteArrayToFile
```

### Was this patch authored or co-authored using generative AI tooling?

No.