### PR TITLE
[SPARK-53261][CORE][SQL] Use Java `String.join|StringJoiner` instead of Guava `Joiner`

### DIFF
--- a/core/src/main/java/org/apache/spark/util/EnumUtil.java
+++ b/core/src/main/java/org/apache/spark/util/EnumUtil.java
@@ -16,10 +16,9 @@
  */
 package org.apache.spark.util;
 
-import org.apache.spark.annotation.Private;
+import java.util.StringJoiner;
 
-import java.util.Arrays;
-import java.util.stream.Collectors;
+import org.apache.spark.annotation.Private;
 
 @Private
 public class EnumUtil {
@@ -34,7 +33,15 @@ public class EnumUtil {
       }
     }
     throw new IllegalArgumentException(
-      String.format("Illegal type='%s'. Supported type values: %s", str,
-        Arrays.stream(constants).map(Object::toString).collect(Collectors.joining(", "))));
+      String.format("Illegal type='%s'. Supported type values: %s",
+        str, joinToString(constants)));
+  }
+
+  private static <E extends Enum<E>> String joinToString(E[] enums) {
+    StringJoiner stringJoiner = new StringJoiner(", ");
+    for (E e : enums) {
+      stringJoiner.add(e.name());
+    }
+    return stringJoiner.toString();
   }
 }

--- a/core/src/main/java/org/apache/spark/util/EnumUtil.java
+++ b/core/src/main/java/org/apache/spark/util/EnumUtil.java
@@ -16,8 +16,10 @@
  */
 package org.apache.spark.util;
 
-import com.google.common.base.Joiner;
 import org.apache.spark.annotation.Private;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 @Private
 public class EnumUtil {
@@ -32,7 +34,7 @@ public class EnumUtil {
       }
     }
     throw new IllegalArgumentException(
-      String.format("Illegal type='%s'. Supported type values: %s",
-        str, Joiner.on(", ").join(constants)));
+      String.format("Illegal type='%s'. Supported type values: %s", str,
+        Arrays.stream(constants).map(Object::toString).collect(Collectors.joining(", "))));
   }
 }

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -192,6 +192,7 @@
             <property name="illegalClasses" value="org.apache.commons.lang3.SystemUtils" />
             <property name="illegalClasses" value="org.apache.hadoop.io.IOUtils" />
             <property name="illegalClasses" value="org.apache.parquet.Preconditions" />
+            <property name="illegalClasses" value="com.google.common.base.Joiner" />
             <property name="illegalClasses" value="com.google.common.base.Objects" />
             <property name="illegalClasses" value="com.google.common.base.Preconditions" />
             <property name="illegalClasses" value="com.google.common.base.Strings" />

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -814,7 +814,7 @@ This file is divided into 3 sections:
 
   <check customId="googleJoiner" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">com\.google\.common\.base\.Joiner\b</parameter></parameters>
-    <customMessage>Use Java APIs (like java.util.Objects) instead.</customMessage>
+    <customMessage>Use Java APIs (like String.join/StringJoiner) instead.</customMessage>
   </check>
 
   <check customId="googleBaseEncoding" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -812,6 +812,11 @@ This file is divided into 3 sections:
     <customMessage>Use Java APIs (like java.util.Objects) instead.</customMessage>
   </check>
 
+  <check customId="googleJoiner" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">com\.google\.common\.base\.Joiner\b</parameter></parameters>
+    <customMessage>Use Java APIs (like java.util.Objects) instead.</customMessage>
+  </check>
+
   <check customId="googleBaseEncoding" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">com\.google\.common\.io\.BaseEncoding\b</parameter></parameters>
     <customMessage>Use Java APIs (like java.util.Base64) instead.</customMessage>

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/LogDivertAppender.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/LogDivertAppender.java
@@ -66,17 +66,17 @@ public class LogDivertAppender extends AbstractWriterAppender<WriterManager> {
     /* Patterns that are excluded in verbose logging level.
      * Filter out messages coming from log processing classes, or we'll run an infinite loop.
      */
-    private static final Pattern verboseExcludeNamePattern = Pattern.compile(
-      String.join("|", LOG.getName(), OperationLog.class.getName(),
-        OperationManager.class.getName()));
+    private static final Pattern verboseExcludeNamePattern = Pattern.compile(String.join("|",
+      LOG.getName(), OperationLog.class.getName(),
+      OperationManager.class.getName()));
 
     /* Patterns that are included in execution logging level.
      * In execution mode, show only select logger messages.
      */
-    private static final Pattern executionIncludeNamePattern = Pattern.compile(
-      String.join("|", "org.apache.hadoop.mapreduce.JobSubmitter",
-        "org.apache.hadoop.mapreduce.Job", "SessionState", Task.class.getName(),
-        "org.apache.hadoop.hive.ql.exec.spark.status.SparkJobMonitor"));
+    private static final Pattern executionIncludeNamePattern = Pattern.compile(String.join("|",
+      "org.apache.hadoop.mapreduce.JobSubmitter",
+      "org.apache.hadoop.mapreduce.Job", "SessionState", Task.class.getName(),
+      "org.apache.hadoop.hive.ql.exec.spark.status.SparkJobMonitor"));
 
     /* Patterns that are included in performance logging level.
      * In performance mode, show execution and performance logger messages.

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/LogDivertAppender.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/LogDivertAppender.java
@@ -38,7 +38,6 @@ import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.appender.AbstractWriterAppender;
 import org.apache.logging.log4j.core.appender.WriterManager;
-import com.google.common.base.Joiner;
 import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.message.Message;
 
@@ -67,17 +66,17 @@ public class LogDivertAppender extends AbstractWriterAppender<WriterManager> {
     /* Patterns that are excluded in verbose logging level.
      * Filter out messages coming from log processing classes, or we'll run an infinite loop.
      */
-    private static final Pattern verboseExcludeNamePattern = Pattern.compile(Joiner.on("|")
-      .join(new String[] {LOG.getName(), OperationLog.class.getName(),
-      OperationManager.class.getName()}));
+    private static final Pattern verboseExcludeNamePattern = Pattern.compile(
+      String.join("|", LOG.getName(), OperationLog.class.getName(),
+        OperationManager.class.getName()));
 
     /* Patterns that are included in execution logging level.
      * In execution mode, show only select logger messages.
      */
-    private static final Pattern executionIncludeNamePattern = Pattern.compile(Joiner.on("|")
-      .join(new String[] {"org.apache.hadoop.mapreduce.JobSubmitter",
-      "org.apache.hadoop.mapreduce.Job", "SessionState", Task.class.getName(),
-      "org.apache.hadoop.hive.ql.exec.spark.status.SparkJobMonitor"}));
+    private static final Pattern executionIncludeNamePattern = Pattern.compile(
+      String.join("|", "org.apache.hadoop.mapreduce.JobSubmitter",
+        "org.apache.hadoop.mapreduce.Job", "SessionState", Task.class.getName(),
+        "org.apache.hadoop.hive.ql.exec.spark.status.SparkJobMonitor"));
 
     /* Patterns that are included in performance logging level.
      * In performance mode, show execution and performance logger messages.


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pull request replaces `com.google.common.base.Joiner#join` with `java.lang.String#join`|`java.util.StringJoiner`.


### Why are the changes needed?
Give priority to using methods within the JDK.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No