### PR TITLE
[SPARK-53207][SDP] Send Pipeline Event to Client Asynchronously

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -6207,6 +6207,16 @@ object SQLConf {
       .createWithDefault(2)
   }
 
+  val PIPELINES_EVENT_QUEUE_CAPACITY = {
+    buildConf("spark.sql.pipelines.event.queue.capacity")
+      .doc("Capacity of the event queue used in pipelined execution. When the queue is full, " +
+        "non-terminal FlowProgressEvents will be dropped.")
+      .version("4.1.0")
+      .intConf
+      .checkValue(v => v > 0, "Event queue capacity must be positive.")
+      .createWithDefault(1000)
+  }
+
   val HADOOP_LINE_RECORD_READER_ENABLED =
     buildConf("spark.sql.execution.datasources.hadoopLineRecordReader.enabled")
       .internal()

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSender.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSender.scala
@@ -33,8 +33,8 @@ import org.apache.spark.sql.pipelines.logging.PipelineEvent
 import org.apache.spark.util.ThreadUtils
 
 /**
- * Handles sending pipeline events to the client in a background thread.
- * This prevents pipeline execution from blocking on streaming events.
+ * Handles sending pipeline events to the client in a background thread. This prevents pipeline
+ * execution from blocking on streaming events.
  */
 class PipelineEventSender(
     responseObserver: StreamObserver[ExecutePlanResponse],
@@ -51,15 +51,14 @@ class PipelineEventSender(
     Executors.newSingleThreadExecutor(threadFactory)
   }
 
-
   /*
-    * Atomic flags to track the state of the sender
-    * - `isShutdown`: Indicates if the sender has been shut down, if true, no new events
-    *    can be accepted, and the loop will exit after processing all already queued events.
-    *
-    * - `isStarted`: Indicates if the sender has been started, if true, the background
-    *    executor is running and processing events. This prevents multiple starts
-    *    which could lead to resource leaks.
+   * Atomic flags to track the state of the sender
+   * - `isShutdown`: Indicates if the sender has been shut down, if true, no new events
+   *    can be accepted, and the loop will exit after processing all already queued events.
+   *
+   * - `isStarted`: Indicates if the sender has been started, if true, the background
+   *    executor is running and processing events. This prevents multiple starts
+   *    which could lead to resource leaks.
    */
   private val isShutdown = new AtomicBoolean(false)
   private val isStarted = new AtomicBoolean(false)
@@ -70,8 +69,8 @@ class PipelineEventSender(
   private case object ShutdownMessage extends PipelineEventMessage
 
   /**
-   * Start the background executor for sending events, only if not already started.
-   * Idempotent operation: calling this multiple times has no effect after the first call.
+   * Start the background executor for sending events, only if not already started. Idempotent
+   * operation: calling this multiple times has no effect after the first call.
    */
   def start(): Unit = {
     if (isStarted.compareAndSet(false, true)) {
@@ -103,11 +102,11 @@ class PipelineEventSender(
   }
 
   /**
-   * Shutdown the event sender, stop taking new events and wait for processing to complete.
-   * Sends a ShutdownMessage serves as a signal to the processing loop to exit gracefully
-   * after processing all currently queued events.
-   * This method blocks until all queued events have been processed.
-   * Idempotent operation: calling this multiple times has no effect after the first call.
+   * Shutdown the event sender, stop taking new events and wait for processing to complete. Sends
+   * a ShutdownMessage serves as a signal to the processing loop to exit gracefully after
+   * processing all currently queued events. This method blocks until all queued events have been
+   * processed. Idempotent operation: calling this multiple times has no effect after the first
+   * call.
    */
   def shutdown(): Unit = {
     if (isShutdown.compareAndSet(false, true)) {
@@ -118,8 +117,9 @@ class PipelineEventSender(
       // Blocks until all tasks have completed execution after a shutdown request,
       // disregard the timeout since we want all events to be processed
       if (!executor.awaitTermination(Long.MaxValue, java.util.concurrent.TimeUnit.MILLISECONDS)) {
-        logError(s"Pipeline event sender for session ${sessionHolder.sessionId}" +
-          s"failed to terminate")
+        logError(
+          s"Pipeline event sender for session ${sessionHolder.sessionId}" +
+            s"failed to terminate")
         executor.shutdownNow()
       }
     }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSender.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSender.scala
@@ -33,11 +33,8 @@ import org.apache.spark.sql.pipelines.logging.PipelineEvent
 import org.apache.spark.util.ThreadUtils
 
 /**
- * Handles sending pipeline events to the client in a background thread using ExecutorService.
- * This prevents pipeline execution from blocking on response observer operations and provides
- * better error isolation between pipeline execution and client communication.
- *
- * Based on the executor pattern used in DataPlaneEventLog for better thread management.
+ * Handles sending pipeline events to the client in a background thread.
+ * This prevents pipeline execution from blocking on streaming events.
  */
 class PipelineEventSender(
     responseObserver: StreamObserver[ExecutePlanResponse],

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSender.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSender.scala
@@ -45,8 +45,8 @@ class PipelineEventSender(
 
   private final val queueCapacity: Int =
     sessionHolder.session.conf
-      .get("spark.sql.connect.pipeline.event.queue.capacity", "1000").toInt
-
+      .get("spark.sql.connect.pipeline.event.queue.capacity", "1000")
+      .toInt
 
   // ExecutorService for background event processing
   private val executor: ThreadPoolExecutor =

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSender.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSender.scala
@@ -43,18 +43,15 @@ class PipelineEventSender(
     extends Logging
     with AutoCloseable {
 
-  private def queueCapacity: Int = {
-    val conf = sessionHolder.session.conf
-    conf.get(
-      "spark.sql.connect.pipeline.event.queue.capacity",
-      "1000"
-    ).toInt
-  }
+  private final val queueCapacity: Int =
+    sessionHolder.session.conf
+      .get("spark.sql.connect.pipeline.event.queue.capacity", "1000").toInt
+
 
   // ExecutorService for background event processing
-  private val executor: ThreadPoolExecutor = ThreadUtils.newDaemonSingleThreadExecutor(
-    threadName = s"PipelineEventSender-${sessionHolder.sessionId}"
-  )
+  private val executor: ThreadPoolExecutor =
+    ThreadUtils.newDaemonSingleThreadExecutor(threadName =
+      s"PipelineEventSender-${sessionHolder.sessionId}")
 
   /*
    * Atomic flags to track the state of the sender
@@ -67,8 +64,8 @@ class PipelineEventSender(
    * Send an event async by submitting it to the executor, if the sender is not shut down.
    * Otherwise, throws an IllegalStateException, to raise awareness of the shutdown state.
    *
-   * For RunProgress events, we ensure they are always queued even if the queue is full.
-   * For other events, we may drop them if the queue is at capacity to prevent blocking.
+   * For RunProgress events, we ensure they are always queued even if the queue is full. For other
+   * events, we may drop them if the queue is at capacity to prevent blocking.
    */
   def sendEvent(event: PipelineEvent): Unit = synchronized {
     if (!isShutdown.get()) {

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSender.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSender.scala
@@ -34,14 +34,15 @@ import org.apache.spark.util.ThreadUtils
 
 /**
  * Handles sending pipeline events to the client in a background thread using ExecutorService.
- * This prevents pipeline execution from blocking on response observer operations
- * and provides better error isolation between pipeline execution and client communication.
+ * This prevents pipeline execution from blocking on response observer operations and provides
+ * better error isolation between pipeline execution and client communication.
  *
  * Based on the executor pattern used in DataPlaneEventLog for better thread management.
  */
 class PipelineEventSender(
     responseObserver: StreamObserver[ExecutePlanResponse],
-    sessionHolder: SessionHolder) extends Logging {
+    sessionHolder: SessionHolder)
+    extends Logging {
 
   // Thread-safe queue for buffering events
   private val eventQueue: BlockingQueue[PipelineEventMessage] = new LinkedBlockingQueue()
@@ -115,19 +116,21 @@ class PipelineEventSender(
           case EventMessage(event) =>
             sendEventToClient(event)
           case ShutdownMessage =>
-            logInfo(s"Reached shutdown signal for session ${sessionHolder.sessionId}," +
-              s"all events processed.")
+            logInfo(
+              s"Reached shutdown signal for session ${sessionHolder.sessionId}," +
+                s"all events processed.")
             return
         }
       } catch {
         case _: InterruptedException =>
-          logInfo(s"Pipeline event sender thread interrupted " +
-            s"for session ${sessionHolder.sessionId}")
+          logInfo(
+            s"Pipeline event sender thread interrupted " +
+              s"for session ${sessionHolder.sessionId}")
           Thread.currentThread().interrupt()
           return
         case NonFatal(e) =>
           logError("Error processing pipeline event", e)
-          // Continue processing other events
+        // Continue processing other events
       }
     }
     logInfo(s"Event processing completed for session ${sessionHolder.sessionId}")

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSender.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSender.scala
@@ -27,7 +27,7 @@ import io.grpc.stub.StreamObserver
 
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.ExecutePlanResponse
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.sql.connect.service.SessionHolder
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.pipelines.common.FlowStatus
@@ -77,7 +77,10 @@ class PipelineEventSender(
               sendEventToClient(event)
             } catch {
               case NonFatal(e) =>
-                logError(s"Failed to send pipeline event to client: ${event.message}", e)
+                logError(
+                  log"Failed to send pipeline event to client: " +
+                    log"${MDC(LogKeys.ERROR, event.message)}",
+                  e)
             }
           }
         })
@@ -120,11 +123,13 @@ class PipelineEventSender(
       // disregard the timeout since we want all events to be processed
       if (!executor.awaitTermination(Long.MaxValue, java.util.concurrent.TimeUnit.MILLISECONDS)) {
         logError(
-          s"Pipeline event sender for session ${sessionHolder.sessionId}" +
-            s"failed to terminate")
+          log"Pipeline event sender for session " +
+            log"${MDC(LogKeys.SESSION_ID, sessionHolder.sessionId)} failed to terminate")
         executor.shutdownNow()
       }
-      logInfo(s"Pipeline event sender shutdown completed for session ${sessionHolder.sessionId}")
+      logInfo(
+        log"Pipeline event sender shutdown completed for session " +
+          log"${MDC(LogKeys.SESSION_ID, sessionHolder.sessionId)}")
     }
   }
 
@@ -171,7 +176,10 @@ class PipelineEventSender(
           .build())
     } catch {
       case NonFatal(e) =>
-        logError(s"Failed to send pipeline event to client: ${event.message}", e)
+        logError(
+          log"Failed to send pipeline event to client: " +
+            log"${MDC(LogKeys.ERROR, event.message)}",
+          e)
     }
   }
 }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSender.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSender.scala
@@ -29,6 +29,7 @@ import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.ExecutePlanResponse
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connect.service.SessionHolder
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.pipelines.common.FlowStatus
 import org.apache.spark.sql.pipelines.logging.{FlowProgress, PipelineEvent, RunProgress}
 import org.apache.spark.util.ThreadUtils
@@ -45,7 +46,7 @@ class PipelineEventSender(
 
   private final val queueCapacity: Int =
     sessionHolder.session.conf
-      .get("spark.sql.connect.pipeline.event.queue.capacity", "1000")
+      .get(SQLConf.PIPELINES_EVENT_QUEUE_CAPACITY.key)
       .toInt
 
   // ExecutorService for background event processing

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSenderSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSenderSuite.scala
@@ -27,6 +27,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.apache.spark.connect.proto.ExecutePlanResponse
 import org.apache.spark.sql.classic.{RuntimeConfig, SparkSession}
 import org.apache.spark.sql.connect.service.SessionHolder
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.pipelines.common.FlowStatus
 import org.apache.spark.sql.pipelines.common.RunState.{COMPLETED, RUNNING}
 import org.apache.spark.sql.pipelines.logging.{EventDetails, EventLevel, FlowProgress, PipelineEvent, PipelineEventOrigin, RunProgress}
@@ -43,7 +44,7 @@ class PipelineEventSenderSuite extends SparkDeclarativePipelinesServerTest with 
     val mockConf = mock[RuntimeConfig]
     when(mockSessionHolder.session).thenReturn(mockSession)
     when(mockSession.conf).thenReturn(mockConf)
-    when(mockConf.get("spark.sql.connect.pipeline.event.queue.capacity", "1000"))
+    when(mockConf.get(SQLConf.PIPELINES_EVENT_QUEUE_CAPACITY.key))
       .thenReturn(queueSize)
     (mockObserver, mockSessionHolder)
   }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSenderSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSenderSuite.scala
@@ -33,8 +33,8 @@ import org.apache.spark.sql.pipelines.logging.{EventDetails, EventLevel, FlowPro
 
 class PipelineEventSenderSuite extends SparkDeclarativePipelinesServerTest with MockitoSugar {
 
-  private def createMockSetup(queueSize: String = "1000"):
-  (StreamObserver[ExecutePlanResponse], SessionHolder) = {
+  private def createMockSetup(
+      queueSize: String = "1000"): (StreamObserver[ExecutePlanResponse], SessionHolder) = {
     val mockObserver = mock[StreamObserver[ExecutePlanResponse]]
     val mockSessionHolder = mock[SessionHolder]
     when(mockSessionHolder.sessionId).thenReturn("test-session-id")
@@ -146,42 +146,51 @@ class PipelineEventSenderSuite extends SparkDeclarativePipelinesServerTest with 
     }
     try {
       // Send FlowProgress.RUNNING event - should be sent
-      val startedEvent = createTestEvent(id = "startedEvent", message = "Flow a started", details =
-        FlowProgress(FlowStatus.STARTING))
+      val startedEvent = createTestEvent(
+        id = "startedEvent",
+        message = "Flow a started",
+        details = FlowProgress(FlowStatus.STARTING))
       eventSender.sendEvent(startedEvent)
 
       // Send FlowProgress.RUNNING event - should be queued
-      val firstRunningEvent = createTestEvent(id = "firstRunningEvent", message = "Flow a running",
+      val firstRunningEvent = createTestEvent(
+        id = "firstRunningEvent",
+        message = "Flow a running",
         details = FlowProgress(FlowStatus.RUNNING))
       eventSender.sendEvent(firstRunningEvent)
 
       // Send FlowProgress.RUNNING event - should be discarded due to full queue
-      val secondRunningEvent = createTestEvent(id = "secondRunningEvent",
+      val secondRunningEvent = createTestEvent(
+        id = "secondRunningEvent",
         message = "Flow a running",
         details = FlowProgress(FlowStatus.RUNNING))
       eventSender.sendEvent(secondRunningEvent)
 
       // Send RunProgress.RUNNING event - should be queued and processed
       val runProgressRunningEvent = createTestEvent(
-        id = "runProgressRunning", message = "Update completed",
+        id = "runProgressRunning",
+        message = "Update completed",
         details = RunProgress(RUNNING))
       eventSender.sendEvent(runProgressRunningEvent)
 
       // Send FlowProgress.RUNNING event - should be discarded due to full queue
-      val thirdRunningEvent = createTestEvent(id = "thirdRunningEvent", message = "Flow a running",
-        details =
-          FlowProgress(FlowStatus.RUNNING))
+      val thirdRunningEvent = createTestEvent(
+        id = "thirdRunningEvent",
+        message = "Flow a running",
+        details = FlowProgress(FlowStatus.RUNNING))
       eventSender.sendEvent(thirdRunningEvent)
 
       // Send FlowProgress.COMPLETED event - should be queued and processed
       val completedEvent = createTestEvent(
-        id = "completed", message = "Flow has completed",
+        id = "completed",
+        message = "Flow has completed",
         details = FlowProgress(FlowStatus.COMPLETED))
       eventSender.sendEvent(completedEvent)
 
       // Send RunProgress.COMPLETED event - should be queued and processed
       val runProgressCompletedEvent = createTestEvent(
-        id = "runProgressCompletedEvent", message = "Update completed",
+        id = "runProgressCompletedEvent",
+        message = "Update completed",
         details = RunProgress(COMPLETED))
       eventSender.sendEvent(runProgressCompletedEvent)
 
@@ -197,19 +206,23 @@ class PipelineEventSenderSuite extends SparkDeclarativePipelinesServerTest with 
       assert(responses.get(0).getPipelineEventResult.getEvent.getMessage == startedEvent.message)
 
       // First FlowProgress.RUNNING should be queued and processed
-      assert(responses.get(1).getPipelineEventResult.getEvent.getMessage
-        == firstRunningEvent.message)
+      assert(
+        responses.get(1).getPipelineEventResult.getEvent.getMessage
+          == firstRunningEvent.message)
 
       // RunProgress.RUNNING should be queued and processed
-      assert(responses.get(2).getPipelineEventResult.getEvent.getMessage
-        == runProgressRunningEvent.message)
+      assert(
+        responses.get(2).getPipelineEventResult.getEvent.getMessage
+          == runProgressRunningEvent.message)
 
       // FlowProgress.COMPLETED event should also be processed because it is terminal
-      assert(responses.get(3).getPipelineEventResult.getEvent.getMessage == completedEvent.message)
+      assert(
+        responses.get(3).getPipelineEventResult.getEvent.getMessage == completedEvent.message)
 
       // RunProgress.COMPLETED event should also be processed
-      assert(responses.get(4).getPipelineEventResult.getEvent.getMessage
-        == runProgressCompletedEvent.message)
+      assert(
+        responses.get(4).getPipelineEventResult.getEvent.getMessage
+          == runProgressCompletedEvent.message)
     } finally {
       eventSender.shutdown()
     }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSenderSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSenderSuite.scala
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.pipelines
+
+import java.sql.Timestamp
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+import scala.collection.mutable.ArrayBuffer
+
+import io.grpc.stub.StreamObserver
+import org.mockito.{ArgumentCaptor, Mockito}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito._
+import org.scalatestplus.mockito.MockitoSugar
+
+import org.apache.spark.connect.proto
+import org.apache.spark.connect.proto.{ExecutePlanResponse, PipelineEvent => ProtoPipelineEvent}
+import org.apache.spark.sql.connect.service.SessionHolder
+import org.apache.spark.sql.pipelines.common.FlowStatus
+import org.apache.spark.sql.pipelines.logging.{EventDetails, EventLevel, FlowProgress, PipelineEvent, PipelineEventOrigin}
+
+class PipelineEventSenderSuite extends SparkDeclarativePipelinesServerTest with MockitoSugar {
+
+  private def createMockSetup(): (StreamObserver[ExecutePlanResponse], SessionHolder) = {
+    val mockObserver = mock[StreamObserver[ExecutePlanResponse]]
+    val mockSessionHolder = mock[SessionHolder]
+    when(mockSessionHolder.sessionId).thenReturn("test-session-id")
+    when(mockSessionHolder.serverSessionId).thenReturn("test-server-session-id")
+    (mockObserver, mockSessionHolder)
+  }
+
+  private def createTestEvent(
+      id: String = "test-event-id",
+      message: String = "Test message",
+      level: EventLevel = EventLevel.INFO,
+      details: EventDetails = FlowProgress(FlowStatus.RUNNING)): PipelineEvent = {
+    PipelineEvent(
+      id = id,
+      timestamp = new Timestamp(System.currentTimeMillis()),
+      origin = PipelineEventOrigin(
+        flowName = Some("test-flow"),
+        datasetName = None,
+        sourceCodeLocation = None
+      ),
+      level = level,
+      message = message,
+      details = details,
+      error = None
+    )
+  }
+
+  test("PipelineEventSender sends events") {
+    val (mockObserver, mockSessionHolder) = createMockSetup()
+
+    val eventSender = new PipelineEventSender(mockObserver, mockSessionHolder)
+    eventSender.start()
+
+    try {
+      val testEvent = createTestEvent()
+      eventSender.sendEvent(testEvent)
+
+      // Give some time for the background thread to process
+      Thread.sleep(100)
+
+      // Verify that onNext was called on the observer
+      val responseCaptor = ArgumentCaptor.forClass(classOf[ExecutePlanResponse])
+       verify(mockObserver, Mockito.timeout(1000)).onNext(responseCaptor.capture())
+
+      val response = responseCaptor.getValue
+      assert(response.getSessionId == "test-session-id")
+      assert(response.getServerSideSessionId == "test-server-session-id")
+      assert(response.hasPipelineEventResult)
+
+      val pipelineEvent = response.getPipelineEventResult.getEvent
+      assert(pipelineEvent.getMessage == "Test message")
+    } finally {
+      eventSender.shutdown()
+    }
+  }
+
+  test("PipelineEventSender graceful shutdown waits for previously queued events to process") {
+    val (mockObserver, mockSessionHolder) = createMockSetup()
+
+    val eventSender = new PipelineEventSender(mockObserver, mockSessionHolder)
+    eventSender.start()
+
+    val events = Seq(1, 2).map { i =>
+      createTestEvent(
+        id = s"event-$i",
+        message = s"Event $i before shutdown",
+        level = EventLevel.INFO,
+        details = FlowProgress(FlowStatus.RUNNING)
+      )
+    }
+
+    events.foreach(
+      event => eventSender.sendEvent(event)
+    )
+
+    eventSender.shutdown()
+
+    // this event should not be processed because shutdown has been called
+    eventSender.sendEvent(createTestEvent(
+      id = s"event-after-shutdown",
+      message = s"Event after shutdown",
+      level = EventLevel.INFO,
+      details = FlowProgress(FlowStatus.RUNNING)
+    ))
+    // Allow some time for the processing to complete
+    Thread.sleep(50)
+    // Event should have been processed before shutdown completed
+    val responseCaptor = ArgumentCaptor.forClass(classOf[ExecutePlanResponse])
+    verify(mockObserver, times(2)).onNext(responseCaptor.capture())
+
+    val responses = responseCaptor.getAllValues
+    assert(responses.size == 2)
+    // Only the first two events should be processed
+    assert(responses.get(0).getPipelineEventResult.getEvent.getMessage == "Event 1 before shutdown")
+    assert(responses.get(1).getPipelineEventResult.getEvent.getMessage == "Event 2 before shutdown")
+  }
+
+
+  test("pipeline execution is not blocked by slow event delivery") {
+    // Create a custom PipelineEventSender that tracks shutdown timing
+    class InstrumentedPipelineEventSender(
+       responseObserver: StreamObserver[proto.ExecutePlanResponse],
+       sessionHolder: SessionHolder) extends PipelineEventSender(responseObserver, sessionHolder) {
+
+      @volatile var shutdownCalledTime: Option[Long] = None
+      @volatile var shutdownReturnedTime: Option[Long] = None
+
+      override def shutdown(): Unit = {
+        shutdownCalledTime = Some(System.currentTimeMillis())
+        super.shutdown()
+        shutdownReturnedTime = Some(System.currentTimeMillis())
+      }
+    }
+
+
+    val mockSessionHolder = mock[SessionHolder]
+    when(mockSessionHolder.sessionId).thenReturn("test-session-id")
+    when(mockSessionHolder.serverSessionId).thenReturn("test-server-session-id")
+
+    val capturedEvents = new ArrayBuffer[ProtoPipelineEvent]()
+    val eventCountDownLatch = new CountDownLatch(5)
+
+    // Simulate a slow client by delaying onNext calls
+    val slowObserver = mock[StreamObserver[proto.ExecutePlanResponse]]
+    doAnswer(invocation => {
+      Thread.sleep(500) // Simulate 500ms delay per event due to slow connection
+      val response = invocation.getArgument[proto.ExecutePlanResponse](0)
+      if (response.hasPipelineEventResult) {
+        capturedEvents.addOne(response.getPipelineEventResult.getEvent)
+        eventCountDownLatch.countDown()
+      }
+      null
+    }).when(slowObserver).onNext(any[proto.ExecutePlanResponse]())
+
+    val instrumentedSender = new InstrumentedPipelineEventSender(slowObserver, mockSessionHolder)
+    instrumentedSender.start()
+
+
+    // Simulate pipeline executed quickly and generated many events
+    val pipelineStartTime = System.currentTimeMillis()
+
+    (1 to 5).foreach { i =>
+      val event = createTestEvent(
+        id = s"event-$i",
+        message = s"Event $i generated during pipeline execution",
+        level = EventLevel.INFO,
+        details = FlowProgress(FlowStatus.RUNNING)
+      )
+      instrumentedSender.sendEvent(event)
+      Thread.sleep(10) // Some pipeline execution time
+    }
+
+    // Simulates that now the pipeline core logic is done and calls shutdown
+    instrumentedSender.shutdown()
+
+    // Events still need to be procesed before the sender shuts down
+    assert(eventCountDownLatch.await(10, TimeUnit.SECONDS),
+      "Not all events delivered within timeout")
+
+    // Key measurements
+    val shutdownCalledTime = instrumentedSender.shutdownCalledTime.get
+    val coreLogicTime = shutdownCalledTime - pipelineStartTime
+
+    // Core logic should complete quickly (events generated and queued fast)
+    assert(coreLogicTime < 500,
+      s"Core pipeline logic took ${coreLogicTime}ms, but should be fast since events are " +
+        s"just queued asynchronously. This suggests events may be processed synchronously.")
+
+    // Verify we got the expected events
+    assert(capturedEvents.size == 5, s"Expected 5 events, got ${capturedEvents.size}")
+  }
+}

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSenderSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSenderSuite.scala
@@ -107,7 +107,7 @@ class PipelineEventSenderSuite extends SparkDeclarativePipelinesServerTest with 
 
     events.foreach(event => eventSender.sendEvent(event))
 
-    eventSender.shutdown()
+    eventSender.shutdown() // blocks until all events are processed
 
     // this event should not be processed because shutdown has been called
     eventSender.sendEvent(
@@ -115,9 +115,10 @@ class PipelineEventSenderSuite extends SparkDeclarativePipelinesServerTest with 
         id = s"event-after-shutdown",
         message = s"Event after shutdown",
         level = EventLevel.INFO,
-        details = FlowProgress(FlowStatus.RUNNING)))
-    // Allow some time for the processing to complete
-    Thread.sleep(50)
+        details = FlowProgress(FlowStatus.RUNNING)
+      )
+    )
+
     // Event should have been processed before shutdown completed
     val responseCaptor = ArgumentCaptor.forClass(classOf[ExecutePlanResponse])
     verify(mockObserver, times(2)).onNext(responseCaptor.capture())

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSenderSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSenderSuite.scala
@@ -61,7 +61,6 @@ class PipelineEventSenderSuite extends SparkDeclarativePipelinesServerTest with 
     val (mockObserver, mockSessionHolder) = createMockSetup()
 
     val eventSender = new PipelineEventSender(mockObserver, mockSessionHolder)
-    eventSender.start()
 
     try {
       val testEvent = createTestEvent()
@@ -87,7 +86,6 @@ class PipelineEventSenderSuite extends SparkDeclarativePipelinesServerTest with 
     val (mockObserver, mockSessionHolder) = createMockSetup()
 
     val eventSender = new PipelineEventSender(mockObserver, mockSessionHolder)
-    eventSender.start()
 
     val events = Seq(1, 2).map { i =>
       createTestEvent(
@@ -117,7 +115,6 @@ class PipelineEventSenderSuite extends SparkDeclarativePipelinesServerTest with 
     val (mockObserver, mockSessionHolder) = createMockSetup()
 
     val eventSender = new PipelineEventSender(mockObserver, mockSessionHolder)
-    eventSender.start()
     eventSender.shutdown()
     intercept[IllegalStateException] {
       eventSender.sendEvent(createTestEvent())

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/common/GraphStates.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/common/GraphStates.scala
@@ -41,6 +41,12 @@ object FlowStatus {
   // This flow is idle because there are no updates to be made because all available data has
   // already been processed.
   case object IDLE extends FlowStatus
+
+  // check if the flow is in a terminal state
+  def isTerminal(status: FlowStatus): Boolean = status match {
+    case COMPLETED | FAILED | SKIPPED | STOPPED => true
+    case _ => false
+  }
 }
 
 sealed trait RunState


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Created `PipelineEventSender` to allow sending pipeline event back to client in a background thread to not block pipeline execution. New events gets queued into the sender and will get processed sequentially. The sender waits until all events are sent back to client before shutting down the processing loop.

Implemented logical capacity checking that examines event types before submission, ensuring RunProgress and terminal FlowProgress events are always queued while other events may be dropped when the queue is full. This prevents buffer from overflowing and impact pipeline execution when the number of events are too large.

The queue size can be controlled by a spark conf `spark.sql.connect.pipeline.event.queue.capacity`, currently defaulted to `1000`


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To ensure event sending do not block pipeline execution.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New and existing tests to ensure events are delivered and not done in a blocking way.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
