### PR TITLE
[SPARK-53171][CORE] Improvement UTF8String repeat

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -1168,8 +1168,19 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
   }
 
   public UTF8String repeat(int times) {
-    if (times <= 0) {
+    if (times <= 0 || numBytes == 0) {
       return EMPTY_UTF8;
+    }
+
+    if (times == 1) {
+      return this;
+    }
+
+    if (numBytes == 1) {
+      byte[] newBytes = new byte[times];
+      byte b = getByte(0);
+      Arrays.fill(newBytes, b);
+      return fromBytes(newBytes);
     }
 
     byte[] newBytes = new byte[Math.multiplyExact(numBytes, times)];


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR improves the UTF8String repeat logic for some special cases


### Why are the changes needed?
performance improvement


### Does this PR introduce _any_ user-facing change?
now


### How was this patch tested?
Passing existing UT and benchmarked like

```
scala> spark.time((1 to 10000000).foreach(_ => UTF8String.fromStri
ng("A").repeat(1024)))
Time taken: 784 ms
scala> spark.time((1 to 10000000).foreach(_ => repeat(UTF8String.f
romString("A"), 1024)))
Time taken: 432 ms
````

### Was this patch authored or co-authored using generative AI tooling?
no