### PR TITLE
[SPARK-52982][PYTHON] Disallow lateral join with Arrow Python UDTFs

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4086,6 +4086,13 @@
     ],
     "sqlState" : "42K0L"
   },
+  "LATERAL_JOIN_WITH_ARROW_UDTF_UNSUPPORTED" : {
+    "message" : [
+      "LATERAL JOIN with Arrow-optimized user-defined table functions (UDTFs) is not supported. Arrow UDTFs cannot be used on the right-hand side of a lateral join.",
+      "Please use a regular UDTF instead, or restructure your query to avoid the lateral join."
+    ],
+    "sqlState" : "0A000"
+  },
   "LOAD_DATA_PATH_NOT_EXISTS" : {
     "message" : [
       "LOAD DATA input path does not exist: <path>."

--- a/python/pyspark/sql/tests/arrow/test_arrow_udtf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udtf.py
@@ -482,9 +482,9 @@ class ArrowUDTFTestsMixin:
         with self.assertRaisesRegex(Exception, "LATERAL_JOIN_WITH_ARROW_UDTF_UNSUPPORTED"):
             self.spark.sql(
                 """
-            SELECT t.id, f.x, f.result
-            FROM test_table t, LATERAL simple_arrow_udtf(t.id) f
-            """
+                SELECT t.id, f.x, f.result
+                FROM test_table t, LATERAL simple_arrow_udtf(t.id) f
+                """
             )
 
     def test_arrow_udtf_lateral_join_with_table_argument_disallowed(self):
@@ -513,9 +513,9 @@ class ArrowUDTFTestsMixin:
         ):
             self.spark.sql(
                 """
-            SELECT t1.id, f.filtered_id
-            FROM test_table1 t1, LATERAL mixed_args_udtf(table(SELECT * FROM test_table2)) f
-            """
+                SELECT t1.id, f.filtered_id
+                FROM test_table1 t1, LATERAL mixed_args_udtf(table(SELECT * FROM test_table2)) f
+                """
             )
 
     def test_arrow_udtf_with_table_argument_then_lateral_join_allowed(self):
@@ -536,11 +536,11 @@ class ArrowUDTFTestsMixin:
 
         result_df = self.spark.sql(
             """
-        SELECT f.processed_id, j.label
-        FROM table_arg_udtf(table(SELECT * FROM source_table)) f,
-             join_table j
-        ORDER BY f.processed_id, j.label
-        """
+            SELECT f.processed_id, j.label
+            FROM table_arg_udtf(table(SELECT * FROM source_table)) f,
+                join_table j
+            ORDER BY f.processed_id, j.label
+            """
         )
 
         expected_data = [
@@ -581,10 +581,10 @@ class ArrowUDTFTestsMixin:
 
         result_df = self.spark.sql(
             """
-        SELECT c.computed_value, m.multiplied
-        FROM compute_udtf(table(SELECT * FROM values_table) WITH SINGLE PARTITION) c,
-             LATERAL multiply_udtf(c.computed_value) m
-        """
+            SELECT c.computed_value, m.multiplied
+            FROM compute_udtf(table(SELECT * FROM values_table) WITH SINGLE PARTITION) c,
+                LATERAL multiply_udtf(c.computed_value) m
+            """
         )
 
         expected_df = self.spark.createDataFrame([(60, 180)], "computed_value int, multiplied int")

--- a/python/pyspark/sql/tests/arrow/test_arrow_udtf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udtf.py
@@ -26,6 +26,7 @@ from pyspark.testing import assertDataFrameEqual
 
 if have_pyarrow:
     import pyarrow as pa
+    import pyarrow.compute as pc
 
 
 @unittest.skipIf(not have_pyarrow, pyarrow_requirement_message)
@@ -459,6 +460,135 @@ class ArrowUDTFTestsMixin:
             "SELECT * FROM test_mixed_args_udtf(TABLE(SELECT id FROM range(0, 8)), 5)"
         )
         assertDataFrameEqual(sql_result_df, expected_df)
+
+    def test_arrow_udtf_lateral_join_disallowed(self):
+        @arrow_udtf(returnType="x int, result int")
+        class SimpleArrowUDTF:
+            def eval(self, input_val: "pa.Array") -> Iterator["pa.Table"]:
+                val = input_val[0].as_py()
+                result_table = pa.table(
+                    {
+                        "x": pa.array([val], type=pa.int32()),
+                        "result": pa.array([val * 2], type=pa.int32()),
+                    }
+                )
+                yield result_table
+
+        self.spark.udtf.register("simple_arrow_udtf", SimpleArrowUDTF)
+
+        test_df = self.spark.createDataFrame([(1,), (2,), (3,)], "id int")
+        test_df.createOrReplaceTempView("test_table")
+
+        with self.assertRaisesRegex(Exception, "LATERAL_JOIN_WITH_ARROW_UDTF_UNSUPPORTED"):
+            self.spark.sql(
+                """
+            SELECT t.id, f.x, f.result
+            FROM test_table t, LATERAL simple_arrow_udtf(t.id) f
+            """
+            )
+
+    def test_arrow_udtf_lateral_join_with_table_argument_disallowed(self):
+        @arrow_udtf(returnType="filtered_id bigint")
+        class MixedArgsUDTF:
+            def eval(self, input_table: "pa.Table") -> Iterator["pa.Table"]:
+                filtered_data = input_table.filter(pc.greater(input_table["id"], 5))
+                result_table = pa.table({"filtered_id": filtered_data["id"]})
+                yield result_table
+
+        self.spark.udtf.register("mixed_args_udtf", MixedArgsUDTF)
+
+        test_df1 = self.spark.createDataFrame([(1,), (2,), (3,)], "id int")
+        test_df1.createOrReplaceTempView("test_table1")
+
+        test_df2 = self.spark.createDataFrame([(6,), (7,), (8,)], "id bigint")
+        test_df2.createOrReplaceTempView("test_table2")
+
+        # Table arguments create nested lateral joins where our CheckAnalysis rule doesn't trigger
+        # because the Arrow UDTF is in the inner lateral join, not the outer one our rule checks.
+        # So Spark's general lateral join validation catches this first with
+        # NON_DETERMINISTIC_LATERAL_SUBQUERIES.
+        with self.assertRaisesRegex(
+            Exception,
+            "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.NON_DETERMINISTIC_LATERAL_SUBQUERIES",
+        ):
+            self.spark.sql(
+                """
+            SELECT t1.id, f.filtered_id
+            FROM test_table1 t1, LATERAL mixed_args_udtf(table(SELECT * FROM test_table2)) f
+            """
+            )
+
+    def test_arrow_udtf_with_table_argument_then_lateral_join_allowed(self):
+        @arrow_udtf(returnType="processed_id bigint")
+        class TableArgUDTF:
+            def eval(self, input_table: "pa.Table") -> Iterator["pa.Table"]:
+                processed_data = pc.add(input_table["id"], 100)
+                result_table = pa.table({"processed_id": processed_data})
+                yield result_table
+
+        self.spark.udtf.register("table_arg_udtf", TableArgUDTF)
+
+        source_df = self.spark.createDataFrame([(1,), (2,), (3,)], "id bigint")
+        source_df.createOrReplaceTempView("source_table")
+
+        join_df = self.spark.createDataFrame([("A",), ("B",), ("C",)], "label string")
+        join_df.createOrReplaceTempView("join_table")
+
+        result_df = self.spark.sql(
+            """
+        SELECT f.processed_id, j.label
+        FROM table_arg_udtf(table(SELECT * FROM source_table)) f,
+             join_table j
+        ORDER BY f.processed_id, j.label
+        """
+        )
+
+        expected_data = [
+            (101, "A"),
+            (101, "B"),
+            (101, "C"),
+            (102, "A"),
+            (102, "B"),
+            (102, "C"),
+            (103, "A"),
+            (103, "B"),
+            (103, "C"),
+        ]
+        expected_df = self.spark.createDataFrame(expected_data, "processed_id bigint, label string")
+        assertDataFrameEqual(result_df, expected_df)
+
+    def test_arrow_udtf_table_argument_with_regular_udtf_lateral_join_allowed(self):
+        @arrow_udtf(returnType="computed_value int")
+        class ComputeUDTF:
+            def eval(self, input_table: "pa.Table") -> Iterator["pa.Table"]:
+                total = pc.sum(input_table["value"]).as_py()
+                result_table = pa.table({"computed_value": pa.array([total], type=pa.int32())})
+                yield result_table
+
+        from pyspark.sql.functions import udtf
+        from pyspark.sql.types import StructType, StructField, IntegerType
+
+        @udtf(returnType=StructType([StructField("multiplied", IntegerType())]))
+        class MultiplyUDTF:
+            def eval(self, input_val: int):
+                yield (input_val * 3,)
+
+        self.spark.udtf.register("compute_udtf", ComputeUDTF)
+        self.spark.udtf.register("multiply_udtf", MultiplyUDTF)
+
+        values_df = self.spark.createDataFrame([(10,), (20,), (30,)], "value int")
+        values_df.createOrReplaceTempView("values_table")
+
+        result_df = self.spark.sql(
+            """
+        SELECT c.computed_value, m.multiplied
+        FROM compute_udtf(table(SELECT * FROM values_table) WITH SINGLE PARTITION) c,
+             LATERAL multiply_udtf(c.computed_value) m
+        """
+        )
+
+        expected_df = self.spark.createDataFrame([(60, 180)], "computed_value int, multiplied int")
+        assertDataFrameEqual(result_df, expected_df)
 
 
 class ArrowUDTFTests(ArrowUDTFTestsMixin, ReusedSQLTestCase):

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -4252,8 +4252,6 @@ object RemoveTempResolvedColumn extends Rule[LogicalPlan] {
   }
 }
 
