### PR TITLE
[SPARK-53252][CORE][TESTS] Use Java `IntStream` instead of `ParSeq` in `CollationFactorySuite`

### DIFF
--- a/common/unsafe/pom.xml
+++ b/common/unsafe/pom.xml
@@ -54,12 +54,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.scala-lang.modules</groupId>
-      <artifactId>scala-parallel-collections_${scala.binary.version}</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>
       <version>${icu4j.version}</version>

--- a/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
+++ b/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark.unsafe.types
 
-import scala.collection.parallel.immutable.ParSeq
+import java.util.stream.IntStream
+
 import scala.jdk.CollectionConverters.MapHasAsScala
 
 import com.ibm.icu.util.ULocale
@@ -293,7 +294,7 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
     (0 to 10).foreach(_ => {
       val collator = fetchCollation("UNICODE").getCollator
 
-      ParSeq(0 to 100).foreach { _ =>
+      IntStream.rangeClosed(0, 100).parallel().forEach { _ =>
         collator.getCollationKey("aaa")
       }
     })


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `IntStream` instead of `ParSeq` in CollationFactorySuite

### Why are the changes needed?

This is the only instance we use` ParSeq`. We can use Java 8+ `IntStream` simply for this testing purpose and removes `scala-parallel-collection_2.13` test dependency.

```
$ git grep scala.collection.parallel.immutable.ParSeq
common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala:import scala.collection.parallel.immutable.ParSeq
```

### Does this PR introduce _any_ user-facing change?

No. This is a test-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.