### PR TITLE
[SPARK-53153][CORE][TESTS] Use Java `Files.readAllLines` in `PluginContainerSuite`

### DIFF
--- a/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
@@ -219,7 +219,7 @@ class PluginContainerSuite extends SparkFunSuite with LocalSparkContext {
       val execFiles =
         children.filter(_.getName.startsWith(NonLocalModeSparkPlugin.executorFileStr))
       assert(execFiles.length === 1)
-      val allLines = Files.readLines(execFiles(0), StandardCharsets.UTF_8)
+      val allLines = java.nio.file.Files.readAllLines(execFiles(0).toPath)
       assert(allLines.size === 1)
       val addrs = NonLocalModeSparkPlugin.extractGpuAddrs(allLines.get(0))
       assert(addrs.length === 2)

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -292,7 +292,12 @@ This file is divided into 3 sections:
     <customMessage>Use Files.readAllLines instead.</customMessage>
   </check>
 
-  <check customId="readLines" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+  <check customId="filesreadLines" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFiles\.readLines\b</parameter></parameters>
+    <customMessage>Use Files.readAllLines instead.</customMessage>
+  </check>
+
+  <check customId="readFileToString" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">\bFileUtils\.readFileToString\b</parameter></parameters>
     <customMessage>Use Files.readString instead.</customMessage>
   </check>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java `Files.readAllLines` instead of `com.google.common.io.Files.readLines`.

In addition, new Scalastyle rule is added because this is the only instance.

### Why are the changes needed?

To use the Java built-in API.

### Does this PR introduce _any_ user-facing change?

No. This is a test-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.