### PR TITLE
[SPARK-53166][CORE] Use `SparkExitCode.EXIT_FAILURE` in `SparkPipelines` object

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkPipelines.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkPipelines.scala
@@ -25,6 +25,7 @@ import scala.jdk.CollectionConverters._
 import org.apache.spark.SparkUserAppException
 import org.apache.spark.internal.Logging
 import org.apache.spark.launcher.SparkSubmitArgumentsParser
+import org.apache.spark.util.SparkExitCode
 
 /**
  * Outer implementation of the spark-pipelines command line interface. Responsible for routing
@@ -62,7 +63,7 @@ object SparkPipelines extends Logging {
           remote = value
         } else if (opt == "--class") {
           logInfo("--class argument not supported.")
-          throw SparkUserAppException(1)
+          throw SparkUserAppException(SparkExitCode.EXIT_FAILURE)
         } else if (opt == "--conf" &&
           value.startsWith("spark.api.mode=") &&
           value != "spark.api.mode=connect") {
@@ -70,7 +71,7 @@ object SparkPipelines extends Logging {
             "--spark.api.mode must be 'connect'. " +
             "Declarative Pipelines currently only supports Spark Connect."
           )
-          throw SparkUserAppException(1)
+          throw SparkUserAppException(SparkExitCode.EXIT_FAILURE)
         } else if (Seq("--name", "-h", "--help").contains(opt)) {
           pipelinesArgs += opt
           if (value != null && value.nonEmpty) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `SparkExitCode.EXIT_FAILURE` instead of the magic number, `1`, in the source code.

```scala
- throw SparkUserAppException(1)
+ throw SparkUserAppException(SparkExitCode.EXIT_FAILURE)
```

### Why are the changes needed?

We had better use the predefined constant variable instead of magic numbers in the code:
- `SparkUserAppException` is designed to have `exitCode`.
- `SparkExitCode` defines `EXIT_FAILURE` for `1`.

https://github.com/apache/spark/blob/46fd5258a16523637f7ac5fa7ece16f626816454/common/utils/src/main/scala/org/apache/spark/SparkException.scala#L156

https://github.com/apache/spark/blob/46fd5258a16523637f7ac5fa7ece16f626816454/core/src/main/scala/org/apache/spark/util/SparkExitCode.scala#L26

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.