### PR TITLE
[SPARK-53208][SQL][TESTS] Use `Hex.unhex` instead of `o.a.commons.codec.binary.Hex.decodeHex`

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
@@ -26,6 +26,7 @@ import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{QueryTest, _}
+import org.apache.spark.sql.catalyst.expressions.Hex
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.hive.execution.HiveTempPath
 import org.apache.spark.sql.hive.test.TestHiveSingleton
@@ -823,8 +824,7 @@ class InsertSuite extends QueryTest with TestHiveSingleton with BeforeAndAfter
       withTempDir { dir =>
         val file = new File(dir, "test.hex")
         val hex = "AABBCC"
-        val bs = org.apache.commons.codec.binary.Hex.decodeHex(hex.toCharArray)
-        Files.write(bs, file)
+        Files.write(Hex.unhex(hex), file)
         val path = file.getParent
         sql(s"create table t1 (c string) STORED AS TEXTFILE location '$path'")
         checkAnswer(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `Hex.unhex` instead of `o.a.commons.codec.binary.Hex.decodeHex`

### Why are the changes needed?

According to our benchmark, `Hex.unhex` is faster than `Apache Commons` library. It's the fastest in the latest Java distribution.

https://github.com/apache/spark/blob/babc78d1ffbf150d5be7672bea75752314902a1e/sql/catalyst/benchmarks/HexBenchmark-jdk21-results.txt#L1-L12

### Does this PR introduce _any_ user-facing change?

No, this is a test-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.