### PR TITLE
[SPARK-53205][CORE][SQL] Support `createParentDirs` in `SparkFileUtils`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkFileUtils.scala
@@ -134,6 +134,16 @@ private[spark] trait SparkFileUtils extends Logging {
     createDirectory(root, namePrefix)
   }
 
+  def createParentDirs(file: File): Unit = {
+    if (file == null) {
+      throw new IllegalArgumentException("Input should not be null.")
+    }
+    val parent = file.getParentFile()
+    if (parent != null) {
+      Files.createDirectories(parent.toPath())
+    }
+  }
+
   /** Delete recursively while keeping the given directory itself. */
   def cleanDirectory(dir: File): Unit = {
     JavaUtils.cleanDirectory(dir)

--- a/core/src/main/scala/org/apache/spark/deploy/RPackageUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/RPackageUtils.scala
@@ -24,8 +24,6 @@ import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import scala.jdk.CollectionConverters._
 
-import com.google.common.io.Files
-
 import org.apache.spark.api.r.RUtils
 import org.apache.spark.internal.{LogEntry, Logging, MessageWithContext}
 import org.apache.spark.internal.LogKeys._
@@ -157,7 +155,7 @@ private[deploy] object RPackageUtils extends Logging {
         } else {
           val inStream = jar.getInputStream(entry)
           val outPath = new File(tempDir, entryPath)
-          Files.createParentDirs(outPath)
+          Utils.createParentDirs(outPath)
           val outStream = new FileOutputStream(outPath)
           if (verbose) {
             print(log"Extracting ${MDC(JAR_ENTRY, entry)} to ${MDC(PATH, outPath)}", printStream)

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -282,6 +282,11 @@ This file is divided into 3 sections:
       scala.jdk.CollectionConverters._ and use .asScala / .asJava methods</customMessage>
   </check>
 
+  <check customId="createParentDirs" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bFiles\.createParentDirs\b</parameter></parameters>
+    <customMessage>Use createParentDirs of SparkFileUtils or Utils instead.</customMessage>
+  </check>
+
   <check customId="filesequal" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">\bFiles\.equal\b</parameter></parameters>
     <customMessage>Use contentEquals of SparkFileUtils or Utils instead.</customMessage>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
@@ -23,7 +23,6 @@ import java.sql.Timestamp
 import java.time.{LocalDateTime, LocalTime, ZoneId, ZoneOffset}
 import java.util.Locale
 
-import com.google.common.io.Files
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.hadoop.ParquetOutputFormat
 
@@ -823,7 +822,7 @@ abstract class ParquetPartitionDiscoverySuite
         .save(dir.getCanonicalPath)
 
       Utils.touch(new File(s"${dir.getCanonicalPath}/b=1", ".DS_Store"))
-      Files.createParentDirs(new File(s"${dir.getCanonicalPath}/b=1/c=1/.foo/bar"))
+      Utils.createParentDirs(new File(s"${dir.getCanonicalPath}/b=1/c=1/.foo/bar"))
 
       checkAnswer(spark.read.format("parquet").load(dir.getCanonicalPath), df)
     }
@@ -840,7 +839,7 @@ abstract class ParquetPartitionDiscoverySuite
         .save(tablePath.getCanonicalPath)
 
       Utils.touch(new File(s"${tablePath.getCanonicalPath}/", "_SUCCESS"))
-      Files.createParentDirs(new File(s"${dir.getCanonicalPath}/b=1/c=1/.foo/bar"))
+      Utils.createParentDirs(new File(s"${dir.getCanonicalPath}/b=1/c=1/.foo/bar"))
 
       checkAnswer(spark.read.format("parquet").load(tablePath.getCanonicalPath), df)
     }
@@ -857,7 +856,7 @@ abstract class ParquetPartitionDiscoverySuite
         .save(tablePath.getCanonicalPath)
 
       Utils.touch(new File(s"${tablePath.getCanonicalPath}/", "_SUCCESS"))
-      Files.createParentDirs(new File(s"${dir.getCanonicalPath}/b=1/c=1/.foo/bar"))
+      Utils.createParentDirs(new File(s"${dir.getCanonicalPath}/b=1/c=1/.foo/bar"))
 
       checkAnswer(spark.read.format("parquet").load(tablePath.getCanonicalPath), df)
     }
@@ -1062,8 +1061,8 @@ abstract class ParquetPartitionDiscoverySuite
       //
       // The summary files and the dot-file under `p0=0` should not fail partition discovery.
 
-      Files.copy(new File(p1, "_metadata"), new File(p0, "_metadata"))
-      Files.copy(new File(p1, "_common_metadata"), new File(p0, "_common_metadata"))
+      Utils.copyFile(new File(p1, "_metadata"), new File(p0, "_metadata"))
+      Utils.copyFile(new File(p1, "_common_metadata"), new File(p0, "_common_metadata"))
       Utils.touch(new File(p0, ".dummy"))
 
       checkAnswer(spark.read.parquet(s"$path"), Seq(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/ParquetHadoopFsRelationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/ParquetHadoopFsRelationSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.sources
 
 import java.io.File
 
-import com.google.common.io.Files
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.hadoop.ParquetOutputFormat
 
@@ -89,7 +88,6 @@ class ParquetHadoopFsRelationSuite extends HadoopFsRelationTest {
       // Creates an arbitrary file.  If this directory gets scanned, ParquetRelation2 will throw
       // since it's not a valid Parquet file.
       val emptyFile = new File(path, "empty")
-      Files.createParentDirs(emptyFile)
       Utils.touch(emptyFile)
 
       // This shouldn't throw anything.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `createParentDirs` in `SparkFileUtils`.

### Why are the changes needed?

To improve Spark's file utility functions.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.