### PR TITLE
[SPARK-53132][CORE][SQL][MLLIB] Support `list(File|Path)s` in `SparkFileUtils` and `JavaUtils`

### DIFF
--- a/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import java.util.stream.Collectors;
 
 import org.apache.spark.internal.SparkLogger;
 import org.apache.spark.internal.SparkLoggerFactory;
@@ -337,6 +338,27 @@ public class JavaUtils {
       return files;
     } else {
       return new File[0];
+    }
+  }
+
+  public static Set<Path> listPaths(File dir) throws IOException {
+    if (dir == null || !dir.exists() || !dir.isDirectory()) {
+      throw new IllegalArgumentException("Invalid input " + dir);
+    }
+    try (var stream = Files.walk(dir.toPath())) {
+      return stream.filter(Files::isRegularFile).collect(Collectors.toCollection(HashSet::new));
+    }
+  }
+
+  public static Set<File> listFiles(File dir) throws IOException {
+    if (dir == null || !dir.exists() || !dir.isDirectory()) {
+      throw new IllegalArgumentException("Invalid input " + dir);
+    }
+    try (var stream = Files.walk(dir.toPath())) {
+      return stream
+        .filter(Files::isRegularFile)
+        .map(Path::toFile)
+        .collect(Collectors.toCollection(HashSet::new));
     }
   }
 

--- a/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
@@ -74,6 +74,20 @@ private[spark] trait SparkFileUtils extends Logging {
   }
 
   /**
+   * Lists regular files recursively.
+   */
+  def listFiles(f: File): java.util.Set[File] = {
+    JavaUtils.listFiles(f)
+  }
+
+  /**
+   * Lists regular paths recursively.
+   */
+  def listPaths(f: File): java.util.Set[Path] = {
+    JavaUtils.listPaths(f)
+  }
+
+  /**
    * Create a directory given the abstract pathname
    * @return true, if the directory is successfully created; otherwise, return false.
    */

