### PR TITLE
[SPARK-53353][PYTHON] Fail Scalar Iterator Arrow UDF with 0-arg

### DIFF
--- a/python/pyspark/sql/pandas/functions.py
+++ b/python/pyspark/sql/pandas/functions.py
@@ -824,6 +824,7 @@ def _validate_vectorized_udf(f, evalType, kind: str = "pandas") -> int:
             evalType == PythonEvalType.SQL_SCALAR_PANDAS_UDF
             or evalType == PythonEvalType.SQL_SCALAR_ARROW_UDF
             or evalType == PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF
+            or evalType == PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF
         )
         and len(argspec.args) == 0
         and argspec.varargs is None

--- a/python/pyspark/sql/pandas/functions.py
+++ b/python/pyspark/sql/pandas/functions.py
@@ -833,7 +833,7 @@ def _validate_vectorized_udf(f, evalType, kind: str = "pandas") -> int:
             errorClass="INVALID_PANDAS_UDF",
             messageParameters={
                 "detail": f"0-arg {kind_str} are not supported. "
-                "Instead, create a 1-arg pandas_udf and ignore the arg in your function.",
+                f"Instead, create a 1-arg {kind_str} and ignore the arg in your function.",
             },
         )
 

--- a/python/pyspark/sql/tests/arrow/test_arrow_udf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf.py
@@ -165,6 +165,13 @@ class ArrowUDFTestsMixin:
                 def zero_with_type():
                     return 1
 
+            with self.assertRaisesRegex(ValueError, "0-arg arrow_udfs.*not.*supported"):
+
+                @arrow_udf(LongType(), ArrowUDFType.SCALAR_ITER)
+                def zero_with_type():
+                    yield 1
+                    yield 2
+
     def test_arrow_udf_timestamp_ntz(self):
         import pyarrow as pa
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf.py
@@ -222,11 +222,19 @@ class PandasUDFTestsMixin:
 
         with self.assertRaisesRegex(ValueError, "0-arg pandas_udfs.*not.*supported"):
             pandas_udf(lambda: 1, LongType(), PandasUDFType.SCALAR)
+
         with self.assertRaisesRegex(ValueError, "0-arg pandas_udfs.*not.*supported"):
 
             @pandas_udf(LongType(), PandasUDFType.SCALAR)
             def zero_with_type():
                 return 1
+
+        with self.assertRaisesRegex(ValueError, "0-arg pandas_udfs.*not.*supported"):
+
+            @pandas_udf(LongType(), PandasUDFType.SCALAR_ITER)
+            def zero_with_type():
+                yield 1
+                yield 2
 
         with self.assertRaises(PySparkTypeError) as pe:
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fail Scalar Iterator Arrow UDF with 0-arg


### Why are the changes needed?
it should raise proper errors


### Does this PR introduce _any_ user-facing change?
error message change


### How was this patch tested?
added tests


### Was this patch authored or co-authored using generative AI tooling?
no
