### PR TITLE
[SPARK-52307][PYTHON][FOLLOW-UP] Fix type hint for Scalar Arrow Iterator UDF

### DIFF
--- a/python/pyspark/sql/pandas/typehints.py
+++ b/python/pyspark/sql/pandas/typehints.py
@@ -149,7 +149,7 @@ def infer_eval_type(
         len(parameters_sig) == 1
         and check_iterator_annotation(
             parameters_sig[0],
-            parameter_check_func=lambda a: (a == pd.Series or a == pa.Array),
+            parameter_check_func=lambda a: a == pa.Array,
         )
         and check_iterator_annotation(
             return_annotation, parameter_check_func=lambda a: a == pa.Array


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Scalar Arrow Iterator UDF


### Why are the changes needed?
exclude `pd.Series` from the type inference


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no
