### PR TITLE
[SPARK-53232][SQL][TESTS] Use Java `Map.copyOf` instead of `ImmutableMap.copyOf`

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -787,6 +787,11 @@ This file is divided into 3 sections:
     <customMessage>Use OutputStream.nullOutputStream instead.</customMessage>
   </check>
 
+  <check customId="ImmutableMapcopyOf" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bImmutableMap\.copyOf\b</parameter></parameters>
+    <customMessage>Use Map.copyOf instead.</customMessage>
+  </check>
+
   <check customId="maputils" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">org\.apache\.commons\.collections4\.MapUtils\b</parameter></parameters>
     <customMessage>Use org.apache.spark.util.collection.Utils instead.</customMessage>

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileScanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileScanSuite.scala
@@ -21,7 +21,6 @@ import java.util.{Map => JMap}
 
 import scala.collection.mutable
 
-import com.google.common.collect.ImmutableMap
 import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.sql.catalyst.dsl.expressions._
@@ -84,9 +83,9 @@ trait FileScanSuiteBase extends SharedSparkSession {
     val pushedFiltersNotEqual =
       Array[Filter](sources.And(sources.IsNull("data"), sources.LessThan("data", 1)))
     val optionsMap = JMap.of("key", "value")
-    val options = new CaseInsensitiveStringMap(ImmutableMap.copyOf(optionsMap))
+    val options = new CaseInsensitiveStringMap(JMap.copyOf(optionsMap))
     val optionsNotEqual =
-      new CaseInsensitiveStringMap(ImmutableMap.copyOf(JMap.of("key2", "value2")))
+      new CaseInsensitiveStringMap(JMap.copyOf(JMap.of("key2", "value2")))
     val partitionFilters = Seq(And(IsNull($"data".int), LessThan($"data".int, 0)))
     val partitionFiltersNotEqual = Seq(And(IsNull($"data".int),
       LessThan($"data".int, 1)))
@@ -115,7 +114,7 @@ trait FileScanSuiteBase extends SharedSparkSession {
           readDataSchema.copy(),
           readPartitionSchema.copy(),
           pushedFilters.clone(),
-          new CaseInsensitiveStringMap(ImmutableMap.copyOf(optionsMap)),
+          new CaseInsensitiveStringMap(JMap.copyOf(optionsMap)),
           Seq(partitionFilters: _*),
           Seq(dataFilters: _*))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java 10+ `Map.copyOf` instead of `ImmutableMap.copyOf`.

In addition, a new Scalastyle rule is added to prevent future regressions.

### Why are the changes needed?

Java native implementation is **significantly faster and simpler** than `ImmutableMap.copyOf`.

```scala
scala> val m = java.util.Map.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
val m: java.util.Map[Int,Int] = {5=6, 7=8, 9=10, 1=2, 3=4}

scala> spark.time((1 until 100_000_000).foreach(_ => com.google.common.collect.ImmutableMap.copyOf(m)))
Time taken: 4404 ms

scala> spark.time((1 until 100_000_000).foreach(_ => java.util.Map.copyOf(m)))
Time taken: 223 ms
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.