### PR TITLE
[SPARK-53160][CORE][SQL][MLLIB][K8S][YARN][SS] Use Java `Files.writeString` instead of `Files.asCharSink`

### DIFF
--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaTestUtils.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaTestUtils.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.kafka010
 
 import java.io.{File, IOException}
 import java.net.InetSocketAddress
-import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.util.{Collections, Properties, UUID}
 import java.util.concurrent.TimeUnit
 import javax.security.auth.login.Configuration
@@ -27,7 +27,6 @@ import javax.security.auth.login.Configuration
 import scala.io.Source
 import scala.jdk.CollectionConverters._
 
-import com.google.common.io.Files
 import kafka.log.LogManager
 import kafka.server.{HostedPartition, KafkaConfig, KafkaServer}
 import kafka.server.checkpoints.OffsetCheckpointFile
@@ -176,7 +175,7 @@ class KafkaTestUtils(
     }
 
     kdc.getKrb5conf.delete()
-    Files.asCharSink(kdc.getKrb5conf, StandardCharsets.UTF_8).write(krb5confStr)
+    Files.writeString(kdc.getKrb5conf.toPath, krb5confStr)
     logDebug(s"krb5.conf file content: $krb5confStr")
   }
 
@@ -240,7 +239,7 @@ class KafkaTestUtils(
       |  principal="$kafkaServerUser@$realm";
       |};
       """.stripMargin.trim
-    Files.asCharSink(file, StandardCharsets.UTF_8).write(content)
+    Files.writeString(file.toPath, content)
     logDebug(s"Created JAAS file: ${file.getPath}")
     logDebug(s"JAAS file content: $content")
     file.getAbsolutePath()

--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -20,7 +20,7 @@ package org.apache.spark
 import java.io.{ByteArrayInputStream, File, FileInputStream, FileOutputStream}
 import java.net.{HttpURLConnection, InetSocketAddress, URL}
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files => JavaFiles, Paths}
+import java.nio.file.{Files, Paths}
 import java.nio.file.attribute.PosixFilePermission.{OWNER_EXECUTE, OWNER_READ, OWNER_WRITE}
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
@@ -37,7 +37,7 @@ import scala.reflect.{classTag, ClassTag}
 import scala.sys.process.Process
 import scala.util.Try
 
-import com.google.common.io.{ByteStreams, Files}
+import com.google.common.io.ByteStreams
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.core.LoggerContext
 import org.apache.logging.log4j.core.appender.ConsoleAppender
@@ -228,13 +228,13 @@ private[spark] object TestUtils extends SparkTestUtils {
   def getAbsolutePathFromExecutable(executable: String): Option[String] = {
     val command = if (Utils.isWindows) s"$executable.exe" else executable
     if (command.split(File.separator, 2).length == 1 &&
-        JavaFiles.isRegularFile(Paths.get(command)) &&
-        JavaFiles.isExecutable(Paths.get(command))) {
+        Files.isRegularFile(Paths.get(command)) &&
+        Files.isExecutable(Paths.get(command))) {
       Some(Paths.get(command).toAbsolutePath.toString)
     } else {
       sys.env("PATH").split(Pattern.quote(File.pathSeparator))
         .map(path => Paths.get(s"${Utils.strip(path, "\"")}${File.separator}$command"))
-        .find(p => JavaFiles.isRegularFile(p) && JavaFiles.isExecutable(p))
+        .find(p => Files.isRegularFile(p) && Files.isExecutable(p))
         .map(_.toString)
     }
   }
@@ -412,7 +412,7 @@ private[spark] object TestUtils extends SparkTestUtils {
   /** Creates a temp JSON file that contains the input JSON record. */
   def createTempJsonFile(dir: File, prefix: String, jsonValue: JValue): String = {
     val file = File.createTempFile(prefix, ".json", dir)
-    JavaFiles.write(file.toPath, compact(render(jsonValue)).getBytes())
+    Files.write(file.toPath, compact(render(jsonValue)).getBytes())
     file.getPath
   }
 
@@ -420,8 +420,8 @@ private[spark] object TestUtils extends SparkTestUtils {
   def createTempScriptWithExpectedOutput(dir: File, prefix: String, output: String): String = {
     val file = File.createTempFile(prefix, ".sh", dir)
     val script = s"cat <<EOF\n$output\nEOF\n"
-    Files.asCharSink(file, StandardCharsets.UTF_8).write(script)
-    JavaFiles.setPosixFilePermissions(file.toPath,
+    Files.writeString(file.toPath, script)
+    Files.setPosixFilePermissions(file.toPath,
       EnumSet.of(OWNER_READ, OWNER_EXECUTE, OWNER_WRITE))
     file.getPath
   }

--- a/core/src/main/scala/org/apache/spark/deploy/worker/DriverRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/DriverRunner.scala
@@ -19,11 +19,10 @@ package org.apache.spark.deploy.worker
 
 import java.io._
 import java.net.URI
-import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.StandardOpenOption
 
 import scala.jdk.CollectionConverters._
-
-import com.google.common.io.{Files, FileWriteMode}
 
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.deploy.{DriverDescription, SparkHadoopUtil}
@@ -216,7 +215,7 @@ private[deploy] class DriverRunner(
       val redactedCommand = Utils.redactCommandLineArgs(conf, builder.command.asScala.toSeq)
         .mkString("\"", "\" \"", "\"")
       val header = "Launch Command: %s\n%s\n\n".format(redactedCommand, "=".repeat(40))
-      Files.asCharSink(stderr, StandardCharsets.UTF_8, FileWriteMode.APPEND).write(header)
+      Files.writeString(stderr.toPath, header, StandardOpenOption.APPEND)
       CommandUtils.redirectStream(process.getErrorStream, stderr)
     }
     runCommandWithRetry(ProcessBuilderLike(builder), initialize, supervise)

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
@@ -18,11 +18,9 @@
 package org.apache.spark.deploy.worker
 
 import java.io._
-import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 
 import scala.jdk.CollectionConverters._
-
-import com.google.common.io.Files
 
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.deploy.{ApplicationDescription, ExecutorState}
@@ -191,7 +189,7 @@ private[deploy] class ExecutorRunner(
       stdoutAppender = FileAppender(process.getInputStream, stdout, conf, true)
 
       val stderr = new File(executorDir, "stderr")
-      Files.asCharSink(stderr, StandardCharsets.UTF_8).write(header)
+      Files.writeString(stderr.toPath, header)
       stderrAppender = FileAppender(process.getErrorStream, stderr, conf, true)
 
       state = ExecutorState.RUNNING

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -19,13 +19,12 @@ package org.apache.spark
 
 import java.io._
 import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.util.zip.GZIPOutputStream
 
 import scala.io.Source
 import scala.util.control.NonFatal
 
-import com.google.common.io.Files
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io._
@@ -334,8 +333,8 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
 
       for (i <- 0 until 8) {
         val tempFile = new File(tempDir, s"part-0000$i")
-        Files.asCharSink(tempFile, StandardCharsets.UTF_8)
-          .write("someline1 in file1\nsomeline2 in file1\nsomeline3 in file1")
+        Files.writeString(tempFile.toPath,
+          "someline1 in file1\nsomeline2 in file1\nsomeline3 in file1")
       }
 
       for (p <- Seq(1, 2, 8)) {

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -19,13 +19,12 @@ package org.apache.spark
 
 import java.io.File
 import java.net.{MalformedURLException, URI}
-import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.util.concurrent.{CountDownLatch, Semaphore, TimeUnit}
 
 import scala.concurrent.duration._
 import scala.io.Source
 
-import com.google.common.io.Files
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{BytesWritable, LongWritable, Text}
@@ -120,8 +119,8 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
       val absolutePath2 = file2.getAbsolutePath
 
       try {
-        Files.asCharSink(file1, StandardCharsets.UTF_8).write("somewords1")
-        Files.asCharSink(file2, StandardCharsets.UTF_8).write("somewords2")
+        Files.writeString(file1.toPath, "somewords1")
+        Files.writeString(file2.toPath, "somewords2")
         val length1 = file1.length()
         val length2 = file2.length()
 
@@ -179,10 +178,10 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
         s"${jarFile.getParent}/../${jarFile.getParentFile.getName}/${jarFile.getName}#zoo"
 
       try {
-        Files.asCharSink(file1, StandardCharsets.UTF_8).write("somewords1")
-        Files.asCharSink(file2, StandardCharsets.UTF_8).write("somewords22")
-        Files.asCharSink(file3, StandardCharsets.UTF_8).write("somewords333")
-        Files.asCharSink(file4, StandardCharsets.UTF_8).write("somewords4444")
+        Files.writeString(file1.toPath, "somewords1")
+        Files.writeString(file2.toPath, "somewords22")
+        Files.writeString(file3.toPath, "somewords333")
+        Files.writeString(file4.toPath, "somewords4444")
         val length1 = file1.length()
         val length2 = file2.length()
         val length3 = file1.length()
@@ -375,8 +374,8 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
       assert(subdir2.mkdir())
       val file1 = new File(subdir1, "file")
       val file2 = new File(subdir2, "file")
-      Files.asCharSink(file1, StandardCharsets.UTF_8).write("old")
-      Files.asCharSink(file2, StandardCharsets.UTF_8).write("new")
+      Files.writeString(file1.toPath, "old")
+      Files.writeString(file2.toPath, "new")
       sc = new SparkContext("local-cluster[1,1,1024]", "test")
       sc.addFile(file1.getAbsolutePath)
       def getAddedFileContents(): String = {
@@ -507,15 +506,12 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
 
         try {
           // Create 5 text files.
-          Files.asCharSink(file1, StandardCharsets.UTF_8)
-            .write("someline1 in file1\nsomeline2 in file1\nsomeline3 in file1")
-          Files.asCharSink(file2, StandardCharsets.UTF_8)
-            .write("someline1 in file2\nsomeline2 in file2")
-          Files.asCharSink(file3, StandardCharsets.UTF_8).write("someline1 in file3")
-          Files.asCharSink(file4, StandardCharsets.UTF_8)
-            .write("someline1 in file4\nsomeline2 in file4")
-          Files.asCharSink(file5, StandardCharsets.UTF_8)
-            .write("someline1 in file2\nsomeline2 in file5")
+          Files.writeString(file1.toPath,
+            "someline1 in file1\nsomeline2 in file1\nsomeline3 in file1")
+          Files.writeString(file2.toPath, "someline1 in file2\nsomeline2 in file2")
+          Files.writeString(file3.toPath, "someline1 in file3")
+          Files.writeString(file4.toPath, "someline1 in file4\nsomeline2 in file4")
+          Files.writeString(file5.toPath, "someline1 in file2\nsomeline2 in file5")
 
           sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
 
@@ -780,7 +776,7 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
     fs.initialize(new URI("file:///"), new Configuration())
     val file = File.createTempFile("SPARK19446", "temp")
     file.deleteOnExit()
-    Files.write(Array.ofDim[Byte](1000), file)
+    Files.write(file.toPath, Array.ofDim[Byte](1000))
     val path = new Path("file:///" + file.getCanonicalPath)
     val stream = fs.open(path)
     val exc = intercept[RuntimeException] {

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -19,13 +19,14 @@ package org.apache.spark.deploy.history
 
 import java.io._
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.util.{Date, Locale}
 import java.util.concurrent.TimeUnit
 import java.util.zip.{ZipInputStream, ZipOutputStream}
 
 import scala.concurrent.duration._
 
-import com.google.common.io.{ByteStreams, Files}
+import com.google.common.io.ByteStreams
 import org.apache.hadoop.fs.{FileStatus, FileSystem, FSDataInputStream, Path}
 import org.apache.hadoop.hdfs.{DFSInputStream, DistributedFileSystem}
 import org.apache.hadoop.ipc.{CallerContext => HadoopCallerContext}
@@ -707,8 +708,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
       entry should not be null
       while (entry != null) {
         val actual = new String(ByteStreams.toByteArray(inputStream), StandardCharsets.UTF_8)
-        val expected =
-          java.nio.file.Files.readString(logs.find(_.getName == entry.getName).get.toPath)
+        val expected = Files.readString(logs.find(_.getName == entry.getName).get.toPath)
         actual should be (expected)
         totalEntries += 1
         entry = inputStream.getNextEntry
@@ -757,7 +757,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     assert(log3.exists())
 
     // Update the third file length while keeping the original modified time
-    Files.write("Add logs to file".getBytes(), log3)
+    Files.writeString(log3.toPath, "Add logs to file")
     log3.setLastModified(secondFileModifiedTime)
     // Should cleanup the second file but not the third file, as filelength changed.
     clock.setTime(secondFileModifiedTime + TimeUnit.SECONDS.toMillis(maxAge) + 1)

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerArgumentsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerArgumentsSuite.scala
@@ -17,9 +17,7 @@
 package org.apache.spark.deploy.history
 
 import java.io.File
-import java.nio.charset.StandardCharsets._
-
-import com.google.common.io.Files
+import java.nio.file.Files
 
 import org.apache.spark._
 import org.apache.spark.internal.config.{ConfigEntry, History}
@@ -45,7 +43,7 @@ class HistoryServerArgumentsSuite extends SparkFunSuite {
   test("Properties File Arguments Parsing --properties-file") {
     withTempDir { tmpDir =>
       val outFile = File.createTempFile("test-load-spark-properties", "test", tmpDir)
-      Files.asCharSink(outFile, UTF_8).write("spark.test.CustomPropertyA blah\n" +
+      Files.writeString(outFile.toPath, "spark.test.CustomPropertyA blah\n" +
         "spark.test.CustomPropertyB notblah\n")
       val argStrings = Array("--properties-file", outFile.getAbsolutePath)
       val hsa = new HistoryServerArguments(conf, argStrings)

--- a/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.internal.plugin
 
 import java.io.File
-import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.util.{Map => JMap}
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
@@ -27,7 +27,6 @@ import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
 import com.codahale.metrics.Gauge
-import com.google.common.io.Files
 import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito.{mock, spy, verify, when}
 import org.scalatest.concurrent.Eventually.{eventually, interval, timeout}
@@ -219,7 +218,7 @@ class PluginContainerSuite extends SparkFunSuite with LocalSparkContext {
       val execFiles =
         children.filter(_.getName.startsWith(NonLocalModeSparkPlugin.executorFileStr))
       assert(execFiles.length === 1)
-      val allLines = java.nio.file.Files.readAllLines(execFiles(0).toPath)
+      val allLines = Files.readAllLines(execFiles(0).toPath)
       assert(allLines.size === 1)
       val addrs = NonLocalModeSparkPlugin.extractGpuAddrs(allLines.get(0))
       assert(addrs.length === 2)
@@ -410,7 +409,7 @@ object NonLocalModeSparkPlugin {
       resources: Map[String, ResourceInformation]): Unit = {
     val path = conf.get(TEST_PATH_CONF)
     val strToWrite = createFileStringWithGpuAddrs(id, resources)
-    Files.asCharSink(new File(path, s"$filePrefix$id"), StandardCharsets.UTF_8).write(strToWrite)
+    Files.writeString(new File(path, s"$filePrefix$id").toPath, strToWrite)
   }
 
   def reset(): Unit = {

--- a/core/src/test/scala/org/apache/spark/resource/ResourceDiscoveryPluginSuite.scala
+++ b/core/src/test/scala/org/apache/spark/resource/ResourceDiscoveryPluginSuite.scala
@@ -18,13 +18,12 @@
 package org.apache.spark.resource
 
 import java.io.File
-import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.util.Optional
 import java.util.UUID
 
 import scala.concurrent.duration._
 
-import com.google.common.io.Files
 import org.scalatest.concurrent.Eventually.{eventually, interval, timeout}
 
 import org.apache.spark._
@@ -148,7 +147,7 @@ object TestResourceDiscoveryPlugin {
   def writeFile(conf: SparkConf, id: String): Unit = {
     val path = conf.get(TEST_PATH_CONF)
     val fileName = s"$id - ${UUID.randomUUID.toString}"
-    Files.asCharSink(new File(path, fileName), StandardCharsets.UTF_8).write(id)
+    Files.writeString(new File(path, fileName).toPath, id)
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.rpc
 
 import java.io.{File, NotSerializableException}
-import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Files
 import java.util.UUID
 import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
 
@@ -27,7 +27,6 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
-import com.google.common.io.Files
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mock, never, verify, when}
 import org.scalatest.concurrent.Eventually._
@@ -868,23 +867,23 @@ abstract class RpcEnvSuite extends SparkFunSuite {
         val conf = createSparkConf()
 
         val file = new File(tempDir, "file")
-        Files.asCharSink(file, UTF_8).write(UUID.randomUUID().toString)
+        Files.writeString(file.toPath, UUID.randomUUID().toString)
         val fileWithSpecialChars = new File(tempDir, "file name")
-        Files.asCharSink(fileWithSpecialChars, UTF_8).write(UUID.randomUUID().toString)
+        Files.writeString(fileWithSpecialChars.toPath, UUID.randomUUID().toString)
         val empty = new File(tempDir, "empty")
-        Files.asCharSink(empty, UTF_8).write("")
+        Files.writeString(empty.toPath, "")
         val jar = new File(tempDir, "jar")
-        Files.asCharSink(jar, UTF_8).write(UUID.randomUUID().toString)
+        Files.writeString(jar.toPath, UUID.randomUUID().toString)
 
         val dir1 = new File(tempDir, "dir1")
         assert(dir1.mkdir())
         val subFile1 = new File(dir1, "file1")
-        Files.asCharSink(subFile1, UTF_8).write(UUID.randomUUID().toString)
+        Files.writeString(subFile1.toPath, UUID.randomUUID().toString)
 
         val dir2 = new File(tempDir, "dir2")
         assert(dir2.mkdir())
         val subFile2 = new File(dir2, "file2")
-        Files.asCharSink(subFile2, UTF_8).write(UUID.randomUUID().toString)
+        Files.writeString(subFile2.toPath, UUID.randomUUID().toString)
 
         val fileUri = env.fileServer.addFile(file)
         val fileWithSpecialCharsUri = env.fileServer.addFile(fileWithSpecialChars)
@@ -921,7 +920,7 @@ abstract class RpcEnvSuite extends SparkFunSuite {
         files.foreach { case (f, uri) =>
           val destFile = new File(destDir, f.getName())
           Utils.fetchFile(uri, destDir, conf, hc, 0L, false)
-          assert(Files.equal(f, destFile))
+          assert(Utils.contentEquals(f, destFile))
         }
 
         // Try to download files that do not exist.

--- a/core/src/test/scala/org/apache/spark/util/FileAppenderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/FileAppenderSuite.scala
@@ -19,13 +19,13 @@ package org.apache.spark.util
 
 import java.io._
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.util.concurrent.CountDownLatch
 import java.util.zip.GZIPInputStream
 
 import scala.collection.mutable.HashSet
 import scala.reflect._
 
-import com.google.common.io.Files
 import org.apache.logging.log4j._
 import org.apache.logging.log4j.core.{Appender, LogEvent, Logger}
 import org.mockito.ArgumentCaptor
@@ -54,11 +54,11 @@ class FileAppenderSuite extends SparkFunSuite with BeforeAndAfter {
     val inputStream = new ByteArrayInputStream(testString.getBytes(StandardCharsets.UTF_8))
     // The `header` should not be covered
     val header = "Add header"
-    Files.asCharSink(testFile, StandardCharsets.UTF_8).write(header)
+    Files.writeString(testFile.toPath, header)
     val appender = new FileAppender(inputStream, testFile)
     inputStream.close()
     appender.awaitTermination()
-    assert(java.nio.file.Files.readString(testFile.toPath) === header + testString)
+    assert(Files.readString(testFile.toPath) === header + testString)
   }
 
   test("SPARK-35027: basic file appender - close stream") {
@@ -392,7 +392,7 @@ class FileAppenderSuite extends SparkFunSuite with BeforeAndAfter {
           Utils.closeQuietly(inputStream)
         }
       } else {
-        java.nio.file.Files.readString(file.toPath)
+        Files.readString(file.toPath)
       }
     }.mkString("")
     assert(allText === expectedText)

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -22,7 +22,7 @@ import java.lang.reflect.Field
 import java.net.{BindException, ServerSocket, URI}
 import java.nio.{ByteBuffer, ByteOrder}
 import java.nio.charset.StandardCharsets.UTF_8
-import java.nio.file.{Files => JFiles}
+import java.nio.file.Files
 import java.text.DecimalFormatSymbols
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -31,7 +31,6 @@ import java.util.zip.GZIPOutputStream
 import scala.collection.mutable.ListBuffer
 import scala.util.{Random, Try}
 
-import com.google.common.io.Files
 import org.apache.commons.math3.stat.inference.ChiSquareTest
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -525,7 +524,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
 
     // The following 3 scenarios are only for the method: createDirectory(File)
     // 6. Symbolic link
-    val scenario6 = java.nio.file.Files.createSymbolicLink(new File(testDir, "scenario6")
+    val scenario6 = Files.createSymbolicLink(new File(testDir, "scenario6")
       .toPath, scenario1.toPath).toFile
     if (Utils.isJavaVersionAtLeast21) {
       assert(Utils.createDirectory(scenario6))
@@ -718,7 +717,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
 
     val tempDir2 = Utils.createTempDir()
     val sourceFile1 = new File(tempDir2, "foo.txt")
-    Files.touch(sourceFile1)
+    Utils.touch(sourceFile1)
     assert(sourceFile1.exists())
     Utils.deleteRecursively(sourceFile1)
     assert(!sourceFile1.exists())
@@ -726,7 +725,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     val tempDir3 = new File(tempDir2, "subdir")
     assert(tempDir3.mkdir())
     val sourceFile2 = new File(tempDir3, "bar.txt")
-    Files.touch(sourceFile2)
+    Utils.touch(sourceFile2)
     assert(sourceFile2.exists())
     Utils.deleteRecursively(tempDir2)
     assert(!tempDir2.exists())
@@ -737,14 +736,14 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
   test("SPARK-50716: deleteRecursively - SymbolicLink To File") {
     val tempDir = Utils.createTempDir()
     val sourceFile = new File(tempDir, "foo.txt")
-    JFiles.write(sourceFile.toPath, "Some content".getBytes)
+    Files.writeString(sourceFile.toPath, "Some content")
     assert(sourceFile.exists())
 
     val symlinkFile = new File(tempDir, "bar.txt")
-    JFiles.createSymbolicLink(symlinkFile.toPath, sourceFile.toPath)
+    Files.createSymbolicLink(symlinkFile.toPath, sourceFile.toPath)
 
     // Check that the symlink was created successfully
-    assert(JFiles.isSymbolicLink(symlinkFile.toPath))
+    assert(Files.isSymbolicLink(symlinkFile.toPath))
     Utils.deleteRecursively(tempDir)
 
     // Verify that everything is deleted
@@ -756,13 +755,13 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     val sourceDir = new File(tempDir, "sourceDir")
     assert(sourceDir.mkdir())
     val sourceFile = new File(sourceDir, "file.txt")
-    JFiles.write(sourceFile.toPath, "Some content".getBytes)
+    Files.writeString(sourceFile.toPath, "Some content")
 
     val symlinkDir = new File(tempDir, "targetDir")
-    JFiles.createSymbolicLink(symlinkDir.toPath, sourceDir.toPath)
+    Files.createSymbolicLink(symlinkDir.toPath, sourceDir.toPath)
 
     // Check that the symlink was created successfully
-    assert(JFiles.isSymbolicLink(symlinkDir.toPath))
+    assert(Files.isSymbolicLink(symlinkDir.toPath))
 
     // Now delete recursively
     Utils.deleteRecursively(tempDir)
@@ -775,7 +774,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     withTempDir { tmpDir =>
       val outFile = File.createTempFile("test-load-spark-properties", "test", tmpDir)
       System.setProperty("spark.test.fileNameLoadB", "2")
-      Files.asCharSink(outFile, UTF_8).write("spark.test.fileNameLoadA true\n" +
+      Files.writeString(outFile.toPath, "spark.test.fileNameLoadA true\n" +
         "spark.test.fileNameLoadB 1\n")
       val properties = Utils.getPropertiesFromFile(outFile.getAbsolutePath)
       properties
@@ -805,7 +804,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
       val innerSourceDir = Utils.createTempDir(root = sourceDir.getPath)
       val sourceFile = File.createTempFile("someprefix", "somesuffix", innerSourceDir)
       val targetDir = new File(tempDir, "target-dir")
-      Files.asCharSink(sourceFile, UTF_8).write("some text")
+      Files.writeString(sourceFile.toPath, "some text")
 
       val path =
         if (Utils.isWindows) {
@@ -1071,7 +1070,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
            |trap "" SIGTERM
            |sleep 10
          """.stripMargin
