### PR TITLE
[SPARK-53169][SQL] Remove comments related to "`Set the logger level of File Appender to`" from `log4j2.properties`

### DIFF
--- a/sql/core/src/test/resources/log4j2.properties
+++ b/sql/core/src/test/resources/log4j2.properties
@@ -44,7 +44,7 @@ appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex
 
 # Set the logger level of File Appender to WARN
 appender.file.filter.threshold.type = ThresholdFilter
-appender.file.filter.threshold.level = info
+appender.file.filter.threshold.level = warn
 
 # Some packages are noisy for no good reason.
 logger.parquet_recordreader.name = org.apache.parquet.hadoop.ParquetRecordReader

--- a/sql/core/src/test/resources/log4j2.properties
+++ b/sql/core/src/test/resources/log4j2.properties
@@ -42,9 +42,9 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex
 
-# Set the logger level of File Appender to WARN
+# Set the logger level of File Appender to INFO
 appender.file.filter.threshold.type = ThresholdFilter
-appender.file.filter.threshold.level = warn
+appender.file.filter.threshold.level = info
 
 # Some packages are noisy for no good reason.
 logger.parquet_recordreader.name = org.apache.parquet.hadoop.ParquetRecordReader

--- a/sql/core/src/test/resources/log4j2.properties
+++ b/sql/core/src/test/resources/log4j2.properties
@@ -42,7 +42,6 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex
 
-# Set the logger level of File Appender to INFO
 appender.file.filter.threshold.type = ThresholdFilter
 appender.file.filter.threshold.level = info
 

--- a/sql/hive-thriftserver/src/test/resources/log4j2.properties
+++ b/sql/hive-thriftserver/src/test/resources/log4j2.properties
@@ -41,7 +41,6 @@ appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex
 
 appender.file.filter.1.type = Filters
 
-# Set the logger level of File Appender to WARN
 appender.file.filter.1.a.type = ThresholdFilter
 appender.file.filter.1.a.level = debug
 

--- a/sql/hive/src/test/resources/log4j2.properties
+++ b/sql/hive/src/test/resources/log4j2.properties
@@ -36,7 +36,6 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex
 
-# Set the logger level of File Appender to INFO
 appender.file.filter.threshold.type = ThresholdFilter
 appender.file.filter.threshold.level = info
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr removes the comments related to "`Set the logger level of File Appender to`" from `log4j2.properties`, as the relevant configuration is self-descriptive and the comments often do not match the actual configuration.


### Why are the changes needed?
Remove redundant comments.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions

### Was this patch authored or co-authored using generative AI tooling?
No