### PR TITLE
[SPARK-53262][SS] Support schema evolution for streaming dedupe operation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -154,7 +154,6 @@ object UnsupportedOperationChecker extends Logging {
     case f: FlatMapGroupsWithState if f.isStreaming => Some("flatMapGroupsWithState")
     case f: FlatMapGroupsInPandasWithState if f.isStreaming =>
       Some("applyInPandasWithState")
-    case d: Deduplicate if d.isStreaming => Some("dropDuplicates")
     case d: DeduplicateWithinWatermark if d.isStreaming => Some("dropDuplicatesWithinWatermark")
     case _ => None
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
@@ -1280,6 +1280,8 @@ abstract class BaseStreamingDeduplicateExec
       keyExpressions, getStateInfo, conf) :: Nil
   }
 
+  override def supportsSchemaEvolution: Boolean = true
+
   protected val schemaForValueRow: StructType
   protected val extraOptionOnStateStore: Map[String, String]
 
@@ -1404,7 +1406,7 @@ case class StreamingDeduplicateExec(
       keyExpressions.toStructType, 0, schemaForValueRow))
     List(StateSchemaCompatibilityChecker.validateAndMaybeEvolveStateSchema(getStateInfo, hadoopConf,
       newStateSchema, session.sessionState, stateSchemaVersion,
-      extraOptions = extraOptionOnStateStore))
+      extraOptions = extraOptionOnStateStore, schemaEvolutionEnabled = true))
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/IncrementalExecution.scala
@@ -286,6 +286,12 @@ class IncrementalExecution(
                   exec.copy(stateInfo = Some(exec.getStateInfo.copy(
                     stateSchemaMetadata = Some(stateSchemaBroadcast))))
                 // Add other cases if needed for different StateStoreWriter implementations
+                case exec: StreamingDeduplicateExec =>
+                  exec.copy(
+                    stateInfo = Some(
+                      exec.getStateInfo.copy(stateSchemaMetadata = Some(stateSchemaBroadcast))
+                    )
+                  )
                 case _ => ssw
               }
             } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationAvroSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationAvroSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming
+
+import org.scalactic.source.Position
+import org.scalatest.Tag
+
+import org.apache.spark.sql.internal.SQLConf
+
+class StreamingDeduplicationAvroSuite extends StreamingDeduplicationSuite {
+
+  import testImplicits._
+
+  override protected def test(testName: String, testTags: Tag*)(testBody: => Any)
+                             (implicit pos: Position): Unit = {
+    super.test(s"$testName (encoding = Avro)", testTags: _*) {
+      withSQLConf(SQLConf.STREAMING_STATE_STORE_ENCODING_FORMAT.key -> "avro") {
+        testBody
+      }
+    }
+  }
+
+  test("deduplicate with add fields schema evolution") {
+
+  }
+
+  test("deduplicate with remove fields schema evolution") {
+
+  }
+
+  test("deduplicate with reorder fields schema evolution") {
+
+  }
+
+  test("deduplicate with upcast fields schema evolution") {
+
+  }
+
+  test("deduplicate with downcast fields would fail") {
+
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationAvroSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationAvroSuite.scala
@@ -21,6 +21,7 @@ import org.scalactic.source.Position
 import org.scalatest.Tag
 
 import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider
 import org.apache.spark.sql.internal.SQLConf
 
 class StreamingDeduplicationAvroSuite extends StreamingDeduplicationSuite {
@@ -30,7 +31,10 @@ class StreamingDeduplicationAvroSuite extends StreamingDeduplicationSuite {
   override protected def test(testName: String, testTags: Tag*)(testBody: => Any)
                              (implicit pos: Position): Unit = {
     super.test(s"$testName (encoding = Avro)", testTags: _*) {
-      withSQLConf(SQLConf.STREAMING_STATE_STORE_ENCODING_FORMAT.key -> "avro") {
+      withSQLConf(
+        SQLConf.STREAMING_STATE_STORE_ENCODING_FORMAT.key -> "avro",
+        SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName
+      ) {
         testBody
       }
     }
@@ -66,10 +70,10 @@ class StreamingDeduplicationAvroSuite extends StreamingDeduplicationSuite {
         assertNumStateRows(total = 3, updated = 1),
         AddData(inputData, ("a", "key4", 2)), // Dropped
         CheckLastBatch(),
-        assertNumStateRows(total = 3, updated = 0),
-        AddData(inputData, ("a", null, 1)), // Dropped
-        CheckLastBatch(),
         assertNumStateRows(total = 3, updated = 0)
+//        AddData(inputData, ("a", null, 1)), // Dropped
+//        CheckLastBatch(),
+//        assertNumStateRows(total = 3, updated = 0)
       )
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationAvroSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationAvroSuite.scala
@@ -70,10 +70,11 @@ class StreamingDeduplicationAvroSuite extends StreamingDeduplicationSuite {
         assertNumStateRows(total = 3, updated = 1),
         AddData(inputData, ("a", "key4", 2)), // Dropped
         CheckLastBatch(),
-        assertNumStateRows(total = 3, updated = 0)
-//        AddData(inputData, ("a", null, 1)), // Dropped
-//        CheckLastBatch(),
-//        assertNumStateRows(total = 3, updated = 0)
+        assertNumStateRows(total = 3, updated = 0),
+        // Would not dropped since key {a, null} does not equal to {a}
+        AddData(inputData, ("a", null, 1)),
+        CheckLastBatch(("a", null, 1)),
+        assertNumStateRows(total = 4, updated = 1)
       )
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationAvroSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationAvroSuite.scala
@@ -41,7 +41,7 @@ class StreamingDeduplicationAvroSuite extends StreamingDeduplicationSuite {
       val dirPath = chkptDir.getCanonicalPath
       val inputData = MemoryStream[(String, String, Int)]
       val result1 = inputData.toDS().dropDuplicates("_1")
-      testStream(result1, OutputMode.Append())(
+      testStream(result1, OutputMode.Append)(
         StartStream(checkpointLocation = dirPath),
         AddData(inputData, ("a", "key1", 1)),
         CheckLastBatch(("a", "key1", 1)),
@@ -56,7 +56,7 @@ class StreamingDeduplicationAvroSuite extends StreamingDeduplicationSuite {
       )
 
       val result2 = inputData.toDS().dropDuplicates("_1", "_2")
-      testStream(result1, OutputMode.Append())(
+      testStream(result2, OutputMode.Append)(
         StartStream(checkpointLocation = dirPath),
         AddData(inputData, ("a", "key3", 1)),
         CheckLastBatch(("a", "key3", 1)),
@@ -69,7 +69,7 @@ class StreamingDeduplicationAvroSuite extends StreamingDeduplicationSuite {
         assertNumStateRows(total = 3, updated = 0),
         AddData(inputData, ("a", null, 1)), // Dropped
         CheckLastBatch(),
-        assertNumStateRows(total = 3, updated = 0),
+        assertNumStateRows(total = 3, updated = 0)
       )
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
