### PR TITLE
[SPARK-52346][SDP] Propagate partition columns from destination for BatchTableWrite

### DIFF
--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
@@ -498,11 +498,11 @@ class PythonPipelineSuite
     val graph = buildGraph("""
            |from pyspark.sql.functions import col
            |
-           |@sdp.materialized_view(partition_cols = ["id_mod"])
+           |@dp.materialized_view(partition_cols = ["id_mod"])
            |def mv():
            |  return spark.range(5).withColumn("id_mod", col("id") % 2)
            |
-           |@sdp.table(partition_cols = ["id_mod"])
+           |@dp.table(partition_cols = ["id_mod"])
            |def st():
            |  return spark.readStream.table("mv")
            |""".stripMargin)

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
@@ -496,32 +496,35 @@ class PythonPipelineSuite
   }
 
   test("MV/ST with partition columns works") {
-    val graph = buildGraph("""
-           |from pyspark.sql.functions import col
-           |
-           |@dp.materialized_view(partition_cols = ["id_mod"])
-           |def mv():
-           |  return spark.range(5).withColumn("id_mod", col("id") % 2)
-           |
-           |@dp.table(partition_cols = ["id_mod"])
-           |def st():
-           |  return spark.readStream.table("mv")
-           |""".stripMargin)
+    withTable("mv", "st") {
+      val graph = buildGraph("""
+             |from pyspark.sql.functions import col
+             |
+             |@dp.materialized_view(partition_cols = ["id_mod"])
+             |def mv():
+             |  return spark.range(5).withColumn("id_mod", col("id") % 2)
+             |
+             |@dp.table(partition_cols = ["id_mod"])
+             |def st():
+             |  return spark.readStream.table("mv")
+             |""".stripMargin)
 
-    val updateContext = new PipelineUpdateContextImpl(graph, eventCallback = _ => ())
-    updateContext.pipelineExecution.runPipeline()
-    updateContext.pipelineExecution.awaitCompletion()
+      val updateContext = new PipelineUpdateContextImpl(graph, eventCallback = _ => ())
+      updateContext.pipelineExecution.runPipeline()
+      updateContext.pipelineExecution.awaitCompletion()
 
-    // check table is created with correct partitioning
-    val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
+      // check table is created with correct partitioning
+      val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
 
-    Seq("mv", "st").foreach { tableName =>
-      val table = catalog.loadTable(Identifier.of(Array("default"), tableName))
-      assert(table.partitioning().map(_.references().head.fieldNames().head) === Array("id_mod"))
+      Seq("mv", "st").foreach { tableName =>
+        val table = catalog.loadTable(Identifier.of(Array("default"), tableName))
+        assert(
+          table.partitioning().map(_.references().head.fieldNames().head) === Array("id_mod"))
 
-      val rows = spark.table(tableName).collect().map(r => (r.getLong(0), r.getLong(1))).toSet
-      val expected = (0 until 5).map(id => (id.toLong, (id % 2).toLong)).toSet
-      assert(rows == expected)
+        val rows = spark.table(tableName).collect().map(r => (r.getLong(0), r.getLong(1))).toSet
+        val expected = (0 until 5).map(id => (id.toLong, (id % 2).toLong)).toSet
+        assert(rows == expected)
+      }
     }
   }
 

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/FlowExecution.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/FlowExecution.scala
@@ -257,6 +257,10 @@ class BatchTableWrite(
         }
         dataFrameWriter
           .mode("append")
+          // In "append" mode with saveAsTable, partition columns must be specified in query
+          // because the format and options of the existing table is used, and the table could
+          // have been created with partition columns.
+          .partitionBy(destination.partitionCols.getOrElse(Seq.empty): _*)
           .saveAsTable(destination.identifier.unquotedString)
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->


### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Propagate partition columns specified in the destination table into during flow execution for batch table write.

Fix below exception during flow execution:
```
org.apache.spark.sql.AnalysisException: Specified partitioning does not match that of the existing table spark_catalog.default.mv.
Specified partition columns: [].
Existing partition columns: [id_mod].
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

In "append" mode with saveAsTable, partition columns must be specified in query because the format and options of the existing table is used, and the table could have been created with partition columns.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

New unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No