### PR TITLE
[SPARK-53162][SQL][TESTS] Mark `DynamicPartitionPruningHive*Suite*` as `SlowHiveTest`

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.execution.adaptive.{DisableAdaptiveExecutionSuite, E
 import org.apache.spark.sql.hive.execution.HiveTableScanExec
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.test.SQLTestUtils
+import org.apache.spark.tags.SlowHiveTest
 
 abstract class DynamicPartitionPruningHiveScanSuiteBase
     extends DynamicPartitionPruningSuiteBase with TestHiveSingleton with SQLTestUtils {
@@ -43,8 +44,10 @@ abstract class DynamicPartitionPruningHiveScanSuiteBase
   }
 }
 
+@SlowHiveTest
 class DynamicPartitionPruningHiveScanSuiteAEOff extends DynamicPartitionPruningHiveScanSuiteBase
   with DisableAdaptiveExecutionSuite
 
+@SlowHiveTest
 class DynamicPartitionPruningHiveScanSuiteAEOn extends DynamicPartitionPruningHiveScanSuiteBase
   with EnableAdaptiveExecutionSuite


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to mark `DynamicPartitionPruningHive*Suite*` as `SlowHiveTest`.
- DynamicPartitionPruningHiveScanSuiteAEOff
- DynamicPartitionPruningHiveScanSuiteAEOn

### Why are the changes needed?

To balance Hive CIs.

| JOB NAME | BEFORE | AFTER |
|---|---|---|
| hive - slow | 46m | 51m |
| hive - other | 89m | 76m |

**BEFORE (master branch)**
<img width="627" height="99" alt="Screenshot 2025-08-06 at 15 52 52" src="https://github.com/user-attachments/assets/b2ea8930-c5f7-4700-b5cb-c7b75f040fac" />


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Check the CI result on this PR.

### Was this patch authored or co-authored using generative AI tooling?

No.