### PR TITLE
[SPARK-53324][K8S] Introduce pending pod limit per ResourceProfile

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -771,8 +771,8 @@ private[spark] object Config extends Logging {
         "independently for each resource profile ID.")
       .version("4.1.0")
       .intConf
-      .checkValue(value => value > 0, 
-        "Maximum number of pending pods per rpid should be a positive integer")
+      .checkValue(value => value > 0,
+        "Maximum number of pending pods per rp id should be a positive integer")
       .createWithDefault(Int.MaxValue)
 
   val KUBERNETES_EXECUTOR_SNAPSHOTS_SUBSCRIBERS_GRACE_PERIOD =

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -771,7 +771,8 @@ private[spark] object Config extends Logging {
         "independently for each resource profile ID.")
       .version("4.1.0")
       .intConf
-      .checkValue(value => value > 0, "Maximum number of pending pods per rpid should be a positive integer")
+      .checkValue(value => value > 0, 
+        "Maximum number of pending pods per rpid should be a positive integer")
       .createWithDefault(Int.MaxValue)
 
   val KUBERNETES_EXECUTOR_SNAPSHOTS_SUBSCRIBERS_GRACE_PERIOD =

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -764,7 +764,7 @@ private[spark] object Config extends Logging {
       .createWithDefault(Int.MaxValue)
 
   val KUBERNETES_MAX_PENDING_PODS_PER_RPID =
-    ConfigBuilder("spark.kubernetes.allocation.maxPendingPodsPerRpid")
+    ConfigBuilder("spark.kubernetes.allocation.maxPendingPodsPerRp")
       .doc("Maximum number of pending PODs allowed per resource profile ID during executor " +
         "allocation. This provides finer-grained control over pending pods by limiting them " +
         "per resource profile rather than globally. When set, this limit is enforced " +

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -763,6 +763,17 @@ private[spark] object Config extends Logging {
       .checkValue(value => value > 0, "Maximum number of pending pods should be a positive integer")
       .createWithDefault(Int.MaxValue)
 
+  val KUBERNETES_MAX_PENDING_PODS_PER_RPID =
+    ConfigBuilder("spark.kubernetes.allocation.maxPendingPodsPerRpid")
+      .doc("Maximum number of pending PODs allowed per resource profile ID during executor " +
+        "allocation. This provides finer-grained control over pending pods by limiting them " +
+        "per resource profile rather than globally. When set, this limit is enforced " +
+        "independently for each resource profile ID.")
+      .version("4.1.0")
+      .intConf
+      .checkValue(value => value > 0, "Maximum number of pending pods per rpid should be a positive integer")
+      .createWithDefault(Int.MaxValue)
+
   val KUBERNETES_EXECUTOR_SNAPSHOTS_SUBSCRIBERS_GRACE_PERIOD =
     ConfigBuilder("spark.kubernetes.executorSnapshotsSubscribersShutdownGracePeriod")
       .doc("Time to wait for graceful shutdown kubernetes-executor-snapshots-subscribers " +

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -369,10 +369,10 @@ class ExecutorPodsAllocator(
             sharedSlotFromPendingPods) =>
         val remainingSlotsForRpId = maxPendingPodsPerRpid - pendingPodCountForRpId
         val numMissingPodsForRpId = targetNum - podCountForRpId
-
         val numExecutorsToAllocate =
           math.min(math.min(math.min(numMissingPodsForRpId, podAllocationSize), 
             sharedSlotFromPendingPods), remainingSlotsForRpId)
+
         logInfo(log"Going to request ${MDC(LogKeys.COUNT, numExecutorsToAllocate)} executors from" +
           log" Kubernetes for ResourceProfile Id: ${MDC(LogKeys.RESOURCE_PROFILE_ID, rpId)}, " +
           log"target: ${MDC(LogKeys.NUM_POD_TARGET, targetNum)}, " +

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -365,19 +365,20 @@ class ExecutorPodsAllocator(
     if (remainingSlotFromPendingPods > 0 && podsToAllocateWithRpId.size > 0 &&
         !(snapshots.isEmpty && podAllocOnPVC && maxPVCs <= PVC_COUNTER.get())) {
       ExecutorPodsAllocator.splitSlots(podsToAllocateWithRpId, remainingSlotFromPendingPods)
-        .foreach { case ((rpId, podCountForRpId, targetNum, pendingPodCountForRpId), sharedSlotFromPendingPods) =>
-        val remainingSlotsForRpId = maxPendingPodsPerRpid - pendingPodCountForRpId 
+        .foreach { case ((rpId, podCountForRpId, targetNum, pendingPodCountForRpId), 
+            sharedSlotFromPendingPods) =>
+        val remainingSlotsForRpId = maxPendingPodsPerRpid - pendingPodCountForRpId
         val numMissingPodsForRpId = targetNum - podCountForRpId
 
         val numExecutorsToAllocate =
-          math.min(math.min(math.min(numMissingPodsForRpId, podAllocationSize), sharedSlotFromPendingPods), remainingSlotsForRpId)
-          
+          math.min(math.min(math.min(numMissingPodsForRpId, podAllocationSize), 
+            sharedSlotFromPendingPods), remainingSlotsForRpId)
         logInfo(log"Going to request ${MDC(LogKeys.COUNT, numExecutorsToAllocate)} executors from" +
           log" Kubernetes for ResourceProfile Id: ${MDC(LogKeys.RESOURCE_PROFILE_ID, rpId)}, " +
           log"target: ${MDC(LogKeys.NUM_POD_TARGET, targetNum)}, " +
           log"known: ${MDC(LogKeys.NUM_POD, podCountForRpId)}, sharedSlotFromPendingPods: " +
           log"${MDC(LogKeys.NUM_POD_SHARED_SLOT, sharedSlotFromPendingPods)}, " +
-          s"remainingSlotsForRpId: $remainingSlotsForRpId.")
+          log"remainingSlotsForRpId: ${MDC(LogKeys.REMAINING_SLOTS, remainingSlotsForRpId)}.")
         requestNewExecutors(numExecutorsToAllocate, applicationId, rpId, k8sKnownPVCNames)
       }
     }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -73,9 +73,12 @@ class ExecutorPodsAllocator(
 
   protected val maxPendingPodsPerRpid = conf.get(KUBERNETES_MAX_PENDING_PODS_PER_RPID)
 
-  require(maxPendingPodsPerRpid <= maxPendingPods,
-    s"Maximum pending pods per resource profile ID ($maxPendingPodsPerRpid) must be less than " +
-      s"or equal to maximum pending pods ($maxPendingPods).")
+  // If maxPendingPodsPerRpid is set, ensure it's not greater than maxPendingPods
+  if (maxPendingPodsPerRpid != Int.MaxValue) {
+    require(maxPendingPodsPerRpid <= maxPendingPods,
+      s"Maximum pending pods per resource profile ID ($maxPendingPodsPerRpid) must be less than " +
+        s"or equal to maximum pending pods ($maxPendingPods).")
+  }
 
   protected val podCreationTimeout = math.max(
     podAllocationDelay * 5,

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -370,7 +370,7 @@ class ExecutorPodsAllocator(
         val numMissingPodsForRpId = targetNum - podCountForRpId
 
         val numExecutorsToAllocate =
-          math.min(math.min(math.min(numMissingPodsForRpId, podAllocationSize), sharedSlotFromPendingPods), remainingSlotForRpId)
+          math.min(math.min(math.min(numMissingPodsForRpId, podAllocationSize), sharedSlotFromPendingPods), remainingSlotsForRpId)
           
         logInfo(log"Going to request ${MDC(LogKeys.COUNT, numExecutorsToAllocate)} executors from" +
           log" Kubernetes for ResourceProfile Id: ${MDC(LogKeys.RESOURCE_PROFILE_ID, rpId)}, " +

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -366,7 +366,7 @@ class ExecutorPodsAllocator(
         !(snapshots.isEmpty && podAllocOnPVC && maxPVCs <= PVC_COUNTER.get())) {
       ExecutorPodsAllocator.splitSlots(podsToAllocateWithRpId, remainingSlotFromPendingPods)
         .foreach { case ((rpId, podCountForRpId, targetNum, pendingPodCountForRpId), sharedSlotFromPendingPods) =>
-        val remainingSlotForRpId = maxPendingPodsPerRpid - pendingPodCountForRpId 
+        val remainingSlotsForRpId = maxPendingPodsPerRpid - pendingPodCountForRpId 
         val numMissingPodsForRpId = targetNum - podCountForRpId
 
         val numExecutorsToAllocate =
@@ -377,9 +377,8 @@ class ExecutorPodsAllocator(
           log"target: ${MDC(LogKeys.NUM_POD_TARGET, targetNum)}, " +
           log"known: ${MDC(LogKeys.NUM_POD, podCountForRpId)}, sharedSlotFromPendingPods: " +
           log"${MDC(LogKeys.NUM_POD_SHARED_SLOT, sharedSlotFromPendingPods)}, " +
-          s"remainingSlotForRpId: $remainingSlotForRpId.")
+          s"remainingSlotsForRpId: $remainingSlotsForRpId.")
         requestNewExecutors(numExecutorsToAllocate, applicationId, rpId, k8sKnownPVCNames)
-        }
       }
     }
     deletedExecutorIds = _deletedExecutorIds

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -365,20 +365,19 @@ class ExecutorPodsAllocator(
     if (remainingSlotFromPendingPods > 0 && podsToAllocateWithRpId.size > 0 &&
         !(snapshots.isEmpty && podAllocOnPVC && maxPVCs <= PVC_COUNTER.get())) {
       ExecutorPodsAllocator.splitSlots(podsToAllocateWithRpId, remainingSlotFromPendingPods)
-        .foreach { case ((rpId, podCountForRpId, targetNum, pendingPodCountForRpId), 
+        .foreach { case ((rpId, podCountForRpId, targetNum, pendingPodCountForRpId),
             sharedSlotFromPendingPods) =>
         val remainingSlotsForRpId = maxPendingPodsPerRpid - pendingPodCountForRpId
         val numMissingPodsForRpId = targetNum - podCountForRpId
         val numExecutorsToAllocate =
-          math.min(math.min(math.min(numMissingPodsForRpId, podAllocationSize), 
+          math.min(math.min(math.min(numMissingPodsForRpId, podAllocationSize),
             sharedSlotFromPendingPods), remainingSlotsForRpId)
 
         logInfo(log"Going to request ${MDC(LogKeys.COUNT, numExecutorsToAllocate)} executors from" +
           log" Kubernetes for ResourceProfile Id: ${MDC(LogKeys.RESOURCE_PROFILE_ID, rpId)}, " +
           log"target: ${MDC(LogKeys.NUM_POD_TARGET, targetNum)}, " +
           log"known: ${MDC(LogKeys.NUM_POD, podCountForRpId)}, sharedSlotFromPendingPods: " +
-          log"${MDC(LogKeys.NUM_POD_SHARED_SLOT, sharedSlotFromPendingPods)}, " +
-          log"remainingSlotsForRpId: ${MDC(LogKeys.REMAINING_SLOTS, remainingSlotsForRpId)}.")
+          log"${MDC(LogKeys.NUM_POD_SHARED_SLOT, sharedSlotFromPendingPods)}.")
         requestNewExecutors(numExecutorsToAllocate, applicationId, rpId, k8sKnownPVCNames)
       }
     }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -372,17 +372,13 @@ class ExecutorPodsAllocator(
         val numExecutorsToAllocate =
           math.min(math.min(math.min(numMissingPodsForRpId, podAllocationSize), sharedSlotFromPendingPods), remainingSlotForRpId)
           
-        if (numExecutorsToAllocate > 0) {
-          logInfo(log"Going to request ${MDC(LogKeys.COUNT, numExecutorsToAllocate)} executors from" +
-            log" Kubernetes for ResourceProfile Id: ${MDC(LogKeys.RESOURCE_PROFILE_ID, rpId)}, " +
-            log"target: ${MDC(LogKeys.NUM_POD_TARGET, targetNum)}, " +
-            log"known: ${MDC(LogKeys.NUM_POD, podCountForRpId)}, sharedSlotFromPendingPods: " +
-            log"${MDC(LogKeys.NUM_POD_SHARED_SLOT, sharedSlotFromPendingPods)}, " +
-            s"remainingSlotForRpId: $remainingSlotForRpId.")
-          requestNewExecutors(numExecutorsToAllocate, applicationId, rpId, k8sKnownPVCNames)
-        } else if (remainingSlotForRpId <= 0) {
-          logDebug(s"ResourceProfile Id $rpId cannot allocate more pods due to per-rpid limit " +
-            s"(pending: $notRunningPodCountForRpId, limit: $maxPendingPodsPerRpid)")
+        logInfo(log"Going to request ${MDC(LogKeys.COUNT, numExecutorsToAllocate)} executors from" +
+          log" Kubernetes for ResourceProfile Id: ${MDC(LogKeys.RESOURCE_PROFILE_ID, rpId)}, " +
+          log"target: ${MDC(LogKeys.NUM_POD_TARGET, targetNum)}, " +
+          log"known: ${MDC(LogKeys.NUM_POD, podCountForRpId)}, sharedSlotFromPendingPods: " +
+          log"${MDC(LogKeys.NUM_POD_SHARED_SLOT, sharedSlotFromPendingPods)}, " +
+          s"remainingSlotForRpId: $remainingSlotForRpId.")
+        requestNewExecutors(numExecutorsToAllocate, applicationId, rpId, k8sKnownPVCNames)
         }
       }
     }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -236,6 +236,83 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     verify(labeledPods, times(1)).delete()
   }
 
+  test("pending pod limit per resource profile ID") {
+    when(podOperations
+      .withField("status.phase", "Pending"))
+      .thenReturn(podOperations)
+    when(podOperations
+      .withLabel(SPARK_APP_ID_LABEL, TEST_SPARK_APP_ID))
+      .thenReturn(podOperations)
+    when(podOperations
+      .withLabel(SPARK_ROLE_LABEL, SPARK_POD_EXECUTOR_ROLE))
+      .thenReturn(podOperations)
+    when(podOperations
+      .withLabelIn(meq(SPARK_EXECUTOR_ID_LABEL), any(classOf[Array[String]]): _*))
+      .thenReturn(podOperations)
+
+    val startTime = Instant.now.toEpochMilli
+    waitForExecutorPodsClock.setTime(startTime)
+
+    // Create two different resource profiles
+    val rpb1 = new ResourceProfileBuilder()
+    val ereq1 = new ExecutorResourceRequests()
+    val treq1 = new TaskResourceRequests()
+    ereq1.cores(2).memory("1g")
+    treq1.cpus(1)
+    rpb1.require(ereq1).require(treq1)
+    val rp1 = rpb1.build()
+
+    val rpb2 = new ResourceProfileBuilder()
+    val ereq2 = new ExecutorResourceRequests()
+    val treq2 = new TaskResourceRequests()
+    ereq2.cores(4).memory("2g")
+    treq2.cpus(2)
+    rpb2.require(ereq2).require(treq2)
+    val rp2 = rpb2.build()
+
+    // Set per-rpid pending pod limit to 2, global limit high enough to not interfere
+    val confWithPerRpidLimit = conf.clone
+      .set(KUBERNETES_MAX_PENDING_PODS.key, "10")
+      .set(KUBERNETES_MAX_PENDING_PODS_PER_RPID.key, "2")
+    podsAllocatorUnderTest = new ExecutorPodsAllocator(confWithPerRpidLimit, secMgr,
+      executorBuilder, kubernetesClient, snapshotsStore, waitForExecutorPodsClock)
+    podsAllocatorUnderTest.start(TEST_SPARK_APP_ID, schedulerBackend)
+
+    // Request 4 executors for rp1 and 3 for rp2
+    // Should only get 2 for each due to per-rpid limit
+    podsAllocatorUnderTest.setTotalExpectedExecutors(Map(rp1 -> 4, rp2 -> 3))
+    assert(podsAllocatorUnderTest.numOutstandingPods.get() == 4) // 2 for each rpid
+    
+    // Verify that exactly 2 pods were requested for each resource profile
+    verify(podsWithNamespace).resource(podWithAttachedContainerForId(1, rp1.id))
+    verify(podsWithNamespace).resource(podWithAttachedContainerForId(2, rp1.id))
+    verify(podsWithNamespace).resource(podWithAttachedContainerForId(3, rp2.id))
+    verify(podsWithNamespace).resource(podWithAttachedContainerForId(4, rp2.id))
+    verify(podResource, times(4)).create()
+
+    // Mark one pod from rp1 as running to free up a slot for that rpid
+    snapshotsStore.updatePod(runningExecutor(1, rp1.id))
+    snapshotsStore.updatePod(pendingExecutor(2, rp1.id))
+    snapshotsStore.updatePod(pendingExecutor(3, rp2.id))
+    snapshotsStore.updatePod(pendingExecutor(4, rp2.id))
+    snapshotsStore.notifySubscribers()
+    
+    // Now rp1 should be able to request one more pod (up to its limit of 2 pending)
+    // but rp2 should still be at its limit
+    assert(podsAllocatorUnderTest.numOutstandingPods.get() == 3) // 1 pending for rp1, 2 for rp2
+    verify(podsWithNamespace).resource(podWithAttachedContainerForId(5, rp1.id))
+    verify(podResource, times(5)).create()
+    
+    // Mark one pod from rp2 as running to free up a slot for that rpid
+    snapshotsStore.updatePod(runningExecutor(3, rp2.id))
+    snapshotsStore.notifySubscribers()
+    
+    // Now rp2 should be able to request one more pod
+    assert(podsAllocatorUnderTest.numOutstandingPods.get() == 3) // 2 pending for rp1, 1 for rp2
+    verify(podsWithNamespace).resource(podWithAttachedContainerForId(6, rp2.id))
+    verify(podResource, times(6)).create()
+  }
+
   test("Initially request executors in batches. Do not request another batch if the" +
     " first has not finished.") {
     podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> (podAllocationSize + 1)))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Introducing a limit for pending PODs (newly created/requested executors included) per resource profile.
There exists a config for a global limit for all resource profiles, but here we add a limit per resource profile. #33492 does a lot of the plumbing for us already, counting newly created and pending pods, and we can just pass through the pending pods per resource profile, and limit the number of requests we were going to make for pods for that resource profile to min(previousRequest, maxPodsPerRP).

### Why are the changes needed?
For multiple resource profile use cases you can set limits that apply at the resource profile level, instead of globally.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
unit tests added


### Was this patch authored or co-authored using generative AI tooling?
No