### PR TITLE
[SPARK-53238][CORE][TESTS] Improve `SorterBenchmark` to include `Arrays.parallelSort`

### DIFF
--- a/core/benchmarks/SorterBenchmark-jdk21-results.txt
+++ b/core/benchmarks/SorterBenchmark-jdk21-results.txt
@@ -2,25 +2,28 @@
 key-value pairs sort
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1014-azure
+OpenJDK 64-Bit Server VM 21.0.8+9-LTS on Linux 6.11.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 key-value pairs sort 25000000:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Tuple-sort using Arrays.sort()                    17292          17584         413          1.4         691.7       1.0X
-KV-sort using Sorter                              21245          21340         134          1.2         849.8       0.8X
+Tuple-sort using Arrays.sort()                    16360          16496         192          1.5         654.4       1.0X
+Tuple-sort using Arrays.parallelSort()             7796           8631        1180          3.2         311.9       2.1X
+KV-sort using Sorter                              19344          19436         130          1.3         773.8       0.8X
 
 
 ================================================================================================
 primitive int array sort
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.7+6-LTS on Linux 6.11.0-1014-azure
+OpenJDK 64-Bit Server VM 21.0.8+9-LTS on Linux 6.11.0-1018-azure
 AMD EPYC 7763 64-Core Processor
-primitive int array sort 25000000:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------
-Java Arrays.sort() on non-primitive int array            14231          14561         468          1.8         569.2       1.0X
-Java Arrays.sort() on primitive int array                 2141           2145           6         11.7          85.6       6.6X
-Sorter without key reuse on primitive int array           8607           8612           7          2.9         344.3       1.7X
-Sorter with key reuse on primitive int array             10602          10621          27          2.4         424.1       1.3X
+primitive int array sort 25000000:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------
+Java Arrays.sort() on non-primitive int array                  14783          14862         111          1.7         591.3       1.0X
+Java Arrays.parallelSort() on non-primitive int array           6336           6423         124          3.9         253.4       2.3X
+Java Arrays.sort() on primitive int array                       2122           2122           0         11.8          84.9       7.0X
+Java Arrays.parallelSort() on primitive int array                833            846          21         30.0          33.3      17.7X
+Sorter without key reuse on primitive int array                 8637           8651          21          2.9         345.5       1.7X
+Sorter with key reuse on primitive int array                   10726          10733          10          2.3         429.0       1.4X
 
 

--- a/core/benchmarks/SorterBenchmark-results.txt
+++ b/core/benchmarks/SorterBenchmark-results.txt
@@ -2,25 +2,28 @@
 key-value pairs sort
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1014-azure
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Linux 6.11.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 key-value pairs sort 25000000:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Tuple-sort using Arrays.sort()                    20545          20560          21          1.2         821.8       1.0X
-KV-sort using Sorter                              26696          26797         143          0.9        1067.8       0.8X
+Tuple-sort using Arrays.sort()                    16765          16984         308          1.5         670.6       1.0X
+Tuple-sort using Arrays.parallelSort()            10521          10746         318          2.4         420.8       1.6X
+KV-sort using Sorter                              22863          23017         219          1.1         914.5       0.7X
 
 
 ================================================================================================
 primitive int array sort
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.15+6-LTS on Linux 6.11.0-1014-azure
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Linux 6.11.0-1018-azure
 AMD EPYC 7763 64-Core Processor
-primitive int array sort 25000000:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------
-Java Arrays.sort() on non-primitive int array            15325          15510         263          1.6         613.0       1.0X
-Java Arrays.sort() on primitive int array                 2088           2141          76         12.0          83.5       7.3X
-Sorter without key reuse on primitive int array           8254           8262          10          3.0         330.2       1.9X
-Sorter with key reuse on primitive int array             10184          10186           3          2.5         407.3       1.5X
+primitive int array sort 25000000:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------
+Java Arrays.sort() on non-primitive int array                  14334          14344          14          1.7         573.3       1.0X
+Java Arrays.parallelSort() on non-primitive int array           6734           7146         582          3.7         269.4       2.1X
+Java Arrays.sort() on primitive int array                       2177           2178           2         11.5          87.1       6.6X
+Java Arrays.parallelSort() on primitive int array               1001           1001           0         25.0          40.0      14.3X
+Sorter without key reuse on primitive int array                 8363           8365           2          3.0         334.5       1.7X
+Sorter with key reuse on primitive int array                   10189          10191           2          2.5         407.6       1.4X
 
 

--- a/core/src/test/scala/org/apache/spark/util/collection/SorterBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/SorterBenchmark.scala
@@ -57,6 +57,15 @@ object SorterBenchmark extends BenchmarkBase {
       timer.stopTiming()
     }
 
+    benchmark.addTimerCase("Tuple-sort using Arrays.parallelSort()") { timer =>
+      val kvTupleArray = new Array[AnyRef](numElements)
+      System.arraycopy(kvTuples, 0, kvTupleArray, 0, numElements)
+      timer.startTiming()
+      util.Arrays.parallelSort(kvTupleArray, (x: AnyRef, y: AnyRef) =>
+        x.asInstanceOf[(JFloat, _)]._1.compareTo(y.asInstanceOf[(JFloat, _)]._1))
+      timer.stopTiming()
+    }
+
     // Test Sorter where each element alternates between Float and Integer, non-primitive
     val keyValues = {
       val data = new Array[AnyRef](numElements * 2)
@@ -106,11 +115,27 @@ object SorterBenchmark extends BenchmarkBase {
       timer.stopTiming()
     }
 
+    benchmark.addTimerCase("Java Arrays.parallelSort() on non-primitive int array") { timer =>
+      val intObjectArray = new Array[Integer](numElements)
+      System.arraycopy(intObjects, 0, intObjectArray, 0, numElements)
+      timer.startTiming()
+      util.Arrays.parallelSort(intObjectArray, (x: Integer, y: Integer) => x.compareTo(y))
+      timer.stopTiming()
+    }
+
     benchmark.addTimerCase("Java Arrays.sort() on primitive int array") { timer =>
       val intPrimitiveArray = new Array[Int](numElements)
       System.arraycopy(ints, 0, intPrimitiveArray, 0, numElements)
       timer.startTiming()
       util.Arrays.sort(intPrimitiveArray)
+      timer.stopTiming()
+    }
+
+    benchmark.addTimerCase("Java Arrays.parallelSort() on primitive int array") { timer =>
+      val intPrimitiveArray = new Array[Int](numElements)
+      System.arraycopy(ints, 0, intPrimitiveArray, 0, numElements)
+      timer.startTiming()
+      util.Arrays.parallelSort(intPrimitiveArray)
       timer.stopTiming()
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `SorterBenchmark` to include `Arrays.parallelSort` additionally.

### Why are the changes needed?

To compare multi-core CPU performance together.

### Does this PR introduce _any_ user-facing change?

No, this is a benchmark improvement.

### How was this patch tested?

Manual review with the generated benchmark result.

### Was this patch authored or co-authored using generative AI tooling?

No.