### PR TITLE
[SPARK-53201][CORE] Use `SparkFileUtils.contentEquals` instead of `Files.equal`

### DIFF
--- a/common/network-common/src/test/java/org/apache/spark/network/RpcIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/RpcIntegrationSuite.java
@@ -25,7 +25,6 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.Sets;
-import com.google.common.io.Files;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -40,6 +39,7 @@ import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.network.util.MapConfigProvider;
 import org.apache.spark.network.util.TransportConf;
 import org.apache.spark.util.Pair;
+import org.apache.spark.util.SparkFileUtils$;
 
 public class RpcIntegrationSuite {
   static TransportConf conf;
@@ -430,7 +430,8 @@ public class RpcIntegrationSuite {
 
     void verify() throws IOException {
       if (streamId.equals("file")) {
-        assertTrue(Files.equal(testData.testFile, outFile), "File stream did not match.");
+        assertTrue(SparkFileUtils$.MODULE$.contentEquals(testData.testFile, outFile),
+          "File stream did not match.");
       } else {
         byte[] result = ((ByteArrayOutputStream)out).toByteArray();
         ByteBuffer srcBuffer = testData.srcBuffer(streamId);

--- a/common/network-common/src/test/java/org/apache/spark/network/StreamSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/StreamSuite.java
@@ -29,7 +29,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.io.Files;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -45,6 +44,7 @@ import org.apache.spark.network.server.StreamManager;
 import org.apache.spark.network.server.TransportServer;
 import org.apache.spark.network.util.MapConfigProvider;
 import org.apache.spark.network.util.TransportConf;
+import org.apache.spark.util.SparkFileUtils$;
 
 public class StreamSuite {
   private static final String[] STREAMS = StreamTestHelper.STREAMS;
@@ -212,7 +212,8 @@ public class StreamSuite {
         callback.waitForCompletion(timeoutMs);
 
         if (srcBuffer == null) {
-          assertTrue(Files.equal(testData.testFile, outFile), "File stream did not match.");
+          assertTrue(SparkFileUtils$.MODULE$.contentEquals(testData.testFile, outFile),
+            "File stream did not match.");
         } else {
           ByteBuffer base;
           synchronized (srcBuffer) {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -46,7 +46,6 @@ import scala.util.matching.Regex
 import _root_.io.netty.channel.unix.Errors.NativeIoException
 import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 import com.google.common.collect.Interners
-import com.google.common.io.{Files => GFiles}
 import com.google.common.net.InetAddresses
 import jakarta.ws.rs.core.UriBuilder
 import org.apache.commons.codec.binary.Hex
@@ -593,7 +592,7 @@ private[spark] object Utils
         case (f1, f2) => filesEqualRecursive(f1, f2)
       }
     } else if (file1.isFile && file2.isFile) {
-      GFiles.equal(file1, file2)
+      contentEquals(file1, file2)
     } else {
       false
     }

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -206,6 +206,10 @@
             <property name="message" value="Use String concatenation instead." />
         </module>
         <module name="RegexpSinglelineJava">
+            <property name="format" value="Files\.equal\("/>
+            <property name="message" value="Use contentEquals of SparkFileUtils or Utils instead." />
+        </module>
+        <module name="RegexpSinglelineJava">
             <property name="format" value="Files\.asCharSink"/>
             <property name="message" value="Use java.nio.file.Files.writeString instead." />
         </module>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -282,6 +282,11 @@ This file is divided into 3 sections:
       scala.jdk.CollectionConverters._ and use .asScala / .asJava methods</customMessage>
   </check>
 
+  <check customId="filesequal" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFiles\.equal\b</parameter></parameters>
+    <customMessage>Use contentEquals of SparkFileUtils or Utils instead.</customMessage>
+  </check>
+
   <check customId="toByteArray" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">\bFiles\.toByteArray\b</parameter></parameters>
     <customMessage>Use java.nio.file.Files.readAllBytes instead.</customMessage>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `SparkFileUtils.contentEquals` instead of `com.google.common.io.Files.equal`.

### Why are the changes needed?

To simplify the code path.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.