### PR TITLE
[SPARK-53124][SQL] Prune unnecessary fields from JsonTuple

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -2585,6 +2585,29 @@ object GenerateOptimization extends Rule[LogicalPlan] {
             p.withNewChildren(Seq(updatedGenerate))
           case _ => p
         }
+
+      case p @ Project(_, g: Generate) if g.generator.isInstanceOf[JsonTuple] =>
+        val generatorOutput = g.generatorOutput
+        val usedOutputs =
+          AttributeSet(generatorOutput).intersect(AttributeSet(p.projectList.flatMap(_.references)))
+
+        usedOutputs.size match {
+          case 0 =>
+            p.withNewChildren(g.children)
+          case n if n < generatorOutput.size =>
+            val originJsonTuple = g.generator.asInstanceOf[JsonTuple]
+            val (newJsonExpressions, newGeneratorOutput) =
+              generatorOutput.zipWithIndex.collect {
+                case (attr, i) if usedOutputs.contains(attr) =>
+                  (originJsonTuple.children(i + 1), attr)
+              }.unzip
+            p.withNewChildren(Seq(g.copy(
+              generator = JsonTuple(originJsonTuple.children.head +: newJsonExpressions),
+              unrequiredChildIndex = Nil,
+              generatorOutput = newGeneratorOutput)))
+          case _ =>
+            p
+        }
     }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -2603,7 +2603,6 @@ object GenerateOptimization extends Rule[LogicalPlan] {
               }.unzip
             p.withNewChildren(Seq(g.copy(
               generator = JsonTuple(originJsonTuple.children.head +: newJsonExpressions),
-              unrequiredChildIndex = Nil,
               generatorOutput = newGeneratorOutput)))
           case _ =>
             p


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enhances the `GenerateOptimization` rule in Spark SQL Catalyst to improve the pruning of unnecessary fields from `JsonTuple` generators.

Explicitly handled these cases:
- No generator outputs used: remove the Generate node.
- Some generator outputs used: prune the JsonTuple to keep only necessary fields.

Example:
```sql
SELECT f2
FROM (SELECT '{"f1": "Spark", "f2": 2025, "f3": 8}' AS json) test
LATERAL VIEW json_tuple(json, 'f1', 'f2', 'f2') jt AS f1, f2, f3
```

Before this PR:
```
== Optimized Logical Plan ==
Project [f2#2]
+- Generate json_tuple({"f1": "Spark", "f2": 2025, "f3": 8}, f1, f2, f2), false, jt, [f1#1, f2#2, f3#3]
   +- OneRowRelation
```

After this PR:
```
== Optimized Logical Plan ==
Generate json_tuple({"f1": "Spark", "f2": 2025, "f3": 8}, f2), false, jt, [f2#2]
+- OneRowRelation
```

### Why are the changes needed?

Prune unnecessary JSON fields, reducing data processing overhead and improving query performance.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added unit tests covering all scenarios: no outputs used, some outputs used, and all outputs used.

### Was this patch authored or co-authored using generative AI tooling?

No.