### PR TITLE
[SPARK-53158][WEBUI] Missing metricsProperties in KV Store should be handled correctly

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
@@ -497,7 +497,7 @@ class ApplicationEnvironmentInfo private[spark] (
     val sparkProperties: collection.Seq[(String, String)],
     val hadoopProperties: collection.Seq[(String, String)],
     val systemProperties: collection.Seq[(String, String)],
-    val metricsProperties: collection.Seq[(String, String)],
+    val metricsProperties: collection.Seq[(String, String)] = Nil,
     val classpathEntries: collection.Seq[(String, String)],
     val resourceProfiles: collection.Seq[ResourceProfileInfo])
 


### PR DESCRIPTION
[SPARK-53158][WEBUI] Missing metricsProperties in KV Store should be handled correctly

### What changes were proposed in this pull request?

When environment property maps (e.g. `metricsProperties`) are null — often due to LevelDBs created by Spark versions that did not have the property, the `Utils.redact(...)` function throws a `NullPointerException` during `.map` or `.toArray` operations.

 ### Why are the changes needed?

Without this change, the rest API response of `/environment` throws a 500 due to the server `NullPointerException`. The `NullPointerException` is the following :
```
Caused by: java.lang.NullPointerException: Cannot invoke "scala.collection.Seq.map(scala.Function1, scala.collection.generic.CanBuildFrom)" because "kvs" is
 null
        at org.apache.spark.util.Utils$.redact(Utils.scala:2923)
        at org.apache.spark.util.Utils$.redact(Utils.scala:2878)
        at org.apache.spark.status.api.v1.AbstractApplicationResource.$anonfun$environmentInfo$1(OneApplicationResource.scala:114)
```

 ### Does this PR introduce _any_ user-facing change?

No

 ### How was this patch tested?
- Tested this change on a local instance of SHS

 ### Was this patch authored or co-authored using generative AI tooling?

No