-      Files.write(cmd.getBytes(UTF_8), file)
+      Files.writeString(file.toPath, cmd)
       file.getAbsoluteFile.setExecutable(true)
 
       process = new ProcessBuilder(file.getAbsolutePath).start()

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -205,6 +205,10 @@
             <property name="message" value="Use String concatenation instead." />
         </module>
         <module name="RegexpSinglelineJava">
+            <property name="format" value="Files\.asCharSink"/>
+            <property name="message" value="Use java.nio.file.Files.writeString instead." />
+        </module>
+        <module name="RegexpSinglelineJava">
             <property name="format" value="FileUtils.writeStringToFile"/>
             <property name="message" value="Use java.nio.file.Files.writeString instead." />
         </module>

--- a/examples/src/main/java/org/apache/spark/examples/streaming/JavaRecoverableNetworkWordCount.java
+++ b/examples/src/main/java/org/apache/spark/examples/streaming/JavaRecoverableNetworkWordCount.java
@@ -18,15 +18,13 @@
 package org.apache.spark.examples.streaming;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import com.google.common.io.FileWriteMode;
 import scala.Tuple2;
-
-import com.google.common.io.Files;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -153,8 +151,7 @@ public final class JavaRecoverableNetworkWordCount {
       System.out.println(output);
       System.out.println("Dropped " + droppedWordsCounter.value() + " word(s) totally");
       System.out.println("Appending to " + outputFile.getAbsolutePath());
-      Files.asCharSink(outputFile, StandardCharsets.UTF_8, FileWriteMode.APPEND)
-        .write(output + "\n");
+      Files.writeString(outputFile.toPath(), output + "\n", StandardOpenOption.APPEND);
     });
 
     return ssc;

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/RecoverableNetworkWordCount.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/RecoverableNetworkWordCount.scala
@@ -19,9 +19,8 @@
 package org.apache.spark.examples.streaming
 
 import java.io.File
