### PR TITLE
[SPARK-53230][SQL] Assign a name to error class _LEGACY_ERROR_TEMP_1011

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -573,6 +573,12 @@
     },
     "sqlState" : "58030"
   },
+  "CANNOT_WRITE_VIEW" : {
+    "message" : [
+      "Writing into a view is not allowed. View: <identifier>."
+    ],
+    "sqlState" : "0A000"
+  },
   "CAST_INVALID_INPUT" : {
     "message" : [
       "The value <expression> of the type <sourceType> cannot be cast to <targetType> because it is malformed. Correct the value as per the syntax, or change its target type. Use `try_cast` to tolerate malformed input and return NULL instead."
@@ -7127,11 +7133,6 @@
   "_LEGACY_ERROR_TEMP_1008" : {
     "message" : [
       "<quoted> is not a temp view of streaming logical plan, please use batch API such as `DataFrameReader.table` to read it."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1011" : {
-    "message" : [
-      "Writing into a view is not allowed. View: <identifier>."
     ]
   },
   "_LEGACY_ERROR_TEMP_1012" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1176,7 +1176,8 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         // Thus, we need to look at the raw plan if `relation` is a temporary view.
         unwrapRelationPlan(relation) match {
           case v: View =>
-            throw QueryCompilationErrors.insertIntoViewNotAllowedError(v.desc.identifier, table)
+            throw QueryCompilationErrors.expectTableNotViewError(
+              v.desc.identifier.nameParts, cmd = "INSERT", suggestAlternative = false, table)
           case other => i.copy(table = other)
         }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -567,18 +567,9 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       origin = t.origin)
   }
 
-  def insertIntoViewNotAllowedError(identifier: TableIdentifier, t: TreeNode[_]): Throwable = {
-    new AnalysisException(
-      errorClass = "EXPECT_TABLE_NOT_VIEW.NO_ALTERNATIVE",
-      messageParameters = Map(
-        "viewName" -> toSQLId(identifier.nameParts),
-        "operation" -> "INSERT"),
-      origin = t.origin)
-  }
-
   def writeIntoViewNotAllowedError(identifier: TableIdentifier, t: TreeNode[_]): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1011",
+      errorClass = "CANNOT_WRITE_VIEW",
       messageParameters = Map("identifier" -> identifier.toString),
       origin = t.origin)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -570,7 +570,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   def writeIntoViewNotAllowedError(identifier: TableIdentifier, t: TreeNode[_]): Throwable = {
     new AnalysisException(
       errorClass = "CANNOT_WRITE_VIEW",
-      messageParameters = Map("identifier" -> identifier.toString),
+      messageParameters = Map("identifier" -> toSQLId(identifier.nameParts)),
       origin = t.origin)
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

- Rename error class `_LEGACY_ERROR_TEMP_1011` into `CANNOT_WRITE_VIEW`.
- Take the chance to remove `insertIntoViewNotAllowedError`, which can be replaced with `expectTableNotViewError` to create the exact same error.

### Why are the changes needed?
This is part of the ongoing migration from legacy error to the error class framework

### Does this PR introduce _any_ user-facing change?
Yes. The `_LEGACY_ERROR_TEMP_1011` error message will now include `CANNOT_WRITE_VIEW` with the appropriate sql state.

### How was this patch tested?
Existing unit tests

### Was this patch authored or co-authored using generative AI tooling?
No