### PR TITLE
[SPARK-53278][INFRA] Improve `merge_spark_pr.py` to accept PR numbers as a CLI argument

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -611,7 +611,11 @@ def main():
     branch_names = sorted(branch_names, reverse=True)
     branch_iter = iter(branch_names)
 
-    pr_num = bold_input("Which pull request would you like to merge? (e.g. 34): ")
+    if len(sys.argv) == 1:
+        pr_num = bold_input("Which pull request would you like to merge? (e.g. 34): ")
+    else:
+        pr_num = sys.argv[1]
+        print("Start to merge pull request #%s" % (pr_num))
     pr = get_json("%s/pulls/%s" % (GITHUB_API_BASE, pr_num))
     pr_events = get_json("%s/issues/%s/events" % (GITHUB_API_BASE, pr_num))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `merge_spark_pr.py` to accept PR numbers as a CLI argument.

### Why are the changes needed?

To provide an alternative shortcut.

**BEFORE**

```
$ dev/merge_spark_pr.py
git rev-parse --abbrev-ref HEAD
Which pull request would you like to merge? (e.g. 34): 52020
================================================================================
```

**AFTER (Additional usage)**

```
$ dev/merge_spark_pr.py 52020
git rev-parse --abbrev-ref HEAD
Start to merge pull request #52020
================================================================================
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test because this is irrelevant to the CI results.

### Was this patch authored or co-authored using generative AI tooling?

No.