### PR TITLE
[SPARK-53227][SQL][TESTS] Use Java `HashMap.equals` instead of `Maps.difference.areEqual`

### DIFF
--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaColumnExpressionSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaColumnExpressionSuite.java
@@ -19,8 +19,6 @@ package test.org.apache.spark.sql;
 
 import java.util.*;
 
-import com.google.common.collect.Maps;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,6 +88,6 @@ public class JavaColumnExpressionSuite {
     messageParameters.put("functionName", "`in`");
     messageParameters.put("dataType", "[\"INT\", \"ARRAY<INT>\"]");
     messageParameters.put("sqlExpr", "\"(a IN (b))\"");
-    Assertions.assertTrue(Maps.difference(e.getMessageParameters(), messageParameters).areEqual());
+    Assertions.assertTrue(e.getMessageParameters().equals(messageParameters));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `HashMap.equals` instead of `com.google.common.collect.Maps.difference(...).areEqual` pattern.

### Why are the changes needed?

In general, Java native implementation is much faster. We had better discourage this API from Spark codebase by using Java native implementation.

```scala
scala> val m1 = new java.util.HashMap[Int,Int]()

scala> val m2 = new java.util.HashMap[Int,Int]()

scala> (1 to 10_000_000).foreach { i => m1.put(i, i) }

scala> (1 to 10_000_000).foreach { i => m2.put(i, i) }

scala> spark.time(m1.equals(m2))
Time taken: 87 ms
val res2: Boolean = true

scala> spark.time(com.google.common.collect.Maps.difference(m1, m2).areEqual())
Time taken: 545 ms
val res3: Boolean = true
```

### Does this PR introduce _any_ user-facing change?

No. This is a test code change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.