### PR TITLE
[SPARK-53189][INFRA] Use `Temurin` JDK distribution in `build_and_test.yml`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -348,7 +348,7 @@ jobs:
     - name: Install Java ${{ matrix.java }}
       uses: actions/setup-java@v4
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: ${{ matrix.java }}
     - name: Install Python 3.11
       uses: actions/setup-python@v5
@@ -598,7 +598,7 @@ jobs:
     - name: Install Java ${{ matrix.java }}
       uses: actions/setup-java@v4
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: ${{ matrix.java }}
     - name: List Python packages (${{ env.PYTHON_TO_TEST }})
       if: ${{ env.PYTHON_TO_TEST != '' }}
@@ -714,7 +714,7 @@ jobs:
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v4
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: ${{ inputs.java }}
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}
@@ -839,7 +839,7 @@ jobs:
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v4
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: ${{ inputs.java }}
     - name: License test
       run: ./dev/check-license
@@ -931,7 +931,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: 17
     - name: Build with Maven
       run: |
@@ -949,7 +949,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: 25-ea
     - name: Build with Maven
       run: |
@@ -1021,7 +1021,7 @@ jobs:
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v4
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: ${{ inputs.java }}
     - name: Install dependencies for documentation generation for branch-3.5
       if: inputs.branch == 'branch-3.5'
@@ -1151,7 +1151,7 @@ jobs:
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v4
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: ${{ inputs.java }}
     - name: Cache TPC-DS generated data
       id: cache-tpcds-sf-1
@@ -1260,7 +1260,7 @@ jobs:
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v4
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: ${{ inputs.java }}
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}
@@ -1319,7 +1319,7 @@ jobs:
       - name: Install Java ${{ inputs.java }}
         uses: actions/setup-java@v4
         with:
-          distribution: zulu
+          distribution: temurin
           java-version: ${{ inputs.java }}
       - name: Install R
         run: |


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to switch JDK distribution to `Temurin` from `Zulu` in GitHub Action. 

### Why are the changes needed?

In these days, GitHub Action CI is flaky due to the following. It happens even if we reverted to the old RocksDB versions. Probably, the root cause is in the recent RocksDB source code (including test code) change. Before doing further investigation, this PR aims to filter out JDK from the usual suspect lists by switching to the different distribution. If we see the same errors similarly. JDK is not a problem. I proposed to merge this and monitor in the `master` branch commit builder and `PR` builder fully for a while.

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x0000000000000000, pid=25847, tid=1179418
#
# JRE version: OpenJDK Runtime Environment Zulu17.60+17-CRaC-CA (17.0.16+8) (build 17.0.16+8-LTS)
# Java VM: OpenJDK 64-Bit Server VM Zulu17.60+17-CRaC-CA (17.0.16+8-LTS, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# C  [librocksdbjni14240090935137458973.so+0x8e85b2]
#
# Core dump will be written. Default location: Core dumps may be processed with "/usr/lib/systemd/systemd-coredump %P %u %g %s %t 9223372036854775808 %h %d" (or dumping to /home/runner/work/spark/spark/sql/core/core.25847)
#
# An error report file with more information is saved as:
# /home/runner/work/spark/spark/sql/core/hs_err_pid25847.log
[info] - transformWithState - check that classified error is thrown from handleInputRows (361 milliseconds)
00:57:32.328 WARN org.apache.spark.sql.execution.streaming.ResolveWriteToStream: spark.sql.adaptive.enabled is not supported in streaming DataFrames/Datasets and will be disabled.

#
# If you would like to submit a bug report, please visit:
#   http://www.azul.com/support/
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#
Warning: Unable to read from client, please check on client for further details of the problem.
```

### Does this PR introduce _any_ user-facing change?

No. This is an infra change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.