### PR TITLE
[SPARK-53348] [SQL] [FOLLOWUP] Don't run `AlwaysPersistedConfigsSuite` in case ANSI was set using the system var

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/AlwaysPersistedConfigsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/AlwaysPersistedConfigsSuite.scala
@@ -17,6 +17,9 @@
 
 package org.apache.spark.sql
 
+import org.scalactic.source.Position
+import org.scalatest.Tag
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.SQLScalarFunction
@@ -37,6 +40,13 @@ import org.apache.spark.sql.types.StructType
  * or a UDF.
  */
 class AlwaysPersistedConfigsSuite extends QueryTest with SharedSparkSession {
+
+  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(
+    implicit pos: Position): Unit = {
+    if (!sys.env.get("SPARK_ANSI_SQL_MODE").contains("false")) {
+      super.test(testName, testTags: _*)(testFun)
+    }
+  }
 
   protected override def sparkConf: SparkConf = {
     super.sparkConf


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR I propose that we fix `AlwaysPersistedConfigsSuite` failures in Build / Non-ANSI by disabling it to run if ANSI was set using the system var.

### Why are the changes needed?
To fix the test.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Fixed test.

### Was this patch authored or co-authored using generative AI tooling?
No.