### PR TITLE
[SPARK-53250][BUILD] Remove unused `Guava` dependency from `unsafe` module

### DIFF
--- a/common/unsafe/pom.xml
+++ b/common/unsafe/pom.xml
@@ -94,10 +94,6 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
 
     <!-- Provided dependencies -->
     <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove unused `Guava` dependency from `unsafe` module.

### Why are the changes needed?

To simplify the dependency tree by removing unused ones.

**BEFORE**

```
$ mvn dependency:tree --pl common/unsafe --am | grep guava
[INFO] +- com.google.guava:guava:jar:33.4.0-jre:provided
[INFO] |  +- com.google.guava:failureaccess:jar:1.0.2:provided
[INFO] |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:provided
```

**AFTER**

```
$ mvn dependency:tree --pl common/unsafe --am | grep guava
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.