### PR TITLE
[SPARK-53141][CORE] Add APIs to get overhead memory size and offheap memory size from resource profile

### DIFF
--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
@@ -106,6 +106,14 @@ class ResourceProfile(
     executorResources.get(ResourceProfile.PYSPARK_MEM).map(_.amount)
   }
 
+  private[spark] def getOverheadMemory: Option[Long] = {
+    executorResources.get(ResourceProfile.OVERHEAD_MEM).map(_.amount)
+  }
+
+  private[spark] def getExecutorOffHeap: Option[Long] = {
+    executorResources.get(ResourceProfile.OFFHEAP_MEM).map(_.amount)
+  }
+
   private[spark] def getExecutorMemory: Option[Long] = {
     executorResources.get(ResourceProfile.MEMORY).map(_.amount)
   }

--- a/core/src/test/scala/org/apache/spark/resource/ResourceProfileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/resource/ResourceProfileSuite.scala
@@ -332,7 +332,7 @@ class ResourceProfileSuite extends SparkFunSuite with MockitoSugar {
       "Executor resources should have 2000 overhead memory")
     assert(rprof.getPySparkMemory.get === 500,
       "Executor resources should have 512 pyspark memory")
-    assert(rprof.getExecutorOffHeap === 1024,
+    assert(rprof.getExecutorOffHeap.get === 1024,
       "Executor resources should have 1024 offHeap memory")
   }
 

