### PR TITLE
[SPARK-53212][PYTHON] improve error handling for scalar Pandas UDFs

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -972,6 +972,11 @@
       "Column names of the returned pandas.DataFrame do not match specified schema.<missing><extra>"
     ]
   },
+  "RESULT_COLUMNS_DUPLICATE_FOR_PANDAS_UDF": {
+    "message": [
+      "The StructType for the Pandas UDF returnType has a duplicate field name: <duplicate>"
+    ]
+  },
   "RESULT_LENGTH_MISMATCH_FOR_PANDAS_UDF": {
     "message": [
       "Number of columns of the returned pandas.DataFrame doesn't match specified schema. Expected: <expected> Actual: <actual>"

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -962,6 +962,11 @@
       "<error_type> on the server but responses were already received from it."
     ]
   },
+  "RESULT_COLUMNS_DUPLICATE_FOR_PANDAS_UDF": {
+    "message": [
+      "The StructType for the Pandas UDF returnType has a duplicate field name: <duplicate>"
+    ]
+  },
   "RESULT_COLUMNS_MISMATCH_FOR_ARROW_UDF": {
     "message": [
       "Column names of the returned pyarrow.Table do not match specified schema.<missing><extra>"
@@ -970,11 +975,6 @@
   "RESULT_COLUMNS_MISMATCH_FOR_PANDAS_UDF": {
     "message": [
       "Column names of the returned pandas.DataFrame do not match specified schema.<missing><extra>"
-    ]
-  },
-  "RESULT_COLUMNS_DUPLICATE_FOR_PANDAS_UDF": {
-    "message": [
-      "The StructType for the Pandas UDF returnType has a duplicate field name: <duplicate>"
     ]
   },
   "RESULT_LENGTH_MISMATCH_FOR_PANDAS_UDF": {

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf.py
@@ -438,7 +438,7 @@ class PandasUDFTestsMixin:
         self.assertRaisesRegex(
             PythonException,
             "Return type of the user-defined function should be pandas.DataFrame, but is Series.",
-            df.select(upper("s")).collect
+            df.select(upper("s")).collect,
         )
 
     def test_pandas_udf_empty_frame(self):

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf.py
@@ -436,7 +436,9 @@ class PandasUDFTestsMixin:
         df = self.spark.createDataFrame([("a",)], schema="s string")
 
         self.assertRaisesRegex(
-            PythonException, "Invalid return type", df.select(upper("s")).collect
+            PythonException,
+            "Return type of the user-defined function should be pandas.DataFrame, but is Series.",
+            df.select(upper("s")).collect
         )
 
     def test_pandas_udf_empty_frame(self):

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -518,7 +518,8 @@ class ScalarPandasUDFTestsMixin:
 
         f = pandas_udf(scalar_func, returnType=return_type, functionType=PandasUDFType.SCALAR)
         # before fix, exception was: KeyError: 'str'
-        with self.assertRaisesRegex(PythonException,
+        with self.assertRaisesRegex(
+            PythonException,
             "Column names of the returned pandas.DataFrame do not match specified schema. "
             "Missing: str.\n",
         ):
@@ -535,7 +536,8 @@ class ScalarPandasUDFTestsMixin:
         # before fix, silently succeeds
         # now raises an exception.  note that because we truncate fields in returned pd.DataFrame the 'str' column
         # will appear to be missing to validation logic
-        with self.assertRaisesRegex(PythonException,
+        with self.assertRaisesRegex(
+            PythonException,
             "Column names of the returned pandas.DataFrame do not match specified schema. "
             "Missing: str. Unexpected: str2.\n",
         ):
@@ -543,15 +545,22 @@ class ScalarPandasUDFTestsMixin:
 
     def test_vectorized_udf_struct_duplicate_field(self):
         df = self.spark.range(10)
-        return_type = StructType([StructField("id", LongType()), StructField("str", StringType()), StructField("str", StringType())])
+        return_type = StructType(
+            [
+                StructField("id", LongType()),
+                StructField("str", StringType()),
+                StructField("str", StringType()),
+            ]
+        )
 
         def scalar_func(id: int) -> pd.DataFrame:
             return pd.DataFrame({"id": id, "str": id.apply(str)})
 
         f = pandas_udf(scalar_func, returnType=return_type, functionType=PandasUDFType.SCALAR)
         # before fix, was: java.lang.IllegalArgumentException: not all nodes, buffers and variadicBufferCounts were consumed.
-        with self.assertRaisesRegex(PythonException,
-            "The StructType for the Pandas UDF returnType has a duplicate field name: str\n"
+        with self.assertRaisesRegex(
+            PythonException,
+            "The StructType for the Pandas UDF returnType has a duplicate field name: str\n",
         ):
             df.select(f(col("id")).alias("struct")).collect()
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -557,7 +557,8 @@ class ScalarPandasUDFTestsMixin:
             return pd.DataFrame({"id": id, "str": id.apply(str)})
 
         f = pandas_udf(scalar_func, returnType=return_type, functionType=PandasUDFType.SCALAR)
-        # before fix, was: java.lang.IllegalArgumentException: not all nodes, buffers and variadicBufferCounts were consumed.
+        # before fix, was: java.lang.IllegalArgumentException:
+        # not all nodes, buffers and variadicBufferCounts were consumed.
         with self.assertRaisesRegex(
             PythonException,
             "The StructType for the Pandas UDF returnType has a duplicate field name: str\n",

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -509,6 +509,52 @@ class ScalarPandasUDFTestsMixin:
             actual = df.select(struct_f(struct(col("id"), col("id").cast("string").alias("str"))))
             self.assertEqual(expected, actual.collect())
 
+    def test_vectorized_udf_struct_missing_field(self):
+        df = self.spark.range(10)
+        return_type = StructType([StructField("id", LongType()), StructField("str", StringType())])
+
+        def scalar_func(id: int) -> pd.DataFrame:
+            return pd.DataFrame({"id": id})
+
+        f = pandas_udf(scalar_func, returnType=return_type, functionType=PandasUDFType.SCALAR)
+        # before fix, exception was: KeyError: 'str'
+        with self.assertRaisesRegex(PythonException,
+            "Column names of the returned pandas.DataFrame do not match specified schema. "
+            "Missing: str.\n",
+        ):
+            df.select(f(col("id")).alias("struct")).collect()
+
+    def test_vectorized_udf_struct_unexpected_field(self):
+        df = self.spark.range(10)
+        return_type = StructType([StructField("id", LongType()), StructField("str", StringType())])
+
+        def scalar_func(id: int) -> pd.DataFrame:
+            return pd.DataFrame({"id": id, "str2": id.apply(str), "str": id.apply(str)})
+
+        f = pandas_udf(scalar_func, returnType=return_type, functionType=PandasUDFType.SCALAR)
+        # before fix, silently succeeds
+        # now raises an exception.  note that because we truncate fields in returned pd.DataFrame the 'str' column
+        # will appear to be missing to validation logic
+        with self.assertRaisesRegex(PythonException,
+            "Column names of the returned pandas.DataFrame do not match specified schema. "
+            "Missing: str. Unexpected: str2.\n",
+        ):
+            df.select(f(col("id")).alias("struct")).collect()
+
+    def test_vectorized_udf_struct_duplicate_field(self):
+        df = self.spark.range(10)
+        return_type = StructType([StructField("id", LongType()), StructField("str", StringType()), StructField("str", StringType())])
+
+        def scalar_func(id: int) -> pd.DataFrame:
+            return pd.DataFrame({"id": id, "str": id.apply(str)})
+
+        f = pandas_udf(scalar_func, returnType=return_type, functionType=PandasUDFType.SCALAR)
+        # before fix, was: java.lang.IllegalArgumentException: not all nodes, buffers and variadicBufferCounts were consumed.
+        with self.assertRaisesRegex(PythonException,
+            "The StructType for the Pandas UDF returnType has a duplicate field name: str\n"
+        ):
+            df.select(f(col("id")).alias("struct")).collect()
+
     def test_vectorized_udf_struct_complex(self):
         df = self.spark.range(10)
         return_type = StructType(

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -533,9 +533,9 @@ class ScalarPandasUDFTestsMixin:
             return pd.DataFrame({"id": id, "str2": id.apply(str), "str": id.apply(str)})
 
         f = pandas_udf(scalar_func, returnType=return_type, functionType=PandasUDFType.SCALAR)
-        # before fix, silently succeeds
-        # now raises an exception.  note that because we truncate fields in returned pd.DataFrame the 'str' column
-        # will appear to be missing to validation logic
+        # before fix, silently succeeds. Now raises an exception.
+        # note that because we truncate fields in returned pd.DataFrame
+        # the 'str' column will appear to be missing to validation logic
         with self.assertRaisesRegex(
             PythonException,
             "Column names of the returned pandas.DataFrame do not match specified schema. "

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -434,12 +434,12 @@ def verify_pandas_result(result, return_type, assign_cols_by_name, truncate_retu
                         "extra": extra,
                     },
                 )
-            elif (
-                assign_cols_by_name
-                and len(field_names) < len(return_type.fields)  # duplicate name in return type
-            ):
+            elif assign_cols_by_name and len(field_names) < len(
+                return_type.fields
+            ):  # duplicate name in return type
                 dup_column = next(
-                    name for name in field_names
+                    name
+                    for name in field_names
                     if sum(1 for field in return_type.fields if field.name == name) > 1
                 )
                 raise PySparkRuntimeError(
@@ -454,7 +454,9 @@ def verify_pandas_result(result, return_type, assign_cols_by_name, truncate_retu
                     errorClass="RESULT_LENGTH_MISMATCH_FOR_PANDAS_UDF",
                     messageParameters={
                         "expected": str(len(return_type)),
-                        "actual": str(len(result_columns)), # if truncated, len(result_columns) <= len(result.columns)
+                        "actual": str(
+                            len(result_columns)
+                        ),  # if truncated, len(result_columns) <= len(result.columns)
                     },
                 )
     else:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Improving the error handling for Scalar Pandas UDFs, by giving more meaningful error messages if there are mismatches between the pd.DataFrame and the StructType expected.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Cryptic error messages that were previously addressed for applyInPandas but not for scalar UDFs

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, to the extent that error messages are different.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
added unit tests that failed before fix, and pass after fix.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Github Copilot via VS.code
Note that use of Copilot was limited to autocomplete -- did not rely on chat or prompts