### PR TITLE
[SPARK-53393][PYTHON] Disable memory profiler for Arrow Scalar Iterator UDFs

### DIFF
--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -436,6 +436,7 @@ class UserDefinedFunction:
             # Disable profiling Pandas UDFs with iterators as input/output.
             if self.evalType in [
                 PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF,
+                PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF,
                 PythonEvalType.SQL_MAP_PANDAS_ITER_UDF,
                 PythonEvalType.SQL_MAP_ARROW_ITER_UDF,
             ]:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Disable memory profiler for Arrow Scalar Iterator UDFs


### Why are the changes needed?
to be consistent with Pandas Scalar Iterator UDFs


### Does this PR introduce _any_ user-facing change?
no, the arrow udf is not yet released


### How was this patch tested?
new test


### Was this patch authored or co-authored using generative AI tooling?
no