### PR TITLE
[SPARK-53150][CORE] Improve `list(File|Path)s` to handle non-existent, non-directory, symlink input

### DIFF
--- a/common/network-common/src/test/java/org/apache/spark/network/util/JavaUtilsSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/util/JavaUtilsSuite.java
@@ -18,6 +18,7 @@ package org.apache.spark.network.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.junit.jupiter.api.Test;
 
@@ -54,5 +55,34 @@ public class JavaUtilsSuite {
     assertThrows(IOException.class,
       () -> JavaUtils.createDirectory(testDirPath, "scenario4"));
     assertTrue(testDir.setWritable(true));
+  }
+
+  @Test
+  public void testListFiles() throws IOException {
+    File tmp = Files.createTempDirectory("testListFiles").toFile();
+    File file = new File(tmp, "file");
+
+    // Return emtpy set on non-existent input
+    assertFalse(file.exists());
+    assertEquals(0, JavaUtils.listFiles(file).size());
+    assertEquals(0, JavaUtils.listPaths(file).size());
+
+    // Return emtpy set on non-directory input
+    file.createNewFile();
+    assertTrue(file.exists());
+    assertEquals(0, JavaUtils.listFiles(file).size());
+    assertEquals(0, JavaUtils.listPaths(file).size());
+
+    // Return empty set on an empty directory location
+    File dir = new File(tmp, "dir");
+    dir.mkdir();
+    new File(dir, "1").createNewFile();
+    assertEquals(1, JavaUtils.listFiles(dir).size());
+    assertEquals(1, JavaUtils.listPaths(dir).size());
+
+    File symlink = new File(tmp, "symlink");
+    Files.createSymbolicLink(symlink.toPath(), dir.toPath());
+    assertEquals(1, JavaUtils.listFiles(symlink).size());
+    assertEquals(1, JavaUtils.listPaths(symlink).size());
   }
 }

--- a/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -26,6 +26,7 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
@@ -368,19 +369,17 @@ public class JavaUtils {
   }
 
   public static Set<Path> listPaths(File dir) throws IOException {
-    if (dir == null || !dir.exists() || !dir.isDirectory()) {
-      throw new IllegalArgumentException("Invalid input " + dir);
-    }
-    try (var stream = Files.walk(dir.toPath())) {
+    if (dir == null) throw new IllegalArgumentException("Input directory is null");
+    if (!dir.exists() || !dir.isDirectory()) return Collections.emptySet();
+    try (var stream = Files.walk(dir.toPath(), FileVisitOption.FOLLOW_LINKS)) {
       return stream.filter(Files::isRegularFile).collect(Collectors.toCollection(HashSet::new));
     }
   }
 
   public static Set<File> listFiles(File dir) throws IOException {
-    if (dir == null || !dir.exists() || !dir.isDirectory()) {
-      throw new IllegalArgumentException("Invalid input " + dir);
-    }
-    try (var stream = Files.walk(dir.toPath())) {
+    if (dir == null) throw new IllegalArgumentException("Input directory is null");
+    if (!dir.exists() || !dir.isDirectory()) return Collections.emptySet();
+    try (var stream = Files.walk(dir.toPath(), FileVisitOption.FOLLOW_LINKS)) {
       return stream
         .filter(Files::isRegularFile)
         .map(Path::toFile)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `listFiles` and `listPaths` API to handle non-existent, non-directory, symlink input. Since the existing test cases didn't have those usage, this PR adds a new test case.

### Why are the changes needed?

- Previously, `listFiles` and `listPaths` methods are implemented on the existing Spark usage and ban all invalid inputs. 
- This PR aims to relaxed the input conditions more generally for non-existent, non-directory, symlink cases.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.