-import java.nio.charset.StandardCharsets
-
-import com.google.common.io.{Files, FileWriteMode}
+import java.nio.file.Files
+import java.nio.file.StandardOpenOption
 
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.broadcast.Broadcast
@@ -134,8 +133,7 @@ object RecoverableNetworkWordCount {
       println(output)
       println(s"Dropped ${droppedWordsCounter.value} word(s) totally")
       println(s"Appending to ${outputFile.getAbsolutePath}")
-      Files.asCharSink(outputFile, StandardCharsets.UTF_8, FileWriteMode.APPEND)
-        .write(output + "\n")
+      Files.writeString(outputFile.toPath, output + "\n", StandardOpenOption.APPEND)
     }
     ssc
   }

--- a/mllib/src/test/java/org/apache/spark/ml/source/libsvm/JavaLibSVMRelationSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/source/libsvm/JavaLibSVMRelationSuite.java
@@ -19,9 +19,7 @@ package org.apache.spark.ml.source.libsvm;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
-import com.google.common.io.Files;
+import java.nio.file.Files;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,7 +48,7 @@ public class JavaLibSVMRelationSuite extends SharedSparkSession {
     tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "datasource");
     File file = new File(tempDir, "part-00000");
     String s = "1 1:1.0 3:2.0 5:3.0\n0\n0 2:4.0 4:5.0 6:6.0";
