### PR TITLE
[SPARK-53381][CONNECT] Avoid creating temporary collections in `toCatalystStruct`

### DIFF
--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
@@ -493,7 +493,8 @@ object LiteralValueProtoConverter {
           val struct = literal.getStruct
           val size = struct.getElementsCount
           val structTypeBuilder = proto.DataType.Struct.newBuilder
-          Iterator.range(0, size).foreach { i =>
+          var i = 0
+          while (i < size) {
             val field = struct.getDataTypeStruct.getFields(i)
             if (field.hasDataType) {
               structTypeBuilder.addFields(field)
@@ -511,6 +512,7 @@ object LiteralValueProtoConverter {
                 case None => return None
               }
             }
+            i += 1
           }
           builder.setStruct(structTypeBuilder.build())
         } else {

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
@@ -23,7 +23,6 @@ import java.sql.{Date, Timestamp}
 import java.time._
 
 import scala.collection.{immutable, mutable}
-import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.Try
@@ -491,13 +490,15 @@ object LiteralValueProtoConverter {
         builder.setCalendarInterval(proto.DataType.CalendarInterval.newBuilder.build())
       case proto.Expression.Literal.LiteralTypeCase.STRUCT =>
         if (recursive) {
-          val structType = literal.getStruct.getDataTypeStruct
-          val structData = literal.getStruct.getElementsList.asScala
+          val struct = literal.getStruct
+          val size = struct.getElementsCount
           val structTypeBuilder = proto.DataType.Struct.newBuilder
-          for ((element, field) <- structData.zip(structType.getFieldsList.asScala)) {
+          Iterator.range(0, size).foreach { i =>
+            val field = struct.getDataTypeStruct.getFields(i)
             if (field.hasDataType) {
               structTypeBuilder.addFields(field)
             } else {
+              val element = struct.getElements(i)
               getInferredDataType(element, recursive = true) match {
                 case Some(dataType) =>
                   val fieldBuilder = structTypeBuilder.addFieldsBuilder()
@@ -675,16 +676,12 @@ object LiteralValueProtoConverter {
       }
     }
 
-    val elements = struct.getElementsList.asScala
-    val dataTypes = structType.getFieldsList.asScala.map(_.getDataType)
-    val structData = elements
-      .zip(dataTypes)
-      .map { case (element, dataType) =>
-        getConverter(dataType)(element)
-      }
-      .asInstanceOf[scala.collection.Seq[Object]]
-      .toSeq
-
+    val size = struct.getElementsCount
+    val structData = Seq.tabulate(size) { i =>
+      val element = struct.getElements(i)
+      val dataType = structType.getFields(i).getDataType
+      getConverter(dataType)(element).asInstanceOf[Object]
+    }
     toTuple(structData)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Avoid creating temporary collections in toCatalystStruct


### Why are the changes needed?
avoid temporary collection creation;



### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no