### PR TITLE
[SPARK-53209][YARN] Add ActiveProcessorCount JVM option to YARN executor and AM

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2933,4 +2933,29 @@ package object config {
       .checkValue(v => v.forall(Set("stdout", "stderr").contains),
         "The value only can be one or more of 'stdout, stderr'.")
       .createWithDefault(Seq("stdout", "stderr"))
+
+  private[spark] val YARN_AM_LIMIT_ACTIVE_PROCESSOR_COUNT_ENABLED =
+    ConfigBuilder("spark.yarn.am.limitActiveProcessorCount.enabled")
+      .doc("Whether to add -XX:ActiveProcessorCount=<spark.yarn.am.cores> to the YARN " +
+        "Application Master JVM options in client mode. In cluster mode, use " +
+        "`spark.driver.limitActiveProcessorCount.enabled` instead.")
+      .version("4.2.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  private[spark] val DRIVER_LIMIT_ACTIVE_PROCESSOR_COUNT_ENABLED =
+    ConfigBuilder("spark.driver.limitActiveProcessorCount.enabled")
+      .doc("Whether to add -XX:ActiveProcessorCount=<spark.driver.cores> to the driver JVM " +
+        "options. Currently, this only takes effect in YARN cluster mode.")
+      .version("4.2.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  private[spark] val EXECUTOR_LIMIT_ACTIVE_PROCESSOR_COUNT_ENABLED =
+    ConfigBuilder("spark.executor.limitActiveProcessorCount.enabled")
+      .doc("Whether to add -XX:ActiveProcessorCount=<spark.executor.cores> to executor JVM " +
+        "options. Currently, this only takes effect in YARN mode.")
+      .version("4.2.0")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1047,6 +1047,16 @@ private[spark] class Client(
 
     val javaOpts = ListBuffer[String]()
 
+    // Set Active Processor Count
+    val limitAPC = if (isClusterMode) {
+      sparkConf.get(DRIVER_LIMIT_ACTIVE_PROCESSOR_COUNT_ENABLED)
+    } else {
+      sparkConf.get(YARN_AM_LIMIT_ACTIVE_PROCESSOR_COUNT_ENABLED)
+    }
+    if (limitAPC) {
+      javaOpts += s"-XX:ActiveProcessorCount=${amCores}"
+    }
+
     javaOpts += s"-Djava.net.preferIPv6Addresses=${Utils.preferIPv6}"
 
     // SPARK-37106: To start AM with Java 17, `JavaModuleOptions.defaultModuleOptions`

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -155,6 +155,11 @@ private[yarn] class ExecutorRunnable(
     // Extra options for the JVM
     val javaOpts = ListBuffer[String]()
 
+    // Set Active Processor Count
+    if (sparkConf.get(EXECUTOR_LIMIT_ACTIVE_PROCESSOR_COUNT_ENABLED)) {
+      javaOpts += s"-XX:ActiveProcessorCount=${executorCores}"
+    }
+
     // Set the JVM memory
     val executorMemoryString = s"${executorMemory}m"
     javaOpts += "-Xmx" + executorMemoryString

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -823,6 +823,112 @@ class ClientSuite extends SparkFunSuite
     }
   }
 
+  test("SPARK-53209: ActiveProcessorCount not set by default") {
+    withSparkHome { sparkHome =>
+      val sparkConf = new SparkConfWithEnv(Map("SPARK_HOME" -> sparkHome))
+        .set("spark.app.name", "test-app")
+        .set(SUBMIT_DEPLOY_MODE, "client")
+        .set(AM_CORES, 3)
+        .set(DRIVER_CORES, 4)  // This should be ignored in client mode
+
+      val client = createClient(sparkConf)
+      val containerLaunchContext = createContainerLaunchContextForTest(client)
+
+      val commands = containerLaunchContext.getCommands.asScala
+      commands should not contain ("-XX:ActiveProcessorCount=")
+    }
+  }
+
+  test("SPARK-53209: ActiveProcessorCount is set to AM cores in client mode") {
+    withSparkHome { sparkHome =>
+      val sparkConf = new SparkConfWithEnv(Map("SPARK_HOME" -> sparkHome))
+        .set("spark.yarn.am.limitActiveProcessorCount.enabled", "true")
+        .set("spark.app.name", "test-app")
+        .set(SUBMIT_DEPLOY_MODE, "client")
+        .set(AM_CORES, 3)
+        .set(DRIVER_CORES, 4)  // This should be ignored in client mode
+
+      val client = createClient(sparkConf)
+      val containerLaunchContext = createContainerLaunchContextForTest(client)
+
+      val commands = containerLaunchContext.getCommands.asScala
+      commands should contain ("-XX:ActiveProcessorCount=3")
+    }
+  }
+
+  test("SPARK-53209: ActiveProcessorCount is set to driver cores in cluster mode") {
+    withSparkHome { sparkHome =>
+      val sparkConf = new SparkConfWithEnv(Map("SPARK_HOME" -> sparkHome))
+        .set("spark.driver.limitActiveProcessorCount.enabled", "true")
+        .set("spark.app.name", "test-app")
+        .set(SUBMIT_DEPLOY_MODE, "cluster")
+        .set(AM_CORES, 3)       // This should be ignored in cluster mode
+        .set(DRIVER_CORES, 4)
+
+      val client = createClient(sparkConf)
+      val containerLaunchContext = createContainerLaunchContextForTest(client)
+
+      val commands = containerLaunchContext.getCommands.asScala
+      commands should contain ("-XX:ActiveProcessorCount=4")
+    }
+  }
+
+  test("SPARK-53209: ActiveProcessorCount defaults to 1 in client mode when AM cores not set") {
+    withSparkHome { sparkHome =>
+      val sparkConf = new SparkConfWithEnv(Map("SPARK_HOME" -> sparkHome))
+        .set("spark.yarn.am.limitActiveProcessorCount.enabled", "true")
+        .set("spark.app.name", "test-app")
+        .set(SUBMIT_DEPLOY_MODE, "client")
+
+      val client = createClient(sparkConf)
+      val containerLaunchContext = createContainerLaunchContextForTest(client)
+
+      val commands = containerLaunchContext.getCommands.asScala
+      commands should contain ("-XX:ActiveProcessorCount=1")
+    }
+  }
+
+  test("SPARK-53209: ActiveProcessorCount defaults to 1 in cluster mode" +
+      " when driver cores not set") {
+    withSparkHome { sparkHome =>
+      val sparkConf = new SparkConfWithEnv(Map("SPARK_HOME" -> sparkHome))
+        .set("spark.driver.limitActiveProcessorCount.enabled", "true")
+        .set("spark.app.name", "test-app")
+        .set(SUBMIT_DEPLOY_MODE, "cluster")
+
+      val client = createClient(sparkConf)
+      val containerLaunchContext = createContainerLaunchContextForTest(client)
+
+      val commands = containerLaunchContext.getCommands.asScala
+      commands should contain ("-XX:ActiveProcessorCount=1")
+    }
+  }
+
+  private def withSparkHome(f: String => Unit): Unit = {
+    withTempDir { dir =>
+      // Create jars dir and RELEASE file to avoid IllegalStateException.
+      val jarsDir = new File(dir, "jars")
+      assert(jarsDir.mkdir())
+      new FileOutputStream(new File(dir, "RELEASE")).close()
+      f(dir.getAbsolutePath)
+    }
+  }
+
+  private def createStagingDir(): String = {
+    val stagingDir = Utils.createTempDir()
+    stagingDir.getAbsolutePath
+  }
+
+  private def createContainerLaunchContextForTest(client: Client): ContainerLaunchContext = {
+    val stagingDirPathField = classOf[Client]
+      .getDeclaredField("org$apache$spark$deploy$yarn$Client$$stagingDirPath")
+    stagingDirPathField.setAccessible(true)
+    stagingDirPathField.set(client, new Path(createStagingDir()))
+    val _createContainerLaunchContext =
+      PrivateMethod[ContainerLaunchContext](Symbol("createContainerLaunchContext"))
+    client invokePrivate _createContainerLaunchContext()
+  }
+
   private val matching = Seq(
     ("files URI match test1", "file:///file1", "file:///file2"),
     ("files URI match test2", "file:///c:file1", "file://c:file2"),

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ExecutorRunnableSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ExecutorRunnableSuite.scala
@@ -25,16 +25,22 @@ import org.apache.hadoop.yarn.api.records.{ContainerLaunchContext, LocalResource
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.util.Records
 import org.mockito.Mockito.{mock, when}
+import org.scalatest.PrivateMethodTester
+import org.scalatest.matchers.must.Matchers.{contain, not}
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkFunSuite}
 import org.apache.spark.internal.config._
 import org.apache.spark.network.util.JavaUtils
 
-class ExecutorRunnableSuite extends SparkFunSuite {
+class ExecutorRunnableSuite extends SparkFunSuite with PrivateMethodTester {
+
+  private val _prepareCommand = PrivateMethod[List[String]](Symbol("prepareCommand"))
 
   private def createExecutorRunnable(
       sparkConf: SparkConf = new SparkConf(),
       securityManager: SecurityManager = mock(classOf[SecurityManager])): ExecutorRunnable = {
+    val executorCores = sparkConf.get(EXECUTOR_CORES)
     new ExecutorRunnable(
       None,
       new YarnConfiguration(),
@@ -43,7 +49,7 @@ class ExecutorRunnableSuite extends SparkFunSuite {
       "exec-1",
       "localhost",
       1,
-      1,
+      executorCores,
       "application_123_1",
       securityManager,
       Map.empty[String, LocalResource],
@@ -102,5 +108,34 @@ class ExecutorRunnableSuite extends SparkFunSuite {
     assert(!metaInfo.containsKey(ExecutorRunnable.SECRET_KEY))
     val metadataStorageVal: Any = metaInfo.get(SHUFFLE_SERVER_RECOVERY_DISABLED.key)
     assert(metadataStorageVal != null && metadataStorageVal.asInstanceOf[Boolean])
+  }
+
+  test("SPARK-53209: ActiveProcessorCount not set by default") {
+    val sparkConf = new SparkConf()
+    val execRunnable = createExecutorRunnable(sparkConf)
+
+    val commands = execRunnable invokePrivate _prepareCommand()
+    commands should not contain ("-XX:ActiveProcessorCount=")
+  }
+
+  test("SPARK-53209: ActiveProcessorCount should default to 1 when executor cores not configured") {
+    val sparkConf = new SparkConf()
+      .set("spark.executor.limitActiveProcessorCount.enabled", "true")
+    val execRunnable = createExecutorRunnable(sparkConf)
+
+    val commands = execRunnable invokePrivate _prepareCommand()
+    commands should contain ("-XX:ActiveProcessorCount=1")
+    commands should contain inOrderElementsOf List("--cores", "1")
+  }
+
+  test("SPARK-53209: ActiveProcessorCount should respect custom executor core count") {
+    val sparkConf = new SparkConf()
+      .set("spark.executor.limitActiveProcessorCount.enabled", "true")
+      .set(EXECUTOR_CORES, 7)
+    val execRunnable = createExecutorRunnable(sparkConf)
+
+    val commands = execRunnable invokePrivate _prepareCommand()
+    commands should contain ("-XX:ActiveProcessorCount=7")
+    commands should contain inOrderElementsOf List("--cores", "7")
   }
 }

--- a/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
+++ b/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
@@ -43,6 +43,7 @@ spark.driver.extraClassPath
 spark.driver.extraJavaOptions
 spark.driver.extraLibraryPath
 spark.driver.host
+spark.driver.limitActiveProcessorCount.enabled
 spark.driver.log.allowErasureCoding
 spark.driver.log.dfsDir
 spark.driver.log.layout
@@ -119,6 +120,7 @@ spark.executor.id
 spark.executor.instances
 spark.executor.isolatedSessionCache.size
 spark.executor.killOnFatalError.depth
+spark.executor.limitActiveProcessorCount.enabled
 spark.executor.logs.redirectConsoleOutputs
 spark.executor.logs.rolling.enableCompression
 spark.executor.logs.rolling.maxRetainedFiles
@@ -1218,6 +1220,7 @@ spark.unsafe.sorter.spill.read.ahead.enabled
 spark.unsafe.sorter.spill.reader.buffer.size
 spark.user.groups.mapping
 spark.worker.executorStateSync.maxAttempts
+spark.yarn.am.limitActiveProcessorCount.enabled
 spark.yarn.dist.forceDownloadSchemes
 spark.yarn.dist.pyFiles
 spark.yarn.isPython


### PR DESCRIPTION
### What changes were proposed in this pull request?

When starting Spark driver and executors on YARN, the JVM process can discover all CPU cores on the node and set thread-pool or GC thread counts based on that value. We should limit what the JVM sees for the number of cores set by the user via `-XX:ActiveProcessorCount`, which was introduced in Java 8u191.

Adds three boolean config flags (default false):
- `spark.yarn.am.limitActiveProcessorCount.enabled`: sets `-XX:ActiveProcessorCount=<spark.yarn.am.cores>` in the YARN AM JVM (client mode).
- `spark.driver.limitActiveProcessorCount.enabled`: sets `-XX:ActiveProcessorCount=<spark.driver.cores>` in the YARN AM JVM (cluster mode).
- `spark.executor.limitActiveProcessorCount.enabled`: sets `-XX:ActiveProcessorCount=<spark.executor.cores>` in executor JVMs on YARN.

### Why are the changes needed?

Without this change, the JVM discovers all CPU cores on the YARN node rather than the cores allocated to the container. Users have assigned driver and executors a number of cores and we should honor that. A simple test would be:
`Runtime.getRuntime().availableProcessors()`

### Does this PR introduce any user-facing change?

Yes — three new public configuration keys.

### How was this patch tested?

New unit tests in `ClientSuite` and `ExecutorRunnableSuite`.

Co-authored-by: Shanyu Zhao <shzhao@microsoft.com>