### PR TITLE
[SPARK-53129][SHELL] Improve `SparkShell` to import `java.net._` by default

### DIFF
--- a/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -73,7 +73,8 @@ class SparkILoop(config: ShellConfig, in0: BufferedReader, out: PrintWriter)
     "import spark.implicits._",
     "import spark.sql",
     "import org.apache.spark.sql.functions._",
-    "import org.apache.spark.util.LogUtils.SPARK_LOG_SCHEMA"
+    "import org.apache.spark.util.LogUtils.SPARK_LOG_SCHEMA",
+    "import java.net._"
   )
 
   override protected def internalReplAutorunCode(): Seq[String] =

--- a/repl/src/test/scala/org/apache/spark/repl/ReplSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/ReplSuite.scala
@@ -461,4 +461,12 @@ class ReplSuite extends SparkFunSuite {
     assertDoesNotContain("Exception", output)
     assertDoesNotContain("assertion failed", output)
   }
+
+  test("SPARK-53129: spark-shell imports java.net._ by default") {
+    val output = runInterpreter("local",
+      """
+        |new URI("https://spark.apache.org")
+      """.stripMargin)
+    assertDoesNotContain("error: not found: type URI", output)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `SparkShell` to import `java.net._` by default.

### Why are the changes needed?

`jshell` is supported since Java 9 but Apache Spark community decided not to provide a `jshell` based interactive environment.

However, it doesn't mean that `spark-shell` should be behind `jshell`.

**JSHELL**
```java
$ jshell
|  Welcome to JShell -- Version 17.0.16
|  For an introduction type: /help intro

jshell> new URI("https://spark.apache.org")
$1 ==> https://spark.apache.org
```

**BEFORE**

```scala
scala> spark.version
val res0: String = 4.1.0-preview1

scala> new URI("https://spark.apache.org")
           ^
       error: not found: type URI
```

**AFTER**

```scala
scala> spark.version
val res0: String = 4.1.0-SNAPSHOT

scala> new URI("https://spark.apache.org")
val res1: java.net.URI = https://spark.apache.org
```

### Does this PR introduce _any_ user-facing change?

No because Scala has no conflicts with `java.net` package.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.