### PR TITLE
[SPARK-53295][PS] Turn on ANSI by default for Pandas API on Spark

### DIFF
--- a/python/docs/source/tutorial/pandas_on_spark/options.rst
+++ b/python/docs/source/tutorial/pandas_on_spark/options.rst
@@ -324,10 +324,10 @@ compute.fail_on_ansi_mode       True                    'compute.fail_on_ansi_mo
                                                         an exception if the underlying Spark is working with
                                                         ANSI mode enabled and the option
                                                         'compute.ansi_mode_support' is False.
-compute.ansi_mode_support       False                   'compute.ansi_mode_support' sets whether or not to
+compute.ansi_mode_support       True                   'compute.ansi_mode_support' sets whether or not to
                                                         support the ANSI mode of the underlying Spark. If
                                                         False, pandas API on Spark may hit unexpected results
-                                                        or errors. The default is False.
+                                                        or errors. The default is True.
 plotting.max_rows               1000                    'plotting.max_rows' sets the visual limit on top-n-
                                                         based plots such as `plot.bar` and `plot.pie`. If it
                                                         is set to 1000, the first 1000 data points will be

--- a/python/docs/source/tutorial/pandas_on_spark/options.rst
+++ b/python/docs/source/tutorial/pandas_on_spark/options.rst
@@ -324,7 +324,7 @@ compute.fail_on_ansi_mode       True                    'compute.fail_on_ansi_mo
                                                         an exception if the underlying Spark is working with
                                                         ANSI mode enabled and the option
                                                         'compute.ansi_mode_support' is False.
-compute.ansi_mode_support       True                   'compute.ansi_mode_support' sets whether or not to
+compute.ansi_mode_support       True                    'compute.ansi_mode_support' sets whether or not to
                                                         support the ANSI mode of the underlying Spark. If
                                                         False, pandas API on Spark may hit unexpected results
                                                         or errors. The default is True.

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -287,7 +287,7 @@ _options: List[Option] = [
             "If False, pandas API on Spark may hit unexpected results or errors. "
             "The default is False."
         ),
-        default=is_testing(),
+        default=True,
         types=bool,
     ),
     Option(

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -24,7 +24,7 @@ from typing import Any, Callable, Dict, Iterator, List, Tuple, Union, Optional
 
 from pyspark._globals import _NoValue, _NoValueType
 from pyspark.sql.session import SparkSession
-from pyspark.pandas.utils import default_session, is_testing
+from pyspark.pandas.utils import default_session
 
 
 __all__ = ["get_option", "set_option", "reset_option", "options", "option_context"]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Turn on ANSI by default for Pandas API on Spark

### Why are the changes needed?
Part of https://issues.apache.org/jira/browse/SPARK-53005

### Does this PR introduce _any_ user-facing change?
No, only the config change.


### How was this patch tested?
Existing tests


### Was this patch authored or co-authored using generative AI tooling?
No
