### PR TITLE
[SPARK-53365] [SQL] Unify code for persisting of configs in views and UDFs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CapturesConfig.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CapturesConfig.scala
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Trait used for persisting the conf values in views/UDFs.
+ */
+trait CapturesConfig {
+  private val configPrefixDenyList = Seq(
+    SQLConf.MAX_NESTED_VIEW_DEPTH.key,
+    "spark.sql.optimizer.",
+    "spark.sql.codegen.",
+    "spark.sql.execution.",
+    "spark.sql.shuffle.",
+    "spark.sql.adaptive.",
+    // ignore optimization configs used in `RelationConversions`
+    "spark.sql.hive.convertMetastoreParquet",
+    "spark.sql.hive.convertMetastoreOrc",
+    "spark.sql.hive.convertInsertingPartitionedTable",
+    "spark.sql.hive.convertInsertingUnpartitionedTable",
+    "spark.sql.hive.convertMetastoreCtas",
+    SQLConf.ADDITIONAL_REMOTE_REPOSITORIES.key)
+
+  private val configAllowList = Set(
+    SQLConf.DISABLE_HINTS.key
+  )
+
+  /**
+   * Set of single-pass resolver confs that shouldn't be stored during view/UDF/proc creation.
+   * This is needed to avoid accidental failures in tentative and dual-run modes when querying the
+   * view.
+   */
+  private val singlePassResolverDenyList = Set(
+    SQLConf.ANALYZER_SINGLE_PASS_RESOLVER_ENABLED_TENTATIVELY.key,
+    SQLConf.ANALYZER_DUAL_RUN_LEGACY_AND_SINGLE_PASS_RESOLVER.key
+  )
+
+  /**
+   * Convert the provided SQL configs to `properties`. Here we only capture the SQL configs that are
+   * modifiable and should be captured, i.e. not in the denyList and in the allowList. We also
+   * capture `SESSION_LOCAL_TIMEZONE` whose default value relies on the JVM system timezone and
+   * the `ANSI_ENABLED` value.
+   *
+   * We need to always capture them to make sure we apply the same configs when querying the
+   * view/UDF.
+   */
+  def sqlConfigsToProps(conf: SQLConf, prefix: String): Map[String, String] = {
+    val modifiedConfs = getModifiedConf(conf)
+
+    val alwaysCaptured = Seq(SQLConf.SESSION_LOCAL_TIMEZONE, SQLConf.ANSI_ENABLED)
+      .filter(c => !modifiedConfs.contains(c.key))
+      .map(c => (c.key, conf.getConf(c).toString))
+
+    val props = new mutable.HashMap[String, String]
+    for ((key, value) <- modifiedConfs ++ alwaysCaptured) {
+      props.put(s"$prefix$key", value)
+    }
+    props.toMap
+  }
+
+  /**
+   * Get all configurations that are modifiable and should be captured.
+   */
+  private def getModifiedConf(conf: SQLConf): Map[String, String] = {
+    conf.getAllConfs.filter { case (k, _) =>
+      conf.isModifiable(k) && shouldCaptureConfig(k)
+    }
+  }
+
+  /**
+   * Capture view config either of:
+   * 1. exists in allowList
+   * 2. do not exists in denyList
+   */
+  private def shouldCaptureConfig(key: String): Boolean = {
+    configAllowList.contains(key) || (
+      !configPrefixDenyList.exists(prefix => key.startsWith(prefix)) &&
+        !singlePassResolverDenyList.contains(key)
+      )
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CreateSQLFunctionCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CreateSQLFunctionCommand.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.{withPosition, Analyzer, SQLFunctionExpression, SQLFunctionNode, SQLScalarFunction, SQLTableFunction, UnresolvedAlias, UnresolvedAttribute, UnresolvedFunction, UnresolvedRelation, UnresolvedTableValuedFunction}
 import org.apache.spark.sql.catalyst.catalog.{SessionCatalog, SQLFunction, UserDefinedFunction, UserDefinedFunctionErrors}
+import org.apache.spark.sql.catalyst.catalog.UserDefinedFunction._
 import org.apache.spark.sql.catalyst.expressions.{Alias, Cast, Expression, Generator, LateralSubquery, Literal, ScalarSubquery, SubqueryExpression, WindowExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.Inner
@@ -509,7 +510,7 @@ case class CreateSQLFunctionCommand(
     }
     val tempVars = ViewHelper.collectTemporaryVariables(analyzed)
 
-    sqlConfigsToProps(conf) ++
+    sqlConfigsToProps(conf, SQL_CONFIG_PREFIX) ++
       catalogAndNamespaceToProps(
         manager.currentCatalog.name,
         manager.currentNamespace.toIndexedSeq) ++

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -25,7 +25,7 @@ import org.json4s.jackson.JsonMethods._
 import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Row, SparkSession}
-import org.apache.spark.sql.catalyst.{SQLConfHelper, TableIdentifier}
+import org.apache.spark.sql.catalyst.{CapturesConfig, SQLConfHelper, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{AnalysisContext, GlobalTempView, LocalTempView, SchemaEvolution, SchemaUnsupported, ViewSchemaMode, ViewType}
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, TemporaryViewRelation}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, SubqueryExpression, VariableReference}
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.classic.ClassicConversions.castToImpl
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.NamespaceHelper
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
+import org.apache.spark.sql.internal.StaticSQLConf
 import org.apache.spark.sql.types.{MetadataBuilder, StructType}
 import org.apache.spark.sql.util.SchemaUtils
 import org.apache.spark.util.ArrayImplicits._
@@ -413,49 +413,7 @@ case class ShowViewsCommand(
   }
 }
 
