### PR TITLE
[SPARK-53302][PYTHON][TESTS] Make doctest of df.unpivot deterministic

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -4182,7 +4182,10 @@ class DataFrame:
         |  2| 12|   1.2|
         +---+---+------+
 
-        >>> df.unpivot("id", ["int", "double"], "var", "val").show()
+        >>> from pyspark.sql import functions as sf
+        >>> df.unpivot(
+        ...     "id", ["int", "double"], "var", "val"
+        ... ).sort("id", sf.desc("var")).show()
         +---+------+----+
         | id|   var| val|
         +---+------+----+


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Make doctest of df.unpivot deterministic


### Why are the changes needed?
it fails occasionally:
```
**********************************************************************
File "/home/jenkins/python/pyspark/sql/dataframe.py", line 4185, in pyspark.sql.dataframe.DataFrame.unpivot
Failed example:
    df.unpivot("id", ["int", "double"], "var", "val").show()
Expected:
    +---+------+----+
    | id|   var| val|
    +---+------+----+
    |  1|   int|11.0|
    |  1|double| 1.1|
    |  2|   int|12.0|
    |  2|double| 1.2|
    +---+------+----+
Got:
    +---+------+----+
    | id|   var| val|
    +---+------+----+
    |  1|   int|11.0|
    |  2|   int|12.0|
    |  1|double| 1.1|
    |  2|double| 1.2|
    +---+------+----+
    <BLANKLINE>
**********************************************************************

```


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no
