### PR TITLE
[SPARK-53403][PS] Improve add/sub tests under ANSI

### DIFF
--- a/python/pyspark/pandas/tests/data_type_ops/test_num_arithmetic.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_arithmetic.py
@@ -20,6 +20,7 @@ import unittest
 import pandas as pd
 
 from pyspark import pandas as ps
+from pyspark.testing.utils import is_ansi_mode_test
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
 
@@ -46,7 +47,6 @@ class ArithmeticTestsMixin:
             pser, psser = pdf[col], psdf[col]
             self.assert_eq(pser + pser, psser + psser, check_exact=False)
             self.assert_eq(pser + 1, psser + 1, check_exact=False)
-            # self.assert_eq(pser + 0.1, psser + 0.1)
             self.assert_eq(pser + pser.astype(bool), psser + psser.astype(bool), check_exact=False)
             self.assert_eq(pser + True, psser + True, check_exact=False)
             self.assert_eq(pser + False, psser + False, check_exact=False)
@@ -57,13 +57,15 @@ class ArithmeticTestsMixin:
                 else:
                     self.assertRaises(TypeError, lambda: psser + psdf[n_col])
 
+            if is_ansi_mode_test and not col.startswith("decimal"):
+                self.assert_eq(pser + 0.1, psser + 0.1)
+
     def test_sub(self):
         pdf, psdf = self.pdf, self.psdf
         for col in self.numeric_df_cols:
             pser, psser = pdf[col], psdf[col]
             self.assert_eq(pser - pser, psser - psser, check_exact=False)
             self.assert_eq(pser - 1, psser - 1, check_exact=False)
-            # self.assert_eq(pser - 0.1, psser - 0.1)
             self.assert_eq(pser - pser.astype(bool), psser - psser.astype(bool), check_exact=False)
             self.assert_eq(pser - True, psser - True, check_exact=False)
             self.assert_eq(pser - False, psser - False, check_exact=False)
@@ -73,6 +75,9 @@ class ArithmeticTestsMixin:
                     self.assert_eq(pser - pdf[n_col], psser - psdf[n_col], check_exact=False)
                 else:
                     self.assertRaises(TypeError, lambda: psser - psdf[n_col])
