### PR TITLE
[SPARK-53174][CORE] Add TMPDIR environment variable with the value of java.io.tmpdir

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -233,6 +233,8 @@ private[spark] class PythonWorkerFactory(
       workerEnv.put("PYTHONPATH", pythonPath)
       // This is equivalent to setting the -u flag; we use it because ipython doesn't support -u:
       workerEnv.put("PYTHONUNBUFFERED", "YES")
+      // add TMPDIR environment variable with the value of java.io.tmpdir
+      workerEnv.put("TMPDIR", System.getProperty("java.io.tmpdir"))
       if (isUnixDomainSock) {
         workerEnv.put("PYTHON_WORKER_FACTORY_SOCK_PATH", sockPath.getPath)
         workerEnv.put("PYTHON_UNIX_DOMAIN_ENABLED", "True")
@@ -321,6 +323,8 @@ private[spark] class PythonWorkerFactory(
         }
         // This is equivalent to setting the -u flag; we use it because ipython doesn't support -u:
         workerEnv.put("PYTHONUNBUFFERED", "YES")
+        // add TMPDIR environment variable with the value of java.io.tmpdir
+        workerEnv.put("TMPDIR", System.getProperty("java.io.tmpdir"))
         daemon = pb.start()
 
         val in = new DataInputStream(daemon.getInputStream)

--- a/core/src/main/scala/org/apache/spark/api/r/BaseRRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/BaseRRunner.scala
@@ -311,6 +311,8 @@ private[r] object BaseRRunner {
     pb.environment().put("SPARKR_SPARKFILES_ROOT_DIR", SparkFiles.getRootDirectory())
     pb.environment().put("SPARKR_IS_RUNNING_ON_WORKER", "TRUE")
     pb.environment().put("SPARKR_WORKER_SECRET", authHelper.secret)
+    // add TMPDIR environment variable with the value of java.io.tmpdir
+    pb.environment().put("TMPDIR", System.getProperty("java.io.tmpdir"))
     pb.redirectErrorStream(true)  // redirect stderr into stdout
     val proc = pb.start()
     val errThread = startStdoutThread(proc)

--- a/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
@@ -99,6 +99,8 @@ object PythonRunner {
     } else {
       sparkConf.getOption("spark.remote").foreach(url => env.put("SPARK_REMOTE", url))
     }
+    // add TMPDIR environment variable with the value of java.io.tmpdir
+    env.put("TMPDIR", System.getProperty("java.io.tmpdir"))
     env.put("PYTHONPATH", pythonPath)
     // This is equivalent to setting the -u flag; we use it because ipython doesn't support -u:
     env.put("PYTHONUNBUFFERED", "YES") // value is needed to be set to a non-empty string

--- a/core/src/main/scala/org/apache/spark/deploy/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/RRunner.scala
@@ -97,6 +97,8 @@ object RRunner {
         env.put("R_PROFILE_USER",
           Seq(rPackageDir(0), "SparkR", "profile", "general.R").mkString(File.separator))
         env.put("SPARKR_BACKEND_AUTH_SECRET", sparkRBackendSecret)
+        // add TMPDIR environment variable with the value of java.io.tmpdir
+        env.put("TMPDIR", System.getProperty("java.io.tmpdir"))
         builder.redirectErrorStream(true) // Ugly but needed for stdout and stderr to synchronize
         val process = builder.start()
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
Add the TMPDIR environment variable when creating R and Python processes



### Why are the changes needed?
Python, R and other programming languages will write temporary files to the `TMPDIR` path. The default value of `TMPDIR` is the system directory `/tmp`, which can easily lead to the `/tmp` directory being full. Referring to the practice of [Hadoop streaming](https://github.com/apache/hadoop/blob/744088a9db6d1b33eb3ad1b1612047c179b65c7a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/PipeMapRed.java#L204) and [Mapreuce,](https://github.com/apache/hadoop/blob/744088a9db6d1b33eb3ad1b1612047c179b65c7a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/pipes/Application.java#L100) we can set `TMPDIR` to the value of `java.io.tmpdir` before creating the process.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
I ran a manual test
``` python
def executor_task(partition):
        import importlib
        import tempfile
        importlib.reload(tempfile)
        files = []
        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=f'_exec_{partition}.txt') as f:
            f.write(f"data from partition num {partition}\n")
            files.append(f.name)
            print(f"Executor file name: {f.name}")
            print(f"Executor: Python Executor gettempdir: {tempfile.gettempdir()}")
        return files

    results = spark.sparkContext.parallelize(range(3), 3).map(executor_task).collect()
```
Before the change, the results are as follows:
```shell
/tmp/tmplzkzBjS5x9.txt
/tmp/35bcc79WPH.txt
/tmp/JtdTT77QgE.txt
```

After the changes, the results are as follows:
```shell
/mnt/ssd/1/yarn/nm-local-dir/usercache/xiaoping.huang/appcache/application_1753165783143_3901251/container_e2014_1753165783143_3901251_01_000002/tmp/tmpMGNnvmp6r5.txt
/mnt/ssd/1/yarn/nm-local-dir/usercache/xiaoping.huang/appcache/application_1753165783143_3901251/container_e2014_1753165783143_3901251_01_000002/tmp/tmpEVKQkdszpq.txt
/mnt/ssd/1/yarn/nm-local-dir/usercache/xiaoping.huang/appcache/application_1753165783143_3901251/container_e2014_1753165783143_3901251_01_000002/tmp/tmp6kLVQI7jIu.txt
```

### Was this patch authored or co-authored using generative AI tooling?
No
