### PR TITLE
[SPARK-53276][SS] Checking if we own the stamp before closing RocksDB

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateMachine.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateMachine.scala
@@ -154,7 +154,7 @@ class RocksDBStateMachine(
       // Convert from nanoseconds to milliseconds
       TimeUnit.MILLISECONDS.convert(elapsedNanos, TimeUnit.NANOSECONDS)
     }
-    while (state == ACQUIRED && timeWaitedMs < rocksDBConf.lockAcquireTimeoutMs) {
+    while (state == ACQUIRED && timeWaitedMs < 2000) {
       stateMachineLock.wait(10)
       // log every 30 seconds
       if (timeWaitedMs % (30 * 1000) == 0) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateMachine.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateMachine.scala
@@ -154,7 +154,7 @@ class RocksDBStateMachine(
       // Convert from nanoseconds to milliseconds
       TimeUnit.MILLISECONDS.convert(elapsedNanos, TimeUnit.NANOSECONDS)
     }
-    while (state == ACQUIRED && timeWaitedMs < 2000) {
+    while (state == ACQUIRED && timeWaitedMs < rocksDBConf.lockAcquireTimeoutMs) {
       stateMachineLock.wait(10)
       // log every 30 seconds
       if (timeWaitedMs % (30 * 1000) == 0) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Apache Software Foundation (ASF) under one or more 
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -767,7 +767,9 @@ private[sql] class RocksDBStateStoreProvider
   }
 
   override def close(): Unit = {
-    rocksDB.close()
+    if (stateMachine.close()) {
+      rocksDB.close()
+    }
   }
 
   override def supportedCustomMetrics: Seq[StateStoreCustomMetric] = ALL_CUSTOM_METRICS

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more 
+ * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreLockHardeningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreLockHardeningSuite.scala
@@ -620,6 +620,175 @@ class RocksDBStateStoreLockHardeningSuite extends SparkFunSuite
     }
   }
 
+  test("lock hardening: safe provider close during concurrent commit operations") {
+    // This test simulates the scenario fixed by SPARK-53276:
+    // - Multiple partitions are processing, some hit errors while others are committing
+    // - StateStore.stop() is called, which tries to close all providers
+    // - The fix ensures RocksDB is only closed when no other thread is using it
+
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      val commitInProgressLatch = new CountDownLatch(1)
+      val proceedWithCloseLatch = new CountDownLatch(1)
+      val commitCompletedLatch = new CountDownLatch(1)
+
+      @volatile var commitThreadException: Option[Throwable] = None
+      @volatile var closeResult: Option[Boolean] = None
+
+      // Thread 1: Simulate partition that's in the middle of commit (partition 1)
+      val commitFuture = Future {
+        val taskContext = TaskContext.empty()
+        TaskContext.setTaskContext(taskContext)
+
+        try {
+          val store = provider.getStore(0)
+          put(store, "partition1_key", 0, 1, StateStore.DEFAULT_COL_FAMILY_NAME)
+
+          // Signal that we're about to start commit
+          commitInProgressLatch.countDown()
+
+          // Wait for close thread to start attempting close
+          proceedWithCloseLatch.await(5, TimeUnit.SECONDS)
+
+          // Simulate some commit processing time
+          Thread.sleep(500)
+
+          // This commit should succeed even while close() is being called
+          val version = store.commit()
+          assert(version === 1)
+
+          commitCompletedLatch.countDown()
+        } catch {
+          case ex: Throwable =>
+            commitThreadException = Some(ex)
+            commitCompletedLatch.countDown()
+        }
+      }
+
+      // Thread 2: Simulate StateStore.stop() being called (from partition 0 error)
+      val closeFuture = Future {
+        try {
+          // Wait for commit thread to start its transaction
+          commitInProgressLatch.await(5, TimeUnit.SECONDS)
+
+          // Signal commit thread to proceed with its work
+          proceedWithCloseLatch.countDown()
+
+          // Attempt to close the provider (this simulates StateStore.stop())
+          // With the fix, this should wait until the commit thread releases the RocksDB
+          provider.close()
+          closeResult = Some(true)
+
+        } catch {
+          case ex: Throwable =>
+            // Log unexpected exceptions for debugging
+            logInfo(s"Close thread exception: ${ex.getClass.getName}: ${ex.getMessage}")
+        }
+      }
+
+      // Wait for both operations to complete
+      awaitResult(commitFuture, 10.seconds)
+      awaitResult(closeFuture, 10.seconds)
+
+      // Verify that commit completed successfully without exceptions
+      assert(commitCompletedLatch.await(1, TimeUnit.SECONDS),
+        "Commit should have completed")
+      assert(commitThreadException.isEmpty,
+        s"Commit should not have thrown exception: ${commitThreadException.map(_.getMessage)}")
+
+      // The state machine should have coordinated the close properly:
+      // - Either close() returned true (indicating it was safe to close)
+      // - Or close() waited until the commit completed before proceeding
+
+      // After everything completes, the provider should be properly closed
+      val stateMachine = PrivateMethod[Any](Symbol("stateMachine"))
+      val stateMachineObj = provider invokePrivate stateMachine()
+
+      // Attempting to get a new store should fail since provider is closed
+      val exception = intercept[StateStoreInvalidStateMachineTransition] {
+        provider.getStore(1)
+      }
+      assert(exception.getMessage.contains("Old state: CLOSED"))
+    }
+  }
+
+  test("lock hardening: close waits for concurrent operations to complete") {
+    // This test verifies that close() properly waits for ongoing operations
+    // to complete before actually closing the RocksDB instance
+
+    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
+      val operationStarted = new CountDownLatch(1)
+      val proceedWithClose = new CountDownLatch(1)
+      val operationCompleted = new CountDownLatch(1)
+
+      @volatile var operationException: Option[Throwable] = None
+      @volatile var closeStartTime: Long = 0
+      @volatile var closeEndTime: Long = 0
+
+      // Thread 1: Long-running operation
+      val operationFuture = Future {
+        val taskContext = TaskContext.empty()
+        TaskContext.setTaskContext(taskContext)
+
+        try {
+          val store = provider.getStore(0)
+          put(store, "key", 0, 1, StateStore.DEFAULT_COL_FAMILY_NAME)
+
+          operationStarted.countDown()
+
+          // Wait for close to be initiated
+          proceedWithClose.await(5, TimeUnit.SECONDS)
+
+          // Simulate some processing time
+          Thread.sleep(1000)
+
+          // This should complete successfully
+          store.commit()
+          operationCompleted.countDown()
+
+        } catch {
+          case ex: Throwable =>
+            operationException = Some(ex)
+            operationCompleted.countDown()
+        }
+      }
+
+      // Thread 2: Close operation
+      val closeFuture = Future {
+        // Wait for operation to start
+        operationStarted.await(5, TimeUnit.SECONDS)
+
+        // Signal operation to proceed
+        proceedWithClose.countDown()
+
+        // Start close - this should wait for the operation to complete
+        closeStartTime = System.currentTimeMillis()
+        provider.close()
+        closeEndTime = System.currentTimeMillis()
+      }
+
+      // Wait for both to complete
+      awaitResult(operationFuture, 10.seconds)
+      awaitResult(closeFuture, 10.seconds)
+
+      // Verify operation completed successfully
+      assert(operationCompleted.await(1, TimeUnit.SECONDS),
+        "Operation should have completed")
+      assert(operationException.isEmpty,
+        s"Operation should not have failed: ${operationException.map(_.getMessage)}")
+
+      // Verify close waited for operation (should take at least 1 second)
+      val closeDuration = closeEndTime - closeStartTime
+      assert(closeDuration >= 900, // Allow some margin for timing
+        s"Close should have waited for operation, but took only $closeDuration ms")
+
+      // Verify provider is properly closed
+      val exception = intercept[StateStoreInvalidStateMachineTransition] {
+        provider.getStore(1)
+      }
+      assert(exception.getMessage.contains("Old state: CLOSED"))
+    }
+  }
+
   // Helper method to assert current thread has ownership
   def assertAcquiredThreadIsCurrentThread(provider: RocksDBStateStoreProvider): Unit = {
     val stateMachine = PrivateMethod[Any](Symbol("stateMachine"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreLockHardeningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreLockHardeningSuite.scala
@@ -620,7 +620,7 @@ class RocksDBStateStoreLockHardeningSuite extends SparkFunSuite
     }
   }
 
-  test("lock hardening: safe provider close during concurrent commit operations") {
+  test("SPARK-53276: safe provider close during concurrent commit operations") {
     // This test simulates the scenario fixed by SPARK-53276:
     // - Multiple partitions are processing, some hit errors while others are committing
     // - StateStore.stop() is called, which tries to close all providers
@@ -711,7 +711,7 @@ class RocksDBStateStoreLockHardeningSuite extends SparkFunSuite
     }
   }
 
-  test("lock hardening: close waits for concurrent operations to complete") {
+  test("SPARK-53276: close waits for concurrent operations to complete") {
     // This test verifies that close() properly waits for ongoing operations
     // to complete before actually closing the RocksDB instance
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -2667,7 +2667,12 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
     tryWithProviderResource(newStoreProvider(provider.stateStoreId,
       useColumnFamilies)) { reloadedProvider =>
       val versionToRead = if (version < 0) reloadedProvider.latestVersion else version
-      reloadedProvider.getStore(versionToRead).iterator().map(rowPairToDataPair).toSet
+      val store = reloadedProvider.getStore(versionToRead)
+      try {
+        store.iterator().map(rowPairToDataPair).toSet
+      } finally {
+        if (!store.hasCommitted) store.abort()
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -654,6 +654,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         (key._1, key._2)
       }.toSeq
       assert(result === timerTimestamps.sorted)
+      store.abort()
     }
   }
 
@@ -1489,6 +1490,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
           (key._1, key._2)
         }.toSeq
       assert(result.map(_._1) === timerTimestamps.map(_._1).sorted)
+      store.abort()
     }
   }
 
@@ -1534,6 +1536,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         (key._1, key._2)
       }.toSeq
       assert(result === timerTimestamps.sorted)
+      store.abort()
     }
   }
 
@@ -1649,6 +1652,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
       assert(valueRowToData(store.get(keyRow2)) === 2)
       store.remove(keyRow2)
       assert(store.get(keyRow2) === null)
+      store.abort()
     }
   }
 
@@ -1757,6 +1761,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         assert(!iterator2.hasNext)
 
         assert(get(store, "a", 0).isEmpty)
+        store.abort()
       }
     }
   }
@@ -1796,6 +1801,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
           )
         }
       }
+      store.abort()
     }
   }
 
@@ -1832,6 +1838,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
           )
         }
       }
+      store.abort()
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Checking if we own the lock before closing the RocksDB instance. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, we don't check whether we own the state machine stamp to close the store, which can lead to incorrect behavior (i.e closing during active commit) which leads to segmentation faults 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No