-    Files.asCharSink(file, StandardCharsets.UTF_8).write(s);
+    Files.writeString(file.toPath(), s);
     path = tempDir.toURI().toString();
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/source/libsvm/LibSVMRelationSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/source/libsvm/LibSVMRelationSuite.scala
@@ -18,9 +18,7 @@
 package org.apache.spark.ml.source.libsvm
 
 import java.io.{File, IOException}
-import java.nio.charset.StandardCharsets
-
-import com.google.common.io.Files
+import java.nio.file.Files
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.attribute.AttributeGroup
@@ -65,9 +63,9 @@ class LibSVMRelationSuite
     val succ = new File(dir, "_SUCCESS")
     val file0 = new File(dir, "part-00000")
     val file1 = new File(dir, "part-00001")
-    Files.asCharSink(succ, StandardCharsets.UTF_8).write("")
-    Files.asCharSink(file0, StandardCharsets.UTF_8).write(lines0)
-    Files.asCharSink(file1, StandardCharsets.UTF_8).write(lines1)
+    Files.writeString(succ.toPath, "")
+    Files.writeString(file0.toPath, lines0)
+    Files.writeString(file1.toPath, lines1)
     path = dir.getPath
   }
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
@@ -18,11 +18,9 @@
 package org.apache.spark.mllib.util
 
 import java.io.File
