### PR TITLE
[SPARK-53283][CONNECT] Make CheckpointCommand/RemoveCachedRemoteRelationCommand in SparkConnectPlanner side effect free

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/command/CheckpointCommand.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/command/CheckpointCommand.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connect.execution.command
+
+import io.grpc.stub.StreamObserver
+
+import org.apache.spark.connect.proto
+import org.apache.spark.connect.proto.ExecutePlanResponse
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.classic.{Dataset, SparkSession}
+import org.apache.spark.storage.StorageLevel
+
+case class CheckpointCommand(
+    query: LogicalPlan,
+    isLocal: Boolean,
+    storageLevelOpt: Option[StorageLevel],
+    eager: Boolean,
+    dfId: String,
+    dfCacher: (String, DataFrame) => Unit)
+    extends ConnectLeafRunnableCommand {
+
+  override def run(session: SparkSession): Seq[Row] = {
+    val target = Dataset.ofRows(session, query)
+    val checkpointed = if (isLocal) {
+      storageLevelOpt match {
+        case Some(storageLevel) =>
+          target.localCheckpoint(eager = eager, storageLevel = storageLevel)
+        case None =>
+          target.localCheckpoint(eager = eager)
+      }
+    } else {
+      target.checkpoint(eager = eager)
+    }
+    dfCacher(dfId, checkpointed)
+    Seq.empty
+  }
+
+  override def handleConnectResponse(
+      responseObserver: StreamObserver[ExecutePlanResponse],
+      sessionId: String,
+      serverSessionId: String): Unit = {
+    responseObserver.onNext(
+      proto.ExecutePlanResponse
+        .newBuilder()
+        .setSessionId(sessionId)
+        .setServerSideSessionId(serverSessionId)
+        .setCheckpointCommandResult(
+          proto.CheckpointCommandResult
+            .newBuilder()
+            .setRelation(proto.CachedRemoteRelation.newBuilder().setRelationId(dfId).build())
+            .build())
+        .build())
+  }
+}

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/command/ConnectLeafRunnableCommand.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/command/ConnectLeafRunnableCommand.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connect.execution.command
+
+import io.grpc.stub.StreamObserver
+
+import org.apache.spark.connect.proto
+import org.apache.spark.sql.{classic, Row, SparkSession}
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+
+trait ConnectLeafRunnableCommand extends LeafRunnableCommand {
+
+  final override def run(sparkSession: SparkSession): Seq[Row] = {
+    run(sparkSession.asInstanceOf[classic.SparkSession])
+  }
+
+  def run(sparkSession: classic.SparkSession): Seq[Row]
+
+  def handleConnectResponse(
+      responseObserver: StreamObserver[proto.ExecutePlanResponse],
+      sessionId: String,
+      serverSessionId: String): Unit = {
+    // Default implementation does nothing.
+  }
+}

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/command/RemoveCachedRemoteRelationCommand.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/command/RemoveCachedRemoteRelationCommand.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connect.execution.command
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.classic.SparkSession
+
+case class RemoveCachedRemoteRelationCommand(dfId: String, cacheRemover: String => Unit)
+    extends ConnectLeafRunnableCommand {
+
+  override def run(session: SparkSession): Seq[Row] = {
+    cacheRemover(dfId)
+    Seq.empty
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR refactors the `CheckpointCommand` and `RemoveCachedRemoteRelationCommand` handling in `SparkConnectPlanner` to make it side-effect free by introducing a new command execution pattern. The key changes include:

1. **New Command Infrastructure**: 
   - Introduced `ConnectLeafRunnableCommand` that extends `LeafRunnableCommand` to provide a standardized way for Connect-specific commands to handle their own response generation.

2. **Refactored CheckpointCommand and RemoveCachedRemoteRelationCommand**: 
   - Moved from direct handling in `SparkConnectPlanner.process()` to a transform-and-execute pattern
   - Created new `CheckpointCommand` and `RemoveCachedRemoteRelationCommand` case class that implement `ConnectLeafRunnableCommand`
   - Extracted checkpoint logic into a dedicated command class with proper response handling

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Make CheckpointCommand/RemoveCachedRemoteRelationCommand in SparkConnectPlanner side effect free

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
**No**. This is a purely internal refactoring 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Cursor 1.4.5