### PR TITLE
[SPARK-53337][CORE] Ensure the application name get escaped.

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -24,6 +24,7 @@ import scala.collection.mutable.LinkedHashSet
 import scala.jdk.CollectionConverters._
 
 import org.apache.avro.{Schema, SchemaNormalization}
+import org.apache.commons.text.StringEscapeUtils
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys
@@ -345,7 +346,7 @@ class SparkConf(loadDefaults: Boolean)
 
   /** Set a name for your application. Shown in the Spark web UI. */
   def setAppName(name: String): SparkConf = {
-    set("spark.app.name", name)
+    set("spark.app.name", StringEscapeUtils.escapeHtml4(name))
   }
 
   /** Set JAR files to distribute to the cluster. */


### PR DESCRIPTION
### What changes were proposed in this pull request?
In spark web, the application name need to be escaped.

### Why are the changes needed?
Not escaped app name could lead to bad thing in the web ui


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tests already exist, it was manually tested.

### Was this patch authored or co-authored using generative AI tooling?
No
