### PR TITLE
[SPARK-53243][PYTHON][SQL] List the supported eval types in arrow nodes

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -19,8 +19,8 @@ package org.apache.spark.sql.execution.python
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.{JobArtifactSet, TaskContext}
-import org.apache.spark.api.python.ChainedPythonFunctions
+import org.apache.spark.{JobArtifactSet, SparkException, TaskContext}
+import org.apache.spark.api.python.{ChainedPythonFunctions, PythonEvalType}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -62,9 +62,14 @@ private[spark] class BatchIterator[T](iter: Iterator[T], batchSize: Int)
 /**
  * A physical plan that evaluates a [[PythonUDF]].
  */
-case class ArrowEvalPythonExec(udfs: Seq[PythonUDF], resultAttrs: Seq[Attribute], child: SparkPlan,
-    evalType: Int)
-  extends EvalPythonExec with PythonSQLMetrics {
+case class ArrowEvalPythonExec(
+    udfs: Seq[PythonUDF],
+    resultAttrs: Seq[Attribute],
+    child: SparkPlan,
+    evalType: Int) extends EvalPythonExec with PythonSQLMetrics {
+  if (!supportedPythonEvalTypes.contains(evalType)) {
+    throw SparkException.internalError(s"Unexpected eval type $evalType")
+  }
 
   private[this] val jobArtifactUUID = JobArtifactSet.getCurrentJobArtifactState.map(_.uuid)
 
@@ -85,6 +90,14 @@ case class ArrowEvalPythonExec(udfs: Seq[PythonUDF], resultAttrs: Seq[Attribute]
 
   override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
     copy(child = newChild)
+
+  private def supportedPythonEvalTypes: Array[Int] =
+    Array(
+      PythonEvalType.SQL_ARROW_BATCHED_UDF,
+      PythonEvalType.SQL_SCALAR_ARROW_UDF,
+      PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF,
+      PythonEvalType.SQL_SCALAR_PANDAS_UDF,
+      PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF)
 }
 
 class ArrowEvalPythonEvaluatorFactory(


### PR DESCRIPTION
### What changes were proposed in this pull request?
List the supported eval types in arrow nodes


### Why are the changes needed?
validate the eval types and make code more readability


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
existing tests


### Was this patch authored or co-authored using generative AI tooling?
no