### PR TITLE
[SPARK-53225][BUILD] Upgrade `datasketches-java` to 7.0.1 and `datasketches-memory` to 4.1.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -56,8 +56,8 @@ curator-recipes/5.9.0//curator-recipes-5.9.0.jar
 datanucleus-api-jdo/4.2.4//datanucleus-api-jdo-4.2.4.jar
 datanucleus-core/4.1.17//datanucleus-core-4.1.17.jar
 datanucleus-rdbms/4.1.19//datanucleus-rdbms-4.1.19.jar
-datasketches-java/6.2.0//datasketches-java-6.2.0.jar
-datasketches-memory/3.0.2//datasketches-memory-3.0.2.jar
+datasketches-java/7.0.1//datasketches-java-7.0.1.jar
+datasketches-memory/4.1.0//datasketches-memory-4.1.0.jar
 derby/10.16.1.1//derby-10.16.1.1.jar
 derbyshared/10.16.1.1//derbyshared-10.16.1.1.jar
 derbytools/10.16.1.1//derbytools-10.16.1.1.jar

--- a/launcher/src/main/java/org/apache/spark/launcher/JavaModuleOptions.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/JavaModuleOptions.java
@@ -27,6 +27,7 @@ package org.apache.spark.launcher;
 public class JavaModuleOptions {
     private static final String[] DEFAULT_MODULE_OPTIONS = {
       "-XX:+IgnoreUnrecognizedVMOptions",
+      "--add-modules=jdk.incubator.foreign",
       "--add-modules=jdk.incubator.vector",
       "--add-opens=java.base/java.lang=ALL-UNNAMED",
       "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,8 @@
     <commons-cli.version>1.10.0</commons-cli.version>
     <bouncycastle.version>1.81</bouncycastle.version>
     <tink.version>1.16.0</tink.version>
-    <datasketches.version>6.2.0</datasketches.version>
+    <!-- DataSketches 8.0.0 requires Java 21 -->
+    <datasketches.version>7.0.1</datasketches.version>
     <netty.version>4.1.123.Final</netty.version>
     <netty-tcnative.version>2.0.72.Final</netty-tcnative.version>
     <icu4j.version>77.1</icu4j.version>
@@ -317,6 +318,7 @@
     <!-- SPARK-36796 for JDK-17 test-->
     <extraJavaTestArgs>
       -XX:+IgnoreUnrecognizedVMOptions
+      --add-modules=jdk.incubator.foreign
       --add-modules=jdk.incubator.vector
       --add-opens=java.base/java.lang=ALL-UNNAMED
       --add-opens=java.base/java.lang.invoke=ALL-UNNAMED

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -327,7 +327,7 @@ object SparkBuild extends PomBuild {
 
     javaOptions ++= {
       // for `dev.ludovic.netlib.blas` which implements such hardware-accelerated BLAS operations
-      Seq("--add-modules=jdk.incubator.vector")
+      Seq("--add-modules=jdk.incubator.foreign", "--add-modules=jdk.incubator.vector")
     },
 
     (Compile / doc / javacOptions) ++= {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade
- `datasketches-java` from 6.2.0 to 7.0.1
- `datasketches-memory` from 3.0.2 to 4.1.0.

### Why are the changes needed?

To bring the latest improvements and bug fixes.
- `datasketches-java` 7.x requires JDK 17.
  - https://github.com/apache/datasketches-java/releases/tag/7.0.1
  - https://github.com/apache/datasketches-java/releases/tag/7.0.0
- `datasketches-memory` 4.x requires JDK 17.
  - https://github.com/apache/datasketches-memory/releases/tag/4.1.0
  - https://github.com/apache/datasketches-memory/releases/tag/4.0.0

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.