### PR TITLE
[SPARK-53256][CORE] Promote `check(Argument|State)` to `JavaUtils`

### DIFF
--- a/common/utils-java/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/utils-java/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -737,4 +737,34 @@ public class JavaUtils {
   public static boolean isUnix = Stream.of("AIX", "HP-UX", "Irix", "Linux", "Mac OS X", "Solaris",
     "SunOS", "FreeBSD", "OpenBSD", "NetBSD")
     .anyMatch(prefix -> osName.regionMatches(true, 0, prefix, 0, prefix.length()));
+
+  /**
+   * Throws IllegalArgumentException if the given object is null.
+   * Keep this clone of CommandBuilderUtils.checkNotNull synced with the original.
+   */
+  public static void checkNotNull(Object o, String arg) {
+    if (o == null) {
+      throw new IllegalArgumentException(String.format("'%s' must not be null.", arg));
+    }
+  }
+
+  /**
+   * Throws IllegalArgumentException with the given message if the check is false.
+   * Keep this clone of CommandBuilderUtils.checkArgument synced with the original.
+   */
+  public static void checkArgument(boolean check, String msg, Object... args) {
+    if (!check) {
+      throw new IllegalArgumentException(String.format(msg, args));
+    }
+  }
+
+  /**
+   * Throws IllegalStateException with the given message if the check is false.
+   * Keep this clone of CommandBuilderUtils.checkState synced with the original.
+   */
+  public static void checkState(boolean check, String msg, Object... args) {
+    if (!check) {
+      throw new IllegalStateException(String.format(msg, args));
+    }
+  }
 }

--- a/common/utils-java/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/utils-java/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -739,16 +739,6 @@ public class JavaUtils {
     .anyMatch(prefix -> osName.regionMatches(true, 0, prefix, 0, prefix.length()));
 
   /**
-   * Throws IllegalArgumentException if the given object is null.
-   * Keep this clone of CommandBuilderUtils.checkNotNull synced with the original.
-   */
-  public static void checkNotNull(Object o, String arg) {
-    if (o == null) {
-      throw new IllegalArgumentException(String.format("'%s' must not be null.", arg));
-    }
-  }
-
-  /**
    * Throws IllegalArgumentException with the given message if the check is false.
    * Keep this clone of CommandBuilderUtils.checkArgument synced with the original.
    */


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to promote the following `checkArgument`, and `checkState` methods to `JavaUtils` by copying.

https://github.com/apache/spark/blob/1ae3d681983be9b7b46ec33282020e7d35b11903/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java#L220-L232

### Why are the changes needed?

- To reuse these Apache Spark utility methods widely in the whole Spark project.
- Note that we need to clone because `launcher` module cannot have the other dependency and the existing methods are not `public`. I added the following style note to ensure them in sync in the future.

  > Keep this clone of CommandBuilderUtils.... synced with the original.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.