+
+            if is_ansi_mode_test and not col.startswith("decimal"):
+                self.assert_eq(pser - 0.1, psser - 0.1)
 
 
 class ArithmeticTests(

--- a/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
@@ -33,19 +33,19 @@ if extension_object_dtypes_available:
 
 class StringOpsTestsMixin:
     @property
-    def bool_pdf(self):
+    def str_pdf(self):
         return pd.DataFrame({"this": ["x", "y", "z"], "that": ["z", "y", "x"]})
 
     @property
-    def bool_non_numeric_pdf(self):
-        return pd.concat([self.bool_pdf, self.non_numeric_pdf], axis=1)
+    def str_non_numeric_pdf(self):
+        return pd.concat([self.str_pdf, self.non_numeric_pdf], axis=1)
 
     @property
-    def bool_non_numeric_psdf(self):
-        return ps.from_pandas(self.bool_non_numeric_pdf)
+    def str_non_numeric_psdf(self):
+        return ps.from_pandas(self.str_non_numeric_pdf)
 
     def test_add(self):
-        pdf, psdf = self.bool_non_numeric_pdf, self.bool_non_numeric_psdf
+        pdf, psdf = self.str_non_numeric_pdf, self.str_non_numeric_psdf
         pser, psser = pdf["this"], psdf["this"]
         other_pser, other_psser = pdf["that"], psdf["that"]
         self.assert_eq(pser + "x", psser + "x")
@@ -188,42 +188,42 @@ class StringOpsTestsMixin:
         self.assertRaises(TypeError, lambda: ~self.psdf["string"])
 
     def test_eq(self):
-        pdf, psdf = self.bool_non_numeric_pdf, self.bool_non_numeric_psdf
+        pdf, psdf = self.str_non_numeric_pdf, self.str_non_numeric_psdf
         pser, psser = pdf["this"], psdf["this"]
         other_pser, other_psser = pdf["that"], psdf["that"]
         self.assert_eq(pser == other_pser, psser == other_psser)
         self.assert_eq(pser == pser, psser == psser)
 
     def test_ne(self):
-        pdf, psdf = self.bool_non_numeric_pdf, self.bool_non_numeric_psdf
+        pdf, psdf = self.str_non_numeric_pdf, self.str_non_numeric_psdf
         pser, psser = pdf["this"], psdf["this"]
         other_pser, other_psser = pdf["that"], psdf["that"]
         self.assert_eq(pser != other_pser, psser != other_psser)
         self.assert_eq(pser != pser, psser != psser)
 
     def test_lt(self):
-        pdf, psdf = self.bool_non_numeric_pdf, self.bool_non_numeric_psdf
+        pdf, psdf = self.str_non_numeric_pdf, self.str_non_numeric_psdf
         pser, psser = pdf["this"], psdf["this"]
         other_pser, other_psser = pdf["that"], psdf["that"]
         self.assert_eq(pser < other_pser, psser < other_psser)
         self.assert_eq(pser < pser, psser < psser)
 
     def test_le(self):
-        pdf, psdf = self.bool_non_numeric_pdf, self.bool_non_numeric_psdf
+        pdf, psdf = self.str_non_numeric_pdf, self.str_non_numeric_psdf
         pser, psser = pdf["this"], psdf["this"]
         other_pser, other_psser = pdf["that"], psdf["that"]
         self.assert_eq(pser <= other_pser, psser <= other_psser)
         self.assert_eq(pser <= pser, psser <= psser)
 
     def test_gt(self):
-        pdf, psdf = self.bool_non_numeric_pdf, self.bool_non_numeric_psdf
+        pdf, psdf = self.str_non_numeric_pdf, self.str_non_numeric_psdf
         pser, psser = pdf["this"], psdf["this"]
         other_pser, other_psser = pdf["that"], psdf["that"]
         self.assert_eq(pser > other_pser, psser > other_psser)
         self.assert_eq(pser > pser, psser > psser)
 
     def test_ge(self):
-        pdf, psdf = self.bool_non_numeric_pdf, self.bool_non_numeric_psdf
+        pdf, psdf = self.str_non_numeric_pdf, self.str_non_numeric_psdf
         pser, psser = pdf["this"], psdf["this"]
         other_pser, other_psser = pdf["that"], psdf["that"]
         self.assert_eq(pser >= other_pser, psser >= other_psser)

--- a/python/pyspark/pandas/tests/test_categorical.py
+++ b/python/pyspark/pandas/tests/test_categorical.py
@@ -91,7 +91,6 @@ class CategoricalTestsMixin:
         self.assert_eq(pser.cat.add_categories([4, 5]), psser.cat.add_categories([4, 5]))
         self.assert_eq(pser.cat.add_categories([]), psser.cat.add_categories([]))
 
-        pser = pser.cat.add_categories(4)
         psser = psser.cat.add_categories(4)
 
         self.assertRaises(ValueError, lambda: psser.cat.add_categories(4))


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Enable add/sub float tests under ANSI
- Code cleanup

### Why are the changes needed?
Part of https://issues.apache.org/jira/browse/SPARK-53389

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Test changes

Commands below pass:
```
 1047  SPARK_ANSI_SQL_MODE=false ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_arithmetic ArithmeticTests.test_add"
 1048  SPARK_ANSI_SQL_MODE=true ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_arithmetic ArithmeticTests.test_add"
 1049  SPARK_ANSI_SQL_MODE=true ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_arithmetic ArithmeticTests.test_sub"
 1050  SPARK_ANSI_SQL_MODE=false ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_arithmetic ArithmeticTests.test_sub"
```

### Was this patch authored or co-authored using generative AI tooling?
No