### PR TITLE
[SPARK-52008][FOLLOWUP] Fixing StateStoreCoordinator `warn` compilation messages from batch commit tracking

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinator.scala
@@ -394,7 +394,7 @@ private class StateStoreCoordinator(
         batchCommitTrackers.put(key, new BatchCommitTracker(runId, batchId, expectedStores))
         logInfo(s"Started tracking commits for batch $batchId with " +
           s"${expectedStores.values.map(_.values.sum).sum} expected stores")
-        context.reply()
+        context.reply(())
       }
 
     case ReportStateStoreCommit(storeId, version, storeName) =>
@@ -404,10 +404,10 @@ private class StateStoreCoordinator(
       batchCommitTrackers.get(key) match {
         case Some(tracker) =>
           tracker.recordCommit(storeId, storeName)
-          context.reply()
+          context.reply(())
         case None =>
           // In case no commit tracker for this batch was found
-          context.reply()
+          context.reply(())
       }
 
     case ValidateStateStoreCommitForBatch(runId, batchId) =>
@@ -417,7 +417,7 @@ private class StateStoreCoordinator(
           try {
             tracker.validateAllCommitted()
             batchCommitTrackers.remove(key) // Clean up after validation
-            context.reply()
+            context.reply(())
           } catch {
             case e: StateStoreCommitValidationFailed =>
               batchCommitTrackers.remove(key) // Clean up even on failure


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Changing the empty `context.reply()` in the StateStoreCoordinator to use `context.reply(())`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This PR: https://github.com/apache/spark/pull/51706 introduced the following `warn` compilation messages, 
```
[warn] /home/runner/work/spark/spark/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinator.scala:397:22: adaptation of an empty argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous
[warn]         signature: RpcCallContext.reply(response: Any): Unit
[warn]   given arguments: <none>
[warn]  after adaptation: RpcCallContext.reply((): Unit)
[warn] Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=deprecation, site=org.apache.spark.sql.execution.streaming.state.StateStoreCoordinator.receiveAndReply, origin=org.apache.spark.rpc.RpcCallContext.reply, version=2.11.0
[warn]         context.reply()
[warn]                      ^
[warn] /home/runner/work/spark/spark/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinator.scala:407:24: adaptation of an empty argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous
[warn]         signature: RpcCallContext.reply(response: Any): Unit
[warn]   given arguments: <none>
[warn]  after adaptation: RpcCallContext.reply((): Unit)
[warn] Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=deprecation, site=org.apache.spark.sql.execution.streaming.state.StateStoreCoordinator.receiveAndReply, origin=org.apache.spark.rpc.RpcCallContext.reply, version=2.11.0
[warn]           context.reply()
[warn]                        ^
[warn] /home/runner/work/spark/spark/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinator.scala:410:24: adaptation of an empty argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous
[warn]         signature: RpcCallContext.reply(response: Any): Unit
[warn]   given arguments: <none>
[warn]  after adaptation: RpcCallContext.reply((): Unit)
[warn] Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=deprecation, site=org.apache.spark.sql.execution.streaming.state.StateStoreCoordinator.receiveAndReply, origin=org.apache.spark.rpc.RpcCallContext.reply, version=2.11.0
[warn]           context.reply()
[warn]                        ^
[warn] /home/runner/work/spark/spark/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinator.scala:420:26: adaptation of an empty argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous
[warn]         signature: RpcCallContext.reply(response: Any): Unit
[warn]   given arguments: <none>
[warn]  after adaptation: RpcCallContext.reply((): Unit)
[warn] Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=deprecation, site=org.apache.spark.sql.execution.streaming.state.StateStoreCoordinator.receiveAndReply, origin=org.apache.spark.rpc.RpcCallContext.reply, version=2.11.0
[warn]             context.reply()
```
By changing these to `context.reply(())` these messages do not show up anymore. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
By running `build/sbt clean "sql/Test/compile"` locally.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No