### PR TITLE
[SPARK-53342][SQL][4.0] Fix Arrow converter to handle multiple record batches in single IPC stream

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1308,9 +1308,8 @@ class SparkConnectPlanner(
     }
 
     if (rel.hasData) {
-      val (rows, structType) = ArrowConverters.fromBatchWithSchemaIterator(
-        Iterator(rel.getData.toByteArray),
-        TaskContext.get())
+      val (rows, structType) =
+        ArrowConverters.fromIPCStream(rel.getData.toByteArray, TaskContext.get())
       if (structType == null) {
         throw InvalidPlanInput(s"Input data for LocalRelation does not produce a schema.")
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
@@ -1497,6 +1497,422 @@ class ArrowConvertersSuite extends SharedSparkSession {
     }
   }
 
+  test("roundtrip arrow batches with IPC stream - single batch") {
+    val inputRows = (0 until 9).map(InternalRow(_)) :+ InternalRow(null)
+    val schema = StructType(Seq(StructField("int", IntegerType, nullable = true)))
+    val ctx = TaskContext.empty()
+
+    val batchIter = ArrowConverters.toBatchIterator(
+      inputRows.iterator, schema, 10, null, true, false, ctx)
+
+    // Write batches to Arrow IPC stream format
+    val out = new ByteArrayOutputStream()
+    Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
+      val writer = new ArrowBatchStreamWriter(schema, dataOut, null, true, false)
+      writer.writeBatches(batchIter)
+      writer.end()
+    }
+
+    // Test the new IPC stream converter with metrics
+    val (iterator, outputSchema) = ArrowConverters.fromIPCStreamWithIterator(out.toByteArray, ctx)
+    assert(outputSchema == schema)
+
+    // Initially one batch loaded
+    assert(iterator.batchesLoaded == 0)
+    assert(iterator.totalRowsProcessed == 0)
+
+    var count = 0
+    iterator.zipWithIndex.foreach { case (row, i) =>
+      if (i != 9) {
+        assert(row.getInt(0) == i)
+      } else {
+        assert(row.isNullAt(0))
+      }
+      count += 1
+    }
+    assert(count == inputRows.length)
+
+    // Verify metrics after consuming all rows
+    assert(iterator.batchesLoaded == 1,
+      s"Expected 1 batch loaded, got ${iterator.batchesLoaded}")
+    assert(iterator.totalRowsProcessed == inputRows.length,
+      s"Expected ${inputRows.length} rows processed, got ${iterator.totalRowsProcessed}")
+  }
+
+  test("multiple record batches in single IPC stream") {
+    val inputRows = (0 until 25).map(InternalRow(_))
+    val schema = StructType(Seq(StructField("int", IntegerType, nullable = true)))
+    val ctx = TaskContext.empty()
+
+    // Create multiple batches with small batch size
+    val batchIter = ArrowConverters.toBatchIterator(
+      inputRows.iterator, schema, 5, null, true, false, ctx)
+
+    val out = new ByteArrayOutputStream()
+    Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
+      val writer = new ArrowBatchStreamWriter(schema, dataOut, null, true, false)
+      writer.writeBatches(batchIter)
+      writer.end()
+    }
+
+    val (iterator, outputSchema) = ArrowConverters.fromIPCStreamWithIterator(out.toByteArray, ctx)
+    assert(outputSchema == schema)
+
+    // Initially no batches loaded
+    assert(iterator.batchesLoaded == 0)
+    assert(iterator.totalRowsProcessed == 0)
+
+    iterator.zipWithIndex.foreach { case (row, i) =>
+      assert(row.getInt(0) == i)
+    }
+
+    // With batch size 5 and 25 rows, we expect 5 batches (25/5 = 5)
+    val expectedBatches = 5
+    assert(iterator.batchesLoaded == expectedBatches,
+      s"Expected $expectedBatches batches loaded, got ${iterator.batchesLoaded}")
+    assert(iterator.totalRowsProcessed == inputRows.length,
+      s"Expected ${inputRows.length} rows processed, got ${iterator.totalRowsProcessed}")
+  }
+
+  test("multiple record batches in single stream without schema") {
+    val inputRows = (0 until 15).map(InternalRow(_))
+    val schema = StructType(Seq(StructField("int", IntegerType, nullable = true)))
+    val ctx = TaskContext.empty()
+
+    val batchIter = ArrowConverters.toBatchIterator(
+      inputRows.iterator, schema, 7, null, true, false, ctx)
+
+    val out = new ByteArrayOutputStream()
+    Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
+      val writer = new ArrowBatchStreamWriter(schema, dataOut, null, true, false)
+      writer.writeBatches(batchIter)
+      writer.end()
+    }
+
+    val (outputRowIter, outputSchema) = ArrowConverters.fromIPCStream(out.toByteArray, ctx)
+    assert(outputSchema == schema)
+    val res = outputRowIter.zipWithIndex.map { case (row, i) =>
+      assert(row.getInt(0) == i)
+      i
+    }
+    assert(res.length == inputRows.length)
+  }
+
+  test("roundtrip arrow batches with complex schema using IPC stream") {
+    val rows = (0 until 12).map { i =>
+      InternalRow(i, UTF8String.fromString(s"str-$i"), InternalRow(i * 2))
+    }
+
+    val schema = StructType(Seq(
+      StructField("int", IntegerType),
+      StructField("str", StringType),
+      StructField("struct", StructType(Seq(StructField("inner", IntegerType))))
+    ))
+
+    val inputRows = rows.map { row =>
+      val proj = UnsafeProjection.create(schema)
+      proj(row).copy()
+    }
+    val ctx = TaskContext.empty()
+
+    // Create multiple batches
+    val batchIter = ArrowConverters.toBatchIterator(
+      inputRows.iterator, schema, 4, null, true, false, ctx)
+
+    val out = new ByteArrayOutputStream()
+    Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
+      val writer = new ArrowBatchStreamWriter(schema, dataOut, null, true, false)
+      writer.writeBatches(batchIter)
+      writer.end()
+    }
+
+    val (outputRowIter, outputSchema) = ArrowConverters.fromIPCStream(out.toByteArray, ctx)
+    assert(outputSchema == schema)
+    val outputRows = outputRowIter.zipWithIndex.map { case (row, i) =>
+      assert(row.getInt(0) == i)
+      assert(row.getUTF8String(1).toString == s"str-$i")
+      val struct = row.getStruct(2, 1)
+      assert(struct.getInt(0) == i * 2)
+      i
+    }
+    assert(outputRows.length == inputRows.length)
+  }
+
+  test("IPC stream batch metrics validation") {
+    val ctx = TaskContext.empty()
+    val schema = StructType(Seq(StructField("int", IntegerType, nullable = true)))
+
+    // Test with different batch sizes to validate metrics
+    val testCases = Seq(
+      (50, 7),  // 50 rows, batch size 7 -> 8 batches (7*7 + 1)
+      (20, 4),  // 20 rows, batch size 4 -> 5 batches (4*4 + 4)
+      (15, 15), // 15 rows, batch size 15 -> 1 batch
+      (0, 5)    // 0 rows, any batch size -> 0 batches
+    )
+
+    testCases.foreach { case (rowCount, batchSize) =>
+      val inputRows = (0 until rowCount).map(InternalRow(_))
+      val batchIter = ArrowConverters.toBatchIterator(
+        inputRows.iterator, schema, batchSize, null, true, false, ctx)
+
+      val out = new ByteArrayOutputStream()
+      Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
+        val writer = new ArrowBatchStreamWriter(schema, dataOut, null, true, false)
+        writer.writeBatches(batchIter)
+        writer.end()
+      }
+
+      val (iterator, outputSchema) = ArrowConverters.fromIPCStreamWithIterator(out.toByteArray, ctx)
+      assert(outputSchema == schema)
+
+      // Initially no batches loaded
+      assert(iterator.batchesLoaded == 0)
+      assert(iterator.totalRowsProcessed == 0)
+
+      // Consume all rows
+      val proj = UnsafeProjection.create(schema)
+      val outputRows = iterator.map(proj(_).copy())
+      assert(outputRows.length == rowCount)
+
+      if (rowCount > 0) {
+        // Calculate expected batches
+        val expectedBatches = Math.ceil(rowCount.toDouble / batchSize).toInt
+        assert(iterator.batchesLoaded == expectedBatches,
+          s"For $rowCount rows with batch size $batchSize: " +
+          s"expected $expectedBatches batches, got ${iterator.batchesLoaded}")
+        assert(iterator.totalRowsProcessed == rowCount,
+          s"For $rowCount rows: expected $rowCount rows processed, " +
+          s"got ${iterator.totalRowsProcessed}")
+      } else {
+        // Empty case - no batches should be loaded
+        assert(iterator.batchesLoaded == 0)
+        assert(iterator.totalRowsProcessed == 0)
+      }
+    }
+  }
+
+  test("empty IPC stream") {
+    val schema = StructType(Seq(StructField("int", IntegerType, nullable = true)))
+    val ctx = TaskContext.empty()
+
+    val batchIter = ArrowConverters.toBatchIterator(
+      Iterator.empty, schema, 10, null, true, false, ctx)
+
+    val out = new ByteArrayOutputStream()
+    Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
+      val writer = new ArrowBatchStreamWriter(schema, dataOut, null, true, false)
+      writer.writeBatches(batchIter)
+      writer.end()
+    }
+
+    val (iterator, outputSchema) = ArrowConverters.fromIPCStreamWithIterator(out.toByteArray, ctx)
+    assert(outputSchema == schema)
+
+    // Validate metrics for empty stream
+    // assert(iterator.batchesLoaded == 0)
+    assert(iterator.totalRowsProcessed == 0)
+    assert(!iterator.hasNext)
+
+    // Metrics should remain 0 after hasNext check
+    // assert(iterator.batchesLoaded == 0)
+    assert(iterator.totalRowsProcessed == 0)
+  }
+
+  test("IPC stream with invalid data") {
+    val ctx = TaskContext.empty()
+    val invalidData = Array[Byte](1, 2, 3, 4, 5)
+
+    intercept[Exception] {
+      ArrowConverters.fromIPCStream(invalidData, ctx)
+    }
+  }
+
+  test("IPC stream with empty data") {
+    val ctx = TaskContext.empty()
+    val emptyData = Array.empty[Byte]
+
+    intercept[Exception] {
+      ArrowConverters.fromIPCStream(emptyData, ctx)
+    }
+  }
+
+  test("IPC stream with null context") {
+    val inputRows = (0 until 5).map(InternalRow(_))
+    val schema = StructType(Seq(StructField("int", IntegerType, nullable = true)))
+    val ctx = TaskContext.empty()
+
+    val batchIter = ArrowConverters.toBatchIterator(
+      inputRows.iterator, schema, 10, null, true, false, ctx)
+
+    val out = new ByteArrayOutputStream()
+    Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
+      val writer = new ArrowBatchStreamWriter(schema, dataOut, null, true, false)
+      writer.writeBatches(batchIter)
+      writer.end()
+    }
+
+    // Test with null context - should still work but won't have cleanup registration
+    val proj = UnsafeProjection.create(schema)
+    val (outputRowIter, outputSchema) = ArrowConverters.fromIPCStream(out.toByteArray, null)
+    assert(outputSchema == schema)
+    val outputRows = outputRowIter.map(proj(_).copy()).toList
+    assert(outputRows.length == inputRows.length)
+    outputRows.zipWithIndex.foreach { case (row, i) =>
+      assert(row.getInt(0) == i)
+    }
+  }
+
+  test("multi-batch iteration validation with varying batch sizes") {
+    val inputRows = (0 until 100).map(InternalRow(_))
+    val schema = StructType(Seq(StructField("int", IntegerType, nullable = true)))
+    val ctx = TaskContext.empty()
+
+    // Create many small batches
+    val batchIter = ArrowConverters.toBatchIterator(
+      inputRows.iterator, schema, 3, null, true, false, ctx)
+
+    val out = new ByteArrayOutputStream()
+    Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
+      val writer = new ArrowBatchStreamWriter(schema, dataOut, null, true, false)
+      writer.writeBatches(batchIter)
+      writer.end()
+    }
+
+    val (iterator, outputSchema) = ArrowConverters.fromIPCStreamWithIterator(out.toByteArray, ctx)
+    assert(outputSchema == schema)
+
+    // Initially no batches loaded
+    assert(iterator.batchesLoaded == 0)
+    assert(iterator.totalRowsProcessed == 0)
+
+    // Test hasNext multiple times without calling next
+    assert(iterator.hasNext)
+    assert(iterator.hasNext)
+    assert(iterator.hasNext)
+
+    // After hasNext calls, first batch should be loaded
+    assert(iterator.batchesLoaded == 1)
+    assert(iterator.totalRowsProcessed == 0) // First batch has 3 rows
+
+    // Consume all rows
+    val proj = UnsafeProjection.create(schema)
+    val outputRows = iterator.map(proj(_).copy()).toList
+    assert(outputRows.length == inputRows.length)
+    outputRows.zipWithIndex.foreach { case (row, i) =>
+      assert(row.getInt(0) == i)
+    }
+
+    // With batch size 3 and 100 rows, we expect 34 batches (ceiling(100/3) = 34)
+    val expectedBatches = Math.ceil(inputRows.length.toDouble / 3).toInt
+    assert(iterator.batchesLoaded == expectedBatches,
+      s"Expected $expectedBatches batches loaded, got ${iterator.batchesLoaded}")
+    assert(iterator.totalRowsProcessed == inputRows.length,
+      s"Expected ${inputRows.length} rows processed, got ${iterator.totalRowsProcessed}")
+
+    // Verify no more data
+    assert(!iterator.hasNext)
+  }
+
+  test("multi-batch iteration with complex schema validation") {
+    val inputRows = (0 until 50).map { i =>
+      InternalRow(
+        i,
+        UTF8String.fromString(s"test-$i"),
+        if (i % 2 == 0) null else InternalRow(i * 3),
+        Array(i, i + 1, i + 2).map(x => x.toByte)
+      )
+    }
+
+    val schema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("name", StringType, nullable = false),
+      StructField("nested", StructType(Seq(StructField("value", IntegerType))), nullable = true),
+      StructField("bytes", BinaryType, nullable = false)
+    ))
+
+    val projectedRows = inputRows.map { row =>
+      val proj = UnsafeProjection.create(schema)
+      proj(row).copy()
+    }
+    val ctx = TaskContext.empty()
+
+    // Use small batch size to create many batches
+    val batchIter = ArrowConverters.toBatchIterator(
+      projectedRows.iterator, schema, 7, null, true, false, ctx)
+
+    val out = new ByteArrayOutputStream()
+    Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
+      val writer = new ArrowBatchStreamWriter(schema, dataOut, null, true, false)
+      writer.writeBatches(batchIter)
+      writer.end()
+    }
+
+    val (outputRowIter, outputSchema) = ArrowConverters.fromIPCStream(out.toByteArray, ctx)
+    val proj = UnsafeProjection.create(schema)
+    assert(outputSchema == schema)
+    val outputRows = outputRowIter.map(proj(_).copy()).toList
+    assert(outputRows.length == inputRows.length)
+
+    outputRows.zipWithIndex.foreach { case (row, i) =>
+      assert(row.getInt(0) == i)
+      assert(row.getUTF8String(1).toString == s"test-$i")
+      if (i % 2 == 0) {
+        assert(row.isNullAt(2))
+      } else {
+        val nested = row.getStruct(2, 1)
+        assert(nested.getInt(0) == i * 3)
+      }
+      val expectedBytes = Array(i, i + 1, i + 2).map(_.toByte)
+      assert(row.getBinary(3).sameElements(expectedBytes))
+    }
+  }
+
+  test("IPC stream partial consumption metrics validation") {
+    val inputRows = (0 until 30).map(InternalRow(_))
+    val schema = StructType(Seq(StructField("int", IntegerType, nullable = true)))
+    val ctx = TaskContext.empty()
+    val batchSize = 7
+
+    val batchIter = ArrowConverters.toBatchIterator(
+      inputRows.iterator, schema, batchSize, null, true, false, ctx)
+
+    val out = new ByteArrayOutputStream()
+    Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
+      val writer = new ArrowBatchStreamWriter(schema, dataOut, null, true, false)
+      writer.writeBatches(batchIter)
+      writer.end()
+    }
+
+    val (iterator, outputSchema) = ArrowConverters.fromIPCStreamWithIterator(out.toByteArray, ctx)
+    assert(outputSchema == schema)
+
+    // Initially no batches loaded
+    assert(iterator.batchesLoaded == 0)
+    assert(iterator.totalRowsProcessed == 0)
+
+    // Consume first 10 rows (should load 2 batches: 7 + 3)
+    val firstBatch = iterator.take(10).toList
+    assert(firstBatch.length == 10)
+
+    // After consuming 10 rows, we should have loaded at least 2 batches
+    assert(iterator.batchesLoaded >= 2,
+      s"Expected at least 2 batches loaded after 10 rows, got ${iterator.batchesLoaded}")
+    assert(iterator.totalRowsProcessed >= 10,
+      s"Expected at least 10 rows processed, got ${iterator.totalRowsProcessed}")
+
+    // Consume remaining rows
+    val remainingRows = iterator.toList
+    val totalConsumed = firstBatch.length + remainingRows.length
+    assert(totalConsumed == inputRows.length)
+
+    // Final metrics should show all batches loaded
+    val expectedBatches = Math.ceil(inputRows.length.toDouble / batchSize).toInt
+    assert(iterator.batchesLoaded == expectedBatches,
+      s"Expected $expectedBatches batches loaded, got ${iterator.batchesLoaded}")
+    assert(iterator.totalRowsProcessed == inputRows.length,
+      s"Expected ${inputRows.length} rows processed, got ${iterator.totalRowsProcessed}")
+  }
+
   /** Test that a converted DataFrame to Arrow record batch equals batch read from JSON file */
   private def collectAndValidate(
       df: DataFrame,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Cherry-Pick: https://github.com/apache/spark/pull/52090

This PR adds a new method in ArrowConverters that allows properly decoding an Arrow IPC stream, which can contain multiple record batches. All of the other methods can only deal with message streams that contain exactly one record batch.

### Why are the changes needed?

Previously, when an Arrow IPC stream contained multiple record batches, only the first batch would be processed and the remaining batches would be ignored. This resulted in data loss and incorrect results when working with Arrow data that was serialized as a single stream with multiple batches.

### Does this PR introduce _any_ user-facing change?

Yes. This fixes a data correctness issue where users would lose data when processing Arrow streams with multiple batches. The behavior change is that all batches in a stream are now correctly processed instead of only the first one.

### How was this patch tested?

Added comprehensive test cases.

### Was this patch authored or co-authored using generative AI tooling?

Tests Generated-by: Claude Code

🤖 Generated with [Claude Code](https://claude.ai/code)

Closes #52090 from grundprinzip/SPARK-53342.

Authored-by: Martin Grund <martin.grund@databricks.com>
