### PR TITLE
[SPARK-53167][DEPLOY] Spark launcher isRemote also respects properties file

### DIFF
--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -18,12 +18,16 @@
 package org.apache.spark.launcher;
 
 import java.io.File;
+import java.io.FileReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.*;
@@ -33,29 +37,35 @@ import static org.junit.jupiter.api.Assertions.*;
 public class SparkSubmitCommandBuilderSuite extends BaseSuite {
 
   private static File dummyPropsFile;
+  private static File connectPropsFile;
   private static SparkSubmitOptionParser parser;
 
   @BeforeAll
   public static void setUp() throws Exception {
     dummyPropsFile = File.createTempFile("spark", "properties");
+    connectPropsFile = File.createTempFile("spark", "properties");
+    Files.writeString(connectPropsFile.toPath(), "spark.remote=sc://connect-server:15002");
     parser = new SparkSubmitOptionParser();
   }
 
   @AfterAll
   public static void cleanUp() throws Exception {
     dummyPropsFile.delete();
+    connectPropsFile.delete();
   }
 
   @Test
   public void testDriverCmdBuilder() throws Exception {
-    testCmdBuilder(true, true);
-    testCmdBuilder(true, false);
+    testCmdBuilder(true, null);
+    testCmdBuilder(true, dummyPropsFile);
+    testCmdBuilder(true, connectPropsFile);
   }
 
   @Test
   public void testClusterCmdBuilder() throws Exception {
-    testCmdBuilder(false, true);
-    testCmdBuilder(false, false);
+    testCmdBuilder(false, null);
+    testCmdBuilder(false, dummyPropsFile);
+    testCmdBuilder(false, connectPropsFile);
   }
 
   @Test
@@ -307,7 +317,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     assertTrue(builder.isClientMode(userProps));
   }
 
-  private void testCmdBuilder(boolean isDriver, boolean useDefaultPropertyFile) throws Exception {
+  private void testCmdBuilder(boolean isDriver, File propertiesFile) throws Exception {
     final String DRIVER_DEFAULT_PARAM = "-Ddriver-default";
     final String DRIVER_EXTRA_PARAM = "-Ddriver-extra";
     String deployMode = isDriver ? "client" : "cluster";
@@ -325,16 +335,16 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     launcher.appArgs.add("bar");
     launcher.conf.put("spark.foo", "foo");
     // either set the property through "--conf" or through default property file
-    if (!useDefaultPropertyFile) {
-      launcher.setPropertiesFile(dummyPropsFile.getAbsolutePath());
+    if (propertiesFile == null) {
+      launcher.childEnv.put("SPARK_CONF_DIR", System.getProperty("spark.test.home")
+          + "/launcher/src/test/resources");
+    } else {
+      launcher.setPropertiesFile(propertiesFile.getAbsolutePath());
       launcher.conf.put(SparkLauncher.DRIVER_MEMORY, "1g");
       launcher.conf.put(SparkLauncher.DRIVER_EXTRA_CLASSPATH, "/driver");
       launcher.conf.put(SparkLauncher.DRIVER_DEFAULT_JAVA_OPTIONS, DRIVER_DEFAULT_PARAM);
       launcher.conf.put(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, DRIVER_EXTRA_PARAM);
       launcher.conf.put(SparkLauncher.DRIVER_EXTRA_LIBRARY_PATH, "/native");
-    } else {
-      launcher.childEnv.put("SPARK_CONF_DIR", System.getProperty("spark.test.home")
-          + "/launcher/src/test/resources");
     }
 
     Map<String, String> env = new HashMap<>();
@@ -348,13 +358,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
         "Driver default options should be configured.");
       assertTrue(cmd.contains(DRIVER_EXTRA_PARAM), "Driver extra options should be configured.");
     } else {
-      boolean found = false;
-      for (String arg : cmd) {
-        if (arg.startsWith("-Xmx")) {
-          found = true;
-          break;
-        }
-      }
+      boolean found = cmd.stream().anyMatch(arg -> arg.startsWith("-Xmx"));
       assertFalse(found, "Memory arguments should not be set.");
       assertFalse(cmd.contains(DRIVER_DEFAULT_PARAM),
         "Driver default options should not be configured.");
@@ -379,8 +383,15 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     }
 
     // Checks below are the same for both driver and non-driver mode.
-    if (!useDefaultPropertyFile) {
-      assertEquals(dummyPropsFile.getAbsolutePath(), findArgValue(cmd, parser.PROPERTIES_FILE));
+    if (propertiesFile != null) {
+      assertEquals(propertiesFile.getAbsolutePath(), findArgValue(cmd, parser.PROPERTIES_FILE));
+      try (FileReader reader = new FileReader(propertiesFile, StandardCharsets.UTF_8)) {
+        Properties props = new Properties();
+        props.load(reader);
+        if (props.containsKey("spark.remote")) {
+          assertTrue(launcher.isRemote);
+        }
+      }
     }
     assertEquals("yarn", findArgValue(cmd, parser.MASTER));
     assertEquals(deployMode, findArgValue(cmd, parser.DEPLOY_MODE));


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR modifies the `SparkSubmitCommandBuilder` to use "effective config" to evaluate `isRemote` instead of the passed args only. This makes `spark.remote` configured in the properties file(`spark-defaults.conf` or other files specified by `--properties-file`) effective.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
```
$ sbin/start-connect-server.sh
$ cat > conf/spark-connect.conf <<EOF
spark.reomte=sc://localhost:15002
EOF
$ bin/spark-shell --properties-file conf/spark-connect.conf
```

```
25/08/07 13:35:56 ERROR Main: Failed to initialize Spark session.
org.apache.spark.SparkException: A master URL must be set in your configuration
	at org.apache.spark.SparkContext.<init>(SparkContext.scala:421)
	at org.apache.spark.SparkContext$.getOrCreate(SparkContext.scala:3055)
	at org.apache.spark.sql.classic.SparkSession$Builder.$anonfun$build$2(SparkSession.scala:839)
	at scala.Option.getOrElse(Option.scala:201)
	at org.apache.spark.sql.classic.SparkSession$Builder.build(SparkSession.scala:830)
	at org.apache.spark.sql.classic.SparkSession$Builder.getOrCreate(SparkSession.scala:859)
	at org.apache.spark.sql.classic.SparkSession$Builder.getOrCreate(SparkSession.scala:732)
	at org.apache.spark.sql.SparkSession$Builder.getOrCreate(SparkSession.scala:923)
	at org.apache.spark.repl.Main$.createSparkSession(Main.scala:116)
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, a kind of bug fix.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT is added, plus manually test:

```
$ sbin/start-connect-server.sh
$ cat > conf/spark-connect.conf <<EOF
spark.reomte=sc://localhost:15002
EOF
$ bin/spark-shell --properties-file conf/spark-connect.conf
```
The previously failed case now works.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.