### PR TITLE
[SPARK-53293][SQL] Modify exprIdToOrdinal implementation for speedup on queries with wide tables

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
@@ -129,6 +129,10 @@ package object expressions  {
         // Create directly indexed array
         val arraySize = (maxExprId - minExprId + 1).toInt
         val ordinalArray = new Array[Int](arraySize)
+
+        // It's possible that `attrs` is a linked list, which can lead to bad O(n) loops when
+        // accessing attributes by their ordinals. To avoid this performance penalty, convert
+        // the input to an array.
         val ordinalAttrsArray = new Array[Attribute](attrs.size)
         java.util.Arrays.fill(ordinalArray, -1) // -1 indicates no attribute with this ID
 
@@ -165,10 +169,6 @@ package object expressions  {
 
     @transient private lazy val exprIdToOrdinalArray: Array[Int] = ordinalArrays._1
 
-
-    // It's possible that `attrs` is a linked list, which can lead to bad O(n) loops when
-    // accessing attributes by their ordinals. To avoid this performance penalty, convert the input
-    // to an array.
     @transient private lazy val attrsArray = ordinalArrays._2
 
     /**
@@ -185,8 +185,7 @@ package object expressions  {
       // Only use one of array or hash map, trying to use array first if possible
       if (attrs.isEmpty) {
         -1
-      }
-      else if (exprIdToOrdinalArray.nonEmpty) {
+      } else if (exprIdToOrdinalArray.nonEmpty) {
         if (id < minExprId || id > maxExprId) {
           -1
         } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst
 
-import java
+import java.util.Locale
 
 import org.apache.spark.sql.catalyst.analysis.{Resolver, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.util.MetadataColumnHelper
@@ -120,8 +120,9 @@ package object expressions  {
       } else {
         // Create directly indexed array
         val arraySize = (maxExprId - minExprId + 1).toInt
-        val ordinalArray = Array.fill(arraySize)(-1) // -1 indicates no attribute with this ID
+        val ordinalArray = new Array[Int](arraySize)
         val ordinalAttrsArray = new Array[Attribute](attrs.size)
+        java.util.Arrays.fill(ordinalArray, -1) // -1 indicates no attribute with this ID
 
         // Populate the array based on expression IDs
         var i = 0

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
@@ -121,8 +121,8 @@ package object expressions  {
       if (attrs.isEmpty) {
         (Array.empty[Int], Array.empty[Attribute])
       } else if (
-        maxExprId - minExprId > Int.MaxValue ||  // prevent overflow
-          maxExprId - minExprId > 2 * attrs.length  // in case of sparse ExprIds
+        maxExprId - minExprId >= 2 * attrs.length ||  // in case of sparse ExprIds
+          maxExprId - minExprId >= Int.MaxValue  // prevent overflow
       ) {
         (Array.empty[Int], attrs.toArray)
       } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
@@ -122,7 +122,7 @@ package object expressions  {
         (_ => -1, Array.empty[Attribute])
       } else if (
         maxExprId - minExprId <= Long.MaxValue &&  // prevent overflow
-          maxExprId - minExprId <= 0.5 * attrs.length  // in case of sparse ExprIds
+          maxExprId - minExprId <= 1.5 * attrs.length  // in case of sparse ExprIds
       ) {
         // Create directly indexed array
         val arraySize = (maxExprId - minExprId + 1).toInt

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
@@ -155,7 +155,7 @@ package object expressions  {
         val arr = attrs.toArray
 
         // Use LongMap to avoid overhead of HashMap while hashing.
-        val map = new mutable.LongMap[Int](arr.length)
+        val map = new mutable.LongMap[Int](_ => -1, arr.length)
 
         // Iterate over the array in reverse order so that the final map value is the first
         // attribute with a given expression id.

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -786,16 +786,20 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-* BroadcastHashJoin Inner BuildRight (10)
+* BroadcastHashJoin Inner BuildRight (14)
 :- * HashAggregate (6)
 :  +- Exchange (5)
 :     +- * HashAggregate (4)
 :        +- * Filter (3)
 :           +- * ColumnarToRow (2)
 :              +- Scan parquet spark_catalog.default.explain_temp1 (1)
-+- BroadcastExchange (9)
-   +- * HashAggregate (8)
-      +- ReusedExchange (7)
++- BroadcastExchange (13)
+   +- * HashAggregate (12)
+      +- Exchange (11)
+         +- * HashAggregate (10)
+            +- * Filter (9)
+               +- * ColumnarToRow (8)
+                  +- Scan parquet spark_catalog.default.explain_temp1 (7)
 
 
 (1) Scan parquet spark_catalog.default.explain_temp1
@@ -830,21 +834,43 @@ Functions [1]: [max(val#x)]
 Aggregate Attributes [1]: [max(val#x)#x]
 Results [2]: [key#x, max(val#x)#x AS max(val)#x]
 
-(7) ReusedExchange [Reuses operator id: 5]
-Output [2]: [key#x, max#x]
+(7) Scan parquet spark_catalog.default.explain_temp1
+Output [2]: [key#x, val#x]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/explain_temp1]
+PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
+ReadSchema: struct<key:int,val:int>
 
-(8) HashAggregate [codegen id : 3]
+(8) ColumnarToRow [codegen id : 2]
+Input [2]: [key#x, val#x]
+
+(9) Filter [codegen id : 2]
+Input [2]: [key#x, val#x]
+Condition : (isnotnull(key#x) AND (key#x > 10))
+
+(10) HashAggregate [codegen id : 2]
+Input [2]: [key#x, val#x]
+Keys [1]: [key#x]
+Functions [1]: [partial_max(val#x)]
+Aggregate Attributes [1]: [max#x]
+Results [2]: [key#x, max#x]
+
+(11) Exchange
+Input [2]: [key#x, max#x]
+Arguments: hashpartitioning(key#x, 4), ENSURE_REQUIREMENTS, [plan_id=x]
+
+(12) HashAggregate [codegen id : 3]
 Input [2]: [key#x, max#x]
 Keys [1]: [key#x]
 Functions [1]: [max(val#x)]
 Aggregate Attributes [1]: [max(val#x)#x]
 Results [2]: [key#x, max(val#x)#x AS max(val)#x]
 
-(9) BroadcastExchange
+(13) BroadcastExchange
 Input [2]: [key#x, max(val)#x]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=x]
 
-(10) BroadcastHashJoin [codegen id : 4]
+(14) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [key#x]
 Right keys [1]: [key#x]
 Join type: Inner


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
`exprIdToOrdinal` in `AttributeSeq` has been changed from a HashMap to an array contains the ordinals corresponding to the `ExprId` when evaluated with an offset. This has been done to speedup the lazy evaluation of `exprIdToOrdinal` for queries on wide tables (many attributes).

The change avoids the overhead of hashing `ExprId` and putting these elements into a `HashMap`. Since `ExprId`s are dense, this change does not cause a significant increase in memory usage.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For queries that involve tables with a very large number of columns, when canonicalizing the query, evaluating the `exprIdToOrdinal` map becomes a dominating step as can be seen in the following flamegraph:
<img width="1615" height="671" alt="image" src="https://github.com/user-attachments/assets/1ca0375d-defd-4587-bc0c-1604d9a26bed" />

This slows down whichever step is the first to run canonicalization, which is often RemoveNoopUnion, but can vary. A speedup is needed here to improve the performance of the first rule to run canonicalization.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Flamegraphs were generated to find if a decrease could be seen in the time spent evaluating `exprIdToOrdinal` and to check that time-consuming steps were removed or minimized, which was found:
<img width="1656" height="653" alt="image" src="https://github.com/user-attachments/assets/002c5215-e353-44de-a0b3-b395d86e9230" />

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: claude-4.1-opus