-
-
 /**
  * Rule that's used to handle `UnresolvedHaving` nodes with resolved `condition` and `child`.
  * It's placed outside the main batch to avoid conflicts with other rules that resolve

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.analysis
 import scala.collection.mutable
 
 import org.apache.spark.{SparkException, SparkThrowable}
+import org.apache.spark.api.python.PythonEvalType
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.ExtendedAnalysisException
 import org.apache.spark.sql.catalyst.analysis.ResolveWithCTE.checkIfSelfReferenceIsPlacedCorrectly
@@ -888,6 +889,17 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
               errorClass = "UNSUPPORTED_EXPR_FOR_OPERATOR",
               messageParameters = Map(
                 "invalidExprSqls" -> invalidExprSqls.mkString(", ")))
+
+          case j @ LateralJoin(_, right, _, _)
+              if j.getTagValue(LateralJoin.BY_TABLE_ARGUMENT).isEmpty =>
+            right.plan.foreach {
+              case Generate(pyudtf: PythonUDTF, _, _, _, _, _)
+                  if pyudtf.evalType == PythonEvalType.SQL_ARROW_UDTF =>
+                  j.failAnalysis(
+                    errorClass = "LATERAL_JOIN_WITH_ARROW_UDTF_UNSUPPORTED",
+                    messageParameters = Map.empty)
+              case _ =>
+            }
 
           case _ => // Analysis successful!
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -2115,6 +2115,15 @@ case class LateralJoin(
   }
 }
 
+
+object LateralJoin {
+  /**
+   * A tag to identify if a Lateral Join is added by resolving table argument.
+   */
+  val BY_TABLE_ARGUMENT = TreeNodeTag[Unit]("by_table_argument")
+}
+
+
 /**
  * A logical plan for as-of join.
  */


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Arrow-optimized User-Defined Table Functions (UDTFs) have arbitrary output cardinality, meaning they can produce different numbers of rows for the same batch input rows. This fundamental characteristic is incompatible with lateral join semantics which combines each row from LHS with all rows from RHS for that particular input row. This PR implements a restriction that blocks Arrow Python UDTFs on the right hand side of lateral join: `SELECT * FROM table, LATERAL arrow_udtf(...)`.

It is always recommended to use table argument with arrow UDTFs:  `SELECT * FROM arrow_udtf(table(...))`

Note Regular UDTFs with lateral joins are allowed (unchanged behavior).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Prevents runtime errors and inconsistent results while maintaining full Arrow UDTF functionality for supported patterns.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No