### PR TITLE
[SPARK-53200][CORE] Use Java `Files.newInputStream` instead of `Files.asByteSource().openStream()`

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/ssl/SSLFactory.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/ssl/SSLFactory.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -40,8 +41,6 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
-
-import com.google.common.io.Files;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.ssl.OpenSsl;
@@ -378,7 +377,7 @@ public class SSLFactory {
 
   private static TrustManager[] defaultTrustManagers(File trustStore, String trustStorePassword)
       throws IOException, KeyStoreException, CertificateException, NoSuchAlgorithmException {
-    try (InputStream input = Files.asByteSource(trustStore).openStream()) {
+    try (InputStream input = Files.newInputStream(trustStore.toPath())) {
       KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
       char[] passwordCharacters = trustStorePassword != null?
         trustStorePassword.toCharArray() : null;

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -218,6 +218,10 @@
             <property name="message" value="Use Java skipNBytes instead." />
         </module>
         <module name="RegexpSinglelineJava">
+            <property name="format" value="Files\.asByteSource"/>
+            <property name="message" value="Use Java Files.newInputStream instead." />
+        </module>
+        <module name="RegexpSinglelineJava">
             <property name="format" value="ByteStreams\.readFully"/>
             <property name="message" value="Use readFully of JavaUtils/SparkStreamUtils/Utils instead." />
         </module>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -287,6 +287,11 @@ This file is divided into 3 sections:
     <customMessage>Use java.nio.file.Files.readAllBytes instead.</customMessage>
   </check>
 
+  <check customId="asByteSource" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFiles\.asByteSource\b</parameter></parameters>
+    <customMessage>Use java.nio.file.Files.newInputStream instead.</customMessage>
+  </check>
+
   <check customId="getTempDirectory" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">\bFileUtils\.getTempDirectory\b</parameter></parameters>
     <customMessage>Use System.getProperty instead.</customMessage>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `Files.newInputStream` instead of `FilesasByteSource().openStream()`.

```java
-    try (InputStream input = Files.asByteSource(trustStore).openStream()) {
+    try (InputStream input = Files.newInputStream(trustStore.toPath())) {
```

### Why are the changes needed?

To use a simple native Java method.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.