### PR TITLE
[SPARK-53222][BUILD] Upgrade `commons-compress` to 1.28.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -40,7 +40,7 @@ commons-codec/1.18.0//commons-codec-1.18.0.jar
 commons-collections/3.2.2//commons-collections-3.2.2.jar
 commons-collections4/4.5.0//commons-collections4-4.5.0.jar
 commons-compiler/3.1.9//commons-compiler-3.1.9.jar
-commons-compress/1.27.1//commons-compress-1.27.1.jar
+commons-compress/1.28.0//commons-compress-1.28.0.jar
 commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-io/2.20.0//commons-io-2.20.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
     <snappy.version>1.1.10.8</snappy.version>
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
     <commons-codec.version>1.18.0</commons-codec.version>
-    <commons-compress.version>1.27.1</commons-compress.version>
+    <commons-compress.version>1.28.0</commons-compress.version>
     <commons-io.version>2.20.0</commons-io.version>
     <!-- To support Hive UDF jars built by Hive 2.0.0 ~ 2.3.9 and 3.0.0 ~ 3.1.3. -->
     <commons-lang2.version>2.6</commons-lang2.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `commons-compress` to 1.28.0 which is tested with **Java 24 and 25-ea** officially.

### Why are the changes needed?

To bring the latest improvements and bug fixes.

- https://commons.apache.org/proper/commons-compress/changes.html#a1.28.0 (2025-07-26)
  - [Java 24 and 25-ea](https://github.com/apache/commons-compress/commit/6be46a41a4f88e7b4a36b42e001c517f0540f694)
  - https://github.com/apache/commons-compress/pull/571
  - https://github.com/apache/commons-compress/pull/624
  - https://github.com/apache/commons-compress/pull/649
  - https://github.com/apache/commons-compress/pull/663
  - https://github.com/apache/commons-compress/pull/655

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.