### PR TITLE
[SPARK-53136][CORE] tryWithResource & tryInitializeResource shall close resource quietly

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkErrorUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkErrorUtils.scala
@@ -47,7 +47,11 @@ private[spark] trait SparkErrorUtils extends Logging {
 
   def tryWithResource[R <: Closeable, T](createResource: => R)(f: R => T): T = {
     val resource = createResource
-    try f.apply(resource) finally resource.close()
+    try {
+      f.apply(resource)
+    } finally {
+      closeQuietly(resource)
+    }
   }
 
   /**
@@ -61,7 +65,7 @@ private[spark] trait SparkErrorUtils extends Logging {
       initialize(resource)
     } catch {
       case e: Throwable =>
-        resource.close()
+        closeQuietly(resource)
         throw e
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR modifies tryWithResource & tryInitializeResource to close the resource quietly

### Why are the changes needed?

Avoid unexpected errors, for example 

We shall see 
```scala
scala> tryWithResource(spark.getClass.getClassLoader.getResourceAsStream("a"))(_.readAllBytes)
java.lang.NullPointerException: Cannot invoke "java.io.InputStream.readAllBytes()" because "x$1" is null
  at $anonfun$res1$2(<console>:1)
  at tryWithResource(<console>:3)
  ... 42 elided
```

instead of
```scala

scala> tryWithResource(spark.getClass.getClassLoader.getResourceAsStream("a"))(_.readAllBytes)
java.lang.NullPointerException: Cannot invoke "java.io.Closeable.close()" because "resource" is null
  at tryWithResource(<console>:4)
  ... 42 elided
```

### Does this PR introduce _any_ user-facing change?

no


### How was this patch tested?

new UT

### Was this patch authored or co-authored using generative AI tooling?

no