### PR TITLE
[SPARK-53120][DOCS] Recover _source directory for PySpark documentation 

### DIFF
--- a/docs/_plugins/build_api_docs.rb
+++ b/docs/_plugins/build_api_docs.rb
@@ -168,7 +168,6 @@ def build_python_docs
   mkdir_p "api/python"
 
   puts "cp -r ../python/docs/build/html/. api/python"
-  rm_r("../python/docs/build/html/_sources")
   cp_r("../python/docs/build/html/.", "api/python")
 end
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a revert of https://github.com/apache/spark/pull/47686

### Why are the changes needed?

See https://github.com/apache/spark/pull/47686#issuecomment-3153001167

### Does this PR introduce _any_ user-facing change?

Yes, documentation. Show Sources button should work.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No
