### PR TITLE
[SPARK-52873][SQL] Further restrict when SHJ semi/anti join can ignore duplicate keys on the build side

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -73,22 +73,21 @@ case class ShuffledHashJoinExec(
     //    all attributes should be from the stream-side.
     val buildKeysSet = ExpressionSet(buildKeys)
     val streamedOutputAttrs = AttributeSet(streamedOutput)
-    validCond0(cond, buildKeysSet, streamedOutputAttrs)
-  }
 
-  private def validCond0(cond: Expression,
-      buildKeysSet: ExpressionSet,
-      streamedOutputAttrs: AttributeSet): Boolean = {
-    cond match {
-      // don't bother traversing any subtree that has a semantic match to a build key
-      case e: Expression if buildKeysSet.contains(e) => true
-      // all attributes (outside any subtree that matches a build key) should be
-      // from the stream side
-      case a: Attribute if !streamedOutputAttrs.contains(a) => false
-      case e: Expression =>
-        e.children.forall(validCond0(_, buildKeysSet, streamedOutputAttrs))
-      case _ => true
+    def validCond(cond: Expression): Boolean = {
+      cond match {
+        // don't bother traversing any subtree that has a semantic match to a build key
+        case e: Expression if buildKeysSet.contains(e) => true
+        // all attributes (outside any subtree that matches a build key) should be
+        // from the stream side
+        case a: Attribute if !streamedOutputAttrs.contains(a) => false
+        case e: Expression =>
+          e.children.forall(validCond(_))
+        case _ => true
+      }
     }
+
+    validCond(cond)
   }
 
   // Exposed for testing

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -67,12 +67,7 @@ case class ShuffledHashJoinExec(
 
   // Exposed for testing
   @transient lazy val ignoreDuplicatedKey = joinType match {
-    case LeftExistence(_) =>
-      // For building hash relation, ignore duplicated rows with same join keys if:
-      // 1. Join condition is empty, or
-      // 2. Join condition only references streamed attributes and build join keys.
-      val streamedOutputAndBuildKeys = AttributeSet(streamedOutput ++ buildKeys)
-      condition.forall(_.references.subsetOf(streamedOutputAndBuildKeys))
+    case LeftExistence(_) if condition.isEmpty => true
     case _ => false
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1765,7 +1765,7 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
     }
   }
 
-  test("SPARK-52873") {
+  test("SPARK-52873: Don't ignore duplicate keys in SHJ when there is a bound condition") {
     val query =
       """select /*+ SHUFFLE_HASH(r) */ * from
         |testData2 l

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1771,6 +1771,19 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       cached.unpersist()
     }
   }
+
+  test("SPARK-52873") {
+    val query =
+      """select /*+ SHUFFLE_HASH(r) */ * from
+        |testData2 l
+        |left semi join testData2 r
+        |on cast(l.a / 100 as long) + 1  = cast(r.a / 100 as int) + 1
+        |and r.a >= cast(l.a/1000 as int) + 3""".stripMargin
+    val df = sql(query)
+    val expected = Row(1, 1) :: Row(1, 2) :: Row(2, 1) :: Row(2, 2) ::
+      Row (3, 1) :: Row(3, 2) :: Nil;
+    checkAnswer(df, expected)
+  }
 }
 
 class ThreadLeakInSortMergeJoinSuite

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1575,17 +1575,10 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
         // No join condition, ignore duplicated key.
         (s"SELECT /*+ SHUFFLE_HASH(t2) */ t1.c1 FROM t1 LEFT SEMI JOIN t2 ON t1.c1 = t2.c1",
           true),
-        // Have join condition on build join key only, ignore duplicated key.
+        // SPARK-52873: Have any join condition at all, do not ignore duplicated key.
         (s"""
             |SELECT /*+ SHUFFLE_HASH(t2) */ t1.c1 FROM t1 LEFT SEMI JOIN t2
             |ON t1.c1 = t2.c1 AND CAST(t1.c2 * 2 AS STRING) != t2.c1
-          """.stripMargin,
-          true),
-        // Have join condition on other build attribute beside join key, do not ignore
-        // duplicated key.
-        (s"""
-            |SELECT /*+ SHUFFLE_HASH(t2) */ t1.c1 FROM t1 LEFT SEMI JOIN t2
-            |ON t1.c1 = t2.c1 AND t1.c2 * 100 != t2.c2
           """.stripMargin,
           false)
       )


### PR DESCRIPTION
### What changes were proposed in this pull request?

After e861b0d93722f76cc103c05c7992c22c7fa23ad6, shuffle hash join for left semi/anti/existence will ignore duplicate keys if the join condition is empty or refers to the same parent attributes as the join keys. This PR proposes that duplicate keys should be ignored only when the join condition has these properties:

1. a subtree that is a semantic match to a build-side key, and/or
1. all attributes, outside of any subtree that is a semantic match to a build-side join key, should be from the stream-side.

### Why are the changes needed?

e861b0d93722f76cc103c05c7992c22c7fa23ad6 causes a correctness issue when a column is transformed in the build-side join keys and also transformed, but differently, in a join condition. As an example:
```
create or replace temp view data(a) as values
("xxxx1111"),
("yyyy2222");

create or replace temp view lookup(k) as values
("xxxx22"),
("xxxx33"),
("xxxx11");

-- this returns one row
select *
from data
left semi join lookup
on substring(a, 1, 4) = substring(k, 1, 4)
and substring(a, 1, 6) >= k;

-- this is the same query as above, but with a shuffle hash join hint, and returns no rows
select /*+ SHUFFLE_HASH(lookup) */ *
from data
left semi join lookup
on substring(a, 1, 4) = substring(k, 1, 4)
and substring(a, 1, 6) >= k;
```
When the join uses broadcast hash join, the hashrelation of lookup has the following key -> values:
```
Key xxxx:
  xxxx11
  xxxx33
  xxxx22
```
The join condition matches on the build side row with the value `xxxx11`.

When the join uses shuffle hash join, on the other hand, the hash relation of lookup has the following key -> values:
```
Key xxxx:
  xxxx22
```
Because the keys must be unique, an arbitrary row is chosen to represent the key, and that row does not match the join condition.

After 1f35577a3ead9c6268b5ba47c2e3aec60484e3cc, a similar issue happens with integer keys:
```
create or replace temp view data(a) as values
(10000),
(30000);

create or replace temp view lookup(k) as values
(1000),
(1001),
(1002),
(1003),
(1004);

-- this query returns one row
select * from data left semi join lookup on a/10000 = cast(k/1000 as int) and k >=  a/10 + 3;

-- this is the same query as above, but with a shuffle hash join hint, and returns no rows
select /*+ SHUFFLE_HASH(lookup) */ * from data left semi join lookup on a/10000 = cast(k/1000 as int) and k >=  a/10 + 3;
```

### Does this PR introduce _any_ user-facing change?

No, except for fixing the correctness issue.

### How was this patch tested?

Modified an existing unit test.

### Was this patch authored or co-authored using generative AI tooling?

No.
