### PR TITLE
[SPARK-53269][PYTHON][FOLLOWUP] Fix GRPC and GRPCStatus check

### DIFF
--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -95,10 +95,10 @@ have_yaml = have_package("yaml")
 yaml_requirement_message = None if have_yaml else "No module named 'yaml'"
 
 have_grpc = have_package("grpc")
-grpc_requirement_message = None if have_yaml else "No module named 'grpc'"
+grpc_requirement_message = None if have_grpc else "No module named 'grpc'"
 
 have_grpc_status = have_package("grpc_status")
-grpc_status_requirement_message = None if have_yaml else "No module named 'grpc_status'"
+grpc_status_requirement_message = None if have_grpc_status else "No module named 'grpc_status'"
 
 
 googleapis_common_protos_requirement_message = None


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `GRPC` and `GRPCStatus` check bug.

### Why are the changes needed?

Currently, `master` branch **Scala Spark Connect** CI is broken due to the Python `import` errors.

https://github.com/apache/spark/actions/runs/16973427262/job/48128703536

```
[info] PythonPipelineSuite:
Python output: Traceback (most recent call last):
Python output:   File "<string>", line 4, in <module>
Python output:   File "/home/runner/work/spark/spark/python/pyspark/pipelines/spark_connect_graph_element_registry.py", line 21, in <module>
Python output:     from pyspark.sql.connect.dataframe import DataFrame as ConnectDataFrame
Python output:   File "/home/runner/work/spark/spark/python/pyspark/sql/connect/dataframe.py", line 79, in <module>
Python output:     from pyspark.sql.connect.merge import MergeIntoWriter
Python output:   File "/home/runner/work/spark/spark/python/pyspark/sql/connect/merge.py", line 26, in <module>
Python output:     from pyspark.sql.connect.functions import expr
Python output: ImportError: cannot import name 'expr' from 'pyspark.sql.connect.functions' (/home/runner/work/spark/spark/python/pyspark/sql/connect/functions/__init__.py)
Python process failed with exit code 1
Output:
Traceback (most recent call last):
  File "<string>", line 4, in <module>
  File "/home/runner/work/spark/spark/python/pyspark/pipelines/spark_connect_graph_element_registry.py", line 21, in <module>
    from pyspark.sql.connect.dataframe import DataFrame as ConnectDataFrame
  File "/home/runner/work/spark/spark/python/pyspark/sql/connect/dataframe.py", line 79, in <module>
    from pyspark.sql.connect.merge import MergeIntoWriter
  File "/home/runner/work/spark/spark/python/pyspark/sql/connect/merge.py", line 26, in <module>
    from pyspark.sql.connect.functions import expr
ImportError: cannot import name 'expr' from 'pyspark.sql.connect.functions' (/home/runner/work/spark/spark/python/pyspark/sql/connect/functions/__init__.py)
[info] - basic *** FAILED *** (1 second, 405 milliseconds)
```

The root causes are obvious typos.

```python
 have_grpc = have_package("grpc")
-grpc_requirement_message = None if have_yaml else "No module named 'grpc'"
+grpc_requirement_message = None if have_grpc else "No module named 'grpc'"

 have_grpc_status = have_package("grpc_status")
-grpc_status_requirement_message = None if have_yaml else "No module named 'grpc_status'"
+grpc_status_requirement_message = None if have_grpc_status else "No module named 'grpc_status'"
```

To recover the CIs.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.