### PR TITLE
[SPARK-53408][SQL] Remove unused functions from `QueryCompilationErrors`

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1846,12 +1846,6 @@
     ],
     "sqlState" : "39000"
   },
-  "FOUND_MULTIPLE_DATA_SOURCES" : {
-    "message" : [
-      "Detected multiple data sources with the name '<provider>'. Please check the data source isn't simultaneously registered and located in the classpath."
-    ],
-    "sqlState" : "42710"
-  },
   "GENERATED_COLUMN_WITH_DEFAULT_VALUE" : {
     "message" : [
       "A column cannot have both a default value and a generation expression but column <colName> has default value: (<defaultValue>) and generation expression: (<genExpr>)."
@@ -6643,12 +6637,6 @@
       "<outputMode> output mode not supported for <statefulOperator> on streaming DataFrames/DataSets without watermark."
     ],
     "sqlState" : "0A000"
-  },
-  "UNSUPPORTED_STREAMING_TABLE_VALUED_FUNCTION" : {
-    "message" : [
-      "The function <funcName> does not support streaming. Please remove the STREAM keyword"
-    ],
-    "sqlState" : "42000"
   },
   "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY" : {
     "message" : [

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3763,13 +3763,6 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     )
   }
 
-  def indeterminateCollationInExpressionError(expr: Expression): Throwable = {
-    new AnalysisException(
-      errorClass = "INDETERMINATE_COLLATION",
-      messageParameters = Map("expr" -> toSQLExpr(expr))
-    )
-  }
-
   def indeterminateCollationInSchemaError(columnPaths: Seq[ColumnPath]): Throwable = {
     new AnalysisException(
       errorClass = "INDETERMINATE_COLLATION_IN_SCHEMA",
@@ -4094,12 +4087,6 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     )
   }
 
-  def foundMultipleDataSources(provider: String): Throwable = {
-    new AnalysisException(
-      errorClass = "FOUND_MULTIPLE_DATA_SOURCES",
-      messageParameters = Map("provider" -> provider))
-  }
-
   def foundMultipleXMLDataSourceError(provider: String,
       sourceNames: Seq[String],
       externalSource: String): Throwable = {
@@ -4396,11 +4383,5 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       ),
       origin = origin
     )
-  }
-
-  def unsupportedStreamingTVF(funcName: Seq[String]): Throwable = {
-    new AnalysisException(
-      errorClass = "UNSUPPORTED_STREAMING_TABLE_VALUED_FUNCTION",
-      messageParameters = Map("funcName" -> toSQLId(funcName)))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR removes the following unused functions from `QueryCompilationErrors`:
1. indeterminateCollationInExpressionError
2. foundMultipleDataSources
3. unsupportedStreamingTVF

Meanwhile, since the error classes `FOUND_MULTIPLE_DATA_SOURCES` and `UNSUPPORTED_STREAMING_TABLE_VALUED_FUNCTION`, which are used by the functions `foundMultipleDataSources` and `unsupportedStreamingTVF` respectively, are no longer referenced, this pr also cleans them up.

### Why are the changes needed?
Code cleanup.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No
