### PR TITLE
[MINOR][CORE] Remove a wrong comment inside `SparkTestUtils.SparkTestUtils`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkTestUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkTestUtils.scala
@@ -66,8 +66,6 @@ private[spark] trait SparkTestUtils {
     assert(result.exists(), "Compiled file not found: " + result.getAbsolutePath())
     val out = new File(destDir, fileName)
 
-    // renameTo cannot handle in and out files in different filesystems
-    // use google's Files.move instead
     Files.move(result.toPath, out.toPath)
 
     assert(out.exists(), "Destination file not moved: " + out.getAbsolutePath())


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove a wrong comment of `SparkTestUtils` to match with the real logic.

### Why are the changes needed?

`SparkTestUtils` imports `java.nio.file.Files` and uses `Files.move` supporting copy-based move between different file systems. So, `SparkTestUtils` doesn't use Google's `Files.move`.

https://github.com/apache/spark/blob/111c7c6d9ff3fdebcc2e43affc5207a1c8e97ffe/common/utils/src/main/scala/org/apache/spark/util/SparkTestUtils.scala#L22

https://github.com/apache/spark/blob/111c7c6d9ff3fdebcc2e43affc5207a1c8e97ffe/common/utils/src/main/scala/org/apache/spark/util/SparkTestUtils.scala#L69-L71

### Does this PR introduce _any_ user-facing change?

No, this is a comment removal.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.