### PR TITLE
[SPARK-53235][CORE][TESTS] Use Java `Set.of` instead of `ImmutableSet.of`

### DIFF
--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
@@ -159,13 +159,13 @@ public class InMemoryStoreSuite {
     assertTrue(store.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       "id",
-      Set.of(new String [] { "things" })));
+      Set.<String[]>of(new String [] { "things" })));
     assertEquals(4, store.count(ArrayKeyIndexType.class));
 
     assertTrue(store.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       "id",
-      Set.of(new String [] { "more things" })));
+      Set.<String[]>of(new String [] { "more things" })));
     assertEquals(0, store.count(ArrayKeyIndexType.class));
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
@@ -17,9 +17,9 @@
 
 package org.apache.spark.util.kvstore;
 
+import java.util.Set;
 import java.util.NoSuchElementException;
 
-import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -147,25 +147,25 @@ public class InMemoryStoreSuite {
     assertFalse(store.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       KVIndex.NATURAL_INDEX_NAME,
-      ImmutableSet.of(new int[] {10, 10, 10}, new int[] { 3, 3, 3 })));
+      Set.of(new int[] {10, 10, 10}, new int[] { 3, 3, 3 })));
     assertEquals(9, store.count(ArrayKeyIndexType.class));
 
     assertTrue(store.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       KVIndex.NATURAL_INDEX_NAME,
-      ImmutableSet.of(new int[] {0, 0, 0}, new int[] { 2, 2, 2 })));
+      Set.of(new int[] {0, 0, 0}, new int[] { 2, 2, 2 })));
     assertEquals(7, store.count(ArrayKeyIndexType.class));
 
     assertTrue(store.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       "id",
-      ImmutableSet.of(new String [] { "things" })));
+      Set.of(new String [] { "things" })));
     assertEquals(4, store.count(ArrayKeyIndexType.class));
 
     assertTrue(store.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       "id",
-      ImmutableSet.of(new String [] { "more things" })));
+      Set.of(new String [] { "more things" })));
     assertEquals(0, store.count(ArrayKeyIndexType.class));
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -25,11 +25,11 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.Spliterators;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import com.google.common.collect.ImmutableSet;
 import org.iq80.leveldb.DBIterator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -220,19 +220,19 @@ public class LevelDBSuite {
     db.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       KVIndex.NATURAL_INDEX_NAME,
-      ImmutableSet.of(new int[] {0, 0, 0}, new int[] { 2, 2, 2 }));
+      Set.of(new int[] {0, 0, 0}, new int[] { 2, 2, 2 }));
     assertEquals(7, db.count(ArrayKeyIndexType.class));
 
     db.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       "id",
-      ImmutableSet.of(new String[] { "things" }));
+      Set.of(new String[] { "things" }));
     assertEquals(4, db.count(ArrayKeyIndexType.class));
 
     db.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       "id",
-      ImmutableSet.of(new String[] { "more things" }));
+      Set.of(new String[] { "more things" }));
     assertEquals(0, db.count(ArrayKeyIndexType.class));
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -226,13 +226,13 @@ public class LevelDBSuite {
     db.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       "id",
-      Set.of(new String[] { "things" }));
+      Set.<String[]>of(new String[] { "things" }));
     assertEquals(4, db.count(ArrayKeyIndexType.class));
 
     db.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       "id",
-      Set.of(new String[] { "more things" }));
+      Set.<String[]>of(new String[] { "more things" }));
     assertEquals(0, db.count(ArrayKeyIndexType.class));
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
@@ -223,13 +223,13 @@ public class RocksDBSuite {
     db.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       "id",
-      Set.of(new String[] { "things" }));
+      Set.<String[]>of(new String[] { "things" }));
     assertEquals(4, db.count(ArrayKeyIndexType.class));
 
     db.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       "id",
-      Set.of(new String[] { "more things" }));
+      Set.<String[]>of(new String[] { "more things" }));
     assertEquals(0, db.count(ArrayKeyIndexType.class));
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
@@ -25,11 +25,11 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.Spliterators;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -217,19 +217,19 @@ public class RocksDBSuite {
     db.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       KVIndex.NATURAL_INDEX_NAME,
-      ImmutableSet.of(new int[] {0, 0, 0}, new int[] { 2, 2, 2 }));
+      Set.of(new int[] {0, 0, 0}, new int[] { 2, 2, 2 }));
     assertEquals(7, db.count(ArrayKeyIndexType.class));
 
     db.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       "id",
-      ImmutableSet.of(new String[] { "things" }));
+      Set.of(new String[] { "things" }));
     assertEquals(4, db.count(ArrayKeyIndexType.class));
 
     db.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       "id",
-      ImmutableSet.of(new String[] { "more things" }));
+      Set.of(new String[] { "more things" }));
     assertEquals(0, db.count(ArrayKeyIndexType.class));
   }
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/CleanupNonShuffleServiceServedFilesSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/CleanupNonShuffleServiceServedFilesSuite.java
@@ -25,7 +25,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,10 +42,10 @@ public class CleanupNonShuffleServiceServedFilesSuite {
   private static final String SORT_MANAGER = "org.apache.spark.shuffle.sort.SortShuffleManager";
 
   private static Set<String> expectedShuffleFilesToKeep =
-    ImmutableSet.of("shuffle_782_450_0.index", "shuffle_782_450_0.data");
+    Set.of("shuffle_782_450_0.index", "shuffle_782_450_0.data");
 
   private static Set<String> expectedShuffleAndRddFilesToKeep =
-    ImmutableSet.of("shuffle_782_450_0.index", "shuffle_782_450_0.data", "rdd_12_34");
+    Set.of("shuffle_782_450_0.index", "shuffle_782_450_0.data", "rdd_12_34");
 
   private TransportConf getConf(boolean isFetchRddEnabled) {
     return new TransportConf(

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -263,6 +263,10 @@
             <property name="format" value="ImmutableMap\.of"/>
             <property name="message" value="Use Map.of instead." />
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="ImmutableSet\.of"/>
+            <property name="message" value="Use Set.of instead." />
+        </module>
         <!-- support structured logging -->
         <module name="RegexpSinglelineJava">
             <property name="format" value="org\.slf4j\.(Logger|LoggerFactory)" />

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -792,6 +792,11 @@ This file is divided into 3 sections:
     <customMessage>Use Map.copyOf instead.</customMessage>
   </check>
 
+  <check customId="ImmutableSetof" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bImmutableSet\.of\b</parameter></parameters>
+    <customMessage>Use java.util.Set.of instead.</customMessage>
+  </check>
+
   <check customId="maputils" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">org\.apache\.commons\.collections4\.MapUtils\b</parameter></parameters>
     <customMessage>Use org.apache.spark.util.collection.Utils instead.</customMessage>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to use Java 9+ `Set.of` API instead of `ImmutableSet.of` API. 

### Why are the changes needed?

Java's native API is **shorter and faster**.

```scala
scala> spark.version
val res0: String = 4.1.0-preview1

scala> spark.time((1 until 100_000_000).foreach(_ => java.util.Set.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)))
Time taken: 4287 ms

scala> spark.time((1 until 100_000_000).foreach(_ => com.google.common.collect.ImmutableSet.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)))
Time taken: 15024 ms
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.