### PR TITLE
[SPARK-53335][K8S] Support `spark.kubernetes.driver.annotateExitException`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -1073,7 +1073,7 @@ private[spark] class SparkSubmit extends Logging {
     try {
       if (!isShell(args.primaryResource) && !isSqlShell(args.mainClass)
           && !isThriftServer(args.mainClass) && !isConnectServer(args.mainClass)) {
-        SparkSubmitUtils.getSparkDiagnosticsSetters(args.master, sparkConf)
+        SparkSubmitUtils.getSparkDiagnosticsSetters(args.master)
           .foreach(_.setDiagnostics(throwable, sparkConf))
       }
     } catch {
@@ -1257,8 +1257,7 @@ private[spark] object SparkSubmitUtils {
   }
 
   private[deploy] def getSparkDiagnosticsSetters(
-      master: String,
-      sparkConf: SparkConf): Option[SparkDiagnosticsSetter] = {
+      master: String): Option[SparkDiagnosticsSetter] = {
     val loader = Utils.getContextOrSparkClassLoader
     val serviceLoaders =
       ServiceLoader.load(classOf[SparkDiagnosticsSetter], loader)

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -1070,7 +1070,7 @@ private[spark] class SparkSubmit extends Logging {
     // Swallow exceptions when storing diagnostics, this shouldn't fail the application.
     try {
       if (!isShell(args.primaryResource) && !isSqlShell(args.mainClass)
-        && !isThriftServer(args.mainClass)) {
+        && !isThriftServer(args.mainClass) && !isConnectServer(args.mainClass)) {
         SparkSubmitUtils.getSparkDiagnosticsSetters(args.master, sparkConf)
           .foreach(_.setDiagnostics(throwable, sparkConf))
       }
@@ -1265,8 +1265,7 @@ private[spark] object SparkSubmitUtils {
 
     serviceLoaders.size match {
       case x if x > 1 =>
-        throw new SparkException(s"Multiple($x) external SparkDiagnosticsSetter" +
-          s"registered for master url $master.")
+        throw new SparkException(s"Multiple($x) external SparkDiagnosticsSetter registered.")
       case 1 =>
         Some(serviceLoaders.headOption.get)
       case _ => None

--- a/resource-managers/kubernetes/core/src/main/resources/META-INF/services/org.apache.spark.deploy.SparkDiagnosticsSetter
+++ b/resource-managers/kubernetes/core/src/main/resources/META-INF/services/org.apache.spark.deploy.SparkDiagnosticsSetter
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.spark.deploy.k8s.SparkKubernetesDiagnosticsSetter

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -784,6 +784,14 @@ private[spark] object Config extends Logging {
       .checkValue(value => value > 0, "Gracefully shutdown period must be a positive time value")
       .createWithDefaultString("20s")
 
+  val KUBERNETES_STORE_DIAGNOSTICS =
+    ConfigBuilder("spark.kubernetes.storeDiagnostics")
+      .doc("If set to true, Spark will store diagnostics information for failed applications in" +
+        s" the Kubernetes API server using the ${DIAGNOSTICS_ANNOTATION} annotation.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val KUBERNETES_DRIVER_LABEL_PREFIX = "spark.kubernetes.driver.label."
   val KUBERNETES_DRIVER_ANNOTATION_PREFIX = "spark.kubernetes.driver.annotation."
   val KUBERNETES_DRIVER_SERVICE_LABEL_PREFIX = "spark.kubernetes.driver.service.label."

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -784,10 +784,10 @@ private[spark] object Config extends Logging {
       .checkValue(value => value > 0, "Gracefully shutdown period must be a positive time value")
       .createWithDefaultString("20s")
 
-  val KUBERNETES_STORE_DIAGNOSTICS =
-    ConfigBuilder("spark.kubernetes.storeDiagnostics")
-      .doc("If set to true, Spark will store diagnostics information for failed applications in" +
-        s" the Kubernetes API server using the $DIAGNOSTICS_ANNOTATION annotation.")
+  val KUBERNETES_ANNOTATE_EXIT_EXCEPTION =
+    ConfigBuilder("spark.kubernetes.driver.annotateExitException")
+      .doc("If set to true, Spark will store the exit exception failed applications in" +
+        s" the Kubernetes API server using the $EXIT_EXCEPTION_ANNOTATION annotation.")
       .version("4.1.0")
       .booleanConf
       .createWithDefault(false)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -787,7 +787,7 @@ private[spark] object Config extends Logging {
   val KUBERNETES_STORE_DIAGNOSTICS =
     ConfigBuilder("spark.kubernetes.storeDiagnostics")
       .doc("If set to true, Spark will store diagnostics information for failed applications in" +
-        s" the Kubernetes API server using the ${DIAGNOSTICS_ANNOTATION} annotation.")
+        s" the Kubernetes API server using the $DIAGNOSTICS_ANNOTATION annotation.")
       .version("4.1.0")
       .booleanConf
       .createWithDefault(false)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
@@ -107,6 +107,7 @@ object Constants {
   val DEFAULT_EXECUTOR_CONTAINER_NAME = "spark-kubernetes-executor"
   val NON_JVM_MEMORY_OVERHEAD_FACTOR = 0.4d
   val CONNECT_GRPC_BINDING_PORT = "spark.connect.grpc.binding.port"
+  val DIAGNOSTICS_ANNOTATION = "spark.kubernetes-diagnostics"
 
   // Hadoop Configuration
   val HADOOP_CONF_VOLUME = "hadoop-properties"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
@@ -107,7 +107,7 @@ object Constants {
   val DEFAULT_EXECUTOR_CONTAINER_NAME = "spark-kubernetes-executor"
   val NON_JVM_MEMORY_OVERHEAD_FACTOR = 0.4d
   val CONNECT_GRPC_BINDING_PORT = "spark.connect.grpc.binding.port"
-  val DIAGNOSTICS_ANNOTATION = "spark.kubernetes-diagnostics"
+  val EXIT_EXCEPTION_ANNOTATION = "spark.exit-exception"
 
   // Hadoop Configuration
   val HADOOP_CONF_VOLUME = "hadoop-properties"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetter.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetter.scala
@@ -48,9 +48,8 @@ private[spark] class DefaultKubernetesClientProvider extends KubernetesClientPro
   }
 }
 
-private[spark] class SparkKubernetesDiagnosticsSetter(
-  clientProvider: KubernetesClientProvider
-  ) extends SparkDiagnosticsSetter with Logging {
+private[spark] class SparkKubernetesDiagnosticsSetter(clientProvider: KubernetesClientProvider)
+  extends SparkDiagnosticsSetter with Logging {
 
   private val KUBERNETES_DIAGNOSTICS_MESSAGE_LIMIT_BYTES = 64 * 1024 // 64 KiB
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetter.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetter.scala
@@ -58,8 +58,6 @@ private[spark] class SparkKubernetesDiagnosticsSetter(clientProvider: Kubernetes
   }
 
   override def setDiagnostics(throwable: Throwable, conf: SparkConf): Unit = {
-    require(conf.get(KUBERNETES_DRIVER_POD_NAME).isDefined,
-      "Driver pod name must be set in order to set diagnostics on the driver pod.")
     val diagnostics = SparkStringUtils.abbreviate(StringUtils.stringifyException(throwable),
       KUBERNETES_EXIT_EXCEPTION_MESSAGE_LIMIT_BYTES)
     Utils.tryWithResource(clientProvider.create(conf)) { client =>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetter.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetter.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s
+
+import io.fabric8.kubernetes.api.model.{Pod, PodBuilder}
+import io.fabric8.kubernetes.client.KubernetesClient
+
+import org.apache.spark.SparkConf
+import org.apache.spark.deploy.SparkDiagnosticsSetter
+import org.apache.spark.deploy.k8s.Config._
+import org.apache.spark.deploy.k8s.Constants.DIAGNOSTICS_ANNOTATION
+import org.apache.spark.deploy.k8s.SparkKubernetesClientFactory.ClientType
+import org.apache.spark.internal.Logging
+
+/**
+ * We use this trait and its implementation to allow for mocking the static
+ * client creation in tests.
+ */
+private[spark] trait KubernetesClientProvider {
+  def create(conf: SparkConf): KubernetesClient
+}
+
+private[spark] class DefaultKubernetesClientProvider extends KubernetesClientProvider {
+  override def create(conf: SparkConf): KubernetesClient = {
+    SparkKubernetesClientFactory.createKubernetesClient(
+      conf.get(KUBERNETES_DRIVER_MASTER_URL),
+      Option(conf.get(KUBERNETES_NAMESPACE)),
+      KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX,
+      ClientType.Driver,
+      conf,
+      None)
+  }
+}
+
+private[spark] class SparkKubernetesDiagnosticsSetter(
+  clientProvider: KubernetesClientProvider
+  ) extends SparkDiagnosticsSetter with Logging {
+
+  def this() = {
+    this(new DefaultKubernetesClientProvider)
+  }
+
+  override def setDiagnostics(diagnostics: String, conf: SparkConf): Unit = {
+    require(conf.get(KUBERNETES_DRIVER_POD_NAME).isDefined,
+      "Driver pod name must be set in order to set diagnostics on the driver pod.")
+    val client = clientProvider.create(conf)
+    conf.get(KUBERNETES_DRIVER_POD_NAME).foreach { podName =>
+      client.pods()
+        .inNamespace(conf.get(KUBERNETES_NAMESPACE))
+        .withName(podName)
+        .edit((p: Pod) => new PodBuilder(p)
+          .editMetadata()
+          .addToAnnotations(DIAGNOSTICS_ANNOTATION, diagnostics)
+          .endMetadata()
+          .build());
+    }
+  }
+
+  override def supports(clusterManagerUrl: String, conf: SparkConf): Boolean = {
+    if (conf.get(KUBERNETES_STORE_DIAGNOSTICS)) {
+      return clusterManagerUrl.startsWith("k8s://")
+    }
+    false
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetter.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetter.scala
@@ -18,6 +18,8 @@ package org.apache.spark.deploy.k8s
 
 import io.fabric8.kubernetes.api.model.{Pod, PodBuilder}
 import io.fabric8.kubernetes.client.KubernetesClient
+import org.apache.hadoop.util.StringUtils
+
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.SparkDiagnosticsSetter
 import org.apache.spark.deploy.k8s.Config._
@@ -59,8 +61,7 @@ private[spark] class SparkKubernetesDiagnosticsSetter(
   override def setDiagnostics(throwable: Throwable, conf: SparkConf): Unit = {
     require(conf.get(KUBERNETES_DRIVER_POD_NAME).isDefined,
       "Driver pod name must be set in order to set diagnostics on the driver pod.")
-    val diagnostics = SparkStringUtils.abbreviate(
-      org.apache.hadoop.util.StringUtils.stringifyException(throwable),
+    val diagnostics = SparkStringUtils.abbreviate(StringUtils.stringifyException(throwable),
       KUBERNETES_DIAGNOSTICS_MESSAGE_LIMIT_BYTES)
     Utils.tryWithResource(clientProvider.create(conf)) { client =>
       conf.get(KUBERNETES_DRIVER_POD_NAME).foreach { podName =>

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetterSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetterSuite.scala
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s
+
+import java.util.function.UnaryOperator
+
+import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.client.KubernetesClient
+import io.fabric8.kubernetes.client.dsl.PodResource
+import org.mockito.{ArgumentCaptor, Mock, MockitoAnnotations}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatestplus.mockito.MockitoSugar
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.k8s.Config._
+import org.apache.spark.deploy.k8s.Constants.DIAGNOSTICS_ANNOTATION
+import org.apache.spark.deploy.k8s.Fabric8Aliases.PODS
+
+class SparkKubernetesDiagnosticsSetterSuite extends SparkFunSuite
+  with MockitoSugar with BeforeAndAfterEach {
+
+  @Mock
+  private var client: KubernetesClient = _
+  @Mock
+  private var clientProvider: KubernetesClientProvider = _
+  @Mock
+  private var podOperations: PODS = _
+  @Mock
+  private var driverPodOperations: PodResource = _
+
+  private val driverPodName: String = "driver-pod"
+  private val k8sClusterManagerUrl: String = "k8s://dummy"
+  private val namespace: String = "default"
+
+  private var setter: SparkKubernetesDiagnosticsSetter = _
+
+  override def beforeEach(): Unit = {
+    MockitoAnnotations.openMocks(this)
+    when(client.pods()).thenReturn(podOperations)
+    when(podOperations.inNamespace(namespace)).thenReturn(podOperations)
+    when(podOperations.withName(driverPodName)).thenReturn(driverPodOperations)
+    when(clientProvider.create(any(classOf[SparkConf]))).thenReturn(client)
+    setter = new SparkKubernetesDiagnosticsSetter(clientProvider)
+  }
+
+  test("supports() should return true only for k8s:// URLs when the feature is enabled") {
+    assert(setter.supports(k8sClusterManagerUrl,
+      new SparkConf().set(KUBERNETES_STORE_DIAGNOSTICS, true)))
+    assert(!setter.supports(k8sClusterManagerUrl, new SparkConf()))
+    assert(!setter.supports(k8sClusterManagerUrl,
+      new SparkConf().set(KUBERNETES_STORE_DIAGNOSTICS, false)))
+    assert(!setter.supports("yarn", new SparkConf().set(KUBERNETES_STORE_DIAGNOSTICS, true)))
+    assert(!setter.supports("spark://localhost", new SparkConf()))
+  }
+
+  test("setDiagnostics should throw if driver pod name is missing") {
+    val conf = new SparkConf()
+      .set(KUBERNETES_DRIVER_MASTER_URL, k8sClusterManagerUrl)
+      .set(KUBERNETES_NAMESPACE, namespace)
+
+    assertThrows[IllegalArgumentException] {
+      setter.setDiagnostics("diag", conf)
+    }
+  }
+
+  test("setDiagnostics should patch pod with diagnostics annotation") {
+    val diagnostics = "Fake diagnostics stack trace"
+    val conf = new SparkConf()
+      .set(KUBERNETES_DRIVER_MASTER_URL, k8sClusterManagerUrl)
+      .set(KUBERNETES_NAMESPACE, namespace)
+      .set(KUBERNETES_DRIVER_POD_NAME, driverPodName)
+
+    setter.setDiagnostics(diagnostics, conf)
+
+    val captor: ArgumentCaptor[UnaryOperator[Pod]] =
+      ArgumentCaptor.forClass(classOf[UnaryOperator[Pod]])
+    verify(driverPodOperations).edit(captor.capture())
+
+    val fn = captor.getValue
+    val initialPod = SparkPod.initialPod().pod
+    val editedPod = fn.apply(initialPod)
+
+    assert(editedPod.getMetadata.getAnnotations.get(DIAGNOSTICS_ANNOTATION) == diagnostics)
+  }
+}

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetterSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetterSuite.scala
@@ -66,16 +66,6 @@ class SparkKubernetesDiagnosticsSetterSuite extends SparkFunSuite
     assert(!setter.supports("spark://localhost"))
   }
 
-  test("setDiagnostics should throw if driver pod name is missing") {
-    val conf = new SparkConf()
-      .set(KUBERNETES_DRIVER_MASTER_URL, k8sClusterManagerUrl)
-      .set(KUBERNETES_NAMESPACE, namespace)
-
-    assertThrows[IllegalArgumentException] {
-      setter.setDiagnostics(new Throwable("diag"), conf)
-    }
-  }
-
   test("setDiagnostics should patch pod with diagnostics annotation") {
     val diagnostics = new Throwable("Fake diagnostics stack trace")
     val conf = new SparkConf()

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetterSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetterSuite.scala
@@ -21,6 +21,7 @@ import java.util.function.UnaryOperator
 import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.dsl.PodResource
+import org.apache.hadoop.util.StringUtils
 import org.mockito.{ArgumentCaptor, Mock, MockitoAnnotations}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
@@ -75,12 +76,12 @@ class SparkKubernetesDiagnosticsSetterSuite extends SparkFunSuite
       .set(KUBERNETES_NAMESPACE, namespace)
 
     assertThrows[IllegalArgumentException] {
-      setter.setDiagnostics("diag", conf)
+      setter.setDiagnostics(new Throwable("diag"), conf)
     }
   }
 
   test("setDiagnostics should patch pod with diagnostics annotation") {
-    val diagnostics = "Fake diagnostics stack trace"
+    val diagnostics = new Throwable("Fake diagnostics stack trace")
     val conf = new SparkConf()
       .set(KUBERNETES_DRIVER_MASTER_URL, k8sClusterManagerUrl)
       .set(KUBERNETES_NAMESPACE, namespace)
@@ -96,6 +97,7 @@ class SparkKubernetesDiagnosticsSetterSuite extends SparkFunSuite
     val initialPod = SparkPod.initialPod().pod
     val editedPod = fn.apply(initialPod)
 
-    assert(editedPod.getMetadata.getAnnotations.get(DIAGNOSTICS_ANNOTATION) == diagnostics)
+    assert(editedPod.getMetadata.getAnnotations.get(DIAGNOSTICS_ANNOTATION)
+      == StringUtils.stringifyException(diagnostics))
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetterSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetterSuite.scala
@@ -30,7 +30,7 @@ import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s.Config._
-import org.apache.spark.deploy.k8s.Constants.DIAGNOSTICS_ANNOTATION
+import org.apache.spark.deploy.k8s.Constants.EXIT_EXCEPTION_ANNOTATION
 import org.apache.spark.deploy.k8s.Fabric8Aliases.PODS
 
 class SparkKubernetesDiagnosticsSetterSuite extends SparkFunSuite
@@ -60,14 +60,10 @@ class SparkKubernetesDiagnosticsSetterSuite extends SparkFunSuite
     setter = new SparkKubernetesDiagnosticsSetter(clientProvider)
   }
 
-  test("supports() should return true only for k8s:// URLs when the feature is enabled") {
-    assert(setter.supports(k8sClusterManagerUrl,
-      new SparkConf().set(KUBERNETES_STORE_DIAGNOSTICS, true)))
-    assert(!setter.supports(k8sClusterManagerUrl, new SparkConf()))
-    assert(!setter.supports(k8sClusterManagerUrl,
-      new SparkConf().set(KUBERNETES_STORE_DIAGNOSTICS, false)))
-    assert(!setter.supports("yarn", new SparkConf().set(KUBERNETES_STORE_DIAGNOSTICS, true)))
-    assert(!setter.supports("spark://localhost", new SparkConf()))
+  test("supports() should return true only for k8s:// URLs") {
+    assert(setter.supports(k8sClusterManagerUrl))
+    assert(!setter.supports("yarn"))
+    assert(!setter.supports("spark://localhost"))
   }
 
   test("setDiagnostics should throw if driver pod name is missing") {
@@ -97,7 +93,7 @@ class SparkKubernetesDiagnosticsSetterSuite extends SparkFunSuite
     val initialPod = SparkPod.initialPod().pod
     val editedPod = fn.apply(initialPod)
 
-    assert(editedPod.getMetadata.getAnnotations.get(DIAGNOSTICS_ANNOTATION)
+    assert(editedPod.getMetadata.getAnnotations.get(EXIT_EXCEPTION_ANNOTATION)
       == StringUtils.stringifyException(diagnostics))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to provide a way for users to annotate the driver pod with exception message when the applications exit with exceptions.

### Why are the changes needed?

For jobs which run on kubernetes there is no native concept of diagnostics (like there is in YARN), which means that for debugging and triaging errors users _must_ go to logs. For jobs which run on YARN this is often not necessary, since the diagnostics contains the root cause reason for failure. Additionally, for platforms which provide automation of failure insights, or make decisions based on failures, there must be a custom solution or deciding why the application failed (e.g. log and stack trace parsing).

We use a similar mechanism as https://github.com/apache/spark/pull/23599 to load custom implementations in order to avoid the dependency on the k8s module from SparkSubmit.

### Does this PR introduce _any_ user-facing change?

Yes, a config, which is defaulted to false.

### How was this patch tested?

Unit tested + verified in production k8s cluster.

### Was this patch authored or co-authored using generative AI tooling?

No