### PR TITLE
[SPARK-53196][CORE] Use Java `OutputStream.nullOutputStream` instead of `ByteStreams.nullOutputStream`

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
@@ -27,8 +27,6 @@ import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
-import com.google.common.io.ByteStreams
-
 import org.apache.spark.{SparkConf, SparkException, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys._
@@ -905,7 +903,7 @@ private[storage] class PartiallySerializedBlock[T](
         // We want to close the output stream in order to free any resources associated with the
         // serializer itself (such as Kryo's internal buffers). close() might cause data to be
         // written, so redirect the output stream to discard that data.
-        redirectableOutputStream.setOutputStream(ByteStreams.nullOutputStream())
+        redirectableOutputStream.setOutputStream(OutputStream.nullOutputStream())
         serializationStream.close()
       } finally {
         discarded = true

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -747,6 +747,11 @@ This file is divided into 3 sections:
     <customMessage>Use readFully of JavaUtils/SparkStreamUtils/Utils instead.</customMessage>
   </check>
 
+  <check customId="nullOutputStream" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bByteStreams\.nullOutputStream\b</parameter></parameters>
+    <customMessage>Use OutputStream.nullOutputStream instead.</customMessage>
+  </check>
+
   <check customId="maputils" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">org\.apache\.commons\.collections4\.MapUtils\b</parameter></parameters>
     <customMessage>Use org.apache.spark.util.collection.Utils instead.</customMessage>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java 11+ `OutputStream.nullOutputStream` instead of `ByteStreams.nullOutputStream`.

### Why are the changes needed?

We had better use native JDK APIs when it's available.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.