### PR TITLE
[SPARK-53300][PYTHON][TESTS] Fix field names in test_unpivot

### DIFF
--- a/python/pyspark/sql/tests/test_stat.py
+++ b/python/pyspark/sql/tests/test_stat.py
@@ -435,12 +435,12 @@ class DataFrameStatTestsMixin:
                     self.assertEqual(
                         actual.collect(),
                         [
-                            Row(var="int", value=10.0),
-                            Row(var="double", value=1.0),
-                            Row(var="int", value=20.0),
-                            Row(var="double", value=2.0),
-                            Row(var="int", value=30.0),
-                            Row(var="double", value=3.0),
+                            Row(var="int", val=10.0),
+                            Row(var="double", val=1.0),
+                            Row(var="int", val=20.0),
+                            Row(var="double", val=2.0),
+                            Row(var="int", val=30.0),
+                            Row(var="double", val=3.0),
                         ],
                     )
 
@@ -455,12 +455,12 @@ class DataFrameStatTestsMixin:
                     self.assertEqual(
                         actual.collect(),
                         [
-                            Row(id=1, var="int", value=10.0),
-                            Row(id=1, var="double", value=1.0),
-                            Row(id=2, var="int", value=20.0),
-                            Row(id=2, var="double", value=2.0),
-                            Row(id=3, var="int", value=30.0),
-                            Row(id=3, var="double", value=3.0),
+                            Row(id=1, var="int", val=10.0),
+                            Row(id=1, var="double", val=1.0),
+                            Row(id=2, var="int", val=20.0),
+                            Row(id=2, var="double", val=2.0),
+                            Row(id=3, var="int", val=30.0),
+                            Row(id=3, var="double", val=3.0),
                         ],
                     )
 
@@ -475,12 +475,12 @@ class DataFrameStatTestsMixin:
                     self.assertEqual(
                         actual.collect(),
                         [
-                            Row(id=1, double=1.0, var="int", value=10.0),
-                            Row(id=1, double=1.0, var="double", value=1.0),
-                            Row(id=2, double=2.0, var="int", value=20.0),
-                            Row(id=2, double=2.0, var="double", value=2.0),
-                            Row(id=3, double=3.0, var="int", value=30.0),
-                            Row(id=3, double=3.0, var="double", value=3.0),
+                            Row(id=1, double=1.0, var="int", val=10.0),
+                            Row(id=1, double=1.0, var="double", val=1.0),
+                            Row(id=2, double=2.0, var="int", val=20.0),
+                            Row(id=2, double=2.0, var="double", val=2.0),
+                            Row(id=3, double=3.0, var="int", val=30.0),
+                            Row(id=3, double=3.0, var="double", val=3.0),
                         ],
                     )
 
@@ -491,15 +491,15 @@ class DataFrameStatTestsMixin:
             self.assertEqual(
                 actual.collect(),
                 [
-                    Row(var="id", value=1.0),
-                    Row(var="int", value=10.0),
-                    Row(var="double", value=1.0),
-                    Row(var="id", value=2.0),
-                    Row(var="int", value=20.0),
-                    Row(var="double", value=2.0),
-                    Row(var="id", value=3.0),
-                    Row(var="int", value=30.0),
-                    Row(var="double", value=3.0),
+                    Row(var="id", val=1.0),
+                    Row(var="int", val=10.0),
+                    Row(var="double", val=1.0),
+                    Row(var="id", val=2.0),
+                    Row(var="int", val=20.0),
+                    Row(var="double", val=2.0),
+                    Row(var="id", val=3.0),
+                    Row(var="int", val=30.0),
+                    Row(var="double", val=3.0),
                 ],
             )
 
@@ -514,12 +514,12 @@ class DataFrameStatTestsMixin:
                     self.assertEqual(
                         actual.collect(),
                         [
-                            Row(id=1, var="int", value=10.0),
-                            Row(id=1, var="double", value=1.0),
-                            Row(id=2, var="int", value=20.0),
-                            Row(id=2, var="double", value=2.0),
-                            Row(id=3, var="int", value=30.0),
-                            Row(id=3, var="double", value=3.0),
+                            Row(id=1, var="int", val=10.0),
+                            Row(id=1, var="double", val=1.0),
+                            Row(id=2, var="int", val=20.0),
+                            Row(id=2, var="double", val=2.0),
+                            Row(id=3, var="int", val=30.0),
+                            Row(id=3, var="double", val=3.0),
                         ],
                     )
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix field names in test_unpivot


### Why are the changes needed?
the field names in the test are incorrect, (although comparing rows seems ignores the names)

```
======================================================================
FAIL [0.000s]: test_unpivot (pyspark.sql.tests.connect.test_parity_stat.DataFrameStatParityTests.test_unpivot) (ids=[], desc='with no identifier')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/python/pyspark/sql/tests/test_stat.py", line 435, in test_unpivot
    self.assertEqual(
AssertionError: Lists differ: [Row(var='int', val=10.0), Row(var='int', val=20.0), Row(var[97 chars]3.0)] != [Row(var='int', value=10.0), Row(var='double', value=1.0), R[109 chars]3.0)]
First differing element 1:
Row(var='int', val=20.0)
Row(var='double', value=1.0)
- [Row(var='int', val=10.0),
+ [Row(var='int', value=10.0),
?                    ++
-  Row(var='int', val=20.0),
-  Row(var='int', val=30.0),
-  Row(var='double', val=1.0),
+  Row(var='double', value=1.0),
?                       ++
+  Row(var='int', value=20.0),
-  Row(var='double', val=2.0),
+  Row(var='double', value=2.0),
?                       ++
+  Row(var='int', value=30.0),
-  Row(var='double', val=3.0)]
+  Row(var='double', value=3.0)]
?                       ++
```

### Does this PR introduce _any_ user-facing change?
test-only

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no