### PR TITLE
[SPARK-53121][SQL] Use `deleteRecursively` instead of `FileUtils.forceDelete`

### DIFF
--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -209,7 +209,11 @@
         </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="FileUtils\.deleteDirectory"/>
-            <property name="message" value="Use deleteRecursively of SparkFileUtils or Utils instead." />
+            <property name="message" value="Use deleteRecursively of JavaUtils/SparkFileUtils/Utils instead." />
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="FileUtils\.forceDelete\("/>
+            <property name="message" value="Use deleteRecursively of JavaUtils/SparkFileUtils/Utils instead." />
         </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="FileUtils\.deleteQuietly"/>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -309,7 +309,12 @@ This file is divided into 3 sections:
 
   <check customId="deleteRecursively" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">\bFileUtils\.deleteDirectory\b</parameter></parameters>
-    <customMessage>Use deleteRecursively of SparkFileUtils or Utils</customMessage>
+    <customMessage>Use deleteRecursively of JavaUtils/SparkFileUtils/Utils</customMessage>
+  </check>
+
+  <check customId="forceDelete" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.forceDelete\b</parameter></parameters>
+    <customMessage>Use deleteRecursively of JavaUtils/SparkFileUtils/Utils</customMessage>
   </check>
 
   <check customId="deleteQuietly" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hive.common.cli.HiveFileProcessor;
 import org.apache.hadoop.hive.common.cli.IHiveFileProcessor;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -74,6 +73,7 @@ import org.apache.spark.internal.SparkLogger;
 import org.apache.spark.internal.SparkLoggerFactory;
 import org.apache.spark.internal.LogKeys;
 import org.apache.spark.internal.MDC;
+import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.util.Utils;
 import org.apache.spark.util.SparkStringUtils;
 
@@ -714,7 +714,7 @@ public class HiveSessionImpl implements HiveSession {
     } else {
       for (File file : fileAry) {
         try {
-          FileUtils.forceDelete(file);
+          JavaUtils.deleteRecursively(file);
         } catch (Exception e) {
           LOG.error("Failed to cleanup pipeout file: {}", e, MDC.of(LogKeys.PATH$.MODULE$, file));
         }
@@ -725,7 +725,7 @@ public class HiveSessionImpl implements HiveSession {
   private void cleanupSessionLogDir() {
     if (isOperationLogEnabled) {
       try {
-        FileUtils.forceDelete(sessionLogDir);
+        JavaUtils.deleteRecursively(sessionLogDir);
       } catch (Exception e) {
         LOG.error("Failed to cleanup session log dir: {}", e,
           MDC.of(LogKeys.SESSION_HANDLE$.MODULE$, sessionHandle));

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/SessionManager.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/SessionManager.java
@@ -231,7 +231,7 @@ public class SessionManager extends CompositeService {
   private void cleanupLoggingRootDir() {
     if (isOperationLogEnabled) {
       try {
-        FileUtils.forceDelete(operationLogRootDir);
+        Utils.deleteRecursively(operationLogRootDir);
       } catch (Exception e) {
         LOG.warn("Failed to cleanup root dir of HS2 logging: {}", e,
           MDC.of(LogKeys.PATH$.MODULE$, operationLogRootDir.getAbsolutePath()));

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnvSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnvSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.hive.thriftserver
 
-import org.apache.commons.io.FileUtils
 import test.custom.listener.{DummyQueryExecutionListener, DummyStreamingQueryListener}
 
 import org.apache.spark.SparkFunSuite
@@ -31,7 +30,7 @@ import org.apache.spark.util.Utils
 class SparkSQLEnvSuite extends SparkFunSuite {
   test("SPARK-29604 external listeners should be initialized with Spark classloader") {
     val metastorePath = Utils.createTempDir("spark_derby")
-    FileUtils.forceDelete(metastorePath)
+    Utils.deleteRecursively(metastorePath)
 
     val jdbcUrl = s"jdbc:derby:;databaseName=$metastorePath;create=true"
 
@@ -61,7 +60,7 @@ class SparkSQLEnvSuite extends SparkFunSuite {
       } finally {
         SparkSQLEnv.stop()
         if (metastorePath.exists()) {
-          FileUtils.forceDelete(metastorePath)
+          Utils.deleteRecursively(metastorePath)
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `deleteRecursively` instead of `FileUtils.forceDelete`.

```scala
- FileUtils.forceDelete(dir)
+ Utils.deleteRecursively(dir)
```

```scala
- FileUtils.forceDelete(dir)
+ JavaUtils.deleteRecursively(dir)
```

### Why are the changes needed?

Apache Spark provides `Utils.deleteRecursively` which contains two versions, `deleteRecursivelyUsingUnixNative` and `deleteRecursivelyUsingJavaIO`. We had better take advantage of Spark's built-in optimized one because it's more optimized than `commons-io`.

https://github.com/apache/spark/blob/7c6693ddec00c32d50d254817a7f09a993d71017/core/src/main/scala/org/apache/spark/util/Utils.scala#L1047-L1052

https://github.com/apache/spark/blob/7c6693ddec00c32d50d254817a7f09a993d71017/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala#L120-L122

https://github.com/apache/spark/blob/7c6693ddec00c32d50d254817a7f09a993d71017/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java#L105-L125

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.