### PR TITLE
[SPARK-52482][SQL][CORE] Improve exception handling for reading certain corrupt zstd 

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import java.io.IOException
 import java.util.Locale
 
 import scala.jdk.CollectionConverters._
@@ -190,6 +191,11 @@ object DataSourceUtils extends PredicateHelper {
       case _ => throw SparkException.internalError(s"Unrecognized format $format.")
     }
     QueryExecutionErrors.sparkUpgradeInWritingDatesError(format, config)
+  }
+
+  def shouldIgnoreCorruptFileException(e: Throwable): Boolean = e match {
+    case _: RuntimeException | _: IOException | _: InternalError => true
+    case _ => false
   }
 
   def createDateRebaseFuncInRead(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import java.io.{Closeable, FileNotFoundException, IOException}
+import java.io.{Closeable, FileNotFoundException}
 import java.net.URI
 
 import org.apache.hadoop.fs.Path
@@ -269,7 +269,8 @@ class FileScanRDD(
                   // Throw FileNotFoundException even if `ignoreCorruptFiles` is true
                   case e: FileNotFoundException if !ignoreMissingFiles => throw e
                   case e @ (_ : AccessControlException | _ : BlockMissingException) => throw e
-                  case e @ (_: RuntimeException | _: IOException) if ignoreCorruptFiles =>
+                  case e if ignoreCorruptFiles &&
+                      DataSourceUtils.shouldIgnoreCorruptFileException(e) =>
                     logWarning(log"Skipped the rest of the content in the corrupted file: " +
                       log"${MDC(PATH, currentFile)}", e)
                     finished = true

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -18,8 +18,9 @@
 package org.apache.spark.sql.execution.datasources.csv
 
 import java.io.{EOFException, File}
+import java.net.URI
 import java.nio.charset.{Charset, StandardCharsets}
-import java.nio.file.{Files, StandardOpenOption}
+import java.nio.file.{Files, Paths, StandardOpenOption}
 import java.sql.{Date, Timestamp}
 import java.text.SimpleDateFormat
 import java.time._
@@ -3491,6 +3492,32 @@ abstract class CSVSuite
     assert(malformedCSVException.getCause.isInstanceOf[TextParsingException])
     val textParsingException = malformedCSVException.getCause.asInstanceOf[TextParsingException]
     assert(textParsingException.getCause.isInstanceOf[ArrayIndexOutOfBoundsException])
+  }
+
+  test("corrupted ZSTD compressed csv respects ignoreCorruptFiles") {
+    withTempDir { dir =>
+      val originalFile = new File(dir, "original.csv.zst")
+      val corruptedHeadFile = new File(dir, "corrupted_head.csv.zst")
+      val corruptedTailFile = new File(dir, "corrupted_tail.csv.zst")
+      val bytes = Files.readAllBytes(Paths.get(new URI(testFile(zstCompressedCarsFile))))
+      Files.write(originalFile.toPath(), bytes)
+      Files.write(corruptedHeadFile.toPath(), bytes.drop(10))
+      Files.write(corruptedTailFile.toPath(), bytes.dropRight(10))
+
+      withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
+        val df = spark.read.format("csv").option("header", "true").load(dir.getAbsolutePath)
+        // check that the entries from originalFile are still read
+        assert(df.count() == 3)
+      }
+
+      withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "false") {
+        val ex = intercept[SparkException] {
+          spark.read.format("csv").option("header", "true").load(dir.getAbsolutePath).collect()
+        }
+        checkErrorMatchPVals(ex, "FAILED_READ_FILE.NO_HINT",
+          Map("path" -> ".*corrupted.*\\.csv\\.zst"))
+      }
+    }
   }
 }
 


### PR DESCRIPTION
The original PR (https://github.com/apache/spark/pull/51916) was [reverted in branch-4.0](https://github.com/apache/spark/pull/51916#issuecomment-3181586493) due to failing CI. 

The error was due to the test suite being re-done in 4.0. 



