### PR TITLE
[SPARK-53218][BUILD] Upgrade `bouncycastle` to 1.81

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -26,7 +26,7 @@ avro/1.12.0//avro-1.12.0.jar
 azure-data-lake-store-sdk/2.3.9//azure-data-lake-store-sdk-2.3.9.jar
 azure-keyvault-core/1.0.0//azure-keyvault-core-1.0.0.jar
 azure-storage/7.0.1//azure-storage-7.0.1.jar
-bcprov-jdk18on/1.80//bcprov-jdk18on-1.80.jar
+bcprov-jdk18on/1.81//bcprov-jdk18on-1.81.jar
 blas/3.0.3//blas-3.0.3.jar
 breeze-macros_2.13/2.1.0//breeze-macros_2.13-2.1.0.jar
 breeze_2.13/2.1.0//breeze_2.13-2.1.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
     <maven-antrun.version>3.1.0</maven-antrun.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.10.0</commons-cli.version>
-    <bouncycastle.version>1.80</bouncycastle.version>
+    <bouncycastle.version>1.81</bouncycastle.version>
     <tink.version>1.16.0</tink.version>
     <datasketches.version>6.2.0</datasketches.version>
     <netty.version>4.1.123.Final</netty.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `bouncycastle` to 1.81.

Note that `bouncycastle` was promoted to the `compile` scope until Apache Hadoop 3.5.0
- #50077
- [HADOOP-19152: Do not hard code security providers](https://issues.apache.org/jira/browse/HADOOP-19152)

### Why are the changes needed?

- Release Note: https://www.bouncycastle.org/download/bouncy-castle-java/?filter=java%3Drelease-1-81

### Does this PR introduce _any_ user-facing change?

No, this is a test dependency change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.