### PR TITLE
[SPARK-53423] [SQL] Move all the single-pass resolver related tags to `ResolverTag`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeduplicateRelations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeduplicateRelations.scala
@@ -19,17 +19,14 @@ package org.apache.spark.sql.catalyst.analysis
 
 import scala.collection.mutable
 
+import org.apache.spark.sql.catalyst.analysis.resolver.ResolverTag
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, AttributeReference, AttributeSet, Expression, NamedExpression, OuterReference, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.internal.SQLConf
 
 object DeduplicateRelations extends Rule[LogicalPlan] {
-  val PROJECT_FOR_EXPRESSION_ID_DEDUPLICATION =
-    TreeNodeTag[Unit]("project_for_expression_id_deduplication")
-
   type ExprIdMap = mutable.HashMap[Class[_], mutable.HashSet[Long]]
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
@@ -77,7 +74,7 @@ object DeduplicateRelations extends Rule[LogicalPlan] {
                   }
                   val project = Project(projectList, child)
                   project.setTagValue(
-                    DeduplicateRelations.PROJECT_FOR_EXPRESSION_ID_DEDUPLICATION,
+                    ResolverTag.PROJECT_FOR_EXPRESSION_ID_DEDUPLICATION,
                     ()
                   )
                   project

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/BinaryArithmeticResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/BinaryArithmeticResolver.scala
@@ -69,8 +69,8 @@ import org.apache.spark.sql.types._
  * top-most node itself is not resolved recursively in order to avoid recursive calls to
  * [[BinaryArithmeticResolver]] and other sub-resolvers. To prevent a case where we resolve the
  * same node twice, we need to mark nodes that will act as a limit for the downwards traversal by
- * applying a [[ExpressionResolver.SINGLE_PASS_SUBTREE_BOUNDARY]] tag to them. These children
- * along with all the nodes below them are guaranteed to be resolved at this point. When
+ * applying a [[ResolverTag.SINGLE_PASS_SUBTREE_BOUNDARY]] tag to them. These children along with
+ * all the nodes below them are guaranteed to be resolved at this point. When
  * [[ExpressionResolver]] reaches one of the tagged nodes, it returns identity rather than
  * resolving it. Finally, after resolving the subtree, we need to resolve the top-most node itself,
  * which in this case means applying a timezone, if necessary.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ExpressionResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ExpressionResolver.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.catalyst.analysis.{
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, LogicalPlan, Sort}
-import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, TreeNodeTag}
+import org.apache.spark.sql.catalyst.trees.CurrentOrigin
 import org.apache.spark.sql.catalyst.util.CollationFactory
 import org.apache.spark.sql.errors.QueryCompilationErrors
 
@@ -685,7 +685,7 @@ class ExpressionResolver(
           case Some(lateralAttributeReference) =>
             scopes.current.lcaRegistry
               .markAttributeLaterallyReferenced(lateralAttributeReference)
-            candidate.setTagValue(ExpressionResolver.SINGLE_PASS_IS_LCA, ())
+            candidate.setTagValue(ResolverTag.SINGLE_PASS_IS_LCA, ())
             expressionResolutionContext.hasLateralColumnAlias = true
           case None =>
         }
@@ -1098,9 +1098,4 @@ class ExpressionResolver(
       s"The replacement is unresolved: ${toSQLExpr(runtimeReplaceable.replacement)}."
     )
   }