-import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 
 import scala.io.Source
-
-import com.google.common.io.Files
 
 import org.apache.spark.{SparkException, SparkFunSuite, SparkRuntimeException}
 import org.apache.spark.mllib.linalg.{DenseVector, Matrices, SparseVector, Vector, Vectors}
@@ -93,7 +91,7 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
       """.stripMargin
     val tempDir = Utils.createTempDir()
     val file = new File(tempDir.getPath, "part-00000")
-    Files.asCharSink(file, StandardCharsets.UTF_8).write(lines)
+    Files.writeString(file.toPath, lines)
     val path = tempDir.toURI.toString
 
     val pointsWithNumFeatures = loadLibSVMFile(sc, path, 6).collect()
@@ -126,7 +124,7 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
       """.stripMargin
     val tempDir = Utils.createTempDir()
     val file = new File(tempDir.getPath, "part-00000")
-    Files.asCharSink(file, StandardCharsets.UTF_8).write(lines)
+    Files.writeString(file.toPath, lines)
     val path = tempDir.toURI.toString
 
     intercept[SparkException] {
@@ -143,7 +141,7 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
       """.stripMargin
     val tempDir = Utils.createTempDir()
     val file = new File(tempDir.getPath, "part-00000")
-    Files.asCharSink(file, StandardCharsets.UTF_8).write(lines)
+    Files.writeString(file.toPath, lines)
     val path = tempDir.toURI.toString
 
     intercept[SparkException] {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStepSuite.scala
@@ -18,10 +18,11 @@ package org.apache.spark.deploy.k8s.features
 
 import java.io.File
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 
 import scala.jdk.CollectionConverters._
 
-import com.google.common.io.{BaseEncoding, Files}
+import com.google.common.io.BaseEncoding
 import io.fabric8.kubernetes.api.model.Secret
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
@@ -128,7 +129,7 @@ class DriverKubernetesCredentialsFeatureStepSuite extends SparkFunSuite {
 
   private def writeCredentials(credentialsFileName: String, credentialsContents: String): File = {
     val credentialsFile = new File(credentialsTempDirectory, credentialsFileName)
-    Files.asCharSink(credentialsFile, StandardCharsets.UTF_8).write(credentialsContents)
+    Files.writeString(credentialsFile.toPath, credentialsContents)
     credentialsFile
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStepSuite.scala
@@ -17,11 +17,10 @@
 package org.apache.spark.deploy.k8s.features
 
 import java.io.File
-import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Files
 
 import scala.jdk.CollectionConverters._
 
-import com.google.common.io.Files
 import io.fabric8.kubernetes.api.model.ConfigMap
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
@@ -48,7 +47,7 @@ class HadoopConfDriverFeatureStepSuite extends SparkFunSuite {
     val confFiles = Set("core-site.xml", "hdfs-site.xml")
 
     confFiles.foreach { f =>
-      Files.asCharSink(new File(confDir, f), UTF_8).write("some data")
+      Files.writeString(new File(confDir, f).toPath, "some data")
     }
 
     val sparkConf = new SparkConfWithEnv(Map(ENV_HADOOP_CONF_DIR -> confDir.getAbsolutePath()))

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/HadoopConfExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/HadoopConfExecutorFeatureStepSuite.scala
@@ -18,9 +18,7 @@
 package org.apache.spark.deploy.k8s.features
 
 import java.io.File
-import java.nio.charset.StandardCharsets.UTF_8
-
-import com.google.common.io.Files
+import java.nio.file.Files
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s.{Constants, KubernetesTestConf, SecretVolumeUtils, SparkPod}
@@ -36,7 +34,7 @@ class HadoopConfExecutorFeatureStepSuite extends SparkFunSuite  {
     val confFiles = Set("core-site.xml", "hdfs-site.xml")
 
     confFiles.foreach { f =>
-      Files.asCharSink(new File(confDir, f), UTF_8).write("some data")
+      Files.writeString(new File(confDir, f).toPath, "some data")
     }
 
     Seq(

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStepSuite.scala
@@ -17,12 +17,11 @@
 package org.apache.spark.deploy.k8s.features
 
 import java.io.File
-import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Files
 import java.security.PrivilegedExceptionAction
 
 import scala.jdk.CollectionConverters._
 
-import com.google.common.io.Files
 import io.fabric8.kubernetes.api.model.{ConfigMap, Secret}
 import org.apache.commons.codec.binary.Base64
 import org.apache.hadoop.io.Text
@@ -55,7 +54,7 @@ class KerberosConfDriverFeatureStepSuite extends SparkFunSuite {
 
   test("create krb5.conf config map if local config provided") {
     val krbConf = File.createTempFile("krb5", ".conf", tmpDir)
-    Files.asCharSink(krbConf, UTF_8).write("some data")
+    Files.writeString(krbConf.toPath, "some data")
 
     val sparkConf = new SparkConf(false)
       .set(KUBERNETES_KERBEROS_KRB5_FILE, krbConf.getAbsolutePath())
@@ -70,7 +69,7 @@ class KerberosConfDriverFeatureStepSuite extends SparkFunSuite {
 
   test("create keytab secret if client keytab file used") {
     val keytab = File.createTempFile("keytab", ".bin", tmpDir)
-    Files.asCharSink(keytab, UTF_8).write("some data")
+    Files.writeString(keytab.toPath, "some data")
 
     val sparkConf = new SparkConf(false)
       .set(KEYTAB, keytab.getAbsolutePath())

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
@@ -17,11 +17,10 @@
 package org.apache.spark.deploy.k8s.integrationtest
 
 import java.io.File
-import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 
 import scala.jdk.CollectionConverters._
 
-import com.google.common.io.Files
 import io.fabric8.kubernetes.api.model.Pod
 import org.scalatest.concurrent.{Eventually, PatienceConfiguration}
 import org.scalatest.matchers.should.Matchers._
@@ -40,7 +39,7 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
     val logConfFilePath = s"${sparkHomeDir.toFile}/conf/log4j2.properties"
 
     try {
-      Files.asCharSink(new File(logConfFilePath), StandardCharsets.UTF_8).write(
+      Files.writeString(new File(logConfFilePath).toPath,
         """rootLogger.level = info
           |rootLogger.appenderRef.stdout.ref = console
           |appender.console.type = Console

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.deploy.yarn
 
 import java.io.{File, FileOutputStream, OutputStreamWriter}
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.Properties
 import java.util.concurrent.TimeUnit

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
@@ -18,14 +18,13 @@
 package org.apache.spark.deploy.yarn
 
 import java.io.{File, FileOutputStream, OutputStreamWriter}
-import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.util.Properties
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
-import com.google.common.io.Files
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.server.MiniYARNCluster
 import org.scalactic.source.Position
@@ -86,7 +85,7 @@ abstract class BaseYarnClusterSuite extends SparkFunSuite with Matchers {
     logConfDir.mkdir()
 
     val logConfFile = new File(logConfDir, "log4j2.properties")
-    Files.asCharSink(logConfFile, StandardCharsets.UTF_8).write(LOG4J_CONF)
+    Files.writeString(logConfFile.toPath, LOG4J_CONF)
 
     // Disable the disk utilization check to avoid the test hanging when people's disks are
     // getting full.
@@ -240,7 +239,7 @@ abstract class BaseYarnClusterSuite extends SparkFunSuite with Matchers {
           .getOrElse("(stdout/stderr was not captured)")
     }
     assert(finalState === SparkAppHandle.State.FINISHED, output)
-    val resultString = java.nio.file.Files.readString(result.toPath)
+    val resultString = Files.readString(result.toPath)
     assert(resultString === expected, output)
   }
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.deploy.yarn
 import java.io.File
 import java.net.URL
 import java.nio.charset.StandardCharsets
-import java.nio.file.Paths
+import java.nio.file.{Files, Paths}
 import java.util.{HashMap => JHashMap}
 
 import scala.collection.mutable

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -27,7 +27,7 @@ import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.io.Source
 
-import com.google.common.io.{ByteStreams, Files}
+import com.google.common.io.ByteStreams
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.exceptions.TestFailedException
@@ -180,7 +180,7 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
       |  </property>
       |</configuration>
       |""".stripMargin
-    Files.asCharSink(new File(customConf, "core-site.xml"), StandardCharsets.UTF_8).write(coreSite)
+    Files.writeString(new File(customConf, "core-site.xml").toPath, coreSite)
 
     val result = File.createTempFile("result", null, tempDir)
     val finalState = runSpark(false,
@@ -353,7 +353,7 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
   test("running Spark in yarn-cluster mode displays driver log links") {
     val log4jConf = new File(tempDir, "log4j2.properties")
     val logOutFile = new File(tempDir, "logs")
-    Files.asCharSink(log4jConf, StandardCharsets.UTF_8).write(
+    Files.writeString(log4jConf.toPath,
       s"""rootLogger.level = debug
          |rootLogger.appenderRef.file.ref = file
          |appender.file.type = File
@@ -367,8 +367,7 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     val confDir = new File(tempDir, "conf")
     confDir.mkdir()
     val javaOptsFile = new File(confDir, "java-opts")
-    Files.asCharSink(javaOptsFile, StandardCharsets.UTF_8)
-      .write(s"-Dlog4j.configurationFile=file://$log4jConf\n")
+    Files.writeString(javaOptsFile.toPath, s"-Dlog4j.configurationFile=file://$log4jConf\n")
 
     val result = File.createTempFile("result", null, tempDir)
     val finalState = runSpark(clientMode = false,
@@ -377,7 +376,7 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
       extraEnv = Map("SPARK_CONF_DIR" -> confDir.getAbsolutePath),
       extraConf = Map(CLIENT_INCLUDE_DRIVER_LOGS_LINK.key -> true.toString))
     checkResult(finalState, result)
-    val logOutput = java.nio.file.Files.readString(logOutFile.toPath)
+    val logOutput = Files.readString(logOutFile.toPath)
     val logFilePattern = raw"""(?s).+\sDriver Logs \(<NAME>\): https?://.+/<NAME>(\?\S+)?\s.+"""
     logOutput should fullyMatch regex logFilePattern.replace("<NAME>", "stdout")
     logOutput should fullyMatch regex logFilePattern.replace("<NAME>", "stderr")
@@ -432,7 +431,7 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
       script: String = TEST_PYFILE): Unit = {
     assume(isPythonAvailable)
     val primaryPyFile = new File(tempDir, "test.py")
-    Files.asCharSink(primaryPyFile, StandardCharsets.UTF_8).write(script)
+    Files.writeString(primaryPyFile.toPath, script)
 
     // When running tests, let's not assume the user has built the assembly module, which also
     // creates the pyspark archive. Instead, let's use PYSPARK_ARCHIVES_PATH to point at the
@@ -460,7 +459,7 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
       subdir
     }
     val pyModule = new File(moduleDir, "mod1.py")
