### PR TITLE
[SPARK-53334][CONNECT] `LiteralValueProtoConverter` should keep the order of input map

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/PlanGenerationTestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/PlanGenerationTestSuite.scala
@@ -3405,7 +3405,7 @@ class PlanGenerationTestSuite
       fn.typedLit(Some(1)),
       fn.typedLit(Array(1, 2, 3)),
       fn.typedLit(Seq(1, 2, 3)),
-      fn.typedLit(Map("a" -> 1, "b" -> 2)),
+      fn.typedLit(mutable.LinkedHashMap("a" -> 1, "b" -> 2)),
       fn.typedLit(("a", 2, 1.0)),
       fn.typedLit[Option[Int]](None),
       fn.typedLit[Array[Option[Int]]](Array(Some(1))),
@@ -3414,9 +3414,20 @@ class PlanGenerationTestSuite
       fn.typedlit[collection.immutable.Map[Int, Option[Int]]](
         collection.immutable.Map(1 -> None)),
       fn.typedLit(Seq(Seq(1, 2, 3), Seq(4, 5, 6), Seq(7, 8, 9))),
-      fn.typedLit(Seq(Map("a" -> 1, "b" -> 2), Map("a" -> 3, "b" -> 4), Map("a" -> 5, "b" -> 6))),
-      fn.typedLit(Map(1 -> Map("a" -> 1, "b" -> 2), 2 -> Map("a" -> 3, "b" -> 4))),
-      fn.typedLit((Seq(1, 2, 3), Map("a" -> 1, "b" -> 2), ("a", Map(1 -> "a", 2 -> "b")))))
+      fn.typedLit(
+        Seq(
+          mutable.LinkedHashMap("a" -> 1, "b" -> 2),
+          mutable.LinkedHashMap("a" -> 3, "b" -> 4),
+          mutable.LinkedHashMap("a" -> 5, "b" -> 6))),
+      fn.typedLit(
+        mutable.LinkedHashMap(
+          1 -> mutable.LinkedHashMap("a" -> 1, "b" -> 2),
+          2 -> mutable.LinkedHashMap("a" -> 3, "b" -> 4))),
+      fn.typedLit(
+        (
+          Seq(1, 2, 3),
+          mutable.LinkedHashMap("a" -> 1, "b" -> 2),
+          ("a", mutable.LinkedHashMap(1 -> "a", 2 -> "b")))))
   }
 
   /* Window API */

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
@@ -439,7 +439,7 @@ object LiteralValueProtoConverter {
         valueConverter: proto.Expression.Literal => V)(implicit
         tagK: ClassTag[K],
         tagV: ClassTag[V]): mutable.Map[K, V] = {
-      val builder = mutable.HashMap.empty[K, V]
+      val builder = mutable.LinkedHashMap.empty[K, V]
       val keys = map.getKeysList.asScala
       val values = map.getValuesList.asScala
       builder.sizeHint(keys.size)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

- use `LinkedHashMap` in the `typedLit` test
- make `LiteralValueProtoConverter` keep the order of input map


### Why are the changes needed?
It might increase randomness of transformed literal values, e.g. the `typedLit` test, it is non-determinisitc


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no
