### PR TITLE
[SPARK-53416][SS][TESTS] Use `createOrReplaceTempView` instead of `registerTempTable` in `StreamingQueryOptimizationCorrectnessSuite`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryOptimizationCorrectnessSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryOptimizationCorrectnessSuite.scala
@@ -458,11 +458,11 @@ class StreamingQueryOptimizationCorrectnessSuite extends StreamTest {
       withTempView("tv1", "tv2") {
         val inputStream1 = MemoryStream[Int]
         val ds1 = inputStream1.toDS()
-        ds1.registerTempTable("tv1")
+        ds1.createOrReplaceTempView("tv1")
 
         val inputStream2 = MemoryStream[Int]
         val ds2 = inputStream2.toDS()
-        ds2.registerTempTable("tv2")
+        ds2.createOrReplaceTempView("tv2")
 
         // DISTINCT is rewritten to AGGREGATE, hence an AGGREGATEs for each source
         val unioned = spark.sql(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to replace the deprecated API `registerTempTable` with `createOrReplaceTempView` in the `StreamingQueryOptimizationCorrectnessSuite`. Since `registerTempTable` has been deprecated since Spark 2.0.0, we should avoid using it outside of the `DeprecatedAPISuite`.

### Why are the changes needed?
Clean up the usage of deprecated APIs


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No