### PR TITLE
[SPARK-52336][CORE] Prepend Spark identifier to GCS user agent

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -524,14 +524,16 @@ private[spark] object SparkHadoopUtil extends Logging {
     // The GCS connector allows appending a custom suffix to the user-agent string.
     // To prepend Spark's application information, we read the existing suffix,
     // add our prefix, and set the result back as the new suffix.
-    val sparkGcsPrefix = s"apache-spark/${org.apache.spark.SPARK_VERSION} (GPN:apache-spark)"
-    val userGcsSuffix = hadoopConf.get("fs.gs.application.name.suffix")
-    val gcsUserAgent = if (userGcsSuffix != null && userGcsSuffix.nonEmpty) {
-      s"$sparkGcsPrefix $userGcsSuffix"
-    } else {
-      sparkGcsPrefix
+    if (Utils.classIsLoadable("com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem")) {
+      val sparkGcsPrefix = s"apache-spark/${org.apache.spark.SPARK_VERSION} (GPN:apache-spark)"
+      val userGcsSuffix = hadoopConf.get("fs.gs.application.name.suffix")
+      val gcsUserAgent = if (userGcsSuffix != null && userGcsSuffix.nonEmpty) {
+        s"$sparkGcsPrefix $userGcsSuffix"
+      } else {
+        sparkGcsPrefix
+      }
+      hadoopConf.set("fs.gs.application.name.suffix", gcsUserAgent, SOURCE_SPARK)
     }
-    hadoopConf.set("fs.gs.application.name.suffix", gcsUserAgent, SOURCE_SPARK)
     if (conf.getOption("spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version").isEmpty) {
       hadoopConf.set("mapreduce.fileoutputcommitter.algorithm.version", "1", setBySpark)
     }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -521,6 +521,17 @@ private[spark] object SparkHadoopUtil extends Logging {
         SOURCE_SPARK_HADOOP)
     }
     val setBySpark = SET_TO_DEFAULT_VALUES
+    // The GCS connector allows appending a custom suffix to the user-agent string.
+    // To prepend Spark's application information, we read the existing suffix,
+    // add our prefix, and set the result back as the new suffix.
+    val sparkGcsPrefix = s"apache_spark/${org.apache.spark.SPARK_VERSION} (GPN:apache_spark)"
+    val userGcsSuffix = hadoopConf.get("fs.gs.application.name.suffix")
+    val gcsUserAgent = if (userGcsSuffix != null && userGcsSuffix.nonEmpty) {
+      s"$sparkGcsPrefix $userGcsSuffix"
+    } else {
+      sparkGcsPrefix
+    }
+    hadoopConf.set("fs.gs.application.name.suffix", gcsUserAgent, SOURCE_SPARK)
     if (conf.getOption("spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version").isEmpty) {
       hadoopConf.set("mapreduce.fileoutputcommitter.algorithm.version", "1", setBySpark)
     }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -524,7 +524,7 @@ private[spark] object SparkHadoopUtil extends Logging {
     // The GCS connector allows appending a custom suffix to the user-agent string.
     // To prepend Spark's application information, we read the existing suffix,
     // add our prefix, and set the result back as the new suffix.
-    val sparkGcsPrefix = s"apache_spark/${org.apache.spark.SPARK_VERSION} (GPN:apache_spark)"
+    val sparkGcsPrefix = s"apache-spark/${org.apache.spark.SPARK_VERSION} (GPN:apache-spark)"
     val userGcsSuffix = hadoopConf.get("fs.gs.application.name.suffix")
     val gcsUserAgent = if (userGcsSuffix != null && userGcsSuffix.nonEmpty) {
       s"$sparkGcsPrefix $userGcsSuffix"

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -528,7 +528,12 @@ private[spark] object SparkHadoopUtil extends Logging {
       val sparkGcsPrefix = s"apache-spark/${org.apache.spark.SPARK_VERSION} (GPN:apache-spark)"
       val userGcsSuffix = hadoopConf.get("fs.gs.application.name.suffix")
       val gcsUserAgent = if (userGcsSuffix != null && userGcsSuffix.nonEmpty) {
-        s"$sparkGcsPrefix $userGcsSuffix"
+        if (userGcsSuffix.contains(sparkGcsPrefix)) {
+          // The prefix is already present, so we'll just use the existing suffix.
+          userGcsSuffix
+        } else {
+          s"$sparkGcsPrefix $userGcsSuffix"
+        }
       } else {
         sparkGcsPrefix
       }

--- a/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
@@ -24,9 +24,12 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.SparkHadoopUtil.{SET_TO_DEFAULT_VALUES, SOURCE_SPARK, SOURCE_SPARK_HADOOP, SOURCE_SPARK_HIVE}
 import org.apache.spark.internal.config.BUFFER_SIZE
+import org.apache.spark.util.Utils
 
 class SparkHadoopUtilSuite extends SparkFunSuite {
 
+  private lazy val gcsConnectorAvailable = Utils.classIsLoadable(gcsConnectorClassName)
+  private val gcsConnectorClassName = "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem"
   /**
    * Verify that spark.hadoop options are propagated, and that
    * the default s3a options are set as expected.
@@ -56,6 +59,7 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
    * Verify that the GCS user agent is set correctly when no custom suffix is provided.
    */
   test("SPARK-52336: GCS user agent should be set when not provided by user") {
+    assume(gcsConnectorAvailable, s"GCS connector '$gcsConnectorClassName' not available.")
     val sparkConf = new SparkConf()
     val hadoopConf = SparkHadoopUtil.newConfiguration(sparkConf)
 
@@ -68,6 +72,7 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
    * Verify that the Spark identifier is prepended to a user-provided GCS user agent suffix.
    */
   test("SPARK-52336: GCS user agent should be prepended when suffix is provided by user") {
+    assume(gcsConnectorAvailable, s"GCS connector '$gcsConnectorClassName' not available.")
     val sparkConf = new SparkConf()
     val userSuffix = "my-awesome-app"
     sparkConf.set("spark.hadoop.fs.gs.application.name.suffix", userSuffix)
@@ -83,6 +88,7 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
    * Verify that the GCS user agent is set correctly when the user provides an empty suffix.
    */
   test("SPARK-52336: GCS user agent should be set when user provided suffix is empty") {
+    assume(gcsConnectorAvailable, s"GCS connector '$gcsConnectorClassName' not available.")
     val sparkConf = new SparkConf()
     sparkConf.set("spark.hadoop.fs.gs.application.name.suffix", "")
     val hadoopConf = SparkHadoopUtil.newConfiguration(sparkConf)

--- a/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
@@ -55,11 +55,11 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
   /**
    * Verify that the GCS user agent is set correctly when no custom suffix is provided.
    */
-  test("GCS user agent should be set when not provided by user") {
+  test("SPARK-52336: GCS user agent should be set when not provided by user") {
     val sparkConf = new SparkConf()
     val hadoopConf = SparkHadoopUtil.newConfiguration(sparkConf)
 
-    val expectedUserAgent = s"apache_spark/${org.apache.spark.SPARK_VERSION} (GPN:apache_spark)"
+    val expectedUserAgent = s"apache-spark/${org.apache.spark.SPARK_VERSION} (GPN:apache-spark)"
     assertConfigMatches(hadoopConf, "fs.gs.application.name.suffix", expectedUserAgent,
       SOURCE_SPARK)
   }
@@ -67,13 +67,13 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
   /**
    * Verify that the Spark identifier is prepended to a user-provided GCS user agent suffix.
    */
-  test("GCS user agent should be prepended when suffix is provided by user") {
+  test("SPARK-52336: GCS user agent should be prepended when suffix is provided by user") {
     val sparkConf = new SparkConf()
     val userSuffix = "my-awesome-app"
     sparkConf.set("spark.hadoop.fs.gs.application.name.suffix", userSuffix)
     val hadoopConf = SparkHadoopUtil.newConfiguration(sparkConf)
 
-    val sparkPrefix = s"apache_spark/${org.apache.spark.SPARK_VERSION} (GPN:apache_spark)"
+    val sparkPrefix = s"apache-spark/${org.apache.spark.SPARK_VERSION} (GPN:apache-spark)"
     val expectedUserAgent = s"$sparkPrefix $userSuffix"
     assertConfigMatches(hadoopConf, "fs.gs.application.name.suffix", expectedUserAgent,
       SOURCE_SPARK)
@@ -82,12 +82,12 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
   /**
    * Verify that the GCS user agent is set correctly when the user provides an empty suffix.
    */
-  test("GCS user agent should be set when user provided suffix is empty") {
+  test("SPARK-52336: GCS user agent should be set when user provided suffix is empty") {
     val sparkConf = new SparkConf()
     sparkConf.set("spark.hadoop.fs.gs.application.name.suffix", "")
     val hadoopConf = SparkHadoopUtil.newConfiguration(sparkConf)
 
-    val expectedUserAgent = s"apache_spark/${org.apache.spark.SPARK_VERSION} (GPN:apache_spark)"
+    val expectedUserAgent = s"apache-spark/${org.apache.spark.SPARK_VERSION} (GPN:apache-spark)"
     assertConfigMatches(hadoopConf, "fs.gs.application.name.suffix", expectedUserAgent,
       SOURCE_SPARK)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pull request proposes a change to automatically prepend a Spark-specific identifier to the Google Cloud Storage (GCS) connector's user agent. The user agent is configured via the _fs.gs.application.name.suffix_ Hadoop property.

To avoid impacting non-GCS users, this change is only applied when the GCS connector is detected on the classpath. The implementation also checks if a user has already configured a suffix with a Spark identifier to prevent duplicate prefixes. If a custom suffix is present without a Spark identifier, the Spark identifier is prepended; otherwise, the Spark identifier is set as the default.

### Why are the changes needed?
The primary goal of this change is to automate a best practice that improves the out-of-the-box observability for Spark on GCS. While advanced users can manually configure the user agent today, this change ensures that it is done consistently and automatically for everyone.

The primary benefits for the end-user are in debugging, performance tuning, and cost management:

- **Improved Observability by Default:** By default, all GCS requests from Spark will be tagged with a standard apache-spark/<version> identifier. This allows users to filter GCS logs to get a consolidated view of all storage operations originating from their Spark infrastructure, which is particularly useful for understanding Spark's overall storage footprint.

- **User Convenience:** The implementation is designed to be convenient. If a user has already set a custom suffix, the Spark identifier is simply prepended to their existing value, so they don't lose their custom identifiers and don't need to take any action to get the benefit of the Spark-specific tag.

- **Standardization and Consistency:** By having Spark automatically prepend a standard identifier, we ensure that all Spark jobs are uniformly identifiable in GCS logs and metrics. This simplifies monitoring and debugging across an organization, as it doesn't rely on users remembering to manually configure this property for every job.

#### Example: Application Identifier
The identifier prepended by Spark is in the format  `apache-spark/<SPARK_VERSION>`. This is combined with the user's custom identifier.

For example, if a user is running Spark 4.0.0 and sets the Hadoop configuration as follows:  `spark.hadoop.fs.gs.application.name.suffix="test-spark-app" `

The final application identifier sent in the user-agent header to GCS will be:  `"apache-spark/4.0.0 test-spark-app" `

As a result, users can filter their GCS audit logs for the custom identifier (test-spark-app) to isolate all storage operations performed by that specific job. For instance, in Google Cloud's Logs Explorer, a user could run the following query:

> SEARCH("test-spark-app")

This would show a filtered view of GCS logs for that application, as seen here:
<img width="3048" height="1378" alt="image" src="https://github.com/user-attachments/assets/dce947f6-f7de-4267-8d3f-5e4e9ca35360" />


### Does this PR introduce _any_ user-facing change?
No, this change is designed to be non-disruptive:
- **No impact on non-GCS users:** The logic to prepend the Spark identifier is only triggered if the GCS connector is found on the classpath. For all other storage systems, this change has no effect
- **Preserves user configuration:** If a user has already set a custom suffix, that suffix is preserved and enhanced with the Spark identifier. The implementation also avoids duplicating the prefix if the user has already included it in their custom suffix.

### How was this patch tested?
This patch was tested by adding new unit tests in SparkHadoopUtilSuite.scala. These tests cover the following scenarios:
- When no _fs.gs.application.name.suffix_ is provided by the user.
- When a custom _fs.gs.application.name.suffix_ is provided by the user.
- When an empty _fs.gs.application.name.suffix_ is provided by the user


### Was this patch authored or co-authored using generative AI tooling?
No
