### PR TITLE
[SPARK-53221][BUILD] Upgrade `commons-codec` to 1.19.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -36,7 +36,7 @@ checker-qual/3.43.0//checker-qual-3.43.0.jar
 chill-java/0.10.0//chill-java-0.10.0.jar
 chill_2.13/0.10.0//chill_2.13-0.10.0.jar
 commons-cli/1.10.0//commons-cli-1.10.0.jar
-commons-codec/1.18.0//commons-codec-1.18.0.jar
+commons-codec/1.19.0//commons-codec-1.19.0.jar
 commons-collections/3.2.2//commons-collections-3.2.2.jar
 commons-collections4/4.5.0//commons-collections4-4.5.0.jar
 commons-compiler/3.1.9//commons-compiler-3.1.9.jar

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
     <ws.xmlschema.version>2.3.1</ws.xmlschema.version>
     <snappy.version>1.1.10.8</snappy.version>
     <netlib.ludovic.dev.version>3.0.4</netlib.ludovic.dev.version>
-    <commons-codec.version>1.18.0</commons-codec.version>
+    <commons-codec.version>1.19.0</commons-codec.version>
     <commons-compress.version>1.28.0</commons-compress.version>
     <commons-io.version>2.20.0</commons-io.version>
     <!-- To support Hive UDF jars built by Hive 2.0.0 ~ 2.3.9 and 3.0.0 ~ 3.1.3. -->


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `commons-codec` to 1.19.0 which is the first version tested with Java 24 and 25-ea.

### Why are the changes needed?

To bring the latest improvements and bug fixes.

- https://commons.apache.org/proper/commons-codec/changes.html#a1.19.0 (2025-07-19)
    - [Java 24 and Java 25-ea](https://github.com/apache/commons-codec/commit/8156a07e4ff478d8bdc7c37421ca9dbb245ca076)
    - [Add `HmacUtils.hmac` and `HmacUtils.hmacHex`](https://github.com/apache/commons-codec/commit/e5d7a7942a4049739904e40845fb5e6b083f3509)

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.