### PR TITLE
[SPARK-53231][TESTS] Ban `com.google.common.collect.Sets`

### DIFF
--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -191,6 +191,7 @@
             <property name="illegalClasses" value="org.apache.commons.lang3.SystemUtils" />
             <property name="illegalClasses" value="org.apache.hadoop.io.IOUtils" />
             <property name="illegalClasses" value="com.google.common.base.Strings" />
+            <property name="illegalClasses" value="com.google.common.collect.Sets" />
             <property name="illegalClasses" value="com.google.common.io.BaseEncoding" />
             <property name="illegalClasses" value="com.google.common.io.Files" />
         </module>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ban `com.google.common.collect.Sets`.

### Why are the changes needed?

Since Apache Spark already migrated to Java 9+ `Set.of` syntax, we had better prevent future regressions.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.