--- a/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
@@ -23,8 +23,6 @@ import java.util.concurrent.{Callable, CyclicBarrier, Executors, ExecutorService
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.commons.io.FileUtils
-import org.apache.commons.io.filefilter.TrueFileFilter
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
 
@@ -37,8 +35,8 @@ import org.apache.spark.scheduler.{MapStatus, MergeStatus, MyRDD, SparkListener,
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
 import org.apache.spark.shuffle.ShuffleWriter
 import org.apache.spark.storage.{ShuffleBlockId, ShuffleDataBlockId, ShuffleIndexBlockId}
+import org.apache.spark.util.{MutablePair, Utils}
 import org.apache.spark.util.ArrayImplicits._
-import org.apache.spark.util.MutablePair
 
 abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalRootDirsTest {
 
@@ -426,8 +424,7 @@ abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalRootDi
 
   test("SPARK-34541: shuffle can be removed") {
     withTempDir { tmpDir =>
-      def getAllFiles: Set[File] =
-        FileUtils.listFiles(tmpDir, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE).asScala.toSet
+      def getAllFiles: Set[File] = Utils.listFiles(tmpDir).asScala.toSet
       conf.set("spark.local.dir", tmpDir.getAbsolutePath)
       sc = new SparkContext("local", "test", conf)
       // For making the taskAttemptId starts from 1.

--- a/core/src/test/scala/org/apache/spark/SortShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SortShuffleSuite.scala
@@ -17,12 +17,8 @@
 
 package org.apache.spark
 
-import java.io.File
-
 import scala.jdk.CollectionConverters._
 
-import org.apache.commons.io.FileUtils
-import org.apache.commons.io.filefilter.TrueFileFilter
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers._
 
@@ -30,6 +26,7 @@ import org.apache.spark.internal.config.{SHUFFLE_CHECKSUM_ALGORITHM, SHUFFLE_MAN
 import org.apache.spark.rdd.ShuffledRDD
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
 import org.apache.spark.shuffle.sort.SortShuffleManager
+import org.apache.spark.util.Utils
 
 class SortShuffleSuite extends ShuffleSuite with BeforeAndAfterAll {
 
@@ -62,8 +59,7 @@ class SortShuffleSuite extends ShuffleSuite with BeforeAndAfterAll {
   }
 
   private def ensureFilesAreCleanedUp(shuffledRdd: ShuffledRDD[_, _, _]): Unit = {
-    def getAllFiles: Set[File] =
-      FileUtils.listFiles(tempDir, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE).asScala.toSet
+    def getAllFiles = Utils.listFiles(tempDir).asScala.toSet
     val filesBeforeShuffle = getAllFiles
     // Force the shuffle to be performed
     shuffledRdd.count()

--- a/core/src/test/scala/org/apache/spark/rdd/RDDCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDCleanerSuite.scala
@@ -21,9 +21,6 @@ import java.io.File
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.commons.io.FileUtils
-import org.apache.commons.io.filefilter.TrueFileFilter
-
 import org.apache.spark._
 import org.apache.spark.util.Utils
 
@@ -34,8 +31,7 @@ class RDDCleanerSuite extends SparkFunSuite with LocalRootDirsTest {
     val conf = new SparkConf()
     val localDir = Utils.createTempDir()
     val checkpointDir = Utils.createTempDir()
-    def getAllFiles: Set[File] =
-      FileUtils.listFiles(localDir, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE).asScala.toSet
+    def getAllFiles: Set[File] = Utils.listFiles(localDir).asScala.toSet
     try {
       conf.set("spark.local.dir", localDir.getAbsolutePath)
       val sc = new SparkContext("local[2]", "test", conf)

--- a/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
@@ -24,9 +24,6 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 
-import org.apache.commons.io.FileUtils
-import org.apache.commons.io.filefilter.TrueFileFilter
-
 import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{RMSE, TEST_SIZE, TRAINING_SIZE}
@@ -1027,13 +1024,7 @@ class ALSCleanerSuite extends SparkFunSuite with LocalRootDirsTest {
     val conf = new SparkConf()
     val localDir = Utils.createTempDir()
     val checkpointDir = Utils.createTempDir()
-    def getAllFiles: Set[File] = {
-      val files = FileUtils.listFiles(
-        localDir,
-        TrueFileFilter.INSTANCE,
-        TrueFileFilter.INSTANCE).asScala.toSet
-      files
-    }
+    def getAllFiles: Set[File] = Utils.listFiles(localDir).asScala.toSet
     try {
       conf.set("spark.local.dir", localDir.getAbsolutePath)
       val sc = new SparkContext("local[2]", "ALSCleanerSuite", conf)

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -383,6 +383,11 @@ This file is divided into 3 sections:
     <customMessage>Use java.nio.file.Files.writeString instead.</customMessage>
   </check>
 
+  <check customId="listFiles" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.listFiles\b</parameter></parameters>
+    <customMessage>Use listFiles of SparkFileUtil or Utils instead.</customMessage>
+  </check>
+
   <check customId="commonslang3javaversion" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">org\.apache\.commons\.lang3\..*JavaVersion</parameter></parameters>
     <customMessage>Use JEP 223 API (java.lang.Runtime.Version) instead of

--- a/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
@@ -20,8 +20,6 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
 
-import org.apache.commons.io.FileUtils
-
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.metrics.source.CodegenMetrics
 import org.apache.spark.sql.classic.SparkSession
@@ -425,7 +423,7 @@ class ArtifactManagerSuite extends SharedSparkSession {
         jarPath, path.resolve("udf_noA.jar"), None)
       artifactManager.addArtifact( // Cached
         Paths.get("cache/test"), randomFilePath, None)
-      assert(FileUtils.listFiles(artifactManager.artifactPath.toFile, null, true).size() === 3)
+      assert(Utils.listPaths(artifactManager.artifactPath.toFile).size() === 3)
 
       // Clone the artifact manager
       val newSession = spark.cloneSession()
@@ -444,7 +442,7 @@ class ArtifactManagerSuite extends SharedSparkSession {
         }
       }
 
-      val allFiles = FileUtils.listFiles(newArtifactManager.artifactPath.toFile, null, true)
+      val allFiles = Utils.listFiles(newArtifactManager.artifactPath.toFile)
       assert(allFiles.size() === 3)
       allFiles.forEach { file =>
         assert(!file.getCanonicalPath.contains(spark.sessionUUID))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -28,7 +28,6 @@ import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.util.Random
 
-import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
 import org.json4s.DefaultFormats
@@ -737,8 +736,8 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
       provider.getStore(0).commit()
 
       // Verify we don't leak temp files
-      val tempFiles = FileUtils.listFiles(new File(provider.stateStoreId.checkpointRootLocation),
-        null, true).asScala.filter(_.getName.startsWith("temp-"))
+      val tempFiles = Utils.listFiles(new File(provider.stateStoreId.checkpointRootLocation))
+        .asScala.filter(_.getName.startsWith("temp-"))
       assert(tempFiles.isEmpty)
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `list(File|Path)s` in `SparkFileUtils` and `JavaUtils`.

### Why are the changes needed?

To provide more convenient Spark file APIs like the following.

```scala
-    def getAllFiles: Set[File] = {
-      val files = FileUtils.listFiles(
-        localDir,
-        TrueFileFilter.INSTANCE,
-        TrueFileFilter.INSTANCE).asScala.toSet
-      files
-    }
+    def getAllFiles: Set[File] = Utils.listFiles(localDir).asScala.toSet
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.