### PR TITLE
[SPARK-53382][SQL] Fix rCTE bug with malformed recursion

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/UnionLoopExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/UnionLoopExec.scala
@@ -228,6 +228,14 @@ case class UnionLoopExec(
           }
       }
 
+      // The optimizer might have removed the UnionLoopRef in the recursion node (for example as a
+      // result of an empty join). In this case, prevPlan is null and needs to be set to the anchor
+      // result manually.
+      if (prevPlan == null) {
+        prevPlan = LogicalRDD.fromDataset(prevDF.queryExecution.toRdd, prevDF,
+          prevDF.isStreaming).newInstance()
+      }
+
       if (levelLimit != -1 && currentLevel > levelLimit) {
         throw new SparkException(
           errorClass = "RECURSION_LEVEL_LIMIT_EXCEEDED",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
@@ -2101,3 +2101,33 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "INVALID_RECURSIVE_CTE",
   "sqlState" : "42836"
 }
+
+
+-- !query
+WITH RECURSIVE t AS (
+    SELECT 1 AS n
+    UNION ALL
+    SELECT n + m
+    FROM (SELECT 2 as m) subq
+             JOIN t ON n = m
+    WHERE n <> m
+)
+SELECT * FROM t
+-- !query analysis
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t
+:     +- UnionLoop xxxx
+:        :- Project [1 AS n#x]
+:        :  +- OneRowRelation
+:        +- Project [(n#x + m#x) AS (n + m)#x]
+:           +- Filter NOT (n#x = m#x)
+:              +- Join Inner, (n#x = m#x)
+:                 :- SubqueryAlias subq
+:                 :  +- Project [2 AS m#x]
+:                 :     +- OneRowRelation
+:                 +- SubqueryAlias t
+:                    +- UnionLoopRef xxxx, [n#x], false
++- Project [n#x]
+   +- SubqueryAlias t
+      +- CTERelationRef xxxx, true, [n#x], false, false

--- a/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
@@ -782,3 +782,14 @@ WITH RECURSIVE t1 AS (
     UNION ALL
     SELECT n+1 FROM t1 WHERE n < 5)
 SELECT * FROM t1;
+
+-- Query with recursion that gets optimized to empty relation
+WITH RECURSIVE t AS (
+    SELECT 1 AS n
+    UNION ALL
+    SELECT n + m
+    FROM (SELECT 2 as m) subq
+             JOIN t ON n = m
+    WHERE n <> m
+)
+SELECT * FROM t;

--- a/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
@@ -1931,3 +1931,19 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "INVALID_RECURSIVE_CTE",
   "sqlState" : "42836"
 }
+
+
+-- !query
+WITH RECURSIVE t AS (
+    SELECT 1 AS n
+    UNION ALL
+    SELECT n + m
+    FROM (SELECT 2 as m) subq
+             JOIN t ON n = m
+    WHERE n <> m
+)
+SELECT * FROM t
+-- !query schema
+struct<n:int>
+-- !query output
+1


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add special handling in UnionLoopExec of case that prevPlan is null. 

### Why are the changes needed?

There is currently a bug where rCTEs crash when the optimizer replaces parts of the plan that return empty results with an empty LocalRelation, which destroys the UnionLoopRef inside the recursion of the UnionLoop, which breaks the assumption in the Exec node that there will be a UnionLoopRef node there. This causes prevPlan to never be defined to a non-null value which causes an spark internal error when tried to evaluate.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New golden file test.

### Was this patch authored or co-authored using generative AI tooling?

No.