### PR TITLE
[SPARK-53249][INFRA] Run `build_maven_java21_arm.yml` every two days

### DIFF
--- a/.github/workflows/build_maven_java21_arm.yml
+++ b/.github/workflows/build_maven_java21_arm.yml
@@ -21,7 +21,7 @@ name: "Build / Maven (master, Scala 2.13, Hadoop 3, JDK 21, ARM)"
 
 on:
   schedule:
-    - cron: '0 15 * * *'
+    - cron: '0 15 */2 * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to reduce `build_maven_java21_arm.yml` frequency from once per day to every two days.

### Why are the changes needed?

`ARM64` GitHub Action job was added recently for Apache Spark 4.1.0 via the following.

- #50553

Like we did for `MacOS` GitHub Action job, we had better adjust the frequency in order to reduce GitHub Action usage to meet ASF INFRA policy for [SPARK-48094 Reduce GitHub Action usage according to ASF project allowance](https://issues.apache.org/jira/browse/SPARK-48094).

- #46343


**ASF Policy**
> The average number of minutes a project uses per calendar week MUST NOT exceed the equivalent of 25 full-time runners (250,000 minutes, or 4,200 hours).

- https://infra-reports.apache.org/#ghactions&project=spark&hours=168

<img width="1137" height="496" alt="Screenshot 2025-08-11 at 12 07 29" src="https://github.com/user-attachments/assets/fbb8b500-e1b2-4fa6-9e31-4d5decd51ebb" />

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

As of Today, `ARM64` job is Top-6 time-consuming job. We need to re-check next week after merging this.

### Was this patch authored or co-authored using generative AI tooling?

Pass the CIs.