### PR TITLE
[SPARK-53199][SQL][TESTS] Use Java `Files.copy` instead of `com.google.common.io.Files.copy`

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
@@ -18,8 +18,9 @@
 package org.apache.spark.sql.hive.execution
 
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 
-import com.google.common.io.Files
 import org.apache.hadoop.fs.{FileContext, FsConstants, Path}
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
@@ -147,7 +148,7 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
         fn(testData)
       } else {
         val tmp = File.createTempFile(testData.getName(), ".tmp")
-        Files.copy(testData, tmp)
+        Files.copy(testData.toPath, tmp.toPath, StandardCopyOption.REPLACE_EXISTING)
         try {
           fn(tmp)
         } finally {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java `Files.copy` instead of `com.google.common.io.Files.copy`.

### Why are the changes needed?

Java implementation is **faster**.

```scala
scala> spark.time(java.nio.file.Files.copy(Path.of("/tmp/1G.bin"), Path.of("/tmp/1G.bin.copy"), StandardCopyOption.REPLACE_EXISTING))
Time taken: 270 ms
val res0: java.nio.file.Path = /tmp/1G.bin.copy

scala> spark.time(com.google.common.io.Files.copy(new java.io.File("/tmp/1G.bin"), new java.io.File("/tmp/1G.bin.copy")))
Time taken: 467 ms
```

### Does this PR introduce _any_ user-facing change?

No. This is a test-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.