### PR TITLE
[SPARK-53296][CORE] ESS exit main thread in case boss thread exits

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.MessageToMessageDecoder;
 
 import java.io.Closeable;
 import java.util.ArrayList;
+import java.util.function.Function;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -164,7 +165,12 @@ public class TransportContext implements Closeable {
 
   /** Create a server which will attempt to bind to a specific port. */
   public TransportServer createServer(int port, List<TransportServerBootstrap> bootstraps) {
-    return new TransportServer(this, null, port, rpcHandler, bootstraps);
+    return createServer(port, bootstraps, null);
+  }
+
+  /** Create a server which will attempt to bind to a specific port */
+  public TransportServer createServer(int port, List<TransportServerBootstrap> bootstraps, Function<Throwable, Void> onUncaughtException) {
+    return new TransportServer(this, null, port, rpcHandler, bootstraps, onUncaughtException);
   }
 
   /** Create a server which will attempt to bind to a specific host and port. */

--- a/common/network-common/src/main/java/org/apache/spark/network/util/BossThreadFactory.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/BossThreadFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.util;
+
+import io.netty.util.concurrent.DefaultThreadFactory;
+
+import java.util.function.Function;
+
+public class BossThreadFactory extends DefaultThreadFactory {
+    private final Function<Throwable, Void> onUncaughtException;
+
+    public BossThreadFactory(String threadPoolPrefix, boolean daemon, Function<Throwable, Void> onUncaughtException) {
+        super(threadPoolPrefix, daemon);
+        this.onUncaughtException = onUncaughtException;
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        Thread t = super.newThread(r);
+        t.setUncaughtExceptionHandler((thread, throwable) -> {
+            if (onUncaughtException != null) {
+                try {
+                    onUncaughtException.apply(throwable);
+                } catch (Exception e) {
+                    System.err.println("Exception in onUncaughtException handler: " + e);
+                }
+            }
+            System.err.println("Uncaught exception in thread " + thread.getName() + ": " + throwable);
+        });
+        return t;
+    }
+}

--- a/common/network-common/src/test/java/org/apache/spark/network/util/BossThreadFactorySuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/util/BossThreadFactorySuite.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.util;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BossThreadFactorySuite {
+
+    @Test
+    public void testBossThreadFactory() throws InterruptedException {
+        AtomicBoolean wasCalled = new AtomicBoolean(false);
+
+        Function<Throwable, Void> onUncaughtException = (throwable) -> {
+            System.out.println("Uncaught exception handler invoked!");
+            wasCalled.set(true);
+            return null;
+        };
+
+        BossThreadFactory factory = new BossThreadFactory("test", false, onUncaughtException);
+
+        Runnable faultyTask = () -> {
+            throw new RuntimeException("Test exception from thread!");
+        };
+
+        Thread thread = factory.newThread(faultyTask);
+        thread.start();
+        thread.join();
+
+        assertTrue(wasCalled.get(), "Test failed: onUncaughtException was not called.");
+    }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds a custom BossThreadFactory that allows registering an onUncaughtException handler for ESS boss threads.

Specifically:

1. Introduced a new BossThreadFactory (extending Netty’s DefaultThreadFactory) to capture uncaught exceptions in boss threads.
2. Added logic in ESS to handle boss thread failures by:
a. Logging the uncaught exception,
b. Stopping the shuffle service,
c. Counting down the shutdown barrier, and
d, Exiting the JVM with a non-zero code to trigger process restart.

With this change, if the boss thread is killed due to an OOM or other fatal error, the main thread will no longer remain alive in a broken state. Instead, the ESS process will exit and be restarted by the JVM/runtime environment, ensuring the host becomes usable again for shuffle operations.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

In the current ESS implementation, if the boss thread encounters an OOM error and is killed, the process enters a degraded state where new connections cannot be established on the affected ESS hosts. This happens because the main thread continues running even after the boss thread has terminated.

This pull request introduces support for terminating the main thread when the boss thread is killed. As a result, the JVM exits and the ESS host is automatically restarted, restoring its ability to serve shuffle-related operations.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Created a new thread and threw an exception -

val threadFactory = new BossThreadFactory("testThread", true, essServerStopFunc)
    val t = threadFactory.newThread(new Runnable {
      override def run(): Unit = {
        logInfo("Throwing exception in test thread")
        throw new RuntimeException("This is a test exception to check if the boss thread " +
          "is properly handling uncaught exceptions.")
      }
    })
    t.start()

With the proposed changes, as the boss thread was killed, the main thread exited as well resulting in the JVM automatically getting restarted and hence ESS was not left in a degraded state


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
