### PR TITLE
Update supported_api_gen.py: remove an invalid escape sequence "\_" using a raw string

### DIFF
--- a/python/pyspark/pandas/supported_api_gen.py
+++ b/python/pyspark/pandas/supported_api_gen.py
@@ -395,7 +395,7 @@ def _escape_func_str(func_str: str) -> str:
     # TODO: Take into account that this function can create links incorrectly
     # We can create alias links or links to parent methods
     if func_str.endswith("_"):
-        return func_str[:-1] + "\_"  # noqa: W605
+        return func_str[:-1] + r"\_"
     else:
         return func_str
 


### PR DESCRIPTION
Re-opening per the instructions in https://github.com/apache/spark/pull/50243#issuecomment-3216004642

### What changes were proposed in this pull request?

Remove an invalid escape sequence "\_" using a raw string instead.

### Why are the changes needed?

There is an invalid escape sequence in the code, which is silenced using a noqa comment. Recent python versions warn when parsing such a string, noqa comment or no. (I believe I may have seen this warning when mypy, a python typechecker, visited the code, or something like that.) Using a raw string removes the warning without changing the value of the string in this case. This change also allows us to remove a noqa comment.

### Does this PR introduce _any_ user-facing change?

No, except a python warning is silenced.

### How was this patch tested?

Manual inspection.

### Was this patch authored or co-authored using generative AI tooling?

No.