### PR TITLE
[SPARK-53253][PYTHON] Fix register UDF of type `SQL_SCALAR_ARROW_ITER_UDF`

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py
@@ -593,6 +593,22 @@ class ScalarArrowUDFTestsMixin:
         self.assertEqual(expected.collect(), res1.collect())
         self.assertEqual(expected.collect(), res2.collect())
 
+        @arrow_udf(LongType())
+        def scalar_iter_add(it: Iterator[Tuple[pa.Array, pa.Array]]) -> Iterator[pa.Array]:
+            for a, b in it:
+                yield pa.compute.add(a, b)
+
+        self.spark.sql("DROP TEMPORARY FUNCTION IF EXISTS add1")
+        new_add = self.spark.udf.register("add1", scalar_iter_add)
+
+        res3 = df.select(new_add(F.col("a"), F.col("b")))
+        res4 = self.spark.sql(
+            "SELECT add1(t.a, t.b) FROM (SELECT id as a, id as b FROM range(10)) t"
+        )
+        expected = df.select(F.expr("a + b"))
+        self.assertEqual(expected.collect(), res3.collect())
+        self.assertEqual(expected.collect(), res4.collect())
+
     def test_catalog_register_arrow_udf_basic(self):
         import pyarrow as pa
 
@@ -618,6 +634,22 @@ class ScalarArrowUDFTestsMixin:
         expected = df.select(F.expr("a + b"))
         self.assertEqual(expected.collect(), res1.collect())
         self.assertEqual(expected.collect(), res2.collect())
+
+        @arrow_udf(LongType())
+        def scalar_iter_add(it: Iterator[Tuple[pa.Array, pa.Array]]) -> Iterator[pa.Array]:
+            for a, b in it:
+                yield pa.compute.add(a, b)
+
+        self.spark.sql("DROP TEMPORARY FUNCTION IF EXISTS add1")
+        new_add = self.spark.catalog.registerFunction("add1", scalar_iter_add)
+
+        res3 = df.select(new_add(F.col("a"), F.col("b")))
+        res4 = self.spark.sql(
+            "SELECT add1(t.a, t.b) FROM (SELECT id as a, id as b FROM range(10)) t"
+        )
+        expected = df.select(F.expr("a + b"))
+        self.assertEqual(expected.collect(), res3.collect())
+        self.assertEqual(expected.collect(), res4.collect())
 
     def test_udf_register_nondeterministic_arrow_udf(self):
         import pyarrow as pa

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -653,6 +653,7 @@ class UDFRegistration:
                 PythonEvalType.SQL_SCALAR_PANDAS_UDF,
                 PythonEvalType.SQL_SCALAR_ARROW_UDF,
                 PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF,
+                PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF,
                 PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
                 PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF,
             ]:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix register UDF of type `SQL_SCALAR_ARROW_ITER_UDF`


### Why are the changes needed?
to fix bug that:
```
In [12]:         @arrow_udf(LongType())
    ...:         def add_one(it: Iterator[pa.Array]) -> Iterator[pa.Array]:
    ...:             for s in it:
    ...:                 yield pa.compute.add(s, 1)
    ...:

...

In [15]: spark.udf.register("xxx", add_one)
---------------------------------------------------------------------------
PySparkTypeError                          Traceback (most recent call last)
Cell In[15], line 1
----> 1 spark.udf.register("xxx", add_one)

File ~/spark/python/pyspark/sql/udf.py:659, in UDFRegistration.register(self, name, f, returnType)
    649 f = cast("UserDefinedFunctionLike", f)
    650 if f.evalType not in [
    651     PythonEvalType.SQL_BATCHED_UDF,
    652     PythonEvalType.SQL_ARROW_BATCHED_UDF,
   (...)    657     PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF,
    658 ]:
--> 659     raise PySparkTypeError(
    660         errorClass="INVALID_UDF_EVAL_TYPE",
    661         messageParameters={
    662             "eval_type": "SQL_BATCHED_UDF, SQL_ARROW_BATCHED_UDF, "
    663             "SQL_SCALAR_PANDAS_UDF, SQL_SCALAR_PANDAS_ITER_UDF, "
    664             "SQL_GROUPED_AGG_PANDAS_UDF or SQL_GROUPED_AGG_ARROW_UDF"
    665         },
    666     )
    667 source_udf = _create_udf(
    668     f.func,
    669     returnType=f.returnType,
   (...)    672     deterministic=f.deterministic,
    673 )
    674 register_udf = source_udf._unwrapped  # type: ignore[attr-defined]

PySparkTypeError: [INVALID_UDF_EVAL_TYPE] ...
```


### Does this PR introduce _any_ user-facing change?
no, this is a new feature in 4.1


### How was this patch tested?
added tests

### Was this patch authored or co-authored using generative AI tooling?
no