### PR TITLE
[SPARK-53224][BUILD] Upgrade `joda-time` to 2.14.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -143,7 +143,7 @@ jjwt-impl/0.12.6//jjwt-impl-0.12.6.jar
 jjwt-jackson/0.12.6//jjwt-jackson-0.12.6.jar
 jline/2.14.6//jline-2.14.6.jar
 jline/3.27.1/jdk8/jline-3.27.1-jdk8.jar
-joda-time/2.13.0//joda-time-2.13.0.jar
+joda-time/2.14.0//joda-time-2.14.0.jar
 jpam/1.1//jpam-1.1.jar
 json/1.8//json-1.8.jar
 json4s-ast_2.13/4.0.7//json4s-ast_2.13-4.0.7.jar

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
     <gson.version>2.11.0</gson.version>
     <janino.version>3.1.9</janino.version>
     <jersey.version>3.0.18</jersey.version>
-    <joda.version>2.13.0</joda.version>
+    <joda.version>2.14.0</joda.version>
     <jsr305.version>3.0.0</jsr305.version>
     <jaxb.version>2.2.11</jaxb.version>
     <libthrift.version>0.16.0</libthrift.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `joda-time` to 2.14.0.

### Why are the changes needed?

To use the updated `DataTimeZone` data.

- https://www.joda.org/joda-time/changes-report.html#a2.14.0
  - DateTimeZone data updated to version 2025bgtz.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.