### PR TITLE
[SPARK-53271][PYTHON][INFRA] Show Python Versions in PySpark Jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -607,8 +607,9 @@ jobs:
       run: |
         for py in $(echo $PYTHON_TO_TEST | tr "," "\n")
         do
-          echo $py
+          $py --version
           $py -m pip list
+          echo ""
         done
     - name: Install Conda for pip packaging test
       if: contains(matrix.modules, 'pyspark-errors')


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Show Python Versions in PySpark Jobs


### Why are the changes needed?
recently we observed a job failure due to [PEP 709](https://docs.python.org/3/whatsnew/3.12.html#pep-709-comprehension-inlining)

- 3.11.13 pass
- 3.12.3 fail
- 3.12.11 pass
- 3.13.5 pass

To debug such issue, we need more details.

### Does this PR introduce _any_ user-facing change?
no, infra-only




### How was this patch tested?
manually check


<img width="768" height="153" alt="image" src="https://github.com/user-attachments/assets/1bc6fc5c-5b98-4e20-a1c1-7d1e999b0d20" />

<img width="822" height="195" alt="image" src="https://github.com/user-attachments/assets/95ca7df0-5c5c-43ab-80f5-bfa16fdf013a" />


### Was this patch authored or co-authored using generative AI tooling?
no
