### PR TITLE
[SPARK-53140][TESTS] Ban `org.apache.commons.io.FileUtils`

### DIFF
--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -184,6 +184,7 @@
             <property name="illegalPkgs" value="org.apache.log4j" />
             <property name="illegalPkgs" value="org.apache.commons.lang" />
             <property name="illegalPkgs" value="org.apache.commons.lang3.tuple" />
+            <property name="illegalClasses" value="org.apache.commons.io.FileUtils" />
             <property name="illegalClasses" value="org.apache.commons.lang3.JavaVersion" />
             <property name="illegalClasses" value="org.apache.commons.lang3.Strings" />
             <property name="illegalClasses" value="org.apache.commons.lang3.StringUtils" />

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -454,6 +454,11 @@ This file is divided into 3 sections:
     <customMessage>Use Utils.strip method instead</customMessage>
   </check>
 
+  <check customId="commonsiofileutils" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.io\.FileUtils\b</parameter></parameters>
+    <customMessage>Use Java API or Spark's JavaUtils/SparkSystemUtils/Utils instead</customMessage>
+  </check>
+
   <check customId="commonslang3stringutils" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">org\.apache\.commons\.lang3\.StringUtils\b</parameter></parameters>
     <customMessage>Use Java String or Spark's Utils/JavaUtils methods instead</customMessage>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ban `org.apache.commons.io.FileUtils` usage in favor of `Java`'s and `Spark`'s built-in methods.

### Why are the changes needed?

Apache Spark already migrated to `Java` or `Spark`'s built-in methods.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.