### PR TITLE
[SPARK-53133][SQL][TESTS] Use Java `System.getProperty` instead of `FileUtils.getTempDirectory`

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -282,6 +282,11 @@ This file is divided into 3 sections:
       scala.jdk.CollectionConverters._ and use .asScala / .asJava methods</customMessage>
   </check>
 
+  <check customId="getTempDirectory" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFileUtils\.getTempDirectory\b</parameter></parameters>
+    <customMessage>Use System.getProperty instead.</customMessage>
+  </check>
+
   <check customId="readLines" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">\bFileUtils\.readLines\b</parameter></parameters>
     <customMessage>Use Files.readAllLines instead.</customMessage>

--- a/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
@@ -23,8 +23,6 @@ import java.nio.file.Files
 
 import scala.collection.mutable
 
-import org.apache.commons.io.FileUtils
-
 import org.apache.spark.sql.catalyst.expressions.AttributeSet
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.execution._
@@ -138,7 +136,7 @@ trait PlanStabilitySuite extends DisableAdaptiveExecutionSuite {
 
   private def checkWithApproved(plan: SparkPlan, name: String, explain: String): Unit = {
     val dir = getDirForTest(name)
-    val tempDir = FileUtils.getTempDirectory
+    val tempDir = System.getProperty("java.io.tmpdir")
     val actualSimplified = getSimplifiedPlan(plan)
     val foundMatch = isApproved(dir, actualSimplified, explain)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java `System.getProperty` instead of `FileUtils.getTempDirectory`.

In addition, a new Scalastyle rule is added to ban `FileUtils.getTempDirectory`.

### Why are the changes needed?

To simplify the code because this test case usage needs only the location.

### Does this PR introduce _any_ user-facing change?

No, this is a test-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.