### PR TITLE
[SPARK-53264][SQL][CATALYST]. Incorrect nullability when correlated scalar subquery ge…

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
@@ -127,3 +127,4 @@ class RewriteSubquerySuite extends PlanTest {
     assert(!leftSideAttrib.nullable)
   }
 }
+


### PR DESCRIPTION
…ts converted into LeftOuterJoin

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
When a scalar correlated subquery is converted into a Left Outer Join, the Project created on top of the Join,  should have nullability as true, for the attribute reference coming from the right side table.


### Why are the changes needed?
This has the potential for Optimizer eventually converting the Left Outer Join to incorrectly convert it into Inner Join.
So far the bug has remain hidden, to an unintended inefficiency in the PushDownPredicates rule. If that inefficiency is handled ( please look at the issue [SPARK-36786](https://issues.apache.org/jira/browse/SPARK-36786)


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added bug test


### Was this patch authored or co-authored using generative AI tooling?
No
