### PR TITLE
[SPARK-53427][PS][TESTS] Test divisor 0 in truediv/floordiv/mod tests under ANSI

### DIFF
--- a/python/pyspark/pandas/tests/computation/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/computation/test_binary_ops.py
@@ -196,6 +196,7 @@ class FrameBinaryOpsMixin:
         pser = pd.Series([1.1, 2.2, 3.3], dtype=np.float32)
         psser = ps.from_pandas(pser)
         self.assert_eq(psser / 1, pser / 1)
+        self.assert_eq(psser / 0, pser / 0)
 
         # Negative
         psdf = ps.DataFrame({"a": ["x"], "b": [1]})

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -103,6 +103,7 @@ class BooleanOpsTestsMixin:
         pdf, psdf = self.pdf, self.psdf
 
         b_pser, b_psser = pdf["bool"], psdf["bool"]
+        self.assert_eq(b_pser / 0, b_psser / 0)
         self.assert_eq(b_pser / 1, b_psser / 1)
         self.assert_eq(b_pser / 0.1, b_psser / 0.1)
         self.assert_eq(b_pser / b_pser.astype(int), b_psser / b_psser.astype(int))
@@ -121,6 +122,7 @@ class BooleanOpsTestsMixin:
 
         # float is always returned in pandas-on-Spark
         self.assert_eq((b_pser // 1).astype("float"), b_psser // 1)
+        self.assert_eq((b_pser // 0).astype("float"), b_psser // 0)
 
         # in pandas, 1 // 0.1 = 9.0; in pandas-on-Spark, 1 // 0.1 = 10.0
         # self.assert_eq(b_pser // 0.1, b_psser // 0.1)
@@ -138,6 +140,7 @@ class BooleanOpsTestsMixin:
         pdf, psdf = self.pdf, self.psdf
 
         b_pser, b_psser = pdf["bool"], psdf["bool"]
+        self.assert_eq(b_pser % 0, b_psser % 0)
         self.assert_eq(b_pser % 1, b_psser % 1)
         self.assert_eq(b_pser % 0.1, b_psser % 0.1)
         self.assert_eq(b_pser % b_pser.astype(float), b_psser % b_psser.astype(float))

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_mod.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_mod.py
@@ -42,6 +42,8 @@ class NumModTestsMixin:
             self.assert_eq(pser % pser.astype(bool), psser % psser.astype(bool), check_exact=False)
             self.assert_eq(pser % True, psser % True, check_exact=False)
             self.assert_eq(pser % 1, psser % 1, check_exact=False)
+            if not col.startswith("decimal"):
+                self.assert_eq(pser % 0, psser % 0, check_exact=False)
             if col in ["int", "int32"]:
                 self.assert_eq(
                     pd.Series([np.nan, np.nan, np.nan], dtype=float, name=col), psser % False


### PR DESCRIPTION
### What changes were proposed in this pull request?
Test divisor 0 in truediv/floordiv/mod tests under ANSI

### Why are the changes needed?
Part of https://issues.apache.org/jira/browse/SPARK-53427

### Does this PR introduce _any_ user-facing change?
No, test change only

### How was this patch tested?
Commands below passed
```
 1067  SPARK_ANSI_SQL_MODE=true ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests.test_truediv"
 1068  SPARK_ANSI_SQL_MODE=false ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests.test_truediv"
 1069  SPARK_ANSI_SQL_MODE=true ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests.test_floordiv"
 1070  SPARK_ANSI_SQL_MODE=false ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests.test_floordiv"
 1071  SPARK_ANSI_SQL_MODE=true ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests.test_mod"
 1072  SPARK_ANSI_SQL_MODE=false ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests.test_mod"
 1073  SPARK_ANSI_SQL_MODE=true ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.computation.test_binary_ops FrameBinaryOpsTests.test_binary_operator_truediv"
 1074  SPARK_ANSI_SQL_MODE=false ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.computation.test_binary_ops FrameBinaryOpsTests.test_binary_operator_truediv"
 1007  SPARK_ANSI_SQL_MODE=true ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_mod NumModTests.test_mod"
 1008  SPARK_ANSI_SQL_MODE=false ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_mod NumModTests.test_mod"
```


### Was this patch authored or co-authored using generative AI tooling?
No
