### PR TITLE
[SPARK-53195][CORE] Use Java `InputStream.readNBytes` instead of `ByteStreams.read`

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -46,7 +46,7 @@ import scala.util.matching.Regex
 import _root_.io.netty.channel.unix.Errors.NativeIoException
 import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 import com.google.common.collect.Interners
-import com.google.common.io.{ByteStreams, Files => GFiles}
+import com.google.common.io.{Files => GFiles}
 import com.google.common.net.InetAddresses
 import jakarta.ws.rs.core.UriBuilder
 import org.apache.commons.codec.binary.Hex
@@ -1558,10 +1558,10 @@ private[spark] object Utils
       gzInputStream = new GZIPInputStream(new FileInputStream(file))
       val bufSize = 1024
       val buf = new Array[Byte](bufSize)
-      var numBytes = ByteStreams.read(gzInputStream, buf, 0, bufSize)
+      var numBytes = gzInputStream.readNBytes(buf, 0, bufSize)
       while (numBytes > 0) {
         fileSize += numBytes
-        numBytes = ByteStreams.read(gzInputStream, buf, 0, bufSize)
+        numBytes = gzInputStream.readNBytes(buf, 0, bufSize)
       }
       fileSize
     } catch {

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -732,6 +732,11 @@ This file is divided into 3 sections:
     <customMessage>Use Java `write` instead.</customMessage>
   </check>
 
+  <check customId="bytestreamsread" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bByteStreams\.read\b</parameter></parameters>
+    <customMessage>Use Java readNBytes instead.</customMessage>
+  </check>
+
   <check customId="bytestreamscopy" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">\bByteStreams\.copy\b</parameter></parameters>
     <customMessage>Use Java transferTo instead.</customMessage>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java 9+ `InputStream.readNBytes` API instead of `ByteStreams.read`.

### Why are the changes needed?

To simplify the code by using native Java API.

```scala
- var numBytes = ByteStreams.read(gzInputStream, buf, 0, bufSize)
+ var numBytes = gzInputStream.readNBytes(buf, 0, bufSize)
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.