### PR TITLE
[SPARK-53275][SQL] Handle stateful expressions when ordering in interpreted mode

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/OrderingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/OrderingSuite.scala
@@ -170,6 +170,10 @@ class OrderingSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("ordering by stateful expressions") {
+    // even though we explicitly create an InterpretedOrdering below, we still need
+    // to set CODEGEN_FACTORY_MODE to NO_CODEGEN because the ScalaUDF expression will
+    // indirectly create an UnsafeProjection, and we want that UnsafeProjection to be
+    // an InterpretedUnsafeProjection
     withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> CodegenObjectFactoryMode.NO_CODEGEN.toString) {
       val udfFunc = (s: String) => if (s == null) null else s
       val stringUdf = ScalaUDF(udfFunc, StringType, BoundReference(1, StringType, true) :: Nil,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/OrderingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/OrderingSuite.scala
@@ -169,7 +169,7 @@ class OrderingSuite extends SparkFunSuite with ExpressionEvalHelper {
     assert(ctx.INPUT_ROW == null)
   }
 
-  test("ordering by stateful expressions") {
+  test("SPARK-53275: ordering by stateful expressions in interpreted mode") {
     // even though we explicitly create an InterpretedOrdering below, we still need
     // to set CODEGEN_FACTORY_MODE to NO_CODEGEN because the ScalaUDF expression will
     // indirectly create an UnsafeProjection, and we want that UnsafeProjection to be


### PR DESCRIPTION
### What changes were proposed in this pull request?
 
This PR updates `InterpretedOrdering` to use a different copy of stateful expressions when evaluating the two input rows.

### Why are the changes needed?

Consider these spark-shell commands:
```
# for this particular example, the bug is exercised when there are 2 executors
bin/spark-shell --master "local[2]"

import org.apache.spark.sql.functions.udf
spark.udf.register("udf", (s: String) => s)

Seq((0, "2"), (0, "1")).toDF("a", "b").createOrReplaceTempView("v1")

// return a correct result: Array([0,1], [0,2])
sql("select a, udf(b) from v1 order by a, udf(b) asc").collect

// run in interpreted mode
sql("set spark.sql.codegen.factoryMode=NO_CODEGEN")

// return an incorrect result: Array([0,2], [0,1])
sql("select a, udf(b) from v1 order by a, udf(b) asc").collect
```
This is because the `ScalaUDF` expression indirectly holds an UnsafeRow as a buffer (via a serializer, which holds an `UnsafeProjection`, which holds the `UnsafeRow` buffer). When the udf is evaluated for the first row, the resulting `UTF8String` uses the `UnsafeRow`'s base object as its own base object. When the udf is evaluated for the second row, that same base object is updated such that both `UTF8String` objects contain the same string value.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New unit test.

### Was this patch authored or co-authored using generative AI tooling?

No.
