### PR TITLE
[SPARK-53197][CORE][SQL] Use `java.util.Objects#requireNonNull` instead of `com.google.common.base.Preconditions#checkNotNull`

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStoreView.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStoreView.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.util.kvstore;
 
+import java.util.Objects;
+
 import com.google.common.base.Preconditions;
 
 import org.apache.spark.annotation.Private;
@@ -58,7 +60,7 @@ public abstract class KVStoreView<T> implements Iterable<T> {
    * Iterates according to the given index.
    */
   public KVStoreView<T> index(String name) {
-    this.index = Preconditions.checkNotNull(name);
+    this.index = Objects.requireNonNull(name);
     return this;
   }
 

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBTypeInfo.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBTypeInfo.java
@@ -18,9 +18,11 @@
 package org.apache.spark.util.kvstore;
 
 import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Preconditions;
@@ -305,8 +307,8 @@ class LevelDBTypeInfo {
     /** The full key in the index that identifies the given entity. */
     byte[] entityKey(byte[] prefix, Object entity) throws Exception {
       Object indexValue = getValue(entity);
-      Preconditions.checkNotNull(indexValue, "Null index value for %s in type %s.",
-        name, type.getName());
+      Objects.requireNonNull(indexValue, () ->
+        String.format("Null index value for %s in type %s.", Arrays.toString(name), type.getName()));
       byte[] entityKey = start(prefix, indexValue);
       if (!isNatural) {
         entityKey = buildKey(false, entityKey, toKey(naturalIndex().getValue(entity)));
@@ -331,8 +333,8 @@ class LevelDBTypeInfo {
         byte[] naturalKey,
         byte[] prefix) throws Exception {
       Object indexValue = getValue(entity);
-      Preconditions.checkNotNull(indexValue, "Null index value for %s in type %s.",
-        name, type.getName());
+      Objects.requireNonNull(indexValue, () ->
+        String.format("Null index value for %s in type %s.", Arrays.toString(name), type.getName()));
 
       byte[] entityKey = start(prefix, indexValue);
       if (!isNatural) {

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBTypeInfo.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBTypeInfo.java
@@ -308,7 +308,8 @@ class LevelDBTypeInfo {
     byte[] entityKey(byte[] prefix, Object entity) throws Exception {
       Object indexValue = getValue(entity);
       Objects.requireNonNull(indexValue, () ->
-        String.format("Null index value for %s in type %s.", Arrays.toString(name), type.getName()));
+        String.format(
+          "Null index value for %s in type %s.", Arrays.toString(name), type.getName()));
       byte[] entityKey = start(prefix, indexValue);
       if (!isNatural) {
         entityKey = buildKey(false, entityKey, toKey(naturalIndex().getValue(entity)));
@@ -334,7 +335,8 @@ class LevelDBTypeInfo {
         byte[] prefix) throws Exception {
       Object indexValue = getValue(entity);
       Objects.requireNonNull(indexValue, () ->
-        String.format("Null index value for %s in type %s.", Arrays.toString(name), type.getName()));
+        String.format(
+          "Null index value for %s in type %s.", Arrays.toString(name), type.getName()));
 
       byte[] entityKey = start(prefix, indexValue);
       if (!isNatural) {

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBTypeInfo.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBTypeInfo.java
@@ -310,7 +310,8 @@ class RocksDBTypeInfo {
     byte[] entityKey(byte[] prefix, Object entity) throws Exception {
       Object indexValue = getValue(entity);
       Objects.requireNonNull(indexValue, () ->
-        String.format("Null index value for %s in type %s.", Arrays.toString(name), type.getName()));
+        String.format(
+          "Null index value for %s in type %s.", Arrays.toString(name), type.getName()));
       byte[] entityKey = start(prefix, indexValue);
       if (!isNatural) {
         entityKey = buildKey(false, entityKey, toKey(naturalIndex().getValue(entity)));
@@ -336,7 +337,8 @@ class RocksDBTypeInfo {
         byte[] prefix) throws Exception {
       Object indexValue = getValue(entity);
       Objects.requireNonNull(indexValue, () ->
-        String.format("Null index value for %s in type %s.", Arrays.toString(name), type.getName()));
+        String.format(
+          "Null index value for %s in type %s.", Arrays.toString(name), type.getName()));
 
       byte[] entityKey = start(prefix, indexValue);
       if (!isNatural) {

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBTypeInfo.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBTypeInfo.java
@@ -17,14 +17,16 @@
 
 package org.apache.spark.util.kvstore;
 
-import com.google.common.base.Preconditions;
-import org.rocksdb.RocksDBException;
-import org.rocksdb.WriteBatch;
-
 import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+
+import com.google.common.base.Preconditions;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.WriteBatch;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -307,8 +309,8 @@ class RocksDBTypeInfo {
     /** The full key in the index that identifies the given entity. */
     byte[] entityKey(byte[] prefix, Object entity) throws Exception {
       Object indexValue = getValue(entity);
-      Preconditions.checkNotNull(indexValue, "Null index value for %s in type %s.",
-        name, type.getName());
+      Objects.requireNonNull(indexValue, () ->
+        String.format("Null index value for %s in type %s.", Arrays.toString(name), type.getName()));
       byte[] entityKey = start(prefix, indexValue);
       if (!isNatural) {
         entityKey = buildKey(false, entityKey, toKey(naturalIndex().getValue(entity)));
@@ -333,8 +335,8 @@ class RocksDBTypeInfo {
         byte[] naturalKey,
         byte[] prefix) throws Exception {
       Object indexValue = getValue(entity);
-      Preconditions.checkNotNull(indexValue, "Null index value for %s in type %s.",
-        name, type.getName());
+      Objects.requireNonNull(indexValue, () ->
+        String.format("Null index value for %s in type %s.", Arrays.toString(name), type.getName()));
 
       byte[] entityKey = start(prefix, indexValue);
       if (!isNatural) {

--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClient.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClient.java
@@ -21,6 +21,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -79,8 +80,8 @@ public class TransportClient implements Closeable {
   private volatile boolean timedOut;
 
   public TransportClient(Channel channel, TransportResponseHandler handler) {
-    this.channel = Preconditions.checkNotNull(channel);
-    this.handler = Preconditions.checkNotNull(handler);
+    this.channel = Objects.requireNonNull(channel);
+    this.handler = Objects.requireNonNull(handler);
     this.timedOut = false;
   }
 

--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
@@ -22,13 +22,13 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.codahale.metrics.MetricSet;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import io.netty.bootstrap.Bootstrap;
@@ -100,9 +100,9 @@ public class TransportClientFactory implements Closeable {
   public TransportClientFactory(
       TransportContext context,
       List<TransportClientBootstrap> clientBootstraps) {
-    this.context = Preconditions.checkNotNull(context);
+    this.context = Objects.requireNonNull(context);
     this.conf = context.getConf();
-    this.clientBootstraps = Lists.newArrayList(Preconditions.checkNotNull(clientBootstraps));
+    this.clientBootstraps = Lists.newArrayList(Objects.requireNonNull(clientBootstraps));
     this.connectionPool = new ConcurrentHashMap<>();
     this.numConnectionsPerPeer = conf.numConnectionsPerPeer();
     this.rand = new Random();

--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/AuthEngine.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/AuthEngine.java
@@ -21,6 +21,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.io.Closeable;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Properties;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -61,10 +62,8 @@ class AuthEngine implements Closeable {
   private TransportCipher sessionCipher;
 
   AuthEngine(String appId, String preSharedSecret, TransportConf conf) {
-    Preconditions.checkNotNull(appId);
-    Preconditions.checkNotNull(preSharedSecret);
-    this.appId = appId;
-    this.preSharedSecret = preSharedSecret.getBytes(UTF_8);
+    this.appId = Objects.requireNonNull(appId);
+    this.preSharedSecret = Objects.requireNonNull(preSharedSecret).getBytes(UTF_8);
     this.conf = conf;
     this.cryptoConf = conf.cryptoConf();
     // This is for backward compatibility with version 1.0 of this protocol,

--- a/common/network-common/src/main/java/org/apache/spark/network/sasl/SparkSaslServer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/sasl/SparkSaslServer.java
@@ -29,8 +29,8 @@ import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Objects;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -182,13 +182,13 @@ public class SparkSaslServer implements SaslEncryptionBackend {
 
   /* Encode a byte[] identifier as a Base64-encoded string. */
   public static String encodeIdentifier(String identifier) {
-    Preconditions.checkNotNull(identifier, "User cannot be null if SASL is enabled");
+    Objects.requireNonNull(identifier, "User cannot be null if SASL is enabled");
     return getBase64EncodedString(identifier);
   }
 
   /** Encode a password as a base64-encoded char[] array. */
   public static char[] encodePassword(String password) {
-    Preconditions.checkNotNull(password, "Password cannot be null if SASL is enabled");
+    Objects.requireNonNull(password, "Password cannot be null if SASL is enabled");
     return getBase64EncodedString(password).toCharArray();
   }
 

--- a/common/network-common/src/main/java/org/apache/spark/network/server/BlockPushNonFatalFailure.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/BlockPushNonFatalFailure.java
@@ -18,6 +18,7 @@
 package org.apache.spark.network.server;
 
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 import com.google.common.base.Preconditions;
 
@@ -101,14 +102,12 @@ public class BlockPushNonFatalFailure extends RuntimeException {
 
   public ByteBuffer getResponse() {
     // Ensure we do not invoke this method if response is not set
-    Preconditions.checkNotNull(response);
-    return response;
+    return Objects.requireNonNull(response);
   }
 
   public ReturnCode getReturnCode() {
     // Ensure we do not invoke this method if returnCode is not set
-    Preconditions.checkNotNull(returnCode);
-    return returnCode;
+    return Objects.requireNonNull(returnCode);
   }
 
   public enum ReturnCode {

--- a/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
@@ -19,6 +19,7 @@ package org.apache.spark.network.server;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -71,7 +72,7 @@ public class OneForOneStreamManager extends StreamManager {
         Channel channel,
         boolean isBufferMaterializedOnNext) {
       this.appId = appId;
-      this.buffers = Preconditions.checkNotNull(buffers);
+      this.buffers = Objects.requireNonNull(buffers);
       this.associatedChannel = channel;
       this.isBufferMaterializedOnNext = isBufferMaterializedOnNext;
     }

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
@@ -20,6 +20,7 @@ package org.apache.spark.network.server;
 import java.io.Closeable;
 import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import com.codahale.metrics.Counter;
@@ -76,7 +77,7 @@ public class TransportServer implements Closeable {
       this.pooledAllocator = NettyUtils.createPooledByteBufAllocator(
           conf.preferDirectBufs(), true /* allowCache */, conf.serverThreads());
     }
-    this.bootstraps = Lists.newArrayList(Preconditions.checkNotNull(bootstraps));
+    this.bootstraps = Lists.newArrayList(Objects.requireNonNull(bootstraps));
 
     boolean shouldClose = true;
     try {

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricSet;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;

--- a/common/network-common/src/main/java/org/apache/spark/network/util/LimitedInputStream.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/LimitedInputStream.java
@@ -21,6 +21,7 @@ package org.apache.spark.network.util;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
 
 import com.google.common.base.Preconditions;
 
@@ -50,9 +51,8 @@ public final class LimitedInputStream extends FilterInputStream {
    * @param closeWrappedStream whether to close {@code in} when {@link #close} is called
      */
   public LimitedInputStream(InputStream in, long limit, boolean closeWrappedStream) {
-    super(in);
+    super(Objects.requireNonNull(in));
     this.closeWrappedStream = closeWrappedStream;
-    Preconditions.checkNotNull(in);
     Preconditions.checkArgument(limit >= 0, "limit must be non-negative");
     left = limit;
   }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/AppsWithRecoveryDisabled.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/AppsWithRecoveryDisabled.java
@@ -22,8 +22,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.google.common.base.Preconditions;
-
 /**
  * Stores the applications which have recovery disabled.
  */

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/AppsWithRecoveryDisabled.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/AppsWithRecoveryDisabled.java
@@ -18,6 +18,7 @@
 package org.apache.spark.network.shuffle;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -41,8 +42,7 @@ public final class AppsWithRecoveryDisabled {
    * @param appId application id
    */
   public static void disableRecoveryOfApp(String appId) {
-    Preconditions.checkNotNull(appId);
-    INSTANCE.appsWithRecoveryDisabled.add(appId);
+    INSTANCE.appsWithRecoveryDisabled.add(Objects.requireNonNull(appId));
   }
 
   /**
@@ -51,8 +51,7 @@ public final class AppsWithRecoveryDisabled {
    * @return true if the application is enabled for recovery; false otherwise.
    */
   public static boolean isRecoveryEnabledForApp(String appId) {
-    Preconditions.checkNotNull(appId);
-    return !INSTANCE.appsWithRecoveryDisabled.contains(appId);
+    return !INSTANCE.appsWithRecoveryDisabled.contains(Objects.requireNonNull(appId));
   }
 
   /**
@@ -60,7 +59,6 @@ public final class AppsWithRecoveryDisabled {
    * @param appId application id
    */
   public static void removeApp(String appId) {
-    Preconditions.checkNotNull(appId);
-    INSTANCE.appsWithRecoveryDisabled.remove(appId);
+    INSTANCE.appsWithRecoveryDisabled.remove(Objects.requireNonNull(appId));
   }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
@@ -20,7 +20,11 @@ package org.apache.spark.network.shuffle;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -32,7 +36,6 @@ import com.codahale.metrics.RatioGauge;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.Counter;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 
 import org.apache.spark.internal.SparkLogger;

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
@@ -20,10 +20,7 @@ package org.apache.spark.network.shuffle;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -585,7 +582,7 @@ public class ExternalBlockHandler extends RpcHandler
 
     @Override
     public ManagedBuffer next() {
-      ManagedBuffer block = Preconditions.checkNotNull(mergeManager.getMergedBlockData(
+      ManagedBuffer block = Objects.requireNonNull(mergeManager.getMergedBlockData(
         appId, shuffleId, shuffleMergeId, reduceIds[reduceIdx], chunkIds[reduceIdx][chunkIdx]));
       if (chunkIdx < chunkIds[reduceIdx].length - 1) {
         chunkIdx += 1;

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/MergedBlockMeta.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/MergedBlockMeta.java
@@ -20,8 +20,8 @@ package org.apache.spark.network.shuffle;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
-import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.roaringbitmap.RoaringBitmap;
@@ -43,7 +43,7 @@ public class MergedBlockMeta {
 
   public MergedBlockMeta(int numChunks, ManagedBuffer chunksBitmapBuffer) {
     this.numChunks = numChunks;
-    this.chunksBitmapBuffer = Preconditions.checkNotNull(chunksBitmapBuffer);
+    this.chunksBitmapBuffer = Objects.requireNonNull(chunksBitmapBuffer);
   }
 
   public int getNumChunks() {

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockPushReturnCode.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockPushReturnCode.java
@@ -41,7 +41,7 @@ public class BlockPushReturnCode extends BlockTransferMessage {
   public final String failureBlockId;
 
   public BlockPushReturnCode(byte returnCode, String failureBlockId) {
-    Preconditions.checkNotNull(BlockPushNonFatalFailure.getReturnCode(returnCode));
+    Objects.requireNonNull(BlockPushNonFatalFailure.getReturnCode(returnCode));
     this.returnCode = returnCode;
     this.failureBlockId = failureBlockId;
   }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockPushReturnCode.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockPushReturnCode.java
@@ -19,7 +19,6 @@ package org.apache.spark.network.shuffle.protocol;
 
 import java.util.Objects;
 
-import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
 
 import org.apache.spark.network.protocol.Encoders;

--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -31,7 +31,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -546,7 +545,7 @@ public class YarnShuffleService extends AuxiliaryService {
    * and DB exists in the local dir of NM by old version of shuffle service.
    */
   protected File initRecoveryDb(String dbName) {
-    Preconditions.checkNotNull(_recoveryPath,
+    Objects.requireNonNull(_recoveryPath,
       "recovery path should not be null if NM recovery is enabled");
 
     File recoveryFile = new File(_recoveryPath.toUri().getPath(), dbName);

--- a/core/src/main/java/org/apache/spark/api/java/Optional.java
+++ b/core/src/main/java/org/apache/spark/api/java/Optional.java
@@ -20,8 +20,6 @@ package org.apache.spark.api.java;
 import java.io.Serializable;
 import java.util.Objects;
 
-import com.google.common.base.Preconditions;
-
 /**
  * <p>Like {@code java.util.Optional} in Java 8, {@code scala.Option} in Scala, and
  * {@code com.google.common.base.Optional} in Google Guava, this class represents a
@@ -71,8 +69,7 @@ public final class Optional<T> implements Serializable {
   }
 
   private Optional(T value) {
-    Preconditions.checkNotNull(value);
-    this.value = value;
+    this.value = Objects.requireNonNull(value);
   }
 
   // java.util.Optional API (subset)
@@ -112,8 +109,7 @@ public final class Optional<T> implements Serializable {
    * @throws NullPointerException if this is empty (contains no value)
    */
   public T get() {
-    Preconditions.checkNotNull(value);
-    return value;
+    return Objects.requireNonNull(value);
   }
 
   /**

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -245,6 +245,10 @@
             <property name="format" value="CharStreams\.toString"/>
             <property name="message" value="Use toString of SparkStreamUtils or Utils instead." />
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="Preconditions\.checkNotNull"/>
+            <property name="message" value="Use requireNonNull of java.util.Objects instead." />
+        </module>
         <!-- support structured logging -->
         <module name="RegexpSinglelineJava">
             <property name="format" value="org\.slf4j\.(Logger|LoggerFactory)" />

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -756,4 +756,9 @@ This file is divided into 3 sections:
     <parameters><parameter name="regex">com\.google\.common\.io\.BaseEncoding\b</parameter></parameters>
     <customMessage>Use Java APIs (like java.util.Base64) instead.</customMessage>
   </check>
+
+  <check customId="preconditionschecknotnull" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bPreconditions\.checkNotNull\b</parameter></parameters>
+    <customMessage>Use requireNonNull of java.util.Objects instead.</customMessage>
+  </check>
 </scalastyle>

--- a/sql/api/src/main/java/org/apache/spark/sql/connector/catalog/IdentifierImpl.java
+++ b/sql/api/src/main/java/org/apache/spark/sql/connector/catalog/IdentifierImpl.java
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.connector.catalog;
 
-import org.apache.arrow.util.Preconditions;
-
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.StringJoiner;
@@ -36,10 +34,8 @@ class IdentifierImpl implements Identifier {
   private String name;
 
   IdentifierImpl(String[] namespace, String name) {
-    Preconditions.checkNotNull(namespace, "Identifier namespace cannot be null");
-    Preconditions.checkNotNull(name, "Identifier name cannot be null");
-    this.namespace = namespace;
-    this.name = name;
+    this.namespace = Objects.requireNonNull(namespace, "Identifier namespace cannot be null");
+    this.name = Objects.requireNonNull(name, "Identifier name cannot be null");
   }
 
   @Override

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableInfo.java
@@ -16,13 +16,13 @@
  */
 package org.apache.spark.sql.connector.catalog;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Map;
+import java.util.Objects;
+
 import com.google.common.collect.Maps;
 import org.apache.spark.sql.connector.catalog.constraints.Constraint;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.types.StructType;
-
-import java.util.Map;
 
 public class TableInfo {
 
@@ -87,7 +87,7 @@ public class TableInfo {
     }
 
     public TableInfo build() {
-      checkNotNull(columns, "columns should not be null");
+      Objects.requireNonNull(columns, "columns should not be null");
       return new TableInfo(this);
     }
   }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableSummary.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableSummary.java
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.connector.catalog;
 
-import org.apache.spark.annotation.Evolving;
+import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import org.apache.spark.annotation.Evolving;
 
 @Evolving
 public interface TableSummary {
@@ -38,7 +38,7 @@ public interface TableSummary {
 
 record TableSummaryImpl(Identifier identifier, String tableType) implements TableSummary {
     TableSummaryImpl {
-        checkNotNull(identifier, "Identifier of a table summary object cannot be null");
-        checkNotNull(tableType, "Table type of a table summary object cannot be null");
+      Objects.requireNonNull(identifier, "Identifier of a table summary object cannot be null");
+      Objects.requireNonNull(tableType, "Table type of a table summary object cannot be null");
     }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr uses `java.util.Objects#requireNonNull` and mentions `com.google.common.base.Preconditions#checkNotNull`. These two methods have the same implementation logic, but `Objects#requireNonNull` is a built-in method in the JDK.


### Why are the changes needed?
Give priority to using the built-in APIs of JDK.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No