### PR TITLE
[SPARK-53367][PYTHON][SQL] add int to decimal coercion for Arrow UDFs

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -453,7 +453,8 @@ class LocalDataToArrowConversion:
                     field.dataType,
                     field.nullable,
                     none_on_identity=True,
-                    int_to_decimal_coercion_enabled=False,  # Default to False for general data conversion
+                    # Default to False for general data conversion
+                    int_to_decimal_coercion_enabled=False,
                 )
                 for field in schema.fields
             ]

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -776,8 +776,11 @@ class ArrowBatchUDFSerializer(ArrowStreamArrowUDFSerializer):
         A timezone to respect when handling timestamp values
     safecheck : bool
         If True, conversion from Arrow to Pandas checks for overflow/truncation
-    input_types : bool
-        If True, then Pandas DataFrames will get columns by name
+    input_types : list
+        List of input data types for the UDF
+    int_to_decimal_coercion_enabled : bool
+        If True, applies additional coercions in Python before converting to Arrow
+        This has performance penalties.
     """
 
     def __init__(
@@ -785,6 +788,7 @@ class ArrowBatchUDFSerializer(ArrowStreamArrowUDFSerializer):
         timezone,
         safecheck,
         input_types,
+        int_to_decimal_coercion_enabled=False,
     ):
         super().__init__(
             timezone=timezone,
@@ -793,6 +797,7 @@ class ArrowBatchUDFSerializer(ArrowStreamArrowUDFSerializer):
             arrow_cast=True,
         )
         self._input_types = input_types
+        self._int_to_decimal_coercion_enabled = int_to_decimal_coercion_enabled
 
     def load_stream(self, stream):
         """
@@ -843,7 +848,11 @@ class ArrowBatchUDFSerializer(ArrowStreamArrowUDFSerializer):
         import pyarrow as pa
 
         def create_array(results, arrow_type, spark_type):
-            conv = LocalDataToArrowConversion._create_converter(spark_type, none_on_identity=True)
+            conv = LocalDataToArrowConversion._create_converter(
+                spark_type,
+                none_on_identity=True,
+                int_to_decimal_coercion_enabled=self._int_to_decimal_coercion_enabled,
+            )
             converted = [conv(res) for res in results] if conv is not None else results
             try:
                 return pa.array(converted, type=arrow_type)

--- a/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
@@ -206,7 +206,7 @@ class ArrowPythonUDFTestsMixin(BaseUDFTestsMixin):
             with self.sql_conf(
                 {"spark.sql.execution.pythonUDF.pandas.intToDecimalCoercionEnabled": False}
             ):
-                with self.assertRaisesRegex(PythonException, "ArrowInvalid"):
+                with self.assertRaisesRegex(PythonException, "An exception was thrown from the Python worker"):
                     df.select(int_to_decimal_udf("id").alias("decimal_val")).collect()
 
             @udf(returnType="decimal(25,1)", useArrow=True)
@@ -228,7 +228,7 @@ class ArrowPythonUDFTestsMixin(BaseUDFTestsMixin):
             with self.sql_conf(
                 {"spark.sql.execution.pythonUDF.pandas.intToDecimalCoercionEnabled": False}
             ):
-                with self.assertRaisesRegex(PythonException, "ArrowInvalid"):
+                with self.assertRaisesRegex(PythonException, "An exception was thrown from the Python worker"):
                     df.select(high_precision_udf("id").alias("decimal_val")).collect()
 
     def test_err_return_type(self):

--- a/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
@@ -206,7 +206,9 @@ class ArrowPythonUDFTestsMixin(BaseUDFTestsMixin):
             with self.sql_conf(
                 {"spark.sql.execution.pythonUDF.pandas.intToDecimalCoercionEnabled": False}
             ):
-                with self.assertRaisesRegex(PythonException, "An exception was thrown from the Python worker"):
+                with self.assertRaisesRegex(
+                    PythonException, "An exception was thrown from the Python worker"
+                ):
                     df.select(int_to_decimal_udf("id").alias("decimal_val")).collect()
 
             @udf(returnType="decimal(25,1)", useArrow=True)
@@ -228,7 +230,9 @@ class ArrowPythonUDFTestsMixin(BaseUDFTestsMixin):
             with self.sql_conf(
                 {"spark.sql.execution.pythonUDF.pandas.intToDecimalCoercionEnabled": False}
             ):
-                with self.assertRaisesRegex(PythonException, "An exception was thrown from the Python worker"):
+                with self.assertRaisesRegex(
+                    PythonException, "An exception was thrown from the Python worker"
+                ):
                     df.select(high_precision_udf("id").alias("decimal_val")).collect()
 
     def test_err_return_type(self):

