### PR TITLE
[SPARK-53170][CORE] Improve `SparkUserAppException` to have `cause` parameter

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/SparkException.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkException.scala
@@ -153,8 +153,8 @@ private[spark] class SparkDriverExecutionException(cause: Throwable)
  * Exception thrown when the main user code is run as a child process (e.g. pyspark) and we want
  * the parent SparkSubmit process to exit with the same exit code.
  */
-private[spark] case class SparkUserAppException(exitCode: Int)
-  extends SparkException(s"User application exited with $exitCode")
+private[spark] case class SparkUserAppException(exitCode: Int, cause: Throwable = null)
+  extends SparkException(s"User application exited with $exitCode", cause)
 
 /**
  * Exception thrown when the relative executor to access is dead.

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -747,7 +747,7 @@ private[spark] class ApplicationMaster(
             e.getCause match {
               case _: InterruptedException =>
                 // Reporter thread can interrupt to stop user class
-              case SparkUserAppException(exitCode) =>
+              case SparkUserAppException(exitCode, _) =>
                 val msg = log"User application exited with status " +
                   log"${MDC(LogKeys.EXIT_CODE, exitCode)}"
                 logError(msg)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `SparkUserAppException` to have `cause` parameter additionally.

```scala
-private[spark] case class SparkUserAppException(exitCode: Int)
+private[spark] case class SparkUserAppException(exitCode: Int, cause: Throwable = null)
```

### Why are the changes needed?

`SparkUserAppException` is used in many places; `SparkSubmit`, `PythonRunner`, `RRunner`, `SparkPipelines`. Although this is defined as `private[spark]`, a new parameter `cause` can be used to enrich the information from the user application to upper layers internally.

### Does this PR introduce _any_ user-facing change?

No, this is defined as `private[spark]`.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.