### PR TITLE
[SPARK-53198][CORE] Support terminating driver JVM after SparkContext is stopped

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkLivenessPlugin.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkLivenessPlugin.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy
+
+import java.util.{Map => JMap}
+import java.util.concurrent.{ScheduledExecutorService, TimeUnit}
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.SparkContext
+import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.LogKeys._
+import org.apache.spark.internal.config._
+import org.apache.spark.util.{SparkExitCode, ThreadUtils}
+
+/**
+ * A built-in plugin to check liveness of Spark essential components, e.g., SparkContext.
+ */
+class SparkLivenessPlugin extends SparkPlugin {
+  override def driverPlugin(): DriverPlugin = new SparkLivenessDriverPlugin()
+
+  // No-op
+  override def executorPlugin(): ExecutorPlugin = null
+}
+
+class SparkLivenessDriverPlugin extends DriverPlugin with Logging {
+
+  private val timer: ScheduledExecutorService =
+    ThreadUtils.newDaemonSingleThreadScheduledExecutor("driver-liveness")
+
+  override def init(sc: SparkContext, ctx: PluginContext): JMap[String, String] = {
+    val checkInterval = sc.conf.get(DRIVER_SPARK_CONTEXT_LIVENESS_CHECK_INTERVAL)
+    val terminateDelay = sc.conf.get(DRIVER_SPARK_CONTEXT_LIVENESS_TERMINATE_DELAY)
+    if (checkInterval == 0) {
+      logWarning("SparkContext liveness check is disabled.")
+    } else {
+      val task: Runnable = () => {
+        if (sc.isStopped) {
+          logWarning(log"SparkContext is stopped, will terminate Driver JVM " +
+            log"after ${MDC(TIME_UNITS, terminateDelay)} seconds.")
+          Thread.sleep(terminateDelay * 1000L)
+          System.exit(SparkExitCode.SPARK_CONTEXT_STOPPED)
+        }
+      }
+      timer.scheduleWithFixedDelay(task, checkInterval, checkInterval, TimeUnit.SECONDS)
+    }
+    Map.empty[String, String].asJava
+  }
+}

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1209,6 +1209,27 @@ package object config {
     .checkValue(v => v >= 0, "The value should be a non-negative time value.")
     .createWithDefaultString("0min")
 
+  private[spark] val DRIVER_SPARK_CONTEXT_LIVENESS_CHECK_INTERVAL =
+    ConfigBuilder("spark.driver.liveness.sparkContext.checkInterval")
+      .doc("If set a positive time value, spark driver periodically checks whether " +
+        "the SparkContext is live. Once the SparkContext is detected to be stopped, " +
+        "terminate the driver with the exit code 69 after a delay. " +
+        "To use, set `spark.plugins=org.apache.spark.deploy.SparkLivenessPlugin`.")
+      .version("4.1.0")
+      .timeConf(TimeUnit.SECONDS)
+      .checkValue(v => v >= 0, "The value should be a non-negative time value.")
+      .createWithDefaultString("10s")
+
+  private[spark] val DRIVER_SPARK_CONTEXT_LIVENESS_TERMINATE_DELAY =
+    ConfigBuilder("spark.driver.liveness.sparkContext.terminateDelay")
+      .doc("Self-terminate waiting duration after detecting SparkContext is stopped. " +
+        s"This config takes effect only when " +
+        s"${DRIVER_SPARK_CONTEXT_LIVENESS_CHECK_INTERVAL.key} effective.")
+      .version("4.1.0")
+      .timeConf(TimeUnit.SECONDS)
+      .checkValue(v => v >= 0, "The value should be a non-negative time value.")
+      .createWithDefaultString("120s")
+
   private[spark] val DRIVER_BIND_ADDRESS = ConfigBuilder("spark.driver.bindAddress")
     .doc("Address where to bind network listen sockets on the driver.")
     .version("2.1.0")

--- a/core/src/main/scala/org/apache/spark/util/SparkExitCode.scala
+++ b/core/src/main/scala/org/apache/spark/util/SparkExitCode.scala
@@ -45,6 +45,9 @@ private[spark] object SparkExitCode {
       OutOfMemoryError. */
   val OOM = 52
 
+  /** Exit because the SparkContext is stopped. */
+  val SPARK_CONTEXT_STOPPED = 69
+
   /** Exit due to ClassNotFoundException or NoClassDefFoundError. */
   val CLASS_NOT_FOUND = 101
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds `SparkLivenessPlugin` to allow checking the liveness of `SparkContext`, which is an essential component of the Spark application, and terminating the Spark driver JVM once the `SparkContext` is detected to be stopped.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This helps two typical use cases:

In local / K8s cluster mode, unlike YARN, the non-daemon thread blocks the driver JVM exit even if `SparkContext` is stopped. This is a challenge for user to migrate their Spark workloads from YARN to K8s, especially when non-daemon threads are created by third-party libraries. SPARK-48547 (https://github.com/apache/spark/pull/46889) was proposed to address such issue but unfortunately does not get in.

In some cases, `SparkContext` may stop abnormally after driver OOM, but the driver JVM does not exit due to other non-daemon threads live, which causes services like Thrift Server / Connect Server to be unable to process new requests, previously, we suggest the user configure `spark.driver.extraJavaOptions=-XX:OnOutOfMemoryError="kill -9 %p"` to mitigate such issues, or consider using https://github.com/Netflix-Skunkworks/jvmquake

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
It's a new feature, disabled by default.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

An [example project](https://github.com/pan3793/SPARK-53198) was created to help reviewers verify this patch in local mode, I also tested it in K8s cluster mode - without this patch, the driver pod runs forever, and with this patch, the driver pod exited after the configured delay interval.

```
...
2025-08-08 21:45:56 [INFO] [main] org.apache.spark.scheduler.cluster.k8s.KubernetesClusterSchedulerBackend#185 - SchedulerBackend is ready for scheduling beginning after reached minRegisteredResourcesRatio: 0.8
SparkSession created
Waiting 10s
Hello from non-daemon thread
Hello from non-daemon thread
Hello from non-daemon thread
Hello from non-daemon thread
2025-08-08 21:46:06 [INFO] [main] org.apache.spark.SparkContext#185 - SparkContext is stopping with exitCode 0 from stop at Main.scala:24.
2025-08-08 21:46:07 [INFO] [main] org.sparkproject.jetty.server.AbstractConnector#383 - Stopped Spark@1117cc7c{HTTP/1.1, (http/1.1)}{0.0.0.0:4040}
2025-08-08 21:46:07 [INFO] [main] org.apache.spark.ui.SparkUI#185 - Stopped Spark web UI at http://io-github-pan3793-main-96561e9889edf8fc-driver-svc.spark.svc:4040
2025-08-08 21:46:07 [INFO] [main] org.apache.spark.scheduler.cluster.k8s.KubernetesClusterSchedulerBackend#185 - Shutting down all executors
2025-08-08 21:46:07 [INFO] [dispatcher-CoarseGrainedScheduler] org.apache.spark.scheduler.cluster.k8s.KubernetesClusterSchedulerBackend$KubernetesDriverEndpoint#185 - Asking each executor to shut down
2025-08-08 21:46:07 [INFO] [-267463507-pool-23-thread-1] org.apache.spark.scheduler.cluster.k8s.ExecutorPodsWatchSnapshotSource#185 - Kubernetes client has been closed.
2025-08-08 21:46:07 [INFO] [dispatcher-event-loop-0] org.apache.spark.MapOutputTrackerMasterEndpoint#185 - MapOutputTrackerMasterEndpoint stopped!
2025-08-08 21:46:07 [INFO] [main] org.apache.spark.storage.memory.MemoryStore#185 - MemoryStore cleared
2025-08-08 21:46:07 [INFO] [main] org.apache.spark.storage.BlockManager#185 - BlockManager stopped
2025-08-08 21:46:07 [INFO] [main] org.apache.spark.storage.BlockManagerMaster#185 - BlockManagerMaster stopped
2025-08-08 21:46:07 [INFO] [dispatcher-event-loop-1] org.apache.spark.scheduler.OutputCommitCoordinator$OutputCommitCoordinatorEndpoint#185 - OutputCommitCoordinator stopped!
2025-08-08 21:46:07 [INFO] [main] org.apache.spark.SparkContext#185 - Successfully stopped SparkContext
SparkSession stopped
Hello from non-daemon thread
2025-08-08 21:46:09 [WARN] [driver-liveness] org.apache.spark.deploy.SparkLivenessDriverPlugin#245 - SparkContext is stopped, will terminate Driver JVM after 30 seconds.
Hello from non-daemon thread
Hello from non-daemon thread
Hello from non-daemon thread
Hello from non-daemon thread
Hello from non-daemon thread
Hello from non-daemon thread
Hello from non-daemon thread
Hello from non-daemon thread
Hello from non-daemon thread
Hello from non-daemon thread
2025-08-08 21:46:39 [INFO] [shutdown-hook-0] org.apache.spark.util.ShutdownHookManager#185 - Shutdown hook called
2025-08-08 21:46:39 [INFO] [shutdown-hook-0] org.apache.spark.util.ShutdownHookManager#185 - Deleting directory /tmp/spark-ef530907-bfdf-4d1d-b089-3e1e4208779e
2025-08-08 21:46:39 [INFO] [shutdown-hook-0] org.apache.spark.util.ShutdownHookManager#185 - Deleting directory /var/data/spark-771d2b86-f238-4f45-a975-ea9e9e70535a/spark-ef68a0af-ab50-4257-b02f-c37966e265a5
2025-08-08 21:46:39 [INFO] [shutdown-hook-0] org.apache.spark.util.ShutdownHookManager#185 - Deleting directory /tmp/spark-f3efedf8-30d5-47d8-81da-cf8ac15d1a79
2025-08-08 21:46:39 [INFO] [shutdown-hook-0] org.apache.spark.util.ShutdownHookManager#185 - Deleting directory /tmp/spark-8e55c898-4fb8-4ba1-9f38-034d156a3b76
<pod terminated>
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.