### PR TITLE
[SPARK-53290][SQL][CONNECT] Fix Metadata backward-compatibility breaking

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/types/Metadata.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/Metadata.scala
@@ -40,13 +40,15 @@ import org.apache.spark.util.ArrayImplicits._
  * @since 1.3.0
  */
 @Stable
-sealed class Metadata private[types] (
-    private[types] val map: Map[String, Any],
-    @transient private[types] val runtimeMap: Map[String, Any])
+@SerialVersionUID(-3987058932362209243L)
+sealed class Metadata private[types] (private[types] val map: Map[String, Any])
     extends Serializable {
 
+  @transient private[types] var runtimeMap: Map[String, Any] = _
+  private[types] def setRuntimeMap(map: Map[String, Any]): Unit = runtimeMap = map
+
   /** No-arg constructor for kryo. */
-  protected def this() = this(null, null)
+  protected def this() = this(null)
 
   /** Tests whether this Metadata contains a binding for a key. */
   def contains(key: String): Boolean = map.contains(key)
@@ -137,7 +139,7 @@ sealed class Metadata private[types] (
 @Stable
 object Metadata {
 
-  private[this] val _empty = new Metadata(Map.empty, Map.empty)
+  private[this] val _empty = new Metadata(Map.empty)
 
   /** Returns an empty Metadata. */
   def empty: Metadata = _empty
@@ -309,7 +311,11 @@ class MetadataBuilder {
       // Save some memory when the metadata is empty
       Metadata.empty
     } else {
-      new Metadata(map.toMap, runtimeMap.toMap)
+      val metadata = new Metadata(map.toMap)
+      if (runtimeMap.nonEmpty) {
+        metadata.setRuntimeMap(runtimeMap.toMap)
+      }
+      metadata
     }
   }
 


### PR DESCRIPTION


### What changes were proposed in this pull request?

This PR adds the SerialVersionUID annotation and moves the newly added runtimeMap out from the ctor.

 

### Why are the changes needed?

With a v400 client to a v410 server,  ```java.io.InvalidClassException: org.apache.spark.sql.types.Metadata;``` raised

```
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 4.0.0
      /_/

Type in expressions to have them evaluated.
Spark connect server version 4.1.0-SNAPSHOT.
Spark session available as 'spark'.

scala> import spark.implicits._
import spark.implicits._

scala> spark.catalog.listCatalogs().map(_.name)
res1: org.apache.spark.sql.connect.Dataset[String] = Invalid Dataframe; [INTERNAL_ERROR] Failed to unpack scala udf. SQLSTATE: XX000
```


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

```
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 4.0.0
      /_/

Type in expressions to have them evaluated.
Spark connect server version 4.1.0-SNAPSHOT.
Spark session available as 'spark'.

scala> import spark.implicits._
import spark.implicits._

scala> spark.catalog.listCatalogs().map(_.name)
res1: org.apache.spark.sql.connect.Dataset[String] = [value: string]

scala> spark.catalog.listCatalogs().map(_.name).collect()
res2: Array[String] = Array("spark_catalog")

```


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
