### PR TITLE
[SPARK-53277][INFRA] Improve `merge_spark_pr.py` to stop early in case of the closed PRs

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -613,6 +613,11 @@ def main():
 
     pr_num = bold_input("Which pull request would you like to merge? (e.g. 34): ")
     pr = get_json("%s/pulls/%s" % (GITHUB_API_BASE, pr_num))
+    # Stop if the PR is closed
+    if pr["state"] == "closed":
+        print("#%s is closed already." % (pr_num))
+        sys.exit(-1)
+
     pr_events = get_json("%s/issues/%s/events" % (GITHUB_API_BASE, pr_num))
 
     url = pr["url"]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `merge_spark_pr.py` to stop early in case of the closed PRs.

### Why are the changes needed?

To help committers by removing the useless interactions.

**BEFORE**

```
$ dev/merge_spark_pr.py
git rev-parse --abbrev-ref HEAD
Which pull request would you like to merge? (e.g. 34): 1
I've re-written the title as follows to match the standard format:
Original: Removed reference to incubation in README.md.
Modified: Removed reference to incubation in README.md
Would you like to use the modified title? (y/N):
...
```

**AFTER**

```
$ dev/merge_spark_pr.py
git rev-parse --abbrev-ref HEAD
Which pull request would you like to merge? (e.g. 34): 1
#1 is closed already.
Restoring head pointer to SPARK-53277
git checkout SPARK-53277
Already on 'SPARK-53277'
git branch
```

### Does this PR introduce _any_ user-facing change?

No, this is used by committers only.

### How was this patch tested?

Manually check.

### Was this patch authored or co-authored using generative AI tooling?

No.