### PR TITLE
[SPARK-53329][CONNECT] Improve exception handling when adding artifacts

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArtifactUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArtifactUtils.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.util
 
+import org.apache.spark.SparkRuntimeException
 import java.nio.file.{Path, Paths}
 
 object ArtifactUtils {
@@ -39,5 +40,18 @@ object ArtifactUtils {
 
   private[sql] def concatenatePaths(basePath: Path, otherPath: String): Path = {
     concatenatePaths(basePath, Paths.get(otherPath))
+  }
+
+  /**
+   * Converts a sequence of exceptions into a single exception by adding all but the first
+   * exceptions as suppressed exceptions to the first one.
+   * @param exceptions
+   * @return
+   */
+  private[sql] def mergeExceptionsWithSuppressed(exceptions: Seq[SparkRuntimeException]): SparkRuntimeException = {
+    require(exceptions.nonEmpty)
+    val mainException = exceptions.head
+    exceptions.drop(1).foreach(mainException.addSuppressed)
+    mainException
   }
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArtifactUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArtifactUtils.scala
@@ -49,8 +49,8 @@ object ArtifactUtils {
    * @param exceptions
    * @return
    */
-  private[sql] def mergeExceptionsWithSuppressed(exceptions: Seq[SparkRuntimeException]):
-      SparkRuntimeException = {
+  private[sql] def mergeExceptionsWithSuppressed(
+      exceptions: Seq[SparkRuntimeException]): SparkRuntimeException = {
     require(exceptions.nonEmpty)
     val mainException = exceptions.head
     exceptions.drop(1).foreach(mainException.addSuppressed)

--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArtifactUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArtifactUtils.scala
@@ -17,8 +17,9 @@
 
 package org.apache.spark.sql.util
 
-import org.apache.spark.SparkRuntimeException
 import java.nio.file.{Path, Paths}
+
+import org.apache.spark.SparkRuntimeException
 
 object ArtifactUtils {
 
@@ -48,7 +49,8 @@ object ArtifactUtils {
    * @param exceptions
    * @return
    */
-  private[sql] def mergeExceptionsWithSuppressed(exceptions: Seq[SparkRuntimeException]): SparkRuntimeException = {
+  private[sql] def mergeExceptionsWithSuppressed(exceptions: Seq[SparkRuntimeException]):
+      SparkRuntimeException = {
     require(exceptions.nonEmpty)
     val mainException = exceptions.head
     exceptions.drop(1).foreach(mainException.addSuppressed)

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
@@ -135,9 +135,7 @@ class SparkConnectAddArtifactsHandler(val responseObserver: StreamObserver[AddAr
     }.toSeq
 
     if (failedArtifactExceptions.nonEmpty) {
-      val exception = failedArtifactExceptions.head
-      failedArtifactExceptions.drop(1).foreach(exception.addSuppressed(_))
-      throw exception
+      throw ArtifactUtils.mergeExceptionsWithSuppressed(failedArtifactExceptions.toSeq)
     }
 
     summaries

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.connect.ResourceHelper
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.ThreadUtils
 
-class AddArtifactsHandlerSuite extends SharedSparkSession  with ResourceHelper {
+class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
 
   private val CHUNK_SIZE: Int = 32 * 1024
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
@@ -32,17 +32,19 @@ import io.grpc.StatusRuntimeException
 import io.grpc.protobuf.StatusProto
 import io.grpc.stub.StreamObserver
 
+import org.apache.spark.SparkRuntimeException
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.{AddArtifactsRequest, AddArtifactsResponse}
 import org.apache.spark.sql.connect.ResourceHelper
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.ThreadUtils
 
-class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
+class AddArtifactsHandlerSuite extends SharedSparkSession  with ResourceHelper {
 
   private val CHUNK_SIZE: Int = 32 * 1024
 
   private val sessionId = UUID.randomUUID.toString()
+  private val sessionKey = SessionKey("c1", sessionId)
 
   class DummyStreamObserver(p: Promise[AddArtifactsResponse])
       extends StreamObserver[AddArtifactsResponse] {
@@ -51,17 +53,31 @@ class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
     override def onCompleted(): Unit = {}
   }
 
-  class TestAddArtifactsHandler(responseObserver: StreamObserver[AddArtifactsResponse])
+  class TestAddArtifactsHandler(responseObserver: StreamObserver[AddArtifactsResponse],
+                                throwIfArtifactExists: Boolean = false)
       extends SparkConnectAddArtifactsHandler(responseObserver) {
 
     // Stop the staged artifacts from being automatically deleted
     override protected def cleanUpStagedArtifacts(): Unit = {}
 
     private val finalArtifacts = mutable.Buffer.empty[String]
+    private val artifactChecksums: mutable.Map[String, Long] = mutable.Map.empty
 
     // Record the artifacts that are sent out for final processing.
     override protected def addStagedArtifactToArtifactManager(artifact: StagedArtifact): Unit = {
+      // Throw if artifact already exists and has different checksum
+      // This mocks the behavior of ArtifactManager.addArtifact without comparing the entire file
+      if (throwIfArtifactExists
+          && finalArtifacts.contains(artifact.name)
+          && artifact.getCrc != artifactChecksums(artifact.name)) {
+        throw new SparkRuntimeException(
+          "ARTIFACT_ALREADY_EXISTS",
+          Map("normalizedRemoteRelativePath" -> artifact.name)
+        )
+      }
+
       finalArtifacts.append(artifact.name)
+      artifactChecksums += (artifact.name -> artifact.getCrc)
     }
 
     def getFinalArtifacts: Seq[String] = finalArtifacts.toSeq
@@ -418,4 +434,80 @@ class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
     }
   }
 
+
+  def addSingleChunkArtifact(
+      handler: SparkConnectAddArtifactsHandler,
+      sessionKey: SessionKey,
+      name: String,
+      artifactPath: Path): Unit = {
+    val dataChunks = getDataChunks(artifactPath)
+    assert(dataChunks.size == 1)
+    val bytes = dataChunks.head
+    val context = proto.UserContext
+      .newBuilder()
+      .setUserId(sessionKey.userId)
+      .build()
+    val fileNameNoExtension = artifactPath.getFileName.toString.split('.').head
+    val singleChunkArtifact = proto.AddArtifactsRequest.SingleChunkArtifact
+      .newBuilder()
+      .setName(name)
+      .setData(
+        proto.AddArtifactsRequest.ArtifactChunk
+          .newBuilder()
+          .setData(bytes)
+          .setCrc(getCrcValues(crcPath.resolve(fileNameNoExtension + ".txt")).head)
+          .build())
+      .build()
+
+    val singleChunkArtifactRequest = AddArtifactsRequest
+      .newBuilder()
+      .setSessionId(sessionKey.sessionId)
+      .setUserContext(context)
+      .setBatch(
+        proto.AddArtifactsRequest.Batch.newBuilder().addArtifacts(singleChunkArtifact).build())
+      .build()
+
+    handler.onNext(singleChunkArtifactRequest)
+  }
+
+  test("All artifacts are added, even if some fail") {
+    val promise = Promise[AddArtifactsResponse]()
+    val handler = new TestAddArtifactsHandler(new DummyStreamObserver(promise),
+                                              throwIfArtifactExists = true)
+    try {
+      val name1 = "jars/dummy1.jar"
+      val name2 = "jars/dummy2.jar"
+      val name3 = "jars/dummy3.jar"
+
+      val artifactPath1 = inputFilePath.resolve("smallClassFile.class")
+      val artifactPath2 = inputFilePath.resolve("smallJar.jar")
+
+      assume(artifactPath1.toFile.exists)
+      addSingleChunkArtifact(handler, sessionKey, name1, artifactPath1)
+      addSingleChunkArtifact(handler, sessionKey, name3, artifactPath1)
+
+      val e = intercept[StatusRuntimeException] {
+        addSingleChunkArtifact(handler, sessionKey, name1, artifactPath2)
+        addSingleChunkArtifact(handler, sessionKey, name2, artifactPath1)
+        addSingleChunkArtifact(handler, sessionKey, name3, artifactPath2)
+        handler.onCompleted()
+      }
+
+      // Both artifacts should be added, despite exception
+      assert(handler.getFinalArtifacts.contains(name1))
+      assert(handler.getFinalArtifacts.contains(name2))
+      assert(handler.getFinalArtifacts.contains(name3))
+
+      assert(e.getStatus.getCode == Code.INTERNAL)
+      val statusProto = StatusProto.fromThrowable(e)
+      assert(statusProto.getDetailsCount == 1)
+      val details = statusProto.getDetails(0)
+      val info = details.unpack(classOf[ErrorInfo])
+
+      assert(e.getMessage.contains("ARTIFACT_ALREADY_EXISTS"))
+      assert(info.getMetadataMap().get("messageParameters").contains(name1))
+    } finally {
+      handler.forceCleanUp()
+    }
+  }
 }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
@@ -53,8 +53,9 @@ class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
     override def onCompleted(): Unit = {}
   }
 
-  class TestAddArtifactsHandler(responseObserver: StreamObserver[AddArtifactsResponse],
-                                throwIfArtifactExists: Boolean = false)
+  class TestAddArtifactsHandler(
+      responseObserver: StreamObserver[AddArtifactsResponse],
+      throwIfArtifactExists: Boolean = false)
       extends SparkConnectAddArtifactsHandler(responseObserver) {
 
     // Stop the staged artifacts from being automatically deleted
@@ -68,12 +69,11 @@ class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
       // Throw if artifact already exists and has different checksum
       // This mocks the behavior of ArtifactManager.addArtifact without comparing the entire file
       if (throwIfArtifactExists
-          && finalArtifacts.contains(artifact.name)
-          && artifact.getCrc != artifactChecksums(artifact.name)) {
+        && finalArtifacts.contains(artifact.name)
+        && artifact.getCrc != artifactChecksums(artifact.name)) {
         throw new SparkRuntimeException(
           "ARTIFACT_ALREADY_EXISTS",
-          Map("normalizedRemoteRelativePath" -> artifact.name)
-        )
+          Map("normalizedRemoteRelativePath" -> artifact.name))
       }
 
       finalArtifacts.append(artifact.name)
@@ -434,7 +434,6 @@ class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
     }
   }
 
-
   def addSingleChunkArtifact(
       handler: SparkConnectAddArtifactsHandler,
       sessionKey: SessionKey,
@@ -472,8 +471,8 @@ class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
 
   test("All artifacts are added, even if some fail") {
     val promise = Promise[AddArtifactsResponse]()
-    val handler = new TestAddArtifactsHandler(new DummyStreamObserver(promise),
-                                              throwIfArtifactExists = true)
+    val handler =
+      new TestAddArtifactsHandler(new DummyStreamObserver(promise), throwIfArtifactExists = true)
     try {
       val name1 = "jars/dummy1.jar"
       val name2 = "jars/dummy2.jar"

--- a/sql/core/src/main/scala/org/apache/spark/sql/artifact/ArtifactManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/artifact/ArtifactManager.scala
@@ -267,7 +267,7 @@ class ArtifactManager(session: SparkSession) extends AutoCloseable with Logging 
    * they are from a permanent location.
    */
   private[sql] def addLocalArtifacts(artifacts: Seq[Artifact]): Unit = {
-    val failedArtifactExceptions = ListBuffer[RuntimeException]()
+    val failedArtifactExceptions = ListBuffer[SparkRuntimeException]()
 
     artifacts.foreach { artifact =>
       try {

--- a/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
@@ -386,8 +386,7 @@ class ArtifactManagerSuite extends SharedSparkSession {
     checkError(
       exception = ex,
       condition = "ARTIFACT_ALREADY_EXISTS",
-      parameters = Map("normalizedRemoteRelativePath" -> s"jars/${targetPath.toString}"),
-    )
+      parameters = Map("normalizedRemoteRelativePath" -> s"jars/${targetPath.toString}"))
 
     assert(ex.getSuppressed.length == 1)
     assert(ex.getSuppressed.head.isInstanceOf[SparkRuntimeException])
@@ -396,8 +395,7 @@ class ArtifactManagerSuite extends SharedSparkSession {
     checkError(
       exception = suppressed,
       condition = "ARTIFACT_ALREADY_EXISTS",
-      parameters = Map("normalizedRemoteRelativePath" -> s"jars/${targetPath.toString}"),
-    )
+      parameters = Map("normalizedRemoteRelativePath" -> s"jars/${targetPath.toString}"))
 
     // Artifact1 should have been added
     val expectedFile1 = ArtifactManager.artifactRootDirectory

--- a/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
@@ -357,7 +357,7 @@ class ArtifactManagerSuite extends SharedSparkSession {
     val targetPath2 = Paths.get(artifact2Path)
 
     val classPath1 = copyDir.resolve("Hello.class")
-    val classPath2 = copyDir.resolve("smallJar.jar")
+    val classPath2 = copyDir.resolve("udf_noA.jar")
     assume(artifactPath.resolve("Hello.class").toFile.exists)
     assume(artifactPath.resolve("smallClassFile.class").toFile.exists)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When a user sends multiple artifacts with the `addArtifacts` API, we process each artifact one at a time on the server-side.

If the server detects the user attempting to modify an artifact (by overwriting an existing artifact of the same path with a different byte sequence), an exception is immediately thrown and artifact addition process is terminated.

 Instead, the operation should be idempotent and the server should try to add as many artifacts as possible instead of returning early.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

As explained, if the server encounters an error while adding artifacts it will return immediately. This can be a bit wasteful as the server discards all other artifacts sent over the wire regardless of their own status. Thus, an improvement can be made to process all artifacts, catch any exceptions and rethrow them at the end.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

This PR does not modify the existing API or the return codes. If the above scenario is triggered, the only user facing change is that the server adds as many artifacts as possible. Therefore it should be fully backwards compatible. Additionally, if more than one artifact already existed, its exception is added as a suppressed exception. Currently, these suppressed exceptions are not serialized into the grpc object and sent over the wire, however.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit tests and local testing.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No