### PR TITLE
[SPARK-53254][PYTHON][TESTS] Skip hanging tests in PyPy daily workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,7 +48,7 @@ on:
           in this file, e.g., build. See precondition job below.
         required: false
         type: string
-        default: '{"pyspark": "true", "pyspark-pandas": "true"}'
+        default: ''
     secrets:
       codecov_token:
         description: The upload token of codecov.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,14 +41,14 @@ on:
         description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false
         type: string
-        default: '{"PYSPARK_IMAGE_TO_TEST": "python-311", "PYTHON_TO_TEST": "python3.11"}'
+        default: '{"PYSPARK_IMAGE_TO_TEST": "pypy-310", "PYTHON_TO_TEST": "pypy3"}'
       jobs:
         description: >-
           Jobs to run, and should be in JSON format. The values should be matched with the job's key defined
           in this file, e.g., build. See precondition job below.
         required: false
         type: string
-        default: ''
+        default: '{"pyspark": "true", "pyspark-pandas": "true"}'
     secrets:
       codecov_token:
         description: The upload token of codecov.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,7 +48,7 @@ on:
           in this file, e.g., build. See precondition job below.
         required: false
         type: string
-        default: ''
+        default: '{"pyspark": "true", "pyspark-pandas": "true"}'
     secrets:
       codecov_token:
         description: The upload token of codecov.

--- a/python/pyspark/sql/tests/streaming/test_streaming.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming.py
@@ -16,9 +16,11 @@
 #
 
 import os
+import platform
 import shutil
 import tempfile
 import time
+import unittest
 
 from pyspark.sql import Row
 from pyspark.sql.functions import lit
@@ -503,6 +505,9 @@ class StreamingTestsMixin:
         self.assertTrue(len(result) >= 6 and len(result) <= 9)
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class StreamingTests(StreamingTestsMixin, ReusedSQLTestCase):
     def _assert_exception_tree_contains_msg(self, exception, msg):
         e = exception
@@ -514,7 +519,6 @@ class StreamingTests(StreamingTestsMixin, ReusedSQLTestCase):
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.sql.tests.streaming.test_streaming import *  # noqa: F401
 
     try:

--- a/python/pyspark/sql/tests/streaming/test_streaming_foreach.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_foreach.py
@@ -16,7 +16,9 @@
 #
 
 import os
+import platform
 import tempfile
+import unittest
 
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 
@@ -278,12 +280,14 @@ class StreamingTestsForeachMixin:
         tester.assert_invalid_writer(WriterWithNonCallableClose(), "ATTRIBUTE_NOT_CALLABLE")
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class StreamingTestsForeach(StreamingTestsForeachMixin, ReusedSQLTestCase):
     pass
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.sql.tests.streaming.test_streaming_foreach import *  # noqa: F401
 
     try:

--- a/python/pyspark/sql/tests/streaming/test_streaming_foreach_batch.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_foreach_batch.py
@@ -15,7 +15,10 @@
 # limitations under the License.
 #
 
+import platform
 import time
+import unittest
+
 from pyspark.sql.dataframe import DataFrame
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 
@@ -226,12 +229,14 @@ class StreamingTestsForeachBatchMixin:
             self.assertEqual(sorted(results), ["hello", "this"])
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class StreamingTestsForeachBatch(StreamingTestsForeachBatchMixin, ReusedSQLTestCase):
     pass
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.sql.tests.streaming.test_streaming_foreach_batch import *  # noqa: F401
 
     try:

--- a/python/pyspark/sql/tests/test_artifact.py
+++ b/python/pyspark/sql/tests/test_artifact.py
@@ -16,6 +16,7 @@
 #
 import unittest
 import os
+import platform
 import tempfile
 
 from pyspark.sql.tests.connect.client.test_artifact import ArtifactTestsMixin
@@ -23,6 +24,9 @@ from pyspark.testing.sqlutils import ReusedSQLTestCase
 from pyspark.errors import PySparkRuntimeError
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class ArtifactTests(ArtifactTestsMixin, ReusedSQLTestCase):
     @classmethod
     def root(cls):

