### PR TITLE
[SPARK-53384][SQL] Refactor variable resolution out

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -23,14 +23,12 @@ import scala.collection.mutable
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.SqlScriptingContextManager
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.SubExprUtils.wrapOuterReference
-import org.apache.spark.sql.catalyst.parser.SqlScriptingLabelContext.isForbiddenLabelOrForVariableName
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.trees.CurrentOrigin.withOrigin
 import org.apache.spark.sql.catalyst.trees.TreePattern._
-import org.apache.spark.sql.connector.catalog.{CatalogManager, Identifier}
+import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.errors.{DataTypeErrorsBase, QueryCompilationErrors}
 import org.apache.spark.sql.internal.SQLConf
 
@@ -235,103 +233,17 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
     }
   }
 
-  /**
-   * Look up variable by nameParts.
-   * If in SQL Script, first check local variables, unless in EXECUTE IMMEDIATE
-   * (EXECUTE IMMEDIATE generated query cannot access local variables).
-   * if not found fall back to session variables.
-   * @param nameParts NameParts of the variable.
-   * @return Reference to the variable.
-   */
-  def lookupVariable(nameParts: Seq[String]): Option[VariableReference] = {
-    // The temp variables live in `SYSTEM.SESSION`, and the name can be qualified or not.
-    def maybeTempVariableName(nameParts: Seq[String]): Boolean = {
-      nameParts.length == 1 || {
-        if (nameParts.length == 2) {
-          nameParts.head.equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE)
-        } else if (nameParts.length == 3) {
-          nameParts(0).equalsIgnoreCase(CatalogManager.SYSTEM_CATALOG_NAME) &&
-            nameParts(1).equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE)
-        } else {
-          false
-        }
-      }
-    }
-
-    val namePartsCaseAdjusted = if (conf.caseSensitiveAnalysis) {
-      nameParts
-    } else {
-      nameParts.map(_.toLowerCase(Locale.ROOT))
-    }
-
-    SqlScriptingContextManager.get().map(_.getVariableManager)
-      // If we are in EXECUTE IMMEDIATE lookup only session variables.
-      .filterNot(_ => AnalysisContext.get.isExecuteImmediate)
-      // If variable name is qualified with session.<varName> treat it as a session variable.
-      .filterNot(_ =>
-        nameParts.length > 2
-          || (nameParts.length == 2 && isForbiddenLabelOrForVariableName(nameParts.head)))
-      .flatMap(_.get(namePartsCaseAdjusted))
-      .map { varDef =>
-        VariableReference(
-          nameParts,
-          FakeLocalCatalog,
-          Identifier.of(Array(varDef.identifier.namespace().last), namePartsCaseAdjusted.last),
-          varDef)
-      }
-      .orElse(
-        if (maybeTempVariableName(nameParts)) {
-          catalogManager.tempVariableManager
-            .get(namePartsCaseAdjusted)
-            .map { varDef =>
-              VariableReference(
-                nameParts,
-                FakeSystemCatalog,
-                Identifier.of(Array(CatalogManager.SESSION_NAMESPACE), namePartsCaseAdjusted.last),
-                varDef
-              )}
-        } else {
-          None
-        }
-      )
-  }
-
   // Resolves `UnresolvedAttribute` to its value.
   protected def resolveVariables(e: Expression): Expression = {
-    def resolveVariable(nameParts: Seq[String]): Option[Expression] = {
-      val isResolvingView = AnalysisContext.get.catalogAndNamespace.nonEmpty
-      if (isResolvingView) {
-        if (AnalysisContext.get.referredTempVariableNames.contains(nameParts)) {
-          lookupVariable(nameParts)
-        } else {
-          None
-        }
-      } else {
-        lookupVariable(nameParts)
-      }
-    }
+    val variableResolution = new VariableResolution(catalogManager.tempVariableManager)
 
     def resolve(nameParts: Seq[String]): Option[Expression] = {
-      var resolvedVariable: Option[Expression] = None
-      // We only support temp variables for now, so the variable name can at most have 3 parts.
-      var numInnerFields: Int = math.max(0, nameParts.length - 3)
-      // Follow the column resolution and prefer the longest match. This makes sure that users
-      // can always use fully qualified variable name to avoid name conflicts.
-      while (resolvedVariable.isEmpty && numInnerFields < nameParts.length) {
-        resolvedVariable = resolveVariable(nameParts.dropRight(numInnerFields))
-        if (resolvedVariable.isEmpty) numInnerFields += 1
-      }
-
-      resolvedVariable.map { variable =>
-        if (numInnerFields != 0) {
-          val nestedFields = nameParts.takeRight(numInnerFields)
-          nestedFields.foldLeft(variable: Expression) { (e, name) =>
-            ExtractValue(e, Literal(name), conf.resolver)
-          }
-        } else {
-          variable
-        }
-      }.map(e => Alias(e, nameParts.last)())
+      variableResolution.resolveMultipartName(
+        nameParts = nameParts,
+        resolvingView = AnalysisContext.get.catalogAndNamespace.nonEmpty,
+        resolvingExecuteImmediate = AnalysisContext.get.isExecuteImmediate,
+        referredTempVariableNames = AnalysisContext.get.referredTempVariableNames
+      ).map(e => Alias(e, nameParts.last)())
     }
 
     def innerResolve(e: Expression, isTopLevel: Boolean): Expression = withOrigin(e.origin) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/VariableResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/VariableResolution.scala
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import java.util.Locale
+
+import org.apache.spark.sql.catalyst.{SQLConfHelper, SqlScriptingContextManager}
+import org.apache.spark.sql.catalyst.catalog.TempVariableManager
+import org.apache.spark.sql.catalyst.expressions.{
+  Expression,
+  ExtractValue,
+  Literal,
+  VariableReference
+}
+import org.apache.spark.sql.catalyst.parser.SqlScriptingLabelContext.isForbiddenLabelOrForVariableName
+import org.apache.spark.sql.connector.catalog.{
+  CatalogManager,
+  Identifier
+}
+
+class VariableResolution(tempVariableManager: TempVariableManager) extends SQLConfHelper {
+
+  /**
+   * Resolves a `multipartName` to an [[Expression]] tree, supporting nested field access.
+   *
+   * This method implements a longest-match strategy similar to column resolution,
+   * preferring fully qualified variable names to avoid naming conflicts. It supports
+   * accessing nested fields within variables through dot notation.
+   *
+   * The resolution process works as follows:
+   * 1. Attempts to resolve the full name as a variable
+   * 2. If unsuccessful, treats the rightmost parts as nested field access
+   * 3. Continues until a variable is found or all combinations are exhausted
+   * 4. Wraps the result in ExtractValue expressions for nested field access
+   *
+   * @param nameParts The sequence of name parts representing the variable identifier
+   *   (e.g., ["catalog", "schema", "variable", "field1", "field2"])
+   * @param resolvingView Whether this resolution is happening within a view context.
+   *   When true, only variables explicitly referred to in the view definition are accessible.
+   * @param resolvingExecuteImmediate Whether this resolution is happening within an
+   *   EXECUTE IMMEDIATE context. When true, local variables are not accessible, only session
+   *   variables.
+   * @param referredTempVariableNames When resolving within a view, this contains the list of
+   *   variable names that the view explicitly references and should have access to.
+   *
+   * @return Some(Expression) if a variable is successfully resolved, potentially wrapped in
+   *   [[ExtractValue]] expressions for nested field access. None if no variable can be resolved
+   *   from the given name parts.
+   */
+  def resolveMultipartName(
+      nameParts: Seq[String],
+      resolvingView: Boolean,
+      resolvingExecuteImmediate: Boolean,
+      referredTempVariableNames: Seq[Seq[String]]): Option[Expression] = {
+    var resolvedVariable: Option[Expression] = None
+    // We only support temp variables for now, so the variable name can at most have 3 parts.
+    var numInnerFields: Int = math.max(0, nameParts.length - 3)
+    // Follow the column resolution and prefer the longest match. This makes sure that users
+    // can always use fully qualified variable name to avoid name conflicts.
+    while (resolvedVariable.isEmpty && numInnerFields < nameParts.length) {
+      resolvedVariable = resolveVariable(
+        nameParts = nameParts.dropRight(numInnerFields),
+        resolvingView = resolvingView,
+        resolvingExecuteImmediate = resolvingExecuteImmediate,
+        referredTempVariableNames = referredTempVariableNames
+      )
+
+      if (resolvedVariable.isEmpty) {
+        numInnerFields += 1
+      }
+    }
+
+    resolvedVariable.map { variable =>
+      if (numInnerFields != 0) {
+        val nestedFields = nameParts.takeRight(numInnerFields)
+        nestedFields.foldLeft(variable: Expression) { (e, name) =>
+          ExtractValue(e, Literal(name), conf.resolver)
+        }
+      } else {
+        variable
+      }
+    }
+  }
+
+  /**
+   * Look up variable by nameParts.
+   * If in SQL Script, first check local variables, unless in EXECUTE IMMEDIATE
+   * (EXECUTE IMMEDIATE generated query cannot access local variables).
+   * if not found fall back to session variables.
+   * @param nameParts NameParts of the variable.
+   * @param resolvingExecuteImmediate Whether the current context is in EXECUTE IMMEDIATE.
+   * @return Reference to the variable.
+   */
+  def lookupVariable(
+      nameParts: Seq[String],
+      resolvingExecuteImmediate: Boolean): Option[VariableReference] = {
+    val namePartsCaseAdjusted = if (conf.caseSensitiveAnalysis) {
+      nameParts
+    } else {
+      nameParts.map(_.toLowerCase(Locale.ROOT))
+    }
+
+    SqlScriptingContextManager
+      .get()
+      .map(_.getVariableManager)
+      // If we are in EXECUTE IMMEDIATE lookup only session variables.
+      .filterNot(_ => resolvingExecuteImmediate)
+      // If variable name is qualified with session.<varName> treat it as a session variable.
+      .filterNot(
+        _ =>
+          nameParts.length > 2
+          || (nameParts.length == 2 && isForbiddenLabelOrForVariableName(nameParts.head))
+      )
+      .flatMap(_.get(namePartsCaseAdjusted))
+      .map { varDef =>
+        VariableReference(
+          nameParts,
+          FakeLocalCatalog,
+          Identifier.of(Array(varDef.identifier.namespace().last), namePartsCaseAdjusted.last),
+          varDef
+        )
+      }
+      .orElse(
+        if (maybeTempVariableName(nameParts)) {
+          tempVariableManager
+            .get(namePartsCaseAdjusted)
+            .map { varDef =>
+              VariableReference(
+                nameParts,
+                FakeSystemCatalog,
+                Identifier.of(Array(CatalogManager.SESSION_NAMESPACE), namePartsCaseAdjusted.last),
+                varDef
+              )
+            }
+        } else {
+          None
+        }
+      )
+  }
+
+  private def resolveVariable(
+      nameParts: Seq[String],
+      resolvingView: Boolean,
+      resolvingExecuteImmediate: Boolean,
+      referredTempVariableNames: Seq[Seq[String]]): Option[Expression] = {
+    if (resolvingView) {
+      if (referredTempVariableNames.contains(nameParts)) {
+        lookupVariable(nameParts = nameParts, resolvingExecuteImmediate = resolvingExecuteImmediate)
+      } else {
+        None
+      }
+    } else {
+      lookupVariable(nameParts = nameParts, resolvingExecuteImmediate = resolvingExecuteImmediate)
+    }
+  }
+
+  // The temp variables live in `SYSTEM.SESSION`, and the name can be qualified or not.
+  private def maybeTempVariableName(nameParts: Seq[String]): Boolean = {
+    nameParts.length == 1 || {
+      if (nameParts.length == 2) {
+        nameParts.head.equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE)
+      } else if (nameParts.length == 3) {
+        nameParts(0).equalsIgnoreCase(CatalogManager.SYSTEM_CATALOG_NAME) &&
+        nameParts(1).equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE)
+      } else {
+        false
+      }
+    }
+  }
+
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/executeImmediate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/executeImmediate.scala
@@ -51,7 +51,8 @@ class SubstituteExecuteImmediate(
     val catalogManager: CatalogManager,
     resolveChild: LogicalPlan => LogicalPlan,
     checkAnalysis: LogicalPlan => Unit)