--- a/core/src/test/scala/org/apache/spark/resource/ResourceProfileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/resource/ResourceProfileSuite.scala
@@ -48,21 +48,21 @@ class ResourceProfileSuite extends SparkFunSuite with MockitoSugar {
     assert(rprof.id === ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID)
     assert(rprof.executorResources.size === 3,
       "Executor resources should contain cores, heap and offheap memory by default")
-    assert(rprof.executorResources(ResourceProfile.CORES).amount === 1,
+    assert(rprof.getExecutorCores.get === 1,
       "Executor resources should have 1 core")
     assert(rprof.getExecutorCores.get === 1,
       "Executor resources should have 1 core")
-    assert(rprof.executorResources(ResourceProfile.MEMORY).amount === 1024,
+    assert(rprof.getExecutorMemory.get === 1024,
       "Executor resources should have 1024 memory")
-    assert(rprof.executorResources.get(ResourceProfile.PYSPARK_MEM) == None,
+    assert(rprof.getPySparkMemory == None,
       "pyspark memory empty if not specified")
-    assert(rprof.executorResources.get(ResourceProfile.OVERHEAD_MEM) == None,
+    assert(rprof.getOverheadMemory == None,
       "overhead memory empty if not specified")
-    assert(rprof.executorResources(ResourceProfile.OFFHEAP_MEM).amount === 0,
+    assert(rprof.getExecutorOffHeap.get === 0,
       "Executor resources should have 0 offheap memory")
     assert(rprof.taskResources.size === 1,
       "Task resources should just contain cpus by default")
-    assert(rprof.taskResources(ResourceProfile.CPUS).amount === 1,
+    assert(rprof.getTaskCpus.get === 1,
       "Task resources should have 1 cpu")
     assert(rprof.getTaskCpus.get === 1,
       "Task resources should have 1 cpu")
@@ -121,17 +121,15 @@ class ResourceProfileSuite extends SparkFunSuite with MockitoSugar {
     assert(execResources.size === 6, s"Executor resources should contain cores, pyspark " +
       s"memory, memory overhead, memory, offHeap memory and gpu $execResources")
     assert(execResources.contains("gpu"), "Executor resources should have gpu")
-    assert(rprof.executorResources(ResourceProfile.CORES).amount === 4,
-      "Executor resources should have 4 core")
     assert(rprof.getExecutorCores.get === 4,
       "Executor resources should have 4 core")
-    assert(rprof.executorResources(ResourceProfile.MEMORY).amount === 4096,
+    assert(rprof.getExecutorMemory.get === 4096,
       "Executor resources should have 1024 memory")
-    assert(rprof.executorResources(ResourceProfile.PYSPARK_MEM).amount == 2048,
+    assert(rprof.getPySparkMemory.get == 2048,
       "pyspark memory empty if not specified")
-    assert(rprof.executorResources(ResourceProfile.OVERHEAD_MEM).amount == 1024,
+    assert(rprof.getOverheadMemory.get == 1024,
       "overhead memory empty if not specified")
-    assert(rprof.executorResources(ResourceProfile.OFFHEAP_MEM).amount == 3,
+    assert(rprof.getExecutorOffHeap.get == 3,
       "Executor resources should have 3 offHeap memory")
     assert(rprof.taskResources.size === 2,
       "Task resources should just contain cpus and gpu")
@@ -238,24 +236,24 @@ class ResourceProfileSuite extends SparkFunSuite with MockitoSugar {
   }
 
   test("Create ResourceProfile") {
-    val rprof = new ResourceProfileBuilder()
+    val rprofBuilder = new ResourceProfileBuilder()
     val taskReq = new TaskResourceRequests().resource("gpu", 1)
     val eReq = new ExecutorResourceRequests().resource("gpu", 2, "myscript", "nvidia")
-    rprof.require(taskReq).require(eReq)
+    rprofBuilder.require(taskReq).require(eReq)
 
-    assert(rprof.executorResources.size === 1)
-    assert(rprof.executorResources.contains("gpu"),
+    assert(rprofBuilder.executorResources.size === 1)
+    assert(rprofBuilder.executorResources.contains("gpu"),
       "Executor resources should have gpu")
-    assert(rprof.executorResources.get("gpu").get.vendor === "nvidia",
+    assert(rprofBuilder.executorResources.get("gpu").get.vendor === "nvidia",
       "gpu vendor should be nvidia")
-    assert(rprof.executorResources.get("gpu").get.discoveryScript === "myscript",
+    assert(rprofBuilder.executorResources.get("gpu").get.discoveryScript === "myscript",
       "discoveryScript should be myscript")
-    assert(rprof.executorResources.get("gpu").get.amount === 2,
+    assert(rprofBuilder.executorResources.get("gpu").get.amount === 2,
     "gpu amount should be 2")
 
-    assert(rprof.taskResources.size === 1, "Should have 1 task resource")
-    assert(rprof.taskResources.contains("gpu"), "Task resources should have gpu")
-    assert(rprof.taskResources.get("gpu").get.amount === 1,
+    assert(rprofBuilder.taskResources.size === 1, "Should have 1 task resource")
+    assert(rprofBuilder.taskResources.contains("gpu"), "Task resources should have gpu")
+    assert(rprofBuilder.taskResources.get("gpu").get.amount === 1,
       "Task resources should have 1 gpu")
 
     val ereqs = new ExecutorResourceRequests()
@@ -264,19 +262,20 @@ class ResourceProfileSuite extends SparkFunSuite with MockitoSugar {
     val treqs = new TaskResourceRequests()
     treqs.cpus(1)
 
-    rprof.require(treqs)
-    rprof.require(ereqs)
+    rprofBuilder.require(treqs)
+    rprofBuilder.require(ereqs)
+    val rprof = rprofBuilder.build()
 
     assert(rprof.executorResources.size === 6)
-    assert(rprof.executorResources(ResourceProfile.CORES).amount === 2,
+    assert(rprof.getExecutorCores.get === 2,
       "Executor resources should have 2 cores")
-    assert(rprof.executorResources(ResourceProfile.MEMORY).amount === 4096,
+    assert(rprof.getExecutorMemory.get === 4096,
       "Executor resources should have 4096 memory")
-    assert(rprof.executorResources(ResourceProfile.OVERHEAD_MEM).amount === 2048,
+    assert(rprof.getOverheadMemory.get === 2048,
       "Executor resources should have 2048 overhead memory")
-    assert(rprof.executorResources(ResourceProfile.PYSPARK_MEM).amount === 1024,
+    assert(rprof.getPySparkMemory.get === 1024,
       "Executor resources should have 1024 pyspark memory")
-    assert(rprof.executorResources(ResourceProfile.OFFHEAP_MEM).amount === 3072,
+    assert(rprof.getExecutorOffHeap.get === 3072,
       "Executor resources should have 3072 offHeap memory")
 
     assert(rprof.taskResources.size === 2)
@@ -320,19 +319,20 @@ class ResourceProfileSuite extends SparkFunSuite with MockitoSugar {
   }
 
   test("Test ExecutorResourceRequests memory helpers") {
-    val rprof = new ResourceProfileBuilder()
+    val rprofBuilder = new ResourceProfileBuilder()
     val ereqs = new ExecutorResourceRequests()
     ereqs.memory("4g")
     ereqs.memoryOverhead("2000m").pysparkMemory("512000k").offHeapMemory("1g")
-    rprof.require(ereqs)
+    rprofBuilder.require(ereqs)
+    val rprof = rprofBuilder.build()
 
-    assert(rprof.executorResources(ResourceProfile.MEMORY).amount === 4096,
+    assert(rprof.getExecutorMemory.get === 4096,
       "Executor resources should have 4096 memory")
-    assert(rprof.executorResources(ResourceProfile.OVERHEAD_MEM).amount === 2000,
+    assert(rprof.getOverheadMemory.get === 2000,
       "Executor resources should have 2000 overhead memory")
-    assert(rprof.executorResources(ResourceProfile.PYSPARK_MEM).amount === 500,
+    assert(rprof.getPySparkMemory.get === 500,
       "Executor resources should have 512 pyspark memory")
-    assert(rprof.executorResources(ResourceProfile.OFFHEAP_MEM).amount === 1024,
+    assert(rprof.getExecutorOffHeap === 1024,
       "Executor resources should have 1024 offHeap memory")
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Add two APIs to get overhead memory size and offheap memory size from resource profile.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?

Simplify retrieving overhead memory size and off-heap memory size.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No.
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
The existing tests with modifications.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No.
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