--- a/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
@@ -180,6 +180,57 @@ class ArrowPythonUDFTestsMixin(BaseUDFTestsMixin):
         with self.assertRaises(PythonException):
             df_floating_value.select(udf(lambda x: x, "decimal")("value").alias("res")).collect()
 
+    def test_arrow_udf_int_to_decimal_coercion(self):
+        from decimal import Decimal
+
+        with self.sql_conf(
+            {"spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled": False}
+        ):
+            df = self.spark.range(0, 3)
+
+            @udf(returnType="decimal(10,2)", useArrow=True)
+            def int_to_decimal_udf(val):
+                values = [123, 456, 789]
+                return values[int(val) % len(values)]
+
+            # Test with coercion enabled
+            with self.sql_conf(
+                {"spark.sql.execution.pythonUDF.pandas.intToDecimalCoercionEnabled": True}
+            ):
+                result = df.select(int_to_decimal_udf("id").alias("decimal_val")).collect()
+                self.assertEqual(result[0]["decimal_val"], Decimal("123.00"))
+                self.assertEqual(result[1]["decimal_val"], Decimal("456.00"))
+                self.assertEqual(result[2]["decimal_val"], Decimal("789.00"))
+
+            # Test with coercion disabled (should fail)
+            with self.sql_conf(
+                {"spark.sql.execution.pythonUDF.pandas.intToDecimalCoercionEnabled": False}
+            ):
+                with self.assertRaisesRegex(PythonException, "ArrowInvalid"):
+                    df.select(int_to_decimal_udf("id").alias("decimal_val")).collect()
+
+            @udf(returnType="decimal(25,1)", useArrow=True)
+            def high_precision_udf(val):
+                values = [1, 2, 3]
+                return values[int(val) % len(values)]
+
+            # Test high precision decimal with coercion enabled
+            with self.sql_conf(
+                {"spark.sql.execution.pythonUDF.pandas.intToDecimalCoercionEnabled": True}
+            ):
+                result = df.select(high_precision_udf("id").alias("decimal_val")).collect()
+                self.assertEqual(len(result), 3)
+                self.assertEqual(result[0]["decimal_val"], Decimal("1.0"))
+                self.assertEqual(result[1]["decimal_val"], Decimal("2.0"))
+                self.assertEqual(result[2]["decimal_val"], Decimal("3.0"))
+
+            # Test high precision decimal with coercion disabled (should fail)
+            with self.sql_conf(
+                {"spark.sql.execution.pythonUDF.pandas.intToDecimalCoercionEnabled": False}
+            ):
+                with self.assertRaisesRegex(PythonException, "ArrowInvalid"):
+                    df.select(high_precision_udf("id").alias("decimal_val")).collect()
+
     def test_err_return_type(self):
         with self.assertRaises(PySparkNotImplementedError) as pe:
             udf(lambda x: x, VarcharType(10), useArrow=True)

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2364,7 +2364,9 @@ def read_udfs(pickleSer, infile, eval_type):
             input_types = [
                 f.dataType for f in _parse_datatype_json_string(utf8_deserializer.loads(infile))
             ]
-            ser = ArrowBatchUDFSerializer(timezone, safecheck, input_types)
+            ser = ArrowBatchUDFSerializer(
+                timezone, safecheck, input_types, int_to_decimal_coercion_enabled
+            )
         else:
             # Scalar Pandas UDF handles struct type arguments as pandas DataFrames instead of
             # pandas Series. See SPARK-27240.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
- this is a followup to https://github.com/apache/spark/pull/51538, it now also adds support for integer to decimal type coercion to udfs with useArrow=True when `spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled=False`.
- For this, we now forwards the existing spark conf `spark.sql.execution.pythonUDF.pandas.intToDecimalCoercionEnabled` from the worker to the ArrowBatchUDFSerializer and then to the Python->Arrow converter. 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Python UDFs with `useArrow=True` and `spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled=False` do not support type coercion from int to DecimalType if the target precision of the DecimalType is too low:

```
@udf(returnType=DecimalType(2, 1), useArrow=True)
def test:
  return 1
spark.range(1,2,1,1).select(test(col('id'))).display() 
# expected: (Decimal) 1.0
# actual:   
File "/deps/pyspark/sql/conversion.py", line 314, in convert_decimal
    assert isinstance(value, decimal.Decimal)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, `spark.sql.execution.pythonUDF.pandas.intToDecimalCoercionEnabled` is still off by default, so this is not a behavior change.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
- added unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No