--- a/python/pyspark/sql/tests/test_collection.py
+++ b/python/pyspark/sql/tests/test_collection.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import platform
 import datetime
 import unittest
 
@@ -409,6 +410,9 @@ class DataFrameCollectionTestsMixin:
         )
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class DataFrameCollectionTests(
     DataFrameCollectionTestsMixin,
     ReusedSQLTestCase,

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -19,6 +19,7 @@
 from enum import Enum
 from itertools import chain
 import datetime
+import platform
 import unittest
 
 from pyspark.sql import Column, Row
@@ -449,6 +450,9 @@ class ColumnTestsMixin:
             self.assertEqual(r, e, str(c))
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class ColumnTests(ColumnTestsMixin, ReusedSQLTestCase):
     pass
 

--- a/python/pyspark/sql/tests/test_context.py
+++ b/python/pyspark/sql/tests/test_context.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 import os
+import platform
 import shutil
 import sys
 import tempfile
@@ -29,6 +30,9 @@ from pyspark.sql.types import StructType, StringType, StructField
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class HiveContextSQLTests(ReusedSQLTestCase):
     @classmethod
     def setUpClass(cls):
@@ -171,6 +175,9 @@ class HiveContextSQLTests(ReusedSQLTestCase):
         reload(window)
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class SQLContextTests(unittest.TestCase):
     def test_get_or_create(self):
         sc = None

--- a/python/pyspark/sql/tests/test_creation.py
+++ b/python/pyspark/sql/tests/test_creation.py
@@ -17,6 +17,7 @@
 
 from decimal import Decimal
 import os
+import platform
 import time
 import unittest
 from typing import cast
@@ -244,6 +245,9 @@ class DataFrameCreationTestsMixin:
                 assertDataFrameEqual(sdf, data)
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class DataFrameCreationTests(
     DataFrameCreationTestsMixin,
     ReusedSQLTestCase,

--- a/python/pyspark/streaming/tests/test_context.py
+++ b/python/pyspark/streaming/tests/test_context.py
@@ -15,14 +15,19 @@
 # limitations under the License.
 #
 import os
+import platform
 import struct
 import tempfile
 import time
+import unittest
 
 from pyspark.streaming import StreamingContext
 from pyspark.testing.streamingutils import PySparkStreamingTestCase
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class StreamingContextTests(PySparkStreamingTestCase):
     duration = 0.1
     setupCalled = False
@@ -171,7 +176,6 @@ class StreamingContextTests(PySparkStreamingTestCase):
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.streaming.tests.test_context import *  # noqa: F401
 
     try:

--- a/python/pyspark/streaming/tests/test_listener.py
+++ b/python/pyspark/streaming/tests/test_listener.py
@@ -14,10 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+import platform
+import unittest
+
 from pyspark.streaming import StreamingListener
 from pyspark.testing.streamingutils import PySparkStreamingTestCase
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class StreamingListenerTests(PySparkStreamingTestCase):
     duration = 0.5
 
@@ -147,7 +154,6 @@ class StreamingListenerTests(PySparkStreamingTestCase):
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.streaming.tests.test_listener import *  # noqa: F401
 
     try:

--- a/python/pyspark/tests/test_appsubmit.py
+++ b/python/pyspark/tests/test_appsubmit.py
@@ -16,6 +16,7 @@
 #
 
 import os
+import platform
 import re
 import shutil
 import subprocess
@@ -26,6 +27,9 @@ import zipfile
 from pyspark.testing.sqlutils import SPARK_HOME
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class SparkSubmitTests(unittest.TestCase):
     def setUp(self):
         self.programDir = tempfile.mkdtemp()

--- a/python/pyspark/tests/test_broadcast.py
+++ b/python/pyspark/tests/test_broadcast.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 import os
+import platform
 import pickle
 import random
 import time
@@ -29,6 +30,9 @@ from pyspark.serializers import ChunkedStream
 from pyspark.sql import SparkSession, Row
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class BroadcastTest(unittest.TestCase):
     def tearDown(self):
         if getattr(self, "sc", None) is not None:
@@ -141,6 +145,9 @@ class BroadcastTest(unittest.TestCase):
         spark.stop()
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class BroadcastFrameProtocolTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/python/pyspark/tests/test_conf.py
+++ b/python/pyspark/tests/test_conf.py
@@ -14,12 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+import platform
 import random
 import unittest
 
 from pyspark import SparkContext, SparkConf
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class ConfTests(unittest.TestCase):
     def test_memory_conf(self):
         memoryList = ["1T", "1G", "1M", "1024K"]

--- a/python/pyspark/tests/test_context.py
+++ b/python/pyspark/tests/test_context.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 import os
+import platform
 import shutil
 import stat
 import tempfile
@@ -28,6 +29,9 @@ from pyspark.testing.sqlutils import SPARK_HOME
 from pyspark.testing.utils import ReusedPySparkTestCase, PySparkTestCase, QuietTest
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class CheckpointTests(ReusedPySparkTestCase):
     def setUp(self):
         self.checkpointDir = tempfile.NamedTemporaryFile(delete=False)
@@ -76,6 +80,9 @@ class CheckpointTests(ReusedPySparkTestCase):
         self.assertEqual([1, 2, 3, 4], recovered.collect())
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class LocalCheckpointTests(ReusedPySparkTestCase):
     def test_basic_localcheckpointing(self):
         parCollection = self.sc.parallelize([1, 2, 3, 4])
@@ -92,6 +99,9 @@ class LocalCheckpointTests(ReusedPySparkTestCase):
         self.assertEqual(flatMappedRDD.collect(), result)
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class AddFileTests(PySparkTestCase):
     def test_add_py_file(self):
         # To ensure that we're actually testing addPyFile's effects, check that
@@ -172,6 +182,9 @@ class AddFileTests(PySparkTestCase):
         self.assertEqual(["My Server"], self.sc.parallelize(range(1)).map(func).collect())
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class ContextTests(unittest.TestCase):
     def test_failed_sparkcontext_creation(self):
         # Regression test for SPARK-1550
@@ -304,6 +317,9 @@ class ContextTests(unittest.TestCase):
             sc.range(2).foreach(lambda _: create_spark_context())
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class ContextTestsWithResources(unittest.TestCase):
     def setUp(self):
         class_name = self.__class__.__name__

--- a/python/pyspark/tests/test_join.py
+++ b/python/pyspark/tests/test_join.py
@@ -14,9 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+import platform
+import unittest
+
 from pyspark.testing.utils import ReusedPySparkTestCase
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class JoinTests(ReusedPySparkTestCase):
     def test_narrow_dependency_in_join(self):
         rdd = self.sc.parallelize(range(10)).map(lambda x: (x, x))
@@ -57,7 +64,6 @@ class JoinTests(ReusedPySparkTestCase):
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.tests.test_join import *  # noqa: F401
 
     try:

--- a/python/pyspark/tests/test_profiler.py
+++ b/python/pyspark/tests/test_profiler.py
@@ -17,6 +17,7 @@
 
 import os
 import sys
+import platform
 import tempfile
 import unittest
 from io import StringIO
@@ -29,6 +30,9 @@ from pyspark.errors import PythonException, PySparkRuntimeError
 from pyspark.testing.utils import PySparkTestCase, PySparkErrorTestUtils
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class ProfilerTests(PySparkTestCase):
     def setUp(self):
         self._old_sys_path = list(sys.path)
@@ -84,6 +88,9 @@ class ProfilerTests(PySparkTestCase):
         rdd.foreach(heavy_foo)
 
 
+@unittest.skipIf(
+    "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"
+)
 class ProfilerTests2(unittest.TestCase, PySparkErrorTestUtils):
     def test_profiler_disabled(self):
         sc = SparkContext(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Skip hanging tests in PyPy daily workflow


### Why are the changes needed?
to make CI green and the remaining tests can be ran


### Does this PR introduce _any_ user-facing change?
no, test-only

### How was this patch tested?
PR builder with
```
default: '{"PYSPARK_IMAGE_TO_TEST": "pypy-310", "PYTHON_TO_TEST": "pypy3"}'
```

~~the result is https://github.com/zhengruifeng/spark/actions/runs/16895943917/job/47865642387~~


### Was this patch authored or co-authored using generative AI tooling?
no
