### PR TITLE
[SPARK-53352][PYTHON] Refine the error message for unsupported return type

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_grouped_agg.py
@@ -818,7 +818,8 @@ class GroupedAggArrowUDFTestsMixin:
         with self.quiet():
             with self.assertRaisesRegex(
                 NotImplementedError,
-                "Invalid return type with grouped aggregate Arrow UDFs.*ArrayType.*YearMonthIntervalType",
+                "Invalid return type with grouped aggregate "
+                "Arrow UDFs.*ArrayType.*YearMonthIntervalType",
             ):
                 arrow_udf(
                     lambda x: x,
@@ -828,7 +829,8 @@ class GroupedAggArrowUDFTestsMixin:
 
             with self.assertRaisesRegex(
                 NotImplementedError,
-                "Invalid return type with grouped aggregate Arrow UDFs.*ArrayType.*YearMonthIntervalType",
+                "Invalid return type with grouped aggregate "
+                "Arrow UDFs.*ArrayType.*YearMonthIntervalType",
             ):
 
                 @arrow_udf(ArrayType(ArrayType(YearMonthIntervalType())), ArrowUDFType.GROUPED_AGG)

--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_grouped_agg.py
@@ -20,6 +20,7 @@ import unittest
 from pyspark.sql.functions import arrow_udf, ArrowUDFType
 from pyspark.util import PythonEvalType
 from pyspark.sql import Row
+from pyspark.sql.types import ArrayType, YearMonthIntervalType
 from pyspark.sql import functions as sf
 from pyspark.errors import AnalysisException, PythonException
 from pyspark.testing.sqlutils import (
@@ -810,6 +811,29 @@ class GroupedAggArrowUDFTestsMixin:
             # pyarrow.lib.ArrowInvalid:
             # Integer value 2147483657 not in range: -2147483648 to 2147483647
             result3.collect()
+
+    def test_unsupported_return_types(self):
+        import pyarrow as pa
+
+        with self.quiet():
+            with self.assertRaisesRegex(
+                NotImplementedError,
+                "Invalid return type with grouped aggregate Arrow UDFs.*ArrayType.*YearMonthIntervalType",
+            ):
+                arrow_udf(
+                    lambda x: x,
+                    ArrayType(ArrayType(YearMonthIntervalType())),
+                    ArrowUDFType.GROUPED_AGG,
+                )
+
+            with self.assertRaisesRegex(
+                NotImplementedError,
+                "Invalid return type with grouped aggregate Arrow UDFs.*ArrayType.*YearMonthIntervalType",
+            ):
+
+                @arrow_udf(ArrayType(ArrayType(YearMonthIntervalType())), ArrowUDFType.GROUPED_AGG)
+                def func_a(a: pa.Array) -> pa.Scalar:
+                    return pa.compute.max(a)
 
 
 class GroupedAggArrowUDFTests(GroupedAggArrowUDFTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py
@@ -43,6 +43,7 @@ from pyspark.sql.types import (
     Row,
     MapType,
     BinaryType,
+    YearMonthIntervalType,
 )
 from pyspark.errors import AnalysisException, PythonException
 from pyspark.testing.sqlutils import (
@@ -1021,6 +1022,26 @@ class ScalarArrowUDFTestsMixin:
             # pyarrow.lib.ArrowInvalid:
             # Integer value 2147483652 not in range: -2147483648 to 2147483647
             result3.collect()
+
+    def test_unsupported_return_types(self):
+        import pyarrow as pa
+
+        with self.quiet():
+            for udf_type in [ArrowUDFType.SCALAR, ArrowUDFType.SCALAR_ITER]:
+                with self.assertRaisesRegex(
+                    NotImplementedError,
+                    "Invalid return type.*scalar Arrow UDF.*ArrayType.*YearMonthIntervalType",
+                ):
+                    arrow_udf(lambda x: x, ArrayType(YearMonthIntervalType()), udf_type)
+
+                with self.assertRaisesRegex(
+                    NotImplementedError,
+                    "Invalid return type.*scalar Arrow UDF.*ArrayType.*YearMonthIntervalType",
+                ):
+
+                    @arrow_udf(ArrayType(YearMonthIntervalType()))
+                    def func_a(a: pa.Array) -> pa.Array:
+                        return a
 
 
 class ScalarArrowUDFTests(ScalarArrowUDFTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -230,6 +230,19 @@ class UserDefinedFunction:
                     },
                 )
         elif (
+            evalType == PythonEvalType.SQL_SCALAR_ARROW_UDF
+            or evalType == PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF
+        ):
+            try:
+                to_arrow_type(returnType)
+            except TypeError:
+                raise PySparkNotImplementedError(
+                    errorClass="NOT_IMPLEMENTED",
+                    messageParameters={
+                        "feature": f"Invalid return type with scalar Arrow UDFs: " f"{returnType}"
+                    },
+                )
+        elif (
             evalType == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF
             or evalType == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF_WITH_STATE
         ):
@@ -352,6 +365,18 @@ class UserDefinedFunction:
                     errorClass="NOT_IMPLEMENTED",
                     messageParameters={
                         "feature": f"Invalid return type with grouped aggregate Pandas UDFs: "
+                        f"{returnType}"
+                    },
+                )
+        elif evalType == PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF:
+            try:
+                # Different from SQL_GROUPED_AGG_PANDAS_UDF, StructType is allowed here
+                to_arrow_type(returnType)
+            except TypeError:
+                raise PySparkNotImplementedError(
+                    errorClass="NOT_IMPLEMENTED",
+                    messageParameters={
+                        "feature": f"Invalid return type with grouped aggregate Arrow UDFs: "
                         f"{returnType}"
                     },
                 )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Refine the error message for unsupported return type


### Why are the changes needed?
the errors should be consistent with other udfs

### Does this PR introduce _any_ user-facing change?
error message change


### How was this patch tested?
new tests

### Was this patch authored or co-authored using generative AI tooling?
no
