### PR TITLE
[SPARK-53128][CORE] Include unmanaged memory bytes in the usage log before execution memory OOM

### DIFF
--- a/core/src/main/java/org/apache/spark/memory/TaskMemoryManager.java
+++ b/core/src/main/java/org/apache/spark/memory/TaskMemoryManager.java
@@ -339,9 +339,12 @@ public class TaskMemoryManager {
         MDC.of(LogKeys.MEMORY_SIZE, memoryNotAccountedFor),
         MDC.of(LogKeys.TASK_ATTEMPT_ID, taskAttemptId));
       logger.info(
-        "{} bytes of memory are used for execution and {} bytes of memory are used for storage",
+        "{} bytes of memory are used for execution " +
+                "and {} bytes of memory are used for storage " +
+                "and {} bytes of memory are used but unmanaged",
         MDC.of(LogKeys.EXECUTION_MEMORY_SIZE, memoryManager.executionMemoryUsed()),
-        MDC.of(LogKeys.STORAGE_MEMORY_SIZE,  memoryManager.storageMemoryUsed()));
+        MDC.of(LogKeys.STORAGE_MEMORY_SIZE,  memoryManager.storageMemoryUsed()),
+        MDC.of(LogKeys.MEMORY_SIZE, UnifiedMemoryManager$.MODULE$.getUnmanagedMemoryUsed()));
     }
   }
 

--- a/core/src/main/java/org/apache/spark/memory/TaskMemoryManager.java
+++ b/core/src/main/java/org/apache/spark/memory/TaskMemoryManager.java
@@ -341,7 +341,7 @@ public class TaskMemoryManager {
       logger.info(
         "{} bytes of memory are used for execution " +
                 "and {} bytes of memory are used for storage " +
-                "and {} bytes of memory are used but unmanaged",
+                "and {} bytes of unmanaged memory are used",
         MDC.of(LogKeys.EXECUTION_MEMORY_SIZE, memoryManager.executionMemoryUsed()),
         MDC.of(LogKeys.STORAGE_MEMORY_SIZE,  memoryManager.storageMemoryUsed()),
         MDC.of(LogKeys.MEMORY_SIZE, UnifiedMemoryManager$.MODULE$.getUnmanagedMemoryUsed()));

--- a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
@@ -274,6 +274,14 @@ object UnifiedMemoryManager extends Logging {
   private val pollingStarted = new AtomicBoolean(false)
 
   /**
+   * Returns the total unmanaged memory in bytes, including both
+   * on-heap unmanaged memory and off-heap unmanaged memory.
+   */
+  private[spark] def getUnmanagedMemoryUsed: Long = {
+    UnifiedMemoryManager.unmanagedOnHeapUsed.get() + UnifiedMemoryManager.unmanagedOffHeapUsed.get()
+  }
+
+  /**
    * Register an unmanaged memory consumer to track its memory usage.
    *
    * Unmanaged memory consumers are components that manage their own memory outside


### PR DESCRIPTION
### What changes were proposed in this pull request?

We have a log before OOM for off-heap memory allocation. 

Before the change, the log is:

> 25/08/05 16:44:32 INFO TaskMemoryManager: 100 bytes of memory are used for execution and 100 bytes of memory are used for storage

After:

> 25/08/05 16:44:32 INFO TaskMemoryManager: 100 bytes of memory are used for execution and 100 bytes of memory are used for storage and 500 bytes of memory are used but unmanaged

### Why are the changes needed?

Following https://github.com/apache/spark/pull/51708, to allow user to know the reason if the unmanaged memory causes OOM.

### Does this PR introduce _any_ user-facing change?

Only changes a log message. 


### How was this patch tested?

Existing tests.


### Was this patch authored or co-authored using generative AI tooling?

No.