### PR TITLE
[SPARK-53050][PS] Enable MultiIndex.to_series() to return struct for each entry

### DIFF
--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -924,21 +924,23 @@ class Index(IndexOpsMixin):
             return result
         else:
             # MultiIndex
-            def struct_to_array(scol: Column) -> Column:
-                field_names = result._internal.spark_type_for(
-                    scol
-                ).fieldNames()  # type: ignore[attr-defined]
-                field_types = [
-                    result._internal.spark_type_for(scol[field]) for field in field_names
-                ]
+            if is_ansi_mode_enabled(self._internal.spark_frame.sparkSession):
 
-                has_str = any(isinstance(t, StringType) for t in field_types)
-                if has_str and is_ansi_mode_enabled(self._internal.spark_frame.sparkSession):
-                    return F.array([scol[field].cast(StringType()) for field in field_names])
-                else:
+                def struct_to_struct(scol: Column) -> Column:
+                    # scol is a struct; keep fields as-is so pandas sees tuples later
+                    field_names = result._internal.spark_type_for(scol).fieldNames()  # type: ignore[attr-defined]
+                    return F.struct(*[(scol[f]).alias(f) for f in field_names])
+
+                return result.spark.transform(struct_to_struct)
+            else:
+
+                def struct_to_array(scol: Column) -> Column:
+                    field_names = result._internal.spark_type_for(
+                        scol
+                    ).fieldNames()  # type: ignore[attr-defined]
                     return F.array([scol[field] for field in field_names])
 
