### PR TITLE
[SPARK-53330][SQL][PYTHON] Fix Arrow UDF with DayTimeIntervalType (bounds != start/end)

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
@@ -21,7 +21,7 @@ from pyspark.errors import AnalysisException, PythonException, PySparkNotImpleme
 from pyspark.sql import Row
 from pyspark.sql.functions import udf
 from pyspark.sql.tests.test_udf import BaseUDFTestsMixin
-from pyspark.sql.types import VarcharType
+from pyspark.sql.types import DayTimeIntervalType, VarcharType
 from pyspark.testing.sqlutils import (
     have_pandas,
     have_pyarrow,
@@ -242,6 +242,28 @@ class ArrowPythonUDFTestsMixin(BaseUDFTestsMixin):
             self.assertEqual(
                 udf(lambda x: str(x), useArrow=False).evalType, PythonEvalType.SQL_BATCHED_UDF
             )
+
+    def test_day_time_interval_type_casting(self):
+        """Test that DayTimeIntervalType UDFs work with Arrow and preserve field specifications."""
+
+        # HOUR TO SECOND
+        @udf(useArrow=True, returnType=DayTimeIntervalType(1, 3))
+        def return_interval(x):
+            return x
+
+        df = (
+            self.spark.sql("SELECT INTERVAL '200:13:50.3' HOUR TO SECOND as value")
+            .select(return_interval("value").alias("result"))
+        )
+        self.assertEqual(df.schema.fields[0].dataType, DayTimeIntervalType(1, 3))
+        self.assertIsNotNone(df.collect()[0]["result"])
+
+        df2 = (
+            self.spark.sql("SELECT INTERVAL '1 10:30:45.123' DAY TO SECOND as value")
+            .select(return_interval("value").alias("result"))
+        )
+        self.assertEqual(df.schema.fields[0].dataType, DayTimeIntervalType(1, 3))
+        self.assertIsNotNone(df2.collect()[0]["result"])
 
 
 @unittest.skipIf(

--- a/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
@@ -251,16 +251,14 @@ class ArrowPythonUDFTestsMixin(BaseUDFTestsMixin):
         def return_interval(x):
             return x
 
-        df = (
-            self.spark.sql("SELECT INTERVAL '200:13:50.3' HOUR TO SECOND as value")
-            .select(return_interval("value").alias("result"))
+        df = self.spark.sql("SELECT INTERVAL '200:13:50.3' HOUR TO SECOND as value").select(
+            return_interval("value").alias("result")
         )
         self.assertEqual(df.schema.fields[0].dataType, DayTimeIntervalType(1, 3))
         self.assertIsNotNone(df.collect()[0]["result"])
 
-        df2 = (
-            self.spark.sql("SELECT INTERVAL '1 10:30:45.123' DAY TO SECOND as value")
-            .select(return_interval("value").alias("result"))
+        df2 = self.spark.sql("SELECT INTERVAL '1 10:30:45.123' DAY TO SECOND as value").select(
+            return_interval("value").alias("result")
         )
         self.assertEqual(df.schema.fields[0].dataType, DayTimeIntervalType(1, 3))
         self.assertIsNotNone(df2.collect()[0]["result"])

--- a/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
@@ -21,7 +21,7 @@ from pyspark.errors import AnalysisException, PythonException, PySparkNotImpleme
 from pyspark.sql import Row
 from pyspark.sql.functions import udf
 from pyspark.sql.tests.test_udf import BaseUDFTestsMixin
-from pyspark.sql.types import DayTimeIntervalType, VarcharType
+from pyspark.sql.types import DayTimeIntervalType, VarcharType, StructType, StructField, StringType
 from pyspark.testing.sqlutils import (
     have_pandas,
     have_pyarrow,
@@ -251,17 +251,46 @@ class ArrowPythonUDFTestsMixin(BaseUDFTestsMixin):
         def return_interval(x):
             return x
 
+        # UDF input: HOUR TO SECOND, UDF output: HOUR TO SECOND
         df = self.spark.sql("SELECT INTERVAL '200:13:50.3' HOUR TO SECOND as value").select(
             return_interval("value").alias("result")
         )
         self.assertEqual(df.schema.fields[0].dataType, DayTimeIntervalType(1, 3))
         self.assertIsNotNone(df.collect()[0]["result"])
 
+        # UDF input: DAY TO SECOND, UDF output: HOUR TO SECOND
         df2 = self.spark.sql("SELECT INTERVAL '1 10:30:45.123' DAY TO SECOND as value").select(
             return_interval("value").alias("result")
         )
         self.assertEqual(df.schema.fields[0].dataType, DayTimeIntervalType(1, 3))
         self.assertIsNotNone(df2.collect()[0]["result"])
+
+    def test_day_time_interval_in_struct(self):
+        """Test that DayTimeIntervalType works within StructType with Arrow UDFs."""
+
+        struct_type = StructType(
+            [
+                StructField("interval_field", DayTimeIntervalType(1, 3)),
+                StructField("name", StringType()),
+            ]
+        )
+
+        @udf(useArrow=True, returnType=struct_type)
+        def create_struct_with_interval(interval_val, name_val):
+            return Row(interval_field=interval_val, name=name_val)
+
+        df = self.spark.sql(
+            """
+            SELECT INTERVAL '15:30:45.678' HOUR TO SECOND as interval_val,
+                   'test_name' as name_val
+        """
+        ).select(create_struct_with_interval("interval_val", "name_val").alias("result"))
+
+        self.assertEqual(df.schema.fields[0].dataType, struct_type)
+        self.assertEqual(df.schema.fields[0].dataType.fields[0].dataType, DayTimeIntervalType(1, 3))
+        result = df.collect()[0]["result"]
+        self.assertIsNotNone(result["interval_field"])
+        self.assertEqual(result["name"], "test_name")
 
 
 @unittest.skipIf(

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -458,6 +458,7 @@ object DataType {
     def transform: PartialFunction[DataType, DataType] = {
       case dt @ (_: CharType | _: VarcharType) => dt
       case _: StringType => StringType
+      case _: DayTimeIntervalType => DayTimeIntervalType
     }
 
     if (checkComplexTypes) {
@@ -465,6 +466,8 @@ object DataType {
     } else {
       (from, to) match {
         case (a: StringType, b: StringType) => a.constraint == b.constraint
+        case (x: DayTimeIntervalType, y: DayTimeIntervalType) =>
+          x.startField <= y.startField && y.endField <= x.endField
 
         case (fromDataType, toDataType) => fromDataType == toDataType
       }

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -458,7 +458,8 @@ object DataType {
     def transform: PartialFunction[DataType, DataType] = {
       case dt @ (_: CharType | _: VarcharType) => dt
       case _: StringType => StringType
-      case _: DayTimeIntervalType => DayTimeIntervalType
+      // SPARK-53330 (see below)
+      case _: DayTimeIntervalType => DayTimeIntervalType.DEFAULT
     }
 
     if (checkComplexTypes) {
@@ -466,8 +467,10 @@ object DataType {
     } else {
       (from, to) match {
         case (a: StringType, b: StringType) => a.constraint == b.constraint
-        case (x: DayTimeIntervalType, y: DayTimeIntervalType) =>
-          x.startField <= y.startField && y.endField <= x.endField
+        // SPARK-53330: Arrow serialization always returns DayTimeIntervalType(0, 3)
+        // as it has the maximum range, we can always assume that we can match
+        // with the target type.
+        case (x: DayTimeIntervalType, y: DayTimeIntervalType) => true
 
         case (fromDataType, toDataType) => fromDataType == toDataType
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
-import org.apache.spark.sql.types.{DataType, DayTimeIntervalType, StructType, UserDefinedType, ArrayType, MapType}
+import org.apache.spark.sql.types.{ArrayType, DataType, DayTimeIntervalType, MapType, StructType, UserDefinedType}
 import org.apache.spark.sql.types.DataType.equalsIgnoreCompatibleCollation
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
 import org.apache.spark.sql.types.{DataType, DayTimeIntervalType, StructType, UserDefinedType, ArrayType, MapType}
 import org.apache.spark.sql.types.DataType.equalsIgnoreCompatibleCollation
-import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
 
 /**
  * Grouped a iterator into batches.
@@ -141,21 +140,21 @@ class ArrowEvalPythonEvaluatorFactory(
         // Arrow always returns the broadest range, so as long as we're not losing information,
         // we can consider the types equal.
         actual.startField <= expected.startField && expected.endField <= actual.endField
-      
+
       case (expected: ArrayType, actual: ArrayType) =>
         typesEqualRecursive(expected.elementType, actual.elementType)
-      
+
       case (expected: MapType, actual: MapType) =>
         typesEqualRecursive(expected.keyType, actual.keyType) &&
         typesEqualRecursive(expected.valueType, actual.valueType)
-      
+
       case (expected: StructType, actual: StructType) =>
         expected.fields.length == actual.fields.length &&
         expected.fields.zip(actual.fields).forall { case (expectedField, actualField) =>
           expectedField.name == actualField.name &&
           typesEqualRecursive(expectedField.dataType, actualField.dataType)
         }
-      
+
       case _ => equalsIgnoreCompatibleCollation(expected, actual)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
-import org.apache.spark.sql.types.{ArrayType, DataType, DayTimeIntervalType, MapType, StructType, UserDefinedType}
+import org.apache.spark.sql.types.{StructType, UserDefinedType}
 import org.apache.spark.sql.types.DataType.equalsIgnoreCompatibleCollation
 
 /**
@@ -124,41 +124,6 @@ class ArrowEvalPythonEvaluatorFactory(
     profiler: Option[String])
   extends EvalPythonEvaluatorFactory(childOutput, udfs, output) {
 
-  private def typesEqual(
-      expectedTypes: Seq[DataType],
-      actualTypes: Seq[DataType]): Boolean = {
-    expectedTypes.length == actualTypes.length &&
-    expectedTypes.zip(actualTypes).forall { case (expected, actual) =>
-      typesEqualRecursive(expected, actual)
-    }
-  }
-
-  private def typesEqualRecursive(expected: DataType, actual: DataType): Boolean = {
-    (expected, actual) match {
-      case (expected: DayTimeIntervalType, actual: DayTimeIntervalType) =>
-        // Use lenient type checking that treats DayTimeIntervalType variants as compatible
-        // Arrow always returns the broadest range, so as long as we're not losing information,
-        // we can consider the types equal.
-        actual.startField <= expected.startField && expected.endField <= actual.endField
-
-      case (expected: ArrayType, actual: ArrayType) =>
-        typesEqualRecursive(expected.elementType, actual.elementType)
-
-      case (expected: MapType, actual: MapType) =>
-        typesEqualRecursive(expected.keyType, actual.keyType) &&
-        typesEqualRecursive(expected.valueType, actual.valueType)
-
-      case (expected: StructType, actual: StructType) =>
-        expected.fields.length == actual.fields.length &&
-        expected.fields.zip(actual.fields).forall { case (expectedField, actualField) =>
-          expectedField.name == actualField.name &&
-          typesEqualRecursive(expectedField.dataType, actualField.dataType)
-        }
-
-      case _ => equalsIgnoreCompatibleCollation(expected, actual)
-    }
-  }
-
   override def evaluate(
       funcs: Seq[(ChainedPythonFunctions, Long)],
       argMetas: Array[Array[ArgumentMetadata]],
@@ -187,12 +152,10 @@ class ArrowEvalPythonEvaluatorFactory(
 
     columnarBatchIter.flatMap { batch =>
       val actualDataTypes = (0 until batch.numCols()).map(i => batch.column(i).dataType())
-
-      if (!typesEqual(outputTypes, actualDataTypes)) {
+      if (!equalsIgnoreCompatibleCollation(outputTypes, actualDataTypes)) {
         throw QueryExecutionErrors.arrowDataTypeMismatchError(
           "pandas_udf()", outputTypes, actualDataTypes)
       }
-
       batch.rowIterator.asScala
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
- makes ArrowEvalPythonExec type check more lenient when comparing `DayTimeIntervalType`s so that they are considered equal when the source type has more information than the target type. The arrow serialization always sends full intervals either way, so that should always be true. We can then rely on the engine to interpret the data according to the node's output type.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When a pyspark udf (useArrow=true) returns interval type data, it currently errors with below error when the resultType (e.g., DayTimeIntervalType) has begin/end that don't span the maximum range.  

`org.apache.spark.SparkException: [ARROW_TYPE_MISMATCH] Invalid schema from pandas_udf(): expected DayTimeIntervalType(1,3), got DayTimeIntervalType(0,3). SQLSTATE: 42K0G`
 

Repro:

```
from pyspark.sql.types import DayTimeIntervalType
from pyspark.sql.functions import udf
 
# this works
@udf(useArrow=True, returnType=DayTimeIntervalType(0, 3))
def return_interval1(x):
  return x

# this fails, although it matches the input type HOUR TO SECOND
@udf(useArrow=True, returnType=DayTimeIntervalType(1, 3)) 
def return_interval2(x):
  return x

spark.sql("SELECT INTERVAL '10:30:45.123' HOUR TO SECOND as value").select(return_interval2("value")).collect()
```

The cause is that when the worker sends data back, it is always just sends a full arrow duration, which does not remember begin or end index. In above example, the begin should be `HOUR` (1), and that causes the node to throw said ARROW_TYPE_MISMATCH.
 
YearToMonthIntervalType is not supported in arrow udfs, so that is currently not a concern.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, a bug fix that enables behavior that previously threw an error.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
- added python tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No