### PR TITLE
[SPARK-53119][CORE] Support `touch` in `SparkFileUtils`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
@@ -201,7 +201,7 @@ private[spark] trait SparkFileUtils extends Logging {
 
   def touch(file: File): Unit = {
     if (file == null) {
-      throw new IllegalArgumentException(s"Invalid input file $file")
+      throw new IllegalArgumentException("Invalid input file: null")
     }
     val path = file.toPath
     if (Files.exists(path)) {

--- a/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
@@ -19,6 +19,7 @@ package org.apache.spark.util
 import java.io.File
 import java.net.{URI, URISyntaxException}
 import java.nio.file.{Files, Path, StandardCopyOption}
+import java.nio.file.attribute.FileTime
 
 import org.apache.spark.internal.{Logging, LogKeys, MDC}
 import org.apache.spark.network.util.JavaUtils
@@ -195,6 +196,22 @@ private[spark] trait SparkFileUtils extends Logging {
       val path1 = file1.toPath
       val path2 = file2.toPath
       Files.isSameFile(path1, path2) || Files.mismatch(path1, path2) == -1L
+    }
+  }
+
+  def touch(file: File): Unit = {
+    if (file == null) {
+      throw new IllegalArgumentException(s"Invalid input file $file")
+    }
+    val path = file.toPath
+    if (Files.exists(path)) {
+      Files.setLastModifiedTime(path, FileTime.fromMillis(System.currentTimeMillis()))
+    } else {
+      val parent = path.getParent()
+      if (parent != null && !Files.exists(parent)) {
+        Files.createDirectories(parent)
+      }
+      Files.createFile(path)
     }
   }
 }

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -32,7 +32,6 @@ import org.apache.avro.Schema.Type._
 import org.apache.avro.file.{DataFileReader, DataFileWriter}
 import org.apache.avro.generic.{GenericData, GenericDatumReader, GenericDatumWriter, GenericRecord}
 import org.apache.avro.generic.GenericData.{EnumSymbol, Fixed}
-import org.apache.commons.io.FileUtils
 
 import org.apache.spark.{SPARK_VERSION_SHORT, SparkConf, SparkException, SparkRuntimeException, SparkThrowable, SparkUpgradeException}
 import org.apache.spark.TestUtils.assertExceptionMsg
@@ -640,7 +639,7 @@ abstract class AvroSuite
 
   private def createDummyCorruptFile(dir: File): Unit = {
     Utils.tryWithResource {
-      FileUtils.forceMkdir(dir)
+      Files.createDirectories(dir.toPath)
       val corruptFile = new File(dir, "corrupt.avro")
       new BufferedWriter(new FileWriter(corruptFile))
     } { writer =>
@@ -1875,7 +1874,7 @@ abstract class AvroSuite
 
     intercept[FileNotFoundException] {
       withTempDir { dir =>
-        FileUtils.touch(new File(dir, "test"))
+        Utils.touch(new File(dir, "test"))
         withSQLConf(AvroFileFormat.IgnoreFilesWithoutExtensionProperty -> "true") {
           spark.read.format("avro").load(dir.toString)
         }
@@ -1884,7 +1883,7 @@ abstract class AvroSuite
 
     intercept[FileNotFoundException] {
       withTempDir { dir =>
-        FileUtils.touch(new File(dir, "test"))
+        Utils.touch(new File(dir, "test"))
 
         spark
           .read

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -363,6 +363,11 @@ This file is divided into 3 sections:
     <customMessage>Use getFile of SparkFileUtil or Utils instead.</customMessage>
   </check>
 
+  <check customId="touch" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.touch\b</parameter></parameters>
+    <customMessage>Use touch of SparkFileUtil or Utils instead.</customMessage>
+  </check>
+
   <check customId="writeStringToFile" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">\bFileUtils\.writeStringToFile\b</parameter></parameters>
     <customMessage>Use java.nio.file.Files.writeString instead.</customMessage>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `touch` method in `SparkFileUtils`.

### Why are the changes needed?

To improve Spark's file utility functions.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.