### PR TITLE
[SPARK-53176][DEPLOY] Spark launcher should respect `--load-spark-defaults`

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -368,11 +368,6 @@ abstract class AbstractCommandBuilder {
    * Configurations from user-specified properties file take precedence over spark-defaults.conf.
    */
   private Properties loadPropertiesFile() throws IOException {
-    Properties defaultsProps = new Properties();
-    if (propertiesFile == null || loadSparkDefaults) {
-      defaultsProps = loadPropertiesFile(new File(getConfDir(), DEFAULT_PROPERTIES_FILE));
-    }
-
     Properties props = new Properties();
     if (propertiesFile != null) {
       File propsFile = new File(propertiesFile);
@@ -380,13 +375,18 @@ abstract class AbstractCommandBuilder {
       props = loadPropertiesFile(propsFile);
     }
 
-    for (Map.Entry<Object, Object> entry : props.entrySet()) {
-      if (!defaultsProps.containsKey(entry.getKey())) {
-        defaultsProps.put(entry.getKey(), entry.getValue());
+    Properties defaultsProps = new Properties();
+    if (propertiesFile == null || loadSparkDefaults) {
+      defaultsProps = loadPropertiesFile(new File(getConfDir(), DEFAULT_PROPERTIES_FILE));
+    }
+
+    for (Map.Entry<Object, Object> entry : defaultsProps.entrySet()) {
+      if (!props.containsKey(entry.getKey())) {
+        props.put(entry.getKey(), entry.getValue());
       }
     }
 
-    return defaultsProps;
+    return props;
   }
 
   private Properties loadPropertiesFile(File propsFile) throws IOException {

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -251,6 +251,10 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
       args.add(propertiesFile);
     }
 
+    if (loadSparkDefaults) {
+      args.add(parser.LOAD_SPARK_DEFAULTS);
+    }
+
     if (isExample) {
       jars.addAll(findExamplesJars());
     }
@@ -550,6 +554,7 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
         }
         case DEPLOY_MODE -> deployMode = value;
         case PROPERTIES_FILE -> propertiesFile = value;
+        case LOAD_SPARK_DEFAULTS -> loadSparkDefaults = true;
         case DRIVER_MEMORY -> conf.put(SparkLauncher.DRIVER_MEMORY, value);
         case DRIVER_JAVA_OPTIONS -> conf.put(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, value);
         case DRIVER_LIBRARY_PATH -> conf.put(SparkLauncher.DRIVER_EXTRA_LIBRARY_PATH, value);

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -63,7 +63,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
   public void testGetEffectiveConfig() throws Exception {
     doTestGetEffectiveConfig(null, true, true);
     doTestGetEffectiveConfig(null, true, false);
-    doTestGetEffectiveConfig(null, false, false);
+    doTestGetEffectiveConfig(null, false, true);
     doTestGetEffectiveConfig(null, false, false);
     doTestGetEffectiveConfig(driverMemPropsFile, true, true);
     doTestGetEffectiveConfig(driverMemPropsFile, true, false);

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -71,7 +71,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     doTestGetEffectiveConfig(driverMemPropsFile, false, false);
   }
 
-  public void doTestGetEffectiveConfig(
+  private void doTestGetEffectiveConfig(
       File propertiesFile, boolean loadSparkDefaults, boolean confDriverMemory) throws Exception {
     SparkSubmitCommandBuilder launcher =
         newCommandBuilder(Collections.emptyList());

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -38,6 +38,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
 
   private static File dummyPropsFile;
   private static File connectPropsFile;
+  private static File driverMemPropsFile;
   private static SparkSubmitOptionParser parser;
 
   @BeforeAll
@@ -45,6 +46,9 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     dummyPropsFile = File.createTempFile("spark", "properties");
     connectPropsFile = File.createTempFile("spark", "properties");
     Files.writeString(connectPropsFile.toPath(), "spark.remote=sc://connect-server:15002");
+    driverMemPropsFile = File.createTempFile("spark", "properties");
+    Files.writeString(driverMemPropsFile.toPath(),
+        "spark.driver.memory=4g\nspark.driver.memoryOverhead=768m");
     parser = new SparkSubmitOptionParser();
   }
 
@@ -52,22 +56,87 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
   public static void cleanUp() throws Exception {
     dummyPropsFile.delete();
     connectPropsFile.delete();
+    driverMemPropsFile.delete();
+  }
+
+  @Test
+  public void testGetEffectiveConfig() throws Exception {
+    doTestGetEffectiveConfig(null, true, true);
+    doTestGetEffectiveConfig(null, true, false);
+    doTestGetEffectiveConfig(null, false, false);
+    doTestGetEffectiveConfig(null, false, false);
+    doTestGetEffectiveConfig(driverMemPropsFile, true, true);
+    doTestGetEffectiveConfig(driverMemPropsFile, true, false);
+    doTestGetEffectiveConfig(driverMemPropsFile, false, true);
+    doTestGetEffectiveConfig(driverMemPropsFile, false, false);
+  }
+
+  public void doTestGetEffectiveConfig(
+      File propertiesFile, boolean loadSparkDefaults, boolean confDriverMemory) throws Exception {
+    SparkSubmitCommandBuilder launcher =
+        newCommandBuilder(Collections.emptyList());
+    launcher.loadSparkDefaults = loadSparkDefaults;
+    launcher.conf.put("spark.foo", "bar");
+    launcher.childEnv.put("SPARK_CONF_DIR", System.getProperty("spark.test.home")
+        + "/launcher/src/test/resources");
+
+    if (propertiesFile != null) {
+      launcher.setPropertiesFile(propertiesFile.getAbsolutePath());
+    }
+
+    if (confDriverMemory) {
+      launcher.conf.put(SparkLauncher.DRIVER_MEMORY, "2g");
+    }
+
+    Map<String, String> effectiveConfig = launcher.getEffectiveConfig();
+
+    assertEquals("bar", effectiveConfig.get("spark.foo"));
+    if (confDriverMemory) {
+      assertEquals("2g", effectiveConfig.get(SparkLauncher.DRIVER_MEMORY));
+    } else if (propertiesFile != null) {
+      try (FileReader reader = new FileReader(propertiesFile, StandardCharsets.UTF_8)) {
+        Properties props = new Properties();
+        props.load(reader);
+        if (props.containsKey(SparkLauncher.DRIVER_MEMORY)) {
+          assertEquals(props.getProperty(SparkLauncher.DRIVER_MEMORY),
+            effectiveConfig.get(SparkLauncher.DRIVER_MEMORY));
+        }
+      }
+    } else {
+      assertEquals("1g", effectiveConfig.get(SparkLauncher.DRIVER_MEMORY));
+    }
+
+    if (propertiesFile != null) {
+      try (FileReader reader = new FileReader(propertiesFile, StandardCharsets.UTF_8)) {
+        Properties props = new Properties();
+        props.load(reader);
+        if (props.containsKey("spark.driver.memoryOverhead")) {
+          assertEquals(props.getProperty("spark.driver.memoryOverhead"),
+              effectiveConfig.get("spark.driver.memoryOverhead"));
+        }
+      }
+      if (loadSparkDefaults) {
+        assertEquals("/driver", effectiveConfig.get(SparkLauncher.DRIVER_EXTRA_CLASSPATH));
+      } else {
+        assertFalse(effectiveConfig.containsKey(SparkLauncher.DRIVER_EXTRA_CLASSPATH));
+      }
+    } else {
+      assertEquals("/driver", effectiveConfig.get(SparkLauncher.DRIVER_EXTRA_CLASSPATH));
+    }
   }
 
   @Test
   public void testDriverCmdBuilder() throws Exception {
-    testCmdBuilder(true, null, false);
-    testCmdBuilder(true, dummyPropsFile, false);
-    testCmdBuilder(true, dummyPropsFile, true);
-    testCmdBuilder(true, connectPropsFile, false);
+    testCmdBuilder(true, null);
+    testCmdBuilder(true, dummyPropsFile);
+    testCmdBuilder(true, connectPropsFile);
   }
 
   @Test
   public void testClusterCmdBuilder() throws Exception {
-    testCmdBuilder(true, null, false);
-    testCmdBuilder(true, dummyPropsFile, false);
-    testCmdBuilder(true, dummyPropsFile, true);
-    testCmdBuilder(true, connectPropsFile, false);
+    testCmdBuilder(false, null);
+    testCmdBuilder(false, dummyPropsFile);
+    testCmdBuilder(false, connectPropsFile);
   }
 
   @Test
@@ -319,15 +388,13 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     assertTrue(builder.isClientMode(userProps));
   }
 
-  private void testCmdBuilder(
-      boolean isDriver, File propertiesFile, boolean loadSparkDefaults) throws Exception {
+  private void testCmdBuilder(boolean isDriver, File propertiesFile) throws Exception {
     final String DRIVER_DEFAULT_PARAM = "-Ddriver-default";
     final String DRIVER_EXTRA_PARAM = "-Ddriver-extra";
     String deployMode = isDriver ? "client" : "cluster";
 
     SparkSubmitCommandBuilder launcher =
       newCommandBuilder(Collections.emptyList());
-    launcher.loadSparkDefaults = loadSparkDefaults;
     launcher.childEnv.put(CommandBuilderUtils.ENV_SPARK_HOME,
       System.getProperty("spark.test.home"));
     launcher.master = "yarn";
@@ -338,10 +405,11 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     launcher.appArgs.add("foo");
     launcher.appArgs.add("bar");
     launcher.conf.put("spark.foo", "foo");
-    launcher.childEnv.put("SPARK_CONF_DIR", System.getProperty("spark.test.home")
-        + "/launcher/src/test/resources");
-    // either set the property through "--conf" or through properties file(s)
-    if (propertiesFile != null) {
+    // either set the property through "--conf" or through default property file
+    if (propertiesFile == null) {
+      launcher.childEnv.put("SPARK_CONF_DIR", System.getProperty("spark.test.home")
+          + "/launcher/src/test/resources");
+    } else {
       launcher.setPropertiesFile(propertiesFile.getAbsolutePath());
       launcher.conf.put(SparkLauncher.DRIVER_MEMORY, "1g");
       launcher.conf.put(SparkLauncher.DRIVER_EXTRA_CLASSPATH, "/driver");
@@ -372,13 +440,8 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     String[] cp = findArgValue(cmd, "-cp").split(Pattern.quote(File.pathSeparator));
     if (isDriver) {
       assertTrue(contains("/driver", cp), "Driver classpath should contain provided entry.");
-      if (propertiesFile == null || loadSparkDefaults) {
-        assertTrue(contains("/driver-default", cp),
-          "Driver classpath should contain provided entry.");
-      }
     } else {
       assertFalse(contains("/driver", cp), "Driver classpath should not be in command.");
-      assertFalse(contains("/driver-default", cp), "Driver classpath should not be in command.");
     }
 
     String libPath = env.get(CommandBuilderUtils.getLibPathEnvName());

--- a/launcher/src/test/resources/spark-defaults.conf
+++ b/launcher/src/test/resources/spark-defaults.conf
@@ -16,6 +16,7 @@
 #
 
 spark.driver.memory=1g
+spark.driver.defaultExtraClassPath=/driver-default
 spark.driver.extraClassPath=/driver
 spark.driver.defaultJavaOptions=-Ddriver-default
 spark.driver.extraJavaOptions=-Ddriver-extra

--- a/launcher/src/test/resources/spark-defaults.conf
+++ b/launcher/src/test/resources/spark-defaults.conf
@@ -16,7 +16,6 @@
 #
 
 spark.driver.memory=1g
-spark.driver.defaultExtraClassPath=/driver-default
 spark.driver.extraClassPath=/driver
 spark.driver.defaultJavaOptions=-Ddriver-default
 spark.driver.extraJavaOptions=-Ddriver-extra


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
SPARK-48392 introduces `--load-spark-defaults`, but does not apply correctly for the Spark launcher process, this mainly affects the driver when Spark runs in local/client mode.

let's say we have
```
$ cat > conf/spark-defaults.conf <<EOF
spark.driver.memory=4g
EOF
$ cat > conf/spark-local.conf <<EOF
spark.master=local[4]
EOF
```

```
$ bin/spark-shell --properties-file conf/spark-local.conf --load-spark-defaults
...
scala> spark.sql("SET spark.driver.memory").show()
+-------------------+-----+
|                key|value|
+-------------------+-----+
|spark.driver.memory|   4g|
+-------------------+-----+
```
even the spark conf reports that driver uses 4GiB heap memory, but if we check the Java process, the config actually does not take effect, the default 1GiB is used instead.
```
$ jinfo <spark-submit-pid>
...
VM Arguments:
jvm_args: -Dscala.usejavacp=true -Xmx1g ...
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bug fix.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, bug fix.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT is modified to cover the change, plus manual tests for the above cases.

```
$ jinfo <spark-submit-pid>
...
VM Arguments:
jvm_args: -Dscala.usejavacp=true -Xmx4g ...
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.