### PR TITLE
[SPARK-53194][INFRA] Set -XX:ErrorFile to build/target directory for tests

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1683,6 +1683,7 @@ object TestSettings {
     (Test / javaOptions) ++= System.getProperties.asScala.filter(_._1.startsWith("spark"))
       .map { case (k,v) => s"-D$k=$v" }.toSeq,
     (Test / javaOptions) += "-ea",
+    (Test / javaOptions) += s"-XX:ErrorFile=${baseDirectory.value}/target/hs_err_pid%p.log",
     (Test / javaOptions) ++= {
       val metaspaceSize = sys.env.get("METASPACE_SIZE").getOrElse("1300m")
       val heapSize = sys.env.get("HEAP_SIZE").getOrElse("4g")


### PR DESCRIPTION

### What changes were proposed in this pull request?

Set -XX:ErrorFile to build/target directory for tests


### Why are the changes needed?

When a fatal error occurs, hs_err_pidXXX.log will be uploaded with other logs for troubleshooting, while we can only see the header section now

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->No


### How was this patch tested?
Test locally 

```
# An error report file with more information is saved as:
# /Users/hzyaoqin/spark/sql/hive/target/hs_err_pid33707.log
#
```

### Was this patch authored or co-authored using generative AI tooling?
no