### PR TITLE
[SPARK-53418][SQL] Support `TimeType` in `ColumnAccessor`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnAccessor.scala
@@ -147,7 +147,7 @@ private[sql] object ColumnAccessor {
       case ByteType => new ByteColumnAccessor(buf)
       case ShortType => new ShortColumnAccessor(buf)
       case IntegerType | DateType | _: YearMonthIntervalType => new IntColumnAccessor(buf)
-      case LongType | TimestampType | TimestampNTZType | _: DayTimeIntervalType =>
+      case LongType | TimestampType | TimestampNTZType | _: DayTimeIntervalType | _: TimeType =>
         new LongColumnAccessor(buf)
       case FloatType => new FloatColumnAccessor(buf)
       case DoubleType => new DoubleColumnAccessor(buf)


### PR DESCRIPTION


### What changes were proposed in this pull request?

This PR makes TimeType be properly handled in ColumnAccessor

### Why are the changes needed?

For a cache deserializer that supports columnar IO for time, ColumnAccessor should add the missing ability for the read side


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
new ut


### Was this patch authored or co-authored using generative AI tooling?
no