-    Files.asCharSink(pyModule, StandardCharsets.UTF_8).write(TEST_PYMODULE)
+    Files.writeString(pyModule.toPath, TEST_PYMODULE)
 
     val mod2Archive = TestUtils.createJarWithFiles(Map("mod2.py" -> TEST_PYMODULE), moduleDir)
     val pyFiles = Seq(pyModule.getAbsolutePath(), mod2Archive.getPath()).mkString(",")
@@ -507,7 +506,7 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
 
   def createEmptyIvySettingsFile: File = {
     val emptyIvySettings = File.createTempFile("ivy", ".xml")
-    Files.asCharSink(emptyIvySettings, StandardCharsets.UTF_8).write("<ivysettings />")
+    Files.writeString(emptyIvySettings.toPath, "<ivysettings />")
     emptyIvySettings
   }
 
@@ -619,7 +618,7 @@ private object YarnClusterDriverUseSparkHadoopUtilConf extends Logging with Matc
       }
       result = "success"
     } finally {
-      Files.asCharSink(status, StandardCharsets.UTF_8).write(result)
+      Files.writeString(status.toPath, result)
       sc.stop()
     }
   }
@@ -722,7 +721,7 @@ private object YarnClusterDriver extends Logging with Matchers {
         assert(driverAttributes === expectationAttributes)
       }
     } finally {
-      Files.asCharSink(status, StandardCharsets.UTF_8).write(result)
+      Files.writeString(status.toPath, result)
       sc.stop()
     }
   }
@@ -771,7 +770,7 @@ private object YarnClasspathTest extends Logging {
       case t: Throwable =>
         error(s"loading test.resource to $resultPath", t)
     } finally {
-      Files.asCharSink(new File(resultPath), StandardCharsets.UTF_8).write(result)
+      Files.writeString(new File(resultPath).toPath, result)
     }
   }
 
@@ -815,7 +814,7 @@ private object YarnAddJarTest extends Logging {
         result = "success"
       }
     } finally {
-      Files.asCharSink(new File(resultPath), StandardCharsets.UTF_8).write(result)
+      Files.writeString(new File(resultPath).toPath, result)
       sc.stop()
     }
   }
@@ -860,7 +859,7 @@ private object ExecutorEnvTestApp {
       executorEnvs.get(k).contains(v)
     }
 
-    Files.asCharSink(new File(status), StandardCharsets.UTF_8).write(result.toString)
+    Files.writeString(new File(status).toPath, result.toString)
     sc.stop()
   }
 
