### PR TITLE
[SPARK-53143][SQL] Fix self join in DataFrame API - Join is not the only expected output from analyzer

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
@@ -682,7 +682,7 @@ class Dataset[T] private[sql](
     analyzedJoinPlan match {
       case project @ Project(_, join: Join) =>
         // SPARK-53143: Handling edge-cases when `AddMetadataColumns` analyzer rule adds `Project`
-        //   node on top of `Join` node.
+        //              node on top of `Join` node.
         // Check "SPARK-53143: self join edge-case when Join is not returned by the analyzer" in
         //   `DataframeSelfJoinSuite` for more details.
         val newProject = project.copy(child = JoinWith.resolveSelfJoinCondition(


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
`Dataset.resolveSelfJoinCondition` expects that analyzer output will always be of `Join` type and that is not correct. There are edge cases when analyzer can produce a plan that has `Project` as the top node.
This PR fixes failures in such cases.

Check [SPARK-53143](https://issues.apache.org/jira/browse/SPARK-53143) for more details.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bug fix.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Manually in shell.
Unit test to cover the problematic case.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.