### PR TITLE
[SPARK-53289][SQL] Invoke cancelJobsWithTag before start passing the SparkListenerSQLExecutionEnd event to prevent execution of canceled tasks.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -212,8 +212,10 @@ object SQLExecution extends Logging {
                 }
               }
 
-              sparkSession.sparkContext.cancelJobsWithTag(
-                executionIdJobTag(sparkSession, executionId))
+              if (executionId == rootExecutionId) {
+                sparkSession.sparkContext.cancelJobsWithTag(
+                  executionIdJobTag(sparkSession, executionId))
+              }
 
               val event = SparkListenerSQLExecutionEnd(
                 executionId,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -212,6 +212,11 @@ object SQLExecution extends Logging {
                 }
               }
 
+              // Cancel all spark jobs associated with this executionID, but only if it's the
+              // root execution.
+
+              // TODO: Consider enhancing this logic to cancel jobs earlier when nested
+              // query executions are completed.
               if (executionId == rootExecutionId) {
                 sparkSession.sparkContext.cancelJobsWithTag(
                   executionIdJobTag(sparkSession, executionId))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -124,6 +124,8 @@ object SQLExecution extends Logging {
           redactedStr.substring(0, Math.min(truncateLength, redactedStr.length))
         }.getOrElse(callSite.shortForm)
 
+      sparkSession.sparkContext.setJobGroup(executionId.toString, desc, true)
+
       val globalConfigs = sparkSession.sharedState.conf.getAll.toMap
       val modifiedConfigs = sparkSession.sessionState.conf.getAllConfs
         .filterNot { case (key, value) =>
@@ -211,6 +213,9 @@ object SQLExecution extends Logging {
                   }
                 }
               }
+
+              sparkSession.sparkContext.cancelJobGroup(executionId.toString)
+
               val event = SparkListenerSQLExecutionEnd(
                 executionId,
                 System.currentTimeMillis(),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -100,6 +100,20 @@ object SQLExecution extends Logging {
     if (sc.getLocalProperty(EXECUTION_ROOT_ID_KEY) == null) {
       sc.setLocalProperty(EXECUTION_ROOT_ID_KEY, executionId.toString)
       sc.addJobTag(executionIdJobTag(sparkSession, executionId))
+      logWarning("EXECUTION_ROOT_ID_KEY is null and  addJobTag :" +
+        " " + executionIdJobTag(sparkSession, executionId) + " " +" " +
+        "the executionId is " + executionId + "" +
+        "and the rootExecutionId is " +
+        "" + sc.getLocalProperty(EXECUTION_ROOT_ID_KEY) +
+        " and the thread is " + Thread.currentThread().getId + "" +
+        " local property hash is " + sc.localProperties.hashCode())
+    } else {
+      logWarning("EXECUTION_ROOT_ID_KEY is not null and " +
+        "the executionId is " + executionId + "" +
+        "and the rootExecutionId is " +
+        "" + sc.getLocalProperty(EXECUTION_ROOT_ID_KEY) + " " +
+        " and the thread is " + Thread.currentThread().getId + "" +
+        " local property hash is " + sc.localProperties.hashCode())
     }
     val rootExecutionId = sc.getLocalProperty(EXECUTION_ROOT_ID_KEY).toLong
     executionIdToQueryExecution.put(executionId, queryExecution)
@@ -249,6 +263,17 @@ object SQLExecution extends Logging {
       if (sc.getLocalProperty(EXECUTION_ROOT_ID_KEY) == executionId.toString) {
         sc.setLocalProperty(EXECUTION_ROOT_ID_KEY, null)
         sc.removeJobTag(executionIdJobTag(sparkSession, executionId))
+        logWarning("if branch removing the jobTag " +
+          "" + executionIdJobTag(sparkSession, executionId) + " thread is " +
+          "" + Thread.currentThread().getId + " executionId is " + executionId +
+          " rootExecutionId is " + sc.getLocalProperty(EXECUTION_ROOT_ID_KEY) + "" +
+          " local property hash is " + sc.localProperties.hashCode())
+      } else {
+        logWarning("not removing the jobTag " +
+          "" + executionIdJobTag(sparkSession, executionId) + " thread is " +
+          "" + Thread.currentThread().getId + " executionId is " + executionId +
+          " rootExecutionId is " + sc.getLocalProperty(EXECUTION_ROOT_ID_KEY) + "" +
+          " local property hash is " + sc.localProperties.hashCode())
       }
       sc.setLocalProperty(SPARK_JOB_INTERRUPT_ON_CANCEL, originalInterruptOnCancel)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -124,8 +124,6 @@ object SQLExecution extends Logging {
           redactedStr.substring(0, Math.min(truncateLength, redactedStr.length))
         }.getOrElse(callSite.shortForm)
 
-      sparkSession.sparkContext.setJobGroup(executionId.toString, desc, true)
-
       val globalConfigs = sparkSession.sharedState.conf.getAll.toMap
       val modifiedConfigs = sparkSession.sessionState.conf.getAllConfs
         .filterNot { case (key, value) =>
@@ -214,7 +212,8 @@ object SQLExecution extends Logging {
                 }
               }
 
-              sparkSession.sparkContext.cancelJobGroup(executionId.toString)
+              sparkSession.sparkContext.cancelJobsWithTag(
+                executionIdJobTag(sparkSession, executionId))
 
               val event = SparkListenerSQLExecutionEnd(
                 executionId,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

We optimized Gluten's broadcast hash join by ensuring the hash table is built only once per executor. When the `SparkListenerSQLExecutionEnd ` event is received, the corresponding hash table is released. However, while running Gluten unit test, we encountered an exception:
After the `SparkListenerSQLExecutionEnd ` event was triggered and the hash table was released, the hash table was unexpectedly recreated, leading to a core dump. After investigating with @wangyum  , we found that the unit test result was None, which triggered the AQEPropagateEmptyRelation rule to skip the join operation. Despite this, the task was not actually canceled, which caused the hash table to be rebuilt after it had already been released.

This PR invokes the `cancelJobsWithTag ` API to send an RPC request to terminate tasks before emitting the `SparkListenerSQLExecutionEnd `event. This helps prevent canceled tasks from continuing execution in most cases. If tasks still fail to terminate properly, enabling `spark.task.reaper.enabled` will forcibly kill the corresponding executors to ensure cleanup.


### Why are the changes needed?
Bug fix.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
