### PR TITLE
[SPARK-53361][SS] Optimizing JVM–Python Communication in TWS by Grouping Multiple Keys into One Arrow Batch

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -1691,9 +1691,9 @@ class TransformWithStateInPandasInitStateSerializer(TransformWithStateInPandasSe
                         k2, grp2 = safe_next(g2)
 
             for batch_key, input_data_iterator, init_state_iterator in groupby_pair(
-                    data_stream(batches_gent_1, "inputData", self.key_offsets),
-                    data_stream(batches_gent_2, "initState", self.init_key_offsets),
-                    keyfunc=lambda x: x[0],
+                data_stream(batches_gent_1, "inputData", self.key_offsets),
+                data_stream(batches_gent_2, "initState", self.init_key_offsets),
+                keyfunc=lambda x: x[0],
             ):
                 input_data_pandas = pd.DataFrame(
                     [d for _, d in input_data_iterator], columns=columns_map["inputData"]
@@ -1702,7 +1702,7 @@ class TransformWithStateInPandasInitStateSerializer(TransformWithStateInPandasSe
                     [d for _, d in init_state_iterator], columns=columns_map["initState"]
                 )
 
-                yield (batch_key,input_data_pandas, init_state_pandas)
+                yield (batch_key, input_data_pandas, init_state_pandas)
 
         _batches = super(ArrowStreamPandasSerializer, self).load_stream(stream)
         data_batches = generate_data_batches(_batches)

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -1520,7 +1520,6 @@ class TransformWithStateInPandasSerializer(ArrowStreamPandasUDFSerializer):
         Please refer the doc of inner function `generate_data_batches` for more details how
         this function works in overall.
         """
-        import pyarrow as pa
         from pyspark.sql.streaming.stateful_processor_util import (
             TransformWithStateInPandasFuncMode,
         )
@@ -1658,7 +1657,7 @@ class TransformWithStateInPandasInitStateSerializer(TransformWithStateInPandasSe
             def groupby_pair(gen1, gen2, keyfunc):
                 """
                 Iterate over two sorted generators in parallel, grouped by the same key.
-                Yields (key, group1, group2), where groups are iterators (empty if no items for the key).
+                Yields (key, group1, group2), where groups are iterators.
                 """
 
                 def safe_next(group_iter):

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -1630,7 +1630,7 @@ class TransformWithStateInPandasInitStateSerializer(TransformWithStateInPandasSe
             """
 
             batches_gent_1, batches_gent_2 = tee(batches)
-            columns_map: dict[str, Optional[list[str]]] = {"inputData": None, "initState": None}
+            columns_map = {"inputData": None, "initState": None}
 
             def data_stream(batch_iter, field_name, key_offsets):
                 nonlocal columns_map

--- a/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
@@ -1913,6 +1913,8 @@ class TransformWithStateInPandasTestsMixin(TransformWithStateTestsMixin):
         cfg.set("spark.sql.session.timeZone", "UTC")
         # TODO SPARK-49046 this config is to stop query from FEB sink gracefully
         cfg.set("spark.sql.streaming.noDataMicroBatches.enabled", "false")
+        # cfg.set("spark.sql.execution.pyspark.udf.faulthandler.enabled", "true")
+        # cfg.set("spark.python.worker.faulthandler.enabled", "true")
         return cfg
 
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
@@ -1913,8 +1913,6 @@ class TransformWithStateInPandasTestsMixin(TransformWithStateTestsMixin):
         cfg.set("spark.sql.session.timeZone", "UTC")
         # TODO SPARK-49046 this config is to stop query from FEB sink gracefully
         cfg.set("spark.sql.streaming.noDataMicroBatches.enabled", "false")
-        # cfg.set("spark.sql.execution.pyspark.udf.faulthandler.enabled", "true")
-        # cfg.set("spark.python.worker.faulthandler.enabled", "true")
         return cfg
 
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -708,7 +708,6 @@ def wrap_grouped_transform_with_state_pandas_udf(f, return_type, runner_conf):
 
 def wrap_grouped_transform_with_state_pandas_init_state_udf(f, return_type, runner_conf):
     def wrapped(stateful_processor_api_client, mode, key, value_series_gen):
-
         state_values_gen, init_states_gen = itertools.tee(value_series_gen, 2)
         state_values = (x for x, _ in state_values_gen if not x.empty)
         init_states = (x for _, x in init_states_gen if not x.empty)

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -694,9 +694,7 @@ def wrap_grouped_map_pandas_udf(f, return_type, argspec, runner_conf):
 
 def wrap_grouped_transform_with_state_pandas_udf(f, return_type, runner_conf):
     def wrapped(stateful_processor_api_client, mode, key, value_series_gen):
-        import pandas as pd
-
-        values = (pd.concat(x, axis=1) for x in value_series_gen)
+        values = (x for x in value_series_gen)
         result_iter = f(stateful_processor_api_client, mode, key, values)
 
         # TODO(SPARK-49100): add verification that elements in result_iter are
@@ -710,11 +708,10 @@ def wrap_grouped_transform_with_state_pandas_udf(f, return_type, runner_conf):
 
 def wrap_grouped_transform_with_state_pandas_init_state_udf(f, return_type, runner_conf):
     def wrapped(stateful_processor_api_client, mode, key, value_series_gen):
-        import pandas as pd
 
         state_values_gen, init_states_gen = itertools.tee(value_series_gen, 2)
-        state_values = (df for x, _ in state_values_gen if not (df := pd.concat(x, axis=1)).empty)
-        init_states = (df for _, x in init_states_gen if not (df := pd.concat(x, axis=1)).empty)
+        state_values = (x for x, _ in state_values_gen if not x.empty)
+        init_states = (x for _, x in init_states_gen if not x.empty)
 
         result_iter = f(stateful_processor_api_client, mode, key, state_values, init_states)
 
@@ -2547,7 +2544,7 @@ def read_udfs(pickleSer, infile, eval_type):
 
                 def values_gen():
                     for x in a[2]:
-                        retVal = [x[1][o] for o in parsed_offsets[0][1]]
+                        retVal = x[1].iloc[:, parsed_offsets[0][1]]
                         yield retVal
 
                 # This must be generator comprehension - do not materialize.
@@ -2584,8 +2581,8 @@ def read_udfs(pickleSer, infile, eval_type):
 
                 def values_gen():
                     for x in a[2]:
-                        retVal = [x[1][o] for o in parsed_offsets[0][1]]
-                        initVal = [x[2][o] for o in parsed_offsets[1][1]]
+                        retVal = x[1].iloc[:, parsed_offsets[0][1]]
+                        initVal = x[2].iloc[:, parsed_offsets[1][1]]
                         yield retVal, initVal
 
                 # This must be generator comprehension - do not materialize.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/BaseStreamingArrowWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/BaseStreamingArrowWriter.scala
@@ -50,11 +50,12 @@ class BaseStreamingArrowWriter(
    *
    * @param dataRow The row to write for current batch.
    */
-  def writeRow(dataRow: InternalRow): Unit = {
+  def writeRow(dataRow: InternalRow): Boolean = {
     // If it exceeds the condition of batch (number of records) and there is more data for the
     // same group, finalize and construct a new batch.
 
-    if (totalNumRowsForBatch >= arrowMaxRecordsPerBatch) {
+    val isCurrentBatchFull = totalNumRowsForBatch >= arrowMaxRecordsPerBatch
+    if (isCurrentBatchFull) {
       finalizeCurrentChunk(isLastChunkForGroup = false)
       finalizeCurrentArrowBatch()
     }
@@ -63,6 +64,7 @@ class BaseStreamingArrowWriter(
 
     numRowsForCurrentChunk += 1
     totalNumRowsForBatch += 1
+    isCurrentBatchFull
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR introduces an optimization to JVM–Python communication in TWS by allowing multiple keys to be grouped into a single Arrow batch.

Currently, each Arrow batch is restricted to contain records for a single key. In high-cardinality scenarios, this results in many small Arrow batches (e.g., [(key1, value1), (key1, value2)], [(key2, value1), (key2, value2)]), which increases the overhead of Arrow batch transmission between the JVM and Python.

With this change, records with different keys can be bin-packed into the same Arrow batch, reducing the number of batches transmitted. On the Python side, we leverage groupBy to regroup records by key, mirroring the behavior of the Scala GroupedIterator implementation.

This approach significantly reduces transmission overhead while preserving correct grouping semantics.

### Why are the changes needed?

Benchmark results show that in high-cardinality scenarios, this optimization improves throughput by ~12% by reducing the overhead of Arrow batch transmission. For low-cardinality scenarios, the change introduces no observable regression,.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing UT and Benchmark.


### Was this patch authored or co-authored using generative AI tooling?
No
