### PR TITLE
[SPARK-53234][CORE][SQL][MLLIB][YARN] Use `java.util.Objects` instead of `com.google.common.base.Objects`

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiConsumer;
@@ -31,7 +32,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
 import org.apache.spark.annotation.Private;
@@ -70,7 +70,7 @@ public class InMemoryStore implements KVStore {
     Object comparable = asKey(indexedValue);
     KVTypeInfo.Accessor accessor = list.getIndexAccessor(index);
     for (Object o : view(type)) {
-      if (Objects.equal(comparable, asKey(accessor.get(o)))) {
+      if (Objects.equals(comparable, asKey(accessor.get(o)))) {
         count++;
       }
     }

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/AbstractMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/AbstractMessage.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.network.protocol;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 import org.apache.spark.network.buffer.ManagedBuffer;
 
@@ -48,7 +48,7 @@ public abstract class AbstractMessage implements Message {
   }
 
   protected boolean equals(AbstractMessage other) {
-    return isBodyInFrame == other.isBodyInFrame && Objects.equal(body, other.body);
+    return isBodyInFrame == other.isBodyInFrame && Objects.equals(body, other.body);
   }
 
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/MergedBlockMetaRequest.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/MergedBlockMetaRequest.java
@@ -17,7 +17,8 @@
 
 package org.apache.spark.network.protocol;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
+
 import io.netty.buffer.ByteBuf;
 
 /**
@@ -77,7 +78,7 @@ public class MergedBlockMetaRequest extends AbstractMessage implements RequestMe
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(requestId, appId, shuffleId, shuffleMergeId, reduceId);
+    return Objects.hash(requestId, appId, shuffleId, shuffleMergeId, reduceId);
   }
 
   @Override
@@ -85,7 +86,7 @@ public class MergedBlockMetaRequest extends AbstractMessage implements RequestMe
     if (other instanceof MergedBlockMetaRequest o) {
       return requestId == o.requestId && shuffleId == o.shuffleId &&
         shuffleMergeId == o.shuffleMergeId && reduceId == o.reduceId &&
-        Objects.equal(appId, o.appId);
+        Objects.equals(appId, o.appId);
     }
     return false;
   }

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/MergedBlockMetaSuccess.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/MergedBlockMetaSuccess.java
@@ -17,7 +17,8 @@
 
 package org.apache.spark.network.protocol;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
+
 import io.netty.buffer.ByteBuf;
 
 import org.apache.spark.network.buffer.ManagedBuffer;
@@ -49,7 +50,7 @@ public class MergedBlockMetaSuccess extends AbstractResponseMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(requestId, numChunks);
+    return Objects.hash(requestId, numChunks);
   }
 
   @Override

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/AbstractFetchShuffleBlocks.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/AbstractFetchShuffleBlocks.java
@@ -17,7 +17,8 @@
 
 package org.apache.spark.network.shuffle.protocol;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
+
 import io.netty.buffer.ByteBuf;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -63,7 +64,7 @@ public abstract class AbstractFetchShuffleBlocks extends BlockTransferMessage {
     if (o == null || getClass() != o.getClass()) return false;
     AbstractFetchShuffleBlocks that = (AbstractFetchShuffleBlocks) o;
     return shuffleId == that.shuffleId
-      && Objects.equal(appId, that.appId) && Objects.equal(execId, that.execId);
+      && Objects.equals(appId, that.appId) && Objects.equals(execId, that.execId);
   }
 
   @Override

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/FinalizeShuffleMerge.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/FinalizeShuffleMerge.java
@@ -17,7 +17,8 @@
 
 package org.apache.spark.network.shuffle.protocol;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
+
 import io.netty.buffer.ByteBuf;
 
 import org.apache.spark.network.protocol.Encoders;
@@ -52,7 +53,7 @@ public class FinalizeShuffleMerge extends BlockTransferMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(appId, appAttemptId, shuffleId, shuffleMergeId);
+    return Objects.hash(appId, appAttemptId, shuffleId, shuffleMergeId);
   }
 
   @Override
@@ -64,7 +65,7 @@ public class FinalizeShuffleMerge extends BlockTransferMessage {
   @Override
   public boolean equals(Object other) {
     if (other instanceof FinalizeShuffleMerge o) {
-      return Objects.equal(appId, o.appId)
+      return Objects.equals(appId, o.appId)
         && appAttemptId == o.appAttemptId
         && shuffleId == o.shuffleId
         && shuffleMergeId == o.shuffleMergeId;

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/MergeStatuses.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/MergeStatuses.java
@@ -19,7 +19,8 @@ package org.apache.spark.network.shuffle.protocol;
 
 import java.util.Arrays;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
+
 import io.netty.buffer.ByteBuf;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -91,8 +92,8 @@ public class MergeStatuses extends BlockTransferMessage {
   @Override
   public boolean equals(Object other) {
     if (other instanceof MergeStatuses o) {
-      return Objects.equal(shuffleId, o.shuffleId)
-        && Objects.equal(shuffleMergeId, o.shuffleMergeId)
+      return Objects.equals(shuffleId, o.shuffleId)
+        && Objects.equals(shuffleMergeId, o.shuffleMergeId)
         && Arrays.equals(bitmaps, o.bitmaps)
         && Arrays.equals(reduceIds, o.reduceIds)
         && Arrays.equals(sizes, o.sizes);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/PushBlockStream.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/PushBlockStream.java
@@ -17,7 +17,8 @@
 
 package org.apache.spark.network.shuffle.protocol;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
+
 import io.netty.buffer.ByteBuf;
 
 import org.apache.spark.network.protocol.Encoders;
@@ -65,7 +66,7 @@ public class PushBlockStream extends BlockTransferMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(appId, appAttemptId, shuffleId, shuffleMergeId, mapIndex , reduceId,
+    return Objects.hash(appId, appAttemptId, shuffleId, shuffleMergeId, mapIndex , reduceId,
       index);
   }
 
@@ -79,7 +80,7 @@ public class PushBlockStream extends BlockTransferMessage {
   @Override
   public boolean equals(Object other) {
     if (other instanceof PushBlockStream o) {
-      return Objects.equal(appId, o.appId)
+      return Objects.equals(appId, o.appId)
         && appAttemptId == o.appAttemptId
         && shuffleId == o.shuffleId
         && shuffleMergeId == o.shuffleMergeId

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/RemoveShuffleMerge.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/RemoveShuffleMerge.java
@@ -17,7 +17,8 @@
 
 package org.apache.spark.network.shuffle.protocol;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
+
 import io.netty.buffer.ByteBuf;
 
 import org.apache.spark.network.protocol.Encoders;
@@ -52,7 +53,7 @@ public class RemoveShuffleMerge extends BlockTransferMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(appId, appAttemptId, shuffleId, shuffleMergeId);
+    return Objects.hash(appId, appAttemptId, shuffleId, shuffleMergeId);
   }
 
   @Override
@@ -64,7 +65,7 @@ public class RemoveShuffleMerge extends BlockTransferMessage {
   @Override
   public boolean equals(Object other) {
     if (other != null && other instanceof RemoveShuffleMerge o) {
-      return Objects.equal(appId, o.appId)
+      return Objects.equals(appId, o.appId)
         && appAttemptId == o.appAttemptId
         && shuffleId == o.shuffleId
         && shuffleMergeId == o.shuffleMergeId;

--- a/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
@@ -17,13 +17,13 @@
 
 package org.apache.spark.rdd
 
+import java.util.Objects
 import java.util.concurrent.atomic.AtomicInteger
 
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonInclude, JsonPropertyOrder}
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.google.common.base.Objects
 
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.Logging
@@ -69,7 +69,7 @@ private[spark] class RDDOperationScope(
     }
   }
 
-  override def hashCode(): Int = Objects.hashCode(id, name, parent)
+  override def hashCode(): Int = Objects.hash(id, name, parent)
 
   override def toString: String = toJson
 }

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -190,6 +190,7 @@
             <property name="illegalClasses" value="org.apache.commons.lang3.StringUtils" />
             <property name="illegalClasses" value="org.apache.commons.lang3.SystemUtils" />
             <property name="illegalClasses" value="org.apache.hadoop.io.IOUtils" />
+            <property name="illegalClasses" value="com.google.common.base.Objects" />
             <property name="illegalClasses" value="com.google.common.base.Strings" />
             <property name="illegalClasses" value="com.google.common.collect.Sets" />
             <property name="illegalClasses" value="com.google.common.io.BaseEncoding" />

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.mllib.linalg
 
-import java.util.{Arrays, Random}
+import java.util.{Arrays, Objects, Random}
 
 import scala.collection.mutable.{ArrayBuffer, ArrayBuilder => MArrayBuilder, HashSet => MHashSet}
 import scala.language.implicitConversions
@@ -314,7 +314,7 @@ class DenseMatrix @Since("1.3.0") (
   }
 
   override def hashCode: Int = {
-    com.google.common.base.Objects.hashCode(numRows: Integer, numCols: Integer, toArray)
+    Objects.hash(numRows: Integer, numCols: Integer, toArray)
   }
 
   private[mllib] def asBreeze: BM[Double] = {

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrix.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.mllib.linalg.distributed
 
+import java.util.Objects
+
 import scala.collection.mutable.ArrayBuffer
 
 import breeze.linalg.{DenseMatrix => BDM, DenseVector => BDV, Matrix => BM}
@@ -90,7 +92,7 @@ private[mllib] class GridPartitioner(
   }
 
   override def hashCode: Int = {
-    com.google.common.base.Objects.hashCode(
+    Objects.hash(
       rows: java.lang.Integer,
       cols: java.lang.Integer,
       rowsPerPart: java.lang.Integer,

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/InformationGainStats.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/InformationGainStats.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.mllib.tree.model
 
+import java.util.Objects
+
 import org.apache.spark.annotation.Since
 import org.apache.spark.mllib.tree.impurity.ImpurityCalculator
 
@@ -56,7 +58,7 @@ class InformationGainStats(
   }
 
   override def hashCode: Int = {
-    com.google.common.base.Objects.hashCode(
+    Objects.hash(
       gain: java.lang.Double,
       impurity: java.lang.Double,
       leftImpurity: java.lang.Double,

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Predict.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Predict.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.mllib.tree.model
 
+import java.util.Objects
+
 import org.apache.spark.annotation.Since
 
 /**
@@ -39,6 +41,6 @@ class Predict @Since("1.2.0") (
   }
 
   override def hashCode: Int = {
-    com.google.common.base.Objects.hashCode(predict: java.lang.Double, prob: java.lang.Double)
+    Objects.hash(predict: java.lang.Double, prob: java.lang.Double)
   }
 }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -22,7 +22,7 @@ import java.net.{InetAddress, UnknownHostException, URI, URL}
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
-import java.util.{Collections, Locale, Properties, UUID}
+import java.util.{Collections, Locale, Objects, Properties, UUID}
 import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import scala.collection.immutable.{Map => IMap}
@@ -31,7 +31,6 @@ import scala.jdk.CollectionConverters._
 import scala.util.Using
 import scala.util.control.NonFatal
 
-import com.google.common.base.Objects
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
 import org.apache.hadoop.fs.permission.FsPermission
@@ -1726,7 +1725,7 @@ private[spark] object Client extends Logging {
       }
     }
 
-    Objects.equal(srcHost, dstHost) && srcUri.getPort() == dstUri.getPort()
+    Objects.equals(srcHost, dstHost) && srcUri.getPort() == dstUri.getPort()
 
   }
 

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -804,7 +804,7 @@ This file is divided into 3 sections:
 
   <check customId="googleObjects" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">com\.google\.common\.base\.Objects\b</parameter></parameters>
-    <customMessage>Use Java APIs (like java.util.Objects instead.</customMessage>
+    <customMessage>Use Java APIs (like java.util.Objects) instead.</customMessage>
   </check>
 
   <check customId="googleBaseEncoding" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -802,6 +802,11 @@ This file is divided into 3 sections:
     <customMessage>Use Java API or Spark's JavaUtils/SparkFileUtils/Utils instead.</customMessage>
   </check>
 
+  <check customId="googleObjects" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">com\.google\.common\.base\.Objects\b</parameter></parameters>
+    <customMessage>Use Java APIs (like java.util.Objects instead.</customMessage>
+  </check>
+
   <check customId="googleBaseEncoding" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">com\.google\.common\.io\.BaseEncoding\b</parameter></parameters>
     <customMessage>Use Java APIs (like java.util.Base64) instead.</customMessage>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -20,13 +20,12 @@ package org.apache.spark.sql.connector.catalog
 import java.time.{Instant, ZoneId}
 import java.time.temporal.ChronoUnit
 import java.util
+import java.util.Objects
 import java.util.OptionalLong
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters._
-
-import com.google.common.base.Objects
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, JoinedRow, MetadataStructFieldWithLogicalName}
@@ -756,7 +755,7 @@ case class PartitionInternalRow(keys: Array[Any])
     this.keys == other.asInstanceOf[PartitionInternalRow].keys
   }
   override def hashCode: Int = {
-    Objects.hashCode(keys)
+    Objects.hash(keys)
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
-import com.google.common.base.Objects
+import java.util.Objects
 
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
@@ -55,7 +55,7 @@ case class BatchScanExec(
       false
   }
 
-  override def hashCode(): Int = Objects.hashCode(batch, runtimeFilters)
+  override def hashCode(): Int = Objects.hash(batch, runtimeFilters)
 
   @transient override lazy val inputPartitions: Seq[InputPartition] =
     batch.planInputPartitions().toImmutableArraySeq
@@ -303,7 +303,7 @@ case class StoragePartitionJoinParams(
       false
   }
 
-  override def hashCode(): Int = Objects.hashCode(
+  override def hashCode(): Int = Objects.hash(
     joinKeyPositions: Option[Seq[Int]],
     commonPartitionValues: Option[Seq[(InternalRow, Int)]],
     applyPartialClustering: java.lang.Boolean,

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -33,7 +33,6 @@ import scala.Tuple3;
 import scala.Tuple4;
 import scala.Tuple5;
 
-import com.google.common.base.Objects;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -1212,12 +1211,12 @@ public class JavaDatasetSuite implements Serializable {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       SmallBean smallBean = (SmallBean) o;
-      return b == smallBean.b && com.google.common.base.Objects.equal(a, smallBean.a);
+      return b == smallBean.b && Objects.equals(a, smallBean.a);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(a, b);
+      return Objects.hash(a, b);
     }
   }
 
@@ -1237,7 +1236,7 @@ public class JavaDatasetSuite implements Serializable {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       NestedSmallBean that = (NestedSmallBean) o;
-      return Objects.equal(f, that.f);
+      return Objects.equals(f, that.f);
     }
 
     @Override
@@ -1279,13 +1278,13 @@ public class JavaDatasetSuite implements Serializable {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       NestedSmallBeanWithNonNullField that = (NestedSmallBeanWithNonNullField) o;
-      return Objects.equal(nullable_f, that.nullable_f) &&
-        Objects.equal(nonNull_f, that.nonNull_f) && Objects.equal(childMap, that.childMap);
+      return Objects.equals(nullable_f, that.nullable_f) &&
+        Objects.equals(nonNull_f, that.nonNull_f) && Objects.equals(childMap, that.childMap);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(nullable_f, nonNull_f, childMap);
+      return Objects.hash(nullable_f, nonNull_f, childMap);
     }
   }
 
@@ -1306,7 +1305,7 @@ public class JavaDatasetSuite implements Serializable {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       NestedSmallBean2 that = (NestedSmallBean2) o;
-      return Objects.equal(f, that.f);
+      return Objects.equals(f, that.f);
     }
 
     @Override
@@ -1848,7 +1847,7 @@ public class JavaDatasetSuite implements Serializable {
     }
 
     public int hashCode() {
-      return Objects.hashCode(enumField, regularField);
+      return Objects.hash(enumField, regularField);
     }
 
     public boolean equals(Object other) {
@@ -2105,7 +2104,7 @@ public class JavaDatasetSuite implements Serializable {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       BeanWithSet that = (BeanWithSet) o;
-      return Objects.equal(fields, that.fields);
+      return Objects.equals(fields, that.fields);
     }
 
     @Override
@@ -2148,14 +2147,14 @@ public class JavaDatasetSuite implements Serializable {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       SpecificListsBean that = (SpecificListsBean) o;
-      return Objects.equal(arrayList, that.arrayList) &&
-        Objects.equal(linkedList, that.linkedList) &&
-        Objects.equal(list, that.list);
+      return Objects.equals(arrayList, that.arrayList) &&
+        Objects.equals(linkedList, that.linkedList) &&
+        Objects.equals(list, that.list);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(arrayList, linkedList, list);
+      return Objects.hash(arrayList, linkedList, list);
     }
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
@@ -18,10 +18,10 @@
 package org.apache.spark.sql.hive
 
 import java.rmi.server.UID
+import java.util.Objects
 
 import scala.jdk.CollectionConverters._
 
-import com.google.common.base.Objects
 import org.apache.avro.Schema
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hive.ql.exec.SerializationUtilities
@@ -129,7 +129,7 @@ private[hive] object HiveShim {
 
     override def hashCode(): Int = {
       if (functionClassName == HIVE_GENERIC_UDF_MACRO_CLS) {
-        Objects.hashCode(functionClassName, instance.asInstanceOf[GenericUDFMacro].getBody())
+        Objects.hash(functionClassName, instance.asInstanceOf[GenericUDFMacro].getBody())
       } else {
         functionClassName.hashCode()
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request replaces `com.google.common.base.Objects` with `java.util.Objects`. Specifically, the following changes have been made:

1. Use `java.util.Objects#equals` instead of `com.google.common.base.Objects#equal`.
2. Use `java.util.Objects#hash` instead of `com.google.common.base.Objects#hashCode`.
3. Ban the use of `com.google.common.base.Objects`.

### Why are the changes needed?

Following the recommendation in `com.google.common.base.Objects`: "

https://github.com/google/guava/blob/5c71d2a15435399fa62508d807d5cc83506f7496/guava/src/com/google/common/base/Objects.java#L37-L80

```java
  /**
   ...
   *
   * <p><b>Note:</b> this method is now unnecessary and should be treated as deprecated; use {@link
   * java.util.Objects#equals} instead.
   */
  public static boolean equal(@CheckForNull Object a, @CheckForNull Object b) {
    return a == b || (a != null && a.equals(b));
  }

  /**
   ...
   *
   * <p><b>Note:</b> this method is now unnecessary and should be treated as deprecated; use {@link
   * java.util.Objects#hash} instead.
   */
  public static int hashCode(@CheckForNull @Nullable Object... objects) {
    return Arrays.hashCode(objects);
  }
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
