### PR TITLE
[SPARK-53211][TESTS] Ban `com.google.common.io.Files`

### DIFF
--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -192,6 +192,7 @@
             <property name="illegalClasses" value="org.apache.hadoop.io.IOUtils" />
             <property name="illegalClasses" value="com.google.common.base.Strings" />
             <property name="illegalClasses" value="com.google.common.io.BaseEncoding" />
+            <property name="illegalClasses" value="com.google.common.io.Files" />
         </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="Charset\.defaultCharset"/>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -782,7 +782,12 @@ This file is divided into 3 sections:
     <customMessage>Use org.apache.spark.util.collection.Utils instead.</customMessage>
   </check>
 
-  <check customId="maputils" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+  <check customId="googleFiles" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">com\.google\.common\.io\.Files\b</parameter></parameters>
+    <customMessage>Use Java API or Spark's JavaUtils/SparkFileUtils/Utils instead.</customMessage>
+  </check>
+
+  <check customId="googleBaseEncoding" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">com\.google\.common\.io\.BaseEncoding\b</parameter></parameters>
     <customMessage>Use Java APIs (like java.util.Base64) instead.</customMessage>
   </check>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ban `com.google.common.io.Files`.

### Why are the changes needed?

Since Apache Spark already migrated to Java's native API or Spark's better implementation, we had better prevent future regressions explicitly.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.