-object ViewHelper extends SQLConfHelper with Logging {
-
-  private val configPrefixDenyList = Seq(
-    SQLConf.MAX_NESTED_VIEW_DEPTH.key,
-    "spark.sql.optimizer.",
-    "spark.sql.codegen.",
-    "spark.sql.execution.",
-    "spark.sql.shuffle.",
-    "spark.sql.adaptive.",
-    // ignore optimization configs used in `RelationConversions`
-    "spark.sql.hive.convertMetastoreParquet",
-    "spark.sql.hive.convertMetastoreOrc",
-    "spark.sql.hive.convertInsertingPartitionedTable",
-    "spark.sql.hive.convertInsertingUnpartitionedTable",
-    "spark.sql.hive.convertMetastoreCtas",
-    SQLConf.ADDITIONAL_REMOTE_REPOSITORIES.key)
-
-  private val configAllowList = Set(
-    SQLConf.DISABLE_HINTS.key
-  )
-
-  /**
-   * Set of single-pass resolver confs that shouldn't be stored during view/UDF/proc creation.
-   * This is needed to avoid accidental failures in tentative and dual-run modes when querying the
-   * view.
-   */
-  private val singlePassResolverDenyList = Set(
-    SQLConf.ANALYZER_SINGLE_PASS_RESOLVER_ENABLED_TENTATIVELY.key,
-    SQLConf.ANALYZER_DUAL_RUN_LEGACY_AND_SINGLE_PASS_RESOLVER.key
-  )
-
-  /**
-   * Capture view config either of:
-   * 1. exists in allowList
-   * 2. do not exists in denyList
-   */
-  private def shouldCaptureConfig(key: String): Boolean = {
-    configAllowList.contains(key) || (
-      !configPrefixDenyList.exists(prefix => key.startsWith(prefix)) &&
-      !singlePassResolverDenyList.contains(key)
-    )
-  }
-
+object ViewHelper extends SQLConfHelper with Logging with CapturesConfig {
   import CatalogTable._
 
   /**
@@ -481,37 +439,6 @@ object ViewHelper extends SQLConfHelper with Logging {
     properties.filterNot { case (key, _) =>
       key.startsWith(VIEW_QUERY_OUTPUT_PREFIX)
     }
-  }
-
-  /**
-   * Get all configurations that are modifiable and should be captured.
-   */
-  def getModifiedConf(conf: SQLConf): Map[String, String] = {
-    conf.getAllConfs.filter { case (k, _) =>
-      conf.isModifiable(k) && shouldCaptureConfig(k)
-    }
-  }
-
-  /**
-   * Convert the view SQL configs to `properties`. Here we only capture the SQL configs that are
-   * modifiable and should be captured, i.e. not in the denyList and in the allowList. We also
-   * capture `SESSION_LOCAL_TIMEZONE` whose default value relies on the JVM system timezone and
-   * the `ANSI_ENABLED` value.
-   *
-   * We need to always capture them to make sure we apply the same configs when querying the view.
-   */
-  private def sqlConfigsToProps(conf: SQLConf): Map[String, String] = {
-    val modifiedConfs = getModifiedConf(conf)
-
-    val alwaysCaptured = Seq(SQLConf.SESSION_LOCAL_TIMEZONE, SQLConf.ANSI_ENABLED)
-      .filter(c => !modifiedConfs.contains(c.key))
-      .map(c => (c.key, conf.getConf(c).toString))
-
-    val props = new mutable.HashMap[String, String]
-    for ((key, value) <- modifiedConfs ++ alwaysCaptured) {
-      props.put(s"$VIEW_SQL_CONFIG_PREFIX$key", value)
-    }
-    props.toMap
   }
 
   /**
@@ -614,7 +541,7 @@ object ViewHelper extends SQLConfHelper with Logging {
     removeReferredTempNames(removeSQLConfigs(removeQueryColumnNames(properties))) ++
       catalogAndNamespaceToProps(
         manager.currentCatalog.name, manager.currentNamespace.toImmutableArraySeq) ++
-      sqlConfigsToProps(conf) ++
+      sqlConfigsToProps(conf, VIEW_SQL_CONFIG_PREFIX) ++
       queryColumnNameProps ++
       referredTempNamesToProps(tempViewNames, tempFunctionNames, tempVariableNames) ++
       viewSchemaModeToProps(viewSchemaMode)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this issue I propose that we unify code for persisting the configs in views and UDFs as it should be the same to avoid further discrepancies (until now, we had separated methods and that's why we didn't have SESSION_LOCAL_TIMEZONE stored for UDFs).

### Why are the changes needed?
To improve the code health and fix existing issues.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Tests added in the PR.

### Was this patch authored or co-authored using generative AI tooling?
No.