### PR TITLE
[SPARK-53177][K8S] Use Java `Base64` instead of `com.google.common.io.BaseEncoding`

### DIFF
--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -191,6 +191,7 @@
             <property name="illegalClasses" value="org.apache.commons.lang3.SystemUtils" />
             <property name="illegalClasses" value="org.apache.hadoop.io.IOUtils" />
             <property name="illegalClasses" value="com.google.common.base.Strings" />
+            <property name="illegalClasses" value="com.google.common.io.BaseEncoding" />
         </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="Charset\.defaultCharset"/>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStep.scala
@@ -19,10 +19,10 @@ package org.apache.spark.deploy.k8s.features
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.util.Base64
 
 import scala.jdk.CollectionConverters._
 
-import com.google.common.io.BaseEncoding
 import io.fabric8.kubernetes.api.model.{ContainerBuilder, HasMetadata, PodBuilder, Secret, SecretBuilder}
 
 import org.apache.spark.deploy.k8s.{KubernetesConf, SparkPod}
@@ -48,7 +48,7 @@ private[spark] class DriverKubernetesCredentialsFeatureStep(kubernetesConf: Kube
   private val oauthTokenBase64 = kubernetesConf
     .getOption(s"$KUBERNETES_AUTH_DRIVER_CONF_PREFIX.$OAUTH_TOKEN_CONF_SUFFIX")
     .map { token =>
-      BaseEncoding.base64().encode(token.getBytes(StandardCharsets.UTF_8))
+      Base64.getEncoder().encodeToString(token.getBytes(StandardCharsets.UTF_8))
     }
 
   private val caCertDataBase64 = safeFileConfToBase64(
@@ -154,7 +154,7 @@ private[spark] class DriverKubernetesCredentialsFeatureStep(kubernetesConf: Kube
       .map { file =>
         require(file.isFile, String.format("%s provided at %s does not exist or is not a file.",
           fileType, file.getAbsolutePath))
-        BaseEncoding.base64().encode(Files.readAllBytes(file.toPath))
+        Base64.getEncoder().encodeToString(Files.readAllBytes(file.toPath))
       }
   }
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStepSuite.scala
@@ -19,10 +19,10 @@ package org.apache.spark.deploy.k8s.features
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.util.Base64
 
 import scala.jdk.CollectionConverters._
 
-import com.google.common.io.BaseEncoding
 import io.fabric8.kubernetes.api.model.Secret
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
@@ -107,7 +107,7 @@ class DriverKubernetesCredentialsFeatureStepSuite extends SparkFunSuite {
     assert(credentialsSecret.getMetadata.getName ===
       s"${kubernetesConf.resourceNamePrefix}-kubernetes-credentials")
     val decodedSecretData = credentialsSecret.getData.asScala.map { data =>
-      (data._1, new String(BaseEncoding.base64().decode(data._2), StandardCharsets.UTF_8))
+      (data._1, new String(Base64.getDecoder().decode(data._2), StandardCharsets.UTF_8))
     }
     val expectedSecretData = Map(
       DRIVER_CREDENTIALS_CA_CERT_SECRET_NAME -> "ca-cert",

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -731,4 +731,9 @@ This file is divided into 3 sections:
     <parameters><parameter name="regex">org\.apache\.commons\.collections4\.MapUtils\b</parameter></parameters>
     <customMessage>Use org.apache.spark.util.collection.Utils instead.</customMessage>
   </check>
+
+  <check customId="maputils" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">com\.google\.common\.io\.BaseEncoding\b</parameter></parameters>
+    <customMessage>Use Java APIs (like java.util.Base64) instead.</customMessage>
+  </check>
 </scalastyle>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java `Base64` instead of `com.google.common.io.BaseEncoding`.

In addition, new Scalastyle and Checkstyle rules are added to ban `com.google.common.io.BaseEncoding` in order to prevent a future regression.

### Why are the changes needed?

Java implementation is **over 2x faster** than Google one.

```scala
scala> val s = "a".repeat(5_000_000).getBytes(java.nio.charset.StandardCharsets.UTF_8)

scala> spark.time(java.util.Base64.getDecoder().decode(java.util.Base64.getEncoder().encodeToString(s)).length)
Time taken: 18 ms
val res0: Int = 5000000

scala> spark.time(com.google.common.io.BaseEncoding.base64().decode(com.google.common.io.BaseEncoding.base64().encode(s)).length)
Time taken: 50 ms
val res1: Int = 5000000
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.