-  extends Rule[LogicalPlan] with ColumnResolutionHelper {
+  extends Rule[LogicalPlan] {
+  private val variableResolution = new VariableResolution(catalogManager.tempVariableManager)
 
   def resolveVariable(e: Expression): Expression = {
 
@@ -201,7 +202,10 @@ class SubstituteExecuteImmediate(
   }
 
   private def getVariableReference(expr: Expression, nameParts: Seq[String]): VariableReference = {
-    lookupVariable(nameParts) match {
+    variableResolution.lookupVariable(
+      nameParts = nameParts,
+      resolvingExecuteImmediate = AnalysisContext.get.isExecuteImmediate
+    ) match {
       case Some(variable) => variable
       case _ =>
         throw QueryCompilationErrors

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.command
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{CONFIG, CONFIG2, KEY, VALUE}
 import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
+import org.apache.spark.sql.catalyst.analysis.{AnalysisContext, VariableResolution}
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.IgnoreCachedData
@@ -107,7 +108,14 @@ case class SetCommand(kv: Option[(String, Option[String])])
           Seq()
         }
         if (varName.nonEmpty && varName.length <= 3) {
-          if (sparkSession.sessionState.analyzer.lookupVariable(varName).isDefined) {
+          val variableResolution = new VariableResolution(
+            sparkSession.sessionState.analyzer.catalogManager.tempVariableManager
+          )
+          val variable = variableResolution.lookupVariable(
+            nameParts = varName,
+            resolvingExecuteImmediate = AnalysisContext.get.isExecuteImmediate
+          )
+          if (variable.isDefined) {
             throw new AnalysisException(
               errorClass = "UNSUPPORTED_FEATURE.SET_VARIABLE_USING_SET",
               messageParameters = Map("variableName" -> toSQLId(varName)))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Refactor variable resolution out to reuse it between single-pass and fixed-point Analyzers.

### Why are the changes needed?

To have compatibility between Analyzers.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
