### PR TITLE
[SPARK-53122][CORE] Support `moveFile` in `SparkFileUtils` and `JavaUtils`

### DIFF
--- a/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -76,6 +76,17 @@ public class JavaUtils {
     }
   }
 
+  /** Move a file from src to dst. */
+  public static void moveFile(File src, File dst) throws IOException {
+    if (src == null || dst == null || !src.exists() || src.isDirectory() || dst.exists()) {
+      throw new IllegalArgumentException("Invalid input " + src + " or " + dst);
+    }
+    if (!src.renameTo(dst)) { // Try to use File.renameTo first
+      Files.move(src.toPath(), dst.toPath());
+    }
+  }
+
+  /** Move a directory from src to dst. */
   public static void moveDirectory(File src, File dst) throws IOException {
     if (src == null || dst == null || !src.exists() || !src.isDirectory() || dst.exists()) {
       throw new IllegalArgumentException("Invalid input " + src + " or " + dst);

--- a/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
@@ -154,6 +154,11 @@ private[spark] trait SparkFileUtils extends Logging {
   }
 
   /** Move src to dst simply. File attribute times are not copied. */
+  def moveFile(src: File, dst: File): Unit = {
+    JavaUtils.moveFile(src, dst)
+  }
+
+  /** Move src to dst simply. File attribute times are not copied. */
   def moveDirectory(src: File, dst: File): Unit = {
     JavaUtils.moveDirectory(src, dst)
   }

--- a/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
@@ -27,7 +27,6 @@ import scala.collection.mutable.ListBuffer
 
 import com.google.common.io.Closeables
 import io.netty.channel.DefaultFileRegion
-import org.apache.commons.io.FileUtils
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkException}
 import org.apache.spark.internal.{config, Logging, MDC}
@@ -151,7 +150,7 @@ private[spark] class DiskStore(
     blockSizes.put(targetBlockId, blockSize)
     val targetFile = diskManager.getFile(targetBlockId.name)
     logDebug(s"${sourceFile.getPath()} -> ${targetFile.getPath()}")
-    FileUtils.moveFile(sourceFile, targetFile)
+    Utils.moveFile(sourceFile, targetFile)
   }
 
   def contains(blockId: BlockId): Boolean = diskManager.containsBlock(blockId)

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -332,6 +332,11 @@ This file is divided into 3 sections:
     <customMessage>Use sizeOf of JavaUtils or Utils instead.</customMessage>
   </check>
 
+  <check customId="moveFile" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.moveFile\b</parameter></parameters>
+    <customMessage>Use copyFile of JavaUtils/SparkFileUtils/Utils instead.</customMessage>
+  </check>
+
   <check customId="copyFile" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">\bFileUtils\.copyFile\b</parameter></parameters>
     <customMessage>Use copyFile of SparkFileUtils or Utils instead.</customMessage>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `moveFile` API in `SparkFileUtils` and `JavaUtils`.

### Why are the changes needed?

To improve Spark file utility functions.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.