### PR TITLE
[SPARK-52969][SQL] Support DSv2 OrcScan Dynamic Partition Pruning

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScan.scala
@@ -23,9 +23,11 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, InSet}
+import org.apache.spark.sql.connector.expressions.{FieldReference, LiteralValue, NamedReference}
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation
-import org.apache.spark.sql.connector.read.PartitionReaderFactory
+import org.apache.spark.sql.connector.expressions.filter.Predicate
+import org.apache.spark.sql.connector.read.{PartitionReaderFactory, SupportsRuntimeV2Filtering}
 import org.apache.spark.sql.execution.datasources.{AggregatePushDownUtils, PartitioningAwareFileIndex}
 import org.apache.spark.sql.execution.datasources.orc.OrcOptions
 import org.apache.spark.sql.execution.datasources.v2.FileScan
@@ -45,12 +47,18 @@ case class OrcScan(
     options: CaseInsensitiveStringMap,
     pushedAggregate: Option[Aggregation] = None,
     pushedFilters: Array[Filter],
-    partitionFilters: Seq[Expression] = Seq.empty,
-    dataFilters: Seq[Expression] = Seq.empty) extends FileScan {
+    originPartitionFilters: Seq[Expression] = Seq.empty,
+    dataFilters: Seq[Expression] = Seq.empty) extends FileScan with SupportsRuntimeV2Filtering {
   override def isSplitable(path: Path): Boolean = {
     // If aggregate is pushed down, only the file footer will be read once,
     // so file should not be split across multiple tasks.
     pushedAggregate.isEmpty
+  }
+
+  private var dppPartitionFilters: Seq[Expression] = Seq.empty;
+
+  override def partitionFilters: Seq[Expression] = {
+    originPartitionFilters ++ dppPartitionFilters
   }
 
   override def readSchema(): StructType = {
@@ -103,5 +111,25 @@ case class OrcScan(
     super.getMetaData() ++ Map("PushedFilters" -> seqToString(pushedFilters.toImmutableArraySeq)) ++
       Map("PushedAggregation" -> pushedAggregationsStr) ++
       Map("PushedGroupBy" -> pushedGroupByStr)
+  }
+
+  override def filterAttributes(): Array[NamedReference] = {
+    val scanFields = readSchema.fields.map(_.name).toSet
+    readPartitionSchema.fields.map(_.name)
+      .filter(ref => scanFields.contains(ref)).map(f => FieldReference(f))
+  }
+
+  override def filter(predicates: Array[Predicate]): Unit = {
+    predicates.foreach {
+      case p: Predicate if p.name().equals("IN") =>
+        if (p.children().length > 1 && p.children()(0).isInstanceOf[FieldReference]
+          && p.children().tail.forall(_.isInstanceOf[LiteralValue[_]])) {
+          val values = p.children().drop(1)
+          val filterRef = p.children()(0).asInstanceOf[FieldReference].references.head
+          val sets = values.map(_.asInstanceOf[LiteralValue[_]].value).toSet[Any]
+          dppPartitionFilters = dppPartitionFilters :+ InSet(AttributeReference(
+            filterRef.toString, values(0).asInstanceOf[LiteralValue[_]].dataType)(), sets)
+        }
+    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScan.scala
@@ -48,14 +48,16 @@ case class OrcScan(
     pushedAggregate: Option[Aggregation] = None,
     pushedFilters: Array[Filter],
     originPartitionFilters: Seq[Expression] = Seq.empty,
-    dataFilters: Seq[Expression] = Seq.empty) extends FileScan with SupportsRuntimeV2Filtering {
+    dataFilters: Seq[Expression] = Seq.empty)
+    extends FileScan
+    with SupportsRuntimeV2Filtering {
   override def isSplitable(path: Path): Boolean = {
     // If aggregate is pushed down, only the file footer will be read once,
     // so file should not be split across multiple tasks.
     pushedAggregate.isEmpty
   }
 
-  private var dppPartitionFilters: Seq[Expression] = Seq.empty;
+  private var dppPartitionFilters: Seq[Expression] = Seq.empty
 
   override def partitionFilters: Seq[Expression] = {
     originPartitionFilters ++ dppPartitionFilters
@@ -127,8 +129,11 @@ case class OrcScan(
           val values = p.children().drop(1)
           val filterRef = p.children()(0).asInstanceOf[FieldReference].references.head
           val sets = values.map(_.asInstanceOf[LiteralValue[_]].value).toSet[Any]
-          dppPartitionFilters = dppPartitionFilters :+ InSet(AttributeReference(
-            filterRef.toString, values(0).asInstanceOf[LiteralValue[_]].dataType)(), sets)
+          dppPartitionFilters = dppPartitionFilters :+ InSet(
+            AttributeReference(
+              filterRef.toString,
+              values(0).asInstanceOf[LiteralValue[_]].dataType)(),
+            sets)
         }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
@@ -93,11 +93,12 @@ trait OrcTest extends QueryTest with FileBasedDataSourceTest with BeforeAndAfter
    * temporary table named `tableName`, then call `f`. The temporary table together with the
    * Orc file will be dropped/deleted after `f` returns.
    */
-  protected def withOrcTable[T <: Product: ClassTag: TypeTag]
-      (data: Seq[T], tableName: String, testVectorized: Boolean = true
-       , partitionNames: Seq[String] = Seq.empty)
-      (f: => Unit): Unit = withDataSourceTable(data, tableName, testVectorized
-    , partitionNames)(f)
+  protected def withOrcTable[T <: Product: ClassTag: TypeTag](
+      data: Seq[T],
+      tableName: String,
+      testVectorized: Boolean = true,
+      partitionNames: Seq[String] = Seq.empty)(f: => Unit): Unit =
+    withDataSourceTable(data, tableName, testVectorized, partitionNames)(f)
 
   protected def makeOrcFile[T <: Product: ClassTag: TypeTag](
       data: Seq[T], path: File): Unit = makeDataSourceFile(data, path)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
@@ -94,8 +94,10 @@ trait OrcTest extends QueryTest with FileBasedDataSourceTest with BeforeAndAfter
    * Orc file will be dropped/deleted after `f` returns.
    */
   protected def withOrcTable[T <: Product: ClassTag: TypeTag]
-      (data: Seq[T], tableName: String, testVectorized: Boolean = true)
-      (f: => Unit): Unit = withDataSourceTable(data, tableName, testVectorized)(f)
+      (data: Seq[T], tableName: String, testVectorized: Boolean = true
+       , partitionNames: Seq[String] = Seq.empty)
+      (f: => Unit): Unit = withDataSourceTable(data, tableName, testVectorized
+    , partitionNames)(f)
 
   protected def makeOrcFile[T <: Product: ClassTag: TypeTag](
       data: Seq[T], path: File): Unit = makeDataSourceFile(data, path)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Support ORCScan Dynamic Partition Prune to greatly improves performance.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Improve dsv2 and enhance the query performance of commonly used ORC files

 
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

UT.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
NO.