### PR TITLE
[SPARK-53279][INFRA] Improve `determine_modules_for_files` to ignore `Scalastyle/Checkstyle` rule files

### DIFF
--- a/dev/sparktestsupport/utils.py
+++ b/dev/sparktestsupport/utils.py
@@ -47,6 +47,12 @@ def determine_modules_for_files(filenames):
     for filename in filenames:
         if filename.endswith("README.md"):
             continue
+        if filename in (
+            "scalastyle-config.xml",
+            "dev/checkstyle.xml",
+            "dev/checkstyle-suppressions.xml",
+        ):
+            continue
         if ("GITHUB_ACTIONS" not in os.environ) and filename.startswith(".github"):
             continue
         matched_at_least_one_module = False


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to reduce the CI running time by improving `determine_modules_for_files` method to ignore `Scalastyle/Checkstyle` rule files.

### Why are the changes needed?

In these days, new `Scalastyle` and `Checkstyle` rules are added frequently and they are recognized as a change on `root`. So, all CIs are triggered.

However, only `Linter CI` is relevant to this change. This is triggered always. So, we can ignore these files like we did for `README.md` files. After this PR, CIs will be triggered in the optimized way by focusing on the real source code changes.

### Does this PR introduce _any_ user-facing change?

No, this is only a testing infra change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.