### PR TITLE
[MINOR][PYTHON][DOCS] Update an UDF example with specified eval type

### DIFF
--- a/python/pyspark/sql/pandas/functions.py
+++ b/python/pyspark/sql/pandas/functions.py
@@ -86,7 +86,7 @@ def arrow_udf(f=None, returnType=None, functionType=None):
 
     >>> from pyspark.sql.functions import ArrowUDFType
     >>> from pyspark.sql.types import IntegerType
-    >>> @arrow_udf(IntegerType())
+    >>> @arrow_udf(IntegerType(), ArrowUDFType.SCALAR)
     ... def slen(v: pa.Array) -> pa.Array:
     ...     return pa.compute.utf8_length(v)
 
@@ -99,7 +99,7 @@ def arrow_udf(f=None, returnType=None, functionType=None):
         The output of the function should always be of the same length as the input.
 
         >>> @arrow_udf("string")
-        ... def to_upper(s: pa.Array, ArrowUDFType.SCALAR) -> pa.Array:
+        ... def to_upper(s: pa.Array) -> pa.Array:
         ...     return pa.compute.ascii_upper(s)
         ...
         >>> df = spark.createDataFrame([("John Doe",)], ("name",))

--- a/python/pyspark/sql/pandas/functions.py
+++ b/python/pyspark/sql/pandas/functions.py
@@ -99,7 +99,7 @@ def arrow_udf(f=None, returnType=None, functionType=None):
         The output of the function should always be of the same length as the input.
 
         >>> @arrow_udf("string")
-        ... def to_upper(s: pa.Array) -> pa.Array:
+        ... def to_upper(s: pa.Array, ArrowUDFType.SCALAR) -> pa.Array:
         ...     return pa.compute.ascii_upper(s)
         ...
         >>> df = spark.createDataFrame([("John Doe",)], ("name",))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Update an UDF example with specified eval type


### Why are the changes needed?
currently the eval types are inferred in all examples, So I think we need a one to show that the eval type can be specified.
And after this change, the examples are consistent with the Pandas UDF examples.

https://github.com/apache/spark/blob/f6cd38598078511fdafd969d31ced14bc4811bb0/python/pyspark/sql/pandas/functions.py#L379


### Does this PR introduce _any_ user-facing change?
yes, doc-only change


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No