-}
-
-object ExpressionResolver {
-  val SINGLE_PASS_SUBTREE_BOUNDARY = TreeNodeTag[Unit]("single_pass_subtree_boundary")
-  val SINGLE_PASS_IS_LCA = TreeNodeTag[Unit]("single_pass_is_lca")
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/JoinResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/JoinResolver.scala
@@ -208,7 +208,7 @@ class JoinResolver(resolver: Resolver, expressionResolver: ExpressionResolver)
       scopes.current.hiddenOutput.filter(_.qualifiedAccessOnly)
 
     val newProjectList =
-      if (unresolvedJoin.getTagValue(Resolver.TOP_LEVEL_OPERATOR).isEmpty) {
+      if (unresolvedJoin.getTagValue(ResolverTag.TOP_LEVEL_OPERATOR).isEmpty) {
         newOutputList ++ qualifiedAccessOnlyColumnsFromHiddenOutput
       } else {
         newOutputList

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/Resolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/Resolver.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.catalyst.expressions.{
   ExprId
 }
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, TreeNodeTag}
+import org.apache.spark.sql.catalyst.trees.CurrentOrigin
 import org.apache.spark.sql.catalyst.util.EvaluateUnresolvedInlineTable
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -171,7 +171,7 @@ class Resolver(
 
     planLogger.logPlanResolutionEvent(planAfterSubstitution, "Main resolution")
 
-    planAfterSubstitution.setTagValue(Resolver.TOP_LEVEL_OPERATOR, ())
+    planAfterSubstitution.setTagValue(ResolverTag.TOP_LEVEL_OPERATOR, ())
 
     resolve(planAfterSubstitution)
   }
@@ -784,11 +784,6 @@ class Resolver(
 }
 
 object Resolver {
-
-  /**
-   * Marks the operator as the top-most operator in a query or a view.
-   */
-  val TOP_LEVEL_OPERATOR = TreeNodeTag[Unit]("top_level_operator")
 
   /**
    * Create a new instance of the [[RelationResolution]].

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ResolverTag.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ResolverTag.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis.resolver
+
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
+
+/**
+ * Object used to store single-pass resolver related tags.
+ */
+object ResolverTag {
+
+  /**
+   * Tag used to mark [[Project]] nodes added for expression ID deduplication.
+   */
+  val PROJECT_FOR_EXPRESSION_ID_DEDUPLICATION =
+    TreeNodeTag[Unit]("project_for_expression_id_deduplication")
+
+  /**
+   * Tag used to mark a node after resolving it to avoid traversing into its subtree twice.
+   */
+  val SINGLE_PASS_SUBTREE_BOUNDARY =
+    TreeNodeTag[Unit]("single_pass_subtree_boundary")
+
+  /**
+   * Tag used to determine whether a node is an LCA.
+   */
+  val SINGLE_PASS_IS_LCA =
+    TreeNodeTag[Unit]("single_pass_is_lca")
+
+  /**
+   * Tag used to mark the operator as the top-most operator in a query or a view.
+   */
+  val TOP_LEVEL_OPERATOR =
+    TreeNodeTag[Unit]("top_level_operator")
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/NormalizePlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/NormalizePlan.scala
@@ -19,10 +19,8 @@ package org.apache.spark.sql.catalyst.plans
 
 import java.util.HashMap
 
-import org.apache.spark.sql.catalyst.analysis.{
-  DeduplicateRelations,
-  NormalizeableRelation
-}
+import org.apache.spark.sql.catalyst.analysis.NormalizeableRelation
+import org.apache.spark.sql.catalyst.analysis.resolver.ResolverTag
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.optimizer.ReplaceExpressions
@@ -149,9 +147,7 @@ object NormalizePlan extends PredicateHelper {
             .reduce(And)
         Join(left, right, newJoinType, Some(newCondition), hint)
       case project: Project
-          if project
-            .getTagValue(DeduplicateRelations.PROJECT_FOR_EXPRESSION_ID_DEDUPLICATION)
-            .isDefined =>
+          if project.getTagValue(ResolverTag.PROJECT_FOR_EXPRESSION_ID_DEDUPLICATION).isDefined =>
         project.child
 
       case aggregate @ Aggregate(_, _, innerProject: Project, _) =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR I propose that we move all the single-pass resolver related tags to `ResolverTag` to have them in a same place.

### Why are the changes needed?
To improve code health of the single-pass resolver.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests (it's a refactor).

### Was this patch authored or co-authored using generative AI tooling?
No.