@@ -875,7 +874,7 @@ private class PyConnectDepChecker(python: String, libPath: Seq[String]) {
   lazy val isSparkConnectJarAvailable: Boolean = {
     val filePath = s"$sparkHome/assembly/target/$scalaDir/jars/" +
       s"spark-connect_$scalaVersion-$SPARK_VERSION.jar"
-    java.nio.file.Files.exists(Paths.get(filePath))
+    Files.exists(Paths.get(filePath))
   }
 
   lazy val isConnectPythonPackagesAvailable: Boolean = Try {

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnShuffleIntegrationSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnShuffleIntegrationSuite.scala
@@ -18,9 +18,8 @@
 package org.apache.spark.deploy.yarn
 
 import java.io.File
-import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 
-import com.google.common.io.Files
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
@@ -181,7 +180,7 @@ private object YarnExternalShuffleDriver extends Logging with Matchers {
       if (execStateCopy != null) {
         Utils.deleteRecursively(execStateCopy)
       }
-      Files.asCharSink(status, StandardCharsets.UTF_8).write(result)
+      Files.writeString(status.toPath, result)
     }
   }
 

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -312,6 +312,11 @@ This file is divided into 3 sections:
     <customMessage>Use Files.writeString instead.</customMessage>
   </check>
 
+  <check customId="asCharSink" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFiles\.asCharSink\b</parameter></parameters>
+    <customMessage>Use Files.writeString instead.</customMessage>
+  </check>
+
   <check customId="writeLines" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">\bFileUtils\.writeLines\b</parameter></parameters>
     <customMessage>Use Files.write instead.</customMessage>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
@@ -17,13 +17,12 @@
 package org.apache.spark.sql.execution.arrow
 
 import java.io.{ByteArrayOutputStream, DataOutputStream, File}
-import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.sql.{Date, Timestamp}
 import java.text.SimpleDateFormat
 import java.time.LocalTime
 import java.util.Locale
 
-import com.google.common.io.Files
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.{VectorLoader, VectorSchemaRoot}
 import org.apache.arrow.vector.ipc.JsonFileReader
@@ -1256,8 +1255,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
 
     val tempFile1 = new File(tempDataPath, "testData2-ints-part1.json")
     val tempFile2 = new File(tempDataPath, "testData2-ints-part2.json")
-    Files.asCharSink(tempFile1, StandardCharsets.UTF_8).write(json1)
-    Files.asCharSink(tempFile2, StandardCharsets.UTF_8).write(json2)
+    Files.writeString(tempFile1.toPath, json1)
+    Files.writeString(tempFile2.toPath, json2)
 
     validateConversion(schema, arrowBatches(0), tempFile1)
     validateConversion(schema, arrowBatches(1), tempFile2)
@@ -1545,7 +1544,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
     // NOTE: coalesce to single partition because can only load 1 batch in validator
     val batchBytes = df.coalesce(1).toArrowBatchRdd.collect().head
     val tempFile = new File(tempDataPath, file)
-    Files.asCharSink(tempFile, StandardCharsets.UTF_8).write(json)
+    Files.writeString(tempFile.toPath, json)
     validateConversion(df.schema, batchBytes, tempFile, timeZoneId, errorOnDuplicatedFieldNames)
   }
 

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.hive.thriftserver
 
 import java.io.{File, FilenameFilter}
 import java.net.URL
-import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.sql.{Date, DriverManager, SQLException, Statement}
 import java.util.{Locale, UUID}
 
@@ -31,7 +31,6 @@ import scala.io.Source
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
-import com.google.common.io.Files
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 import org.apache.hive.jdbc.HiveDriver
 import org.apache.hive.service.auth.PlainSaslHelper
@@ -1224,7 +1223,7 @@ abstract class HiveThriftServer2TestBase extends SparkFunSuite with BeforeAndAft
       // overrides all other potential log4j configurations contained in other dependency jar files.
       val tempLog4jConf = Utils.createTempDir().getCanonicalPath
 
