### PR TITLE
[SPARK-53180][CORE] Use Java `InputStream.skipNBytes` instead of `ByteStreams.skipFully`

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/FileSegmentManagedBuffer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/FileSegmentManagedBuffer.java
@@ -26,7 +26,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
 
-import com.google.common.io.ByteStreams;
 import io.netty.channel.DefaultFileRegion;
 import io.netty.handler.stream.ChunkedStream;
 
@@ -98,7 +97,7 @@ public final class FileSegmentManagedBuffer extends ManagedBuffer {
     boolean shouldClose = true;
     try {
       is = new FileInputStream(file);
-      ByteStreams.skipFully(is, offset);
+      is.skipNBytes(offset);
       InputStream r = new LimitedInputStream(is, length);
       shouldClose = false;
       return r;

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/checksum/ShuffleChecksumHelper.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/checksum/ShuffleChecksumHelper.java
@@ -21,8 +21,6 @@ import java.io.*;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.*;
 
-import com.google.common.io.ByteStreams;
-
 import org.apache.spark.internal.SparkLogger;
 import org.apache.spark.internal.SparkLoggerFactory;
 import org.apache.spark.internal.LogKeys;
@@ -88,7 +86,7 @@ public class ShuffleChecksumHelper {
 
   private static long readChecksumByReduceId(File checksumFile, int reduceId) throws IOException {
     try (DataInputStream in = new DataInputStream(new FileInputStream(checksumFile))) {
-      ByteStreams.skipFully(in, reduceId * 8L);
+      in.skipNBytes(reduceId * 8L);
       return in.readLong();
     }
   }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1588,7 +1588,7 @@ private[spark] object Utils
     }
 
     try {
-      ByteStreams.skipFully(stream, effectiveStart)
+      stream.skipNBytes(effectiveStart)
       ByteStreams.readFully(stream, buff)
     } finally {
       stream.close()

--- a/core/src/main/scala/org/apache/spark/util/io/ChunkedByteBuffer.scala
+++ b/core/src/main/scala/org/apache/spark/util/io/ChunkedByteBuffer.scala
@@ -21,7 +21,6 @@ import java.io.{Externalizable, File, FileInputStream, InputStream, ObjectInput,
 import java.nio.ByteBuffer
 import java.nio.channels.WritableByteChannel
 
-import com.google.common.io.ByteStreams
 import com.google.common.primitives.UnsignedBytes
 import io.netty.handler.stream.ChunkedStream
 
@@ -245,7 +244,7 @@ private[spark] object ChunkedByteBuffer {
     // and spark currently is not expecting memory-mapped buffers in the memory store, it conflicts
     // with other parts that manage the lifecycle of buffers and dispose them.  See SPARK-25422.
     val is = new FileInputStream(file)
-    ByteStreams.skipFully(is, offset)
+    is.skipNBytes(offset)
     val in = new LimitedInputStream(is, length)
     val chunkSize = math.min(ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH, length).toInt
     val out = new ChunkedByteBufferOutputStream(chunkSize, ByteBuffer.allocate _)

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -210,6 +210,10 @@
             <property name="message" value="Use java.nio.file.Files.writeString instead." />
         </module>
         <module name="RegexpSinglelineJava">
+            <property name="format" value="ByteStreams\.skipFully"/>
+            <property name="message" value="Use Java skipNBytes instead." />
+        </module>
+        <module name="RegexpSinglelineJava">
             <property name="format" value="FileUtils.writeStringToFile"/>
             <property name="message" value="Use java.nio.file.Files.writeString instead." />
         </module>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -727,6 +727,11 @@ This file is divided into 3 sections:
     <customMessage>Use Java `write` instead.</customMessage>
   </check>
 
+  <check customId="skipFully" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bByteStreams\.skipFully\b</parameter></parameters>
+    <customMessage>Use Java `skipNBytes` instead.</customMessage>
+  </check>
+
   <check customId="maputils" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">org\.apache\.commons\.collections4\.MapUtils\b</parameter></parameters>
     <customMessage>Use org.apache.spark.util.collection.Utils instead.</customMessage>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java `InputStream.skipNBytes` instead of `ByteStreams.skipFully`.

```scala
-    ByteStreams.skipFully(is, offset)
+    is.skipNBytes(offset)
```

### Why are the changes needed?

Java 12+ supports `skipNBytes` natively. We had better use this simple style.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.