### PR TITLE
[SPARK-53184][PS] Fix melt() when value columns mix strings and numbers

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -10647,7 +10647,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             }
 
             value_col_types = [field_by_label[label].spark_type for label in value_vars]
-            print(value_col_types)
             # If any value column is of StringType, cast all value columns to StringType to avoid
             # ANSI mode errors during explode - mixing strings and integers.
             string_cast_required_type = (

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -13829,15 +13829,11 @@ def _test() -> None:
     import uuid
     from pyspark.sql import SparkSession
     import pyspark.pandas.frame
-    from pyspark.testing.utils import is_ansi_mode_test
 
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.frame.__dict__.copy()
     globs["ps"] = pyspark.pandas
-
-    if is_ansi_mode_test:
-        del pyspark.pandas.frame.DataFrame.melt.__doc__
 
     spark = (
         SparkSession.builder.master("local[4]").appName("pyspark.pandas.frame tests").getOrCreate()

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -3879,7 +3879,6 @@ def _test() -> None:
     from pyspark.sql import SparkSession
     import pyspark.pandas.namespace
     from pandas.util.version import Version
-    from pyspark.testing.utils import is_ansi_mode_test
 
     os.chdir(os.environ["SPARK_HOME"])
 
@@ -3892,9 +3891,6 @@ def _test() -> None:
     globs = pyspark.pandas.namespace.__dict__.copy()
     globs["ps"] = pyspark.pandas
     globs["sf"] = F
-
-    if is_ansi_mode_test:
-        del pyspark.pandas.namespace.melt.__doc__
 
     spark = (
         SparkSession.builder.master("local[4]")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the issue of `melt` when "value" has mixed type containing strings.

### Why are the changes needed?
Ensure pandas on spark works well under ANSI

Part of https://issues.apache.org/jira/browse/SPARK-52984

### Does this PR introduce _any_ user-facing change?
Yes. melt when "value" has MultiIndex column labels works under ANSI

```py
>>> pdf = pd.DataFrame({'A': {0: 'a', 1: 'b', 2: 'c'},
...                            'B': {0: 1, 1: 3, 2: 5},
...                            'C': {0: 2, 1: 4, 2: 6}},
...                           columns=['A', 'B', 'C'])
>>> psdf = ps.from_pandas(pdf)
>>> psdf.melt()
  variable value                                                                
0        A     a
1        B     1
2        C     2
3        A     b
4        B     3
5        C     4
6        A     c
7        B     5
8        C     6
```


### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.
