### PR TITLE
[SPARK-53241][CORE] Support `createArray` in `SparkCollectionUtils`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkCollectionUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkCollectionUtils.scala
@@ -16,7 +16,10 @@
  */
 package org.apache.spark.util
 
+import java.util.Arrays
+
 import scala.collection.immutable
+import scala.reflect.ClassTag
 
 private[spark] trait SparkCollectionUtils {
   /**
@@ -38,6 +41,30 @@ private[spark] trait SparkCollectionUtils {
   }
 
   def isNotEmpty[K, V](map: java.util.Map[K, V]): Boolean = !isEmpty(map)
+
+  def createArray[K: ClassTag](size: Int, defaultValue: K): Array[K] = {
+    val arr = Array.ofDim[K](size)
+    val classTag = implicitly[ClassTag[K]]
+    classTag.runtimeClass match {
+      case c if c == classOf[Boolean] =>
+        Arrays.fill(arr.asInstanceOf[Array[Boolean]], defaultValue.asInstanceOf[Boolean])
+      case c if c == classOf[Byte] =>
+        Arrays.fill(arr.asInstanceOf[Array[Byte]], defaultValue.asInstanceOf[Byte])
+      case c if c == classOf[Short] =>
+        Arrays.fill(arr.asInstanceOf[Array[Short]], defaultValue.asInstanceOf[Short])
+      case c if c == classOf[Int] =>
+        Arrays.fill(arr.asInstanceOf[Array[Int]], defaultValue.asInstanceOf[Int])
+      case c if c == classOf[Long] =>
+        Arrays.fill(arr.asInstanceOf[Array[Long]], defaultValue.asInstanceOf[Long])
+      case c if c == classOf[Float] =>
+        Arrays.fill(arr.asInstanceOf[Array[Float]], defaultValue.asInstanceOf[Float])
+      case c if c == classOf[Double] =>
+        Arrays.fill(arr.asInstanceOf[Array[Double]], defaultValue.asInstanceOf[Double])
+      case _ =>
+        Arrays.fill(arr.asInstanceOf[Array[AnyRef]], defaultValue.asInstanceOf[AnyRef])
+    }
+    arr
+  }
 }
 
 private[spark] object SparkCollectionUtils extends SparkCollectionUtils


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `createArray` in `SparkCollectionUtils` to take advantage of `java.util.Arrays.fill()` method which is faster than Scala `Array.fill`'s operation.

Apache Spark uses `Array.fill()` many times.
```
$ git grep Array.fill | wc -l
     530
```

Like the following example, new method is much faster.

https://github.com/apache/spark/blob/d2dc05575294a9515564f62fac6473d9c9e5321e/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala#L870-L873

```scala
scala> spark.time((1 until 1024).map(Array.fill[Byte](5 * 1024 * 1024)('X')).size)
Time taken: 15 ms
val res0: Int = 1023

scala> spark.time((1 until 1024).map(org.apache.spark.util.SparkCollectionUtils.createArray[Byte](5 * 1024 * 1024, 'X')).size)
Time taken: 0 ms
val res1: Int = 1023
```

### Why are the changes needed?

To support a better implementation.

```scala
$ bin/spark-shell --driver-memory 12G
...
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 4.1.0-SNAPSHOT
      /_/

Using Scala version 2.13.16 (OpenJDK 64-Bit Server VM, Java 21.0.8)
...
scala> spark.time(Array.fill[Byte](2_000_000_000)(7))
Time taken: 387 ms

scala> spark.time(org.apache.spark.util.SparkCollectionUtils.createArray[Byte](2_000_000_000, 7))
Time taken: 190 ms
```

### Does this PR introduce _any_ user-facing change?

No, this is a new utility method.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.