-            return result.spark.transform(struct_to_array)
+                return result.spark.transform(struct_to_array)
 
     def to_frame(self, index: bool = True, name: Optional[Name] = None) -> DataFrame:
         """

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -929,7 +929,9 @@ class Index(IndexOpsMixin):
             else:
 
                 def struct_to_array(scol: Column) -> Column:
-                    field_names = result._internal.spark_type_for(scol).fieldNames()  # type: ignore[attr-defined]
+                    field_names = result._internal.spark_type_for(
+                        scol
+                    ).fieldNames()  # type: ignore[attr-defined]
                     return F.array([scol[field] for field in field_names])
 
                 return result.spark.transform(struct_to_array)

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -50,7 +50,6 @@ from pyspark.sql import functions as F
 from pyspark.sql.types import (
     DayTimeIntervalType,
     IntegralType,
-    StringType,
     TimestampType,
     TimestampNTZType,
 )

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -925,19 +925,11 @@ class Index(IndexOpsMixin):
         else:
             # MultiIndex
             if is_ansi_mode_enabled(self._internal.spark_frame.sparkSession):
-
-                def struct_to_struct(scol: Column) -> Column:
-                    # scol is a struct; keep fields as-is so pandas sees tuples later
-                    field_names = result._internal.spark_type_for(scol).fieldNames()  # type: ignore[attr-defined]
-                    return F.struct(*[(scol[f]).alias(f) for f in field_names])
-
-                return result.spark.transform(struct_to_struct)
+                return result
             else:
 
                 def struct_to_array(scol: Column) -> Column:
-                    field_names = result._internal.spark_type_for(
-                        scol
-                    ).fieldNames()  # type: ignore[attr-defined]
+                    field_names = result._internal.spark_type_for(scol).fieldNames()  # type: ignore[attr-defined]
                     return F.array([scol[field] for field in field_names])
 
                 return result.spark.transform(struct_to_array)

--- a/python/pyspark/pandas/tests/indexes/test_conversion.py
+++ b/python/pyspark/pandas/tests/indexes/test_conversion.py
@@ -20,7 +20,6 @@ from datetime import datetime
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.sql import Row
 from pyspark.testing.pandasutils import PandasOnSparkTestCase, SPARK_CONF_ARROW_ENABLED
 from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.testing.utils import is_ansi_mode_test
@@ -200,6 +199,15 @@ class ConversionMixin:
                     {"__index_level_0__": 2, "__index_level_1__": "blue"},
                 ],
             )
+            with self.sql_conf(
+                {
+                    "spark.sql.execution.pandas.structHandlingMode": "row",
+                }
+            ):
+                self.assert_eq(
+                    list(psidx.to_series().values),
+                    list(pidx.to_series().values),
+                )
         else:
             self.assert_eq(list(psidx.to_series().values), [["1", "red"], ["2", "blue"]])
 

--- a/python/pyspark/pandas/tests/indexes/test_conversion.py
+++ b/python/pyspark/pandas/tests/indexes/test_conversion.py
@@ -20,8 +20,10 @@ from datetime import datetime
 import pandas as pd
 
 from pyspark import pandas as ps
+from pyspark.sql import Row
 from pyspark.testing.pandasutils import PandasOnSparkTestCase, SPARK_CONF_ARROW_ENABLED
 from pyspark.testing.sqlutils import SQLTestUtils
+from pyspark.testing.utils import is_ansi_mode_test
 
 
 class ConversionMixin:
@@ -187,10 +189,19 @@ class ConversionMixin:
 
         # Multiindex
         arrays = [[1, 2], ["red", "blue"]]
-        psidx = ps.MultiIndex.from_arrays(arrays, names=("number", "color"))
-        res_psser = psidx.to_series()
-        # TODO(SPARK-53050): MultiIndex.to_series() should return tuples for each entry
-        self.assert_eq(list(res_psser.values), [["1", "red"], ["2", "blue"]])
+        pidx = pd.MultiIndex.from_arrays(arrays, names=("number", "color"))
+        psidx = ps.from_pandas(pidx)
+
+        if is_ansi_mode_test:
+            self.assert_eq(
+                list(psidx.to_series().values),
+                [
+                    {"__index_level_0__": 1, "__index_level_1__": "red"},
+                    {"__index_level_0__": 2, "__index_level_1__": "blue"},
+                ],
+            )
+        else:
+            self.assert_eq(list(psidx.to_series().values), [["1", "red"], ["2", "blue"]])
 
         pidx = self.pdf.set_index("b", append=True).index
         psidx = self.psdf.set_index("b", append=True).index

--- a/python/pyspark/pandas/tests/indexes/test_conversion.py
+++ b/python/pyspark/pandas/tests/indexes/test_conversion.py
@@ -20,7 +20,11 @@ from datetime import datetime
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import PandasOnSparkTestCase, SPARK_CONF_ARROW_ENABLED
+from pyspark.testing.pandasutils import (
+    PandasOnSparkTestCase,
+    SPARK_CONF_ARROW_ENABLED,
+    SPARK_CONF_PANDAS_STRUCT_MODE,
+)
 from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.testing.utils import is_ansi_mode_test
 
@@ -192,16 +196,9 @@ class ConversionMixin:
         psidx = ps.from_pandas(pidx)
 
         if is_ansi_mode_test:
-            self.assert_eq(
-                list(psidx.to_series().values),
-                [
-                    {"__index_level_0__": 1, "__index_level_1__": "red"},
-                    {"__index_level_0__": 2, "__index_level_1__": "blue"},
-                ],
-            )
             with self.sql_conf(
                 {
-                    "spark.sql.execution.pandas.structHandlingMode": "row",
+                    SPARK_CONF_PANDAS_STRUCT_MODE: "row",
                 }
             ):
                 self.assert_eq(
@@ -214,7 +211,7 @@ class ConversionMixin:
         pidx = self.pdf.set_index("b", append=True).index
         psidx = self.psdf.set_index("b", append=True).index
 
-        with self.sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
+        with self.sql_conf({SPARK_CONF_ARROW_ENABLED: False, SPARK_CONF_PANDAS_STRUCT_MODE: "row"}):
             self.assert_eq(psidx.to_series(), pidx.to_series(), check_exact=False)
             self.assert_eq(psidx.to_series(name="a"), pidx.to_series(name="a"), check_exact=False)
 

--- a/python/pyspark/pandas/tests/indexes/test_conversion.py
+++ b/python/pyspark/pandas/tests/indexes/test_conversion.py
@@ -20,10 +20,10 @@ from datetime import datetime
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.pandas.utils import SPARK_CONF_PANDAS_STRUCT_MODE
 from pyspark.testing.pandasutils import (
     PandasOnSparkTestCase,
     SPARK_CONF_ARROW_ENABLED,
+    SPARK_CONF_PANDAS_STRUCT_MODE,
 )
 from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.testing.utils import is_ansi_mode_test

--- a/python/pyspark/pandas/tests/indexes/test_conversion.py
+++ b/python/pyspark/pandas/tests/indexes/test_conversion.py
@@ -20,10 +20,10 @@ from datetime import datetime
 import pandas as pd
 
 from pyspark import pandas as ps
+from pyspark.pandas.utils import SPARK_CONF_PANDAS_STRUCT_MODE
 from pyspark.testing.pandasutils import (
     PandasOnSparkTestCase,
     SPARK_CONF_ARROW_ENABLED,
-    SPARK_CONF_PANDAS_STRUCT_MODE,
 )
 from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.testing.utils import is_ansi_mode_test

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -71,6 +71,7 @@ ERROR_MESSAGE_CANNOT_COMBINE = (
 
 
 SPARK_CONF_ARROW_ENABLED = "spark.sql.execution.arrow.pyspark.enabled"
+SPARK_CONF_PANDAS_STRUCT_MODE = "spark.sql.execution.pandas.structHandlingMode"
 
 
 class PandasAPIOnSparkAdviceWarning(Warning):

--- a/python/pyspark/testing/pandasutils.py
+++ b/python/pyspark/testing/pandasutils.py
@@ -36,7 +36,10 @@ import pyspark.pandas as ps
 from pyspark.pandas.frame import DataFrame
 from pyspark.pandas.indexes import Index
 from pyspark.pandas.series import Series
-from pyspark.pandas.utils import SPARK_CONF_ARROW_ENABLED
+from pyspark.pandas.utils import (
+    SPARK_CONF_ARROW_ENABLED,
+    SPARK_CONF_PANDAS_STRUCT_MODE,  # noqa: F401
+)
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 from pyspark.testing.utils import is_ansi_mode_test
 from pyspark.errors import PySparkAssertionError


### PR DESCRIPTION
### What changes were proposed in this pull request?
MultiIndex.to_series() builds a Spark array column, produces a list for each index value.
This PR uses Spark struct column instead, which enables MultiIndex.to_series() to return Rows for each entry, with `"spark.sql.execution.pandas.structHandlingMode"` setting to "row".

### Why are the changes needed?
Part of https://issues.apache.org/jira/browse/SPARK-52984

### Does this PR introduce _any_ user-facing change?
Yes

```py
>>> arrays = [[1,  2], ["red", "blue"]]
>>> pidx = pd.MultiIndex.from_arrays(arrays, names=("number", "color"))
>>> psidx = ps.from_pandas(pidx)
```

Before
```py
>>> psidx.to_series()
number  color
1       red       [1, red]
2       blue     [2, blue]
dtype: object
```

After
```py
>>> spark.conf.set("spark.sql.execution.arrow.pyspark.enabled", "true")
>>> spark.conf.set("spark.sql.execution.pandas.structHandlingMode", "row")
>>> psidx.to_series()
number  color
1       red       (1, red)
2       blue     (2, blue)
dtype: object

>>> spark.conf.set("spark.sql.execution.arrow.pyspark.enabled", "false")
>>> psidx.to_series()
number  color
1       red       (1, red)
2       blue     (2, blue)
dtype: object
```

### How was this patch tested?
Unit tests


### Was this patch authored or co-authored using generative AI tooling?
No
