### PR TITLE
[SPARK-53125][TEST] RemoteSparkSession prints whole `spark-submit` command

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/RemoteSparkSession.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/RemoteSparkSession.scala
@@ -71,7 +71,7 @@ object SparkConnectServerUtils {
       findJar("sql/catalyst", "spark-catalyst", "spark-catalyst", test = true).getCanonicalPath
 
     val command = Seq.newBuilder[String]
-    command += "bin/spark-submit"
+    command += s"$sparkHome/bin/spark-submit"
     command += "--driver-class-path" += connectJar
     command += "--class" += "org.apache.spark.sql.connect.SimpleSparkConnectService"
     command += "--jars" += catalystTestJar
@@ -79,7 +79,14 @@ object SparkConnectServerUtils {
     command ++= testConfigs
     command ++= debugConfigs
     command += connectJar
-    val builder = new ProcessBuilder(command.result(): _*)
+    val cmds = command.result()
+    debug {
+      cmds.reduce[String] {
+        case (acc, cmd) if cmd startsWith "-" => acc + " \\\n    " + cmd
+        case (acc, cmd) => acc + " " + cmd
+      }
+    }
+    val builder = new ProcessBuilder(cmds: _*)
     builder.directory(new File(sparkHome))
     val environment = builder.environment()
     environment.remove("SPARK_DIST_CLASSPATH")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Make RemoteSparkSession print the whole `spark-submit` command in debug mode, which helps the developers to understand the SPARK_HOME, classpath, log output, etc. of the testing connect server process.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improve the debug message.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
```
export SPARK_DEBUG_SC_JVM_CLIENT=true
```
```
sbt:spark-connect-client-jvm> testOnly *ClientE2ETestSuite -- -z "throw SparkException with large cause exception"
[info] ClientE2ETestSuite:
Starting the Spark Connect Server...
Using jar: /Users/chengpan/Projects/apache-spark/sql/connect/server/target/scala-2.13/spark-connect-assembly-4.1.0-SNAPSHOT.jar
Using jar: /Users/chengpan/Projects/apache-spark/sql/catalyst/target/scala-2.13/spark-catalyst_2.13-4.1.0-SNAPSHOT-tests.jar
/Users/chengpan/Projects/apache-spark/bin/spark-submit \
    --driver-class-path /Users/chengpan/Projects/apache-spark/sql/connect/server/target/scala-2.13/spark-connect-assembly-4.1.0-SNAPSHOT.jar \
    --class org.apache.spark.sql.connect.SimpleSparkConnectService \
    --jars /Users/chengpan/Projects/apache-spark/sql/catalyst/target/scala-2.13/spark-catalyst_2.13-4.1.0-SNAPSHOT-tests.jar \
    --conf spark.connect.grpc.binding.port=15707 \
    --conf spark.sql.catalog.testcat=org.apache.spark.sql.connector.catalog.InMemoryTableCatalog \
    --conf spark.sql.catalogImplementation=hive \
    --conf spark.connect.execute.reattachable.senderMaxStreamDuration=1s \
    --conf spark.connect.execute.reattachable.senderMaxStreamSize=123 \
    --conf spark.connect.grpc.arrow.maxBatchSize=10485760 \
    --conf spark.ui.enabled=false \
    --conf spark.driver.extraJavaOptions=-Dlog4j.configurationFile=/Users/chengpan/Projects/apache-spark/sql/connect/client/jvm/src/test/resources/log4j2.properties /Users/chengpan/Projects/apache-spark/sql/connect/server/target/scala-2.13/spark-connect-assembly-4.1.0-SNAPSHOT.jar
...
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.