-      Files.asCharSink(new File(s"$tempLog4jConf/log4j2.properties"), StandardCharsets.UTF_8).write(
+      Files.writeString(new File(s"$tempLog4jConf/log4j2.properties").toPath,
         """rootLogger.level = info
           |rootLogger.appenderRef.stdout.ref = console
           |appender.console.type = Console

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/UISeleniumSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/UISeleniumSuite.scala
@@ -18,11 +18,10 @@
 package org.apache.spark.sql.hive.thriftserver
 
 import java.io.File
-import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 
 import scala.util.Random
 
-import com.google.common.io.Files
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.htmlunit.HtmlUnitDriver
@@ -75,7 +74,7 @@ class UISeleniumSuite
       // overrides all other potential log4j configurations contained in other dependency jar files.
       val tempLog4jConf = org.apache.spark.util.Utils.createTempDir().getCanonicalPath
 
-      Files.asCharSink(new File(s"$tempLog4jConf/log4j2.properties"), StandardCharsets.UTF_8).write(
+      Files.writeString(new File(s"$tempLog4jConf/log4j2.properties").toPath,
         """rootLogger.level = info
           |rootLogger.appenderRef.file.ref = console
           |appender.console.type = Console

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.hive.execution
 import java.io.File
 import java.net.URI
 import java.nio.file.Files
-import java.nio.file.StandardOpenOption
 import java.sql.{Date, Timestamp}
 import java.util.{Locale, Set}
 
@@ -2042,7 +2041,7 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
     withTempDir { dir =>
       val path = dir.toURI.toString.stripSuffix("/")
       val dirPath = dir.getAbsoluteFile
-      Files.writeString(new File(dirPath, "part-r-000011").toPath, "1", StandardOpenOption.APPEND)
+      Files.writeString(new File(dirPath, "part-r-000011").toPath, "1")
       withTable("part_table") {
         withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
           sql(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -19,11 +19,11 @@ package org.apache.spark.sql.hive.execution
 
 import java.io.File
 import java.net.URI
-import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.StandardOpenOption
 import java.sql.{Date, Timestamp}
 import java.util.{Locale, Set}
 
-import com.google.common.io.{Files, FileWriteMode}
 import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.{SPARK_DOC_ROOT, SparkException, TestUtils}
@@ -1950,10 +1950,10 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
       val path = dir.toURI.toString.stripSuffix("/")
       val dirPath = dir.getAbsoluteFile
       for (i <- 1 to 3) {
-        Files.asCharSink(new File(dirPath, s"part-r-0000$i"), StandardCharsets.UTF_8).write(s"$i")
+        Files.writeString(new File(dirPath, s"part-r-0000$i").toPath, s"$i")
       }
       for (i <- 5 to 7) {
-        Files.asCharSink(new File(dirPath, s"part-s-0000$i"), StandardCharsets.UTF_8).write(s"$i")
+        Files.writeString(new File(dirPath, s"part-s-0000$i").toPath, s"$i")
       }
 
       withTable("load_t") {
@@ -1974,7 +1974,7 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
       val path = dir.toURI.toString.stripSuffix("/")
       val dirPath = dir.getAbsoluteFile
       for (i <- 1 to 3) {
-        Files.asCharSink(new File(dirPath, s"part-r-0000 $i"), StandardCharsets.UTF_8).write(s"$i")
+        Files.writeString(new File(dirPath, s"part-r-0000 $i").toPath, s"$i")
       }
       withTable("load_t") {
         sql("CREATE TABLE load_t (a STRING) USING hive")
@@ -1989,7 +1989,7 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
       val path = dir.toURI.toString.stripSuffix("/")
       val dirPath = dir.getAbsoluteFile
       for (i <- 1 to 3) {
-        Files.asCharSink(new File(dirPath, s"part-r-0000$i"), StandardCharsets.UTF_8).write(s"$i")
+        Files.writeString(new File(dirPath, s"part-r-0000$i").toPath, s"$i")
       }
       withTable("load_t") {
         sql("CREATE TABLE load_t (a STRING) USING hive")
@@ -2013,7 +2013,7 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
       val path = dir.toURI.toString.stripSuffix("/")
       val dirPath = dir.getAbsoluteFile
       for (i <- 1 to 3) {
-        Files.asCharSink(new File(dirPath, s"part-r-0000$i"), StandardCharsets.UTF_8).write(s"$i")
+        Files.writeString(new File(dirPath, s"part-r-0000$i").toPath, s"$i")
       }
       withTable("load_t1") {
         sql("CREATE TABLE load_t1 (a STRING) USING hive")
@@ -2028,7 +2028,7 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
       val path = dir.toURI.toString.stripSuffix("/")
       val dirPath = dir.getAbsoluteFile
       for (i <- 1 to 3) {
-        Files.asCharSink(new File(dirPath, s"part-r-0000$i"), StandardCharsets.UTF_8).write(s"$i")
+        Files.writeString(new File(dirPath, s"part-r-0000$i").toPath, s"$i")
       }
       withTable("load_t2") {
         sql("CREATE TABLE load_t2 (a STRING) USING hive")
@@ -2042,8 +2042,7 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
     withTempDir { dir =>
       val path = dir.toURI.toString.stripSuffix("/")
       val dirPath = dir.getAbsoluteFile
-      Files.asCharSink(
-        new File(dirPath, "part-r-000011"), StandardCharsets.UTF_8, FileWriteMode.APPEND).write("1")
+      Files.writeString(new File(dirPath, "part-r-000011").toPath, "1", StandardOpenOption.APPEND)
       withTable("part_table") {
         withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
           sql(

--- a/streaming/src/test/java/test/org/apache/spark/streaming/JavaAPISuite.java
+++ b/streaming/src/test/java/test/org/apache/spark/streaming/JavaAPISuite.java
@@ -19,6 +19,7 @@ package test.org.apache.spark.streaming;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -39,7 +40,6 @@ import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import com.google.common.io.Files;
 import com.google.common.collect.Sets;
 
 import org.apache.spark.HashPartitioner;
@@ -1641,7 +1641,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
 
   private static List<List<String>> fileTestPrepare(File testDir) throws IOException {
     File existingFile = new File(testDir, "0");
-    Files.asCharSink(existingFile, StandardCharsets.UTF_8).write("0\n");
+    Files.writeString(existingFile.toPath(), "0\n");
     Assertions.assertTrue(existingFile.setLastModified(1000));
     Assertions.assertEquals(1000, existingFile.lastModified());
     return Arrays.asList(Arrays.asList("0"));

--- a/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.streaming
 
 import java.io._
-import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentLinkedQueue
 
 import scala.jdk.CollectionConverters._
@@ -649,7 +648,7 @@ class CheckpointSuite extends TestSuiteBase with LocalStreamingContext with DStr
      */
     def writeFile(i: Int, clock: Clock): Unit = {
       val file = new File(testDir, i.toString)
-      Files.asCharSink(file, StandardCharsets.UTF_8).write(s"$i\n")
+      java.nio.file.Files.writeString(file.toPath, s"$i\n")
       assert(file.setLastModified(clock.getTimeMillis()))
       // Check that the file's modification date is actually the value we wrote, since rounding or
       // truncation will break the test:

--- a/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.streaming
 import java.io.{BufferedWriter, File, OutputStreamWriter}
 import java.net.{ServerSocket, Socket, SocketException}
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files.writeString
 import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -131,7 +132,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
       val batchDuration = Seconds(2)
       // Create a file that exists before the StreamingContext is created:
       val existingFile = new File(testDir, "0")
-      Files.asCharSink(existingFile, StandardCharsets.UTF_8).write("0\n")
+      writeString(existingFile.toPath, "0\n")
       assert(existingFile.setLastModified(10000) && existingFile.lastModified === 10000)
 
       // Set up the streaming context and input streams
@@ -190,7 +191,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
 
       // Create a file that exists before the StreamingContext is created:
       val existingFile = new File(testDir, "0")
-      Files.asCharSink(existingFile, StandardCharsets.UTF_8).write("0\n")
+      writeString(existingFile.toPath, "0\n")
       assert(existingFile.setLastModified(10000) && existingFile.lastModified === 10000)
 
       val pathWithWildCard = testDir.toString + "/*/"
@@ -214,7 +215,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
 
         def createFileAndAdvanceTime(data: Int, dir: File): Unit = {
           val file = new File(testSubDir1, data.toString)
-          Files.asCharSink(file, StandardCharsets.UTF_8).write(s"$data\n")
+          writeString(file.toPath, s"$data\n")
           assert(file.setLastModified(clock.getTimeMillis()))
           assert(file.lastModified === clock.getTimeMillis())
           logInfo(s"Created file $file")
@@ -477,7 +478,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
       val batchDuration = Seconds(2)
       // Create a file that exists before the StreamingContext is created:
       val existingFile = new File(testDir, "0")
-      Files.asCharSink(existingFile, StandardCharsets.UTF_8).write("0\n")
+      writeString(existingFile.toPath, "0\n")
       assert(existingFile.setLastModified(10000) && existingFile.lastModified === 10000)
 
       // Set up the streaming context and input streams
@@ -501,7 +502,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
         val input = Seq(1, 2, 3, 4, 5)
         input.foreach { i =>
           val file = new File(testDir, i.toString)
-          Files.asCharSink(file, StandardCharsets.UTF_8).write(s"$i\n")
+          writeString(file.toPath, s"$i\n")
           assert(file.setLastModified(clock.getTimeMillis()))
           assert(file.lastModified === clock.getTimeMillis())
           logInfo("Created file " + file)

--- a/streaming/src/test/scala/org/apache/spark/streaming/MasterFailureTest.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/MasterFailureTest.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.streaming
 
 import java.io.{File, IOException}
-import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
@@ -27,7 +27,6 @@ import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 import scala.util.Random
 
-import com.google.common.io.Files
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.scalatest.Assertions._
@@ -375,7 +374,7 @@ class FileGeneratingThread(input: Seq[String], testDir: Path, interval: Long)
         val localFile = new File(localTestDir, (i + 1).toString)
         val hadoopFile = new Path(testDir, (i + 1).toString)
         val tempHadoopFile = new Path(testDir, ".tmp_" + (i + 1).toString)
-        Files.asCharSink(localFile, StandardCharsets.UTF_8).write(input(i) + "\n")
+        Files.writeString(localFile.toPath, input(i) + "\n")
         var tries = 0
         var done = false
             while (!done && tries < maxTries) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java `Files.writeString` instead of `Files.asCharSink`.

### Why are the changes needed?

In general, Java built-in `Files.writeString` is over 4 times faster than Google `Files.asCharSink`.

```scala
scala> val s = "a".repeat(500_000_000)

scala> spark.time(com.google.common.io.Files.asCharSink(new java.io.File("/dev/null"), java.nio.charset.StandardCharsets.UTF_8).write(s))
Time taken: 265 ms

scala> spark.time(java.nio.file.Files.writeString(Path.of("/dev/null"), s))
Time taken: 59 ms
val res1: java.nio.file.Path = /dev/null
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No