### PR TITLE
[SPARK-53351][CORE] Use consistent string type blockId for block data access in external block handler

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockIdUtils.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockIdUtils.java
@@ -69,7 +69,7 @@ public class BlockIdUtils {
    * Returns the name of the ShuffleChecksumBlockId. This should be in sync with
    *  IndexShuffleBlockResolver.getChecksumFile
    */
-  static public String getChecksumFileName(String blockId, String algorithm) {
+  public static String getChecksumFileName(String blockId, String algorithm) {
     String[] blockIdParts = blockId.split("_");
     if (blockIdParts.length <  4) {
       throw new IllegalArgumentException("Unexpected shuffle block id format: " + blockId);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockIdUtils.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockIdUtils.java
@@ -36,8 +36,6 @@ public class BlockIdUtils {
   }
 
   public static Boolean isShuffleChunk(String blockId) {
-    // Shuffle chunk block is not supported by Aether, and we don't need to check for wrapped
-    // Aether blocks.
     return blockId.startsWith(SHUFFLE_CHUNK_PREFIX);
   }
 

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockIdUtils.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockIdUtils.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle;
+
+import org.apache.spark.network.shuffle.checksum.ShuffleChecksumHelper;
+
+public class BlockIdUtils {
+    public static final String SHUFFLE_BLOCK_PREFIX = "shuffle_";
+
+    public static final String SHUFFLE_CHUNK_PREFIX = "shuffleChunk_";
+
+    public static final String RDD_BLOCK_PREFIX = "rdd_";
+
+    private static final String NOOP_REDUCE_ID = "0";
+
+    public static Boolean isRddBlock(String blockId) {
+        if (blockId.startsWith(RDD_BLOCK_PREFIX)) return true;
+        return false;
+    }
+
+    public static Boolean isShuffleBlock(String blockId) {
+        if (blockId.startsWith(SHUFFLE_BLOCK_PREFIX)) return true;
+        return false;
+    }
+
+    public static Boolean isShuffleChunk(String blockId) {
+        // Shuffle chunk block is not supported by Aether, and we don't need to check for wrapped
+        // Aether blocks.
+        return blockId.startsWith(SHUFFLE_CHUNK_PREFIX);
+    }
+
+    public static int getShuffleId(String blockId) {
+        String[] blockIdParts = blockId.split("_");
+        if (blockIdParts.length <  4) {
+          throw new IllegalArgumentException("Unexpected shuffle block id format: " + blockId);
+        }
+        return Integer.parseInt(blockIdParts[1]);
+    }
+
+    public static long getMapId(String blockId) {
+        String[] blockIdParts = blockId.split("_");
+        if (blockIdParts.length <  4) {
+          throw new IllegalArgumentException("Unexpected shuffle block id format: " + blockId);
+        }
+        return Long.parseLong(blockIdParts[2]);
+    }
+
+    public static int getReduceId(String blockId) {
+        String[] blockIdParts = blockId.split("_");
+        if (blockIdParts.length <  4) {
+          throw new IllegalArgumentException("Unexpected shuffle block id format: " + blockId);
+        }
+        return Integer.parseInt(blockIdParts[3]);
+    }
+
+    /**
+     * Returns the name of the ShuffleChecksumBlockId. This should be in sync with
+     *  IndexShuffleBlockResolver.getChecksumFile
+     */
+    static public String getChecksumFileName(String blockId, String algorithm) {
+        String[] blockIdParts = blockId.split("_");
+        if (blockIdParts.length <  4) {
+          throw new IllegalArgumentException("Unexpected shuffle block id format: " + blockId);
+        }
+        // Replace the reduceId with NOOP_REDUCE_ID to get the checksum file name
+        if (blockIdParts.length == 4 && isShuffleBlock(blockId)) {
+          blockIdParts[3] = NOOP_REDUCE_ID;
+        } else {
+          throw new IllegalArgumentException("Unexpected block id format");
+        }
+
+        return ShuffleChecksumHelper.getChecksumFileName(
+         String.join("_", blockIdParts) + ".checksum", algorithm);
+    }
+}

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockIdUtils.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockIdUtils.java
@@ -20,71 +20,68 @@ package org.apache.spark.network.shuffle;
 import org.apache.spark.network.shuffle.checksum.ShuffleChecksumHelper;
 
 public class BlockIdUtils {
-    public static final String SHUFFLE_BLOCK_PREFIX = "shuffle_";
+  public static final String SHUFFLE_BLOCK_PREFIX = "shuffle_";
+  public static final String SHUFFLE_CHUNK_PREFIX = "shuffleChunk_";
+  public static final String RDD_BLOCK_PREFIX = "rdd_";
+  private static final String NOOP_REDUCE_ID = "0";
 
-    public static final String SHUFFLE_CHUNK_PREFIX = "shuffleChunk_";
+  public static Boolean isRddBlock(String blockId) {
+    if (blockId.startsWith(RDD_BLOCK_PREFIX)) return true;
+    return false;
+  }
 
-    public static final String RDD_BLOCK_PREFIX = "rdd_";
+  public static Boolean isShuffleBlock(String blockId) {
+    if (blockId.startsWith(SHUFFLE_BLOCK_PREFIX)) return true;
+    return false;
+  }
 
-    private static final String NOOP_REDUCE_ID = "0";
+  public static Boolean isShuffleChunk(String blockId) {
+    // Shuffle chunk block is not supported by Aether, and we don't need to check for wrapped
+    // Aether blocks.
+    return blockId.startsWith(SHUFFLE_CHUNK_PREFIX);
+  }
 
-    public static Boolean isRddBlock(String blockId) {
-        if (blockId.startsWith(RDD_BLOCK_PREFIX)) return true;
-        return false;
+  public static int getShuffleId(String blockId) {
+    String[] blockIdParts = blockId.split("_");
+    if (blockIdParts.length <  4) {
+      throw new IllegalArgumentException("Unexpected shuffle block id format: " + blockId);
+    }
+    return Integer.parseInt(blockIdParts[1]);
+  }
+
+  public static long getMapId(String blockId) {
+    String[] blockIdParts = blockId.split("_");
+    if (blockIdParts.length <  4) {
+      throw new IllegalArgumentException("Unexpected shuffle block id format: " + blockId);
+    }
+    return Long.parseLong(blockIdParts[2]);
+  }
+
+  public static int getReduceId(String blockId) {
+    String[] blockIdParts = blockId.split("_");
+    if (blockIdParts.length <  4) {
+      throw new IllegalArgumentException("Unexpected shuffle block id format: " + blockId);
+    }
+    return Integer.parseInt(blockIdParts[3]);
+  }
+
+  /**
+   * Returns the name of the ShuffleChecksumBlockId. This should be in sync with
+   *  IndexShuffleBlockResolver.getChecksumFile
+   */
+  static public String getChecksumFileName(String blockId, String algorithm) {
+    String[] blockIdParts = blockId.split("_");
+    if (blockIdParts.length <  4) {
+      throw new IllegalArgumentException("Unexpected shuffle block id format: " + blockId);
+    }
+    // Replace the reduceId with NOOP_REDUCE_ID to get the checksum file name
+    if (blockIdParts.length == 4 && isShuffleBlock(blockId)) {
+      blockIdParts[3] = NOOP_REDUCE_ID;
+    } else {
+      throw new IllegalArgumentException("Unexpected block id format");
     }
 
-    public static Boolean isShuffleBlock(String blockId) {
-        if (blockId.startsWith(SHUFFLE_BLOCK_PREFIX)) return true;
-        return false;
-    }
-
-    public static Boolean isShuffleChunk(String blockId) {
-        // Shuffle chunk block is not supported by Aether, and we don't need to check for wrapped
-        // Aether blocks.
-        return blockId.startsWith(SHUFFLE_CHUNK_PREFIX);
-    }
-
-    public static int getShuffleId(String blockId) {
-        String[] blockIdParts = blockId.split("_");
-        if (blockIdParts.length <  4) {
-          throw new IllegalArgumentException("Unexpected shuffle block id format: " + blockId);
-        }
-        return Integer.parseInt(blockIdParts[1]);
-    }
-
-    public static long getMapId(String blockId) {
-        String[] blockIdParts = blockId.split("_");
-        if (blockIdParts.length <  4) {
-          throw new IllegalArgumentException("Unexpected shuffle block id format: " + blockId);
-        }
-        return Long.parseLong(blockIdParts[2]);
-    }
-
-    public static int getReduceId(String blockId) {
-        String[] blockIdParts = blockId.split("_");
-        if (blockIdParts.length <  4) {
-          throw new IllegalArgumentException("Unexpected shuffle block id format: " + blockId);
-        }
-        return Integer.parseInt(blockIdParts[3]);
-    }
-
-    /**
-     * Returns the name of the ShuffleChecksumBlockId. This should be in sync with
-     *  IndexShuffleBlockResolver.getChecksumFile
-     */
-    static public String getChecksumFileName(String blockId, String algorithm) {
-        String[] blockIdParts = blockId.split("_");
-        if (blockIdParts.length <  4) {
-          throw new IllegalArgumentException("Unexpected shuffle block id format: " + blockId);
-        }
-        // Replace the reduceId with NOOP_REDUCE_ID to get the checksum file name
-        if (blockIdParts.length == 4 && isShuffleBlock(blockId)) {
-          blockIdParts[3] = NOOP_REDUCE_ID;
-        } else {
-          throw new IllegalArgumentException("Unexpected block id format");
-        }
-
-        return ShuffleChecksumHelper.getChecksumFileName(
-         String.join("_", blockIdParts) + ".checksum", algorithm);
-    }
+    return ShuffleChecksumHelper.getChecksumFileName(
+     String.join("_", blockIdParts) + ".checksum", algorithm);
+  }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
@@ -69,15 +69,13 @@ public abstract class BlockStoreClient implements Closeable {
       String host,
       int port,
       String execId,
-      int shuffleId,
-      long mapId,
-      int reduceId,
+      String blockId,
       long checksum,
       String algorithm) {
     try {
       TransportClient client = clientFactory.createClient(host, port);
       ByteBuffer response = client.sendRpcSync(
-        new DiagnoseCorruption(appId, execId, shuffleId, mapId, reduceId, checksum, algorithm)
+        new DiagnoseCorruption(appId, execId, blockId, checksum, algorithm)
           .toByteBuffer(),
         transportConf.connectionTimeoutMs()
       );

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
@@ -192,11 +192,11 @@ public class ExternalShuffleBlockResolver {
    * Obtains a FileSegmentManagedBuffer from a single block (shuffleId, mapId, reduceId).
    */
   public ManagedBuffer getBlockData(
-          String appId,
-          String execId,
-          int shuffleId,
-          long mapId,
-          int reduceId) {
+      String appId,
+      String execId,
+      int shuffleId,
+      long mapId,
+      int reduceId) {
     return getContinuousBlocksData(appId, execId, shuffleId, mapId, reduceId, reduceId + 1);
   }
 

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/DiagnoseCorruption.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/DiagnoseCorruption.java
@@ -24,25 +24,19 @@ import org.apache.spark.network.protocol.Encoders;
 public class DiagnoseCorruption extends BlockTransferMessage {
   public final String appId;
   public final String execId;
-  public final int shuffleId;
-  public final long mapId;
-  public final int reduceId;
+  public final String blockId;
   public final long checksum;
   public final String algorithm;
 
   public DiagnoseCorruption(
       String appId,
       String execId,
-      int shuffleId,
-      long mapId,
-      int reduceId,
+      String blockId,
       long checksum,
       String algorithm) {
     this.appId = appId;
     this.execId = execId;
-    this.shuffleId = shuffleId;
-    this.mapId = mapId;
-    this.reduceId = reduceId;
+    this.blockId = blockId;
     this.checksum = checksum;
     this.algorithm = algorithm;
   }
@@ -54,8 +48,8 @@ public class DiagnoseCorruption extends BlockTransferMessage {
 
   @Override
   public String toString() {
-    return "DiagnoseCorruption[appId=" + appId + ",execId=" + execId + ",shuffleId=" + shuffleId +
-        ",mapId=" + mapId + ",reduceId=" + reduceId + ",checksum=" + checksum +
+    return "DiagnoseCorruption[appId=" + appId + ",execId=" + execId +
+        ",blockId=" + blockId + ",checksum=" + checksum +
         ",algorithm=" + algorithm + "]";
   }
 
@@ -67,9 +61,7 @@ public class DiagnoseCorruption extends BlockTransferMessage {
     DiagnoseCorruption that = (DiagnoseCorruption) o;
 
     if (checksum != that.checksum) return false;
-    if (shuffleId != that.shuffleId) return false;
-    if (mapId != that.mapId) return false;
-    if (reduceId != that.reduceId) return false;
+    if (!blockId.equals(that.blockId)) return false;
     if (!algorithm.equals(that.algorithm)) return false;
     if (!appId.equals(that.appId)) return false;
     if (!execId.equals(that.execId)) return false;
@@ -80,9 +72,7 @@ public class DiagnoseCorruption extends BlockTransferMessage {
   public int hashCode() {
     int result = appId.hashCode();
     result = 31 * result + execId.hashCode();
-    result = 31 * result + Integer.hashCode(shuffleId);
-    result = 31 * result + Long.hashCode(mapId);
-    result = 31 * result + Integer.hashCode(reduceId);
+    result = 31 * result + blockId.hashCode();
     result = 31 * result + Long.hashCode(checksum);
     result = 31 * result + algorithm.hashCode();
     return result;
@@ -92,9 +82,7 @@ public class DiagnoseCorruption extends BlockTransferMessage {
   public int encodedLength() {
     return Encoders.Strings.encodedLength(appId)
       + Encoders.Strings.encodedLength(execId)
-      + 4 /* encoded length of shuffleId */
-      + 8 /* encoded length of mapId */
-      + 4 /* encoded length of reduceId */
+      + Encoders.Strings.encodedLength(blockId)
       + 8 /* encoded length of checksum */
       + Encoders.Strings.encodedLength(algorithm); /* encoded length of algorithm */
   }
@@ -103,9 +91,7 @@ public class DiagnoseCorruption extends BlockTransferMessage {
   public void encode(ByteBuf buf) {
     Encoders.Strings.encode(buf, appId);
     Encoders.Strings.encode(buf, execId);
-    buf.writeInt(shuffleId);
-    buf.writeLong(mapId);
-    buf.writeInt(reduceId);
+    Encoders.Strings.encode(buf, blockId);
     buf.writeLong(checksum);
     Encoders.Strings.encode(buf, algorithm);
   }
@@ -113,11 +99,9 @@ public class DiagnoseCorruption extends BlockTransferMessage {
   public static DiagnoseCorruption decode(ByteBuf buf) {
     String appId = Encoders.Strings.decode(buf);
     String execId = Encoders.Strings.decode(buf);
-    int shuffleId = buf.readInt();
-    long mapId = buf.readLong();
-    int reduceId = buf.readInt();
+    String blockId = Encoders.Strings.decode(buf);
     long checksum = buf.readLong();
     String algorithm = Encoders.Strings.decode(buf);
-    return new DiagnoseCorruption(appId, execId, shuffleId, mapId, reduceId, checksum, algorithm);
+    return new DiagnoseCorruption(appId, execId, blockId, checksum, algorithm);
   }
 }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalBlockHandlerSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalBlockHandlerSuite.java
@@ -226,8 +226,10 @@ public class ExternalBlockHandlerSuite {
 
   @Test
   public void testFetchShuffleBlocks() {
-    when(blockResolver.getContinuousBlocksData("app0", "exec1", 0, 0, 0, 1)).thenReturn(blockMarkers[0]);
-    when(blockResolver.getContinuousBlocksData("app0", "exec1", 0, 0, 1, 2)).thenReturn(blockMarkers[1]);
+    when(blockResolver.getContinuousBlocksData("app0", "exec1", 0, 0, 0, 1))
+      .thenReturn(blockMarkers[0]);
+    when(blockResolver.getContinuousBlocksData("app0", "exec1", 0, 0, 1, 2))
+      .thenReturn(blockMarkers[1]);
 
     FetchShuffleBlocks fetchShuffleBlocks = new FetchShuffleBlocks(
       "app0", "exec1", 0, new long[] { 0 }, new int[][] {{ 0, 1 }}, false);

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockRpcServer.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockRpcServer.scala
@@ -162,7 +162,7 @@ class NettyBlockRpcServer(
 
       case diagnose: DiagnoseCorruption =>
         val cause = blockManager.diagnoseShuffleBlockCorruption(
-          ShuffleBlockId(diagnose.shuffleId, diagnose.mapId, diagnose.reduceId ),
+          BlockId(diagnose.blockId),
           diagnose.checksum,
           diagnose.algorithm)
         responseContext.onSuccess(new CorruptionCause(cause).toByteBuffer)

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -1124,7 +1124,7 @@ final class ShuffleBlockFetcherIterator(
           while (checkedIn.read(buffer) != -1) {}
           val checksum = checkedIn.getChecksum.getValue
           cause = shuffleClient.diagnoseCorruption(address.host, address.port, address.executorId,
-            shuffleBlock.shuffleId, shuffleBlock.mapId, shuffleBlock.reduceId, checksum,
+            shuffleBlock.name, checksum,
             checksumAlgorithm)
         } catch {
           case e: Exception =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR refactors the code around external block handler to make it use the consistent string type `blockId` when accessing different block types.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Code clean up and better readability.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Updated unit tests.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.
