### PR TITLE
[SPARK-53229][CORE][SQL][EXAMPLES][TESTS] Use Java `Map.of` instead of `ImmutableMap.of`

### DIFF
--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
@@ -21,7 +21,6 @@ import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.crypto.tink.subtle.Hex;
 import org.apache.spark.network.util.*;
 
@@ -49,7 +48,7 @@ abstract class AuthEngineSuite {
   static TransportConf getConf(int authEngineVerison, boolean useCtr) {
     String authEngineVersion = (authEngineVerison == 1) ? "1" : "2";
     String mode = useCtr ? "AES/CTR/NoPadding" : "AES/GCM/NoPadding";
-    Map<String, String> confMap = ImmutableMap.of(
+    Map<String, String> confMap = Map.of(
             "spark.network.crypto.enabled", "true",
             "spark.network.crypto.authEngineVersion", authEngineVersion,
             "spark.network.crypto.cipher", mode

--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthIntegrationSuite.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
 import io.netty.channel.Channel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -214,7 +213,7 @@ public class AuthIntegrationSuite {
     }
 
     AuthTestCtx(RpcHandler rpcHandler, String mode) throws Exception {
-      Map<String, String> testConf = ImmutableMap.of(
+      Map<String, String> testConf = Map.of(
               "spark.network.crypto.enabled", "true",
               "spark.network.crypto.cipher", mode);
       this.conf = new TransportConf("rpc", new MapConfigProvider(testConf));

--- a/common/network-common/src/test/java/org/apache/spark/network/sasl/SparkSaslSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/sasl/SparkSaslSuite.java
@@ -244,7 +244,7 @@ public class SparkSaslSuite {
 
   @Test
   public void testFileRegionEncryption() throws Exception {
-    Map<String, String> testConf = ImmutableMap.of(
+    Map<String, String> testConf = Map.of(
       "spark.network.sasl.maxEncryptedBlockSize", "1k");
 
     AtomicReference<ManagedBuffer> response = new AtomicReference<>();
@@ -298,7 +298,7 @@ public class SparkSaslSuite {
   public void testServerAlwaysEncrypt() {
     Exception re = assertThrows(Exception.class,
       () -> new SaslTestCtx(mock(RpcHandler.class), false, false,
-              ImmutableMap.of("spark.network.sasl.serverAlwaysEncrypt", "true")));
+              Map.of("spark.network.sasl.serverAlwaysEncrypt", "true")));
     assertTrue(re.getCause() instanceof SaslException);
   }
 

--- a/common/network-common/src/test/java/org/apache/spark/network/util/CryptoUtilsSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/util/CryptoUtilsSuite.java
@@ -20,7 +20,6 @@ package org.apache.spark.network.util;
 import java.util.Map;
 import java.util.Properties;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -38,7 +37,7 @@ public class CryptoUtilsSuite {
     String confVal2 = "val2";
     String cryptoKey2 = CryptoUtils.COMMONS_CRYPTO_CONFIG_PREFIX + "A.b.c";
 
-    Map<String, String> conf = ImmutableMap.of(
+    Map<String, String> conf = Map.of(
       confKey1, confVal1,
       confKey2, confVal2);
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/CleanupNonShuffleServiceServedFilesSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/CleanupNonShuffleServiceServedFilesSuite.java
@@ -28,7 +28,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
 
@@ -54,7 +53,7 @@ public class CleanupNonShuffleServiceServedFilesSuite {
   private TransportConf getConf(boolean isFetchRddEnabled) {
     return new TransportConf(
       "shuffle",
-      new MapConfigProvider(ImmutableMap.of(
+      new MapConfigProvider(Map.of(
         Constants.SHUFFLE_SERVICE_FETCH_RDD_ENABLED,
         Boolean.toString(isFetchRddEnabled))));
   }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleSecuritySuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleSecuritySuite.java
@@ -19,8 +19,8 @@ package org.apache.spark.network.shuffle;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,7 +46,7 @@ public class ExternalShuffleSecuritySuite {
   protected TransportConf createTransportConf(boolean encrypt) {
     if (encrypt) {
       return new TransportConf("shuffle", new MapConfigProvider(
-        ImmutableMap.of("spark.authenticate.enableSaslEncryption", "true")));
+        Map.of("spark.authenticate.enableSaslEncryption", "true")));
     } else {
       return new TransportConf("shuffle", MapConfigProvider.EMPTY);
     }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
@@ -39,7 +39,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -97,7 +96,7 @@ public class RemoteBlockPushResolverSuite {
   public void before() throws IOException {
     localDirs = createLocalDirs(2);
     MapConfigProvider provider = new MapConfigProvider(
-      ImmutableMap.of("spark.shuffle.push.server.minChunkSizeInMergedShuffleFile", "4"));
+      Map.of("spark.shuffle.push.server.minChunkSizeInMergedShuffleFile", "4"));
     conf = new TransportConf("shuffle", provider);
     pushResolver = new RemoteBlockPushResolver(conf, null);
     registerExecutor(TEST_APP, prepareLocalDirs(localDirs, MERGE_DIRECTORY), MERGE_DIRECTORY_META);

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RetryingBlockTransferorSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RetryingBlockTransferorSuite.java
@@ -353,15 +353,15 @@ public class RetryingBlockTransferorSuite {
             new TimeoutException());
     IOException ioException = new IOException();
     List<? extends Map<String, Object>> interactions = Arrays.asList(
-            ImmutableMap.of("b0", saslExceptionInitial),
-            ImmutableMap.of("b0", ioException),
-            ImmutableMap.of("b0", saslExceptionInitial),
-            ImmutableMap.of("b0", ioException),
-            ImmutableMap.of("b0", saslExceptionFinal),
+            Map.of("b0", saslExceptionInitial),
+            Map.of("b0", ioException),
+            Map.of("b0", saslExceptionInitial),
+            Map.of("b0", ioException),
+            Map.of("b0", saslExceptionFinal),
             // will not get invoked because the connection fails
-            ImmutableMap.of("b0", ioException),
+            Map.of("b0", ioException),
             // will not get invoked
-            ImmutableMap.of("b0", block0)
+            Map.of("b0", block0)
     );
     configMap.put("spark.shuffle.sasl.enableRetries", "true");
     performInteractions(interactions, listener);

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SslExternalShuffleSecuritySuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SslExternalShuffleSecuritySuite.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.network.shuffle;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 
 import org.apache.spark.network.ssl.SslSampleConfigs;
 import org.apache.spark.network.util.TransportConf;
@@ -30,9 +30,7 @@ public class SslExternalShuffleSecuritySuite extends ExternalShuffleSecuritySuit
       return new TransportConf(
         "shuffle",
         SslSampleConfigs.createDefaultConfigProviderForRpcNamespaceWithAdditionalEntries(
-          ImmutableMap.of(
-          "spark.authenticate.enableSaslEncryption",
-          "true")
+          Map.of("spark.authenticate.enableSaslEncryption", "true")
         )
       );
     } else {

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SslShuffleTransportContextSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SslShuffleTransportContextSuite.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.network.shuffle;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 
 import org.apache.spark.network.ssl.SslSampleConfigs;
 import org.apache.spark.network.util.TransportConf;
@@ -29,7 +29,7 @@ public class SslShuffleTransportContextSuite extends ShuffleTransportContextSuit
     return new TransportConf(
       "shuffle",
       SslSampleConfigs.createDefaultConfigProviderForRpcNamespaceWithAdditionalEntries(
-        ImmutableMap.of(
+        Map.of(
           "spark.shuffle.server.finalizeShuffleMergeThreadsPercent",
           separateFinalizeThread ? "1" : "0")
       )

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -24,7 +24,6 @@ import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.spark.unsafe.Platform;
 import org.apache.spark.unsafe.UTF8StringBuilder;
 
@@ -495,7 +494,7 @@ public class UTF8StringSuite {
   public void translate() {
     assertEquals(
       fromString("1a2s3ae"),
-      fromString("translate").translate(ImmutableMap.of(
+      fromString("translate").translate(Map.of(
         "r", "1",
         "n", "2",
         "l", "3",
@@ -506,7 +505,7 @@ public class UTF8StringSuite {
       fromString("translate").translate(new HashMap<>()));
     assertEquals(
       fromString("asae"),
-      fromString("translate").translate(ImmutableMap.of(
+      fromString("translate").translate(Map.of(
         "r", "\0",
         "n", "\0",
         "l", "\0",
@@ -514,7 +513,7 @@ public class UTF8StringSuite {
       )));
     assertEquals(
       fromString("aa世b"),
-      fromString("花花世界").translate(ImmutableMap.of(
+      fromString("花花世界").translate(Map.of(
         "花", "a",
         "界", "b"
       )));

--- a/core/src/test/java/test/org/apache/spark/JavaAPISuite.java
+++ b/core/src/test/java/test/org/apache/spark/JavaAPISuite.java
@@ -45,7 +45,6 @@ import scala.Tuple3;
 import scala.Tuple4;
 import scala.jdk.javaapi.CollectionConverters;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
@@ -1263,7 +1262,7 @@ public class JavaAPISuite implements Serializable {
     JavaPairRDD<Integer, Integer> combinedRDD = originalRDD.keyBy(keyFunction)
       .combineByKey(createCombinerFunction, mergeValueFunction, mergeValueFunction);
     Map<Integer, Integer> results = combinedRDD.collectAsMap();
-    ImmutableMap<Integer, Integer> expected = ImmutableMap.of(0, 9, 1, 5, 2, 7);
+    Map<Integer, Integer> expected = Map.of(0, 9, 1, 5, 2, 7);
     assertEquals(expected, results);
 
     Partitioner defaultPartitioner = Partitioner.defaultPartitioner(

--- a/core/src/test/scala/org/apache/spark/shuffle/ShuffleDriverComponentsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/ShuffleDriverComponentsSuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.shuffle
 import java.util.{Map => JMap}
 import java.util.concurrent.atomic.AtomicBoolean
 
-import com.google.common.collect.ImmutableMap
 import org.scalatest.Assertions._
 
 import org.apache.spark.{LocalSparkContext, SparkConf, SparkContext, SparkFunSuite}
@@ -61,7 +60,7 @@ class TestShuffleDataIO(sparkConf: SparkConf) extends ShuffleDataIO {
 
 class TestShuffleDriverComponents extends ShuffleDriverComponents {
   override def initializeApplication(): JMap[String, String] = {
-    ImmutableMap.of("test-plugin-key", "plugin-set-value")
+    JMap.of("test-plugin-key", "plugin-set-value")
   }
 
   override def cleanupApplication(): Unit = {}

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -258,6 +258,10 @@
             <property name="format" value="Preconditions\.checkNotNull"/>
             <property name="message" value="Use requireNonNull of java.util.Objects instead." />
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="ImmutableMap\.of"/>
+            <property name="message" value="Use Map.of instead." />
+        </module>
         <!-- support structured logging -->
         <module name="RegexpSinglelineJava">
             <property name="format" value="org\.slf4j\.(Logger|LoggerFactory)" />

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaStratifiedSamplingExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaStratifiedSamplingExample.java
@@ -17,7 +17,6 @@
 
 package org.apache.spark.examples.mllib;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 
@@ -48,7 +47,7 @@ public class JavaStratifiedSamplingExample {
     JavaPairRDD<Integer, Character> data = jsc.parallelizePairs(list);
 
     // specify the exact fraction desired from each key Map<K, Double>
-    ImmutableMap<Integer, Double> fractions = ImmutableMap.of(1, 0.1, 2, 0.6, 3, 0.3);
+    Map<Integer, Double> fractions = Map.of(1, 0.1, 2, 0.6, 3, 0.3);
 
     // Get an approximate sample from each stratum
     JavaPairRDD<Integer, Character> approxSample = data.sampleByKey(false, fractions);

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -27,7 +27,6 @@ import java.math.BigDecimal;
 import scala.collection.Seq;
 import scala.jdk.javaapi.CollectionConverters;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
 import org.junit.jupiter.api.*;
 
@@ -133,7 +132,7 @@ public class JavaDataFrameSuite {
   public static class Bean implements Serializable {
     private double a = 0.0;
     private Integer[] b = { 0, 1 };
-    private Map<String, int[]> c = ImmutableMap.of("hello", new int[] { 1, 2 });
+    private Map<String, int[]> c = Map.of("hello", new int[] { 1, 2 });
     private List<String> d = Arrays.asList("floppy", "disk");
     private BigInteger e = new BigInteger("1234567");
     private NestedBean f = new NestedBean();
@@ -312,7 +311,7 @@ public class JavaDataFrameSuite {
   @Test
   public void testSampleBy() {
     Dataset<Row> df = spark.range(0, 100, 1, 2).select(col("id").mod(3).as("key"));
-    Dataset<Row> sampled = df.stat().sampleBy("key", ImmutableMap.of(0, 0.1, 1, 0.2), 0L);
+    Dataset<Row> sampled = df.stat().sampleBy("key", Map.of(0, 0.1, 1, 0.2), 0L);
     List<Row> actual = sampled.groupBy("key").count().orderBy("key").collectAsList();
     Assertions.assertEquals(0, actual.get(0).getLong(0));
     Assertions.assertTrue(0 <= actual.get(0).getLong(1) && actual.get(0).getLong(1) <= 8);
@@ -338,7 +337,7 @@ public class JavaDataFrameSuite {
   @Test
   public void testSampleByColumn() {
     Dataset<Row> df = spark.range(0, 100, 1, 2).select(col("id").mod(3).as("key"));
-    Dataset<Row> sampled = df.stat().sampleBy(col("key"), ImmutableMap.of(0, 0.1, 1, 0.2), 0L);
+    Dataset<Row> sampled = df.stat().sampleBy(col("key"), Map.of(0, 0.1, 1, 0.2), 0L);
     List<Row> actual = sampled.groupBy("key").count().orderBy("key").collectAsList();
     Assertions.assertEquals(0, actual.get(0).getLong(0));
     Assertions.assertTrue(0 <= actual.get(0).getLong(1) && actual.get(0).getLong(1) <= 8);

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileScanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileScanSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql
 
+import java.util.{Map => JMap}
+
 import scala.collection.mutable
 
 import com.google.common.collect.ImmutableMap
@@ -81,10 +83,10 @@ trait FileScanSuiteBase extends SharedSparkSession {
       Array[Filter](sources.And(sources.IsNull("data"), sources.LessThan("data", 0)))
     val pushedFiltersNotEqual =
       Array[Filter](sources.And(sources.IsNull("data"), sources.LessThan("data", 1)))
-    val optionsMap = ImmutableMap.of("key", "value")
+    val optionsMap = JMap.of("key", "value")
     val options = new CaseInsensitiveStringMap(ImmutableMap.copyOf(optionsMap))
     val optionsNotEqual =
-      new CaseInsensitiveStringMap(ImmutableMap.copyOf(ImmutableMap.of("key2", "value2")))
+      new CaseInsensitiveStringMap(ImmutableMap.copyOf(JMap.of("key2", "value2")))
     val partitionFilters = Seq(And(IsNull($"data".int), LessThan($"data".int, 0)))
     val partitionFiltersNotEqual = Seq(And(IsNull($"data".int),
       LessThan($"data".int, 1)))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java 9+ `Map.of` API instead of `ImmutableMap.of` API. Mostly, test files are changed and one MLLib example, `JavaStratifiedSamplingExample.java`, is updated.

### Why are the changes needed?

Java's native API is **shorter and faster**.

```scala
scala> spark.version
val res0: String = 4.1.0-preview1

scala> spark.time((1 until 100_000_000).foreach(_ => java.util.Map.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)))
Time taken: 2171 ms

scala> spark.time((1 until 100_000_000).foreach(_ => com.google.common.collect.ImmutableMap.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)))
Time taken: 3246 ms
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.