### PR TITLE
[SPARK-53206][CORE] Use `SparkFileUtils.move` instead of `com.google.common.io.Files.move`

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/logging/RollingFileAppender.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/RollingFileAppender.scala
@@ -20,8 +20,6 @@ package org.apache.spark.util.logging
 import java.io._
 import java.util.zip.GZIPOutputStream
 
-import com.google.common.io.Files
-
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.internal.config
@@ -100,7 +98,7 @@ private[spark] class RollingFileAppender(
         Utils.closeQuietly(gzOutputStream)
       }
     } else {
-      Files.move(activeFile, rolloverFile)
+      Utils.moveFile(activeFile, rolloverFile)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/executor/ExecutorClassLoaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/ExecutorClassLoaderSuite.scala
@@ -105,7 +105,7 @@ class ExecutorClassLoaderSuite
     assert(result.exists(), "Compiled file not found: " + result.getAbsolutePath)
 
     val out = new File(scalaDir, filename)
-    Files.move(result, out)
+    Utils.moveFile(result, out)
     assert(out.exists(), "Destination file not moved: " + out.getAbsolutePath)
 
     // construct class loader tree


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `SparkFileUtils.move` instead of `com.google.common.io.Files.move`.

### Why are the changes needed?

For consistency.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.