### PR TITLE
[SPARK-53157][CORE] Decouple driver and executor polling intervals

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -614,7 +614,7 @@ class SparkContext(config: SparkConf) extends Logging {
     _heartbeater = new Heartbeater(
       () => SparkContext.this.reportHeartBeat(_executorMetricsSource),
       "driver-heartbeater",
-      conf.get(DRIVER_HEARTBEAT_INTERVAL))
+      conf.get(DRIVER_METRICS_POLLING_INTERVAL))
     _heartbeater.start()
 
     // start TaskScheduler after taskScheduler sets DAGScheduler reference in DAGScheduler's

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -614,7 +614,7 @@ class SparkContext(config: SparkConf) extends Logging {
     _heartbeater = new Heartbeater(
       () => SparkContext.this.reportHeartBeat(_executorMetricsSource),
       "driver-heartbeater",
-      conf.get(EXECUTOR_HEARTBEAT_INTERVAL))
+      conf.get(DRIVER_HEARTBEAT_INTERVAL))
     _heartbeater.start()
 
     // start TaskScheduler after taskScheduler sets DAGScheduler reference in DAGScheduler's

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -359,8 +359,8 @@ package object config {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("10s")
 
-  private[spark] val DRIVER_HEARTBEAT_INTERVAL =
-    ConfigBuilder("spark.driver.heartbeatInterval")
+  private[spark] val DRIVER_METRICS_POLLING_INTERVAL =
+    ConfigBuilder("spark.driver.metrics.pollingInterval")
       .version("4.1.0")
       .fallbackConf(EXECUTOR_HEARTBEAT_INTERVAL)
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -359,6 +359,11 @@ package object config {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("10s")
 
+  private[spark] val DRIVER_HEARTBEAT_INTERVAL =
+    ConfigBuilder("spark.driver.heartbeatInterval")
+      .version("3.1.1")
+      .fallbackConf(EXECUTOR_HEARTBEAT_INTERVAL)
+
   private[spark] val EXECUTOR_HEARTBEAT_MAX_FAILURES =
     ConfigBuilder("spark.executor.heartbeat.maxFailures")
       .internal()

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -359,11 +359,6 @@ package object config {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("10s")
 
-  private[spark] val DRIVER_METRICS_POLLING_INTERVAL =
-    ConfigBuilder("spark.driver.metrics.pollingInterval")
-      .version("4.1.0")
-      .fallbackConf(EXECUTOR_HEARTBEAT_INTERVAL)
-
   private[spark] val EXECUTOR_HEARTBEAT_MAX_FAILURES =
     ConfigBuilder("spark.executor.heartbeat.maxFailures")
       .internal()
@@ -1213,6 +1208,14 @@ package object config {
     .timeConf(TimeUnit.MINUTES)
     .checkValue(v => v >= 0, "The value should be a non-negative time value.")
     .createWithDefaultString("0min")
+
+  private[spark] val DRIVER_METRICS_POLLING_INTERVAL =
+    ConfigBuilder("spark.driver.metrics.pollingInterval")
+      .doc("How often to collect driver metrics (in milliseconds). " +
+        "If 0, the polling is done at the executor heartbeat interval. " +
+        "If positive, the polling is done at this interval.")
+      .version("4.1.0")
+      .fallbackConf(EXECUTOR_HEARTBEAT_INTERVAL)
 
   private[spark] val DRIVER_BIND_ADDRESS = ConfigBuilder("spark.driver.bindAddress")
     .doc("Address where to bind network listen sockets on the driver.")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1212,8 +1212,8 @@ package object config {
   private[spark] val DRIVER_METRICS_POLLING_INTERVAL =
     ConfigBuilder("spark.driver.metrics.pollingInterval")
       .doc("How often to collect driver metrics (in milliseconds). " +
-        "If 0, the polling is done at the executor heartbeat interval. " +
-        "If positive, the polling is done at this interval.")
+        "If unset, the polling is done at the executor heartbeat interval. " +
+        "If set, the polling is done at this interval.")
       .version("4.1.0")
       .fallbackConf(EXECUTOR_HEARTBEAT_INTERVAL)
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -361,7 +361,7 @@ package object config {
 
   private[spark] val DRIVER_HEARTBEAT_INTERVAL =
     ConfigBuilder("spark.driver.heartbeatInterval")
-      .version("3.1.1")
+      .version("4.1.0")
       .fallbackConf(EXECUTOR_HEARTBEAT_INTERVAL)
 
   private[spark] val EXECUTOR_HEARTBEAT_MAX_FAILURES =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add a config `spark.driver.metrics.pollingInterval`, and schedule driver polling interval / heartbeat at that schedule.


### Why are the changes needed?
Decouple driver and executor heartbeat intervals. Due to sampling frequencies in memory metric reporting intervals we do not have a 100% accurate view of stats at drivers and executors. This is particularly observed at the driver, where we don't have the benefit of a larger sample size of metrics from N executors in application. 

Here we can provide a way increase (or change in general) the rate of collection of metrics at the driver, to aid in overcoming the sampling problem, without requiring users to also increase executor heartbeat frequencies.


### Does this PR introduce _any_ user-facing change?
Yes, introduces a spark config


### How was this patch tested?
Verified that metric collection was improved when sampling rates were increased, and verified that the number of events were expected when rate was changed.

Methodology for validating that increased driver heartbeat intervals would improve memory collection:
1. Using a 6gb driver heap, wrote a job to broadcast a table, gradually increasing the size of the table until OOM.
2. Increased driver memory to 10gb, large enough for the same broadcast to succeed.
3. Repeated this job and tracked the peak memory usage that was written to event log. 
4. After repeated experiments, witnessed that the median peak heap typical usage was tracked at <=5GiB.
5. Added my change, and decreased the heartbeat interval.
6. Re-ran same jobs with 10gb heap, and saw that the typical peak memory usage tracked was ~8GiB, more accurately reflecting the increased memory needs.

### Was this patch authored or co-authored using generative AI tooling?
No