### PR TITLE
[SPARK-53263][PYTHON] Support TimeType in df.toArrow

### DIFF
--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -128,6 +128,8 @@ def to_arrow_type(
         arrow_type = pa.timestamp("us", tz=None)
     elif type(dt) == DayTimeIntervalType:
         arrow_type = pa.duration("us")
+    elif type(dt) == TimeType:
+        arrow_type = pa.time64("ns")
     elif type(dt) == ArrayType:
         field = pa.field(
             "element",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
1, Support TimeType in `df.toArrow`
2, Add tests for collection (collect/toPandas/toArrow)

### Why are the changes needed?

`df.toArrow` doesn't work when the schema includes TimeType

```
In [1]:         query = """
   ...:                 SELECT * FROM VALUES
   ...:                 (TIME '12:34:56', 'a'), (TIME '22:56:01', 'b'), (NULL, 'c')
   ...:                 AS tab(t, i)
   ...:                 """
   ...:
   ...:         df = spark.sql(query)

In [2]: df.collect()
Out[2]:
[Row(t=datetime.time(12, 34, 56), i='a'),
 Row(t=datetime.time(22, 56, 1), i='b'),
 Row(t=None, i='c')]

In [3]: df.toPandas()
Out[3]:
          t  i
0  12:34:56  a
1  22:56:01  b
2      None  c

In [4]: df.toArrow()
---------------------------------------------------------------------------
PySparkTypeError                          Traceback (most recent call last)
...
File ~/spark/python/pyspark/sql/pandas/types.py:204, in to_arrow_type(dt, error_on_duplicated_field_names_in_struct, timestamp_utc, prefers_large_types)
    202     arrow_type = pa.struct(fields)
    203 else:
--> 204     raise PySparkTypeError(
    205         errorClass="UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION",
    206         messageParameters={"data_type": str(dt)},
    207     )
    208 return arrow_type

PySparkTypeError: [UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION] TimeType(6) is not supported in conversion to Arrow.
```


### Does this PR introduce _any_ user-facing change?
yes, df.toArrow supports TimeType


### How was this patch tested?
added test

### Was this patch authored or co-authored using generative AI tooling?
no
