### PR TITLE
[SPARK-53239][SQL] Improve `MapSort` and `SortArray` performance via `parallelSort`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1004,7 +1004,7 @@ case class MapSort(base: Expression)
        |    ${CodeGenerator.getValue(values, valueType, i)});
        |}
        |
-       |java.util.Arrays.sort($sortArray, new java.util.Comparator<Object>() {
+       |java.util.Arrays.parallelSort($sortArray, new java.util.Comparator<Object>() {
        |  @Override public int compare(Object $o1entry, Object $o2entry) {
        |    Object $o1 = (($simpleEntryType) $o1entry).getKey();
        |    Object $o2 = (($simpleEntryType) $o2entry).getKey();
@@ -1149,7 +1149,7 @@ case class SortArray(base: Expression, ascendingOrder: Expression)
   private def sortEval(array: Any, ascending: Boolean): Any = {
     val data = array.asInstanceOf[ArrayData].toArray[AnyRef](elementType)
     if (elementType != NullType) {
-      java.util.Arrays.sort(data, if (ascending) lt else gt)
+      java.util.Arrays.parallelSort(data, if (ascending) lt else gt)
     }
     new GenericArrayData(data.asInstanceOf[Array[Any]])
   }
@@ -1191,7 +1191,7 @@ case class SortArray(base: Expression, ascendingOrder: Expression)
         s"""
            |if ($order) {
            |  $javaType[] $array = $base.to${primitiveTypeName}Array();
-           |  java.util.Arrays.sort($array);
+           |  java.util.Arrays.parallelSort($array);
            |  ${ev.value} = $unsafeArrayData.fromPrimitiveArray($array);
            |} else
            """.stripMargin
@@ -1203,7 +1203,7 @@ case class SortArray(base: Expression, ascendingOrder: Expression)
          |{
          |  Object[] $array = $base.toObjectArray($elementTypeTerm);
          |  final int $sortOrder = $order ? 1 : -1;
-         |  java.util.Arrays.sort($array, new java.util.Comparator() {
+         |  java.util.Arrays.parallelSort($array, new java.util.Comparator() {
          |    @Override public int compare(Object $o1, Object $o2) {
          |      if ($o1 == null && $o2 == null) {
          |        return 0;


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `MapSort` and `SortArray` performance by switching to `Arrays.parallelSort` from `Arrays.sort` to utilize the multi-core more if applicable.

```scala
// Large data: 10M
scala> val a = scala.util.Random.shuffle(1 to 10_000_000).toArray
scala> val b = a.clone
scala> spark.time(java.util.Arrays.sort(a))
Time taken: 574 ms
scala> spark.time(java.util.Arrays.parallelSort(b))
Time taken: 160 ms

// Small data
scala> val a = scala.util.Random.shuffle(1 to 10).toArray
scala> val b = a.clone()
scala> spark.time(java.util.Arrays.sort(a))
Time taken: 0 ms
scala> spark.time(java.util.Arrays.parallelSort(b))
Time taken: 0 ms
```

### Why are the changes needed?

**DATA GENERATION**

```scala
scala> sql("CREATE TABLE T AS SELECT shuffle(sequence(1, 10000000)) AS a")
```

**AFTER (4s)**

```scala

scala> spark.time(sql("SELECT sort_array(a) FROM T").show())
+--------------------+
| sort_array(a, true)|
+--------------------+
|[1, 2, 3, 4, 5, 6...|
+--------------------+

Time taken: 4320 ms

scala> spark.time(sql("SELECT sort_array(a) FROM T").show())
+--------------------+
| sort_array(a, true)|
+--------------------+
|[1, 2, 3, 4, 5, 6...|
+--------------------+

Time taken: 3903 ms
```

**BEFORE (4.1.0-preview1): 6s**

```scala
scala> spark.version
val res0: String = 4.1.0-preview1

scala> spark.time(sql("SELECT sort_array(a) FROM T").show())
+--------------------+
| sort_array(a, true)|
+--------------------+
|[1, 2, 3, 4, 5, 6...|
+--------------------+

Time taken: 8774 ms

scala> spark.time(sql("SELECT sort_array(a) FROM T").show())
+--------------------+
| sort_array(a, true)|
+--------------------+
|[1, 2, 3, 4, 5, 6...|
+--------------------+

Time taken: 6043 ms
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.