### PR TITLE
[SPARK-53280][CORE] Use Java `instanceof` instead of `Throwables.throwIf*` methods

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import org.fusesource.leveldbjni.JniDBFactory;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.DBIterator;
@@ -256,7 +255,7 @@ public class LevelDB implements KVStore {
           iteratorTracker.add(new WeakReference<>(it));
           return it;
         } catch (Exception e) {
-          Throwables.throwIfUnchecked(e);
+          if (e instanceof RuntimeException re) throw re;
           throw new RuntimeException(e);
         }
       }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
@@ -26,7 +26,6 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import org.iq80.leveldb.DBIterator;
 
 import org.apache.spark.internal.SparkLogger;
@@ -151,7 +150,7 @@ class LevelDBIterator<T> implements KVStoreIterator<T> {
       next = null;
       return ret;
     } catch (Exception e) {
-      Throwables.throwIfUnchecked(e);
+      if (e instanceof RuntimeException re) throw re;
       throw new RuntimeException(e);
     }
   }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDB.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import org.rocksdb.*;
 
 import org.apache.spark.annotation.Private;
@@ -288,7 +287,7 @@ public class RocksDB implements KVStore {
           iteratorTracker.add(new WeakReference<>(it));
           return it;
         } catch (Exception e) {
-          Throwables.throwIfUnchecked(e);
+          if (e instanceof RuntimeException re) throw re;
           throw new RuntimeException(e);
         }
       }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBIterator.java
@@ -23,7 +23,6 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import org.rocksdb.RocksIterator;
 
 import org.apache.spark.network.util.JavaUtils;
@@ -138,7 +137,7 @@ class RocksDBIterator<T> implements KVStoreIterator<T> {
       next = null;
       return ret;
     } catch (Exception e) {
-      Throwables.throwIfUnchecked(e);
+      if (e instanceof RuntimeException re) throw re;
       throw new RuntimeException(e);
     }
   }

--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClient.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClient.java
@@ -28,7 +28,6 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.SettableFuture;
 import io.netty.channel.Channel;
 import io.netty.util.concurrent.Future;
@@ -289,10 +288,9 @@ public class TransportClient implements Closeable {
     try {
       return result.get(timeoutMs, TimeUnit.MILLISECONDS);
     } catch (ExecutionException e) {
-      Throwables.throwIfUnchecked(e.getCause());
       throw new RuntimeException(e.getCause());
     } catch (Exception e) {
-      Throwables.throwIfUnchecked(e);
+      if (e instanceof RuntimeException re) throw re;
       throw new RuntimeException(e);
     }
   }

--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
@@ -30,7 +30,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.codahale.metrics.MetricSet;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
@@ -342,7 +341,7 @@ public class TransportClientFactory implements Closeable {
       logger.error("Exception while bootstrapping client after {} ms", e,
         MDC.of(LogKeys.BOOTSTRAP_TIME, bootstrapTimeMs));
       client.close();
-      Throwables.throwIfUnchecked(e);
+      if (e instanceof RuntimeException re) throw re;
       throw new RuntimeException(e);
     }
     long postBootstrap = System.nanoTime();

--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/AuthRpcHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/AuthRpcHandler.java
@@ -20,7 +20,6 @@ package org.apache.spark.network.crypto;
 import java.nio.ByteBuffer;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -132,7 +131,7 @@ class AuthRpcHandler extends AbstractAuthRpcHandler {
         try {
           engine.close();
         } catch (Exception e) {
-          Throwables.throwIfUnchecked(e);
+          if (e instanceof RuntimeException re) throw re;
           throw new RuntimeException(e);
         }
       }

--- a/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
+++ b/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
@@ -28,8 +28,6 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import javax.annotation.concurrent.GuardedBy;
 
-import com.google.common.base.Throwables;
-
 import org.apache.spark.internal.SparkLogger;
 import org.apache.spark.internal.SparkLoggerFactory;
 import org.apache.spark.internal.LogKeys;
@@ -120,8 +118,10 @@ public class ReadAheadInputStream extends InputStream {
 
   private void checkReadException() throws IOException {
     if (readAborted) {
-      Throwables.throwIfInstanceOf(readException, IOException.class);
-      Throwables.throwIfUnchecked(readException);
+      if (readException == null) throw new NullPointerException("readException is not captured.");
+      if (readException instanceof IOException ie) throw ie;
+      if (readException instanceof Error error) throw error;
+      if (readException instanceof RuntimeException re) throw re;
       throw new IOException(readException);
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to optimize exception handling code by using Java 16+ [JEP 394: Pattern Matching for instanceof ](https://openjdk.org/jeps/394) instead of `Throwables.throwIf*` wrapper methods.

### Why are the changes needed?

There are multiple categories.

**Category Misuse (1 instance):** We need to remove `Throwables.throwIfUnchecked` because `ExecutionException` is incompatible with `Error` or `RuntimeException` from the beginning and `e` cannot be `null`.

```scala
     } catch (ExecutionException e) {
-      Throwables.throwIfUnchecked(e.getCause());
       throw new RuntimeException(e.getCause());
     }
```

**Category Unoptimized (7 instances):** We had better inline the one-liner to check the code because `Exception` cannot be `Error` and `e` cannot be `null`.

```scala
     } catch (Exception e) {
-      Throwables.throwIfUnchecked(e);
+      if (e instanceof RuntimeException re) throw re;
       throw new RuntimeException(e);
     }
```

**Category Other (1 instance):** We have only one instance to check a `Throwable` type variable. We also can do like the following in a straight-forward way in order to avoid repeated function operations and duplicated operations inside those functions.

```scala
-      Throwables.throwIfInstanceOf(readException, IOException.class);
-      Throwables.throwIfUnchecked(readException);
+      if (readException == null) throw new NullPointerException("readException is not captured.");
+      if (readException instanceof IOException ie) throw ie;
+      if (readException instanceof Error error) throw error;
+      if (readException instanceof RuntimeException re) throw re;
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.