### PR TITLE
[SPARK-53216][CORE] Move `is*(Blank|Empty)` from `object SparkStringUtils` to `trait SparkStringUtils`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkStringUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkStringUtils.scala
@@ -38,6 +38,14 @@ private[spark] trait SparkStringUtils {
     SPACE_DELIMITED_UPPERCASE_HEX.parseHex(hex.stripPrefix("[").stripSuffix("]"))
   }
 
+  def isEmpty(str: String): Boolean = str == null || str.length() == 0
+
+  def isNotEmpty(str: String): Boolean = !isEmpty(str)
+
+  def isBlank(str: String): Boolean = str == null || str.isBlank
+
+  def isNotBlank(str: String): Boolean = !isBlank(str)
+
   def abbreviate(str: String, abbrevMarker: String, len: Int): String = {
     if (str == null || abbrevMarker == null) {
       null
@@ -135,12 +143,4 @@ private[spark] object SparkStringUtils extends SparkStringUtils with Logging {
   def truncatedString[T](seq: Seq[T], sep: String, maxFields: Int): String = {
     truncatedString(seq, "", sep, "", maxFields)
   }
-
-  def isEmpty(str: String): Boolean = str == null || str.length() == 0
-
-  def isNotEmpty(str: String): Boolean = !isEmpty(str)
-
-  def isBlank(str: String): Boolean = str == null || str.isBlank
-
-  def isNotBlank(str: String): Boolean = !isBlank(str)
 }

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
@@ -29,7 +29,7 @@ import javax.security.sasl.AuthenticationException;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hive.service.ServiceUtils;
 
-import org.apache.spark.util.SparkStringUtils;
+import org.apache.spark.util.Utils;
 
 public class LdapAuthenticationProviderImpl implements PasswdAuthenticationProvider {
 
@@ -63,8 +63,8 @@ public class LdapAuthenticationProviderImpl implements PasswdAuthenticationProvi
 
     // setup the security principal
     List<String> candidatePrincipals = new ArrayList<>();
-    if (SparkStringUtils.isBlank(userDNPattern)) {
-      if (SparkStringUtils.isNotBlank(baseDN)) {
+    if (Utils.isBlank(userDNPattern)) {
+      if (Utils.isNotBlank(baseDN)) {
         String pattern = "uid=" + user + "," + baseDN;
         candidatePrincipals.add(pattern);
       }

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
@@ -75,7 +75,6 @@ import org.apache.spark.internal.LogKeys;
 import org.apache.spark.internal.MDC;
 import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.util.Utils;
-import org.apache.spark.util.SparkStringUtils;
 
 import static org.apache.hadoop.hive.conf.SystemVariables.ENV_PREFIX;
 import static org.apache.hadoop.hive.conf.SystemVariables.HIVECONF_PREFIX;
@@ -610,7 +609,7 @@ public class HiveSessionImpl implements HiveSession {
       String tableName, String columnName)  throws HiveSQLException {
     acquire(true);
     String addedJars = Utilities.getResourceFiles(hiveConf, SessionState.ResourceType.JAR);
-    if (SparkStringUtils.isNotBlank(addedJars)) {
+    if (Utils.isNotBlank(addedJars)) {
        IMetaStoreClient metastoreClient = getSession().getMetaStoreClient();
        metastoreClient.setHiveAddedJars(addedJars);
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to move the following API from `object SparkStringUtils` to `trait SparkStringUtils` in order to improve the reusability. For example, `Utils.isEmpty` is possible because `Utils` includes `trait SparkStringUtils`.

- isBlank
- isNotBlank
- isEmpty
- isNotEmpty

### Why are the changes needed?

To use these APIs more conveniently.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.